### PR TITLE
feat(clas): default --clas-kinematic-reseed-position to on

### DIFF
--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -240,7 +240,7 @@ void printUsage(const char* program_name) {
         << "  --clas-atmos-stale-after-seconds <seconds>\n"
         << "                          Balanced policy stale threshold (default: 15.0)\n"
         << "  --clas-kinematic-reseed-position\n"
-        << "                          CLASLIB-faithful: re-init position state from SPP every kinematic epoch (default off)\n"
+        << "                          CLASLIB-faithful: re-init position state from SPP every kinematic epoch (default on)\n"
         << "  --no-clas-kinematic-reseed-position\n"
         << "                          Disable CLASLIB-faithful kinematic position re-seed\n"
         << "  --clas-kinematic-reseed-position-variance <m^2>\n"

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -211,7 +211,7 @@ struct PPPConfig {
     double clas_anchor_sigma = 5.0;               // SPP anchor constraint sigma (m)
     double clas_outlier_sigma_scale = 50.0;       // Inflate variance when residual > N*sigma
     bool clas_decouple_clock_position = true;      // Zero clock cross-covariance each epoch
-    bool clas_kinematic_position_reseed = false;   // CLASLIB-faithful: re-init position from SPP every kinematic epoch
+    bool clas_kinematic_position_reseed = true;    // CLASLIB-faithful: re-init position from SPP every kinematic epoch
     double clas_kinematic_position_reseed_variance = 10000.0; // CLASLIB VAR_POS = 100^2
 
     bool apply_ocean_loading = false;


### PR DESCRIPTION
## Summary

Flip `clas_kinematic_position_reseed` default from `false` to `true`. Kinematic CLAS PPP users now get the CLASLIB-faithful per-epoch position re-seed automatically (no flag needed).

Follow-up to #45 — full mechanism / rationale documented there.

## Why now

Regression matrix from #45 covered 4 kinematic + 1 static dataset and showed uniform net wins:

| dataset | mode | improvement |
| --- | --- | --- |
| Tokyo run1 1500ep | kinematic | H_med 44x, TAIL-200 114x |
| Tokyo run2 300ep | kinematic | H_med 6.6x, TAIL-100 34x |
| Tokyo run3 300ep | kinematic | H_max 7.7x, TAIL-100 29x (median +24% slight regress) |
| Nagoya run1 300ep | kinematic | H_med 1.1x, TAIL-100 2.1x |
| 0627239Q 100ep | static | bit-identical (gated by kinematic_mode) |

Pattern: trades small "best case" decrease (Tokyo run3 median +0.26m) for huge "worst case" stability gains. Static is bit-identical. No "OFF wins" case found.

## Diff

2 lines:
- include/libgnss++/algorithms/ppp_shared.hpp: default false -> true
- apps/gnss_ppp.cpp: help text (default off) -> (default on)

## Opt-out

Existing CLI surface preserved: --no-clas-kinematic-reseed-position disables.

## Test plan

- [x] Builds clean
- [x] --help shows new default
- [ ] CI test suite (will run on PR)