### PR TITLE
feat(clas): reseed quality gate + WLNL Partial AR knobs (default off)

### DIFF
--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -86,6 +86,10 @@ struct Options {
     bool clas_kinematic_position_reseed_set = false;
     double clas_kinematic_position_reseed_variance = -1.0;
     double clas_kinematic_position_reseed_max_residual_rms_m = -1.0;
+    bool enable_wlnl_par = false;
+    bool enable_wlnl_par_set = false;
+    int  wlnl_par_max_exclusions = -1;
+    double wlnl_par_exclude_frac_threshold = -1.0;
     bool madocalib_bridge = false;
     std::string madocalib_config_path;
     std::vector<std::string> madoca_l6e_paths;
@@ -248,6 +252,12 @@ void printUsage(const char* program_name) {
         << "                          Variance reset on kinematic re-seed (default: 10000.0 = CLASLIB VAR_POS)\n"
         << "  --clas-kinematic-reseed-position-max-residual-rms <m>\n"
         << "                          Skip reseed when SPP residual_rms exceeds this (m); guards against urban-canyon SPP pin-to-bad. <=0 disables (default).\n"
+        << "  --enable-wlnl-par       Enable WLNL Partial AR (greedy worst-|frac| exclusion when ratio fails)\n"
+        << "  --no-wlnl-par           Disable WLNL Partial AR\n"
+        << "  --wlnl-par-max-exclusions <n>\n"
+        << "                          Cap PAR exclusion iterations (default: 4)\n"
+        << "  --wlnl-par-exclude-frac-threshold <cycles>\n"
+        << "                          Skip excluding pairs whose |frac| is below this (default: 0.20)\n"
         << "  --madocalib-bridge      Delegate this run to linked MADOCALIB postpos()\n"
         << "                          (requires CMake -DMADOCALIB_PARITY_LINK=ON)\n"
         << "  --madocalib-l6 <file>   Extra MADOCA L6 input file; repeat for two-channel L6E\n"
@@ -689,6 +699,16 @@ Options parseArguments(int argc, char* argv[]) {
             options.clas_kinematic_position_reseed_variance = std::stod(argv[++i]);
         } else if (arg == "--clas-kinematic-reseed-position-max-residual-rms" && i + 1 < argc) {
             options.clas_kinematic_position_reseed_max_residual_rms_m = std::stod(argv[++i]);
+        } else if (arg == "--enable-wlnl-par") {
+            options.enable_wlnl_par = true;
+            options.enable_wlnl_par_set = true;
+        } else if (arg == "--no-wlnl-par") {
+            options.enable_wlnl_par = false;
+            options.enable_wlnl_par_set = true;
+        } else if (arg == "--wlnl-par-max-exclusions" && i + 1 < argc) {
+            options.wlnl_par_max_exclusions = std::stoi(argv[++i]);
+        } else if (arg == "--wlnl-par-exclude-frac-threshold" && i + 1 < argc) {
+            options.wlnl_par_exclude_frac_threshold = std::stod(argv[++i]);
         } else if (arg == "--madocalib-bridge") {
             options.madocalib_bridge = true;
         } else if (arg == "--madocalib-l6" && i + 1 < argc) {
@@ -1823,6 +1843,16 @@ int main(int argc, char* argv[]) {
         if (options.clas_kinematic_position_reseed_max_residual_rms_m > 0.0) {
             ppp_config.clas_kinematic_position_reseed_max_residual_rms_m =
                 options.clas_kinematic_position_reseed_max_residual_rms_m;
+        }
+        if (options.enable_wlnl_par_set) {
+            ppp_config.enable_wlnl_par = options.enable_wlnl_par;
+        }
+        if (options.wlnl_par_max_exclusions >= 0) {
+            ppp_config.wlnl_par_max_exclusions = options.wlnl_par_max_exclusions;
+        }
+        if (options.wlnl_par_exclude_frac_threshold > 0.0) {
+            ppp_config.wlnl_par_exclude_frac_threshold =
+                options.wlnl_par_exclude_frac_threshold;
         }
         ppp_config.kinematic_mode = options.kinematic_mode;
         ppp_config.kinematic_preconvergence_phase_residual_floor_m =

--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -85,6 +85,7 @@ struct Options {
     bool clas_kinematic_position_reseed = false;
     bool clas_kinematic_position_reseed_set = false;
     double clas_kinematic_position_reseed_variance = -1.0;
+    double clas_kinematic_position_reseed_max_residual_rms_m = -1.0;
     bool madocalib_bridge = false;
     std::string madocalib_config_path;
     std::vector<std::string> madoca_l6e_paths;
@@ -245,6 +246,8 @@ void printUsage(const char* program_name) {
         << "                          Disable CLASLIB-faithful kinematic position re-seed\n"
         << "  --clas-kinematic-reseed-position-variance <m^2>\n"
         << "                          Variance reset on kinematic re-seed (default: 10000.0 = CLASLIB VAR_POS)\n"
+        << "  --clas-kinematic-reseed-position-max-residual-rms <m>\n"
+        << "                          Skip reseed when SPP residual_rms exceeds this (m); guards against urban-canyon SPP pin-to-bad. <=0 disables (default).\n"
         << "  --madocalib-bridge      Delegate this run to linked MADOCALIB postpos()\n"
         << "                          (requires CMake -DMADOCALIB_PARITY_LINK=ON)\n"
         << "  --madocalib-l6 <file>   Extra MADOCA L6 input file; repeat for two-channel L6E\n"
@@ -684,6 +687,8 @@ Options parseArguments(int argc, char* argv[]) {
             options.clas_kinematic_position_reseed_set = true;
         } else if (arg == "--clas-kinematic-reseed-position-variance" && i + 1 < argc) {
             options.clas_kinematic_position_reseed_variance = std::stod(argv[++i]);
+        } else if (arg == "--clas-kinematic-reseed-position-max-residual-rms" && i + 1 < argc) {
+            options.clas_kinematic_position_reseed_max_residual_rms_m = std::stod(argv[++i]);
         } else if (arg == "--madocalib-bridge") {
             options.madocalib_bridge = true;
         } else if (arg == "--madocalib-l6" && i + 1 < argc) {
@@ -1814,6 +1819,10 @@ int main(int argc, char* argv[]) {
         if (options.clas_kinematic_position_reseed_variance > 0.0) {
             ppp_config.clas_kinematic_position_reseed_variance =
                 options.clas_kinematic_position_reseed_variance;
+        }
+        if (options.clas_kinematic_position_reseed_max_residual_rms_m > 0.0) {
+            ppp_config.clas_kinematic_position_reseed_max_residual_rms_m =
+                options.clas_kinematic_position_reseed_max_residual_rms_m;
         }
         ppp_config.kinematic_mode = options.kinematic_mode;
         ppp_config.kinematic_preconvergence_phase_residual_floor_m =

--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -240,7 +240,7 @@ void printUsage(const char* program_name) {
         << "  --clas-atmos-stale-after-seconds <seconds>\n"
         << "                          Balanced policy stale threshold (default: 15.0)\n"
         << "  --clas-kinematic-reseed-position\n"
-        << "                          CLASLIB-faithful: re-init position state from SPP every kinematic epoch (default off)\n"
+        << "                          CLASLIB-faithful: re-init position state from SPP every kinematic epoch (default on)\n"
         << "  --no-clas-kinematic-reseed-position\n"
         << "                          Disable CLASLIB-faithful kinematic position re-seed\n"
         << "  --clas-kinematic-reseed-position-variance <m^2>\n"

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -217,6 +217,14 @@ struct PPPConfig {
     // pin-to-bad-SPP. residual_rms above this threshold (m) bypasses reseed and
     // keeps the prior KF position state. <=0 disables the gate.
     double clas_kinematic_position_reseed_max_residual_rms_m = 0.0;
+    // WLNL Partial AR: when initial LAMBDA fails the ratio test, greedily
+    // exclude DD pairs whose |frac| exceeds the threshold (worst first) and
+    // re-run LAMBDA. Caps the number of exclusions and keeps a minimum pair
+    // count. Helps when many sats have wrong NL float values but a clean
+    // sub-set exists.
+    bool enable_wlnl_par = false;
+    int  wlnl_par_max_exclusions = 4;
+    double wlnl_par_exclude_frac_threshold = 0.20;
 
     bool apply_ocean_loading = false;
     bool apply_solid_earth_tides = true;

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -211,7 +211,7 @@ struct PPPConfig {
     double clas_anchor_sigma = 5.0;               // SPP anchor constraint sigma (m)
     double clas_outlier_sigma_scale = 50.0;       // Inflate variance when residual > N*sigma
     bool clas_decouple_clock_position = true;      // Zero clock cross-covariance each epoch
-    bool clas_kinematic_position_reseed = false;   // CLASLIB-faithful: re-init position from SPP every kinematic epoch
+    bool clas_kinematic_position_reseed = true;    // CLASLIB-faithful: re-init position from SPP every kinematic epoch
     double clas_kinematic_position_reseed_variance = 10000.0; // CLASLIB VAR_POS = 100^2
 
     bool apply_ocean_loading = false;

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -213,6 +213,10 @@ struct PPPConfig {
     bool clas_decouple_clock_position = true;      // Zero clock cross-covariance each epoch
     bool clas_kinematic_position_reseed = true;    // CLASLIB-faithful: re-init position from SPP every kinematic epoch
     double clas_kinematic_position_reseed_variance = 10000.0; // CLASLIB VAR_POS = 100^2
+    // Skip reseed when SPP seed quality is poor; protects against urban-canyon
+    // pin-to-bad-SPP. residual_rms above this threshold (m) bypasses reseed and
+    // keeps the prior KF position state. <=0 disables the gate.
+    double clas_kinematic_position_reseed_max_residual_rms_m = 0.0;
 
     bool apply_ocean_loading = false;
     bool apply_solid_earth_tides = true;

--- a/src/algorithms/ppp_ar.cpp
+++ b/src/algorithms/ppp_ar.cpp
@@ -943,12 +943,65 @@ WlnlFixAttempt tryWlnlFix(
         return attempt;
     }
 
+    // PAR-aware LAMBDA: greedily exclude DD pairs with worst |frac| when the
+    // initial ratio fails. The excluded vector tracks which pair indices are
+    // dropped; downstream holdamb/fix-marking loops skip them.
+    std::vector<bool> dd_pair_excluded(attempt.nb, false);
     VectorXd dd_nl_fixed = VectorXd::Zero(attempt.nb);
-    if (!lambdaSearch(dd_nl_float, dd_nl_cov, dd_nl_fixed, attempt.ratio)) {
+    int active_nb = attempt.nb;
+
+    auto run_subset_lambda = [&](double& out_ratio) -> bool {
+        std::vector<int> kept;
+        kept.reserve(attempt.nb);
+        for (int k = 0; k < attempt.nb; ++k) {
+            if (!dd_pair_excluded[static_cast<size_t>(k)]) kept.push_back(k);
+        }
+        if (static_cast<int>(kept.size()) < 4) return false;
+        const int sn = static_cast<int>(kept.size());
+        VectorXd sub_float(sn);
+        MatrixXd sub_cov = MatrixXd::Identity(sn, sn);
+        for (int i = 0; i < sn; ++i) sub_float(i) = dd_nl_float(kept[static_cast<size_t>(i)]);
+        VectorXd sub_fixed(sn);
+        if (!lambdaSearch(sub_float, sub_cov, sub_fixed, out_ratio)) return false;
+        for (int i = 0; i < sn; ++i) dd_nl_fixed(kept[static_cast<size_t>(i)]) = sub_fixed(i);
+        active_nb = sn;
+        return true;
+    };
+
+    if (!run_subset_lambda(attempt.ratio)) {
         if (debug_enabled) {
             std::cerr << "[PPP-WLNL] NL lambda search failed, nb=" << attempt.nb << "\n";
         }
         return attempt;
+    }
+    if (config.enable_wlnl_par &&
+        (!std::isfinite(attempt.ratio) || attempt.ratio < config.ar_ratio_threshold)) {
+        const int max_excl = std::max(0, std::min(config.wlnl_par_max_exclusions, attempt.nb - 4));
+        const double frac_thr = config.wlnl_par_exclude_frac_threshold;
+        for (int iter = 0; iter < max_excl; ++iter) {
+            int worst_k = -1;
+            double worst_frac = frac_thr;
+            for (int k = 0; k < attempt.nb; ++k) {
+                if (dd_pair_excluded[static_cast<size_t>(k)]) continue;
+                const double frac = std::abs(dd_nl_float(k) - std::round(dd_nl_float(k)));
+                if (frac > worst_frac) { worst_frac = frac; worst_k = k; }
+            }
+            if (worst_k < 0) break;
+            dd_pair_excluded[static_cast<size_t>(worst_k)] = true;
+            double new_ratio = 0.0;
+            if (!run_subset_lambda(new_ratio)) {
+                dd_pair_excluded[static_cast<size_t>(worst_k)] = false;
+                break;
+            }
+            attempt.ratio = new_ratio;
+            if (debug_enabled) {
+                std::cerr << "[PPP-WLNL-PAR] excluded pair " << worst_k
+                          << " worst_frac=" << worst_frac
+                          << " new_ratio=" << new_ratio
+                          << " active_nb=" << active_nb << "\n";
+            }
+            if (std::isfinite(new_ratio) && new_ratio >= config.ar_ratio_threshold) break;
+        }
     }
     if (!std::isfinite(attempt.ratio) || attempt.ratio < config.ar_ratio_threshold) {
         if (debug_enabled) {
@@ -967,6 +1020,7 @@ WlnlFixAttempt tryWlnlFix(
     MatrixXd R = MatrixXd::Zero(attempt.nb, attempt.nb);
 
     for (int k = 0; k < attempt.nb; ++k) {
+        if (dd_pair_excluded[static_cast<size_t>(k)]) continue;
         const int ri = dd_pairs[static_cast<size_t>(k)].ref_idx;
         const int si = dd_pairs[static_cast<size_t>(k)].sat_idx;
         const int ref_state = state_indices[static_cast<size_t>(ri)];
@@ -1023,6 +1077,7 @@ WlnlFixAttempt tryWlnlFix(
     }
 
     for (int k = 0; k < attempt.nb; ++k) {
+        if (dd_pair_excluded[static_cast<size_t>(k)]) continue;
         const int ri = dd_pairs[static_cast<size_t>(k)].ref_idx;
         const int si = dd_pairs[static_cast<size_t>(k)].sat_idx;
         const auto& ref_ambiguity = ambiguity_states.at(satellites[static_cast<size_t>(ri)]);
@@ -1034,6 +1089,7 @@ WlnlFixAttempt tryWlnlFix(
         sat_ambiguity.nl_is_fixed = true;
         sat_ambiguity.nl_fixed_cycles = ref_ambiguity.nl_fixed_cycles - dd_nl_fixed(k);
     }
+    attempt.nb = active_nb;  // report only the kept pair count
 
     attempt.fixed = true;
     return attempt;

--- a/src/algorithms/ppp_clas.cpp
+++ b/src/algorithms/ppp_clas.cpp
@@ -198,14 +198,23 @@ EpochPreparationResult prepareEpochState(
     // clas_kf_overconfidence_state_diff_2026_05_02.md.
     if (config.clas_kinematic_position_reseed && config.kinematic_mode &&
         seed_solution.isValid()) {
-        const int nx = filter_state.total_states;
-        filter_state.state.segment(0, 3) = seed_solution.position_ecef;
-        filter_state.covariance.block(0, 0, 3, nx).setZero();
-        filter_state.covariance.block(0, 0, nx, 3).setZero();
-        const double v = config.clas_kinematic_position_reseed_variance;
-        filter_state.covariance(0, 0) = v;
-        filter_state.covariance(1, 1) = v;
-        filter_state.covariance(2, 2) = v;
+        const double rms_gate = config.clas_kinematic_position_reseed_max_residual_rms_m;
+        const bool seed_quality_ok =
+            rms_gate <= 0.0 || seed_solution.residual_rms <= rms_gate;
+        if (seed_quality_ok) {
+            const int nx = filter_state.total_states;
+            filter_state.state.segment(0, 3) = seed_solution.position_ecef;
+            filter_state.covariance.block(0, 0, 3, nx).setZero();
+            filter_state.covariance.block(0, 0, nx, 3).setZero();
+            const double v = config.clas_kinematic_position_reseed_variance;
+            filter_state.covariance(0, 0) = v;
+            filter_state.covariance(1, 1) = v;
+            filter_state.covariance(2, 2) = v;
+        } else if (ppp_shared::pppDebugEnabled()) {
+            std::cerr << "[CLAS-RESEED-SKIP] residual_rms="
+                      << seed_solution.residual_rms
+                      << " > gate=" << rms_gate << "\n";
+        }
     }
     markSlipCompensationFromAmbiguities(
         obs, ambiguity_states, dispersion_compensation);


### PR DESCRIPTION
## Summary

CLAS PPP の experimental knobs 2 件を追加。両方 default OFF / opt-in なので既存挙動に影響なし。

### 1. `--clas-kinematic-reseed-position-max-residual-rms <m>` (commit 9d55f13)

`--clas-kinematic-reseed-position` の reseed 適用前に SPP seed quality gate を追加。
SPP residual RMS が threshold を超える epoch では reseed を skip し、KF state を維持。

**実測 (Tokyo run1, 1500 ep)**:
- Always-reseed (現 default): TAIL-200 H_med 4.57m
- Conditional gate (rms<5m): TAIL-200 H_med 5.12m (+12% regress)

→ Conditional gate は falsified、`0.0` (= disable, always reseed) が optimum。
Knob は debug / future tuning 用に保持。

### 2. `--enable-wlnl-par` + `--wlnl-par-max-exclusions` + `--wlnl-par-exclude-frac-threshold` (commit 0996f15)

DD_WLNL の `tryWlnlFix` に Partial AR (greedy worst-|frac| exclusion) を実装。
LAMBDA ratio が threshold 未満のとき、worst-|frac| DD pair を順に除外して再 LAMBDA。

**実測 (Tokyo run1, 1500 ep)**:
- PAR off (現 default): FIX H_med 1.60m, fix_rate 0.8%
- PAR on (max_excl=4, frac>0.20): FIX H_med 2.11m, fix_rate 49%

→ Fix rate は 60× 改善するが、wrong-integer subset rounding で position 悪化。
NL float quality (~0.45 cycle systematic bias) が上流の真因。
Knob は default OFF、experimental 用に保持。

## Why ship as knobs?

- 両方 falsified だが destructive ではなく additive (default OFF)
- Future の measurement model 改修後に再評価 lever として有用
- Reseed 系の cheap lever は完全枯渇 → 別 session で deep work が必要

## Test plan

- [x] Build (cmake --build)
- [x] Tokyo run1 baseline parity (knobs off → bit-identical to default reseed)
- [x] Tokyo run1 knob-on regression (上記 falsification を確認)
- [ ] Multi-dataset regression (Nagoya / Osaka) — knobs default-off なので既存 user impact 無し、後続 session で