### PR TITLE
[rtk] Add --max-consec-float-reset AR auto-reset gate (default-off)

### DIFF
--- a/apps/gnss_solve.cpp
+++ b/apps/gnss_solve.cpp
@@ -95,6 +95,7 @@ struct SolveConfig {
         libgnss::RTKProcessor::RTKConfig::ARPolicy::EXTENDED;
     double max_hold_divergence_m = 0.0;
     double max_position_jump_m = 0.0;
+    int max_consecutive_float_for_reset = 0;
 };
 
 double timeDiffSeconds(const libgnss::GNSSTime& a, const libgnss::GNSSTime& b) {
@@ -408,6 +409,9 @@ void printUsage(const char* program_name) {
         << "                             (default: 0, disabled)\n"
         << "  --max-pos-jump <v>         Max AR fix jump from last fixed pos in meters\n"
         << "                             (default: 0, disabled; additional to history check)\n"
+        << "  --max-consec-float-reset <n>\n"
+        << "                             Reset ambiguity state after n consecutive float epochs\n"
+        << "                             (default: 0, disabled; e.g. 10 for aggressive urban reconvergence)\n"
         << "  --max-baseline-m <v>       Max baseline length in meters (default: 20000)\n"
         << "  --base-ecef <x> <y> <z>    Override base ECEF position in meters\n"
         << "  --skip-epochs <n>          Skip the first n rover epochs before solving\n"
@@ -572,6 +576,8 @@ SolveConfig parseArguments(int argc, char* argv[]) {
             config.max_hold_divergence_m = std::stod(argv[++i]);
         } else if (arg == "--max-pos-jump" && i + 1 < argc) {
             config.max_position_jump_m = std::stod(argv[++i]);
+        } else if (arg == "--max-consec-float-reset" && i + 1 < argc) {
+            config.max_consecutive_float_for_reset = std::stoi(argv[++i]);
         } else if (arg == "--max-baseline-m" && i + 1 < argc) {
             config.max_baseline_length_m = std::stod(argv[++i]);
         } else if (arg == "--base-ecef" && i + 3 < argc) {
@@ -753,6 +759,7 @@ int main(int argc, char* argv[]) {
         rtk_config.ar_policy = config.ar_policy;
         rtk_config.max_hold_divergence_m = config.max_hold_divergence_m;
         rtk_config.max_position_jump_m = config.max_position_jump_m;
+        rtk_config.max_consecutive_float_for_reset = config.max_consecutive_float_for_reset;
         rtk_processor.setRTKConfig(rtk_config);
         libgnss::SPPProcessor::SPPConfig spp_config;
         spp_config.use_multi_constellation = true;

--- a/include/libgnss++/algorithms/rtk.hpp
+++ b/include/libgnss++/algorithms/rtk.hpp
@@ -117,6 +117,10 @@ public:
         /// Applied in addition to the history-based exceedsFixHistoryJump check.
         /// 0 (default) disables the check — existing behavior preserved.
         double max_position_jump_m = 0.0;
+
+        /// Reset ambiguity state after N consecutive float epochs (aggressive reconvergence).
+        /// 0 (default) disables the check — existing behavior preserved.
+        int max_consecutive_float_for_reset = 0;
     };
 
     RTKProcessor();
@@ -235,6 +239,9 @@ private:
 
     // Consecutive fix tracking for holdamb
     int consecutive_fix_count_ = 0;
+
+    // Consecutive float tracking for ambiguity auto-reset gate
+    int consecutive_float_count_ = 0;
 
     // Last fix data for holdamb
     struct DDPair {
@@ -359,6 +366,13 @@ private:
      * Kinematic position reset: SPP position with large variance (RTKLIB udpos)
      */
     void resetPositionToSPP(const ObservationData& rover_obs, const NavigationData& nav);
+
+    /**
+     * Reset ambiguity states after N consecutive float epochs (experimental gate).
+     * No-op when max_consecutive_float_for_reset == 0 (default).
+     */
+    void handleConsecutiveFloatReset(const ObservationData& rover_obs,
+                                     const NavigationData& nav);
 
     /**
      * Full KF update with DD observation model mapping to SD states

--- a/src/algorithms/rtk.cpp
+++ b/src/algorithms/rtk.cpp
@@ -259,6 +259,7 @@ void RTKProcessor::reset() {
     code_phase_history_l1_m_.clear();
     code_phase_history_l2_m_.clear();
     consecutive_fix_count_ = 0;
+    consecutive_float_count_ = 0;
     last_ar_ratio_ = 0.0;
     last_num_fixed_ambiguities_ = 0;
     std::lock_guard<std::mutex> lock(stats_mutex_);
@@ -937,6 +938,35 @@ void RTKProcessor::incrementLockCounts(const std::map<SatelliteId, SatelliteData
     }
 }
 
+void RTKProcessor::handleConsecutiveFloatReset(const ObservationData& rover_obs,
+                                               const NavigationData& nav) {
+    if (rtk_config_.max_consecutive_float_for_reset <= 0 ||
+        consecutive_float_count_ < rtk_config_.max_consecutive_float_for_reset) {
+        return;
+    }
+
+    // Skip reset under DEMO5_CONTINUOUS policy (simple AR maintains its own state).
+    if (rtk_config_.ar_policy == RTKConfig::ARPolicy::DEMO5_CONTINUOUS) {
+        consecutive_float_count_ = 0;
+        return;
+    }
+
+    // Reset ambiguity states but keep held DD integers for hold fix.
+    for (auto& [sat, idx] : filter_state_.n1_indices) {
+        filter_state_.state(idx) = 0.0;
+        filter_state_.covariance(idx, idx) = 900.0;
+    }
+    for (auto& [sat, idx] : filter_state_.n2_indices) {
+        filter_state_.state(idx) = 0.0;
+        filter_state_.covariance(idx, idx) = 900.0;
+    }
+    // Also reset position to SPP to prevent baseline drift.
+    resetPositionToSPP(rover_obs, nav);
+    // DO NOT clear held DD integers (last_dd_fixed_, last_dd_pairs_,
+    // last_best_subset_) — they enable hold fix after reset.
+    consecutive_float_count_ = 0;
+}
+
 void RTKProcessor::resetPositionToSPP(const ObservationData& rover_obs, const NavigationData& nav) {
     if (rtk_config_.position_mode == RTKConfig::PositionMode::STATIC) {
         // Static: position accumulates with process noise
@@ -1008,6 +1038,7 @@ PositionSolution RTKProcessor::processRTKEpoch(const ObservationData& rover_obs,
             auto spp = spp_processor_.processEpoch(rover_obs, nav);
             rememberSolution(spp);
             consecutive_fix_count_ = 0;
+            consecutive_float_count_ = 0;
             return spp;
         }
 
@@ -1040,6 +1071,7 @@ PositionSolution RTKProcessor::processRTKEpoch(const ObservationData& rover_obs,
             if (spp.isValid()) spp.status = SolutionStatus::SPP;
             rememberSolution(spp);
             consecutive_fix_count_ = 0;
+            consecutive_float_count_ = 0;
             return spp;
         };
 
@@ -1065,6 +1097,8 @@ PositionSolution RTKProcessor::processRTKEpoch(const ObservationData& rover_obs,
         }
 
         resetPositionToSPP(rover_obs, nav);
+
+        handleConsecutiveFloatReset(rover_obs, nav);
 
         auto sat_data = collectSatelliteData(rover_obs, base_obs, nav);
         if (sat_data.size() < 4) {
@@ -1335,6 +1369,7 @@ PositionSolution RTKProcessor::processRTKEpoch(const ObservationData& rover_obs,
                     } else {
                         updateStatistics(SolutionStatus::FIXED);
                         consecutive_fix_count_++;
+                        consecutive_float_count_ = 0;
 
                         // Save fixed position for next epoch's position reset
                         last_fixed_position_ = base_position_ + fixed_baseline_;
@@ -1362,6 +1397,7 @@ PositionSolution RTKProcessor::processRTKEpoch(const ObservationData& rover_obs,
                 if (tryHoldFix(sat_data, rover_obs.time, n_sats, solution)) {
                     updateStatistics(SolutionStatus::FIXED);
                     consecutive_fix_count_++;
+                    consecutive_float_count_ = 0;
                     if (consecutive_fix_count_ >= rtk_config_.min_hold_count) {
                         applyHoldAmbiguity();
                     }
@@ -1374,6 +1410,7 @@ PositionSolution RTKProcessor::processRTKEpoch(const ObservationData& rover_obs,
                 rememberSolution(float_solution);
                 updateStatistics(SolutionStatus::FLOAT);
                 consecutive_fix_count_ = 0;
+                consecutive_float_count_++;
             }
         } else {
             return fallback_spp();
@@ -1383,6 +1420,7 @@ PositionSolution RTKProcessor::processRTKEpoch(const ObservationData& rover_obs,
         auto spp = spp_processor_.processEpoch(rover_obs, nav);
         rememberSolution(spp);
         consecutive_fix_count_ = 0;
+        consecutive_float_count_ = 0;
         return spp;
     }
     return solution;

--- a/tests/test_rtk_legacy.cpp
+++ b/tests/test_rtk_legacy.cpp
@@ -345,6 +345,26 @@ TEST(RTKLegacyCompatibilityStandaloneTest, MaxPositionJumpDefaultDisabled) {
     EXPECT_DOUBLE_EQ(processor.getRTKConfig().max_position_jump_m, 0.0);
 }
 
+TEST(RTKLegacyCompatibilityStandaloneTest, MaxConsecutiveFloatResetDefaultDisabled) {
+    RTKProcessor processor;
+    EXPECT_EQ(processor.getRTKConfig().max_consecutive_float_for_reset, 0);
+
+    RTKProcessor::RTKConfig cfg;
+    cfg.max_consecutive_float_for_reset = 0;
+    processor.setRTKConfig(cfg);
+    EXPECT_EQ(processor.getRTKConfig().max_consecutive_float_for_reset, 0);
+
+    RTKProcessor::RTKConfig cfg2;
+    cfg2.max_consecutive_float_for_reset = 10;
+    processor.setRTKConfig(cfg2);
+    EXPECT_EQ(processor.getRTKConfig().max_consecutive_float_for_reset, 10);
+
+    RTKProcessor::RTKConfig cfg3;
+    cfg3.max_consecutive_float_for_reset = 0;
+    processor.setRTKConfig(cfg3);
+    EXPECT_EQ(processor.getRTKConfig().max_consecutive_float_for_reset, 0);
+}
+
 TEST(RTKLegacyCompatibilityStandaloneTest, ArPolicyDemo5ContinuousDisablesHoldFix) {
     // Under DEMO5_CONTINUOUS, the hold-fix fallback code path is gated off.
     // We verify by checking that tryHoldFix returns false when called directly


### PR DESCRIPTION
## Summary

- 新 CLI option `--max-consec-float-reset <n>` 追加、default 0 (disabled)、既存挙動 byte-identical
- 連続 N epoch float が続いたら ambiguity state (n1/n2 indices の state+covariance) を reset し位置を SPP に戻す recovery policy
- 既存の `consecutive_fix_count_` 機構とは独立、追加の `consecutive_float_count_` counter を導入

## Motivation

- 都市部 RTK で false-lineage の AR integers が居座ると Fix 数/精度が劣化
- 長期 float → ambiguity reset で固定取り直しを強制する experimental recovery
- DEMO5_CONTINUOUS policy 下では自前 state 管理のため reset skip

## Test

- `MaxConsecutiveFloatResetDefaultDisabled` unit test
- default (未指定) vs `--max-consec-float-reset 0` 明示 で `cmp exit 0`
- tight threshold smoke check (threshold=5) で gate 発火確認: default 1268 fix epochs → threshold=5 1433 fix epochs

## Limitation

- 発火時 Fix 数変化の方向は dataset 依存 (reconvergence が早まる場合もあれば false fix 増加の場合もある)
- 適切な threshold 値 tuning は本 PR スコープ外 (default 0 で opt-in)
- held DD integers (`last_dd_fixed_` 等) は reset 後も保持するため hold fix は継続可能
- Unit test は config field の default/round-trip のみ (PR #19, #20 と同 pattern)
