### PR TITLE
fix(rinex): parse TIME OF FIRST OBS so raw-L6 resolves the right GPS week

### DIFF
--- a/src/io/rinex.cpp
+++ b/src/io/rinex.cpp
@@ -610,6 +610,35 @@ bool RINEXReader::parseHeaderLine(const std::string& line, RINEXHeader& header) 
         const double north = std::stod(line.substr(28, 14));
         header.antenna_delta = Vector3d(east, north, height);
     }
+    else if (label.find("TIME OF FIRST OBS") != std::string::npos) {
+        try {
+            const int year = std::stoi(line.substr(0, 6));
+            const int month = std::stoi(line.substr(6, 6));
+            const int day = std::stoi(line.substr(12, 6));
+            const int hour = std::stoi(line.substr(18, 6));
+            const int minute = std::stoi(line.substr(24, 6));
+            const double second = std::stod(line.substr(30, 13));
+            auto days_from_civil = [](int y, unsigned m, unsigned d) -> int {
+                y -= m <= 2;
+                const int era = (y >= 0 ? y : y - 399) / 400;
+                const unsigned yoe = static_cast<unsigned>(y - era * 400);
+                const unsigned doy = (153 * (m + (m > 2 ? -3 : 9)) + 2) / 5 + d - 1;
+                const unsigned doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+                return era * 146097 + static_cast<int>(doe) - 719468;
+            };
+            const int gps_epoch_days = days_from_civil(1980, 1, 6);
+            const int current_days = days_from_civil(
+                year, static_cast<unsigned>(month), static_cast<unsigned>(day));
+            const int days_since_gps = current_days - gps_epoch_days;
+            const int gps_week = days_since_gps / 7;
+            const int day_of_week = days_since_gps % 7;
+            const double tow = day_of_week * 86400.0 + hour * 3600.0
+                + minute * 60.0 + second;
+            header.first_obs = GNSSTime(gps_week, tow);
+        } catch (...) {
+            // Leave first_obs at default if parsing fails.
+        }
+    }
     else if (label.find("# / TYPES OF OBSERV") != std::string::npos) {
         // RINEX 2: Parse number of observation types
         int num_types = std::stoi(line.substr(0, 6));


### PR DESCRIPTION
## Summary

- `RINEXReader::parseHeaderLine` ignored the `TIME OF FIRST OBS` field, leaving `header.first_obs.week = 0`.
- Result: `apps/gnss_ppp` skipped propagating the week into `ppp_config.l6_gps_week`, and `L6Decoder::loadL6Products` fell back to a hardcoded **2068** (257 weeks off for week-2325 obs).
- Every `ssr.interpolateCorrection()` returned `false`; CLAS strict-OSR silently degraded to SPP-only on **raw `.l6` input** (cached compact CSV embeds the week and bypassed it).
- Adds a `TIME OF FIRST OBS` parser branch using the same `days_from_civil` algorithm already in `parseObservationEpochV3`.

## Effect (PPC nagoya_run1, raw L6, 1500 epochs)

| metric         | before | after  |
| -------------- | -----: | -----: |
| Q=1 (SPP)      |   1500 |     35 |
| Q=5 (FLOAT)    |      0 |    317 |
| Q=6 (FIXED)    |      0 |   1132 |
| H_med (fix)    |    n/a |  1.32m |

The fix-only structural floor (~1.3 m) is unchanged — that's a separate AR/measurement-model issue tracked elsewhere.

## Why the bug hid for so long

The PPP wrappers (`apps/gnss_clas_ppp.py`, `gnss_ppc_demo.py`) expand raw L6 to a compact CSV before invoking `gnss_ppp`. The compact CSV embeds the correct GPS week, so the bug only fires when the raw `.l6` is passed directly via `--ssr`.

## Test plan

- [x] Build clean (`cmake --build build -j8`)
- [x] PPC nagoya_run1 raw-L6: 0/1500 -> 1132/1500 PPP fixes
- [ ] Tokyo run1 / nagoya run2/3 raw-L6 sanity (existing wrapper-driven runs unaffected)
- [ ] Confirm no regression on cached compact CSV path