### PR TITLE
[codex] Harden CI lanes and optional signoff summaries

### DIFF
--- a/.github/actions/prepare-build/action.yml
+++ b/.github/actions/prepare-build/action.yml
@@ -1,0 +1,129 @@
+name: Prepare Build
+description: Install CI build dependencies, configure CMake, and build the project.
+
+inputs:
+  os-name:
+    description: GitHub runner OS label.
+    required: true
+  python-version:
+    description: Python version to install for the job.
+    required: false
+    default: "3.12"
+  compiler:
+    description: Compiler selection for the job.
+    required: false
+    default: gcc
+  build-type:
+    description: CMake build type.
+    required: false
+    default: Release
+  install-docs-deps:
+    description: Whether to install docs Python dependencies.
+    required: false
+    default: "false"
+  install-playwright:
+    description: Whether to install Playwright and Chromium.
+    required: false
+    default: "false"
+
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: pip
+        cache-dependency-path: |
+          requirements-docs.txt
+          .github/actions/prepare-build/action.yml
+
+    - name: Restore Playwright browser cache
+      if: ${{ startsWith(inputs.os-name, 'ubuntu') && inputs.install-playwright == 'true' }}
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: playwright-${{ inputs.os-name }}-chromium-${{ hashFiles('.github/actions/prepare-build/action.yml') }}
+
+    - name: Restore ccache
+      uses: actions/cache@v4
+      with:
+        path: ${{ runner.os == 'Linux' && '~/.cache/ccache' || '~/Library/Caches/ccache' }}
+        key: ${{ runner.os }}-ccache-${{ hashFiles('CMakeLists.txt', 'src/**', 'include/**') }}
+
+    - name: Install dependencies (Ubuntu)
+      if: ${{ startsWith(inputs.os-name, 'ubuntu') }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        packages=(
+          libeigen3-dev
+          libgtest-dev
+          cmake
+          build-essential
+          ccache
+          python3-dev
+          pybind11-dev
+          python3-numpy
+          python3-matplotlib
+        )
+        if [ "${{ inputs.compiler }}" = "clang" ]; then
+          packages+=(clang)
+        fi
+        sudo apt-get update
+        sudo apt-get install -y "${packages[@]}"
+        python -m pip install --upgrade pip
+        if [ "${{ inputs.install-docs-deps }}" = "true" ]; then
+          python -m pip install --user -r requirements-docs.txt
+        fi
+        if [ "${{ inputs.install-playwright }}" = "true" ]; then
+          python -m pip install --user playwright
+          python -m playwright install --with-deps chromium
+        fi
+
+    - name: Install dependencies (macOS)
+      if: ${{ startsWith(inputs.os-name, 'macos') }}
+      shell: bash
+      run: |
+        set -euo pipefail
+        brew install eigen googletest cmake pybind11 python ccache
+        python -m venv .venv
+        . .venv/bin/activate
+        python -m pip install --upgrade pip
+        python -m pip install numpy matplotlib
+        if [ "${{ inputs.install-docs-deps }}" = "true" ]; then
+          python -m pip install -r requirements-docs.txt
+        fi
+        echo "${GITHUB_WORKSPACE}/.venv/bin" >> "$GITHUB_PATH"
+
+    - name: Configure ccache
+      shell: bash
+      run: |
+        set -euo pipefail
+        echo "CMAKE_C_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
+        echo "CMAKE_CXX_COMPILER_LAUNCHER=ccache" >> "$GITHUB_ENV"
+        ccache --set-config=max_size=500M
+        ccache --set-config=compression=true
+
+    - name: Configure CMake
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ "${{ inputs.compiler }}" = "clang" ]; then
+          export CC=clang
+          export CXX=clang++
+        fi
+        cmake_args=(
+          -B build
+          -DCMAKE_BUILD_TYPE=${{ inputs.build-type }}
+          "-DCMAKE_C_COMPILER_LAUNCHER=${CMAKE_C_COMPILER_LAUNCHER}"
+          "-DCMAKE_CXX_COMPILER_LAUNCHER=${CMAKE_CXX_COMPILER_LAUNCHER}"
+        )
+        if [[ "${{ inputs.os-name }}" == macos* ]]; then
+          cmake_args+=("-DPython3_EXECUTABLE=${GITHUB_WORKSPACE}/.venv/bin/python")
+        fi
+        cmake "${cmake_args[@]}"
+
+    - name: Build
+      shell: bash
+      run: cmake --build build --config "${{ inputs.build-type }}" --parallel

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,77 @@ on:
   push:
     branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      docs_only: ${{ steps.scope.outputs.docs_only }}
+      run_heavy: ${{ steps.scope.outputs.run_heavy }}
+      changed_paths_json: ${{ steps.scope.outputs.changed_paths_json }}
+    steps:
+    - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
+    - name: Collect changed paths
+      shell: bash
+      run: |
+        set -euo pipefail
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          git diff --name-only "${{ github.event.pull_request.base.sha }}" "${{ github.sha }}" > changed_paths.txt
+        elif [ "${{ github.event_name }}" = "push" ]; then
+          before="${{ github.event.before }}"
+          if [ -z "${before}" ] || [ "${before}" = "0000000000000000000000000000000000000000" ]; then
+            git diff-tree --no-commit-id --name-only -r "${{ github.sha }}" > changed_paths.txt
+          else
+            git diff --name-only "${before}" "${{ github.sha }}" > changed_paths.txt
+          fi
+        else
+          : > changed_paths.txt
+        fi
+        sed -i '/^$/d' changed_paths.txt
+        sort -u changed_paths.txt -o changed_paths.txt || true
+        echo "Changed paths:"
+        if [ -s changed_paths.txt ]; then
+          cat changed_paths.txt
+        else
+          echo "(none; workflow_dispatch or empty diff)"
+        fi
+
+    - name: Classify CI scope
+      id: scope
+      run: python3 scripts/ci/detect_ci_scope.py --paths-file changed_paths.txt --github-output "$GITHUB_OUTPUT"
+
+  hygiene:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Python
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.12"
+
+    - name: Run hygiene checks
+      run: bash scripts/ci/run_hygiene.sh
+
   build-and-test:
+    needs: [changes, hygiene]
+    if: needs.changes.outputs.run_heavy == 'true'
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
@@ -21,166 +87,200 @@ jobs:
     steps:
     - uses: actions/checkout@v4
 
-    - name: Install dependencies (Ubuntu)
-      if: matrix.os == 'ubuntu-latest'
+    - name: Prepare build
+      uses: ./.github/actions/prepare-build
+      with:
+        os-name: ${{ matrix.os }}
+        compiler: ${{ matrix.compiler }}
+        build-type: Release
+        install-docs-deps: "true"
+
+    - name: Show ccache stats
+      run: ccache -s
+
+    - name: Run core tests
+      run: bash scripts/ci/run_core_tests.sh
+
+    - name: Upload CTest diagnostics
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ctest-diagnostics-${{ matrix.os }}-${{ matrix.compiler }}
+        path: |
+          build/CMakeCache.txt
+          build/Testing/Temporary/LastTest.log
+          build/Testing/Temporary/LastTestsFailed.log
+        if-no-files-found: ignore
+
+    - name: Append build summary
+      if: always()
+      shell: bash
+      env:
+        CI_OS: ${{ matrix.os }}
+        CI_BUILD_TYPE: Release
       run: |
-        sudo apt-get update
-        sudo apt-get install -y libeigen3-dev libgtest-dev cmake build-essential python3-dev pybind11-dev python3-numpy python3-matplotlib
-        if [ "${{ matrix.compiler }}" = "clang" ]; then
-          sudo apt-get install -y clang
-        fi
+        set -euo pipefail
+        python - <<'PY'
+        import os
+        import re
+        import subprocess
+        from pathlib import Path
 
-    - name: Install dependencies (macOS)
-      if: matrix.os == 'macos-latest'
-      run: |
-        brew install eigen googletest cmake pybind11 python
-        python3 -m venv .venv
-        . .venv/bin/activate
-        python -m pip install --upgrade pip
-        python -m pip install numpy matplotlib
-        echo "${GITHUB_WORKSPACE}/.venv/bin" >> "$GITHUB_PATH"
+        os_name = os.environ["CI_OS"]
+        build_type = os.environ["CI_BUILD_TYPE"]
 
-    - name: Install docs dependencies (Ubuntu)
-      if: matrix.os == 'ubuntu-latest'
-      run: python3 -m pip install --user -r requirements-docs.txt
+        passed = "unknown"
+        failed = "unknown"
+        last_test_log = Path("build/Testing/Temporary/LastTest.log")
+        if last_test_log.exists():
+            last_test_text = last_test_log.read_text(encoding="utf-8", errors="ignore")
+            match = re.search(r"(\d+)% tests passed, (\d+) tests failed out of (\d+)", last_test_text)
+            if match is not None:
+                failed_count = int(match.group(2))
+                total_count = int(match.group(3))
+                passed = str(total_count - failed_count)
+                failed = str(failed_count)
 
-    - name: Install docs dependencies (macOS)
-      if: matrix.os == 'macos-latest'
-      run: |
-        . .venv/bin/activate
-        python -m pip install -r requirements-docs.txt
+        hit_rate = "unknown"
+        stats_output = subprocess.run(["ccache", "-s"], check=False, capture_output=True, text=True).stdout
+        match = re.search(r"^\s*Hits:.*\(([^)]+)\)", stats_output, re.MULTILINE)
+        if match is not None:
+            hit_rate = match.group(1).strip()
+        else:
+            direct_hits = 0
+            preprocessed_hits = 0
+            misses = 0
+            for line in stats_output.splitlines():
+                stripped = line.strip()
+                if re.fullmatch(r"cache hit \(direct\)\s+\d+", stripped):
+                    direct_hits = int(stripped.rsplit(None, 1)[-1])
+                elif re.fullmatch(r"cache hit \(preprocessed\)\s+\d+", stripped):
+                    preprocessed_hits = int(stripped.rsplit(None, 1)[-1])
+                elif re.fullmatch(r"cache miss\s+\d+", stripped):
+                    misses = int(stripped.rsplit(None, 1)[-1])
+            total_calls = direct_hits + preprocessed_hits + misses
+            if total_calls > 0:
+                hit_rate = f"{((direct_hits + preprocessed_hits) / total_calls) * 100:.2f}%"
 
-    - name: Configure CMake
-      run: |
-        if [ "${{ matrix.compiler }}" = "clang" ]; then
-          export CC=clang
-          export CXX=clang++
-        fi
-        cmake_args="-B build -DCMAKE_BUILD_TYPE=Release"
-        if [ "${{ matrix.os }}" = "macos-latest" ]; then
-          cmake_args="$cmake_args -DPython3_EXECUTABLE=${GITHUB_WORKSPACE}/.venv/bin/python"
-        fi
-        cmake ${cmake_args}
+        summary_path = Path(os.environ["GITHUB_STEP_SUMMARY"])
+        with summary_path.open("a", encoding="utf-8") as handle:
+            handle.write("### Build Summary\n\n")
+            handle.write("| Field | Value |\n")
+            handle.write("| --- | --- |\n")
+            handle.write(f"| OS | {os_name} |\n")
+            handle.write(f"| Build type | {build_type} |\n")
+            handle.write(f"| CTest passed | {passed} |\n")
+            handle.write(f"| CTest failed | {failed} |\n")
+            handle.write(f"| ccache hit rate | {hit_rate} |\n")
+        PY
 
-    - name: Build
-      run: cmake --build build --config Release --parallel
+  linux-extended-tests:
+    needs: [changes, hygiene, build-and-test]
+    if: needs.changes.outputs.run_heavy == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4
 
-    - name: Run tests
-      working-directory: build
-      run: ctest --output-on-failure
+    - name: Prepare build
+      uses: ./.github/actions/prepare-build
+      with:
+        os-name: ubuntu-latest
+        build-type: Release
+        install-docs-deps: "true"
+        install-playwright: "true"
+
+    - name: Show ccache stats
+      run: ccache -s
+
+    - name: Run extended tests
+      run: bash scripts/ci/run_extended_tests.sh
+
+    - name: Upload CTest diagnostics
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ctest-diagnostics-ubuntu-extended
+        path: |
+          build/CMakeCache.txt
+          build/Testing/Temporary/LastTest.log
+          build/Testing/Temporary/LastTestsFailed.log
+        if-no-files-found: ignore
 
     - name: Docker smoke
-      if: matrix.os == 'ubuntu-latest' && matrix.compiler == 'gcc'
       run: |
         docker build -t libgnsspp-ci .
         docker run --rm libgnsspp-ci --help >/dev/null
         docker run --rm libgnsspp-ci web --help >/dev/null
         docker compose -f compose.yaml config >/dev/null
 
-    - name: Optional PPC RTK sign-off
-      if: matrix.os == 'ubuntu-latest' && matrix.compiler == 'gcc'
+    - name: Generate dashboard artifacts
+      run: bash scripts/ci/generate_dashboard_artifacts.sh
+
+    - name: Upload dashboard artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: dashboard-artifacts-ubuntu
+        path: |
+          output/artifact_manifest.json
+          output/visibility_static_summary.json
+          output/visibility_static.csv
+          output/visibility_static.png
+        if-no-files-found: ignore
+
+  linux-optional-signoffs:
+    needs: [changes, linux-extended-tests]
+    if: needs.changes.outputs.run_heavy == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Prepare build
+      uses: ./.github/actions/prepare-build
+      with:
+        os-name: ubuntu-latest
+        build-type: Release
+        install-docs-deps: "true"
+
+    - name: Run optional integration tests
+      run: bash scripts/ci/run_optional_tests.sh
+
+    - name: Upload CTest diagnostics
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: ctest-diagnostics-ubuntu-optional
+        path: |
+          build/CMakeCache.txt
+          build/Testing/Temporary/LastTest.log
+          build/Testing/Temporary/LastTestsFailed.log
+        if-no-files-found: ignore
+
+    - name: Optional RTK sign-offs
       env:
         GNSSPP_PPC_DATASET_ROOT: ${{ vars.GNSSPP_PPC_DATASET_ROOT }}
         GNSSPP_RTKLIB_BIN: ${{ vars.GNSSPP_RTKLIB_BIN }}
-      run: |
-        if [ -z "${GNSSPP_PPC_DATASET_ROOT}" ] || [ ! -d "${GNSSPP_PPC_DATASET_ROOT}" ]; then
-          echo "PPC-Dataset root is unavailable; skipping PPC RTK sign-off."
-          exit 0
-        fi
-        mkdir -p output
-        python3 apps/gnss.py ppc-rtk-signoff \
-          --dataset-root "${GNSSPP_PPC_DATASET_ROOT}" \
-          --city nagoya \
-          --max-epochs 120 \
-          --summary-json output/ppc_nagoya_run1_rtk_summary.json
-        if [ -n "${GNSSPP_RTKLIB_BIN}" ] && [ -x "${GNSSPP_RTKLIB_BIN}" ]; then
-          python3 apps/gnss.py ppc-rtk-signoff \
-            --dataset-root "${GNSSPP_PPC_DATASET_ROOT}" \
-            --city tokyo \
-            --max-epochs 120 \
-            --rtklib-bin "${GNSSPP_RTKLIB_BIN}" \
-            --summary-json output/ppc_tokyo_run1_rtk_summary.json
-        else
-          echo "RTKLIB binary is unavailable; skipping Tokyo RTKLIB side-by-side sign-off."
-        fi
-
-    - name: Upload PPC sign-off summaries
-      if: always() && matrix.os == 'ubuntu-latest' && matrix.compiler == 'gcc'
-      uses: actions/upload-artifact@v4
-      with:
-        name: ppc-signoff-${{ matrix.os }}-${{ matrix.compiler }}
-        path: |
-          output/ppc_nagoya_run1_rtk_summary.json
-          output/ppc_tokyo_run1_rtk_summary.json
-        if-no-files-found: ignore
-
-    - name: Optional SCORPION moving-base sign-off
-      if: matrix.os == 'ubuntu-latest' && matrix.compiler == 'gcc'
-      env:
         GNSSPP_SCORPION_MOVING_BASE_INPUT: ${{ vars.GNSSPP_SCORPION_MOVING_BASE_INPUT }}
         GNSSPP_SCORPION_MOVING_BASE_URL: ${{ vars.GNSSPP_SCORPION_MOVING_BASE_URL }}
-      run: |
-        input_args=()
-        if [ -n "${GNSSPP_SCORPION_MOVING_BASE_INPUT}" ] && [ -e "${GNSSPP_SCORPION_MOVING_BASE_INPUT}" ]; then
-          input_args=(--input "${GNSSPP_SCORPION_MOVING_BASE_INPUT}")
-        elif [ -n "${GNSSPP_SCORPION_MOVING_BASE_URL}" ]; then
-          input_args=(--input-url "${GNSSPP_SCORPION_MOVING_BASE_URL}")
-        else
-          echo "SCORPION moving-base input is unavailable; skipping sign-off."
-          exit 0
-        fi
-        mkdir -p output
-        python3 apps/gnss.py scorpion-moving-base-signoff \
-          "${input_args[@]}" \
-          --summary-json output/scorpion_moving_base_summary.json \
-          --max-epochs 120 \
-          --require-matched-epochs-min 80 \
-          --require-fix-rate-min 90 \
-          --require-p95-baseline-error-max 0.20 \
-          --require-p95-heading-error-max 10 \
-          --require-realtime-factor-min 1.0
+      run: bash scripts/ci/run_optional_rtk_signoffs.sh
 
-    - name: Optional PPP products sign-off with MALIB comparison
-      if: matrix.os == 'ubuntu-latest' && matrix.compiler == 'gcc'
-      env:
-        GNSSPP_MALIB_BIN: ${{ vars.GNSSPP_MALIB_BIN }}
-      run: |
-        if [ -z "${GNSSPP_MALIB_BIN}" ] || [ ! -x "${GNSSPP_MALIB_BIN}" ]; then
-          echo "MALIB binary is unavailable; skipping PPP products comparison sign-off."
-          exit 0
-        fi
-        mkdir -p output
-        python3 apps/gnss.py ppp-products-signoff \
-          --profile kinematic \
-          --obs data/rover_kinematic.obs \
-          --base data/base_kinematic.obs \
-          --nav data/navigation_kinematic.nav \
-          --summary-json output/ppp_kinematic_products_summary.json \
-          --max-epochs 60 \
-          --malib-bin "${GNSSPP_MALIB_BIN}" \
-          --require-common-epoch-pairs-min 20 \
-          --require-ppp-solution-rate-min 100
-
-    - name: Generate dashboard artifacts
-      if: matrix.os == 'ubuntu-latest' && matrix.compiler == 'gcc'
-      run: |
-        mkdir -p output
-        python3 apps/gnss.py visibility \
-          --obs data/rover_static.obs \
-          --nav data/navigation_static.nav \
-          --csv output/visibility_static.csv \
-          --summary-json output/visibility_static_summary.json \
-          --max-epochs 5 \
-          --quiet
-        python3 apps/gnss.py visibility-plot output/visibility_static.csv output/visibility_static.png
-        python3 apps/gnss.py artifact-manifest --root . --output output/artifact_manifest.json
-
-    - name: Upload SCORPION moving-base artifacts
-      if: always() && matrix.os == 'ubuntu-latest' && matrix.compiler == 'gcc'
+    - name: Upload RTK sign-off artifacts
+      if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: scorpion-moving-base-${{ matrix.os }}-${{ matrix.compiler }}
+        name: rtk-signoffs-ubuntu
         path: |
+          output/ci_optional_rtk_signoffs_summary.json
+          output/ci_optional_rtk_signoffs/*.log
+          output/ppc_nagoya_run1_rtk_summary.json
+          output/ppc_nagoya_run1_rtk.pos
+          output/ppc_nagoya_run1_rtk_events.csv
+          output/ppc_tokyo_run1_rtk_summary.json
+          output/ppc_tokyo_run1_rtk.pos
+          output/ppc_tokyo_run1_rtk_events.csv
+          output/ppc_tokyo_run1_rtk_rtklib.pos
           output/scorpion_moving_base_summary.json
           output/scorpion_moving_base/prepare_summary.json
           output/scorpion_moving_base/products_summary.json
@@ -190,14 +290,26 @@ jobs:
           output/scorpion_moving_base/reference.csv
         if-no-files-found: ignore
 
+    - name: Optional PPP products sign-off with MALIB comparison
+      env:
+        GNSSPP_MALIB_BIN: ${{ vars.GNSSPP_MALIB_BIN }}
+        GNSSPP_PPP_PRODUCTS_OBS: ${{ vars.GNSSPP_PPP_PRODUCTS_OBS }}
+        GNSSPP_PPP_PRODUCTS_BASE: ${{ vars.GNSSPP_PPP_PRODUCTS_BASE }}
+        GNSSPP_PPP_PRODUCTS_NAV: ${{ vars.GNSSPP_PPP_PRODUCTS_NAV }}
+        GNSSPP_PPP_PRODUCTS_MALIB_CONFIG: ${{ vars.GNSSPP_PPP_PRODUCTS_MALIB_CONFIG }}
+      run: bash scripts/ci/run_optional_ppp_products_signoff.sh
+
     - name: Upload PPP products comparison artifacts
-      if: always() && matrix.os == 'ubuntu-latest' && matrix.compiler == 'gcc'
+      if: always()
       uses: actions/upload-artifact@v4
       with:
-        name: ppp-products-${{ matrix.os }}-${{ matrix.compiler }}
+        name: ppp-products-ubuntu
         path: |
+          output/ci_optional_ppp_products_summary.json
+          output/ci_optional_ppp_products/*.log
           output/ppp_kinematic_products_summary.json
           output/ppp_kinematic_products_solution.pos
+          output/ppp_kinematic_products_reference.pos
           output/ppp_kinematic_products_comparison.csv
           output/ppp_kinematic_products_comparison.png
           output/malib_ppp_kinematic_solution.pos
@@ -207,20 +319,11 @@ jobs:
           output/ppp_static_products_comparison.png
         if-no-files-found: ignore
 
-    - name: Upload dashboard artifacts
-      if: always() && matrix.os == 'ubuntu-latest' && matrix.compiler == 'gcc'
-      uses: actions/upload-artifact@v4
-      with:
-        name: dashboard-artifacts-${{ matrix.os }}-${{ matrix.compiler }}
-        path: |
-          output/artifact_manifest.json
-          output/visibility_static_summary.json
-          output/visibility_static.csv
-          output/visibility_static.png
-        if-no-files-found: ignore
-
   static-analysis:
+    needs: [changes, hygiene]
+    if: needs.changes.outputs.run_heavy == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
     - uses: actions/checkout@v4
 
@@ -230,10 +333,4 @@ jobs:
         sudo apt-get install -y libeigen3-dev cppcheck
 
     - name: Run cppcheck
-      run: |
-        cppcheck --enable=warning,style --std=c++17 \
-          --suppress=missingIncludeSystem \
-          --suppress=unusedFunction \
-          --suppress=unmatchedSuppression \
-          -I include/ \
-          src/
+      run: bash scripts/ci/run_cppcheck.sh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,22 @@ name: Docs
 on:
   push:
     branches: [ develop ]
+    paths:
+      - ".github/workflows/docs.yml"
+      - "README.md"
+      - "docs/**"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+      - "scripts/generate_architecture_diagram.py"
+  pull_request:
+    branches: [ main, develop ]
+    paths:
+      - ".github/workflows/docs.yml"
+      - "README.md"
+      - "docs/**"
+      - "mkdocs.yml"
+      - "requirements-docs.txt"
+      - "scripts/generate_architecture_diagram.py"
   workflow_dispatch:
 
 permissions:
@@ -11,7 +27,7 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  group: pages-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -24,6 +40,8 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: "3.12"
+          cache: pip
+          cache-dependency-path: requirements-docs.txt
       - name: Install docs dependencies
         run: python -m pip install --upgrade pip && python -m pip install -r requirements-docs.txt
       - name: Generate docs visuals
@@ -32,19 +50,14 @@ jobs:
         run: python scripts/generate_architecture_diagram.py --output docs/libgnsspp_architecture.png
       - name: Build MkDocs site
         run: python -m mkdocs build --strict
-      - name: Assemble GitHub Pages site
-        run: |
-          mkdir -p _site/docs _site/demo
-          cp site-pages/index.html _site/
-          cp site-pages/demo/index.html _site/demo/
-          cp -r site/* _site/docs/
       - name: Upload Pages artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: _site
+          path: site
 
   deploy:
     needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/develop'
     runs-on: ubuntu-latest
     environment:
       name: github-pages

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,22 @@ Minimum relevant checks:
 - `python3 tests/test_ros2_node.py`
 - `ctest --test-dir build --output-on-failure`
 
+If the PR touches workflow or docs pipeline files, also run:
+
+- `bash scripts/ci/run_hygiene.sh`
+- `bash scripts/ci/run_cppcheck.sh`
+- `python3 -m mkdocs build --strict`
+
+CI lanes are split as follows:
+
+- `bash scripts/ci/run_core_tests.sh` for the cross-platform gate
+- `bash scripts/ci/run_extended_tests.sh` for Linux-only heavy checks such as web, packaging, and ROS2 surfaces
+- `bash scripts/ci/run_optional_tests.sh` for broader Linux-only integration suites such as the full CLI and benchmark script regressions
+- `bash scripts/ci/run_optional_rtk_signoffs.sh` for dataset-gated RTK sign-offs with JSON/log artifacts under `output/ci_optional_rtk_signoffs*`
+- `bash scripts/ci/generate_dashboard_artifacts.sh` for the dashboard/manifest artifact path used in CI
+
+Docs-only changes keep CI on the lightweight path: hygiene here, plus the separate Docs workflow.
+
 If the PR touches only a subset, include the focused command you used in the PR body.
 
 ## External Code References

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -29,6 +29,22 @@ Run the smallest relevant set and the broad regression set:
 - `python3 tests/test_ros2_node.py`
 - `ctest --test-dir build --output-on-failure`
 
+If the PR touches workflow or docs pipeline files, also run:
+
+- `bash scripts/ci/run_hygiene.sh`
+- `bash scripts/ci/run_cppcheck.sh`
+- `python3 -m mkdocs build --strict`
+
+CI lanes are split as follows:
+
+- `bash scripts/ci/run_core_tests.sh` for the cross-platform gate
+- `bash scripts/ci/run_extended_tests.sh` for Linux-only heavy checks such as web, packaging, and ROS2 surfaces
+- `bash scripts/ci/run_optional_tests.sh` for broader Linux-only integration suites such as the full CLI and benchmark script regressions
+- `bash scripts/ci/run_optional_rtk_signoffs.sh` for dataset-gated RTK sign-offs with JSON/log artifacts under `output/ci_optional_rtk_signoffs*`
+- `bash scripts/ci/generate_dashboard_artifacts.sh` for the dashboard/manifest artifact path used in CI
+
+Docs-only changes keep CI on the lightweight path: hygiene here, plus the separate Docs workflow.
+
 ## External code references
 
 When taking ideas from external repos:

--- a/scripts/ci/detect_ci_scope.py
+++ b/scripts/ci/detect_ci_scope.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python3
+"""Classify changed paths to decide whether heavy CI lanes should run."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Sequence
+
+
+DOCS_ONLY_EXACT_PATHS = {
+    ".github/workflows/docs.yml",
+    "README.md",
+    "CONTRIBUTING.md",
+    "mkdocs.yml",
+    "requirements-docs.txt",
+    "scripts/generate_architecture_diagram.py",
+}
+DOCS_ONLY_PREFIXES = (
+    "docs/",
+    "notes/",
+)
+
+
+def normalize_paths(paths: Sequence[str]) -> list[str]:
+    cleaned = {path.strip().lstrip("./") for path in paths if path.strip()}
+    return sorted(cleaned)
+
+
+def is_docs_only_path(path: str) -> bool:
+    if path in DOCS_ONLY_EXACT_PATHS:
+        return True
+    return any(path.startswith(prefix) for prefix in DOCS_ONLY_PREFIXES)
+
+
+def classify_changed_paths(paths: Sequence[str]) -> dict[str, object]:
+    normalized = normalize_paths(paths)
+    docs_only = bool(normalized) and all(is_docs_only_path(path) for path in normalized)
+    return {
+        "changed_paths": normalized,
+        "docs_only": docs_only,
+        "run_heavy": not docs_only,
+    }
+
+
+def render_markdown_summary(payload: dict[str, object]) -> str:
+    docs_only = bool(payload["docs_only"])
+    run_heavy = bool(payload["run_heavy"])
+    changed_paths = list(payload["changed_paths"])
+    lines = [
+        "## CI Scope",
+        "",
+        f"- `docs_only`: `{str(docs_only).lower()}`",
+        f"- `run_heavy`: `{str(run_heavy).lower()}`",
+        f"- `changed_paths`: `{len(changed_paths)}`",
+        "",
+    ]
+    if changed_paths:
+        lines.append("Changed paths:")
+        lines.append("")
+        for path in changed_paths[:20]:
+            lines.append(f"- `{path}`")
+        if len(changed_paths) > 20:
+            lines.append(f"- `...` ({len(changed_paths) - 20} more)")
+    else:
+        lines.append("Changed paths: `(none)`")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--paths-file", type=Path, required=True)
+    parser.add_argument("--github-output", type=Path, default=None)
+    parser.add_argument("--github-step-summary", type=Path, default=None)
+    return parser.parse_args()
+
+
+def append_github_outputs(path: Path, payload: dict[str, object]) -> None:
+    lines = [
+        f"docs_only={'true' if payload['docs_only'] else 'false'}",
+        f"run_heavy={'true' if payload['run_heavy'] else 'false'}",
+        f"changed_paths_json={json.dumps(payload['changed_paths'])}",
+    ]
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write("\n".join(lines) + "\n")
+
+
+def append_github_step_summary(path: Path, payload: dict[str, object]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(render_markdown_summary(payload))
+        handle.write("\n")
+
+
+def main() -> int:
+    args = parse_args()
+    payload = classify_changed_paths(args.paths_file.read_text(encoding="utf-8").splitlines())
+    print(json.dumps(payload, indent=2))
+    if args.github_output is not None:
+        append_github_outputs(args.github_output, payload)
+    summary_path = args.github_step_summary
+    if summary_path is None:
+        summary_env = os.environ.get("GITHUB_STEP_SUMMARY", "").strip()
+        summary_path = Path(summary_env) if summary_env else None
+    if summary_path is not None:
+        append_github_step_summary(summary_path, payload)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/generate_dashboard_artifacts.sh
+++ b/scripts/ci/generate_dashboard_artifacts.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${repo_root}"
+
+python_bin="${PYTHON:-python3}"
+output_dir="${OUTPUT_DIR:-output}"
+visibility_obs="${VISIBILITY_OBS:-data/rover_static.obs}"
+visibility_nav="${VISIBILITY_NAV:-data/navigation_static.nav}"
+
+mkdir -p "${output_dir}"
+if [[ -f "${visibility_obs}" && -f "${visibility_nav}" ]]; then
+    "${python_bin}" apps/gnss.py visibility \
+        --obs "${visibility_obs}" \
+        --nav "${visibility_nav}" \
+        --csv "${output_dir}/visibility_static.csv" \
+        --summary-json "${output_dir}/visibility_static_summary.json" \
+        --max-epochs 5 \
+        --quiet
+    "${python_bin}" apps/gnss.py visibility-plot \
+        "${output_dir}/visibility_static.csv" \
+        "${output_dir}/visibility_static.png"
+else
+    echo "Skipping visibility artifact generation: sample data is unavailable." >&2
+fi
+"${python_bin}" apps/gnss.py artifact-manifest \
+    --root . \
+    --output "${output_dir}/artifact_manifest.json"

--- a/scripts/ci/run_core_tests.sh
+++ b/scripts/ci/run_core_tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+exec bash "${repo_root}/scripts/ci/run_ctest_label.sh" core "$@"

--- a/scripts/ci/run_cppcheck.sh
+++ b/scripts/ci/run_cppcheck.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${repo_root}"
+
+cppcheck --enable=warning,style --std=c++17 \
+    --suppress=missingIncludeSystem \
+    --suppress=unusedFunction \
+    --suppress=unmatchedSuppression \
+    -I include/ \
+    src/

--- a/scripts/ci/run_ctest_label.sh
+++ b/scripts/ci/run_ctest_label.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -lt 1 ]; then
+    echo "usage: $(basename "$0") <label> [ctest args...]" >&2
+    exit 2
+fi
+
+label="$1"
+shift
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${repo_root}"
+
+build_dir="${BUILD_DIR:-build}"
+
+ctest --test-dir "${build_dir}" --output-on-failure -L "${label}" "$@"

--- a/scripts/ci/run_extended_tests.sh
+++ b/scripts/ci/run_extended_tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+exec bash "${repo_root}/scripts/ci/run_ctest_label.sh" extended "$@"

--- a/scripts/ci/run_hygiene.sh
+++ b/scripts/ci/run_hygiene.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${repo_root}"
+
+if ! command -v docker >/dev/null 2>&1; then
+    echo "docker is required to run actionlint hygiene locally" >&2
+    exit 1
+fi
+
+python_bin="${PYTHON:-python3}"
+
+docker run --rm -v "${repo_root}:/repo" -w /repo rhysd/actionlint:latest
+"${python_bin}" -m compileall -q apps python scripts tests

--- a/scripts/ci/run_optional_ppp_products_signoff.py
+++ b/scripts/ci/run_optional_ppp_products_signoff.py
@@ -1,0 +1,386 @@
+#!/usr/bin/env python3
+"""Run optional PPP products sign-off and persist a diagnostic summary."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class SignoffStep:
+    name: str
+    slug: str
+    command: list[str] | None
+    outputs: list[str]
+    summary_json: str
+    skip_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class SignoffContext:
+    repo_root: Path
+    output_dir: Path
+    gnss_command: list[str]
+    malib_bin: Path | None
+    malib_config: Path | None
+    obs: Path
+    base: Path
+    nav: Path
+
+
+def repo_root_from_script() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def resolve_optional_path(repo_root: Path, value: str, default: Path | None = None) -> Path | None:
+    text = value.strip()
+    if not text:
+        return default
+    path = Path(text)
+    if path.is_absolute():
+        return path
+    return repo_root / path
+
+
+def is_executable_file(path: Path | None) -> bool:
+    return path is not None and path.is_file() and os.access(path, os.X_OK)
+
+
+def build_context(
+    repo_root: Path,
+    output_dir: Path,
+    environ: Mapping[str, str],
+    *,
+    python_executable: str = sys.executable,
+) -> SignoffContext:
+    return SignoffContext(
+        repo_root=repo_root,
+        output_dir=output_dir,
+        gnss_command=[python_executable, str(repo_root / "apps" / "gnss.py")],
+        malib_bin=resolve_optional_path(repo_root, environ.get("GNSSPP_MALIB_BIN", "")),
+        malib_config=resolve_optional_path(repo_root, environ.get("GNSSPP_PPP_PRODUCTS_MALIB_CONFIG", "")),
+        obs=resolve_optional_path(
+            repo_root,
+            environ.get("GNSSPP_PPP_PRODUCTS_OBS", ""),
+            repo_root / "data" / "rover_kinematic.obs",
+        ),
+        base=resolve_optional_path(
+            repo_root,
+            environ.get("GNSSPP_PPP_PRODUCTS_BASE", ""),
+            repo_root / "data" / "base_kinematic.obs",
+        ),
+        nav=resolve_optional_path(
+            repo_root,
+            environ.get("GNSSPP_PPP_PRODUCTS_NAV", ""),
+            repo_root / "data" / "navigation_kinematic.nav",
+        ),
+    )
+
+
+def make_step(context: SignoffContext) -> SignoffStep:
+    name = "PPP products sign-off with MALIB comparison"
+    slug = "ppp_kinematic_products"
+    summary_json = context.output_dir / f"{slug}_summary.json"
+    solution_pos = context.output_dir / f"{slug}_solution.pos"
+    reference_pos = context.output_dir / f"{slug}_reference.pos"
+    comparison_csv = context.output_dir / f"{slug}_comparison.csv"
+    comparison_png = context.output_dir / f"{slug}_comparison.png"
+    malib_pos = context.output_dir / "malib_ppp_kinematic_solution.pos"
+    outputs = [
+        summary_json,
+        solution_pos,
+        reference_pos,
+        comparison_csv,
+        comparison_png,
+        malib_pos,
+    ]
+
+    if not is_executable_file(context.malib_bin):
+        return SignoffStep(
+            name=name,
+            slug=slug,
+            command=None,
+            outputs=[str(path) for path in outputs],
+            summary_json=str(summary_json),
+            skip_reason="MALIB binary is unavailable.",
+        )
+
+    missing_inputs = [
+        (label, path)
+        for label, path in (
+            ("rover observation", context.obs),
+            ("base observation", context.base),
+            ("navigation", context.nav),
+        )
+        if not path.is_file()
+    ]
+    if missing_inputs:
+        missing_text = ", ".join(f"{label}: {path}" for label, path in missing_inputs)
+        return SignoffStep(
+            name=name,
+            slug=slug,
+            command=None,
+            outputs=[str(path) for path in outputs],
+            summary_json=str(summary_json),
+            skip_reason=f"PPP products input is unavailable ({missing_text}).",
+        )
+
+    command = [
+        *context.gnss_command,
+        "ppp-products-signoff",
+        "--profile",
+        "kinematic",
+        "--obs",
+        str(context.obs),
+        "--base",
+        str(context.base),
+        "--nav",
+        str(context.nav),
+        "--out",
+        str(solution_pos),
+        "--reference-pos",
+        str(reference_pos),
+        "--summary-json",
+        str(summary_json),
+        "--comparison-csv",
+        str(comparison_csv),
+        "--comparison-png",
+        str(comparison_png),
+        "--max-epochs",
+        "60",
+        "--malib-bin",
+        str(context.malib_bin),
+        "--malib-pos",
+        str(malib_pos),
+        "--require-common-epoch-pairs-min",
+        "20",
+        "--require-ppp-solution-rate-min",
+        "100",
+    ]
+    if context.malib_config is not None:
+        command.extend(["--malib-config", str(context.malib_config)])
+    return SignoffStep(
+        name=name,
+        slug=slug,
+        command=command,
+        outputs=[str(path) for path in outputs],
+        summary_json=str(summary_json),
+    )
+
+
+def build_step_plan(
+    repo_root: Path,
+    output_dir: Path,
+    environ: Mapping[str, str],
+    *,
+    python_executable: str = sys.executable,
+) -> list[SignoffStep]:
+    context = build_context(repo_root, output_dir, environ, python_executable=python_executable)
+    return [make_step(context)]
+
+
+def load_summary_metrics(summary_json: Path) -> dict[str, object]:
+    if not summary_json.is_file():
+        return {}
+    try:
+        payload = json.loads(summary_json.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    keys = [
+        "products_signoff_profile",
+        "dataset",
+        "ppp_solution_rate_pct",
+        "common_epoch_pairs",
+        "reference_common_epoch_pairs",
+        "mean_position_error_m",
+        "p95_position_error_m",
+        "max_position_error_m",
+        "comparison_target",
+        "comparison_status",
+        "libgnss_minus_malib_mean_error_m",
+        "libgnss_minus_malib_p95_error_m",
+        "libgnss_minus_malib_max_error_m",
+    ]
+    return {key: payload[key] for key in keys if key in payload}
+
+
+def run_step(step: SignoffStep, repo_root: Path, log_dir: Path) -> dict[str, object]:
+    log_path = log_dir / f"{step.slug}.log"
+    summary_json = Path(step.summary_json)
+    record: dict[str, object] = {
+        "name": step.name,
+        "slug": step.slug,
+        "outputs": step.outputs,
+        "summary_json": step.summary_json,
+        "log_path": str(log_path),
+    }
+    if step.skip_reason is not None:
+        record["status"] = "skipped"
+        record["skip_reason"] = step.skip_reason
+        log_path.write_text(step.skip_reason + "\n", encoding="utf-8")
+        print(f"Skipping {step.name}: {step.skip_reason}")
+        return record
+
+    assert step.command is not None
+    command_display = " ".join(step.command)
+    print(f"+ {command_display}")
+    started = time.monotonic()
+    completed = subprocess.run(
+        step.command,
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    elapsed = time.monotonic() - started
+    combined_log = completed.stdout
+    if completed.stderr:
+        if combined_log and not combined_log.endswith("\n"):
+            combined_log += "\n"
+        combined_log += completed.stderr
+    log_path.write_text(f"$ {command_display}\n\n{combined_log}", encoding="utf-8")
+    record["command"] = step.command
+    record["elapsed_s"] = elapsed
+    record["returncode"] = completed.returncode
+    metrics = load_summary_metrics(summary_json)
+    if metrics:
+        record["metrics"] = metrics
+    if completed.returncode == 0:
+        record["status"] = "passed"
+        print(f"Passed {step.name} in {elapsed:.2f}s")
+    else:
+        record["status"] = "failed"
+        lines = combined_log.splitlines()
+        tail = "\n".join(lines[-20:])
+        if tail:
+            print(tail)
+        print(f"Failed {step.name} in {elapsed:.2f}s; see {log_path}")
+    return record
+
+
+def format_metric_value(value: object, *, suffix: str = "") -> str:
+    if isinstance(value, float):
+        text = f"{value:.3f}".rstrip("0").rstrip(".")
+    else:
+        text = str(value)
+    return text + suffix
+
+
+def render_result_detail(result: dict[str, object]) -> str:
+    status = str(result["status"])
+    if status == "skipped":
+        return str(result.get("skip_reason", ""))
+    if status == "failed":
+        log_path = result.get("log_path")
+        return f"see `{log_path}`" if log_path else "failed"
+
+    detail_parts: list[str] = []
+    elapsed = result.get("elapsed_s")
+    if isinstance(elapsed, (float, int)):
+        detail_parts.append(f"{elapsed:.2f}s")
+    metrics = result.get("metrics")
+    if isinstance(metrics, dict):
+        profile = metrics.get("products_signoff_profile")
+        if profile is not None:
+            detail_parts.append(f"profile `{profile}`")
+        solution_rate = metrics.get("ppp_solution_rate_pct")
+        if solution_rate is not None:
+            detail_parts.append(f"PPP solution {format_metric_value(solution_rate, suffix='%')}")
+        common_pairs = metrics.get("common_epoch_pairs")
+        if common_pairs is not None:
+            detail_parts.append(f"common pairs `{common_pairs}`")
+        p95 = metrics.get("p95_position_error_m")
+        if p95 is not None:
+            detail_parts.append(f"p95 {format_metric_value(p95, suffix=' m')}")
+        comparison_status = metrics.get("comparison_status")
+        if comparison_status is not None:
+            detail_parts.append(f"comparison `{comparison_status}`")
+    return ", ".join(detail_parts)
+
+
+def render_markdown_summary(results: list[dict[str, object]]) -> str:
+    passed = sum(1 for result in results if result["status"] == "passed")
+    failed = sum(1 for result in results if result["status"] == "failed")
+    skipped = sum(1 for result in results if result["status"] == "skipped")
+    lines = [
+        "## Optional PPP Products Sign-off",
+        "",
+        f"- `passed`: `{passed}`",
+        f"- `failed`: `{failed}`",
+        f"- `skipped`: `{skipped}`",
+        "",
+        "| Step | Status | Detail |",
+        "| --- | --- | --- |",
+    ]
+    for result in results:
+        lines.append(f"| {result['name']} | `{result['status']}` | {render_result_detail(result)} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_summary(summary_path: Path, steps: list[SignoffStep], results: list[dict[str, object]]) -> None:
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "steps": [asdict(step) for step in steps],
+        "results": results,
+        "counts": {
+            "passed": sum(1 for result in results if result["status"] == "passed"),
+            "failed": sum(1 for result in results if result["status"] == "failed"),
+            "skipped": sum(1 for result in results if result["status"] == "skipped"),
+        },
+    }
+    summary_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def append_github_step_summary(path: Path, results: list[dict[str, object]]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(render_markdown_summary(results))
+        handle.write("\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, default=repo_root_from_script())
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--summary-json", type=Path, default=None)
+    parser.add_argument("--github-step-summary", type=Path, default=None)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    output_dir = (args.output_dir if args.output_dir is not None else repo_root / "output").resolve()
+    summary_json = (
+        args.summary_json
+        if args.summary_json is not None
+        else output_dir / "ci_optional_ppp_products_summary.json"
+    ).resolve()
+    log_dir = output_dir / "ci_optional_ppp_products"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    steps = build_step_plan(repo_root, output_dir, os.environ)
+    results = [run_step(step, repo_root, log_dir) for step in steps]
+    write_summary(summary_json, steps, results)
+    summary_path = args.github_step_summary
+    if summary_path is None:
+        summary_env = os.environ.get("GITHUB_STEP_SUMMARY", "").strip()
+        summary_path = Path(summary_env) if summary_env else None
+    if summary_path is not None:
+        append_github_step_summary(summary_path, results)
+    return 1 if any(result["status"] == "failed" for result in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/run_optional_ppp_products_signoff.sh
+++ b/scripts/ci/run_optional_ppp_products_signoff.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${repo_root}"
+
+python3 scripts/ci/run_optional_ppp_products_signoff.py "$@"

--- a/scripts/ci/run_optional_rtk_signoffs.py
+++ b/scripts/ci/run_optional_rtk_signoffs.py
@@ -1,0 +1,323 @@
+#!/usr/bin/env python3
+"""Run optional RTK-related sign-offs and persist a diagnostic summary."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+from typing import Mapping
+
+
+@dataclass(frozen=True)
+class SignoffStep:
+    name: str
+    slug: str
+    command: list[str] | None
+    outputs: list[str]
+    skip_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class SignoffContext:
+    repo_root: Path
+    output_dir: Path
+    gnss_command: list[str]
+    dataset_root: Path | None
+    rtklib_bin: Path | None
+    scorpion_input: Path | None
+    scorpion_url: str
+
+
+def repo_root_from_script() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def is_executable_file(path: Path | None) -> bool:
+    return path is not None and path.is_file() and os.access(path, os.X_OK)
+
+
+def build_context(
+    repo_root: Path,
+    output_dir: Path,
+    environ: Mapping[str, str],
+    *,
+    python_executable: str = sys.executable,
+) -> SignoffContext:
+    dataset_root_value = environ.get("GNSSPP_PPC_DATASET_ROOT", "").strip()
+    rtklib_bin_value = environ.get("GNSSPP_RTKLIB_BIN", "").strip()
+    scorpion_input_value = environ.get("GNSSPP_SCORPION_MOVING_BASE_INPUT", "").strip()
+    return SignoffContext(
+        repo_root=repo_root,
+        output_dir=output_dir,
+        gnss_command=[python_executable, str(repo_root / "apps" / "gnss.py")],
+        dataset_root=Path(dataset_root_value) if dataset_root_value else None,
+        rtklib_bin=Path(rtklib_bin_value) if rtklib_bin_value else None,
+        scorpion_input=Path(scorpion_input_value) if scorpion_input_value else None,
+        scorpion_url=environ.get("GNSSPP_SCORPION_MOVING_BASE_URL", "").strip(),
+    )
+
+
+def make_step(name: str, slug: str, command: list[str], outputs: list[Path]) -> SignoffStep:
+    return SignoffStep(name=name, slug=slug, command=command, outputs=[str(path) for path in outputs])
+
+
+def skip_step(name: str, slug: str, outputs: list[Path], reason: str) -> SignoffStep:
+    return SignoffStep(
+        name=name,
+        slug=slug,
+        command=None,
+        outputs=[str(path) for path in outputs],
+        skip_reason=reason,
+    )
+
+
+def make_ppc_rtk_step(context: SignoffContext, city: str, *, require_rtklib: bool) -> SignoffStep:
+    step_name = (
+        f"PPC {city.capitalize()} RTK sign-off with RTKLIB comparison"
+        if require_rtklib
+        else f"PPC {city.capitalize()} RTK sign-off"
+    )
+    slug = f"ppc_{city}_run1_rtk"
+    outputs = [
+        context.output_dir / f"{slug}_summary.json",
+        context.output_dir / f"{slug}.pos",
+        context.output_dir / f"{slug}_events.csv",
+    ]
+    if require_rtklib:
+        outputs.append(context.output_dir / f"{slug}_rtklib.pos")
+
+    if context.dataset_root is None or not context.dataset_root.is_dir():
+        return skip_step(step_name, slug, outputs, "PPC-Dataset root is unavailable.")
+    if require_rtklib and not is_executable_file(context.rtklib_bin):
+        return skip_step(step_name, slug, outputs, "RTKLIB binary is unavailable.")
+
+    command = [
+        *context.gnss_command,
+        "ppc-rtk-signoff",
+        "--dataset-root",
+        str(context.dataset_root),
+        "--city",
+        city,
+        "--max-epochs",
+        "120",
+        "--out",
+        str(context.output_dir / f"{slug}.pos"),
+        "--debug-epoch-log",
+        str(context.output_dir / f"{slug}_events.csv"),
+        "--summary-json",
+        str(context.output_dir / f"{slug}_summary.json"),
+    ]
+    if require_rtklib:
+        command.extend(
+            [
+                "--rtklib-bin",
+                str(context.rtklib_bin),
+                "--rtklib-pos",
+                str(context.output_dir / f"{slug}_rtklib.pos"),
+            ]
+        )
+    return make_step(step_name, slug, command, outputs)
+
+
+def make_scorpion_step(context: SignoffContext) -> SignoffStep:
+    slug = "scorpion_moving_base"
+    name = "SCORPION moving-base sign-off"
+    outputs = [
+        context.output_dir / "scorpion_moving_base_summary.json",
+        context.output_dir / "scorpion_moving_base" / "prepare_summary.json",
+        context.output_dir / "scorpion_moving_base" / "products_summary.json",
+        context.output_dir / "scorpion_moving_base" / "scorpion_moving_base.pos",
+        context.output_dir / "scorpion_moving_base" / "scorpion_moving_base_matches.csv",
+        context.output_dir / "scorpion_moving_base" / "scorpion_moving_base.png",
+        context.output_dir / "scorpion_moving_base" / "reference.csv",
+    ]
+
+    input_args: list[str]
+    if context.scorpion_input is not None and context.scorpion_input.exists():
+        input_args = ["--input", str(context.scorpion_input)]
+    elif context.scorpion_url:
+        input_args = ["--input-url", context.scorpion_url]
+    else:
+        return skip_step(name, slug, outputs, "SCORPION moving-base input is unavailable.")
+
+    command = [
+        *context.gnss_command,
+        "scorpion-moving-base-signoff",
+        *input_args,
+        "--summary-json",
+        str(context.output_dir / "scorpion_moving_base_summary.json"),
+        "--max-epochs",
+        "120",
+        "--require-matched-epochs-min",
+        "80",
+        "--require-fix-rate-min",
+        "90",
+        "--require-p95-baseline-error-max",
+        "0.20",
+        "--require-p95-heading-error-max",
+        "10",
+        "--require-realtime-factor-min",
+        "1.0",
+    ]
+    return make_step(name, slug, command, outputs)
+
+
+def build_step_plan(
+    repo_root: Path,
+    output_dir: Path,
+    environ: Mapping[str, str],
+    *,
+    python_executable: str = sys.executable,
+) -> list[SignoffStep]:
+    context = build_context(
+        repo_root,
+        output_dir,
+        environ,
+        python_executable=python_executable,
+    )
+    return [
+        make_ppc_rtk_step(context, "nagoya", require_rtklib=False),
+        make_ppc_rtk_step(context, "tokyo", require_rtklib=True),
+        make_scorpion_step(context),
+    ]
+
+
+def run_step(step: SignoffStep, repo_root: Path, log_dir: Path) -> dict[str, object]:
+    log_path = log_dir / f"{step.slug}.log"
+    record: dict[str, object] = {
+        "name": step.name,
+        "slug": step.slug,
+        "outputs": step.outputs,
+        "log_path": str(log_path),
+    }
+    if step.skip_reason is not None:
+        record["status"] = "skipped"
+        record["skip_reason"] = step.skip_reason
+        log_path.write_text(step.skip_reason + "\n", encoding="utf-8")
+        print(f"Skipping {step.name}: {step.skip_reason}")
+        return record
+
+    assert step.command is not None
+    command_display = " ".join(step.command)
+    print(f"+ {command_display}")
+    started = time.monotonic()
+    completed = subprocess.run(
+        step.command,
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    elapsed = time.monotonic() - started
+    combined_log = completed.stdout
+    if completed.stderr:
+        if combined_log and not combined_log.endswith("\n"):
+            combined_log += "\n"
+        combined_log += completed.stderr
+    log_path.write_text(f"$ {command_display}\n\n{combined_log}", encoding="utf-8")
+    record["command"] = step.command
+    record["elapsed_s"] = elapsed
+    record["returncode"] = completed.returncode
+    if completed.returncode == 0:
+        record["status"] = "passed"
+        print(f"Passed {step.name} in {elapsed:.2f}s")
+    else:
+        record["status"] = "failed"
+        lines = combined_log.splitlines()
+        tail = "\n".join(lines[-20:])
+        if tail:
+            print(tail)
+        print(f"Failed {step.name} in {elapsed:.2f}s; see {log_path}")
+    return record
+
+
+def render_markdown_summary(results: list[dict[str, object]]) -> str:
+    passed = sum(1 for result in results if result["status"] == "passed")
+    failed = sum(1 for result in results if result["status"] == "failed")
+    skipped = sum(1 for result in results if result["status"] == "skipped")
+    lines = [
+        "## Optional RTK Sign-offs",
+        "",
+        f"- `passed`: `{passed}`",
+        f"- `failed`: `{failed}`",
+        f"- `skipped`: `{skipped}`",
+        "",
+        "| Step | Status | Detail |",
+        "| --- | --- | --- |",
+    ]
+    for result in results:
+        status = str(result["status"])
+        detail = ""
+        if status == "skipped":
+            detail = str(result.get("skip_reason", ""))
+        elif status == "passed":
+            elapsed = result.get("elapsed_s")
+            detail = f"{elapsed:.2f}s" if isinstance(elapsed, (float, int)) else ""
+        elif status == "failed":
+            log_path = result.get("log_path")
+            detail = f"see `{log_path}`" if log_path else "failed"
+        lines.append(f"| {result['name']} | `{status}` | {detail} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_summary(summary_path: Path, steps: list[SignoffStep], results: list[dict[str, object]]) -> None:
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "steps": [asdict(step) for step in steps],
+        "results": results,
+        "counts": {
+            "passed": sum(1 for result in results if result["status"] == "passed"),
+            "failed": sum(1 for result in results if result["status"] == "failed"),
+            "skipped": sum(1 for result in results if result["status"] == "skipped"),
+        },
+    }
+    summary_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def append_github_step_summary(path: Path, results: list[dict[str, object]]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(render_markdown_summary(results))
+        handle.write("\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, default=repo_root_from_script())
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--summary-json", type=Path, default=None)
+    parser.add_argument("--github-step-summary", type=Path, default=None)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    output_dir = (args.output_dir if args.output_dir is not None else repo_root / "output").resolve()
+    summary_json = (
+        args.summary_json if args.summary_json is not None else output_dir / "ci_optional_rtk_signoffs_summary.json"
+    ).resolve()
+    log_dir = output_dir / "ci_optional_rtk_signoffs"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    steps = build_step_plan(repo_root, output_dir, os.environ)
+    results = [run_step(step, repo_root, log_dir) for step in steps]
+    write_summary(summary_json, steps, results)
+    summary_path = args.github_step_summary
+    if summary_path is None:
+        summary_env = os.environ.get("GITHUB_STEP_SUMMARY", "").strip()
+        summary_path = Path(summary_env) if summary_env else None
+    if summary_path is not None:
+        append_github_step_summary(summary_path, results)
+    return 1 if any(result["status"] == "failed" for result in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/run_optional_rtk_signoffs.sh
+++ b/scripts/ci/run_optional_rtk_signoffs.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "${repo_root}"
+
+python3 scripts/ci/run_optional_rtk_signoffs.py "$@"

--- a/scripts/ci/run_optional_tests.sh
+++ b/scripts/ci/run_optional_tests.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+exec bash "${repo_root}/scripts/ci/run_ctest_label.sh" optional "$@"

--- a/tests/test_benchmark_scripts.py
+++ b/tests/test_benchmark_scripts.py
@@ -18,9 +18,11 @@ from unittest import mock
 ROOT_DIR = Path(__file__).resolve().parents[1]
 APPS_DIR = ROOT_DIR / "apps"
 SCRIPTS_DIR = ROOT_DIR / "scripts"
+CI_SCRIPTS_DIR = SCRIPTS_DIR / "ci"
 
 sys.path.insert(0, str(APPS_DIR))
 sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(CI_SCRIPTS_DIR))
 
 import gnss_odaiba_benchmark as benchmark  # noqa: E402
 import gnss_clas_ppp as clas_ppp  # noqa: E402
@@ -36,6 +38,9 @@ import generate_architecture_diagram as architecture_diagram  # noqa: E402
 import generate_feature_overview_card as feature_overview  # noqa: E402
 import generate_odaiba_scorecard as scorecard  # noqa: E402
 import generate_odaiba_social_card as social_card  # noqa: E402
+import detect_ci_scope as ci_scope  # noqa: E402
+import run_optional_ppp_products_signoff as ci_ppp_products_signoff  # noqa: E402
+import run_optional_rtk_signoffs as ci_rtk_signoffs  # noqa: E402
 
 
 class ScorecardHelpersTest(unittest.TestCase):
@@ -207,6 +212,323 @@ class PPCRTKSignoffHelpersTest(unittest.TestCase):
         self.assertEqual(tokyo["arfilter"], True)
         self.assertEqual(nagoya["preset"], "low-cost")
         self.assertEqual(nagoya["arfilter"], False)
+
+
+class OptionalRTKSignoffScriptTest(unittest.TestCase):
+    def test_build_step_plan_marks_missing_inputs_as_skipped(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_rtk_skip_") as temp_dir:
+            output_dir = Path(temp_dir) / "output"
+            steps = ci_rtk_signoffs.build_step_plan(ROOT_DIR, output_dir, {})
+
+            self.assertEqual(
+                [step.slug for step in steps],
+                ["ppc_nagoya_run1_rtk", "ppc_tokyo_run1_rtk", "scorpion_moving_base"],
+            )
+            self.assertTrue(all(step.command is None for step in steps))
+            self.assertEqual(steps[0].skip_reason, "PPC-Dataset root is unavailable.")
+            self.assertEqual(steps[1].skip_reason, "PPC-Dataset root is unavailable.")
+            self.assertEqual(steps[2].skip_reason, "SCORPION moving-base input is unavailable.")
+
+    def test_build_step_plan_uses_dataset_rtklib_and_scorpion_url(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_rtk_plan_") as temp_dir:
+            temp_root = Path(temp_dir)
+            dataset_root = temp_root / "PPC-Dataset"
+            dataset_root.mkdir()
+            rtklib_bin = temp_root / "rnx2rtkp"
+            rtklib_bin.write_text("#!/bin/sh\nexit 0\n", encoding="ascii")
+            rtklib_bin.chmod(0o755)
+            output_dir = temp_root / "output"
+            env = {
+                "GNSSPP_PPC_DATASET_ROOT": str(dataset_root),
+                "GNSSPP_RTKLIB_BIN": str(rtklib_bin),
+                "GNSSPP_SCORPION_MOVING_BASE_URL": "https://example.com/scorpion.ubx",
+            }
+
+            steps = ci_rtk_signoffs.build_step_plan(ROOT_DIR, output_dir, env)
+
+            nagoya, tokyo, scorpion = steps
+            self.assertIsNotNone(nagoya.command)
+            self.assertIn("--dataset-root", nagoya.command)
+            self.assertIn(str(dataset_root), nagoya.command)
+            self.assertIn("--debug-epoch-log", nagoya.command)
+            self.assertIsNotNone(tokyo.command)
+            self.assertIn("--rtklib-bin", tokyo.command)
+            self.assertIn(str(rtklib_bin), tokyo.command)
+            self.assertIn("--rtklib-pos", tokyo.command)
+            self.assertIsNotNone(scorpion.command)
+            self.assertIn("--input-url", scorpion.command)
+            self.assertIn("https://example.com/scorpion.ubx", scorpion.command)
+
+    def test_build_step_plan_skips_tokyo_when_rtklib_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_rtk_missing_rtklib_") as temp_dir:
+            temp_root = Path(temp_dir)
+            dataset_root = temp_root / "PPC-Dataset"
+            dataset_root.mkdir()
+            steps = ci_rtk_signoffs.build_step_plan(
+                ROOT_DIR,
+                temp_root / "output",
+                {"GNSSPP_PPC_DATASET_ROOT": str(dataset_root)},
+            )
+
+            nagoya, tokyo, _ = steps
+            self.assertIsNotNone(nagoya.command)
+            self.assertIsNone(tokyo.command)
+            self.assertEqual(tokyo.skip_reason, "RTKLIB binary is unavailable.")
+
+    def test_run_step_writes_log_for_skipped_and_passed_steps(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_rtk_exec_") as temp_dir:
+            temp_root = Path(temp_dir)
+            log_dir = temp_root / "logs"
+            log_dir.mkdir()
+
+            skipped = ci_rtk_signoffs.SignoffStep(
+                name="Skipped example",
+                slug="skip_example",
+                command=None,
+                outputs=[],
+                skip_reason="not configured",
+            )
+            skipped_result = ci_rtk_signoffs.run_step(skipped, ROOT_DIR, log_dir)
+            self.assertEqual(skipped_result["status"], "skipped")
+            self.assertTrue((log_dir / "skip_example.log").exists())
+
+            passed = ci_rtk_signoffs.SignoffStep(
+                name="Passed example",
+                slug="pass_example",
+                command=[sys.executable, "-c", "print('ok')"],
+                outputs=[],
+            )
+            passed_result = ci_rtk_signoffs.run_step(passed, ROOT_DIR, log_dir)
+            self.assertEqual(passed_result["status"], "passed")
+            self.assertEqual(passed_result["returncode"], 0)
+            self.assertIn("ok", (log_dir / "pass_example.log").read_text(encoding="utf-8"))
+
+    def test_render_markdown_summary_reports_status_table(self) -> None:
+        markdown = ci_rtk_signoffs.render_markdown_summary(
+            [
+                {
+                    "name": "PPC Nagoya RTK sign-off",
+                    "status": "passed",
+                    "elapsed_s": 1.25,
+                    "log_path": "/tmp/a.log",
+                },
+                {
+                    "name": "PPC Tokyo RTK sign-off with RTKLIB comparison",
+                    "status": "skipped",
+                    "skip_reason": "RTKLIB binary is unavailable.",
+                    "log_path": "/tmp/b.log",
+                },
+                {
+                    "name": "SCORPION moving-base sign-off",
+                    "status": "failed",
+                    "log_path": "/tmp/c.log",
+                },
+            ]
+        )
+
+        self.assertIn("## Optional RTK Sign-offs", markdown)
+        self.assertIn("`passed`: `1`", markdown)
+        self.assertIn("`failed`: `1`", markdown)
+        self.assertIn("`skipped`: `1`", markdown)
+        self.assertIn("| PPC Nagoya RTK sign-off | `passed` | 1.25s |", markdown)
+        self.assertIn("RTKLIB binary is unavailable.", markdown)
+        self.assertIn("see `/tmp/c.log`", markdown)
+
+class OptionalPPPProductsSignoffScriptTest(unittest.TestCase):
+    def test_build_step_plan_skips_when_malib_is_missing(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_ppp_skip_") as temp_dir:
+            output_dir = Path(temp_dir) / "output"
+            steps = ci_ppp_products_signoff.build_step_plan(ROOT_DIR, output_dir, {})
+
+            self.assertEqual([step.slug for step in steps], ["ppp_kinematic_products"])
+            self.assertIsNone(steps[0].command)
+            self.assertEqual(steps[0].skip_reason, "MALIB binary is unavailable.")
+
+    def test_build_step_plan_skips_when_inputs_are_missing(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_ppp_missing_inputs_") as temp_dir:
+            temp_root = Path(temp_dir)
+            malib_bin = temp_root / "malib"
+            malib_bin.write_text("#!/bin/sh\nexit 0\n", encoding="ascii")
+            malib_bin.chmod(0o755)
+
+            steps = ci_ppp_products_signoff.build_step_plan(
+                ROOT_DIR,
+                temp_root / "output",
+                {"GNSSPP_MALIB_BIN": str(malib_bin)},
+            )
+
+            self.assertIsNone(steps[0].command)
+            self.assertIsNotNone(steps[0].skip_reason)
+            self.assertIn("PPP products input is unavailable", str(steps[0].skip_reason))
+
+    def test_build_step_plan_uses_configured_inputs_and_malib_config(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_ppp_plan_") as temp_dir:
+            temp_root = Path(temp_dir)
+            malib_bin = temp_root / "malib"
+            malib_bin.write_text("#!/bin/sh\nexit 0\n", encoding="ascii")
+            malib_bin.chmod(0o755)
+            malib_config = temp_root / "malib.conf"
+            obs = temp_root / "rover.obs"
+            base = temp_root / "base.obs"
+            nav = temp_root / "base.nav"
+            for path in (malib_config, obs, base, nav):
+                path.write_text("synthetic\n", encoding="ascii")
+            output_dir = temp_root / "output"
+            env = {
+                "GNSSPP_MALIB_BIN": str(malib_bin),
+                "GNSSPP_PPP_PRODUCTS_MALIB_CONFIG": str(malib_config),
+                "GNSSPP_PPP_PRODUCTS_OBS": str(obs),
+                "GNSSPP_PPP_PRODUCTS_BASE": str(base),
+                "GNSSPP_PPP_PRODUCTS_NAV": str(nav),
+            }
+
+            steps = ci_ppp_products_signoff.build_step_plan(ROOT_DIR, output_dir, env)
+
+            command = steps[0].command
+            self.assertIsNotNone(command)
+            assert command is not None
+            self.assertIn("ppp-products-signoff", command)
+            self.assertIn("--obs", command)
+            self.assertIn(str(obs), command)
+            self.assertIn("--base", command)
+            self.assertIn(str(base), command)
+            self.assertIn("--nav", command)
+            self.assertIn(str(nav), command)
+            self.assertIn("--malib-bin", command)
+            self.assertIn(str(malib_bin), command)
+            self.assertIn("--malib-config", command)
+            self.assertIn(str(malib_config), command)
+            self.assertIn(str(output_dir / "ppp_kinematic_products_summary.json"), command)
+
+    def test_run_step_collects_metrics_from_summary_json(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_ppp_exec_") as temp_dir:
+            temp_root = Path(temp_dir)
+            log_dir = temp_root / "logs"
+            log_dir.mkdir()
+            summary_json = temp_root / "ppp_summary.json"
+            payload = {
+                "products_signoff_profile": "kinematic",
+                "ppp_solution_rate_pct": 100.0,
+                "common_epoch_pairs": 24,
+                "p95_position_error_m": 0.42,
+                "comparison_status": "better",
+            }
+            code = (
+                "import json\n"
+                "from pathlib import Path\n"
+                f"Path({str(summary_json)!r}).write_text(json.dumps({payload!r}), encoding='utf-8')\n"
+            )
+            step = ci_ppp_products_signoff.SignoffStep(
+                name="PPP products sign-off with MALIB comparison",
+                slug="ppp_pass",
+                command=[sys.executable, "-c", code],
+                outputs=[],
+                summary_json=str(summary_json),
+            )
+
+            result = ci_ppp_products_signoff.run_step(step, ROOT_DIR, log_dir)
+
+            self.assertEqual(result["status"], "passed")
+            self.assertEqual(result["returncode"], 0)
+            self.assertEqual(result["metrics"], payload)
+
+    def test_render_markdown_summary_reports_status_table_and_metrics(self) -> None:
+        markdown = ci_ppp_products_signoff.render_markdown_summary(
+            [
+                {
+                    "name": "PPP products sign-off with MALIB comparison",
+                    "status": "passed",
+                    "elapsed_s": 1.25,
+                    "metrics": {
+                        "products_signoff_profile": "kinematic",
+                        "ppp_solution_rate_pct": 100.0,
+                        "common_epoch_pairs": 24,
+                        "p95_position_error_m": 0.42,
+                        "comparison_status": "better",
+                    },
+                },
+                {
+                    "name": "PPP products sign-off with MALIB comparison",
+                    "status": "skipped",
+                    "skip_reason": "MALIB binary is unavailable.",
+                },
+                {
+                    "name": "PPP products sign-off with MALIB comparison",
+                    "status": "failed",
+                    "log_path": "/tmp/ppp.log",
+                },
+            ]
+        )
+
+        self.assertIn("## Optional PPP Products Sign-off", markdown)
+        self.assertIn("`passed`: `1`", markdown)
+        self.assertIn("`failed`: `1`", markdown)
+        self.assertIn("`skipped`: `1`", markdown)
+        self.assertIn("profile `kinematic`", markdown)
+        self.assertIn("PPP solution 100%", markdown)
+        self.assertIn("common pairs `24`", markdown)
+        self.assertIn("p95 0.42 m", markdown)
+        self.assertIn("comparison `better`", markdown)
+        self.assertIn("MALIB binary is unavailable.", markdown)
+        self.assertIn("see `/tmp/ppp.log`", markdown)
+
+
+class CIScopeDetectionTest(unittest.TestCase):
+    def test_classify_changed_paths_marks_docs_only_changes(self) -> None:
+        payload = ci_scope.classify_changed_paths(
+            [
+                "docs/guide.md",
+                "notes/2026-04-11_ci.md",
+                "README.md",
+                "scripts/generate_architecture_diagram.py",
+            ]
+        )
+
+        self.assertEqual(
+            payload["changed_paths"],
+            [
+                "README.md",
+                "docs/guide.md",
+                "notes/2026-04-11_ci.md",
+                "scripts/generate_architecture_diagram.py",
+            ],
+        )
+        self.assertTrue(payload["docs_only"])
+        self.assertFalse(payload["run_heavy"])
+
+    def test_classify_changed_paths_runs_heavy_when_code_changes_exist(self) -> None:
+        payload = ci_scope.classify_changed_paths(
+            [
+                "docs/guide.md",
+                "src/algorithms/rtk.cpp",
+                ".github/workflows/ci.yml",
+            ]
+        )
+
+        self.assertFalse(payload["docs_only"])
+        self.assertTrue(payload["run_heavy"])
+
+    def test_classify_changed_paths_runs_heavy_for_empty_diff(self) -> None:
+        payload = ci_scope.classify_changed_paths([])
+
+        self.assertEqual(payload["changed_paths"], [])
+        self.assertFalse(payload["docs_only"])
+        self.assertTrue(payload["run_heavy"])
+
+    def test_render_markdown_summary_includes_paths_and_flags(self) -> None:
+        markdown = ci_scope.render_markdown_summary(
+            {
+                "changed_paths": ["README.md", "docs/guide.md"],
+                "docs_only": True,
+                "run_heavy": False,
+            }
+        )
+
+        self.assertIn("## CI Scope", markdown)
+        self.assertIn("`docs_only`: `true`", markdown)
+        self.assertIn("`run_heavy`: `false`", markdown)
+        self.assertIn("`README.md`", markdown)
+        self.assertIn("`docs/guide.md`", markdown)
 
 
 class MovingBaseSignoffHelpersTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

This PR hardens the CI workflow by splitting lightweight scope detection from heavier lanes, moving build setup and CTest label runners into reusable helpers, and adding structured summaries for optional RTK and PPP products sign-offs.

## Changes

- Add a `changes` job that classifies docs-only changes and skips heavy lanes when appropriate.
- Add `.github/actions/prepare-build` for shared Python, dependency, Playwright, ccache, CMake, and build setup.
- Move repeated CTest, cppcheck, dashboard, RTK sign-off, and PPP products sign-off orchestration into `scripts/ci` helpers.
- Add GitHub step summaries and JSON/log artifacts for optional RTK and PPP products sign-offs.
- Document the CI lanes and docs-only behavior for contributors.
- Add regression coverage for CI scope detection and optional sign-off helper behavior.

## Validation

- `python3 -m py_compile scripts/ci/detect_ci_scope.py scripts/ci/run_optional_rtk_signoffs.py scripts/ci/run_optional_ppp_products_signoff.py tests/test_benchmark_scripts.py`
- `python3 tests/test_benchmark_scripts.py -k OptionalPPPProductsSignoffScriptTest -k OptionalRTKSignoffScriptTest -k CIScopeDetectionTest`
- `python3 tests/test_benchmark_scripts.py`
- `bash scripts/ci/run_optional_ppp_products_signoff.sh --output-dir /tmp/gnsspp_ci_branch_optional_ppp --github-step-summary /tmp/gnsspp_ci_branch_optional_ppp.md`
- `bash scripts/ci/run_optional_rtk_signoffs.sh --output-dir /tmp/gnsspp_ci_branch_optional_rtk --github-step-summary /tmp/gnsspp_ci_branch_optional_rtk.md`
- `bash scripts/ci/run_hygiene.sh`
- `git diff --check`

## Notes

The optional PPP products sign-off records a skipped status when the MALIB binary or runner-specific PPP inputs are unavailable instead of silently exiting from inline shell.
