### PR TITLE
[codex] Surface commercial receiver comparisons in web UI

### DIFF
--- a/apps/gnss_artifact_manifest.py
+++ b/apps/gnss_artifact_manifest.py
@@ -81,6 +81,15 @@ def normalize_artifact_path(root_dir: Path, value: Any) -> str | None:
         return value
 
 
+def normalize_commercial_receiver(root_dir: Path, payload: Any) -> dict[str, Any] | None:
+    if not isinstance(payload, dict):
+        return None
+    normalized = dict(payload)
+    for key in ("solution_pos", "matched_csv"):
+        normalized[key] = normalize_artifact_path(root_dir, normalized.get(key))
+    return normalized
+
+
 def classify_realtime_status(realtime_factor: Any) -> str:
     if not isinstance(realtime_factor, (int, float)):
         return "n/a"
@@ -145,6 +154,16 @@ def build_ppc_entries(root_dir: Path, pattern: str) -> list[dict[str, Any]]:
             continue
         quality_status = classify_accuracy_status(payload.get("p95_h_m"))
         runtime_status = classify_realtime_status(payload.get("realtime_factor"))
+        commercial_receiver = normalize_commercial_receiver(root_dir, payload.get("commercial_receiver"))
+        commercial_delta = payload.get("delta_vs_commercial_receiver")
+        if not isinstance(commercial_delta, dict):
+            commercial_delta = None
+        comparison_status = classify_comparison_status(
+            commercial_delta.get("median_h_m") if commercial_delta else None,
+            commercial_delta.get("p95_h_m") if commercial_delta else None,
+            commercial_delta.get("max_h_m") if commercial_delta else None,
+            commercial_delta.get("p95_abs_up_m") if commercial_delta else None,
+        )
         entries.append(
             {
                 "category": "ppc",
@@ -153,6 +172,7 @@ def build_ppc_entries(root_dir: Path, pattern: str) -> list[dict[str, Any]]:
                 "status": quality_status,
                 "quality_status": quality_status,
                 "runtime_status": runtime_status,
+                "comparison_status": comparison_status,
                 "headline": (
                     f"{payload.get('matched_epochs', 'n/a')} matched / "
                     f"{payload.get('fix_rate_pct', 'n/a')} fix / "
@@ -163,6 +183,12 @@ def build_ppc_entries(root_dir: Path, pattern: str) -> list[dict[str, Any]]:
                     "solution": normalize_artifact_path(root_dir, payload.get("solution_pos")),
                     "reference": normalize_artifact_path(root_dir, payload.get("reference_pos")),
                     "rtklib": normalize_artifact_path(root_dir, payload.get("rtklib_solution_pos")),
+                    "commercial_solution": (
+                        commercial_receiver.get("solution_pos") if commercial_receiver else None
+                    ),
+                    "commercial_matches": (
+                        commercial_receiver.get("matched_csv") if commercial_receiver else None
+                    ),
                 },
                 "metrics": {
                     "matched_epochs": payload.get("matched_epochs"),
@@ -172,6 +198,8 @@ def build_ppc_entries(root_dir: Path, pattern: str) -> list[dict[str, Any]]:
                     "solver_wall_time_s": payload.get("solver_wall_time_s"),
                     "realtime_factor": payload.get("realtime_factor"),
                     "effective_epoch_rate_hz": payload.get("effective_epoch_rate_hz"),
+                    "commercial_receiver": commercial_receiver,
+                    "delta_vs_commercial_receiver": commercial_delta,
                 },
             }
         )
@@ -264,6 +292,16 @@ def build_moving_base_entries(root_dir: Path, pattern: str) -> list[dict[str, An
             continue
         quality_status = classify_baseline_status(payload.get("p95_baseline_error_m"))
         runtime_status = classify_realtime_status(payload.get("realtime_factor"))
+        commercial_receiver = normalize_commercial_receiver(root_dir, payload.get("commercial_receiver"))
+        commercial_delta = payload.get("libgnss_vs_commercial_receiver")
+        if not isinstance(commercial_delta, dict):
+            commercial_delta = None
+        comparison_status = classify_comparison_status(
+            commercial_delta.get("median_baseline_error_m_delta") if commercial_delta else None,
+            commercial_delta.get("p95_baseline_error_m_delta") if commercial_delta else None,
+            commercial_delta.get("max_baseline_error_m_delta") if commercial_delta else None,
+            commercial_delta.get("p95_heading_error_deg_delta") if commercial_delta else None,
+        )
         entries.append(
             {
                 "category": "moving-base",
@@ -272,6 +310,7 @@ def build_moving_base_entries(root_dir: Path, pattern: str) -> list[dict[str, An
                 "status": quality_status,
                 "quality_status": quality_status,
                 "runtime_status": runtime_status,
+                "comparison_status": comparison_status,
                 "headline": (
                     f"{payload.get('matched_epochs', 'n/a')} matched / "
                     f"{payload.get('fix_rate_pct', 'n/a')} fix / "
@@ -287,6 +326,16 @@ def build_moving_base_entries(root_dir: Path, pattern: str) -> list[dict[str, An
                     "nav_rinex": normalize_artifact_path(root_dir, payload.get("nav_rinex")),
                     "input": normalize_artifact_path(root_dir, payload.get("input")),
                     "input_url": normalize_artifact_path(root_dir, payload.get("input_url")),
+                    "commercial_solution": (
+                        commercial_receiver.get("solution_pos")
+                        if commercial_receiver
+                        else normalize_artifact_path(root_dir, payload.get("commercial_receiver_csv"))
+                    ),
+                    "commercial_matches": (
+                        commercial_receiver.get("matched_csv")
+                        if commercial_receiver
+                        else normalize_artifact_path(root_dir, payload.get("commercial_receiver_matched_csv"))
+                    ),
                 },
                 "metrics": {
                     "matched_epochs": payload.get("matched_epochs"),
@@ -298,6 +347,8 @@ def build_moving_base_entries(root_dir: Path, pattern: str) -> list[dict[str, An
                     "termination": payload.get("termination"),
                     "realtime_factor": payload.get("realtime_factor"),
                     "effective_epoch_rate_hz": payload.get("effective_epoch_rate_hz"),
+                    "commercial_receiver": commercial_receiver,
+                    "libgnss_vs_commercial_receiver": commercial_delta,
                 },
             }
         )

--- a/apps/gnss_web.py
+++ b/apps/gnss_web.py
@@ -170,6 +170,15 @@ def normalize_artifact_path(root_dir: Path, value: Any) -> str | None:
         return None
 
 
+def normalize_commercial_receiver(root_dir: Path, payload: Any) -> dict[str, Any] | None:
+    if not isinstance(payload, dict):
+        return None
+    normalized = dict(payload)
+    for key in ("solution_pos", "matched_csv"):
+        normalized[key] = normalize_artifact_path(root_dir, normalized.get(key))
+    return normalized
+
+
 def resolve_under_root(root_dir: Path, path_text: str) -> Path:
     candidate = Path(path_text)
     if not candidate.is_absolute():
@@ -266,6 +275,18 @@ def classify_ppp_products_status(
     return "warming"
 
 
+def classify_comparison_status(*deltas: Any) -> str | None:
+    numeric = [float(value) for value in deltas if isinstance(value, (int, float))]
+    if not numeric:
+        return None
+    worst = max(numeric)
+    if worst <= 0.0:
+        return "better"
+    if worst <= 0.25:
+        return "close"
+    return "worse"
+
+
 def downsample_points(points: list[dict[str, Any]], limit: int = MAX_RENDER_POINTS) -> list[dict[str, Any]]:
     if len(points) <= limit:
         return points
@@ -353,6 +374,18 @@ def build_overview(args: argparse.Namespace) -> dict[str, Any]:
         payload["_path"] = relative_display(path, root_dir)
         payload["runtime_status"] = classify_realtime_status(payload.get("realtime_factor"))
         payload["quality_status"] = classify_accuracy_status(payload.get("p95_h_m"))
+        commercial_receiver = normalize_commercial_receiver(root_dir, payload.get("commercial_receiver"))
+        commercial_delta = payload.get("delta_vs_commercial_receiver")
+        if not isinstance(commercial_delta, dict):
+            commercial_delta = None
+        if commercial_receiver is not None:
+            payload["commercial_receiver"] = commercial_receiver
+            payload["commercial_comparison_status"] = classify_comparison_status(
+                commercial_delta.get("median_h_m") if commercial_delta else None,
+                commercial_delta.get("p95_h_m") if commercial_delta else None,
+                commercial_delta.get("max_h_m") if commercial_delta else None,
+                commercial_delta.get("p95_abs_up_m") if commercial_delta else None,
+            )
         ppc_summaries.append(payload)
 
     live_summaries: list[dict[str, Any]] = []
@@ -424,6 +457,10 @@ def build_overview(args: argparse.Namespace) -> dict[str, Any]:
         payload = load_json(path)
         if payload is None:
             continue
+        commercial_receiver = normalize_commercial_receiver(root_dir, payload.get("commercial_receiver"))
+        commercial_delta = payload.get("libgnss_vs_commercial_receiver")
+        if not isinstance(commercial_delta, dict):
+            commercial_delta = None
         moving_base_summaries.append(
             {
                 "_path": relative_display(path, root_dir),
@@ -444,6 +481,22 @@ def build_overview(args: argparse.Namespace) -> dict[str, Any]:
                 "prepare_summary_json": normalize_artifact_path(root_dir, payload.get("prepare_summary_json")),
                 "products_summary_json": normalize_artifact_path(root_dir, payload.get("products_summary_json")),
                 "plot_png": normalize_artifact_path(root_dir, payload.get("plot_png")),
+                "commercial_receiver_csv": normalize_artifact_path(
+                    root_dir,
+                    payload.get("commercial_receiver_csv"),
+                ),
+                "commercial_receiver_matched_csv": normalize_artifact_path(
+                    root_dir,
+                    payload.get("commercial_receiver_matched_csv"),
+                ),
+                "commercial_receiver": commercial_receiver,
+                "libgnss_vs_commercial_receiver": commercial_delta,
+                "commercial_comparison_status": classify_comparison_status(
+                    commercial_delta.get("median_baseline_error_m_delta") if commercial_delta else None,
+                    commercial_delta.get("p95_baseline_error_m_delta") if commercial_delta else None,
+                    commercial_delta.get("max_baseline_error_m_delta") if commercial_delta else None,
+                    commercial_delta.get("p95_heading_error_deg_delta") if commercial_delta else None,
+                ),
                 "signoff_profile": payload.get("signoff_profile"),
                 "nav_rinex": normalize_artifact_path(root_dir, payload.get("nav_rinex")),
                 "input": normalize_artifact_path(root_dir, payload.get("input")),
@@ -768,6 +821,8 @@ def render_html() -> str:
             <th>Fix rate</th>
             <th>Median H</th>
             <th>P95 H</th>
+            <th>Receiver</th>
+            <th>Δ receiver</th>
             <th>Quality</th>
             <th>Realtime</th>
             <th>Wall</th>
@@ -795,6 +850,8 @@ def render_html() -> str:
                 <th>Fix rate</th>
                 <th>P95 baseline</th>
                 <th>P95 heading</th>
+                <th>Receiver</th>
+                <th>Δ receiver</th>
                 <th>Quality</th>
                 <th>Realtime</th>
                 <th>Rate</th>
@@ -1203,6 +1260,66 @@ def render_html() -> str:
       return `<span class="badge ${className}">${normalized}</span>`;
     }
 
+    function commercialReceiverArtifactLinks(row) {
+      const receiver = row.commercial_receiver || {};
+      const solution = receiver.solution_pos || row.commercial_receiver_csv;
+      const matches = receiver.matched_csv || row.commercial_receiver_matched_csv;
+      return [
+        solution ? artifactLink(solution, "receiver") : null,
+        matches ? artifactLink(matches, "receiver-matches") : null,
+      ].filter(Boolean);
+    }
+
+    function commercialReceiverSummary(row, mode) {
+      const receiver = row.commercial_receiver;
+      if (!receiver) return "n/a";
+      const metric = mode === "moving-base"
+        ? `p95 ${formatMaybeNumber(receiver.p95_baseline_error_m, 3, " m")}`
+        : `p95 H ${formatMaybeNumber(receiver.p95_h_m, 3, " m")}`;
+      const bits = [
+        receiver.label || "receiver",
+        `${receiver.matched_epochs ?? "n/a"} matched`,
+        `fix ${formatMaybeNumber(receiver.fix_rate_pct, 2, "%")}`,
+        metric,
+      ].filter(Boolean);
+      const links = commercialReceiverArtifactLinks(row);
+      return `${bits.join(" / ")}${links.length ? `<br><span class="tiny">${links.join(" / ")}</span>` : ""}`;
+    }
+
+    function commercialDeltaSummary(delta, mode, status) {
+      if (!delta) return "n/a";
+      const bits = [];
+      if (mode === "moving-base") {
+        if (delta.fix_rate_pct_delta !== null && delta.fix_rate_pct_delta !== undefined) {
+          bits.push(`Δfix ${formatMaybeNumber(delta.fix_rate_pct_delta, 2, "%")}`);
+        }
+        if (delta.median_baseline_error_m_delta !== null && delta.median_baseline_error_m_delta !== undefined) {
+          bits.push(`Δmedian ${formatMaybeNumber(delta.median_baseline_error_m_delta, 3, " m")}`);
+        }
+        if (delta.p95_baseline_error_m_delta !== null && delta.p95_baseline_error_m_delta !== undefined) {
+          bits.push(`Δp95 ${formatMaybeNumber(delta.p95_baseline_error_m_delta, 3, " m")}`);
+        }
+        if (delta.p95_heading_error_deg_delta !== null && delta.p95_heading_error_deg_delta !== undefined) {
+          bits.push(`Δhead ${formatMaybeNumber(delta.p95_heading_error_deg_delta, 2, " deg")}`);
+        }
+      } else {
+        if (delta.fix_rate_pct !== null && delta.fix_rate_pct !== undefined) {
+          bits.push(`Δfix ${formatMaybeNumber(delta.fix_rate_pct, 2, "%")}`);
+        }
+        if (delta.median_h_m !== null && delta.median_h_m !== undefined) {
+          bits.push(`Δmedian ${formatMaybeNumber(delta.median_h_m, 3, " m")}`);
+        }
+        if (delta.p95_h_m !== null && delta.p95_h_m !== undefined) {
+          bits.push(`Δp95 ${formatMaybeNumber(delta.p95_h_m, 3, " m")}`);
+        }
+        if (delta.p95_abs_up_m !== null && delta.p95_abs_up_m !== undefined) {
+          bits.push(`Δup95 ${formatMaybeNumber(delta.p95_abs_up_m, 3, " m")}`);
+        }
+      }
+      if (status) bits.push(renderBadge(status));
+      return bits.length ? bits.join(" / ") : "n/a";
+    }
+
     function bundleMetricSummary(bundle) {
       if (!bundle || !bundle.metrics) return "";
       const metrics = bundle.metrics;
@@ -1355,6 +1472,8 @@ def render_html() -> str:
           <td>${formatMaybeNumber(row.fix_rate_pct, 2, "%")}</td>
           <td>${formatMaybeNumber(row.median_h_m, 3, " m")}</td>
           <td>${formatMaybeNumber(row.p95_h_m, 2, " m")}</td>
+          <td>${commercialReceiverSummary(row, "ppc")}</td>
+          <td>${commercialDeltaSummary(row.delta_vs_commercial_receiver, "ppc", row.commercial_comparison_status)}</td>
           <td>${renderBadge(row.quality_status)}</td>
           <td>${renderBadge(row.runtime_status)} ${formatMaybeNumber(row.realtime_factor, 2, "x")}</td>
           <td>${formatMaybeNumber(row.solver_wall_time_s, 2, " s")}</td>
@@ -1374,6 +1493,7 @@ def render_html() -> str:
           row.input ? artifactLink(row.input, "input") : null,
           row.input_url ? smartLink(row.input_url, "source") : null,
           row.plot_png ? artifactLink(row.plot_png, "plot") : null,
+          ...commercialReceiverArtifactLinks(row),
         ].filter(Boolean).join(" / ");
         const tr = document.createElement("tr");
         tr.innerHTML = `
@@ -1382,6 +1502,8 @@ def render_html() -> str:
           <td>${formatMaybeNumber(row.fix_rate_pct, 2, "%")}</td>
           <td>${formatMaybeNumber(row.p95_baseline_error_m, 3, " m")}</td>
           <td>${formatMaybeNumber(row.p95_heading_error_deg, 2, " deg")}</td>
+          <td>${commercialReceiverSummary(row, "moving-base")}</td>
+          <td>${commercialDeltaSummary(row.libgnss_vs_commercial_receiver, "moving-base", row.commercial_comparison_status)}</td>
           <td>${renderBadge(row.quality_status)}</td>
           <td>${renderBadge(row.runtime_status)} ${formatMaybeNumber(row.realtime_factor, 2, "x")}</td>
           <td>${formatMaybeNumber(row.effective_epoch_rate_hz, 2, " Hz")}</td>
@@ -1393,14 +1515,29 @@ def render_html() -> str:
       const movingBaseProvenance = document.getElementById("moving-base-provenance");
       const firstMovingBase = (overview.moving_base_summaries || []).find((row) => row.plot_png);
       if (firstMovingBase) {
-        renderMetricGrid(movingBaseMetrics, [
+        const metricEntries = [
           ["matched", firstMovingBase.matched_epochs ?? "n/a"],
           ["fix rate", formatMaybeNumber(firstMovingBase.fix_rate_pct, 2, "%")],
           ["p95 baseline", formatMaybeNumber(firstMovingBase.p95_baseline_error_m, 3, " m")],
           ["p95 heading", formatMaybeNumber(firstMovingBase.p95_heading_error_deg, 2, " deg")],
           ["realtime", formatMaybeNumber(firstMovingBase.realtime_factor, 2, "x")],
           ["epoch rate", formatMaybeNumber(firstMovingBase.effective_epoch_rate_hz, 2, " Hz")],
-        ]);
+        ];
+        if (firstMovingBase.commercial_receiver) {
+          metricEntries.push(
+            ["receiver fix", formatMaybeNumber(firstMovingBase.commercial_receiver.fix_rate_pct, 2, "%")],
+            ["receiver p95", formatMaybeNumber(firstMovingBase.commercial_receiver.p95_baseline_error_m, 3, " m")]
+          );
+        }
+        if (firstMovingBase.libgnss_vs_commercial_receiver) {
+          metricEntries.push(
+            [
+              "Δ receiver p95",
+              formatMaybeNumber(firstMovingBase.libgnss_vs_commercial_receiver.p95_baseline_error_m_delta, 3, " m"),
+            ]
+          );
+        }
+        renderMetricGrid(movingBaseMetrics, metricEntries);
         movingBaseProvenance.innerHTML = [
           firstMovingBase.summary_path ? artifactLink(firstMovingBase.summary_path, "summary") : null,
           firstMovingBase.prepare_summary_json ? artifactLink(firstMovingBase.prepare_summary_json, "prepare") : null,
@@ -1408,6 +1545,7 @@ def render_html() -> str:
           firstMovingBase.nav_rinex ? artifactLink(firstMovingBase.nav_rinex, "nav") : null,
           firstMovingBase.input ? artifactLink(firstMovingBase.input, "input") : null,
           firstMovingBase.input_url ? smartLink(firstMovingBase.input_url, "source") : null,
+          ...commercialReceiverArtifactLinks(firstMovingBase),
         ].filter(Boolean).join(" / ");
       } else {
         renderMetricGrid(movingBaseMetrics, [["status", "n/a"], ["summary", "unavailable"]]);

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -84,7 +84,7 @@ The ROS2 playback node publishes `.pos` files as:
 
 ## Local web UI
 
-`gnss web` is a local visualization layer for existing artifacts, including live, moving-base, and PPP-product sign-off summaries, artifact bundles, moving-base history charts, and direct links to summary, plot, product, comparison CSV/PNG, match CSV, and provenance files.
+`gnss web` is a local visualization layer for existing artifacts, including live, moving-base, PPC, and PPP-product sign-off summaries, artifact bundles, moving-base history charts, commercial receiver side-by-side metrics, and direct links to summary, plot, product, comparison CSV/PNG, match CSV, and provenance files.
 
 It shows:
 
@@ -92,6 +92,7 @@ It shows:
 - PPC summaries
 - live sign-off summaries
 - moving-base plots
+- commercial receiver comparisons for PPC and moving-base sign-offs
 - 2D trajectories
 - visibility summaries and a polar visibility view
 - `gnss rcv` receiver status

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -87,7 +87,7 @@ python3 apps/gnss.py web \
   --rcv-status output/receiver.status.json
 ```
 
-Open `http://127.0.0.1:8085` to inspect benchmark tables, live/moving-base/PPP-product sign-offs, receiver status, moving-base/visibility plots, moving-base history, and linked artifacts/provenance. PPP-product rows include direct links to fetched products, MALIB `.pos`, comparison CSV/PNG, and dataset reference files.
+Open `http://127.0.0.1:8085` to inspect benchmark tables, live/moving-base/PPP-product sign-offs, receiver status, moving-base/visibility plots, moving-base history, commercial receiver side-by-side metrics, and linked artifacts/provenance. PPC and moving-base rows include receiver comparison deltas when their summaries contain commercial receiver results; PPP-product rows include direct links to fetched products, MALIB `.pos`, comparison CSV/PNG, and dataset reference files.
 
 You can also store the same arguments in `configs/web.example.toml` and run:
 

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -11594,6 +11594,10 @@ class CLIToolsTest(unittest.TestCase):
             visibility_csv = temp_root / "output" / "visibility_static.csv"
             visibility_png = temp_root / "output" / "visibility_static.png"
             moving_base_summary = temp_root / "output" / "scorpion_moving_base_summary.json"
+            moving_base_commercial = temp_root / "output" / "commercial_receiver_solution.csv"
+            moving_base_commercial_matches = temp_root / "output" / "commercial_receiver_matches.csv"
+            ppc_commercial = temp_root / "output" / "ppc_commercial_receiver.csv"
+            ppc_commercial_matches = temp_root / "output" / "ppc_commercial_receiver_matches.csv"
             artifact_manifest = temp_root / "output" / "artifact_manifest.json"
             port_file = temp_root / "port.txt"
 
@@ -11675,9 +11679,38 @@ class CLIToolsTest(unittest.TestCase):
                         "solver_wall_time_s": 12.34,
                         "realtime_factor": 1.23,
                         "effective_epoch_rate_hz": 15.67,
+                        "commercial_receiver": {
+                            "label": "survey_receiver",
+                            "solution_pos": str(ppc_commercial),
+                            "format": "csv",
+                            "matched_csv": str(ppc_commercial_matches),
+                            "matched_epochs": 120,
+                            "valid_epochs": 120,
+                            "fixed_epochs": 118,
+                            "fix_rate_pct": 98.33,
+                            "median_h_m": 0.095,
+                            "p95_h_m": 0.105,
+                            "p95_abs_up_m": 0.120,
+                        },
+                        "delta_vs_commercial_receiver": {
+                            "matched_epochs": 0,
+                            "fixed_epochs": -2,
+                            "fix_rate_pct": -1.66,
+                            "median_h_m": 0.013,
+                            "p95_h_m": 0.005,
+                            "p95_abs_up_m": -0.010,
+                        },
                     }
                 ),
                 encoding="utf-8",
+            )
+            ppc_commercial.write_text(
+                "gps_week,gps_tow_s,lat_deg,lon_deg,height_m,solution_status,num_satellites\n",
+                encoding="ascii",
+            )
+            ppc_commercial_matches.write_text(
+                "gps_tow_s,traj_east_m,traj_north_m,traj_up_m,east_error_m,north_error_m,up_error_m,horizontal_error_m,status\n",
+                encoding="ascii",
             )
             moving_base_summary.write_text(
                 json.dumps(
@@ -11699,9 +11732,40 @@ class CLIToolsTest(unittest.TestCase):
                         "nav_rinex": str(temp_root / "output" / "brdc0010.24n"),
                         "input_url": "https://example.com/scorpion.zip",
                         "signoff_profile": "scorpion-moving-base",
+                        "commercial_receiver_csv": str(moving_base_commercial),
+                        "commercial_receiver_matched_csv": str(moving_base_commercial_matches),
+                        "commercial_receiver": {
+                            "label": "rover_nav_pvt",
+                            "solution_pos": str(moving_base_commercial),
+                            "format": "csv",
+                            "matched_csv": str(moving_base_commercial_matches),
+                            "matched_epochs": 120,
+                            "valid_epochs": 120,
+                            "fixed_epochs": 120,
+                            "fix_rate_pct": 100.0,
+                            "median_baseline_error_m": 0.102,
+                            "p95_baseline_error_m": 0.133,
+                            "p95_heading_error_deg": 3.80,
+                        },
+                        "libgnss_vs_commercial_receiver": {
+                            "matched_epochs_delta": -26,
+                            "fixed_epochs_delta": -30,
+                            "fix_rate_pct_delta": -4.26,
+                            "median_baseline_error_m_delta": -0.060,
+                            "p95_baseline_error_m_delta": -0.032,
+                            "p95_heading_error_deg_delta": 2.05,
+                        },
                     }
                 ),
                 encoding="utf-8",
+            )
+            moving_base_commercial.write_text(
+                "gps_week,gps_tow_s,lat_deg,lon_deg,height_m,solution_status,num_satellites\n",
+                encoding="ascii",
+            )
+            moving_base_commercial_matches.write_text(
+                "gps_week,gps_tow_s,baseline_error_m,baseline_length_m,heading_error_deg,status,satellites\n",
+                encoding="ascii",
             )
             (temp_root / "output" / "scorpion_moving_base.png").write_bytes(
                 binascii.a2b_base64(
@@ -11848,6 +11912,17 @@ class CLIToolsTest(unittest.TestCase):
                 self.assertEqual(len(overview["ppc_summaries"]), 1)
                 self.assertEqual(overview["ppc_summaries"][0]["runtime_status"], "realtime")
                 self.assertEqual(overview["ppc_summaries"][0]["quality_status"], "excellent")
+                self.assertEqual(overview["ppc_summaries"][0]["commercial_receiver"]["label"], "survey_receiver")
+                self.assertEqual(
+                    overview["ppc_summaries"][0]["commercial_receiver"]["solution_pos"],
+                    "output/ppc_commercial_receiver.csv",
+                )
+                self.assertEqual(
+                    overview["ppc_summaries"][0]["commercial_receiver"]["matched_csv"],
+                    "output/ppc_commercial_receiver_matches.csv",
+                )
+                self.assertEqual(overview["ppc_summaries"][0]["delta_vs_commercial_receiver"]["p95_h_m"], 0.005)
+                self.assertEqual(overview["ppc_summaries"][0]["commercial_comparison_status"], "close")
                 self.assertEqual(len(overview["moving_base_summaries"]), 1)
                 self.assertEqual(overview["moving_base_summaries"][0]["runtime_status"], "realtime")
                 self.assertEqual(overview["moving_base_summaries"][0]["quality_status"], "excellent")
@@ -11855,6 +11930,21 @@ class CLIToolsTest(unittest.TestCase):
                 self.assertEqual(overview["moving_base_summaries"][0]["signoff_profile"], "scorpion-moving-base")
                 self.assertTrue(overview["moving_base_summaries"][0]["plot_png"].endswith("scorpion_moving_base.png"))
                 self.assertTrue(overview["moving_base_summaries"][0]["matched_csv"].endswith("scorpion_moving_base_matches.csv"))
+                self.assertEqual(
+                    overview["moving_base_summaries"][0]["commercial_receiver"]["solution_pos"],
+                    "output/commercial_receiver_solution.csv",
+                )
+                self.assertEqual(
+                    overview["moving_base_summaries"][0]["commercial_receiver"]["matched_csv"],
+                    "output/commercial_receiver_matches.csv",
+                )
+                self.assertEqual(
+                    overview["moving_base_summaries"][0]["libgnss_vs_commercial_receiver"][
+                        "p95_baseline_error_m_delta"
+                    ],
+                    -0.032,
+                )
+                self.assertEqual(overview["moving_base_summaries"][0]["commercial_comparison_status"], "worse")
                 self.assertEqual(overview["moving_base_summaries"][0]["nav_rinex"], "output/brdc0010.24n")
                 self.assertEqual(overview["moving_base_summaries"][0]["input_url"], "https://example.com/scorpion.zip")
                 self.assertEqual(len(overview["ppp_products_summaries"]), 1)
@@ -11880,6 +11970,15 @@ class CLIToolsTest(unittest.TestCase):
                 self.assertIn("moving-base", manifest_categories)
                 self.assertIn("ppp-products", manifest_categories)
                 self.assertIn("visibility", manifest_categories)
+                ppc_bundle = next(entry for entry in overview["artifact_manifest"] if entry["category"] == "ppc")
+                self.assertEqual(ppc_bundle["artifacts"]["commercial_solution"], "output/ppc_commercial_receiver.csv")
+                moving_base_bundle = next(
+                    entry for entry in overview["artifact_manifest"] if entry["category"] == "moving-base"
+                )
+                self.assertEqual(
+                    moving_base_bundle["artifacts"]["commercial_matches"],
+                    "output/commercial_receiver_matches.csv",
+                )
 
                 with request.urlopen(
                     f"http://127.0.0.1:{bound_port}/api/visibility?path=output/visibility_static.csv"
@@ -11966,6 +12065,18 @@ class CLIToolsTest(unittest.TestCase):
                         "matched_csv": str(output_dir / "scorpion_moving_base_matches.csv"),
                         "plot_png": str(output_dir / "scorpion_moving_base.png"),
                         "input_url": "https://example.com/scorpion.zip",
+                        "commercial_receiver": {
+                            "label": "rover_nav_pvt",
+                            "solution_pos": str(output_dir / "commercial_receiver_solution.csv"),
+                            "matched_csv": str(output_dir / "commercial_receiver_matches.csv"),
+                            "matched_epochs": 120,
+                            "fix_rate_pct": 100.0,
+                            "p95_baseline_error_m": 0.133,
+                        },
+                        "libgnss_vs_commercial_receiver": {
+                            "fix_rate_pct_delta": -4.26,
+                            "p95_baseline_error_m_delta": -0.032,
+                        },
                     }
                 ),
                 encoding="utf-8",
@@ -11993,6 +12104,14 @@ class CLIToolsTest(unittest.TestCase):
             moving_base_entry = next(entry for entry in payload["bundles"] if entry["category"] == "moving-base")
             self.assertEqual(moving_base_entry["artifacts"]["input_url"], "https://example.com/scorpion.zip")
             self.assertEqual(moving_base_entry["artifacts"]["matched_csv"], "output/scorpion_moving_base_matches.csv")
+            self.assertEqual(
+                moving_base_entry["artifacts"]["commercial_solution"],
+                "output/commercial_receiver_solution.csv",
+            )
+            self.assertEqual(
+                moving_base_entry["metrics"]["libgnss_vs_commercial_receiver"]["p95_baseline_error_m_delta"],
+                -0.032,
+            )
             ppp_entry = next(entry for entry in payload["bundles"] if entry["category"] == "ppp-products")
             self.assertEqual(ppp_entry["artifacts"]["sp3"], "output/igs.sp3")
             self.assertEqual(ppp_entry["artifacts"]["reference"], "output/ppc_reference.csv")

--- a/tests/test_web_ui.py
+++ b/tests/test_web_ui.py
@@ -54,7 +54,11 @@ class WebUISmokeTest(unittest.TestCase):
             status_json = temp_root / "receiver.status.json"
             live_summary = temp_root / "output" / "live_replay_summary.json"
             ppc_summary = temp_root / "output" / "ppc_tokyo_run1_rtk_summary.json"
+            ppc_commercial = temp_root / "output" / "ppc_commercial_receiver.csv"
+            ppc_commercial_matches = temp_root / "output" / "ppc_commercial_receiver_matches.csv"
             moving_base_summary = temp_root / "output" / "scorpion_moving_base_summary.json"
+            moving_base_commercial = temp_root / "output" / "commercial_receiver_solution.csv"
+            moving_base_commercial_matches = temp_root / "output" / "commercial_receiver_matches.csv"
             ppp_products_summary = temp_root / "output" / "ppp_static_products_summary.json"
             visibility_summary = temp_root / "output" / "visibility_static_summary.json"
             visibility_csv = temp_root / "output" / "visibility_static.csv"
@@ -142,9 +146,38 @@ class WebUISmokeTest(unittest.TestCase):
                         "solver_wall_time_s": 12.34,
                         "realtime_factor": 1.23,
                         "effective_epoch_rate_hz": 15.67,
+                        "commercial_receiver": {
+                            "label": "survey_receiver",
+                            "solution_pos": str(ppc_commercial),
+                            "format": "csv",
+                            "matched_csv": str(ppc_commercial_matches),
+                            "matched_epochs": 120,
+                            "valid_epochs": 120,
+                            "fixed_epochs": 118,
+                            "fix_rate_pct": 98.33,
+                            "median_h_m": 0.095,
+                            "p95_h_m": 0.105,
+                            "p95_abs_up_m": 0.120,
+                        },
+                        "delta_vs_commercial_receiver": {
+                            "matched_epochs": 0,
+                            "fixed_epochs": -2,
+                            "fix_rate_pct": -1.66,
+                            "median_h_m": 0.013,
+                            "p95_h_m": 0.005,
+                            "p95_abs_up_m": -0.010,
+                        },
                     }
                 ),
                 encoding="utf-8",
+            )
+            ppc_commercial.write_text(
+                "gps_week,gps_tow_s,lat_deg,lon_deg,height_m,solution_status,num_satellites\n",
+                encoding="ascii",
+            )
+            ppc_commercial_matches.write_text(
+                "gps_tow_s,traj_east_m,traj_north_m,traj_up_m,east_error_m,north_error_m,up_error_m,horizontal_error_m,status\n",
+                encoding="ascii",
             )
             moving_base_summary.write_text(
                 json.dumps(
@@ -166,9 +199,40 @@ class WebUISmokeTest(unittest.TestCase):
                         "nav_rinex": str(temp_root / "output" / "brdc0010.24n"),
                         "input_url": "https://example.com/scorpion.zip",
                         "signoff_profile": "scorpion-moving-base",
+                        "commercial_receiver_csv": str(moving_base_commercial),
+                        "commercial_receiver_matched_csv": str(moving_base_commercial_matches),
+                        "commercial_receiver": {
+                            "label": "rover_nav_pvt",
+                            "solution_pos": str(moving_base_commercial),
+                            "format": "csv",
+                            "matched_csv": str(moving_base_commercial_matches),
+                            "matched_epochs": 120,
+                            "valid_epochs": 120,
+                            "fixed_epochs": 120,
+                            "fix_rate_pct": 100.0,
+                            "median_baseline_error_m": 0.102,
+                            "p95_baseline_error_m": 0.133,
+                            "p95_heading_error_deg": 3.80,
+                        },
+                        "libgnss_vs_commercial_receiver": {
+                            "matched_epochs_delta": -26,
+                            "fixed_epochs_delta": -30,
+                            "fix_rate_pct_delta": -4.26,
+                            "median_baseline_error_m_delta": -0.060,
+                            "p95_baseline_error_m_delta": -0.032,
+                            "p95_heading_error_deg_delta": 2.05,
+                        },
                     }
                 ),
                 encoding="utf-8",
+            )
+            moving_base_commercial.write_text(
+                "gps_week,gps_tow_s,lat_deg,lon_deg,height_m,solution_status,num_satellites\n",
+                encoding="ascii",
+            )
+            moving_base_commercial_matches.write_text(
+                "gps_week,gps_tow_s,baseline_error_m,baseline_length_m,heading_error_deg,status,satellites\n",
+                encoding="ascii",
             )
             (temp_root / "output" / "scorpion_moving_base.png").write_bytes(
                 base64.b64decode(
@@ -350,11 +414,16 @@ class WebUISmokeTest(unittest.TestCase):
                     self.assertIn("FIXED", page.locator("#status-legend").text_content())
                     self.assertIn("ppc_tokyo_run1_rtk_summary.json", page.locator("#ppc-table tbody").text_content())
                     self.assertIn("96.67%", page.locator("#ppc-table tbody").text_content())
+                    self.assertIn("survey_receiver", page.locator("#ppc-table tbody").text_content())
+                    self.assertIn("Δp95 0.005 m", page.locator("#ppc-table tbody").text_content())
+                    self.assertIn("receiver-matches", page.locator("#ppc-table tbody").text_content())
                     self.assertIn("excellent", page.locator("#ppc-table tbody").text_content())
                     self.assertIn("12.34 s", page.locator("#ppc-table tbody").text_content())
                     self.assertIn("scorpion_moving_base_summary.json", page.locator("#moving-base-table tbody").text_content())
                     self.assertIn("95.74%", page.locator("#moving-base-table tbody").text_content())
                     self.assertIn("0.101 m", page.locator("#moving-base-table tbody").text_content())
+                    self.assertIn("rover_nav_pvt", page.locator("#moving-base-table tbody").text_content())
+                    self.assertIn("Δhead 2.05 deg", page.locator("#moving-base-table tbody").text_content())
                     self.assertIn("completed", page.locator("#moving-base-table tbody").text_content())
                     self.assertIn("matches", page.locator("#moving-base-table tbody").text_content())
                     self.assertIn("prepare", page.locator("#moving-base-table tbody").text_content())
@@ -371,8 +440,10 @@ class WebUISmokeTest(unittest.TestCase):
                     self.assertIn("summary", page.locator("#moving-base-provenance").text_content())
                     self.assertIn("prepare", page.locator("#moving-base-provenance").text_content())
                     self.assertIn("products", page.locator("#moving-base-provenance").text_content())
+                    self.assertIn("receiver", page.locator("#moving-base-provenance").text_content())
                     self.assertIn("95.74%", page.locator("#moving-base-metrics").text_content())
                     self.assertIn("0.101 m", page.locator("#moving-base-metrics").text_content())
+                    self.assertIn("-0.032 m", page.locator("#moving-base-metrics").text_content())
                     self.assertIn("ppp_static_products_summary.json", page.locator("#ppp-products-table tbody").text_content())
                     self.assertIn("PPC-Dataset tokyo run1", page.locator("#ppp-products-table tbody").text_content())
                     self.assertIn("2024-01-02", page.locator("#ppp-products-table tbody").text_content())
@@ -389,6 +460,8 @@ class WebUISmokeTest(unittest.TestCase):
                     self.assertIn("44.70 dB-Hz", page.locator("#visibility-table tbody").text_content())
                     self.assertIn("Artifact bundles", page.locator("body").text_content())
                     self.assertIn("94 matched", page.locator("#artifact-manifest-table tbody").text_content())
+                    self.assertIn("commercial_solution", page.locator("#artifact-manifest-table tbody").text_content())
+                    self.assertIn("commercial_matches", page.locator("#artifact-manifest-table tbody").text_content())
                     self.assertIn("ppp-products", page.locator("#artifact-manifest-table tbody").text_content())
                     self.assertIn("moving-base", page.locator("#artifact-manifest-table tbody").text_content())
                     self.assertIn("visibility", page.locator("#artifact-manifest-table tbody").text_content())


### PR DESCRIPTION
## Summary
- surface commercial receiver metrics and deltas in `gnss web` PPC and moving-base summaries
- include commercial receiver solution/match artifacts in artifact manifests
- update web/API fixtures and docs for the new side-by-side fields

## Validation
- `python3 -m py_compile apps/gnss_web.py apps/gnss_artifact_manifest.py`
- `python3 tests/test_cli_tools.py CLIToolsTest.test_web_serves_overview_solution_and_status_api CLIToolsTest.test_artifact_manifest_cli_collects_bundle_metadata`
- `python3 tests/test_web_ui.py WebUISmokeTest.test_web_ui_renders_overview_status_and_ppc_rows`
- `git diff --check`
