### PR TITLE
Drop kinematic post-filter cascade; single-epoch drop on height jump

### DIFF
--- a/apps/gnss_solve.cpp
+++ b/apps/gnss_solve.cpp
@@ -43,7 +43,6 @@ constexpr double kDefaultFixedBridgeBurstGuardMaxAnchorGapSeconds = 30.0;
 constexpr double kDefaultFixedBridgeBurstGuardMinBoundaryGapSeconds = 1.0;
 constexpr double kDefaultFixedBridgeBurstGuardMaxResidualMeters = 20.0;
 constexpr int kDefaultFixedBridgeBurstGuardMaxSegmentEpochs = 12;
-constexpr int kReacquireFixedCount = 5;
 
 enum class ModeChoice {
     AUTO,
@@ -1614,28 +1613,21 @@ int main(int argc, char* argv[]) {
         if (config.enable_kinematic_post_filter &&
             rtk_config.position_mode != libgnss::RTKProcessor::RTKConfig::PositionMode::STATIC &&
             !solution.isEmpty()) {
+            // Single-epoch drop on height-step jumps. The previous "suppress
+            // until N consecutive FIXED" cascade was removed because, with
+            // PR #34's state-restore in validateFixedSolution and PR #35's
+            // --max-pos-jump=5.0 default, wrong-FIX is already rejected at
+            // the AR layer. A wrong-FIX occasionally still slipped past and
+            // became `last_kept`, after which the cascade silently dropped
+            // many subsequent valid epochs (truth validation: 92.1% -> 47.8%
+            // coverage). Drop only the offending epoch and leave `last_kept`
+            // pointing at the prior trusted anchor.
             libgnss::Solution filtered_solution;
             filtered_solution.solutions.reserve(solution.solutions.size());
-            bool suppress_until_fix_recovery = false;
-            int recovery_fixed_streak = 0;
             bool have_kept_fixed = false;
             const libgnss::PositionSolution* last_kept = nullptr;
             for (const auto& epoch_solution : solution.solutions) {
                 if (!epoch_solution.isValid()) {
-                    continue;
-                }
-                if (suppress_until_fix_recovery) {
-                    if (epoch_solution.isFixed()) {
-                        recovery_fixed_streak++;
-                        if (recovery_fixed_streak >= kReacquireFixedCount) {
-                            filtered_solution.addSolution(epoch_solution);
-                            last_kept = &filtered_solution.solutions.back();
-                            suppress_until_fix_recovery = false;
-                            recovery_fixed_streak = 0;
-                        }
-                    } else {
-                        recovery_fixed_streak = 0;
-                    }
                     continue;
                 }
 
@@ -1650,8 +1642,8 @@ int main(int argc, char* argv[]) {
                     const double max_height_step =
                         std::max(kDefaultVerticalStepGuardMeters, 4.0 * dt);
                     if (height_step > max_height_step) {
-                        suppress_until_fix_recovery = true;
-                        recovery_fixed_streak = epoch_solution.isFixed() ? 1 : 0;
+                        // Drop this single epoch only; do not advance the
+                        // anchor or trigger a multi-epoch suppression.
                         continue;
                     }
                 }


### PR DESCRIPTION
## Summary

Remove the kinematic post-filter recovery cascade (`suppress_until_fix_recovery` + `kReacquireFixedCount=5`). When a height-step jump is detected, drop only that single epoch instead of suppressing all output until 5 consecutive FIXED epochs return. The anchor (`last_kept`) is unchanged on drop.

## Why

Truth-validation against the PPC reference dataset (6 runs: tokyo/nagoya x run1-3) showed coverage collapsing from 92.1% (`--no-kinematic-post-filter`) to 47.8% (default cascade). The pathology: a wrong-FIX that slips past AR gates becomes the anchor; the next correct FIX/FLOAT looks like a height jump from the anchor; the cascade then suppresses output for many epochs while waiting for 5 consecutive FIXED.

After PR #34's state-restore in `validateFixedSolution` and PR #35's `--max-pos-jump 5.0` default, wrong-FIX rate is already cut at the AR layer. The post-filter cascade is now redundant double-defense that costs >40 pp coverage. Replacing it with single-epoch drop keeps the height-jump safety net for residual wrong-FIX without the cascade penalty.

## Changes

- `apps/gnss_solve.cpp`: replace post-filter loop body — remove `suppress_until_fix_recovery` / `recovery_fixed_streak` state and the `kReacquireFixedCount` constant. Height-jump path now does `continue` (single-epoch drop) without touching `last_kept`. `kDefaultVerticalStepGuardMeters` and the `enable_kinematic_post_filter` flag (with `--no-kinematic-post-filter` CLI escape) remain.

## Validation

- `cmake --build build -j` PASS
- `run_tests --gtest_filter='*RTK*'` PASS (61 passed, 20 skipped — fixture data not in repo)
- `pytest tests/test_benchmark_scripts.py -q` PASS (91 passed)
- 6-run truth validation deferred to post-merge sasaki bench

## Out of scope

- Adding new post-filter state (anchor recovery, look-ahead buffers) — separate PR if needed
- Removing `enable_kinematic_post_filter` flag — kept as escape hatch
- Changing `kDefaultVerticalStepGuardMeters` (1.0 m) — physics threshold, separate sweep PR
- Touching `validateFixedSolution` (state-restore is PR #34's domain)
- Static-base / moving-base behavior (post-filter is already skipped in STATIC mode)