### PR TITLE
docs: sync RTK framing to post-PR #19-#23 demo5 dominance

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,21 +44,64 @@ See `docs/clas_port_architecture.md` for the port design and `docs/clas_validate
 
 ## RTK Performance vs RTKLIB (demo5)
 
-UrbanNav Tokyo Odaiba dataset (2018-12-19, Trimble rover/base, ~170m baseline):
+gnssplusplus `develop` (post PR #19–#23) dominates RTKLIB `demo5` on the
+PPC-Dataset Tokyo and Nagoya urban runs across Fix count, Fix rate, and
+precision — with **no Phase 2 opt-in flags**. UrbanNav Tokyo Odaiba is dominated
+on Fix count, Hp95, and Vp95; Hmed sits within 9 cm of demo5 once
+`--enable-wide-lane-ar --wide-lane-threshold 0.10` is opted in.
 
-| Metric | gnssplusplus | RTKLIB |
-|--------|-------------|--------|
-| Matched epochs | **11,637** | 8,241 |
-| Fix rate | **8.11%** | 7.22% |
-| All-epoch p95 horizontal | **7.58 m** | 27.88 m |
-| Common-epoch median horizontal | 0.733 m | **0.704 m** |
-| Common-epoch p95 horizontal | **5.94 m** | 27.67 m |
+All runs below use `--mode kinematic --preset low-cost --match-tolerance-s 0.25`.
+
+### PPC Tokyo (kinematic, low-cost preset, no Phase 2 flags)
+
+| Run  | gnssplusplus Fix / rate | RTKLIB Fix / rate | Hmed (m)              | Vp95 (m)               |
+|------|------------------------:|------------------:|:---------------------:|:----------------------:|
+| run1 | **3572 / 81.26%**       | 2418 / 30.52%     | **0.037** vs 1.567 (42×) | **1.259** vs 36.703 (29×) |
+| run2 | **4674 / 80.12%**       | 2127 / 27.58%     | **0.016** vs 0.835 (52×) | **0.313** vs 42.624 (136×) |
+| run3 | **7516 / 86.84%**       | 5778 / 40.55%     | **0.012** vs 0.666 (56×) | **0.137** vs 24.521 (179×) |
+
+### PPC Nagoya (same preset)
+
+| Run  | Fix delta    | rate delta    | Hmed delta     |
+|------|-------------:|--------------:|---------------:|
+| run1 | **+1743**    | **+58.03 pp** | **9× better**  |
+| run2 | **+1735**    | **+64.00 pp** | **10× better** |
+| run3 | **+154**     | **+50.16 pp** | **44× better** |
+
+### UrbanNav Tokyo Odaiba (kinematic, low-cost preset)
+
+| Config                                                                     | Fix              | Rate        | Hmed (m)           | Hp95 (m)    | Vp95 (m)    |
+|----------------------------------------------------------------------------|-----------------:|------------:|:------------------:|:-----------:|:-----------:|
+| RTKLIB demo5                                                               | 595              | 7.22%       | **0.707**          | 27.878      | 45.212      |
+| gnssplusplus default                                                       | **1268** (+673)  | **36.98%**  | 1.707              | **19.585**  | **25.495**  |
+| gnssplusplus `--enable-wide-lane-ar --wide-lane-threshold 0.10`            | 818 (+223)       | 33.65%      | **0.799** (9 cm gap) | **19.971**  | **26.429**  |
+
+PPC Tokyo + Nagoya need no Phase 2 flags. On Odaiba, `--enable-wide-lane-ar
+--wide-lane-threshold 0.10` is the precision optimum.
 
 | RTKLIB 2D | libgnss++ 2D |
 |---|---|
 | ![RTKLIB 2D](docs/driving_odaiba_comparison_rtklib_2d.png) | ![libgnss++ 2D](docs/driving_odaiba_comparison_libgnss_2d.png) |
 
-gnssplusplus produces 41% more epochs and 3.7x better p95 accuracy in urban multipath conditions. See [Benchmark Snapshot](#benchmark-snapshot) for details.
+## Phase 2 opt-in tuning gates
+
+The default RTK pipeline already dominates demo5 on the production datasets
+above. Five additional gates ship default-off for situations where you want to
+push further on precision-vs-fix-count tradeoffs. All are byte-identical to the
+default behavior unless explicitly enabled.
+
+| Flag | Purpose | Default |
+|------|---------|---------|
+| `--ar-policy {extended\|demo5-continuous}` | AR extras gate. `demo5-continuous` disables relaxed-hold-ratio / subset-fallback / hold-fix / Q-regularization for demo5-style continuous ambiguity tracking. | `extended` |
+| `--max-hold-div <m>` | Reject fix if the hold-state diverges from float by more than N meters. | `0` (disabled) |
+| `--max-pos-jump <m>` | Reject fix if the epoch-to-epoch position jump exceeds N meters. | `0` (disabled) |
+| `--max-consec-float-reset <N>` | Auto-reset ambiguities after N consecutive float epochs. | `0` (disabled) |
+| `--max-postfix-rms <m>` | Reject fix if the L1 post-fix DD phase residual RMS exceeds N meters. | `0` (disabled) |
+| `--enable-wide-lane-ar` + `--wide-lane-threshold <cycle>` | Pre-compute MW wide-lane integers and inject them as Kalman constraints into the LAMBDA search. Halves Hmed on Odaiba at the cost of ~35% Fix count. | `false` / `0.25` |
+
+These were added in PR #19–#23. On PPC Tokyo and Nagoya the defaults already
+win, so leave them off. On Odaiba (or other urban multipath sets),
+`--enable-wide-lane-ar --wide-lane-threshold 0.10` is the precision optimum.
 
 ## Docs
 
@@ -350,13 +393,14 @@ python3 apps/gnss.py ppc-rtk-signoff \
 Dataset: [UrbanNav Tokyo Odaiba](https://github.com/IPNL-POLYU/UrbanNavDataset) (`2018-12-19`, Trimble rover/base, ~`170 m` baseline).
 Comparison baseline: [RTKLIB](https://github.com/tomojitakasu/RTKLIB).
 
-Current checked-in snapshot:
+Current checked-in snapshot (kinematic, low-cost preset):
 
-- All matched epochs: libgnss++ `11637` vs RTKLIB `8241`
-- Fix rate: libgnss++ `8.11%` vs RTKLIB `7.22%`
-- All-epoch p95 horizontal: libgnss++ `7.58 m` vs RTKLIB `27.88 m`
-- Common-epoch median horizontal: libgnss++ `0.733 m` vs RTKLIB `0.704 m`
-- Common-epoch p95 horizontal: libgnss++ `5.94 m` vs RTKLIB `27.67 m`
+- RTKLIB demo5: Fix `595` / Rate `7.22%` / Hmed `0.707 m` / Hp95 `27.878 m` / Vp95 `45.212 m`
+- libgnss++ default: Fix `1268` (+673) / Rate `36.98%` / Hmed `1.707 m` / Hp95 `19.585 m` / Vp95 `25.495 m`
+- libgnss++ `--enable-wide-lane-ar --wide-lane-threshold 0.10`: Fix `818` (+223) / Rate `33.65%` / Hmed `0.799 m` (9 cm gap) / Hp95 `19.971 m` / Vp95 `26.429 m`
+
+libgnss++ dominates Fix count, Hp95, and Vp95 at any config; Hmed is the sole
+demo5 edge under default flags, and Phase 2 wide-lane AR closes it to 9 cm.
 
 | RTKLIB 2D | libgnss++ 2D |
 |---|---|

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -1,17 +1,41 @@
 # Benchmarks
 
+gnssplusplus `develop` (post PR #19–#23) dominates RTKLIB `demo5` on the
+PPC-Dataset Tokyo and Nagoya urban runs across Fix count, rate, and precision
+— with no Phase 2 opt-in flags. UrbanNav-Odaiba is dominated on Fix count,
+Hp95, and Vp95; Hmed is within 9 cm of demo5 with
+`--enable-wide-lane-ar --wide-lane-threshold 0.10` opted in.
+
+All runs below use `--mode kinematic --preset low-cost --match-tolerance-s 0.25`.
+
+## PPC Tokyo (kinematic, low-cost preset, no Phase 2 flags)
+
+| Run  | gnssplusplus Fix / rate | RTKLIB Fix / rate | Hmed (m)              | Vp95 (m)               |
+|------|------------------------:|------------------:|:---------------------:|:----------------------:|
+| run1 | **3572 / 81.26%**       | 2418 / 30.52%     | **0.037** vs 1.567 (42×) | **1.259** vs 36.703 (29×) |
+| run2 | **4674 / 80.12%**       | 2127 / 27.58%     | **0.016** vs 0.835 (52×) | **0.313** vs 42.624 (136×) |
+| run3 | **7516 / 86.84%**       | 5778 / 40.55%     | **0.012** vs 0.666 (56×) | **0.137** vs 24.521 (179×) |
+
+## PPC Nagoya (same preset)
+
+| Run  | Fix delta    | rate delta    | Hmed delta     |
+|------|-------------:|--------------:|---------------:|
+| run1 | **+1743**    | **+58.03 pp** | **9× better**  |
+| run2 | **+1735**    | **+64.00 pp** | **10× better** |
+| run3 | **+154**     | **+50.16 pp** | **44× better** |
+
 ## UrbanNav Tokyo Odaiba
 
 Dataset: [UrbanNav Tokyo Odaiba](https://github.com/IPNL-POLYU/UrbanNavDataset)  
 Comparison baseline: [RTKLIB](https://github.com/tomojitakasu/RTKLIB)
 
-Current checked-in snapshot:
+Current checked-in snapshot (kinematic, low-cost preset):
 
-- All matched epochs: libgnss++ `11637` vs RTKLIB `8241`
-- Fix rate: libgnss++ `8.11%` vs RTKLIB `7.22%`
-- All-epoch p95 horizontal: libgnss++ `7.58 m` vs RTKLIB `27.88 m`
-- Common-epoch median horizontal: libgnss++ `0.733 m` vs RTKLIB `0.704 m`
-- Common-epoch p95 horizontal: libgnss++ `5.94 m` vs RTKLIB `27.67 m`
+| Config                                                                     | Fix              | Rate        | Hmed (m)              | Hp95 (m)    | Vp95 (m)    |
+|----------------------------------------------------------------------------|-----------------:|------------:|:---------------------:|:-----------:|:-----------:|
+| RTKLIB demo5                                                               | 595              | 7.22%       | **0.707**             | 27.878      | 45.212      |
+| libgnss++ default                                                          | **1268** (+673)  | **36.98%**  | 1.707                 | **19.585**  | **25.495**  |
+| libgnss++ `--enable-wide-lane-ar --wide-lane-threshold 0.10`               | 818 (+223)       | 33.65%      | **0.799** (9 cm gap)  | **19.971**  | **26.429**  |
 
 | RTKLIB 2D | libgnss++ 2D |
 |---|---|

--- a/docs/references/demo5-gap.md
+++ b/docs/references/demo5-gap.md
@@ -51,12 +51,12 @@ Relevant code entrypoints today:
 
 | Gap | Current libgnss++ state | Why it matters |
 |---|---|---|
-| Explicit `arfilter` policy switch | Present as an explicit subset-candidate ratio-margin knob in solver CLI/config, but intentionally narrower than demo5's broader tuning surface | Useful as a practical false-fix guard without collapsing the staged RTK design |
+| Explicit `arfilter` policy switch | Present as an explicit subset-candidate ratio-margin knob in solver CLI/config, and also has `--ar-policy demo5-continuous` (PR #19) as a broader AR extras gate, though intentionally narrower than demo5's full tuning surface | Useful as a practical false-fix guard without collapsing the staged RTK design |
 | Explicit `PAR` implementation | `PARTIAL` exists in config, but there is no separately documented demo5-style partial ambiguity-resolution path | This matters if we want to claim parity with demo5 tuning ideas rather than just naming compatibility |
 | Doppler-aided slip threshold path | A basic Doppler/carrier consistency slip guard now exists in the RTK bias-update path, but it is not yet a broader demo5-style tuning surface with receiver-class-specific knobs | demo5 uses Doppler/carrier disagreement as an additional practical slip signal |
 | Code-based slip path | A basic single-difference code-minus-phase slip guard now exists in the RTK bias-update path, but it is intentionally smaller than a full demo5 tuning surface | This is another low-cost-receiver guard often useful when carrier-only logic is not enough |
 | Receiver-oriented tuning presets | Named CLI presets now exist for `survey`, `low-cost`, and `moving-base`, and PPC RTK sign-off now carries city-specific tuning defaults (`Tokyo`: low-cost + arfilter, `Nagoya`: low-cost + no-arfilter) | demo5 is strong partly because it is operationally easy to tune for receiver classes |
-| Hold tuning knobs such as `varholdamb` / `gainholdamb` | `min_hold_count` and hold-active ratio threshold are now public knobs and are exercised through PPC RTK sign-off tuning profiles, but the broader hold policy remains intentionally simpler than demo5 | Useful when pushing harder on low-cost data without forking the solver |
+| Hold tuning knobs such as `varholdamb` / `gainholdamb` | `min_hold_count` and hold-active ratio threshold are now public knobs and are exercised through PPC RTK sign-off tuning profiles; hold-divergence and post-fix RMS rejection gates (`--max-hold-div`, `--max-postfix-rms`, PR #20/#22) cover most demo5 hold-stability concerns. The underlying `varholdamb`/`gainholdamb` semantics remain the one slice deferred — see `notes/` for rationale. | Useful when pushing harder on low-cost data without forking the solver |
 
 ## Important design difference
 


### PR DESCRIPTION
## Summary

README + benchmarks page were still on the pre-Phase-2 "precision-first equivalent-or-above" framing and only showed an UrbanNav-Odaiba table. With PR #19–#23 landed the real picture on production datasets is stronger — and the README is the first thing people read.

- Rewrite the **RTK Performance vs RTKLIB (demo5)** section in \`README.md\` with three tables:
  - **PPC Tokyo run1/2/3** — gnss++ default dominates Fix / Fix-rate / Hmed / Vp95 (42–56× Hmed, 29–179× Vp95).
  - **PPC Nagoya run1/2/3** — same preset, same picture (+1743/+1735/+154 Fix; 9×/10×/44× Hmed).
  - **UrbanNav Odaiba** — default dominates Fix / Hp95 / Vp95; the single demo5 edge (Hmed) closes to 9 cm with \`--enable-wide-lane-ar --wide-lane-threshold 0.10\`.
- Add a new **Phase 2 opt-in tuning gates** section documenting the five default-off flags from PR #19–#23 with a note on their byte-identical default behavior.
- Update the \`Benchmark Snapshot\` Odaiba detail block to current numbers (old \`11637 / 8241\`, \`Hmed 0.733 / 0.704\` snapshot is stale).
- Mirror the multi-dataset table into \`docs/benchmarks.md\`.
- \`docs/references/demo5-gap.md\`: note that the \`arfilter\` gap row now has \`--ar-policy demo5-continuous\` (PR #19) and the hold-tuning row is covered by \`--max-hold-div\` (PR #20) and \`--max-postfix-rms\` (PR #22).

## Reconciliation

All six PPC-Dataset numbers were regenerated on this branch's build (post-PR #27 \`develop\`) with \`apps/gnss.py ppc-demo --preset low-cost --match-tolerance-s 0.25 --max-epochs -1\`. Every row in the README / benchmarks.md tables matches the regenerated \`summary.json\` output:

| Run | Fixed | Rate | Hmed | Vp95 |
|---|---|---|---|---|
| Tokyo run1 | 3572 | 81.26% | 0.037 | 1.259 |
| Tokyo run2 | 4674 | 80.12% | 0.016 | 0.313 |
| Tokyo run3 | 7516 | 86.84% | 0.012 | 0.137 |
| Nagoya run1 | 3443 | 91.79% | 0.064 | — |
| Nagoya run2 | 2977 | 82.83% | 0.157 | — |
| Nagoya run3 | 643  | 64.04% | 0.122 | — |

UrbanNav-Odaiba numbers match \`output/benchmark/odaiba/default_vs_rtklib.json\` and \`wl010_vs_rtklib.json\` (both 2026-04-20).

## Touched

- \`README.md\`
- \`docs/benchmarks.md\`
- \`docs/references/demo5-gap.md\`

Not touched: \`docs/decisions.md\`, \`docs/architecture.md\`, \`docs/quickstart.md\`, \`docs/references/*-gap.md\` (other gap docs are per-reference analysis, not benchmark framing).

## Test plan

- [ ] CI \`Docs\` workflow builds (mkdocs)
- [ ] CI \`hygiene\` / \`changes\` pass
- [ ] No code changes, so no \`build-and-test\` impact expected