### PR TITLE
[rtk] Add --max-postfix-rms post-fix residual gate (default-off)

### DIFF
--- a/apps/gnss_solve.cpp
+++ b/apps/gnss_solve.cpp
@@ -96,6 +96,7 @@ struct SolveConfig {
     double max_hold_divergence_m = 0.0;
     double max_position_jump_m = 0.0;
     int max_consecutive_float_for_reset = 0;
+    double max_postfix_residual_rms = 0.0;
 };
 
 double timeDiffSeconds(const libgnss::GNSSTime& a, const libgnss::GNSSTime& b) {
@@ -409,6 +410,8 @@ void printUsage(const char* program_name) {
         << "                             (default: 0, disabled)\n"
         << "  --max-pos-jump <v>         Max AR fix jump from last fixed pos in meters\n"
         << "                             (default: 0, disabled; additional to history check)\n"
+        << "  --max-postfix-rms <v>      Max L1 post-fix phase residual RMS in meters\n"
+        << "                             (default: 0, disabled)\n"
         << "  --max-consec-float-reset <n>\n"
         << "                             Reset ambiguity state after n consecutive float epochs\n"
         << "                             (default: 0, disabled; e.g. 10 for aggressive urban reconvergence)\n"
@@ -576,6 +579,8 @@ SolveConfig parseArguments(int argc, char* argv[]) {
             config.max_hold_divergence_m = std::stod(argv[++i]);
         } else if (arg == "--max-pos-jump" && i + 1 < argc) {
             config.max_position_jump_m = std::stod(argv[++i]);
+        } else if (arg == "--max-postfix-rms" && i + 1 < argc) {
+            config.max_postfix_residual_rms = std::stod(argv[++i]);
         } else if (arg == "--max-consec-float-reset" && i + 1 < argc) {
             config.max_consecutive_float_for_reset = std::stoi(argv[++i]);
         } else if (arg == "--max-baseline-m" && i + 1 < argc) {
@@ -760,6 +765,7 @@ int main(int argc, char* argv[]) {
         rtk_config.max_hold_divergence_m = config.max_hold_divergence_m;
         rtk_config.max_position_jump_m = config.max_position_jump_m;
         rtk_config.max_consecutive_float_for_reset = config.max_consecutive_float_for_reset;
+        rtk_config.max_postfix_residual_rms = config.max_postfix_residual_rms;
         rtk_processor.setRTKConfig(rtk_config);
         libgnss::SPPProcessor::SPPConfig spp_config;
         spp_config.use_multi_constellation = true;

--- a/include/libgnss++/algorithms/rtk.hpp
+++ b/include/libgnss++/algorithms/rtk.hpp
@@ -121,6 +121,11 @@ public:
         /// Reset ambiguity state after N consecutive float epochs (aggressive reconvergence).
         /// 0 (default) disables the check — existing behavior preserved.
         int max_consecutive_float_for_reset = 0;
+
+        /// Max L1 post-fix phase residual RMS in meters.
+        /// Computed after the LAMBDA fix is obtained, using the fixed DD ambiguities.
+        /// 0 (default) disables the check — existing behavior preserved.
+        double max_postfix_residual_rms = 0.0;
     };
 
     RTKProcessor();

--- a/src/algorithms/rtk.cpp
+++ b/src/algorithms/rtk.cpp
@@ -2115,6 +2115,146 @@ bool RTKProcessor::validateFixedSolution(const std::map<SatelliteId, SatelliteDa
         }
     }
 
+    auto computePostFixResidualRms = [&]() {
+        if (last_dd_fixed_.size() == 0 ||
+            last_best_subset_.size() != static_cast<size_t>(last_dd_fixed_.size()) ||
+            filter_state_.state.size() < 3) {
+            return std::numeric_limits<double>::infinity();
+        }
+
+        VectorXd fixed_state = filter_state_.state;
+        fixed_state.head<3>() = fixed_baseline_;
+        for (int i = 0; i < static_cast<int>(last_best_subset_.size()); ++i) {
+            const int dd_idx = last_best_subset_[i];
+            if (dd_idx < 0 || dd_idx >= static_cast<int>(last_dd_pairs_.size())) {
+                return std::numeric_limits<double>::infinity();
+            }
+            const auto& pair = last_dd_pairs_[dd_idx];
+            if (pair.ref_idx < 0 || pair.sat_idx < 0 ||
+                pair.ref_idx >= fixed_state.size() || pair.sat_idx >= fixed_state.size()) {
+                return std::numeric_limits<double>::infinity();
+            }
+            fixed_state(pair.sat_idx) = fixed_state(pair.ref_idx) - last_dd_fixed_(i);
+        }
+
+        const Vector3d rover_pos = base_position_ + fixed_baseline_;
+        double l1_sum_sq = 0.0;
+        int l1_count = 0;
+        double all_sum_sq = 0.0;
+        int all_count = 0;
+
+        for (int i = 0; i < static_cast<int>(last_best_subset_.size()); ++i) {
+            const int dd_idx = last_best_subset_[i];
+            if (dd_idx < 0 || dd_idx >= static_cast<int>(last_dd_pairs_.size())) {
+                continue;
+            }
+            const auto& pair = last_dd_pairs_[dd_idx];
+            const auto ref_it = sat_data.find(pair.ref_sat);
+            const auto sat_it = sat_data.find(pair.sat);
+            if (ref_it == sat_data.end() || sat_it == sat_data.end()) {
+                continue;
+            }
+
+            const auto& ref_sd = ref_it->second;
+            const auto& sd = sat_it->second;
+            const bool use_l1 = pair.freq == 0;
+            if ((use_l1 && (!ref_sd.has_l1 || !sd.has_l1)) ||
+                (!use_l1 && (!ref_sd.has_l2 || !sd.has_l2))) {
+                continue;
+            }
+
+            const double ref_wavelength = use_l1 ? ref_sd.l1_wavelength : ref_sd.l2_wavelength;
+            const double sat_wavelength = use_l1 ? sd.l1_wavelength : sd.l2_wavelength;
+            if (ref_wavelength <= 0.0 || sat_wavelength <= 0.0 ||
+                pair.ref_idx < 0 || pair.sat_idx < 0 ||
+                pair.ref_idx >= fixed_state.size() || pair.sat_idx >= fixed_state.size()) {
+                continue;
+            }
+
+            const double ref_phase = use_l1 ? ref_sd.rover_l1_phase - ref_sd.base_l1_phase
+                                            : ref_sd.rover_l2_phase - ref_sd.base_l2_phase;
+            const double sat_phase = use_l1 ? sd.rover_l1_phase - sd.base_l1_phase
+                                            : sd.rover_l2_phase - sd.base_l2_phase;
+            const double rr_ref =
+                geodist_range(ref_sd.sat_pos, rover_pos) + tropModel(rover_pos, ref_sd.elevation);
+            const double br_ref = geodist_range(ref_sd.sat_pos_base, base_position_) +
+                                  tropModel(base_position_, ref_sd.base_elevation);
+            const double rr =
+                geodist_range(sd.sat_pos, rover_pos) + tropModel(rover_pos, sd.elevation);
+            const double br = geodist_range(sd.sat_pos_base, base_position_) +
+                              tropModel(base_position_, sd.base_elevation);
+            const double geom_dd = (rr_ref - br_ref) - (rr - br);
+            const double amb_term =
+                ref_wavelength * fixed_state(pair.ref_idx) -
+                sat_wavelength * fixed_state(pair.sat_idx);
+            const bool autocal_glonass =
+                usesGlonassAutocal(rtk_config_) &&
+                ref_sd.satellite.system == GNSSSystem::GLONASS &&
+                sd.satellite.system == GNSSSystem::GLONASS &&
+                pair.freq < GLO_HWBIAS_STATES;
+            const double df_mhz =
+                autocal_glonass
+                    ? (((use_l1 ? ref_sd.l1_frequency_hz : ref_sd.l2_frequency_hz) -
+                        (use_l1 ? sd.l1_frequency_hz : sd.l2_frequency_hz)) / 1e6)
+                    : 0.0;
+            const double glonass_icb =
+                glonassInterChannelBiasMeters(
+                    rtk_config_,
+                    ref_sd.satellite.system,
+                    sd.satellite.system,
+                    use_l1 ? ref_sd.l1_frequency_hz : ref_sd.l2_frequency_hz,
+                    use_l1 ? sd.l1_frequency_hz : sd.l2_frequency_hz,
+                    pair.freq);
+            const double phase_iono_term =
+                usesEstimatedIono(rtk_config_)
+                    ? (-ionoFrequencyScale(
+                           pair.freq,
+                           ref_sd.l1_frequency_hz,
+                           use_l1 ? ref_sd.l1_frequency_hz : ref_sd.l2_frequency_hz) *
+                           fixed_state(II(pair.ref_sat)) +
+                       ionoFrequencyScale(
+                           pair.freq,
+                           sd.l1_frequency_hz,
+                           use_l1 ? sd.l1_frequency_hz : sd.l2_frequency_hz) *
+                           fixed_state(II(pair.sat)))
+                    : 0.0;
+
+            double residual =
+                ref_phase * ref_wavelength - sat_phase * sat_wavelength -
+                geom_dd - amb_term - glonass_icb - phase_iono_term;
+            if (autocal_glonass) {
+                residual -= df_mhz * fixed_state(IL(pair.freq));
+            }
+            if (!std::isfinite(residual)) {
+                continue;
+            }
+
+            all_sum_sq += residual * residual;
+            all_count++;
+            if (use_l1) {
+                l1_sum_sq += residual * residual;
+                l1_count++;
+            }
+        }
+
+        if (l1_count > 0) {
+            return std::sqrt(l1_sum_sq / static_cast<double>(l1_count));
+        }
+        if (all_count > 0) {
+            return std::sqrt(all_sum_sq / static_cast<double>(all_count));
+        }
+        return std::numeric_limits<double>::infinity();
+    };
+
+    const double max_postfix_residual_rms = rtk_config_.max_postfix_residual_rms;
+    if (filter_initialized_ &&
+        filter_state_.state.size() >= 3 &&
+        std::isfinite(max_postfix_residual_rms) &&
+        max_postfix_residual_rms > 0.0 &&
+        computePostFixResidualRms() > max_postfix_residual_rms) {
+        return false;
+    }
+
     return true;
 }
 

--- a/tests/test_rtk_legacy.cpp
+++ b/tests/test_rtk_legacy.cpp
@@ -365,6 +365,64 @@ TEST(RTKLegacyCompatibilityStandaloneTest, MaxConsecutiveFloatResetDefaultDisabl
     EXPECT_EQ(processor.getRTKConfig().max_consecutive_float_for_reset, 0);
 }
 
+TEST(RTKLegacyCompatibilityStandaloneTest, MaxPostfixResidualRmsDefaultDisabled) {
+    // Default max_postfix_residual_rms must be 0.0 (disabled — existing behavior preserved).
+    RTKProcessor processor;
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().max_postfix_residual_rms, 0.0);
+
+    // Explicitly set 0.0 and confirm round-trip.
+    RTKProcessor::RTKConfig cfg;
+    cfg.max_postfix_residual_rms = 0.0;
+    processor.setRTKConfig(cfg);
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().max_postfix_residual_rms, 0.0);
+
+    // Setting a non-zero value should be stored correctly.
+    RTKProcessor::RTKConfig cfg2;
+    cfg2.max_postfix_residual_rms = 0.5;
+    processor.setRTKConfig(cfg2);
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().max_postfix_residual_rms, 0.5);
+
+    // Reset to 0 confirms disabled state.
+    RTKProcessor::RTKConfig cfg3;
+    cfg3.max_postfix_residual_rms = 0.0;
+    processor.setRTKConfig(cfg3);
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().max_postfix_residual_rms, 0.0);
+}
+
+TEST(RTKLegacyCompatibilityStandaloneTest, MaxPostfixResidualRmsConfigurable) {
+    RTKProcessor processor;
+
+    // 1.0 m threshold
+    RTKProcessor::RTKConfig cfg1;
+    cfg1.max_postfix_residual_rms = 1.0;
+    processor.setRTKConfig(cfg1);
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().max_postfix_residual_rms, 1.0);
+
+    // 0.5 m threshold
+    RTKProcessor::RTKConfig cfg2;
+    cfg2.max_postfix_residual_rms = 0.5;
+    processor.setRTKConfig(cfg2);
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().max_postfix_residual_rms, 0.5);
+
+    // infinity sentinel (disabled)
+    RTKProcessor::RTKConfig cfg3;
+    cfg3.max_postfix_residual_rms = std::numeric_limits<double>::infinity();
+    processor.setRTKConfig(cfg3);
+    EXPECT_TRUE(std::isinf(processor.getRTKConfig().max_postfix_residual_rms));
+
+    // NaN sentinel (also disabled by isfinite guard)
+    RTKProcessor::RTKConfig cfg4;
+    cfg4.max_postfix_residual_rms = std::numeric_limits<double>::quiet_NaN();
+    processor.setRTKConfig(cfg4);
+    EXPECT_TRUE(std::isnan(processor.getRTKConfig().max_postfix_residual_rms));
+
+    // 0.0 (disabled)
+    RTKProcessor::RTKConfig cfg5;
+    cfg5.max_postfix_residual_rms = 0.0;
+    processor.setRTKConfig(cfg5);
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().max_postfix_residual_rms, 0.0);
+}
+
 TEST(RTKLegacyCompatibilityStandaloneTest, ArPolicyDemo5ContinuousDisablesHoldFix) {
     // Under DEMO5_CONTINUOUS, the hold-fix fallback code path is gated off.
     // We verify by checking that tryHoldFix returns false when called directly


### PR DESCRIPTION
## Summary

- 新 CLI option 追加、default 0.0 (disabled) で既存挙動 byte-identical:
  - `--max-postfix-rms <v>`: LAMBDA fix 確定直前に post-fix L1 phase residual RMS を算出、> v なら reject
- post-fix residual 計算は `last_dd_fixed_` + `last_best_subset_` + `last_dd_pairs_` を使い、fixed state を
  ローカルコピーに反映してから DD phase の residual を sum。GLONASS ICB / iono estimation に対応。

## Motivation

- RTK investigation で false-fix 検出の post-fix 側 discriminator を opt-in で使えるようにする。
- default-off なので production default 挙動不変。
- PR #19/#20/#21 と同じ additive gate pattern。

## Test

- `MaxPostfixResidualRmsDefaultDisabled` / `MaxPostfixResidualRmsConfigurable` unit test
- default (未指定) 実行と `--max-postfix-rms 0` 明示で `cmp` exit 0 (byte-identical)
- tight threshold (0.005m): fixed 921/964 (95.54%) — gate 発火、fix 数減少を確認
- loose threshold (1.0m): fixed 960/964 (99.59%) — default と同等

## Limitation

- gate 値 tuning data は本 PR スコープ外 (default 0 で opt-in のみ)
- L2 残差単独使用 / LC 残差 / 多周波複合は今回未対応 (worktree と同じ L1 fallback→all の二段式)
