### PR TITLE
[verify] docs-only change triggers CI heavy-lane skip

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If this repo is useful, star it.
 
 ![UrbanNav Odaiba social card](docs/driving_odaiba_social_card.png)
 
-Contribution and PR workflow: [CONTRIBUTING.md](CONTRIBUTING.md)
+Contributing and PR workflow: [CONTRIBUTING.md](CONTRIBUTING.md)
 Architecture notes: [docs/architecture.md](docs/architecture.md)
 Documentation index: [docs/index.md](docs/index.md)
 


### PR DESCRIPTION
## Summary
- PR #16 で入った `detect_ci_scope.py` による docs-only skip が本番ランナーで効くかを検証する verification PR
- 差分は README.md の 1 行 (wording tidy のみ) で、docs-only path set に合致する

## Expected behavior
- `changes` job: `docs_only == true`, `run_heavy == false`, step summary に `## CI Scope` 表示
- `hygiene` job: 実行 (docs-only でも必要)
- `build-and-test (*)`, `linux-extended-tests`, `linux-optional-signoffs`, `static-analysis`: **skip**
- `Docs` workflow の `build` は実行

## Plan
- Actions を一巡観察し、上記が成立するか確認する
- 成立を確認したら close (merge しない)
- 成立しない場合は `detect_ci_scope.py` の path set または workflow の `needs.changes.outputs.run_heavy` 条件を見直す