### PR TITLE
[codex] Add commercial receiver baseline to moving-base signoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,8 +272,8 @@ python3 apps/gnss.py sbf-info \
 | `gnss ppp-kinematic-signoff` | Kinematic PPP sign-off |
 | `gnss ppp-products-signoff` | Static, kinematic, or PPC PPP sign-off with fetched SP3/CLK/IONEX/DCB products, optional MALIB delta gates, and comparison CSV/PNG artifacts |
 | `gnss live-signoff` | Realtime/error-handling sign-off for recorded RTCM/UBX live inputs |
-| `gnss ppc-demo` | External PPC-Dataset RTK/PPP verification against `reference.csv` |
-| `gnss ppc-rtk-signoff` | Fixed RTK sign-off profiles for PPC Tokyo/Nagoya, with optional RTKLIB side-by-side gates |
+| `gnss ppc-demo` | External PPC-Dataset RTK/PPP verification against `reference.csv`, with optional RTKLIB/commercial receiver side-by-side summaries |
+| `gnss ppc-rtk-signoff` | Fixed RTK sign-off profiles for PPC Tokyo/Nagoya, with optional RTKLIB/commercial receiver side-by-side gates |
 | `gnss moving-base-signoff` | Real moving-base replay/live sign-off against per-epoch base/rover reference coordinates |
 | `gnss odaiba-benchmark` | End-to-end Odaiba benchmark pipeline |
 | `gnss web` | Local browser UI for summary JSON, live/moving-base/PPP-product sign-offs, `.pos` trajectories, moving-base/visibility plots and histories, receiver status, and artifact/provenance links |
@@ -439,6 +439,8 @@ python3 apps/gnss.py ppc-rtk-signoff \
   --dataset-root /datasets/PPC-Dataset \
   --city tokyo \
   --rtklib-bin /path/to/rnx2rtkp \
+  --commercial-pos /datasets/PPC-Dataset/tokyo/run1/commercial_receiver.csv \
+  --commercial-matched-csv output/ppc_tokyo_run1_commercial_matches.csv \
   --summary-json output/ppc_tokyo_run1_rtk_signoff.json
 ```
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ LIBGNSSPP_IMAGE=ghcr.io/rsasaki0109/gnssplusplus-library:v0.1.0 docker compose u
 - Raw/log tooling: `NMEA`, `NovAtel`, `SBP`, `SBF`, `Trimble`, `SkyTraq`, `BINEX`
 - Product tooling: `fetch-products`, `ionex-info`, `dcb-info`
 - Analysis tooling: `visibility`, `visibility-plot`, and `moving-base-plot` for az/el/SNR exports plus moving-base/visibility PNG quick-looks
-- Moving-base tooling: `moving-base-prepare` plus `moving-base-signoff` for real bag/replay/live validation
+- Moving-base tooling: `moving-base-prepare` plus `moving-base-signoff` for real bag/replay/live validation, including optional commercial receiver side-by-side summaries
 - One CLI entrypoint: `gnss spp`, `solve`, `ppp`, `visibility`, `stream`, `convert`, `live`, `rcv`
 - Local web UI: `gnss web` for benchmark snapshots, live/moving-base/PPP-product sign-offs, 2D trajectories, visibility views, artifact bundles, receiver status, and artifact links
 - Built-in sign-off scripts and checked-in benchmark artifacts
@@ -254,8 +254,8 @@ python3 apps/gnss.py sbf-info \
 | `gnss visibility-plot` | Render a visibility CSV into a polar/elevation PNG quick-look |
 | `gnss moving-base-plot` | Render a moving-base solution/reference pair into a baseline/heading PNG quick-look |
 | `gnss fetch-products` | Fetch and cache `SP3`/`CLK`/`IONEX`/`DCB` files from local or remote sources |
-| `gnss moving-base-prepare` | Extract rover/base UBX plus reference CSV from a ROS2 moving-base bag |
-| `gnss scorpion-moving-base-signoff` | Prepare and validate the public SCORPION moving-base ROS2 bag through replay |
+| `gnss moving-base-prepare` | Extract rover/base UBX, reference CSV, and optional receiver CSV from a ROS2 moving-base bag |
+| `gnss scorpion-moving-base-signoff` | Prepare and validate the public SCORPION moving-base ROS2 bag through replay with receiver side-by-side output |
 | `gnss stream` | Inspect and relay RTCM over file, NTRIP, TCP, or serial |
 | `gnss convert` | Convert RTCM or UBX into simple RINEX outputs |
 | `gnss ubx-info` | Inspect `NAV-PVT`, `RAWX`, `SFRBX` from file or serial |
@@ -316,6 +316,7 @@ python3 apps/gnss.py moving-base-prepare \
   --rover-ubx-out output/moving_base_rover.ubx \
   --base-ubx-out output/moving_base_base.ubx \
   --reference-csv output/moving_base_reference.csv \
+  --commercial-csv output/commercial_receiver_solution.csv \
   --summary-json output/moving_base_prepare.json
 
 python3 apps/gnss.py fetch-products \
@@ -336,7 +337,6 @@ python3 apps/gnss.py moving-base-signoff \
   --max-epochs 120
 
 python3 apps/gnss.py scorpion-moving-base-signoff \
-  --input-url https://zenodo.org/api/records/8083431/files/2023-06-14T174658Z.zip/content \
   --summary-json output/scorpion_moving_base_summary.json \
   --require-matched-epochs-min 100 \
   --require-fix-rate-min 80

--- a/apps/gnss.py
+++ b/apps/gnss.py
@@ -147,12 +147,12 @@ COMMANDS = {
     "scorpion-moving-base-signoff": {
         "kind": "python",
         "target": os.path.join(APPS_DIR, "gnss_scorpion_moving_base_signoff.py"),
-        "summary": "Prepare and validate the public SCORPION moving-base ROS2 bag through replay plus BRDC nav fetch.",
+        "summary": "Prepare and validate the public SCORPION moving-base ROS2 bag through replay plus receiver side-by-side output.",
     },
     "moving-base-prepare": {
         "kind": "python",
         "target": os.path.join(APPS_DIR, "gnss_moving_base_prepare.py"),
-        "summary": "Extract rover/base UBX files plus reference CSV from a ROS2 moving-base bag with u-blox topics.",
+        "summary": "Extract rover/base UBX files plus reference and optional receiver CSVs from a ROS2 moving-base bag.",
     },
     "moving-base-plot": {
         "kind": "python",

--- a/apps/gnss_moving_base_prepare.py
+++ b/apps/gnss_moving_base_prepare.py
@@ -48,6 +48,9 @@ class NavPvtSample:
     lat_deg: float
     lon_deg: float
     height_m: float
+    fix_type: int
+    flags: int
+    num_sv: int
 
 
 @dataclass
@@ -79,6 +82,12 @@ def parse_args() -> argparse.Namespace:
         type=Path,
         default=ROOT_DIR / "output/moving_base_reference.csv",
         help="Output reference CSV for gnss moving-base-signoff.",
+    )
+    parser.add_argument(
+        "--commercial-csv",
+        type=Path,
+        default=None,
+        help="Optional normalized commercial receiver solution CSV from rover NAV-PVT.",
     )
     parser.add_argument(
         "--summary-json",
@@ -261,6 +270,9 @@ def navpvt_sample(message: object) -> NavPvtSample:
         lat_deg=float(message.lat) * 1e-7,
         lon_deg=float(message.lon) * 1e-7,
         height_m=float(message.height) * 1e-3,
+        fix_type=int(message.fix_type),
+        flags=int(message.flags),
+        num_sv=int(message.num_sv),
     )
 
 
@@ -327,7 +339,19 @@ class PreparedBag:
             self._temp_dir = None
 
 
-def collect_messages(args: argparse.Namespace, bag_dir: Path) -> tuple[bytes, bytes, list[RawxEpoch], list[NavPvtSample], list[NavRelPosSample], dict[str, int], str | None]:
+def collect_messages(
+    args: argparse.Namespace,
+    bag_dir: Path,
+) -> tuple[
+    bytes,
+    bytes,
+    list[RawxEpoch],
+    list[NavPvtSample],
+    list[NavPvtSample],
+    list[NavRelPosSample],
+    dict[str, int],
+    str | None,
+]:
     reader = rosbag2_py.SequentialReader()
     reader.open(
         rosbag2_py.StorageOptions(uri=str(bag_dir), storage_id="sqlite3"),
@@ -351,6 +375,7 @@ def collect_messages(args: argparse.Namespace, bag_dir: Path) -> tuple[bytes, by
     rover_frames = bytearray()
     base_frames = bytearray()
     rover_epochs: list[RawxEpoch] = []
+    rover_nav: list[NavPvtSample] = []
     base_nav: list[NavPvtSample] = []
     relpos: list[NavRelPosSample] = []
     date_text: str | None = None
@@ -372,6 +397,7 @@ def collect_messages(args: argparse.Namespace, bag_dir: Path) -> tuple[bytes, by
         if topic == args.rover_navpvt_topic:
             rover_frames.extend(pack_nav_pvt(message))
             sample = navpvt_sample(message)
+            rover_nav.append(sample)
             if date_text is None:
                 date_text = f"{sample.year:04d}-{sample.month:02d}-{sample.day:02d}"
         elif topic == args.base_navpvt_topic:
@@ -392,11 +418,81 @@ def collect_messages(args: argparse.Namespace, bag_dir: Path) -> tuple[bytes, by
 
     if not rover_epochs:
         raise SystemExit(f"No RAWX epochs found on {args.rover_rawx_topic}")
+    if not rover_nav:
+        raise SystemExit(f"No NavPVT messages found on {args.rover_navpvt_topic}")
     if not base_nav:
         raise SystemExit(f"No NavPVT messages found on {args.base_navpvt_topic}")
     if not relpos:
         raise SystemExit(f"No NavRELPOSNED messages found on {args.rover_relpos_topic}")
-    return bytes(rover_frames), bytes(base_frames), rover_epochs, base_nav, relpos, counts, date_text
+    return bytes(rover_frames), bytes(base_frames), rover_epochs, rover_nav, base_nav, relpos, counts, date_text
+
+
+def navpvt_solution_status(sample: NavPvtSample) -> str:
+    carrier_solution = (sample.flags >> 6) & 0x03
+    if sample.fix_type >= 3 and carrier_solution == 2:
+        return "rtk_fixed"
+    if sample.fix_type >= 3 and carrier_solution == 1:
+        return "rtk_float"
+    if sample.fix_type >= 3 and sample.flags & 0x02:
+        return "dgnss"
+    if sample.fix_type >= 2:
+        return "single"
+    return "invalid"
+
+
+def write_commercial_receiver_csv(
+    rover_epochs: list[RawxEpoch],
+    rover_nav: list[NavPvtSample],
+    tolerance_ms: int,
+    output_path: Path,
+) -> dict[str, object]:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    matched_rows = 0
+    skipped_no_rover_nav = 0
+    with output_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(
+            [
+                "gps_week",
+                "gps_tow_s",
+                "lat_deg",
+                "lon_deg",
+                "height_m",
+                "solution_status",
+                "num_satellites",
+                "navpvt_fix_type",
+                "navpvt_flags",
+            ]
+        )
+        for epoch in rover_epochs:
+            target_i_tow_ms = int(round(epoch.tow_s * 1000.0))
+            nav_index = nearest_sample_index(rover_nav, target_i_tow_ms, tolerance_ms, lambda item: item.i_tow_ms)
+            if nav_index is None:
+                skipped_no_rover_nav += 1
+                continue
+            sample = rover_nav[nav_index]
+            writer.writerow(
+                [
+                    epoch.week,
+                    f"{epoch.tow_s:.3f}",
+                    f"{sample.lat_deg:.10f}",
+                    f"{sample.lon_deg:.10f}",
+                    f"{sample.height_m:.4f}",
+                    navpvt_solution_status(sample),
+                    sample.num_sv,
+                    sample.fix_type,
+                    f"0x{sample.flags:02X}",
+                ]
+            )
+            matched_rows += 1
+
+    if matched_rows == 0:
+        raise SystemExit("Failed to match rover RAWX epochs to rover NavPVT commercial receiver rows")
+    return {
+        "commercial_receiver_csv": str(output_path),
+        "matched_commercial_receiver_rows": matched_rows,
+        "skipped_missing_rover_nav": skipped_no_rover_nav,
+    }
 
 
 def write_reference_csv(
@@ -476,7 +572,10 @@ def main() -> int:
     ensure_input_exists(args.input)
     prepared_bag = PreparedBag(args.input)
     try:
-        rover_frames, base_frames, rover_epochs, base_nav, relpos, counts, date_text = collect_messages(args, prepared_bag.bag_dir)
+        rover_frames, base_frames, rover_epochs, rover_nav, base_nav, relpos, counts, date_text = collect_messages(
+            args,
+            prepared_bag.bag_dir,
+        )
     finally:
         prepared_bag.close()
 
@@ -492,6 +591,14 @@ def main() -> int:
         args.match_tolerance_ms,
         args.reference_csv,
     )
+    commercial_metrics: dict[str, object] = {}
+    if args.commercial_csv is not None:
+        commercial_metrics = write_commercial_receiver_csv(
+            rover_epochs,
+            rover_nav,
+            args.match_tolerance_ms,
+            args.commercial_csv,
+        )
 
     summary = {
         "input": str(args.input),
@@ -507,6 +614,7 @@ def main() -> int:
         "base_ubx_bytes": len(base_frames),
         "topics": counts,
         **reference_metrics,
+        **commercial_metrics,
     }
     args.summary_json.parent.mkdir(parents=True, exist_ok=True)
     args.summary_json.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -516,6 +624,8 @@ def main() -> int:
         print(f"  rover_ubx: {args.rover_ubx_out}")
         print(f"  base_ubx: {args.base_ubx_out}")
         print(f"  reference_csv: {args.reference_csv}")
+        if args.commercial_csv is not None:
+            print(f"  commercial_csv: {args.commercial_csv}")
         print(f"  summary_json: {args.summary_json}")
         print(f"  rover_epochs: {summary['rover_epochs']}")
         print(f"  matched_reference_rows: {summary['matched_reference_rows']}")

--- a/apps/gnss_moving_base_signoff.py
+++ b/apps/gnss_moving_base_signoff.py
@@ -57,6 +57,32 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--plot-png", type=Path, default=None)
     parser.add_argument("--plot-title", default="Moving-base sign-off")
     parser.add_argument("--log-out", type=Path, default=None)
+    parser.add_argument(
+        "--commercial-pos",
+        type=Path,
+        default=None,
+        help=(
+            "Optional commercial receiver solution, as libgnss .pos or normalized CSV, "
+            "to summarize against the same reference."
+        ),
+    )
+    parser.add_argument(
+        "--commercial-format",
+        choices=("auto", "pos", "csv"),
+        default="auto",
+        help="Commercial receiver solution format (default: auto from suffix).",
+    )
+    parser.add_argument(
+        "--commercial-label",
+        default="commercial_receiver",
+        help="Label stored in the commercial receiver summary.",
+    )
+    parser.add_argument(
+        "--commercial-matched-csv",
+        type=Path,
+        default=None,
+        help="Optional CSV of commercial receiver epochs matched to the reference.",
+    )
     parser.add_argument("--max-epochs", type=int, default=120)
     parser.add_argument("--match-tolerance-s", type=float, default=0.25)
     parser.add_argument("--use-existing-solution", action="store_true")
@@ -169,6 +195,150 @@ def read_pos_records(path: Path) -> list[dict[str, float | int]]:
                 }
             )
     return records
+
+
+def parse_solution_status(token: str | None) -> int:
+    if token is None or token == "":
+        return 0
+    try:
+        return int(float(token))
+    except ValueError:
+        normalized = normalize_field(token)
+    if normalized in {"fix", "fixed", "rtkfix", "rtkfixed", "integer", "integerfix"}:
+        return 4
+    if normalized in {"float", "rtkfloat", "rtkflt"}:
+        return 3
+    if normalized in {"dgps", "dgnss", "differential"}:
+        return 2
+    if normalized in {"single", "spp", "standalone"}:
+        return 1
+    return 0
+
+
+def read_commercial_csv_records(path: Path) -> list[dict[str, float | int]]:
+    records: list[dict[str, float | int]] = []
+    with path.open(encoding="utf-8", newline="") as handle:
+        reader = csv.DictReader(handle)
+        for row in reader:
+            week_token = get_token(row, "gps_week", "week")
+            tow_token = get_token(row, "gps_tow_s", "tow_s", "tow", "gpstow")
+            if week_token is None or tow_token is None:
+                raise SystemExit(
+                    f"{path} must contain gps_week/week and gps_tow_s/tow columns"
+                )
+
+            x_token = get_token(
+                row,
+                "ecef_x_m",
+                "x_m",
+                "x",
+                "rover_ecef_x_m",
+                "rover_x_m",
+                "rover_x",
+            )
+            y_token = get_token(
+                row,
+                "ecef_y_m",
+                "y_m",
+                "y",
+                "rover_ecef_y_m",
+                "rover_y_m",
+                "rover_y",
+            )
+            z_token = get_token(
+                row,
+                "ecef_z_m",
+                "z_m",
+                "z",
+                "rover_ecef_z_m",
+                "rover_z_m",
+                "rover_z",
+            )
+            if x_token is not None and y_token is not None and z_token is not None:
+                x, y, z = float(x_token), float(y_token), float(z_token)
+            else:
+                lat_token = get_token(
+                    row,
+                    "lat_deg",
+                    "latitude_deg",
+                    "lat",
+                    "rover_lat_deg",
+                    "rover_lat",
+                )
+                lon_token = get_token(
+                    row,
+                    "lon_deg",
+                    "longitude_deg",
+                    "lon",
+                    "rover_lon_deg",
+                    "rover_lon",
+                )
+                h_token = get_token(
+                    row,
+                    "height_m",
+                    "h_m",
+                    "height",
+                    "ellipsoid_height_m",
+                    "rover_height_m",
+                    "rover_h_m",
+                    "rover_height",
+                )
+                if lat_token is None or lon_token is None or h_token is None:
+                    raise SystemExit(
+                        f"{path} must contain ECEF x/y/z or lat/lon/height columns"
+                    )
+                x, y, z = geodetic_to_ecef(float(lat_token), float(lon_token), float(h_token))
+
+            status = parse_solution_status(
+                get_token(
+                    row,
+                    "status",
+                    "quality",
+                    "quality_status",
+                    "fix_type",
+                    "solution_status",
+                )
+            )
+            satellites_token = get_token(
+                row,
+                "satellites",
+                "num_satellites",
+                "ns",
+                "n_sats",
+                "sats",
+            )
+            satellites = int(float(satellites_token)) if satellites_token not in (None, "") else 0
+            records.append(
+                {
+                    "week": int(float(week_token)),
+                    "tow": float(tow_token),
+                    "x": x,
+                    "y": y,
+                    "z": z,
+                    "status": status,
+                    "satellites": satellites,
+                }
+            )
+    records.sort(key=lambda item: (int(item["week"]), float(item["tow"])))
+    return records
+
+
+def resolve_commercial_format(path: Path, requested_format: str) -> str:
+    if requested_format != "auto":
+        return requested_format
+    return "pos" if path.suffix.lower() == ".pos" else "csv"
+
+
+def read_commercial_solution_records(
+    path: Path,
+    requested_format: str,
+) -> tuple[list[dict[str, float | int]], str]:
+    resolved_format = resolve_commercial_format(path, requested_format)
+    if resolved_format == "pos":
+        return read_pos_records(path), resolved_format
+    if resolved_format == "csv":
+        return read_commercial_csv_records(path), resolved_format
+    raise SystemExit(f"Unsupported commercial receiver solution format: {requested_format}")
 
 
 def read_reference_rows(path: Path) -> list[dict[str, float]]:
@@ -361,6 +531,94 @@ def write_matches_csv(path: Path, matches: list[dict[str, float]]) -> None:
             )
 
 
+def summarize_solution_quality(
+    solution_records: list[dict[str, float | int]],
+    matches: list[dict[str, float]],
+) -> dict[str, object]:
+    heading_errors = [
+        float(match["heading_error_deg"])
+        for match in matches
+        if match["heading_error_deg"] is not None
+    ]
+    baseline_errors = [float(match["baseline_error_m"]) for match in matches]
+    baseline_lengths = [float(match["baseline_length_m"]) for match in matches]
+    valid_epochs = len(solution_records)
+    fixed_epochs = sum(1 for record in solution_records if int(record["status"]) == 4)
+    return {
+        "epochs": valid_epochs,
+        "valid_epochs": valid_epochs,
+        "matched_epochs": len(matches),
+        "fixed_epochs": fixed_epochs,
+        "fix_rate_pct": rounded(100.0 * fixed_epochs / valid_epochs) if valid_epochs else 0.0,
+        "median_baseline_error_m": (
+            rounded(percentile(baseline_errors, 0.5)) if baseline_errors else None
+        ),
+        "p95_baseline_error_m": (
+            rounded(percentile(baseline_errors, 0.95)) if baseline_errors else None
+        ),
+        "max_baseline_error_m": rounded(max(baseline_errors)) if baseline_errors else None,
+        "mean_baseline_length_m": (
+            rounded(sum(baseline_lengths) / len(baseline_lengths)) if baseline_lengths else None
+        ),
+        "heading_samples": len(heading_errors),
+        "median_heading_error_deg": (
+            rounded(percentile(heading_errors, 0.5)) if heading_errors else None
+        ),
+        "p95_heading_error_deg": (
+            rounded(percentile(heading_errors, 0.95)) if heading_errors else None
+        ),
+        "max_heading_error_deg": rounded(max(heading_errors)) if heading_errors else None,
+    }
+
+
+def build_commercial_summary(
+    args: argparse.Namespace,
+    records: list[dict[str, float | int]],
+    matches: list[dict[str, float]],
+    resolved_format: str,
+) -> dict[str, object]:
+    summary = summarize_solution_quality(records, matches)
+    summary.update(
+        {
+            "label": args.commercial_label,
+            "solution_pos": str(args.commercial_pos),
+            "format": resolved_format,
+            "matched_csv": (
+                str(args.commercial_matched_csv)
+                if args.commercial_matched_csv is not None
+                else None
+            ),
+        }
+    )
+    return summary
+
+
+def build_commercial_delta(
+    lib_summary: dict[str, object],
+    commercial_summary: dict[str, object],
+) -> dict[str, object]:
+    def optional_delta(key: str) -> float | None:
+        left = lib_summary.get(key)
+        right = commercial_summary.get(key)
+        if left is None or right is None:
+            return None
+        return rounded(float(left) - float(right))
+
+    return {
+        "fixed_epochs_delta": (
+            int(lib_summary["fixed_epochs"]) - int(commercial_summary["fixed_epochs"])
+        ),
+        "matched_epochs_delta": (
+            int(lib_summary["matched_epochs"]) - int(commercial_summary["matched_epochs"])
+        ),
+        "fix_rate_pct_delta": optional_delta("fix_rate_pct"),
+        "median_baseline_error_m_delta": optional_delta("median_baseline_error_m"),
+        "p95_baseline_error_m_delta": optional_delta("p95_baseline_error_m"),
+        "max_baseline_error_m_delta": optional_delta("max_baseline_error_m"),
+        "p95_heading_error_deg_delta": optional_delta("p95_heading_error_deg"),
+    }
+
+
 def build_solver_command(args: argparse.Namespace) -> list[str]:
     command = [*resolve_gnss_command(ROOT_DIR), args.solver]
     if args.solver == "replay":
@@ -429,16 +687,10 @@ def build_summary_payload(
     stdout_text: str,
     stderr_text: str,
     exit_code: int | None,
+    commercial_summary: dict[str, object] | None,
 ) -> dict[str, object]:
-    heading_errors = [
-        float(match["heading_error_deg"])
-        for match in matches
-        if match["heading_error_deg"] is not None
-    ]
-    baseline_errors = [float(match["baseline_error_m"]) for match in matches]
-    baseline_lengths = [float(match["baseline_length_m"]) for match in matches]
+    lib_summary = summarize_solution_quality(solution_records, matches)
     valid_epochs = len(solution_records)
-    fixed_epochs = sum(1 for record in solution_records if int(record["status"]) == 4)
     solution_span_s = 0.0
     if solution_records:
         first = solution_records[0]
@@ -472,19 +724,6 @@ def build_summary_payload(
         "log_out": str(args.log_out) if args.log_out is not None else None,
         "use_existing_solution": bool(args.use_existing_solution),
         "match_tolerance_s": rounded(args.match_tolerance_s),
-        "epochs": valid_epochs,
-        "valid_epochs": valid_epochs,
-        "matched_epochs": len(matches),
-        "fixed_epochs": fixed_epochs,
-        "fix_rate_pct": rounded(100.0 * fixed_epochs / valid_epochs) if valid_epochs else 0.0,
-        "median_baseline_error_m": rounded(percentile(baseline_errors, 0.5)) if baseline_errors else None,
-        "p95_baseline_error_m": rounded(percentile(baseline_errors, 0.95)) if baseline_errors else None,
-        "max_baseline_error_m": rounded(max(baseline_errors)) if baseline_errors else None,
-        "mean_baseline_length_m": rounded(sum(baseline_lengths) / len(baseline_lengths)) if baseline_lengths else None,
-        "heading_samples": len(heading_errors),
-        "median_heading_error_deg": rounded(percentile(heading_errors, 0.5)) if heading_errors else None,
-        "p95_heading_error_deg": rounded(percentile(heading_errors, 0.95)) if heading_errors else None,
-        "max_heading_error_deg": rounded(max(heading_errors)) if heading_errors else None,
         "solution_span_s": rounded(solution_span_s),
         "solver_wall_time_s": rounded(effective_wall_time_s),
         "realtime_factor": rounded(realtime_factor),
@@ -495,6 +734,13 @@ def build_summary_payload(
         "plot_png": str(args.plot_png) if args.plot_png is not None else None,
         "matched_csv": str(args.matched_csv) if args.matched_csv is not None else None,
     }
+    payload.update(lib_summary)
+    if commercial_summary is not None:
+        payload["commercial_receiver"] = commercial_summary
+        payload["libgnss_vs_commercial_receiver"] = build_commercial_delta(
+            lib_summary,
+            commercial_summary,
+        )
     if solver_metrics is not None:
         payload["solver_metrics"] = solver_metrics
         for key in (
@@ -562,6 +808,10 @@ def enforce_requirements(payload: dict[str, object], args: argparse.Namespace) -
 def main() -> int:
     args = parse_args()
     ensure_input_exists(args.reference_csv, "moving-base reference CSV", ROOT_DIR)
+    if args.commercial_pos is not None:
+        ensure_input_exists(args.commercial_pos, "commercial receiver solution", ROOT_DIR)
+    elif args.commercial_matched_csv is not None:
+        raise SystemExit("--commercial-matched-csv requires --commercial-pos")
     if args.use_existing_solution:
         ensure_input_exists(args.out, "existing moving-base solution", ROOT_DIR)
 
@@ -607,6 +857,27 @@ def main() -> int:
     matches = match_solution_to_reference(solution_records, reference_rows, args.match_tolerance_s)
     if args.matched_csv is not None:
         write_matches_csv(args.matched_csv, matches)
+    commercial_summary = None
+    if args.commercial_pos is not None:
+        commercial_records, commercial_format = read_commercial_solution_records(
+            args.commercial_pos,
+            args.commercial_format,
+        )
+        if not commercial_records:
+            raise SystemExit(f"No commercial receiver epochs found in {args.commercial_pos}")
+        commercial_matches = match_solution_to_reference(
+            commercial_records,
+            reference_rows,
+            args.match_tolerance_s,
+        )
+        if args.commercial_matched_csv is not None:
+            write_matches_csv(args.commercial_matched_csv, commercial_matches)
+        commercial_summary = build_commercial_summary(
+            args,
+            commercial_records,
+            commercial_matches,
+            commercial_format,
+        )
     payload = build_summary_payload(
         args,
         solution_records,
@@ -616,6 +887,7 @@ def main() -> int:
         stdout_text,
         stderr_text,
         exit_code,
+        commercial_summary,
     )
     if args.plot_png is not None:
         from gnss_moving_base_plot import render_matches_plot
@@ -631,6 +903,8 @@ def main() -> int:
         print(f"  plot: {args.plot_png}")
     if args.matched_csv is not None:
         print(f"  matched_csv: {args.matched_csv}")
+    if args.commercial_pos is not None:
+        print(f"  commercial_receiver: {args.commercial_pos}")
     print(f"  matched_epochs: {payload['matched_epochs']}")
     print(f"  fix_rate_pct: {payload['fix_rate_pct']}")
     print(f"  p95_baseline_error_m: {payload['p95_baseline_error_m']}")

--- a/apps/gnss_ppc_demo.py
+++ b/apps/gnss_ppc_demo.py
@@ -27,6 +27,7 @@ WGS84_E2 = 6.69437999014e-3
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 import generate_driving_comparison as comparison  # noqa: E402
+import gnss_moving_base_signoff as moving_base_signoff  # noqa: E402
 
 
 def parse_args() -> argparse.Namespace:
@@ -161,6 +162,38 @@ def parse_args() -> argparse.Namespace:
         type=float,
         default=None,
         help="Optional RTKLIB wall time in seconds. If omitted, actual runtime is recorded when RTKLIB is executed.",
+    )
+    parser.add_argument(
+        "--commercial-pos",
+        type=Path,
+        default=None,
+        help=(
+            "Optional commercial receiver solution, as libgnss .pos or normalized CSV, "
+            "to summarize against the PPC reference."
+        ),
+    )
+    parser.add_argument(
+        "--commercial-format",
+        choices=("auto", "pos", "csv"),
+        default="auto",
+        help="Commercial receiver solution format (default: auto from suffix).",
+    )
+    parser.add_argument(
+        "--commercial-label",
+        default="commercial_receiver",
+        help="Label stored in the commercial receiver summary.",
+    )
+    parser.add_argument(
+        "--commercial-matched-csv",
+        type=Path,
+        default=None,
+        help="Optional CSV of commercial receiver epochs matched to the PPC reference.",
+    )
+    parser.add_argument(
+        "--commercial-solver-wall-time-s",
+        type=float,
+        default=None,
+        help="Optional commercial receiver wall time in seconds for realtime metrics.",
     )
     parser.add_argument(
         "--enable-ar",
@@ -462,6 +495,99 @@ def summarize_solution_epochs(
     return payload
 
 
+def read_commercial_solution_epochs(
+    path: Path,
+    requested_format: str,
+) -> tuple[list[comparison.SolutionEpoch], str]:
+    records, resolved_format = moving_base_signoff.read_commercial_solution_records(
+        path,
+        requested_format,
+    )
+    epochs: list[comparison.SolutionEpoch] = []
+    for record in records:
+        x = float(record["x"])
+        y = float(record["y"])
+        z = float(record["z"])
+        lat_deg, lon_deg, height_m = llh_from_ecef(x, y, z)
+        ecef = comparison.llh_to_ecef(lat_deg, lon_deg, height_m)
+        epochs.append(
+            comparison.SolutionEpoch(
+                week=int(record["week"]),
+                tow=float(record["tow"]),
+                lat_deg=lat_deg,
+                lon_deg=lon_deg,
+                height_m=height_m,
+                ecef=ecef,
+                status=int(record["status"]),
+                num_satellites=int(record["satellites"]),
+            )
+        )
+    return epochs, resolved_format
+
+
+def write_reference_matches_csv(
+    path: Path,
+    matches: list[comparison.MatchedEpoch],
+) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(
+            [
+                "gps_tow_s",
+                "traj_east_m",
+                "traj_north_m",
+                "traj_up_m",
+                "east_error_m",
+                "north_error_m",
+                "up_error_m",
+                "horizontal_error_m",
+                "status",
+            ]
+        )
+        for match in matches:
+            writer.writerow(
+                [
+                    f"{match.tow:.3f}",
+                    f"{match.traj_east_m:.6f}",
+                    f"{match.traj_north_m:.6f}",
+                    f"{match.traj_up_m:.6f}",
+                    f"{match.east_m:.6f}",
+                    f"{match.north_m:.6f}",
+                    f"{match.up_m:.6f}",
+                    f"{match.horiz_error_m:.6f}",
+                    int(match.status),
+                ]
+            )
+
+
+def solution_metric_delta(
+    left: dict[str, object],
+    right: dict[str, object],
+) -> dict[str, object]:
+    def optional_delta(key: str) -> float | None:
+        left_value = left.get(key)
+        right_value = right.get(key)
+        if left_value is None or right_value is None:
+            return None
+        return rounded(float(left_value) - float(right_value))
+
+    return {
+        "valid_epochs": int(left["valid_epochs"]) - int(right["valid_epochs"]),
+        "matched_epochs": int(left["matched_epochs"]) - int(right["matched_epochs"]),
+        "fixed_epochs": int(left["fixed_epochs"]) - int(right["fixed_epochs"]),
+        "fix_rate_pct": optional_delta("fix_rate_pct"),
+        "mean_h_m": optional_delta("mean_h_m"),
+        "median_h_m": optional_delta("median_h_m"),
+        "p95_h_m": optional_delta("p95_h_m"),
+        "max_h_m": optional_delta("max_h_m"),
+        "median_abs_up_m": optional_delta("median_abs_up_m"),
+        "p95_abs_up_m": optional_delta("p95_abs_up_m"),
+        "solver_wall_time_s": optional_delta("solver_wall_time_s"),
+        "realtime_factor": optional_delta("realtime_factor"),
+    }
+
+
 def resolve_run_dir(args: argparse.Namespace) -> Path:
     if args.run_dir is not None:
         return args.run_dir
@@ -674,6 +800,44 @@ def build_summary_payload(
             ),
         }
 
+    commercial_pos = getattr(args, "commercial_pos", None)
+    if commercial_pos is not None and Path(commercial_pos).exists():
+        commercial_epochs, commercial_format = read_commercial_solution_epochs(
+            Path(commercial_pos),
+            getattr(args, "commercial_format", "auto"),
+        )
+        commercial_metrics = summarize_solution_epochs(
+            reference,
+            commercial_epochs,
+            4,
+            getattr(args, "commercial_label", "commercial_receiver"),
+            args.match_tolerance_s,
+            getattr(args, "commercial_solver_wall_time_s", None),
+        )
+        commercial_matched_csv = getattr(args, "commercial_matched_csv", None)
+        if commercial_matched_csv is not None:
+            commercial_matches = comparison.match_to_reference(
+                commercial_epochs,
+                reference,
+                args.match_tolerance_s,
+            )
+            write_reference_matches_csv(Path(commercial_matched_csv), commercial_matches)
+        commercial_metrics.update(
+            {
+                "label": getattr(args, "commercial_label", "commercial_receiver"),
+                "solution_pos": str(commercial_pos),
+                "format": commercial_format,
+                "matched_csv": (
+                    str(commercial_matched_csv) if commercial_matched_csv is not None else None
+                ),
+            }
+        )
+        payload["commercial_receiver"] = commercial_metrics
+        payload["delta_vs_commercial_receiver"] = solution_metric_delta(
+            payload,
+            commercial_metrics,
+        )
+
     summary_json.parent.mkdir(parents=True, exist_ok=True)
     summary_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     return payload
@@ -809,6 +973,10 @@ def main() -> int:
         args.rtklib_pos = rtklib_pos
 
     ensure_input_exists(reference_csv, "PPC reference CSV", ROOT_DIR)
+    if args.commercial_pos is not None:
+        ensure_input_exists(args.commercial_pos, "commercial receiver solution", ROOT_DIR)
+    elif args.commercial_matched_csv is not None:
+        raise SystemExit("--commercial-matched-csv requires --commercial-pos")
     if args.max_epochs == 0:
         raise SystemExit("--max-epochs must be positive or -1")
 
@@ -901,6 +1069,14 @@ def main() -> int:
             f" fix={payload['delta_vs_rtklib']['fix_rate_pct']} %"
             f", p95_h={payload['delta_vs_rtklib']['p95_h_m']} m"
             f", wall={payload['delta_vs_rtklib']['solver_wall_time_s']} s"
+        )
+    if "commercial_receiver" in payload:
+        commercial = payload["commercial_receiver"]
+        print(f"  commercial_receiver: {commercial['solution_pos']}")
+        print(
+            "  vs commercial_receiver:"
+            f" fix={payload['delta_vs_commercial_receiver']['fix_rate_pct']} %"
+            f", p95_h={payload['delta_vs_commercial_receiver']['p95_h_m']} m"
         )
     return 0
 

--- a/apps/gnss_ppc_rtk_signoff.py
+++ b/apps/gnss_ppc_rtk_signoff.py
@@ -110,6 +110,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--rtklib-pos", type=Path, default=None)
     parser.add_argument("--use-existing-rtklib-solution", action="store_true")
     parser.add_argument("--rtklib-solver-wall-time-s", type=float, default=None)
+    parser.add_argument("--commercial-pos", type=Path, default=None)
+    parser.add_argument("--commercial-format", choices=("auto", "pos", "csv"), default="auto")
+    parser.add_argument("--commercial-label", default="commercial_receiver")
+    parser.add_argument("--commercial-matched-csv", type=Path, default=None)
+    parser.add_argument("--commercial-solver-wall-time-s", type=float, default=None)
     parser.add_argument("--match-tolerance-s", type=float, default=0.25)
     parser.add_argument("--preset", choices=("survey", "low-cost", "moving-base"), default=None)
     parser.add_argument("--arfilter", dest="arfilter", action="store_true")
@@ -222,6 +227,21 @@ def build_ppc_demo_command(args: argparse.Namespace,
         command.append("--use-existing-rtklib-solution")
     if args.rtklib_solver_wall_time_s is not None:
         command.extend(["--rtklib-solver-wall-time-s", str(args.rtklib_solver_wall_time_s)])
+    if args.commercial_pos is not None:
+        command.extend(
+            [
+                "--commercial-pos",
+                str(args.commercial_pos),
+                "--commercial-format",
+                args.commercial_format,
+                "--commercial-label",
+                args.commercial_label,
+            ]
+        )
+    if args.commercial_matched_csv is not None:
+        command.extend(["--commercial-matched-csv", str(args.commercial_matched_csv)])
+    if args.commercial_solver_wall_time_s is not None:
+        command.extend(["--commercial-solver-wall-time-s", str(args.commercial_solver_wall_time_s)])
 
     preset = tuning.get("preset")
     if isinstance(preset, str):
@@ -270,6 +290,10 @@ def main() -> int:
         ensure_input_exists(out, "existing PPC RTK solution", ROOT_DIR)
     if args.use_existing_rtklib_solution and args.rtklib_pos is not None:
         ensure_input_exists(args.rtklib_pos, "existing RTKLIB solution", ROOT_DIR)
+    if args.commercial_pos is not None:
+        ensure_input_exists(args.commercial_pos, "commercial receiver solution", ROOT_DIR)
+    elif args.commercial_matched_csv is not None:
+        raise SystemExit("--commercial-matched-csv requires --commercial-pos")
 
     thresholds = selected_thresholds(
         args,
@@ -287,6 +311,7 @@ def main() -> int:
     payload["signoff_thresholds"] = thresholds
     payload["tuning_profile"] = tuning
     payload["rtklib_comparison_enabled"] = "delta_vs_rtklib" in payload
+    payload["commercial_receiver_comparison_enabled"] = "delta_vs_commercial_receiver" in payload
     summary_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
     print("Finished PPC RTK sign-off.")

--- a/apps/gnss_scorpion_moving_base_signoff.py
+++ b/apps/gnss_scorpion_moving_base_signoff.py
@@ -29,8 +29,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--input", type=Path, default=None, help="Local SCORPION bag directory or zip path.")
     parser.add_argument(
         "--input-url",
-        default=None,
-        help="Optional SCORPION zip URL. If omitted, a local --input is required.",
+        default=DEFAULT_SCORPION_ZIP_URL,
+        help="Optional SCORPION zip URL. Defaults to the public Zenodo SCORPION bag.",
     )
     parser.add_argument(
         "--download-cache-dir",
@@ -86,7 +86,9 @@ def resolve_output_paths(args: argparse.Namespace) -> dict[str, Path]:
         "rover_ubx": work_dir / "rover.ubx",
         "base_ubx": work_dir / "base.ubx",
         "reference_csv": work_dir / "reference.csv",
+        "commercial_csv": work_dir / "commercial_receiver_solution.csv",
         "matched_csv": work_dir / "scorpion_moving_base_matches.csv",
+        "commercial_matched_csv": work_dir / "commercial_receiver_matches.csv",
         "prepare_summary_json": work_dir / "prepare_summary.json",
         "products_summary_json": work_dir / "products_summary.json",
         "plot_png": work_dir / "scorpion_moving_base.png",
@@ -104,13 +106,24 @@ def ensure_local_input(args: argparse.Namespace) -> tuple[Path, str | None]:
         raise SystemExit("Provide --input or --input-url for scorpion-moving-base-signoff")
 
     args.download_cache_dir.mkdir(parents=True, exist_ok=True)
-    parsed = parse.urlparse(args.input_url)
-    filename = Path(parsed.path).name or "scorpion_moving_base.zip"
+    filename = download_cache_filename(args.input_url)
     destination = args.download_cache_dir / filename
     if not destination.exists():
         with request.urlopen(args.input_url, timeout=60.0) as response, destination.open("wb") as handle:
             handle.write(response.read())
     return destination, args.input_url
+
+
+def download_cache_filename(url: str) -> str:
+    parsed = parse.urlparse(url)
+    path_parts = [parse.unquote(part) for part in parsed.path.split("/") if part]
+    for part in reversed(path_parts):
+        if part.lower().endswith(".zip"):
+            return Path(part).name
+    filename = Path(path_parts[-1]).name if path_parts else ""
+    if filename.lower().endswith(".zip"):
+        return filename
+    return "scorpion_moving_base.zip"
 
 
 def run_json_command(command: list[str]) -> dict[str, object]:
@@ -194,6 +207,15 @@ def build_signoff_command(
         command.extend(["--nav-rinex", str(nav_rinex)])
     if args.log_out is not None:
         command.extend(["--log-out", str(args.log_out)])
+    if paths["commercial_csv"].exists():
+        command.extend(
+            [
+                "--commercial-pos",
+                str(paths["commercial_csv"]),
+                "--commercial-matched-csv",
+                str(paths["commercial_matched_csv"]),
+            ]
+        )
     if args.use_existing_solution:
         command.append("--use-existing-solution")
     if args.solver_wall_time_s is not None:
@@ -240,6 +262,8 @@ def main() -> int:
         str(paths["base_ubx"]),
         "--reference-csv",
         str(paths["reference_csv"]),
+        "--commercial-csv",
+        str(paths["commercial_csv"]),
         "--summary-json",
         str(paths["prepare_summary_json"]),
         "--max-epochs",
@@ -280,6 +304,12 @@ def main() -> int:
         str(paths["products_summary_json"]) if paths["products_summary_json"].exists() else None
     )
     summary_payload["matched_csv"] = str(paths["matched_csv"]) if paths["matched_csv"].exists() else None
+    summary_payload["commercial_receiver_csv"] = (
+        str(paths["commercial_csv"]) if paths["commercial_csv"].exists() else None
+    )
+    summary_payload["commercial_receiver_matched_csv"] = (
+        str(paths["commercial_matched_csv"]) if paths["commercial_matched_csv"].exists() else None
+    )
     summary_payload["plot_png"] = str(paths["plot_png"]) if paths["plot_png"].exists() else None
     summary_payload["prepare_summary"] = prepare_payload
     summary_payload["products_summary"] = products_payload

--- a/configs/moving_base_signoff.example.toml
+++ b/configs/moving_base_signoff.example.toml
@@ -9,6 +9,11 @@ summary_json = "output/moving_base_summary.json"
 matched_csv = "output/moving_base_matches.csv"
 plot_png = "output/moving_base_plot.png"
 plot_title = "Moving-base sign-off"
+# Optional commercial receiver side-by-side baseline, converted to normalized CSV or .pos.
+# commercial_pos = "output/commercial_receiver_solution.csv"
+# commercial_format = "auto"
+# commercial_label = "commercial_receiver"
+# commercial_matched_csv = "output/commercial_receiver_matches.csv"
 max_epochs = 120
 match_tolerance_s = 0.25
 require_matched_epochs_min = 100

--- a/configs/ppc_rtk_signoff.example.toml
+++ b/configs/ppc_rtk_signoff.example.toml
@@ -6,6 +6,11 @@ out = "output/ppc_tokyo_run1_rtk.pos"
 summary_json = "output/ppc_tokyo_run1_rtk_summary.json"
 max_epochs = 120
 rtklib_bin = "/opt/rtklib/bin/rnx2rtkp"
+# Optional commercial receiver side-by-side baseline against the PPC reference.csv.
+# commercial_pos = "output/ppc_tokyo_run1_commercial_receiver.csv"
+# commercial_format = "auto"
+# commercial_label = "commercial_receiver"
+# commercial_matched_csv = "output/ppc_tokyo_run1_commercial_receiver_matches.csv"
 preset = "low-cost"
 arfilter = true
 arfilter_margin = 0.35

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -72,4 +72,7 @@ python3 apps/gnss.py ppc-rtk-signoff \
 ```
 
 `ppc-rtk-signoff` is the fixed-threshold path for Tokyo/Nagoya quality and
-runtime checks, with optional RTKLIB delta gates.
+runtime checks, with optional RTKLIB delta gates. Add `--commercial-pos` with
+a normalized receiver CSV or `.pos` file to summarize a commercial receiver
+against the same PPC `reference.csv`; `--commercial-matched-csv` writes the
+per-epoch commercial receiver matches.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -270,10 +270,11 @@ When a suite config is used, the output tree is partitioned by case:
 
 `gnss solve`, `gnss replay`, and `gnss live` accept `--mode moving-base`.
 
-`gnss moving-base-prepare` extracts rover/base UBX streams plus a per-epoch reference CSV from a ROS2 moving-base bag or Zenodo zip. `gnss moving-base-signoff` is the validation entrypoint for replay/live runs against those references. `gnss scorpion-moving-base-signoff` wraps the public SCORPION bag flow by chaining prepare, BRDC nav fetch, and replay validation. Together they cover:
+`gnss moving-base-prepare` extracts rover/base UBX streams plus a per-epoch reference CSV from a ROS2 moving-base bag or Zenodo zip. It can also export the rover receiver `NAV-PVT` solution as a normalized commercial receiver CSV. `gnss moving-base-signoff` is the validation entrypoint for replay/live runs against those references. `gnss scorpion-moving-base-signoff` wraps the public SCORPION bag flow by chaining prepare, BRDC nav fetch, replay validation, and receiver side-by-side matching. Together they cover:
 
 - ROS2 bag or zip ingestion with u-blox `NAV-PVT` / `RXM-RAWX` / `NAV-RELPOSNED`
 - replay inputs via `--rover-ubx` and `--base-ubx`
+- public receiver side-by-side summaries via `--commercial-csv` / `--commercial-pos`
 - fix rate
 - baseline error percentiles
 - heading error percentiles

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -77,7 +77,7 @@ python3 apps/gnss.py replay \
 | `gnss dcb-info` | Inspect `Bias-SINEX` or auxiliary DCB products |
 | `gnss qzss-l6-info` | Inspect direct QZSS L6 frames and export Compact SSR payloads |
 | `gnss web` | Local browser UI for summary JSON, live/moving-base/PPP-product sign-offs, trajectories, moving-base/visibility plots, receiver status, and artifact links |
-| `gnss ppc-rtk-signoff` | Fixed RTK sign-off profiles for PPC Tokyo/Nagoya |
+| `gnss ppc-rtk-signoff` | Fixed RTK sign-off profiles for PPC Tokyo/Nagoya, with optional RTKLIB/commercial receiver side-by-side output |
 
 ## Local web UI
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -65,9 +65,9 @@ python3 apps/gnss.py replay \
 | `gnss visibility` | Export azimuth/elevation/SNR visibility rows and summary JSON from rover/nav RINEX |
 | `gnss visibility-plot` | Render a visibility CSV into a polar/elevation PNG quick-look |
 | `gnss moving-base-plot` | Render a moving-base solution/reference pair into a baseline/heading PNG quick-look |
-| `gnss moving-base-prepare` | Extract rover/base UBX plus reference CSV from a ROS2 moving-base bag |
+| `gnss moving-base-prepare` | Extract rover/base UBX, reference CSV, and optional receiver CSV from a ROS2 moving-base bag |
 | `gnss moving-base-signoff` | Validate a real moving-base replay/live dataset against per-epoch base/rover reference coordinates |
-| `gnss scorpion-moving-base-signoff` | One-command prepare + BRDC fetch + replay validation for the public SCORPION bag |
+| `gnss scorpion-moving-base-signoff` | One-command prepare + BRDC fetch + replay validation for the public SCORPION bag with receiver side-by-side output |
 | `gnss fetch-products` | Fetch and cache `SP3`/`CLK`/`IONEX`/`DCB` files from local or remote sources |
 | `gnss ppp-products-signoff` | Run static, kinematic, or PPC PPP sign-off with fetched product presets or templates, plus comparison CSV/PNG artifacts |
 | `gnss stream` | Inspect and relay RTCM over file, NTRIP, TCP, or serial |
@@ -113,14 +113,14 @@ python3 apps/gnss.py moving-base-prepare \
   --input /datasets/moving_base/2023-06-14T174658Z.zip \
   --rover-ubx-out output/moving_base_rover.ubx \
   --base-ubx-out output/moving_base_base.ubx \
-  --reference-csv output/moving_base_reference.csv
+  --reference-csv output/moving_base_reference.csv \
+  --commercial-csv output/commercial_receiver_solution.csv
 
 python3 apps/gnss.py fetch-products \
   --date 2023-06-14 \
   --preset brdc-nav
 
 python3 apps/gnss.py scorpion-moving-base-signoff \
-  --input /datasets/moving_base/2023-06-14T174658Z.zip \
   --summary-json output/scorpion_moving_base_summary.json
 
 python3 apps/gnss.py moving-base-signoff \

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -126,6 +126,11 @@ python3 apps/gnss.py scorpion-moving-base-signoff \
 python3 apps/gnss.py moving-base-signoff \
   --config-toml configs/moving_base_signoff.example.toml
 
+python3 apps/gnss.py moving-base-signoff \
+  --config-toml configs/moving_base_signoff.example.toml \
+  --commercial-pos output/commercial_receiver_solution.csv \
+  --commercial-matched-csv output/commercial_receiver_matches.csv
+
 python3 apps/gnss.py live-signoff \
   --config-toml configs/live_signoff.example.toml
 ```

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -95,7 +95,7 @@ python3 apps/gnss.py ppp-products-signoff \
 - solver wall time / realtime factor / effective epoch rate,
 - `live` termination and decoder errors.
 
-Use `gnss moving-base-prepare` first when the source dataset is a ROS2 bag or Zenodo zip carrying u-blox `NAV-PVT`, `RXM-RAWX`, and `NAV-RELPOSNED` topics. For replay mode, pair the exported `rover.ubx` / `base.ubx` files with a fetched BRDC navigation file from `gnss fetch-products --preset brdc-nav`.
+Use `gnss moving-base-prepare` first when the source dataset is a ROS2 bag or Zenodo zip carrying u-blox `NAV-PVT`, `RXM-RAWX`, and `NAV-RELPOSNED` topics. For replay mode, pair the exported `rover.ubx` / `base.ubx` files with a fetched BRDC navigation file from `gnss fetch-products --preset brdc-nav`. Add `--commercial-csv` to export the rover receiver's `NAV-PVT` solution as a normalized commercial receiver CSV.
 
 For commercial receiver side-by-side evaluation, add `--commercial-pos` with a normalized receiver
 solution CSV or `.pos` file. The commercial solution is matched to the same reference CSV and stored
@@ -103,7 +103,7 @@ under `commercial_receiver` in the summary JSON. Treat RTKLIB/demo5 as a public 
 baseline; moving-RTK quality claims should use independent reference data plus commercial receiver
 output when available.
 
-For the public SCORPION dataset, `gnss scorpion-moving-base-signoff` wraps the same flow into one command and emits the same summary JSON fields, plus the prepare/fetch provenance, matched CSV artifact, and plot preview that `gnss web` can render directly.
+For the public SCORPION dataset, `gnss scorpion-moving-base-signoff` wraps the same flow into one command and defaults to the public Zenodo zip when no `--input` is supplied. It emits the same summary JSON fields plus prepare/fetch provenance, libgnss matched CSV, commercial receiver CSV, commercial receiver matched CSV, and a plot preview that `gnss web` can render directly. The SCORPION receiver CSV comes from rover `NAV-PVT`; it is a public receiver side-by-side baseline, not an independent survey truth source.
 
 ## Test layers
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -61,6 +61,8 @@ For the `ppc` profile with `--malib-pos` or `--malib-bin`, the command also emit
 `gnss scorpion-moving-base-signoff`, and `gnss ppc-rtk-signoff`
 also accept `--config-toml`, so you can pin long threshold sets and artifact paths in a file instead of repeating them on the command line.
 
+For PPC-Dataset RTK runs, `gnss ppc-demo` and `gnss ppc-rtk-signoff` also accept `--commercial-pos`. This is the public-data path for comparing libgnss++ against a commercial receiver solution when the dataset has an independent `reference.csv`; the receiver summary is stored under `commercial_receiver`, and `delta_vs_commercial_receiver` reports libgnss++ minus receiver deltas for fix rate and horizontal/up error metrics.
+
 If you already have a MALIB `.pos` file, you can gate the delta directly:
 
 ```bash

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -97,6 +97,12 @@ python3 apps/gnss.py ppp-products-signoff \
 
 Use `gnss moving-base-prepare` first when the source dataset is a ROS2 bag or Zenodo zip carrying u-blox `NAV-PVT`, `RXM-RAWX`, and `NAV-RELPOSNED` topics. For replay mode, pair the exported `rover.ubx` / `base.ubx` files with a fetched BRDC navigation file from `gnss fetch-products --preset brdc-nav`.
 
+For commercial receiver side-by-side evaluation, add `--commercial-pos` with a normalized receiver
+solution CSV or `.pos` file. The commercial solution is matched to the same reference CSV and stored
+under `commercial_receiver` in the summary JSON. Treat RTKLIB/demo5 as a public reproducible
+baseline; moving-RTK quality claims should use independent reference data plus commercial receiver
+output when available.
+
 For the public SCORPION dataset, `gnss scorpion-moving-base-signoff` wraps the same flow into one command and emits the same summary JSON fields, plus the prepare/fetch provenance, matched CSV artifact, and plot preview that `gnss web` can render directly.
 
 ## Test layers

--- a/scripts/ci/run_optional_rtk_signoffs.py
+++ b/scripts/ci/run_optional_rtk_signoffs.py
@@ -134,6 +134,8 @@ def make_scorpion_step(context: SignoffContext) -> SignoffStep:
         context.output_dir / "scorpion_moving_base" / "products_summary.json",
         context.output_dir / "scorpion_moving_base" / "scorpion_moving_base.pos",
         context.output_dir / "scorpion_moving_base" / "scorpion_moving_base_matches.csv",
+        context.output_dir / "scorpion_moving_base" / "commercial_receiver_solution.csv",
+        context.output_dir / "scorpion_moving_base" / "commercial_receiver_matches.csv",
         context.output_dir / "scorpion_moving_base" / "scorpion_moving_base.png",
         context.output_dir / "scorpion_moving_base" / "reference.csv",
     ]

--- a/tests/test_benchmark_scripts.py
+++ b/tests/test_benchmark_scripts.py
@@ -159,6 +159,11 @@ class PPCRTKSignoffHelpersTest(unittest.TestCase):
                 rtklib_pos=temp_root / "rtklib.pos",
                 use_existing_rtklib_solution=True,
                 rtklib_solver_wall_time_s=0.8,
+                commercial_pos=temp_root / "commercial.csv",
+                commercial_format="csv",
+                commercial_label="survey_receiver",
+                commercial_matched_csv=temp_root / "commercial_matches.csv",
+                commercial_solver_wall_time_s=0.9,
                 preset=None,
                 arfilter=None,
                 arfilter_margin=None,
@@ -189,6 +194,10 @@ class PPCRTKSignoffHelpersTest(unittest.TestCase):
             self.assertIn("--rtklib-bin", command)
             self.assertIn(str(args.rtklib_bin), command)
             self.assertIn("--use-existing-rtklib-solution", command)
+            self.assertIn("--commercial-pos", command)
+            self.assertIn(str(args.commercial_pos), command)
+            self.assertIn("--commercial-matched-csv", command)
+            self.assertIn(str(args.commercial_matched_csv), command)
             self.assertIn("--require-fix-rate-min", command)
             self.assertIn("95.0", command)
             self.assertIn("--require-lib-fix-rate-vs-rtklib-min-delta", command)
@@ -1724,6 +1733,8 @@ class PPCDemoTest(unittest.TestCase):
             reference_csv = run_dir / "reference.csv"
             out = temp_root / "ppc_demo.pos"
             rtklib_pos = temp_root / "ppc_demo_rtklib.pos"
+            commercial_pos = temp_root / "commercial_receiver.csv"
+            commercial_matches = temp_root / "commercial_receiver_matches.csv"
             summary_json = temp_root / "ppc_demo_summary.json"
 
             rover.write_text("synthetic rover\n", encoding="ascii")
@@ -1753,6 +1764,18 @@ class PPCDemoTest(unittest.TestCase):
                     (2300, 1000.4, 35.1000205, 139.1000404, 42.6, 2),
                 ],
             )
+            commercial_pos.write_text(
+                "\n".join(
+                    [
+                        "gps_week,gps_tow_s,lat_deg,lon_deg,height_m,solution_status,num_satellites",
+                        "2300,1000.0,35.1000001,139.1000001,42.1,rtk_fixed,14",
+                        "2300,1000.2,35.1000101,139.1000201,42.2,rtk_fixed,14",
+                        "2300,1000.4,35.1000201,139.1000401,42.4,rtk_float,13",
+                    ]
+                )
+                + "\n",
+                encoding="ascii",
+            )
 
             args = argparse.Namespace(
                 dataset_root=None,
@@ -1771,6 +1794,11 @@ class PPCDemoTest(unittest.TestCase):
                 rtklib_config=None,
                 use_existing_rtklib_solution=True,
                 rtklib_solver_wall_time_s=0.1,
+                commercial_pos=commercial_pos,
+                commercial_format="auto",
+                commercial_label="survey_receiver",
+                commercial_matched_csv=commercial_matches,
+                commercial_solver_wall_time_s=0.2,
                 max_epochs=120,
                 match_tolerance_s=0.25,
                 use_existing_solution=True,
@@ -1832,6 +1860,13 @@ class PPCDemoTest(unittest.TestCase):
             self.assertEqual(payload["rtklib"]["solver_wall_time_s"], 0.1)
             self.assertAlmostEqual(payload["rtklib"]["realtime_factor"], 4.0, places=5)
             self.assertIn("delta_vs_rtklib", payload)
+            self.assertIn("commercial_receiver", payload)
+            self.assertEqual(payload["commercial_receiver"]["label"], "survey_receiver")
+            self.assertEqual(payload["commercial_receiver"]["matched_epochs"], 3)
+            self.assertEqual(payload["commercial_receiver"]["fixed_epochs"], 2)
+            self.assertEqual(payload["commercial_receiver"]["matched_csv"], str(commercial_matches))
+            self.assertTrue(commercial_matches.exists())
+            self.assertIn("delta_vs_commercial_receiver", payload)
             self.assertTrue(summary_json.exists())
 
             failing_args = argparse.Namespace(

--- a/tests/test_benchmark_scripts.py
+++ b/tests/test_benchmark_scripts.py
@@ -588,6 +588,32 @@ class MovingBaseSignoffHelpersTest(unittest.TestCase):
         self.assertGreater(matches[0]["baseline_length_m"], 0.0)
         self.assertIsNotNone(matches[0]["heading_error_deg"])
 
+    def test_read_commercial_csv_records_accepts_receiver_solution_columns(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_commercial_rtk_") as temp_dir:
+            commercial_csv = Path(temp_dir) / "receiver.csv"
+            commercial_csv.write_text(
+                "\n".join(
+                    [
+                        "gps_week,gps_tow_s,rover_ecef_x_m,rover_ecef_y_m,rover_ecef_z_m,fix_type,num_satellites",
+                        "2200,345600.0,3875001.0,332002.0,5029000.5,rtk_fixed,14",
+                        "2200,345601.0,3875001.1,332002.1,5029000.5,rtk_float,12",
+                    ]
+                )
+                + "\n",
+                encoding="ascii",
+            )
+
+            records, resolved_format = moving_base_signoff.read_commercial_solution_records(
+                commercial_csv,
+                "auto",
+            )
+
+            self.assertEqual(resolved_format, "csv")
+            self.assertEqual(len(records), 2)
+            self.assertEqual(records[0]["status"], 4)
+            self.assertEqual(records[1]["status"], 3)
+            self.assertEqual(records[0]["satellites"], 14)
+
 
 class DrivingComparisonHelpersTest(unittest.TestCase):
     @staticmethod

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -11277,6 +11277,7 @@ class CLIToolsTest(unittest.TestCase):
             rover_ubx = temp_root / "rover.ubx"
             base_ubx = temp_root / "base.ubx"
             reference_csv = temp_root / "reference.csv"
+            commercial_csv = temp_root / "commercial_receiver.csv"
             summary_json = temp_root / "summary.json"
 
             result = self.run_gnss(
@@ -11289,6 +11290,8 @@ class CLIToolsTest(unittest.TestCase):
                 str(base_ubx),
                 "--reference-csv",
                 str(reference_csv),
+                "--commercial-csv",
+                str(commercial_csv),
                 "--summary-json",
                 str(summary_json),
                 "--max-epochs",
@@ -11300,6 +11303,7 @@ class CLIToolsTest(unittest.TestCase):
             self.assertTrue(rover_ubx.exists())
             self.assertTrue(base_ubx.exists())
             self.assertTrue(reference_csv.exists())
+            self.assertTrue(commercial_csv.exists())
             self.assertTrue(summary_json.exists())
             self.assertGreater(rover_ubx.stat().st_size, 0)
             self.assertGreater(base_ubx.stat().st_size, 0)
@@ -11307,6 +11311,8 @@ class CLIToolsTest(unittest.TestCase):
             summary = json.loads(summary_json.read_text(encoding="utf-8"))
             self.assertEqual(summary["rover_epochs"], 2)
             self.assertEqual(summary["matched_reference_rows"], 2)
+            self.assertEqual(summary["matched_commercial_receiver_rows"], 2)
+            self.assertEqual(summary["commercial_receiver_csv"], str(commercial_csv))
             self.assertEqual(summary["gps_week"], 2200)
             self.assertEqual(summary["date"], "2023-06-14")
 
@@ -11316,6 +11322,12 @@ class CLIToolsTest(unittest.TestCase):
             self.assertEqual(rows[0]["gps_week"], "2200")
             self.assertEqual(rows[0]["gps_tow_s"], "345600.000")
             self.assertIn("baseline_n_m", rows[0])
+            with commercial_csv.open(encoding="utf-8", newline="") as handle:
+                commercial_rows = list(csv.DictReader(handle))
+            self.assertEqual(len(commercial_rows), 2)
+            self.assertEqual(commercial_rows[0]["gps_week"], "2200")
+            self.assertEqual(commercial_rows[0]["solution_status"], "rtk_fixed")
+            self.assertEqual(commercial_rows[0]["num_satellites"], "18")
 
     def test_moving_base_prepare_help_mentions_rosbag_and_ubx_exports(self) -> None:
         result = self.run_gnss("moving-base-prepare", "--help")
@@ -11323,6 +11335,22 @@ class CLIToolsTest(unittest.TestCase):
         self.assertIn("ROS2 bag directory or Zenodo zip", result.stdout)
         self.assertIn("--rover-ubx-out", result.stdout)
         self.assertIn("--base-ubx-out", result.stdout)
+        self.assertIn("--commercial-csv", result.stdout)
+
+    def test_scorpion_cache_filename_preserves_zenodo_zip_name(self) -> None:
+        sys_path_backup = sys.path[:]
+        sys.path.insert(0, str(ROOT_DIR / "apps"))
+        try:
+            import gnss_scorpion_moving_base_signoff as scorpion_signoff
+
+            self.assertEqual(
+                scorpion_signoff.download_cache_filename(
+                    "https://zenodo.org/api/records/8083431/files/2023-06-14T174658Z.zip/content"
+                ),
+                "2023-06-14T174658Z.zip",
+            )
+        finally:
+            sys.path[:] = sys_path_backup
 
     @unittest.skipUnless(ros2_bag_support_available(), "ROS2 rosbag + ublox_msgs support not available")
     def test_scorpion_moving_base_signoff_wraps_prepare_and_existing_solution(self) -> None:
@@ -11399,6 +11427,10 @@ class CLIToolsTest(unittest.TestCase):
             self.assertIsNone(payload["products_summary_json"])
             self.assertTrue(Path(payload["prepare_summary_json"]).exists())
             self.assertTrue(Path(payload["matched_csv"]).exists())
+            self.assertTrue(Path(payload["commercial_receiver_csv"]).exists())
+            self.assertTrue(Path(payload["commercial_receiver_matched_csv"]).exists())
+            self.assertIn("commercial_receiver", payload)
+            self.assertEqual(payload["commercial_receiver"]["matched_epochs"], 2)
 
     def test_live_signoff_summarizes_existing_log_and_enforces_realtime_gate(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_live_signoff_cli_") as temp_dir:

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -7960,6 +7960,8 @@ class CLIToolsTest(unittest.TestCase):
             run_dir.mkdir(parents=True)
             solution_path = temp_root / "ppc_demo.pos"
             rtklib_path = temp_root / "ppc_demo_rtklib.pos"
+            commercial_path = temp_root / "ppc_commercial_receiver.csv"
+            commercial_matches = temp_root / "ppc_commercial_matches.csv"
             summary_path = temp_root / "ppc_demo_summary.json"
             reference_csv = run_dir / "reference.csv"
 
@@ -7997,6 +7999,18 @@ class CLIToolsTest(unittest.TestCase):
                     (2300, 1000.4, 35.1000205, 139.1000404, 42.6, 2, 11),
                 ],
             )
+            commercial_path.write_text(
+                "\n".join(
+                    [
+                        "gps_week,gps_tow_s,lat_deg,lon_deg,height_m,solution_status,num_satellites",
+                        "2300,1000.0,35.1000001,139.1000001,42.1,rtk_fixed,14",
+                        "2300,1000.2,35.1000101,139.1000201,42.2,rtk_fixed,14",
+                        "2300,1000.4,35.1000201,139.1000401,42.4,rtk_float,13",
+                    ]
+                )
+                + "\n",
+                encoding="ascii",
+            )
 
             result = self.run_gnss(
                 "ppc-demo",
@@ -8014,6 +8028,14 @@ class CLIToolsTest(unittest.TestCase):
                 "--use-existing-rtklib-solution",
                 "--rtklib-solver-wall-time-s",
                 "0.1",
+                "--commercial-pos",
+                str(commercial_path),
+                "--commercial-label",
+                "survey_receiver",
+                "--commercial-matched-csv",
+                str(commercial_matches),
+                "--commercial-solver-wall-time-s",
+                "0.2",
                 "--summary-json",
                 str(summary_path),
                 "--require-valid-epochs-min",
@@ -8069,7 +8091,15 @@ class CLIToolsTest(unittest.TestCase):
             self.assertEqual(payload["rtklib"]["solver_wall_time_s"], 0.1)
             self.assertAlmostEqual(payload["rtklib"]["realtime_factor"], 4.0, places=5)
             self.assertIn("delta_vs_rtklib", payload)
+            self.assertIn("commercial_receiver", payload)
+            self.assertEqual(payload["commercial_receiver"]["label"], "survey_receiver")
+            self.assertEqual(payload["commercial_receiver"]["matched_epochs"], 3)
+            self.assertEqual(payload["commercial_receiver"]["fixed_epochs"], 2)
+            self.assertEqual(payload["commercial_receiver"]["matched_csv"], str(commercial_matches))
+            self.assertTrue(commercial_matches.exists())
+            self.assertIn("delta_vs_commercial_receiver", payload)
             self.assertIn("rtklib performance: wall=0.1 s", result.stdout)
+            self.assertIn("commercial_receiver:", result.stdout)
             self.assertIn("performance: wall=0.5 s, span=0.4 s, rtf=0.8, rate=6.0 Hz", result.stdout)
 
     def test_ppc_rtk_signoff_cli_wraps_profile_with_existing_solutions(self) -> None:
@@ -8079,6 +8109,8 @@ class CLIToolsTest(unittest.TestCase):
             run_dir.mkdir(parents=True)
             solution_path = temp_root / "ppc_signoff.pos"
             rtklib_path = temp_root / "ppc_signoff_rtklib.pos"
+            commercial_path = temp_root / "ppc_signoff_commercial.csv"
+            commercial_matches = temp_root / "ppc_signoff_commercial_matches.csv"
             summary_path = temp_root / "ppc_signoff_summary.json"
             reference_csv = run_dir / "reference.csv"
 
@@ -8116,6 +8148,18 @@ class CLIToolsTest(unittest.TestCase):
                     (2300, 1000.4, 35.1000205, 139.1000404, 42.6, 2, 11),
                 ],
             )
+            commercial_path.write_text(
+                "\n".join(
+                    [
+                        "gps_week,gps_tow_s,lat_deg,lon_deg,height_m,solution_status,num_satellites",
+                        "2300,1000.0,35.1000001,139.1000001,42.1,rtk_fixed,14",
+                        "2300,1000.2,35.1000101,139.1000201,42.2,rtk_fixed,14",
+                        "2300,1000.4,35.1000201,139.1000401,42.4,rtk_float,13",
+                    ]
+                )
+                + "\n",
+                encoding="ascii",
+            )
 
             result = self.run_gnss(
                 "ppc-rtk-signoff",
@@ -8133,6 +8177,12 @@ class CLIToolsTest(unittest.TestCase):
                 "--use-existing-rtklib-solution",
                 "--rtklib-solver-wall-time-s",
                 "0.1",
+                "--commercial-pos",
+                str(commercial_path),
+                "--commercial-matched-csv",
+                str(commercial_matches),
+                "--commercial-solver-wall-time-s",
+                "0.2",
                 "--summary-json",
                 str(summary_path),
                 "--require-valid-epochs-min",
@@ -8173,6 +8223,9 @@ class CLIToolsTest(unittest.TestCase):
             self.assertIn("signoff_thresholds", payload)
             self.assertEqual(payload["signoff_thresholds"]["require_fix_rate_min"], 60.0)
             self.assertIn("delta_vs_rtklib", payload)
+            self.assertTrue(payload["commercial_receiver_comparison_enabled"])
+            self.assertIn("commercial_receiver", payload)
+            self.assertTrue(commercial_matches.exists())
 
     def test_ppc_rtk_signoff_cli_reads_config_toml(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ppc_rtk_signoff_toml_") as temp_dir:

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -12010,6 +12010,83 @@ class CLIToolsTest(unittest.TestCase):
             self.assertEqual(payload["plot_png"], str(plot_path))
             self.assertTrue(Path(payload["matched_csv"]).exists())
 
+    def test_moving_base_signoff_summarizes_commercial_receiver_solution(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_moving_base_commercial_") as temp_dir:
+            temp_root = Path(temp_dir)
+            solution_path = temp_root / "moving_base.pos"
+            commercial_path = temp_root / "commercial_receiver.csv"
+            reference_csv = temp_root / "reference.csv"
+            summary_path = temp_root / "moving_base_summary.json"
+            matched_csv = temp_root / "moving_base_matches.csv"
+            commercial_matched_csv = temp_root / "commercial_matches.csv"
+
+            solution_path.write_text(
+                "\n".join(
+                    [
+                        "% synthetic moving-base solution fixture",
+                        "2200 345600.000 3875001.100000 332002.000000 5029000.400000 35.0 139.0 10.0 4 12 1.0",
+                        "2200 345601.000 3875001.200000 332002.100000 5029000.450000 35.0 139.0 10.0 4 12 1.0",
+                    ]
+                )
+                + "\n",
+                encoding="ascii",
+            )
+            commercial_path.write_text(
+                "\n".join(
+                    [
+                        "gps_week,gps_tow_s,rover_ecef_x_m,rover_ecef_y_m,rover_ecef_z_m,fix_type,num_satellites",
+                        "2200,345600.0,3875001.0,332002.0,5029000.5,rtk_fixed,14",
+                        "2200,345601.0,3875001.1,332002.1,5029000.5,rtk_float,13",
+                    ]
+                )
+                + "\n",
+                encoding="ascii",
+            )
+            reference_csv.write_text(
+                "\n".join(
+                    [
+                        "gps_week,gps_tow_s,base_ecef_x_m,base_ecef_y_m,base_ecef_z_m,rover_ecef_x_m,rover_ecef_y_m,rover_ecef_z_m",
+                        "2200,345600.0,3875000.0,332000.0,5029000.0,3875001.0,332002.0,5029000.5",
+                        "2200,345601.0,3875000.1,332000.1,5029000.0,3875001.1,332002.1,5029000.5",
+                    ]
+                )
+                + "\n",
+                encoding="ascii",
+            )
+
+            result = self.run_gnss(
+                "moving-base-signoff",
+                "--solver",
+                "replay",
+                "--use-existing-solution",
+                "--out",
+                str(solution_path),
+                "--reference-csv",
+                str(reference_csv),
+                "--summary-json",
+                str(summary_path),
+                "--matched-csv",
+                str(matched_csv),
+                "--commercial-pos",
+                str(commercial_path),
+                "--commercial-matched-csv",
+                str(commercial_matched_csv),
+                "--solver-wall-time-s",
+                "0.5",
+            )
+
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            self.assertIn("commercial_receiver:", result.stdout)
+            payload = json.loads(summary_path.read_text(encoding="utf-8"))
+            commercial = payload["commercial_receiver"]
+            self.assertEqual(commercial["format"], "csv")
+            self.assertEqual(commercial["matched_epochs"], 2)
+            self.assertEqual(commercial["fixed_epochs"], 1)
+            self.assertEqual(commercial["fix_rate_pct"], 50.0)
+            self.assertEqual(commercial["matched_csv"], str(commercial_matched_csv))
+            self.assertTrue(commercial_matched_csv.exists())
+            self.assertIn("libgnss_vs_commercial_receiver", payload)
+
     def test_moving_base_signoff_reads_config_toml(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_moving_base_signoff_toml_") as temp_dir:
             temp_root = Path(temp_dir)


### PR DESCRIPTION
## Summary

Adds optional commercial RTK receiver side-by-side support to `gnss moving-base-signoff` and wires it into the public SCORPION moving-base flow.

What changed:

- Adds `--commercial-pos` for a commercial receiver solution file.
- Supports `--commercial-format auto|pos|csv`:
  - `.pos` reuses the existing libgnss position parser.
  - normalized CSV accepts GPS week/TOW plus ECEF or LLH rover position columns.
- Adds status normalization for common receiver labels such as `rtk_fixed`, `rtk_float`, `single`, and numeric status codes.
- Writes the commercial receiver metrics under `commercial_receiver` in the moving-base summary JSON.
- Adds `libgnss_vs_commercial_receiver` deltas for fix count/rate and baseline/heading error metrics.
- Adds optional `--commercial-matched-csv` for matched commercial epochs.
- Adds `gnss moving-base-prepare --commercial-csv` to export rover `NAV-PVT` as a normalized receiver solution CSV.
- Makes `gnss scorpion-moving-base-signoff` default to the public Zenodo SCORPION zip when no `--input` is supplied, fixes the `/content` download cache name to preserve the `.zip`, and passes the generated receiver CSV into signoff automatically.
- Documents the flow in the moving-base config example, quickstart, interfaces, and validation docs.

## Why

RTKLIB/demo5 remains useful as a public reproducible baseline, but moving-RTK performance should also be compared with commercial RTK receiver output on the same public data/corrections and against an independent reference trajectory when available.

This PR adds the plumbing for that comparison and enables a public SCORPION receiver side-by-side baseline without adding dataset-specific performance claims or gates.

## Validation

- `python3 -m py_compile apps/gnss_moving_base_prepare.py apps/gnss_scorpion_moving_base_signoff.py apps/gnss_moving_base_signoff.py apps/gnss.py`
- `python3 -m py_compile scripts/ci/run_optional_rtk_signoffs.py apps/gnss_moving_base_prepare.py apps/gnss_scorpion_moving_base_signoff.py apps/gnss.py`
- `python3 tests/test_cli_tools.py CLIToolsTest.test_scorpion_cache_filename_preserves_zenodo_zip_name CLIToolsTest.test_moving_base_prepare_help_mentions_rosbag_and_ubx_exports CLIToolsTest.test_moving_base_prepare_exports_ubx_and_reference_csv CLIToolsTest.test_scorpion_moving_base_signoff_wraps_prepare_and_existing_solution CLIToolsTest.test_moving_base_signoff_summarizes_commercial_receiver_solution`
- `python3 tests/test_benchmark_scripts.py MovingBaseSignoffHelpersTest OptionalRTKSignoffScriptTest`
- `python3 apps/gnss.py --help | rg 'moving-base-prepare|scorpion-moving-base-signoff'`
- `python3 apps/gnss.py scorpion-moving-base-signoff --help`
- `python3 apps/gnss.py moving-base-prepare --help`
- `git diff --check`

## Notes

The public SCORPION receiver CSV comes from rover `NAV-PVT`, while the current reference CSV is derived from base `NAV-PVT` plus `NAV-RELPOSNED`. That gives a public receiver side-by-side baseline, not an independent survey truth source. A commercial-grade claim still needs a real dataset with same antenna/correction/time base and an independent reference trajectory.

## Public SCORPION Run

Ran the public Zenodo SCORPION zip locally with the new receiver side-by-side path:

- `curl -L --fail --retry 5 -C - -o output/downloads/2023-06-14T174658Z.zip https://zenodo.org/api/records/8083431/files/2023-06-14T174658Z.zip/content`
- `unzip -t output/downloads/2023-06-14T174658Z.zip`
- `python3 apps/gnss.py scorpion-moving-base-signoff --input output/downloads/2023-06-14T174658Z.zip --work-dir output/scorpion_moving_base_public --summary-json output/scorpion_moving_base_public_summary.json --max-epochs 120`

Results from `output/scorpion_moving_base_public_summary.json`:

| Metric | libgnss replay | receiver `NAV-PVT` CSV |
|---|---:|---:|
| matched epochs | 94 | 120 |
| fixed epochs | 90 | 120 |
| fix rate | 95.744681% | 100.0% |
| median baseline error | 0.054886 m | 0.101539 m |
| p95 baseline error | 0.101096 m | 0.132507 m |
| max baseline error | 0.407210 m | 0.165632 m |
| p95 heading error | 5.852947 deg | 3.800148 deg |
| realtime factor | 2.308291 | n/a |

Artifacts generated locally under `output/scorpion_moving_base_public/`:

- `reference.csv`
- `commercial_receiver_solution.csv`
- `commercial_receiver_matches.csv`
- `scorpion_moving_base_matches.csv`
- `scorpion_moving_base.pos`
- `scorpion_moving_base.png`

## PPC Independent-Reference Extension

Added the same commercial receiver side-by-side plumbing to `gnss ppc-demo` and `gnss ppc-rtk-signoff`, where public PPC-Dataset runs already carry an independent `reference.csv` trajectory:

- `--commercial-pos` accepts normalized receiver CSV or libgnss `.pos` input.
- `--commercial-format auto|pos|csv`, `--commercial-label`, and `--commercial-solver-wall-time-s` mirror the moving-base flow.
- `--commercial-matched-csv` writes per-epoch receiver/reference matches.
- PPC summaries now include `commercial_receiver` and `delta_vs_commercial_receiver`.
- `ppc-rtk-signoff` forwards the commercial receiver options and records `commercial_receiver_comparison_enabled`.

Additional validation:

- `python3 -m py_compile apps/gnss_ppc_demo.py apps/gnss_ppc_rtk_signoff.py apps/gnss_moving_base_signoff.py`
- `python3 tests/test_benchmark_scripts.py PPCRTKSignoffHelpersTest PPCDemoTest`
- `python3 tests/test_cli_tools.py CLIToolsTest.test_ppc_rtk_signoff_cli_reads_config_toml CLIToolsTest.test_ppc_demo_cli_summarizes_existing_solution_against_reference_csv CLIToolsTest.test_ppc_rtk_signoff_cli_wraps_profile_with_existing_solutions`
- `python3 apps/gnss.py ppc-demo --help | rg -- '--commercial|commercial'`
- `python3 apps/gnss.py ppc-rtk-signoff --help | rg -- '--commercial|commercial'`
- `git diff --check`
