### PR TITLE
feat(spp): expose corrected pseudoranges via preprocessEpoch API

### DIFF
--- a/include/libgnss++/algorithms/spp.hpp
+++ b/include/libgnss++/algorithms/spp.hpp
@@ -5,7 +5,10 @@
 #include "../core/navigation.hpp"
 #include "../core/solution.hpp"
 #include <Eigen/Dense>
+#include <array>
 #include <mutex>
+#include <utility>
+#include <vector>
 
 namespace libgnss {
 
@@ -38,7 +41,18 @@ public:
         bool enable_beidou = true;                    ///< Enable BeiDou SPP support
         bool enable_glonass = true;                   ///< Enable GLONASS SPP support
     };
-    
+
+    /**
+     * @brief Corrected measurement for external solvers (e.g. particle filter)
+     */
+    struct CorrectedMeasurement {
+        std::array<double, 3> satellite_ecef;    ///< Sagnac-corrected satellite ECEF [m]
+        double corrected_pseudorange;            ///< Fully corrected pseudorange [m]
+        double weight;                           ///< Elevation-based weight (sin^2(el))
+        double elevation;                        ///< Elevation angle [rad]
+        int system_id;                           ///< 0=GPS, 1=GLONASS, 2=Galileo, 3=BeiDou, 4=QZSS
+    };
+
     SPPProcessor();
     explicit SPPProcessor(const SPPConfig& spp_config);
     ~SPPProcessor() override = default;
@@ -48,7 +62,17 @@ public:
     PositionSolution processEpoch(const ObservationData& obs, const NavigationData& nav) override;
     ProcessorStats getStats() const override;
     void reset() override;
-    
+
+    /**
+     * @brief Preprocess epoch: apply all corrections and return corrected measurements
+     *
+     * Returns satellite positions (Sagnac-corrected), corrected pseudoranges,
+     * and elevation-based weights for external use (e.g. particle filter input).
+     * Also returns the SPP position solution for reference.
+     */
+    std::pair<PositionSolution, std::vector<CorrectedMeasurement>>
+    preprocessEpoch(const ObservationData& obs, const NavigationData& nav);
+
     /**
      * @brief Set SPP-specific configuration
      */

--- a/python/libgnsspp/__init__.py
+++ b/python/libgnsspp/__init__.py
@@ -9,6 +9,7 @@ import sys
 import tempfile
 
 from ._libgnsspp import (
+    CorrectedMeasurement,
     GNSSTime,
     PositionSolution,
     Solution,
@@ -17,6 +18,7 @@ from ._libgnsspp import (
     ecef_to_geodetic_deg,
     geodetic_deg_to_ecef,
     load_solution,
+    preprocess_spp_file,
     read_rinex_header,
     read_rinex_observation_epochs,
     solution_status_name,
@@ -120,6 +122,7 @@ def solve_rtk_file(
 
 
 __all__ = [
+    "CorrectedMeasurement",
     "GNSSTime",
     "PositionSolution",
     "Solution",
@@ -128,6 +131,7 @@ __all__ = [
     "ecef_to_geodetic_deg",
     "geodetic_deg_to_ecef",
     "load_solution",
+    "preprocess_spp_file",
     "read_rinex_header",
     "read_rinex_observation_epochs",
     "solve_ppp_file",

--- a/python/libgnsspp/bindings.cpp
+++ b/python/libgnsspp/bindings.cpp
@@ -519,4 +519,52 @@ PYBIND11_MODULE(_libgnsspp, m) {
     m.def("solution_status_name", &solutionStatusName, py::arg("status"));
     m.def("ecef_to_geodetic_deg", &ecefToGeodeticDegrees, py::arg("ecef_m"));
     m.def("geodetic_deg_to_ecef", &geodeticDegreesToEcef, py::arg("llh_deg_m"));
+
+    // CorrectedMeasurement for external solvers (PF, etc.)
+    py::class_<libgnss::SPPProcessor::CorrectedMeasurement>(m, "CorrectedMeasurement")
+        .def_readonly("satellite_ecef", &libgnss::SPPProcessor::CorrectedMeasurement::satellite_ecef)
+        .def_readonly("corrected_pseudorange", &libgnss::SPPProcessor::CorrectedMeasurement::corrected_pseudorange)
+        .def_readonly("weight", &libgnss::SPPProcessor::CorrectedMeasurement::weight)
+        .def_readonly("elevation", &libgnss::SPPProcessor::CorrectedMeasurement::elevation)
+        .def_readonly("system_id", &libgnss::SPPProcessor::CorrectedMeasurement::system_id);
+
+    m.def("preprocess_spp_file",
+          [](const std::string& obs_path, const std::string& nav_path, size_t max_epochs) {
+              libgnss::io::RINEXReader obs_reader;
+              if (!obs_reader.open(obs_path)) {
+                  throw std::runtime_error("failed to open: " + obs_path);
+              }
+              libgnss::io::RINEXReader::RINEXHeader obs_header;
+              if (!obs_reader.readHeader(obs_header)) {
+                  throw std::runtime_error("failed to read header: " + obs_path);
+              }
+              const auto nav = loadNavigationData(nav_path);
+
+              libgnss::ProcessorConfig config;
+              config.mode = libgnss::PositioningMode::SPP;
+              libgnss::SPPProcessor processor;
+              processor.initialize(config);
+
+              using EpochResult = std::pair<
+                  libgnss::PositionSolution,
+                  std::vector<libgnss::SPPProcessor::CorrectedMeasurement>>;
+              std::vector<EpochResult> results;
+
+              libgnss::ObservationData obs;
+              size_t processed = 0;
+              while (obs_reader.readObservationEpoch(obs)) {
+                  if (obs_header.approximate_position.norm() > 0.0) {
+                      obs.receiver_position = obs_header.approximate_position;
+                  }
+                  auto [sol, measurements] = processor.preprocessEpoch(obs, nav);
+                  results.emplace_back(sol, measurements);
+                  ++processed;
+                  if (max_epochs > 0 && processed >= max_epochs) break;
+              }
+              return results;
+          },
+          py::arg("obs_path"),
+          py::arg("nav_path"),
+          py::arg("max_epochs") = 0,
+          "Preprocess RINEX with full SPP corrections, return corrected measurements per epoch");
 }

--- a/src/algorithms/spp.cpp
+++ b/src/algorithms/spp.cpp
@@ -619,4 +619,96 @@ Vector3d geodeticToEcef(const GeodeticCoord& geodetic_pos) {
 
 } // namespace spp_utils
 
+std::pair<PositionSolution, std::vector<SPPProcessor::CorrectedMeasurement>>
+SPPProcessor::preprocessEpoch(const ObservationData& obs, const NavigationData& nav) {
+    // Run normal SPP processing
+    auto solution = processEpoch(obs, nav);
+
+    // Re-run measurement construction to extract corrected pseudoranges
+    std::vector<CorrectedMeasurement> result;
+    auto valid_obs = validateObservations(obs, nav, obs.time);
+    if (valid_obs.empty()) return {solution, result};
+
+    auto sat_states = calculateSatelliteStates(valid_obs, nav, obs.time);
+    Vector3d position = estimated_position_;
+
+    for (const auto& o : valid_obs) {
+        auto it = sat_states.find(o.satellite);
+        if (it == sat_states.end() || !it->second.valid) continue;
+
+        const auto& st = it->second;
+        double sat_clk = st.clock_bias;
+
+        // Signal travel time and Earth rotation correction (Sagnac)
+        double range_approx = (st.position - position).norm();
+        double travel_time = range_approx / constants::SPEED_OF_LIGHT;
+        double angle = constants::OMEGA_E * travel_time;
+        double cos_a = std::cos(angle), sin_a = std::sin(angle);
+        Vector3d corrected_sat_pos(
+            st.position.x() * cos_a + st.position.y() * sin_a,
+           -st.position.x() * sin_a + st.position.y() * cos_a,
+            st.position.z());
+
+        // Geometry
+        auto geom = nav.calculateGeometry(position, corrected_sat_pos);
+        if (geom.elevation < 5.0 * M_PI / 180.0) continue;
+
+        // Receiver LLH for atmospheric models
+        auto rcv_geo = spp_utils::ecefToGeodetic(position);
+        double rcv_lat = rcv_geo.latitude;
+        double rcv_lon = rcv_geo.longitude;
+
+        // Troposphere
+        double trop_delay = 0.0;
+        if (spp_config_.apply_atmospheric_corrections) {
+            trop_delay = models::tropDelaySaastamoinen(position, geom.elevation);
+        }
+
+        // Ionosphere
+        double iono_delay = 0.0;
+        const auto* eph = nav.getEphemeris(o.satellite, obs.time);
+        if (spp_config_.apply_atmospheric_corrections && nav.ionosphere_model.valid) {
+            iono_delay = models::ionoDelayKlobuchar(
+                rcv_lat, rcv_lon, geom.azimuth, geom.elevation,
+                obs.time.tow,
+                nav.ionosphere_model.alpha,
+                nav.ionosphere_model.beta);
+            double signal_frequency = eph ? signalFrequencyHz(o.signal, eph) : 0.0;
+            if (signal_frequency > 0.0) {
+                double freq_scale = constants::GPS_L1_FREQ / signal_frequency;
+                iono_delay *= freq_scale * freq_scale;
+            }
+        }
+
+        double corrected_pr = o.pseudorange
+                              + sat_clk * constants::SPEED_OF_LIGHT
+                              - trop_delay
+                              - iono_delay
+                              - (eph ? groupDelayCorrectionMeters(o, *eph) : 0.0);
+
+        double sin_el = std::sin(geom.elevation);
+        if (sin_el < 0.1) sin_el = 0.1;
+
+        int sys_id = 0;
+        switch (o.satellite.system) {
+            case GNSSSystem::GPS:     sys_id = 0; break;
+            case GNSSSystem::GLONASS: sys_id = 1; break;
+            case GNSSSystem::Galileo: sys_id = 2; break;
+            case GNSSSystem::BeiDou:  sys_id = 3; break;
+            case GNSSSystem::QZSS:    sys_id = 4; break;
+            default: continue;
+        }
+
+        CorrectedMeasurement cm;
+        cm.satellite_ecef = {corrected_sat_pos.x(), corrected_sat_pos.y(), corrected_sat_pos.z()};
+        cm.corrected_pseudorange = corrected_pr;
+        cm.weight = sin_el * sin_el;
+        cm.elevation = geom.elevation;
+        cm.system_id = sys_id;
+        result.push_back(cm);
+    }
+
+    return {solution, result};
+}
+
 } // namespace libgnss


### PR DESCRIPTION
Reimplementation of stale PR #3 on current `develop` (original PR had 14-day divergence and `gh pr update-branch` reported conflicts; the scope is a clean additive API, so this reuses the Phase 2 fresh-reimplement pattern from PR #19-#23).

## Motivation

Downstream tooling (particle filters, external Kalman solvers) needs the SPP pre-processed measurement set — satellite positions after Sagnac correction, fully corrected pseudoranges (sat clock + ionosphere + troposphere + group delay), and elevation-derived weights — without re-implementing the corrections. Today that pipeline is buried inside `SPPProcessor::solvePositionLS` and is not reachable from outside.

## Summary

- `SPPProcessor::CorrectedMeasurement` struct: `satellite_ecef`, `corrected_pseudorange`, `weight`, `elevation`, `system_id`.
- `SPPProcessor::preprocessEpoch(obs, nav)` returns `std::pair<PositionSolution, std::vector<CorrectedMeasurement>>`. It runs `processEpoch` first to get the SPP solution and then re-reconstructs the per-satellite corrected measurements at the solved position.
- Python: `libgnsspp.CorrectedMeasurement` and `libgnsspp.preprocess_spp_file(obs_path, nav_path, max_epochs=0)` expose the same API.

## Byte-identical guarantee

`processEpoch()` is not modified; `preprocessEpoch()` is pure addition called only by the new binding. Verified on `rover_static.obs` (100 epochs): `diff` on the `.pos` output between stashed-baseline and patched builds is empty.

## Verification

- `cmake --build build -j` — clean.
- `./tests/run_tests` — 186 passed / 33 skipped (skips are pre-existing, driven by missing local fixture data) / 0 failures.
- `gnss_spp` byte-identical diff vs baseline.
- Python smoke: `preprocess_spp_file` on rover_static.obs returns 5 epochs, 9 corrected measurements in epoch 0, reasonable PR / weight / elevation values.

## Scope

- `include/libgnss++/algorithms/spp.hpp` — struct + method declaration.
- `src/algorithms/spp.cpp` — implementation (~92 LOC, reuses existing Sagnac / Klobuchar / Saastamoinen helpers in the same TU).
- `python/libgnsspp/bindings.cpp` — `CorrectedMeasurement` pybind class + `preprocess_spp_file` lambda.
- `python/libgnsspp/__init__.py` — re-export.

No changes to `processEpoch`, RTK, PPP, CLAS, Phase 2 gates, or `apps/`.

Closes #3 after merge (via `--delete-branch`).