### PR TITLE
[rtk] Add --enable-wide-lane-ar MW wide-lane pre-step (default-off)

### DIFF
--- a/apps/gnss_solve.cpp
+++ b/apps/gnss_solve.cpp
@@ -97,6 +97,8 @@ struct SolveConfig {
     double max_position_jump_m = 0.0;
     int max_consecutive_float_for_reset = 0;
     double max_postfix_residual_rms = 0.0;
+    bool enable_wide_lane_ar = false;
+    double wide_lane_acceptance_threshold = 0.25;
 };
 
 double timeDiffSeconds(const libgnss::GNSSTime& a, const libgnss::GNSSTime& b) {
@@ -412,6 +414,8 @@ void printUsage(const char* program_name) {
         << "                             (default: 0, disabled; additional to history check)\n"
         << "  --max-postfix-rms <v>      Max L1 post-fix phase residual RMS in meters\n"
         << "                             (default: 0, disabled)\n"
+        << "  --enable-wide-lane-ar      Enable MW wide-lane AR pre-step (default: off)\n"
+        << "  --wide-lane-threshold <v>  WL float->int threshold in cycles (default: 0.25)\n"
         << "  --max-consec-float-reset <n>\n"
         << "                             Reset ambiguity state after n consecutive float epochs\n"
         << "                             (default: 0, disabled; e.g. 10 for aggressive urban reconvergence)\n"
@@ -581,6 +585,10 @@ SolveConfig parseArguments(int argc, char* argv[]) {
             config.max_position_jump_m = std::stod(argv[++i]);
         } else if (arg == "--max-postfix-rms" && i + 1 < argc) {
             config.max_postfix_residual_rms = std::stod(argv[++i]);
+        } else if (arg == "--enable-wide-lane-ar") {
+            config.enable_wide_lane_ar = true;
+        } else if (arg == "--wide-lane-threshold" && i + 1 < argc) {
+            config.wide_lane_acceptance_threshold = std::stod(argv[++i]);
         } else if (arg == "--max-consec-float-reset" && i + 1 < argc) {
             config.max_consecutive_float_for_reset = std::stoi(argv[++i]);
         } else if (arg == "--max-baseline-m" && i + 1 < argc) {
@@ -766,6 +774,8 @@ int main(int argc, char* argv[]) {
         rtk_config.max_position_jump_m = config.max_position_jump_m;
         rtk_config.max_consecutive_float_for_reset = config.max_consecutive_float_for_reset;
         rtk_config.max_postfix_residual_rms = config.max_postfix_residual_rms;
+        rtk_config.enable_wide_lane_ar = config.enable_wide_lane_ar;
+        rtk_config.wide_lane_acceptance_threshold = config.wide_lane_acceptance_threshold;
         rtk_processor.setRTKConfig(rtk_config);
         libgnss::SPPProcessor::SPPConfig spp_config;
         spp_config.use_multi_constellation = true;

--- a/include/libgnss++/algorithms/rtk.hpp
+++ b/include/libgnss++/algorithms/rtk.hpp
@@ -126,6 +126,18 @@ public:
         /// Computed after the LAMBDA fix is obtained, using the fixed DD ambiguities.
         /// 0 (default) disables the check — existing behavior preserved.
         double max_postfix_residual_rms = 0.0;
+
+        /// Enable MW wide-lane AR pre-step.
+        /// When true, fix wide-lane integers per L1/L2 pair before the N1/N2 LAMBDA
+        /// search and inject the fixed WL integers as hard constraints into the
+        /// search problem (head_state, dd_float, Qb, Qab).
+        /// false (default) disables — existing behavior preserved.
+        bool enable_wide_lane_ar = false;
+
+        /// Threshold for accepting a wide-lane float as an integer (cycles).
+        /// |WL_float - round(WL_float)| < threshold → fix. 0.25 is the worktree
+        /// default; only referenced when enable_wide_lane_ar = true.
+        double wide_lane_acceptance_threshold = 0.25;
     };
 
     RTKProcessor();

--- a/src/algorithms/rtk.cpp
+++ b/src/algorithms/rtk.cpp
@@ -171,6 +171,53 @@ double ionoFrequencyScale(int freq, double l1_frequency_hz, double current_frequ
     return ratio * ratio;
 }
 
+inline double distanceToNearestInteger(double value) {
+    return std::abs(value - std::round(value));
+}
+
+bool applyAmbiguityConstraintUpdate(VectorXd& head_state,
+                                    VectorXd& dd_float,
+                                    MatrixXd& Qb,
+                                    MatrixXd& Qab,
+                                    int lhs_index,
+                                    int rhs_index,
+                                    double fixed_difference,
+                                    double measurement_variance) {
+    if (lhs_index < 0 || rhs_index < 0 ||
+        lhs_index >= dd_float.size() || rhs_index >= dd_float.size() ||
+        lhs_index >= Qb.rows() || rhs_index >= Qb.rows() ||
+        lhs_index >= Qb.cols() || rhs_index >= Qb.cols() ||
+        lhs_index >= Qab.cols() || rhs_index >= Qab.cols()) {
+        return false;
+    }
+
+    VectorXd h = VectorXd::Zero(dd_float.size());
+    h(lhs_index) = 1.0;
+    h(rhs_index) = -1.0;
+    const VectorXd Qb_h = Qb * h;
+    const auto h_Qb = h.transpose() * Qb;
+    const VectorXd Qab_h = Qab * h;
+    const double innovation_variance =
+        h.dot(Qb_h) + std::max(measurement_variance, 1e-6);
+    if (!std::isfinite(innovation_variance) || innovation_variance <= 0.0) {
+        return false;
+    }
+
+    const double innovation = fixed_difference - h.dot(dd_float);
+    dd_float += (Qb_h / innovation_variance) * innovation;
+    head_state += (Qab_h / innovation_variance) * innovation;
+    Qb -= (Qb_h * h_Qb) / innovation_variance;
+    Qab -= (Qab_h * h_Qb) / innovation_variance;
+    Qb = (Qb + Qb.transpose()) * 0.5;
+    for (int i = 0; i < Qb.rows(); ++i) {
+        if (Qb(i, i) < 1e-6) {
+            Qb(i, i) = 1e-6;
+        }
+    }
+    return dd_float.allFinite() && head_state.allFinite() &&
+           Qb.allFinite() && Qab.allFinite();
+}
+
 double glonassInterChannelBiasMeters(const RTKProcessor::RTKConfig& config,
                                      GNSSSystem ref_system,
                                      GNSSSystem sat_system,
@@ -1719,9 +1766,170 @@ bool RTKProcessor::resolveAmbiguities(std::vector<DDPair> dd_pairs) {
         }
     }
 
+    // === Wide-lane AR pre-step (default-off) ===
+    // Frozen copies of full-size matrices for use in build_search_problem
+    // (best_candidate may update dd_float/Qb/Qab to subset-sized values later)
+    const VectorXd base_dd_float = dd_float;
+    const MatrixXd base_Qb = Qb;
+    const MatrixXd base_Qab = Qab;
+    const VectorXd base_head_state = head_state;
+
+    std::vector<int> full_subset(nb);
+    for (int i = 0; i < nb; ++i) {
+        full_subset[i] = i;
+    }
+
+    struct WideLaneConstraint {
+        int l1_index = -1;
+        int l2_index = -1;
+        double fixed_integer = 0.0;
+    };
+    std::vector<WideLaneConstraint> wide_lane_constraints;
+    int wide_lane_total = 0;
+    int wide_lane_fixed = 0;
+
+    auto compute_wide_lane_float = [&](int l1_index, int l2_index, double& wide_lane_float) {
+        if (l1_index < 0 || l2_index < 0 ||
+            l1_index >= nb || l2_index >= nb ||
+            dd_pairs[l1_index].freq != 0 || dd_pairs[l2_index].freq != 1) {
+            return false;
+        }
+
+        const auto ref_it = sat_data.find(dd_pairs[l1_index].ref_sat);
+        const auto sat_it = sat_data.find(dd_pairs[l1_index].sat);
+        if (ref_it == sat_data.end() || sat_it == sat_data.end()) {
+            return false;
+        }
+        const auto& ref_sd = ref_it->second;
+        const auto& sd = sat_it->second;
+        if (!ref_sd.has_l1 || !ref_sd.has_l2 || !sd.has_l1 || !sd.has_l2) {
+            return false;
+        }
+
+        const double f1 = ref_sd.l1_frequency_hz;
+        const double f2 = ref_sd.l2_frequency_hz;
+        const double lambda_wl_m = wideLaneWavelength(f1, f2);
+        if (f1 <= 0.0 || f2 <= 0.0 || lambda_wl_m <= 0.0) {
+            return false;
+        }
+
+        auto single_difference_wide_lane = [&](const SatelliteData& data) {
+            const double phi1_m =
+                (data.rover_l1_phase - data.base_l1_phase) * data.l1_wavelength;
+            const double phi2_m =
+                (data.rover_l2_phase - data.base_l2_phase) * data.l2_wavelength;
+            const double code_term =
+                (f1 * (data.rover_l1_code - data.base_l1_code) +
+                 f2 * (data.rover_l2_code - data.base_l2_code)) / (f1 + f2);
+            return ((f1 * phi1_m - f2 * phi2_m) / (f1 - f2) - code_term) / lambda_wl_m;
+        };
+
+        wide_lane_float = single_difference_wide_lane(ref_sd) -
+                          single_difference_wide_lane(sd);
+        return std::isfinite(wide_lane_float);
+    };
+
+    if (rtk_config_.enable_wide_lane_ar) {
+        const double wide_lane_threshold =
+            std::max(0.0, rtk_config_.wide_lane_acceptance_threshold);
+        for (int i = 0; i < nb; ++i) {
+            if (dd_pairs[i].freq != 0 || dd_pairs[i].ref_sat.system == GNSSSystem::GLONASS) {
+                continue;
+            }
+            int l2_pair = -1;
+            for (int j = 0; j < nb; ++j) {
+                if (dd_pairs[j].freq == 1 &&
+                    dd_pairs[j].sat == dd_pairs[i].sat &&
+                    dd_pairs[j].ref_sat == dd_pairs[i].ref_sat) {
+                    l2_pair = j;
+                    break;
+                }
+            }
+            if (l2_pair < 0) {
+                continue;
+            }
+
+            wide_lane_total++;
+            double wide_lane_float = 0.0;
+            if (!compute_wide_lane_float(i, l2_pair, wide_lane_float)) {
+                continue;
+            }
+            const double fixed_integer = std::round(wide_lane_float);
+            if (distanceToNearestInteger(wide_lane_float) >= wide_lane_threshold) {
+                continue;
+            }
+
+            wide_lane_constraints.push_back({i, l2_pair, fixed_integer});
+            wide_lane_fixed++;
+        }
+        if (wide_lane_total > 0) {
+            std::clog << "[RTK-AR] WL fixed " << wide_lane_fixed
+                      << "/" << wide_lane_total << "\n";
+        }
+    }
+
+    struct SearchProblem {
+        VectorXd head_state;
+        VectorXd dd_float;
+        MatrixXd Qb;
+        MatrixXd Qab;
+    };
+    auto build_search_problem = [&](const std::vector<int>& subset) {
+        SearchProblem problem;
+        problem.head_state = base_head_state;
+        if (subset.size() == static_cast<size_t>(nb)) {
+            problem.dd_float = base_dd_float;
+            problem.Qb = base_Qb;
+            problem.Qab = base_Qab;
+        } else {
+            const auto subset_matrices =
+                rtk_ar_evaluation::extractSubset(base_dd_float, base_Qb, base_Qab, subset);
+            problem.dd_float = subset_matrices.dd_float;
+            problem.Qb = subset_matrices.Qb;
+            problem.Qab = subset_matrices.Qab;
+        }
+
+        if (!wide_lane_constraints.empty()) {
+            std::map<int, int> local_index_by_full_index;
+            for (int local = 0; local < static_cast<int>(subset.size()); ++local) {
+                local_index_by_full_index[subset[local]] = local;
+            }
+
+            for (const auto& constraint : wide_lane_constraints) {
+                const auto l1_it = local_index_by_full_index.find(constraint.l1_index);
+                const auto l2_it = local_index_by_full_index.find(constraint.l2_index);
+                if (l1_it == local_index_by_full_index.end() ||
+                    l2_it == local_index_by_full_index.end()) {
+                    continue;
+                }
+                applyAmbiguityConstraintUpdate(problem.head_state,
+                                               problem.dd_float,
+                                               problem.Qb,
+                                               problem.Qab,
+                                               l1_it->second,
+                                               l2_it->second,
+                                               constraint.fixed_integer,
+                                               1e-4);
+            }
+        }
+
+        if (wide_lane_constraints.empty()) {
+            return problem;
+        }
+
+        problem.Qb = (problem.Qb + problem.Qb.transpose()) * 0.5;
+        for (int i = 0; i < problem.Qb.rows(); ++i) {
+            if (problem.Qb(i, i) < 1e-6) {
+                problem.Qb(i, i) = 1e-6;
+            }
+        }
+        return problem;
+    };
+
     // Standard LAMBDA path
     if (!fixed) {
-        if (lambdaMethod(dd_float, Qb, dd_fixed, ratio)) {
+        const auto full_problem = build_search_problem(full_subset);
+        if (lambdaMethod(full_problem.dd_float, full_problem.Qb, dd_fixed, ratio)) {
             if (ratio >= effective_ratio_threshold) {
                 fixed = true;
 
@@ -1887,21 +2095,16 @@ bool RTKProcessor::resolveAmbiguities(std::vector<DDPair> dd_pairs) {
             fixed, ratio, effective_ratio_threshold, max_var);
 
     if (nb > 4 && (search_preferred_subsets || search_drop_subsets)) {
-        const VectorXd full_dd_float = dd_float;
-        const MatrixXd full_Qb = Qb;
-        const MatrixXd full_Qab = Qab;
-
         auto try_subset = [&](const std::vector<int>& subset) {
             const int ns = subset.size();
             if (ns < 4) {
                 return false;
             }
 
-            const auto subset_matrices =
-                rtk_ar_evaluation::extractSubset(full_dd_float, full_Qb, full_Qab, subset);
+            const auto subset_problem = build_search_problem(subset);
             VectorXd sub_fixed;
             double sub_ratio = 0.0;
-            if (!lambdaMethod(subset_matrices.dd_float, subset_matrices.Qb, sub_fixed, sub_ratio)) {
+            if (!lambdaMethod(subset_problem.dd_float, subset_problem.Qb, sub_fixed, sub_ratio)) {
                 return false;
             }
             if (sub_ratio < effective_ratio_threshold) {
@@ -1910,6 +2113,10 @@ bool RTKProcessor::resolveAmbiguities(std::vector<DDPair> dd_pairs) {
 
             if (rtk_ar_evaluation::preferCandidate(
                     best_candidate.ratio, best_candidate.fixed, sub_ratio)) {
+                rtk_ar_evaluation::SubsetMatrices subset_matrices;
+                subset_matrices.dd_float = subset_problem.dd_float;
+                subset_matrices.Qb = subset_problem.Qb;
+                subset_matrices.Qab = subset_problem.Qab;
                 rtk_ar_evaluation::adoptCandidate(
                     best_candidate, subset, subset_matrices, sub_fixed, sub_ratio);
                 return true;
@@ -1920,7 +2127,7 @@ bool RTKProcessor::resolveAmbiguities(std::vector<DDPair> dd_pairs) {
         std::vector<rtk_ar_selection::PairDescriptor> descriptors;
         descriptors.reserve(nb);
         for (int i = 0; i < nb; ++i) {
-            descriptors.push_back({dd_pairs[i].ref_sat.system, full_Qb(i, i)});
+            descriptors.push_back({dd_pairs[i].ref_sat.system, Qb(i, i)});
         }
 
         const std::vector<std::vector<int>> preferred_subsets =
@@ -1965,8 +2172,13 @@ bool RTKProcessor::resolveAmbiguities(std::vector<DDPair> dd_pairs) {
     if (!fixed) return false;
 
     // Fixed solution: xa = y[:na] - Qab * Qb^{-1} * (dd_float - dd_fixed)
+    const auto fixed_problem = build_search_problem(best_candidate.subset);
     VectorXd xa;
-    if (!rtk_ar_evaluation::solveFixedHeadState(head_state, Qab, Qb, dd_float, dd_fixed, xa)) {
+    if (!rtk_ar_evaluation::solveFixedHeadState(fixed_problem.head_state,
+                                                fixed_problem.Qab,
+                                                fixed_problem.Qb,
+                                                fixed_problem.dd_float,
+                                                dd_fixed, xa)) {
         return false;
     }
     fixed_baseline_ = xa.head<3>();

--- a/tests/test_rtk_legacy.cpp
+++ b/tests/test_rtk_legacy.cpp
@@ -423,6 +423,64 @@ TEST(RTKLegacyCompatibilityStandaloneTest, MaxPostfixResidualRmsConfigurable) {
     EXPECT_DOUBLE_EQ(processor.getRTKConfig().max_postfix_residual_rms, 0.0);
 }
 
+TEST(RTKLegacyCompatibilityStandaloneTest, WideLaneArDefaultDisabled) {
+    // Default enable_wide_lane_ar must be false (disabled — existing behavior preserved).
+    RTKProcessor processor;
+    EXPECT_FALSE(processor.getRTKConfig().enable_wide_lane_ar);
+
+    // Default wide_lane_acceptance_threshold must be 0.25.
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().wide_lane_acceptance_threshold, 0.25);
+
+    // Explicitly set false and confirm round-trip.
+    RTKProcessor::RTKConfig cfg;
+    cfg.enable_wide_lane_ar = false;
+    processor.setRTKConfig(cfg);
+    EXPECT_FALSE(processor.getRTKConfig().enable_wide_lane_ar);
+
+    // Setting true should be stored correctly.
+    RTKProcessor::RTKConfig cfg2;
+    cfg2.enable_wide_lane_ar = true;
+    processor.setRTKConfig(cfg2);
+    EXPECT_TRUE(processor.getRTKConfig().enable_wide_lane_ar);
+
+    // Reset to false confirms disabled state.
+    RTKProcessor::RTKConfig cfg3;
+    cfg3.enable_wide_lane_ar = false;
+    processor.setRTKConfig(cfg3);
+    EXPECT_FALSE(processor.getRTKConfig().enable_wide_lane_ar);
+
+    // Threshold default preserved after round-trip.
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().wide_lane_acceptance_threshold, 0.25);
+}
+
+TEST(RTKLegacyCompatibilityStandaloneTest, WideLaneArConfigurable) {
+    RTKProcessor processor;
+
+    // threshold 0.10
+    RTKProcessor::RTKConfig cfg1;
+    cfg1.enable_wide_lane_ar = true;
+    cfg1.wide_lane_acceptance_threshold = 0.10;
+    processor.setRTKConfig(cfg1);
+    EXPECT_TRUE(processor.getRTKConfig().enable_wide_lane_ar);
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().wide_lane_acceptance_threshold, 0.10);
+
+    // threshold 0.25 (worktree default)
+    RTKProcessor::RTKConfig cfg2;
+    cfg2.enable_wide_lane_ar = true;
+    cfg2.wide_lane_acceptance_threshold = 0.25;
+    processor.setRTKConfig(cfg2);
+    EXPECT_TRUE(processor.getRTKConfig().enable_wide_lane_ar);
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().wide_lane_acceptance_threshold, 0.25);
+
+    // threshold 0.50
+    RTKProcessor::RTKConfig cfg3;
+    cfg3.enable_wide_lane_ar = true;
+    cfg3.wide_lane_acceptance_threshold = 0.50;
+    processor.setRTKConfig(cfg3);
+    EXPECT_TRUE(processor.getRTKConfig().enable_wide_lane_ar);
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().wide_lane_acceptance_threshold, 0.50);
+}
+
 TEST(RTKLegacyCompatibilityStandaloneTest, ArPolicyDemo5ContinuousDisablesHoldFix) {
     // Under DEMO5_CONTINUOUS, the hold-fix fallback code path is gated off.
     // We verify by checking that tryHoldFix returns false when called directly


### PR DESCRIPTION
## Summary

- 新 CLI option 追加、default false で既存挙動 byte-identical:
  - `--enable-wide-lane-ar`: LAMBDA search 前に L1/L2 MW wide-lane combination を計算、
    `|WL_float - round| < threshold` なら WL 整数を固定し、hard constraint として
    head_state / dd_float / Qb / Qab に measurement update で注入。
  - `--wide-lane-threshold <v>`: WL 固定閾値 (cycles)、default 0.25。
- 既存 AR search の 3 call-site (full / subset / fixed) を `build_search_problem` lambda に
  統合し、constraint apply を一元化。full-size frozen copies (base_dd_float/base_Qb/base_Qab)
  を使うことで、best_candidate 更新後の subset-sized matrices を誤って参照しない。
- `applyAmbiguityConstraintUpdate` helper (file-static, 45 LOC) を追加。

## Motivation

- 2-frequency dataset で MW wide-lane AR を導入して N1/N2 LAMBDA の探索空間を縮小、
  fix 堅牢性向上の opt-in experiment gate を用意。
- default-off なので production default 挙動不変 (cmp byte-identical 検証済み)。
- PR #19/#20/#21/#22 と同じ additive gate pattern。

## Test

- `WideLaneArDefaultDisabled` / `WideLaneArConfigurable` unit test pass (186 tests total)
- default (flag 未指定) 実行と先行 develop (a58140e) との `cmp` exit 0 (byte-identical)
- `--enable-wide-lane-ar` で stderr に `[RTK-AR] WL fixed N/M` 出力確認
- `--enable-wide-lane-ar` / `--wide-lane-threshold 0.10` 両方で fix 率変化を確認

## Limitation

- WL 固定は GPS/Galileo/BeiDou/QZSS の 2-freq pair のみ (GLONASS は ICB のため skip)
- WL 閾値 tuning データは本 PR スコープ外 (default 0.25 で opt-in のみ)
- `rtk_ar_evaluation::shouldAcceptSubsetFix` / `buildProgressiveResidualDropSubsets` (別の subset-selection variant) は本 PR 外