### PR TITLE
[rtk] Add --max-hold-div and --max-pos-jump fix validation gates (default-off)

### DIFF
--- a/apps/gnss_solve.cpp
+++ b/apps/gnss_solve.cpp
@@ -93,6 +93,8 @@ struct SolveConfig {
     bool hold_ratio_threshold_set = false;
     libgnss::RTKProcessor::RTKConfig::ARPolicy ar_policy =
         libgnss::RTKProcessor::RTKConfig::ARPolicy::EXTENDED;
+    double max_hold_divergence_m = 0.0;
+    double max_position_jump_m = 0.0;
 };
 
 double timeDiffSeconds(const libgnss::GNSSTime& a, const libgnss::GNSSTime& b) {
@@ -402,6 +404,10 @@ void printUsage(const char* program_name) {
         << "                             demo5-continuous disables relaxed-hold-ratio,\n"
         << "                             subset/partial AR fallback, hold-fix fallback,\n"
         << "                             and Q regularization (raw Q passed to LAMBDA)\n"
+        << "  --max-hold-div <v>         Max hold fix divergence from float in meters\n"
+        << "                             (default: 0, disabled)\n"
+        << "  --max-pos-jump <v>         Max AR fix jump from last fixed pos in meters\n"
+        << "                             (default: 0, disabled; additional to history check)\n"
         << "  --max-baseline-m <v>       Max baseline length in meters (default: 20000)\n"
         << "  --base-ecef <x> <y> <z>    Override base ECEF position in meters\n"
         << "  --skip-epochs <n>          Skip the first n rover epochs before solving\n"
@@ -562,6 +568,10 @@ SolveConfig parseArguments(int argc, char* argv[]) {
             } else {
                 argumentError("unsupported --ar-policy value: " + policy_str, argv[0]);
             }
+        } else if (arg == "--max-hold-div" && i + 1 < argc) {
+            config.max_hold_divergence_m = std::stod(argv[++i]);
+        } else if (arg == "--max-pos-jump" && i + 1 < argc) {
+            config.max_position_jump_m = std::stod(argv[++i]);
         } else if (arg == "--max-baseline-m" && i + 1 < argc) {
             config.max_baseline_length_m = std::stod(argv[++i]);
         } else if (arg == "--base-ecef" && i + 3 < argc) {
@@ -741,6 +751,8 @@ int main(int argc, char* argv[]) {
         rtk_config.glonass_icb_l1_m_per_mhz = config.glonass_icb_l1_m_per_mhz;
         rtk_config.glonass_icb_l2_m_per_mhz = config.glonass_icb_l2_m_per_mhz;
         rtk_config.ar_policy = config.ar_policy;
+        rtk_config.max_hold_divergence_m = config.max_hold_divergence_m;
+        rtk_config.max_position_jump_m = config.max_position_jump_m;
         rtk_processor.setRTKConfig(rtk_config);
         libgnss::SPPProcessor::SPPConfig spp_config;
         spp_config.use_multi_constellation = true;

--- a/include/libgnss++/algorithms/rtk.hpp
+++ b/include/libgnss++/algorithms/rtk.hpp
@@ -108,6 +108,15 @@ public:
         ///                     no Q regularization (raw Q passed to LAMBDA).
         enum class ARPolicy { EXTENDED, DEMO5_CONTINUOUS };
         ARPolicy ar_policy = ARPolicy::EXTENDED;
+
+        /// Max hold fix divergence from float baseline in meters.
+        /// 0 (default) disables the check — existing behavior preserved.
+        double max_hold_divergence_m = 0.0;
+
+        /// Max AR fix position jump from last fixed position in meters.
+        /// Applied in addition to the history-based exceedsFixHistoryJump check.
+        /// 0 (default) disables the check — existing behavior preserved.
+        double max_position_jump_m = 0.0;
     };
 
     RTKProcessor();

--- a/src/algorithms/rtk.cpp
+++ b/src/algorithms/rtk.cpp
@@ -1984,6 +1984,13 @@ bool RTKProcessor::validateFixedSolution(const std::map<SatelliteId, SatelliteDa
             consecutive_fix_count_)) {
         return false;
     }
+    if (!isMovingBasePositionMode(rtk_config_) &&
+        rtk_config_.max_position_jump_m > 0.0 &&
+        rtk_validation::exceedsAbsoluteJump(
+            new_pos, last_fixed_position_, has_last_fixed_position_,
+            rtk_config_.max_position_jump_m)) {
+        return false;
+    }
 
     // Sanity check: reject fixes where any component is unreasonably large
     if (fixed_baseline_.norm() > rtk_config_.max_baseline_length) {
@@ -2198,6 +2205,12 @@ bool RTKProcessor::tryHoldFix(const std::map<SatelliteId, SatelliteData>& sat_da
     if (rtk_validation::exceedsAbsoluteJump(
             test_pos, last_fixed_position_, has_last_fixed_position_, max_hold_jump_m)) {
         return false;
+    }
+    if (rtk_config_.max_hold_divergence_m > 0.0 && filter_state_.state.size() >= 3) {
+        const Vector3d float_pos = base_position_ + filter_state_.state.head<3>();
+        if ((test_pos - float_pos).norm() > rtk_config_.max_hold_divergence_m) {
+            return false;
+        }
     }
 
     // Accept hold fix

--- a/tests/test_rtk_legacy.cpp
+++ b/tests/test_rtk_legacy.cpp
@@ -297,6 +297,54 @@ TEST(RTKLegacyCompatibilityStandaloneTest, ArPolicyDemo5ContinuousDisablesSubset
               RTKProcessor::RTKConfig::ARPolicy::DEMO5_CONTINUOUS);
 }
 
+TEST(RTKLegacyCompatibilityStandaloneTest, MaxHoldDivergenceDefaultDisabled) {
+    // Default max_hold_divergence_m must be 0.0 (disabled — existing behavior preserved).
+    RTKProcessor processor;
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().max_hold_divergence_m, 0.0);
+
+    // Explicitly set 0.0 and confirm round-trip.
+    RTKProcessor::RTKConfig cfg;
+    cfg.max_hold_divergence_m = 0.0;
+    processor.setRTKConfig(cfg);
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().max_hold_divergence_m, 0.0);
+
+    // Setting a non-zero value should be stored correctly.
+    RTKProcessor::RTKConfig cfg2;
+    cfg2.max_hold_divergence_m = 0.5;
+    processor.setRTKConfig(cfg2);
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().max_hold_divergence_m, 0.5);
+
+    // Reset to 0 confirms disabled state.
+    RTKProcessor::RTKConfig cfg3;
+    cfg3.max_hold_divergence_m = 0.0;
+    processor.setRTKConfig(cfg3);
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().max_hold_divergence_m, 0.0);
+}
+
+TEST(RTKLegacyCompatibilityStandaloneTest, MaxPositionJumpDefaultDisabled) {
+    // Default max_position_jump_m must be 0.0 (disabled — existing behavior preserved).
+    RTKProcessor processor;
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().max_position_jump_m, 0.0);
+
+    // Explicitly set 0.0 and confirm round-trip.
+    RTKProcessor::RTKConfig cfg;
+    cfg.max_position_jump_m = 0.0;
+    processor.setRTKConfig(cfg);
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().max_position_jump_m, 0.0);
+
+    // Setting a non-zero value should be stored correctly.
+    RTKProcessor::RTKConfig cfg2;
+    cfg2.max_position_jump_m = 1.0;
+    processor.setRTKConfig(cfg2);
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().max_position_jump_m, 1.0);
+
+    // Reset to 0 confirms disabled state.
+    RTKProcessor::RTKConfig cfg3;
+    cfg3.max_position_jump_m = 0.0;
+    processor.setRTKConfig(cfg3);
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().max_position_jump_m, 0.0);
+}
+
 TEST(RTKLegacyCompatibilityStandaloneTest, ArPolicyDemo5ContinuousDisablesHoldFix) {
     // Under DEMO5_CONTINUOUS, the hold-fix fallback code path is gated off.
     // We verify by checking that tryHoldFix returns false when called directly


### PR DESCRIPTION
## Summary

- 新 CLI option 2 つ追加、どちらも default 0.0 (disabled)、既存挙動 byte-identical:
  - `--max-hold-div <v>`: hold fix が float position から <v> m 以上離れたら reject
  - `--max-pos-jump <v>`: AR fix が前回 fix から <v> m 以上 jump したら reject (既存 `exceedsFixHistoryJump` に追加)
- 両 gate とも既存 validation の **additive** 強化。既存挙動を書き換えない。

## Motivation

- RTK investigation で false fix 検出 policy を experimental に試す基盤。
- default-off なので production default 挙動不変。
- 各 gate は独立、個別に閾値設定可能。

## Test

- `MaxHoldDivergenceDefaultDisabled` / `MaxPositionJumpDefaultDisabled` unit test
- default (未指定) 実行で既存 develop output と byte-identical `cmp` exit 0
- tight threshold (0.01m) で両 gate 発火確認 (fix 数変化の方向性)

## Limitation

- Gate 値 tuning data は本 PR スコープ外 (default 0 で opt-in のみ)
- `--max-postfix-rms` は `computePostFixResidualStats` の移植を要するため別 PR
