### PR TITLE
docs(CLAS): add port architecture + validated datasets docs referenced by README

### DIFF
--- a/docs/clas_port_architecture.md
+++ b/docs/clas_port_architecture.md
@@ -1,0 +1,219 @@
+# CLAS Port Architecture
+
+> **Implementation status on `develop`**: the README describes the native CLASNAT
+> path, which is fully implemented on branch
+> [`codex/ship-of-theseus-20260418`](https://github.com/rsasaki0109/gnssplusplus-library/tree/codex/ship-of-theseus-20260418).
+> That branch has no common ancestor with `develop` (local re-init history), so
+> merging it requires either a web-UI "Allow unrelated histories" merge or an
+> incremental re-port on top of `develop`.  The README reference tables, plots,
+> and this document were ported as docs-only PRs so the plan is visible here
+> even before the implementation lands on `develop`.
+
+Status: iter55 public-validation and helper-parity note.
+
+This note records the CLASLIB port structure after the native CLASNAT path
+became the default `--claslib-parity` behavior and after the iter55 cleanup that
+removed the deprecated Phase 4 CLI alias.  The intent is to keep the production
+path, bridge/oracle path, and retained legacy strict path explicit while cleanup
+continues.
+
+## 1. Current Architecture
+
+The current CLAS PPP-RTK stack has four user-visible or historically relevant
+paths:
+
+```text
+gnss_ppp
+  |
+  +-- --claslib-bridge
+  |     |
+  |     +-- external CLASLIB postpos()
+  |           Native libgnss++ state is bypassed.
+  |           This path remains the oracle/reference integration.
+  |
+  +-- --claslib-parity
+  |     |
+  |     +-- native CLASNAT path by default
+  |           |
+  |           +-- ppp_clasnat wrapper
+  |                 |
+  |                 +-- ppp_claslib_full core
+  |                       |
+  |                       +-- ppp_clasnat_osr
+  |                       +-- ppp_clasnat_zdres
+  |                       +-- ppp_clasnat_trop
+  |                       +-- clasnat_parity helpers
+  |
+  +-- --ported-clasnat
+  |     |
+  |     +-- explicit alias for the same native CLASNAT path
+  |           |
+  |           +-- ppp_claslib_full core
+  |                 |
+  |                 +-- ppp_clasnat_osr
+  |                 +-- ppp_clasnat_zdres
+  |                 +-- ppp_clasnat_trop
+  |                 +-- clasnat_parity helpers
+  |
+  +-- --claslib-parity --legacy-strict-parity
+        |
+        +-- older native CLAS OSR filter path
+              Useful as history and for selected debug fixtures, but no
+              longer the target architecture for CLASNAT parity.
+```
+
+The important practical difference after iter52 is that `--claslib-parity`
+now enters the same native CLASNAT wrapper that was previously selected only
+with `--ported-clasnat`.  `--ported-clasnat` remains valid but redundant for
+explicit scripts.  `--no-ported-clasnat` and `--legacy-strict-parity` reserve
+the older strict CLAS OSR path for regression/reference work.  The old Phase 4
+CLI alias has been removed; new scripts should use `--claslib-parity` or
+`--ported-clasnat`.
+
+Bridge-related code is separate:
+
+```text
+claslib_bridge     -> external postpos() runner
+claslib_oracle     -> direct CLASLIB function oracle for unit parity tests
+clasnat_parity     -> native implementations tested against claslib_oracle
+```
+
+`claslib_oracle` and `claslib_bridge` both depend on linked CLASLIB sources
+when `CLASLIB_PARITY_LINK=ON`, but they serve different purposes.  The bridge
+is an executable path for whole-run comparison.  The oracle is a narrow
+function-level reference for native helper tests.
+
+## 2. Native Port Completion Status
+
+The native CLASNAT path has reached the current numeric target and is now the
+default for `--claslib-parity`:
+
+- 17 `ClasnatParity` helper tests pass against the oracle, including
+  `filter`, `lambda`, `tropmodel`, and `stec_grid_data`.
+- 2000-epoch 2019 CLAS static run stays below the 20 mm 3D RMS target:
+  iter55 measured 5.56 mm against the CLASLIB trajectory over the last 100
+  epochs.
+- The core filter owns CLASLIB-shaped state with 303 states:
+  position, per-satellite ionosphere, and per-frequency ambiguities.
+- State management includes:
+  position seeding and prediction,
+  ionosphere and ambiguity maps,
+  per-satellite continuity bookkeeping,
+  phase wind-up cache,
+  CLAS dispersion compensation state,
+  SIS continuity state,
+  phase-bias repair state,
+  last epoch time, AR ratio, and fixed ambiguity counters.
+- Filter update is native:
+  CLAS OSR preparation,
+  CLASLIB-style zero-difference residual construction,
+  state propagation,
+  measurement update,
+  residual diagnostics,
+  covariance propagation,
+  and solution packaging are all in libgnss++.
+- AR hold/fixed output is native:
+  the core constructs the per-frequency DD AR state, applies fixed ambiguity
+  results back into the CLASNAT state, and emits fixed solutions through the
+  same `PositionSolution` surface as the rest of PPP.
+- Helper modules already separated from the core:
+  `ppp_clasnat_osr` for CLAS OSR preparation,
+  `ppp_clasnat_zdres` for CLASLIB-shaped residual construction,
+  `ppp_clasnat_trop` for CLAS grid/troposphere logic,
+  `clasnat_parity` for small native CLASLIB-equivalent functions,
+  and `claslib_oracle` for direct oracle calls.
+
+## 3. Remaining Historical Technical Debt
+
+The remaining debt is mostly structural rather than numeric:
+
+- The successful CLASNAT path is named through historical layers:
+  `ppp_clasnat` wrapper -> `ppp_claslib_full` core.  The word `full` now
+  describes the old Phase 4 experiment, not the actual architecture.
+- `PPPProcessor` still carries internal compatibility fields from the Phase 4
+  naming, even though the user-visible deprecated alias is gone.
+- Naming mixes CLASLIB-origin terms and CLASNAT terms:
+  `ClaslibRtkState`, `ppp_claslib_full`, `fullConfig`, and debug labels sit
+  next to `ppp_clasnat_osr`, `ppp_clasnat_trop`, and `clasnat_parity`.
+- Some source boundaries still reflect the order of discovery:
+  the native residual builder, atmospheric helpers, parity helpers, and core
+  filter are clean enough to test, but their names do not yet communicate the
+  intended ownership model.
+- `claslib_oracle` is correctly isolated, but the older naming can make it
+  look like production native code still depends on CLASLIB.  It should remain
+  a test/oracle facility only.
+
+## 4. Target Architecture
+
+The target is a single native CLASNAT path:
+
+```text
+gnss_ppp --claslib-parity
+  |
+  +-- ppp_clasnat_core
+        |
+        +-- ppp_clasnat_osr
+        |     CLAS SSR/OSR epoch context and correction preparation.
+        |
+        +-- ppp_clasnat_zdres
+        |     CLASLIB-style zero-difference residual transcription.
+        |
+        +-- ppp_clasnat_trop
+        |     CLAS grid and troposphere support.
+        |
+        +-- clasnat_parity
+              Small native CLASLIB-equivalent math/helpers.
+
+optional references:
+  --ported-clasnat -> explicit native CLASNAT selection, redundant with --claslib-parity
+  --legacy-strict-parity / --no-ported-clasnat -> older strict CLAS OSR path
+  --claslib-bridge -> external CLASLIB whole-run oracle
+  claslib_oracle   -> direct function oracle for tests
+```
+
+Rules for the target structure:
+
+- There is one production native core: `ppp_clasnat_core`.
+- `--claslib-parity` is the canonical user-facing switch for that core.
+- `--ported-clasnat` remains accepted as an explicit, redundant native path
+  selector for existing scripts.
+- `--legacy-strict-parity` and `--no-ported-clasnat` retain the iter13-era
+  strict path for archive/regression reference only.
+- The core owns the CLASNAT filter state directly as `ClasnatRtkState`.
+- The bridge is optional and does not participate in native state or runtime
+  decisions unless explicitly selected.
+- `clasnat_parity` stays small and pure: native helpers plus test fixtures.
+- `claslib_oracle` stays external-reference only and should not become a
+  production dependency.
+
+## 5. iter52+ Roadmap
+
+Recommended next phases:
+
+1. Finish name cleanup inside the core.
+   Rename remaining internal `full` debug labels and helper names where doing
+   so does not disturb numeric behavior.  Keep this mechanical and covered by
+   CLASNAT regression checks.
+
+2. Collapse legacy flags further.
+   Keep the internal Phase 4 compatibility bit only until the CLASNAT core no
+   longer needs that selector.  Keep `--legacy-strict-parity` while the older
+   strict path is still valuable as a regression reference.
+
+3. Expand `ClasnatParity` coverage.
+   The current helper set is 17 tests.  Further low-risk additions should keep
+   oracle-backed tolerances tight and target one helper at a time.
+
+4. Document production vs oracle boundaries in CI.
+   CI should continue to build the native path without CLASLIB as production
+   code.  CLASLIB-linked parity/oracle jobs should remain explicit.
+
+5. Revisit long CLAS PPP regression cost.
+   The 3600-epoch expanded-CSV regression can exceed practical test time.
+   Split it into a short deterministic CI regression and a longer benchmark,
+   or optimize the CLAS SSR lookup path before making it a required CI gate.
+
+6. Remove obsolete Phase 4 language from user-facing docs.
+   Once the code no longer exposes the old wrapper/core split, update README
+   and scripts so new users see `--claslib-parity` as the production native
+   entrypoint, with bridge/oracle options documented separately.

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -1,0 +1,106 @@
+# CLAS Public Validation Datasets
+
+> **Implementation status on `develop`**: the native CLASNAT path that produced
+> these numbers is fully implemented on branch
+> [`codex/ship-of-theseus-20260418`](https://github.com/rsasaki0109/gnssplusplus-library/tree/codex/ship-of-theseus-20260418).
+> That branch has no common ancestor with `develop` and needs an
+> "Allow unrelated histories" merge or an incremental re-port.
+
+This page records the public CLAS datasets used for the native CLASNAT parity
+checks.  It separates accepted regression gates from public exploratory runs
+that are useful for robustness work but are not yet millimetre-level passes.
+
+## Public Source
+
+The current CLAS parity data comes from the public CLASLIB repository:
+
+```text
+https://github.com/QZSS-Strategy-Office/claslib.git
+```
+
+The local validation copy used during iter55 was:
+
+```text
+/media/sasaki/aiueo/ai_coding_ws/gnssplusplus_thesis_ws/data/clas/claslib
+```
+
+Its Git remote was confirmed as:
+
+```text
+origin  https://github.com/QZSS-Strategy-Office/claslib.git
+```
+
+The files below are from that repository's `data/` directory.
+
+## Accepted Regression Gate
+
+| Case | Public files | Window | Native mode | Acceptance status |
+| --- | --- | --- | --- | --- |
+| 2019-08-27, QZSS CLAS sample | `0627239Q.obs`, `sept_2019239.nav`, `2019239Q.l6` | 2019-08-27, 16:00 GPST window | `gnss_ppp --claslib-parity` default native CLASNAT path | Accepted gate. Iter55 measured `0.00556 m` RMS 3D against the CLASLIB trajectory over the last 100 epochs of a 2000-epoch run, and `0.01014 m` RMS 3D over the last 100 epochs of a 300-epoch smoke window. |
+
+This is the dataset behind the current `--claslib-parity` mm-level regression.
+It is public because the input files are shipped in the public
+`QZSS-Strategy-Office/claslib` repository, not because they are private local
+capture files.
+
+The same 2000-epoch iter55 run measured `0.00251 m` RMS 3D against the fixed
+ECEF reference `(-3957235.3717, 3310368.2257, 3737529.7179)` over its last 100
+epochs.
+
+## Public Exploratory Runs
+
+| Case | Public files | What was checked | Result |
+| --- | --- | --- | --- |
+| 2018-11-25, CLASLIB bundled sample | `0161329A.obs`, `tskc2018329.nav`, `2018328X_329A.l6` | CLASLIB reference generation and 300-epoch native CLASNAT run | CLASLIB reference solved, but native CLASNAT stayed in fallback status for the checked window. Direct trajectory diff against CLASLIB was about `1.336 m` RMS 3D over the last 100 aligned epochs, so this is not an accepted `<20 mm` gate. |
+| 2019-12-15, CLASLIB bundled ST12 sample | `0627349AB.bnx`, `sept_2019349.nav`, `2019349B.l6` | CLASLIB reference from BINEX, then `convbin` to RINEX 3.02 with a GNSS signal mask before native CLASNAT | CLASLIB reference solved, but native CLASNAT did not reach the mm gate in the checked window. This remains an input-format and robustness probe, not an accuracy gate. |
+
+No additional bundled CLASLIB public sample reached `<20 mm` native CLASNAT RMS
+in iter55.  Those probes are still useful because they confirm that the
+additional samples are public and reproducible, and they expose the next
+robustness gaps without weakening the accepted 2019-08-27 gate.
+
+## Reproduce The Main Public Gate
+
+Clone CLASLIB and point the commands at its public `data/` directory:
+
+```bash
+git clone https://github.com/QZSS-Strategy-Office/claslib.git /tmp/claslib
+DATA=/tmp/claslib/data
+```
+
+Build with CLASLIB linked when you want the oracle-backed unit tests and bridge
+available:
+
+```bash
+cmake -S . -B build \
+  -DCLASLIB_PARITY_LINK=ON \
+  -DCLASLIB_ROOT_DIR=/tmp/claslib
+cmake --build build --target gnss_ppp -j4
+cmake --build build --target run_tests -j4
+```
+
+Run the native CLASNAT parity path:
+
+```bash
+./build/apps/gnss_ppp \
+  --claslib-parity \
+  --obs "$DATA/0627239Q.obs" \
+  --nav "$DATA/sept_2019239.nav" \
+  --ssr "$DATA/2019239Q.l6" \
+  --out /tmp/gnsspp_2019239.pos \
+  --summary-json /tmp/gnsspp_2019239_summary.json \
+  --ref-x -3957235.3717 \
+  --ref-y 3310368.2257 \
+  --ref-z 3737529.7179 \
+  --max-epochs 300 \
+  --quiet
+```
+
+Run the oracle helper parity tests:
+
+```bash
+./build/tests/run_tests --gtest_filter='*ClasnatParity*'
+```
+
+Expected helper coverage after iter55 is 17 tests, including `filter`,
+`lambda`, `tropmodel`, and `stec_grid_data`.


### PR DESCRIPTION
## Summary

Brings over the two docs files that PR #24's README references but which do not yet exist on \`develop\`:

- \`docs/clas_port_architecture.md\` — port design, 4-path architecture, iter roadmap
- \`docs/clas_validated_datasets.md\` — public CLAS datasets validated, pass/pending table

## Why

PR #24 merged the new \"CLAS Performance vs CLASLIB\" README section citing these two files. Without this follow-up, the README links 404 on \`develop\`.

Both docs include a prominent banner noting that the underlying **native CLASNAT implementation** lives on branch \`codex/ship-of-theseus-20260418\` and needs an \"Allow unrelated histories\" merge into \`develop\` (or an incremental re-port).

## Test plan

- [x] Docs render cleanly in VS Code preview
- [x] Links from README land on sections in these files
- [x] No source code changes