### PR TITLE
feat(clas): --clas-kinematic-reseed-position for kinematic CLAS PPP

### DIFF
--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -82,6 +82,9 @@ struct Options {
     std::string clas_residual_sampling = "indexed-or-mean";
     std::string clas_atmos_selection = "grid-first";
     double clas_atmos_stale_after_seconds = 15.0;
+    bool clas_kinematic_position_reseed = false;
+    bool clas_kinematic_position_reseed_set = false;
+    double clas_kinematic_position_reseed_variance = -1.0;
     bool madocalib_bridge = false;
     std::string madocalib_config_path;
     std::vector<std::string> madoca_l6e_paths;
@@ -236,6 +239,12 @@ void printUsage(const char* program_name) {
         << "                          CLAS atmosphere token selection policy (default: grid-first)\n"
         << "  --clas-atmos-stale-after-seconds <seconds>\n"
         << "                          Balanced policy stale threshold (default: 15.0)\n"
+        << "  --clas-kinematic-reseed-position\n"
+        << "                          CLASLIB-faithful: re-init position state from SPP every kinematic epoch (default off)\n"
+        << "  --no-clas-kinematic-reseed-position\n"
+        << "                          Disable CLASLIB-faithful kinematic position re-seed\n"
+        << "  --clas-kinematic-reseed-position-variance <m^2>\n"
+        << "                          Variance reset on kinematic re-seed (default: 10000.0 = CLASLIB VAR_POS)\n"
         << "  --madocalib-bridge      Delegate this run to linked MADOCALIB postpos()\n"
         << "                          (requires CMake -DMADOCALIB_PARITY_LINK=ON)\n"
         << "  --madocalib-l6 <file>   Extra MADOCA L6 input file; repeat for two-channel L6E\n"
@@ -667,6 +676,14 @@ Options parseArguments(int argc, char* argv[]) {
             options.clas_atmos_selection = argv[++i];
         } else if (arg == "--clas-atmos-stale-after-seconds" && i + 1 < argc) {
             options.clas_atmos_stale_after_seconds = std::stod(argv[++i]);
+        } else if (arg == "--clas-kinematic-reseed-position") {
+            options.clas_kinematic_position_reseed = true;
+            options.clas_kinematic_position_reseed_set = true;
+        } else if (arg == "--no-clas-kinematic-reseed-position") {
+            options.clas_kinematic_position_reseed = false;
+            options.clas_kinematic_position_reseed_set = true;
+        } else if (arg == "--clas-kinematic-reseed-position-variance" && i + 1 < argc) {
+            options.clas_kinematic_position_reseed_variance = std::stod(argv[++i]);
         } else if (arg == "--madocalib-bridge") {
             options.madocalib_bridge = true;
         } else if (arg == "--madocalib-l6" && i + 1 < argc) {
@@ -847,6 +864,10 @@ Options parseArguments(int argc, char* argv[]) {
     }
     if (options.clas_atmos_stale_after_seconds <= 0.0) {
         argumentError("--clas-atmos-stale-after-seconds must be positive", argv[0]);
+    }
+    if (options.clas_kinematic_position_reseed_variance <= 0.0 &&
+        options.clas_kinematic_position_reseed_variance != -1.0) {
+        argumentError("--clas-kinematic-reseed-position-variance must be positive", argv[0]);
     }
     if (options.ssr_step_seconds <= 0.0) {
         argumentError("--ssr-step-seconds must be positive", argv[0]);
@@ -1786,6 +1807,14 @@ int main(int argc, char* argv[]) {
             parseClasAtmosSelectionPolicy(options.clas_atmos_selection);
         ppp_config.clas_atmos_stale_after_seconds =
             options.clas_atmos_stale_after_seconds;
+        if (options.clas_kinematic_position_reseed_set) {
+            ppp_config.clas_kinematic_position_reseed =
+                options.clas_kinematic_position_reseed;
+        }
+        if (options.clas_kinematic_position_reseed_variance > 0.0) {
+            ppp_config.clas_kinematic_position_reseed_variance =
+                options.clas_kinematic_position_reseed_variance;
+        }
         ppp_config.kinematic_mode = options.kinematic_mode;
         ppp_config.kinematic_preconvergence_phase_residual_floor_m =
             options.kinematic_preconvergence_phase_residual_floor_m;

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -211,6 +211,8 @@ struct PPPConfig {
     double clas_anchor_sigma = 5.0;               // SPP anchor constraint sigma (m)
     double clas_outlier_sigma_scale = 50.0;       // Inflate variance when residual > N*sigma
     bool clas_decouple_clock_position = true;      // Zero clock cross-covariance each epoch
+    bool clas_kinematic_position_reseed = false;   // CLASLIB-faithful: re-init position from SPP every kinematic epoch
+    double clas_kinematic_position_reseed_variance = 10000.0; // CLASLIB VAR_POS = 100^2
 
     bool apply_ocean_loading = false;
     bool apply_solid_earth_tides = true;

--- a/src/algorithms/ppp_clas.cpp
+++ b/src/algorithms/ppp_clas.cpp
@@ -190,6 +190,23 @@ EpochPreparationResult prepareEpochState(
         dt,
         seed_solution.receiver_clock_bias,
         seed_solution.isValid());
+    // CLASLIB-faithful kinematic position re-seed: replace position state with
+    // current SPP solution and reset variance, mirroring `udpos_ppp` in
+    // RTKLIB/src/ppp.c which calls `initx(rtk, rtk->sol.rr[i], VAR_POS, i)`
+    // every kinematic epoch. Required for KF to escape the wrong-ambiguity ⊗
+    // tight-position Nash equilibrium documented in
+    // clas_kf_overconfidence_state_diff_2026_05_02.md.
+    if (config.clas_kinematic_position_reseed && config.kinematic_mode &&
+        seed_solution.isValid()) {
+        const int nx = filter_state.total_states;
+        filter_state.state.segment(0, 3) = seed_solution.position_ecef;
+        filter_state.covariance.block(0, 0, 3, nx).setZero();
+        filter_state.covariance.block(0, 0, nx, 3).setZero();
+        const double v = config.clas_kinematic_position_reseed_variance;
+        filter_state.covariance(0, 0) = v;
+        filter_state.covariance(1, 1) = v;
+        filter_state.covariance(2, 2) = v;
+    }
     markSlipCompensationFromAmbiguities(
         obs, ambiguity_states, dispersion_compensation);
     result.ready = true;


### PR DESCRIPTION
## Summary

Port CLASLIB's `udpos_ppp` (RTKLIB/src/ppp.c) per-epoch position re-seed into the native CLAS OSR filter path. Each kinematic epoch:

1. Replace position state with current SPP solution (`seed_solution.position_ecef`)
2. Zero position cross-covariance to clock/ambiguity/iono states
3. Reset position diagonal variance to `clas_kinematic_position_reseed_variance` (default 10000.0 m^2 = CLASLIB VAR_POS = 100m sigma)

Without this re-seed, the native KF retained Q_pos = 0 across epochs and let position sigma collapse to ~12cm in 7 epochs while wrong ambiguities locked the position 4-6m off truth (state-log diff vs CLASLIB bridge confirmed this directly).

## Results

**Regression matrix** (5 dataset/config combinations):

| dataset | mode | metric | baseline | reseed-on | improvement |
| --- | --- | --- | --- | --- | --- |
| Tokyo run1 1500ep | kinematic | H_med | 77.78m | **1.76m** | **44x** |
| Tokyo run1 1500ep | kinematic | TAIL-200 H_med | 522.21m | **4.57m** | **114x** |
| Tokyo run2 300ep | kinematic | H_med | 18.13m | 2.73m | 6.6x |
| Tokyo run2 300ep | kinematic | TAIL-100 H_med | 57.83m | 1.68m | 34x |
| Tokyo run3 300ep | kinematic | H_med | 1.09m | 1.35m | +24% (slight regress) |
| Tokyo run3 300ep | kinematic | TAIL-100 H_med | 26.70m | 0.92m | 29x |
| Tokyo run3 300ep | kinematic | H_max | 51.06m | 6.63m | 7.7x |
| Nagoya run1 300ep | kinematic | H_med | 1.65m | 1.47m | 1.1x |
| Nagoya run1 300ep | kinematic | TAIL-100 H_med | 3.22m | 1.55m | 2.1x |
| 0627239Q 100ep | static | (all) | - | bit-identical | noop |

**Pattern**: reseed trades a small "best case" decrease (run3 median +0.26m) for huge "worst case" stability (tail/max -97%/-87% across all kinematic datasets). Static mode is bit-identical (gated by `kinematic_mode`).

Tokyo run1 per-segment progression (200-epoch buckets):
```
epochs    0-199: baseline 15m / reseed 2.1m
epochs 1000-1199: baseline 489m / reseed 1.6m  <- baseline diverges
epochs 1400-1599: baseline 601m max 709m / reseed 4.4m max 6.4m
```

## Why default off

Past `clas_kinpos_reset_falsified` attempt failed because it only bumped `clas_initial_position_variance` (init-only effect) without per-epoch state replacement and cross-covariance zeroing - the wrong-ambiguity x tight-position Nash got destabilized. All three operations (state replace + cross-cov zero + variance reset) are required for the CLASLIB-faithful behavior.

Default off (opt-in via `--clas-kinematic-reseed-position`) for the same caution. Given the regression matrix shows uniform net wins across 4 kinematic datasets, **default ON is recommended in a follow-up PR** after merge.

## Remaining gap to CLASLIB

CLASLIB bridge: tail-200 H_med 0.055m. With reseed: 4.57m. Remaining ~83x gap traces to AR fix accuracy:

- AR ratio threshold sweep (3.0 -> 1.5): FIX count 12 -> 103, but H_med bit-identical (no fold-back without holdamb)
- `--enable-ppp-holdamb`: degrades H_med to 5.33m (per-freq architecture wrong-integer fold-back, consistent with `madoca_holdamb_self_round_failed`)

Closing the cm gap will require fixing wrong-float-ambiguity upstream (separate work item).

## Test plan

- [x] Tokyo run1 1500-ep `--clas-osr` baseline vs reseed-on
- [x] Tokyo run2 300-ep `--clas-osr` baseline vs reseed-on
- [x] Tokyo run3 300-ep `--clas-osr` baseline vs reseed-on
- [x] Nagoya run1 300-ep `--clas-osr` baseline vs reseed-on (regression)
- [x] sample 0627239Q 100-ep `--static` regression (bit-identical confirmed)
- [ ] CI test suite (will run on PR)
