### PR TITLE
feat(ppp-ar): --enable-ppp-holdamb Kalman pseudo-obs update for DD_IFLC paths

### DIFF
--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -106,6 +106,8 @@ struct Options {
     double initial_troposphere_variance = -1.0;
     double code_phase_error_ratio_l1 = -1.0;
     double code_phase_error_ratio_l2 = -1.0;
+    bool enable_ppp_holdamb = false;
+    double ppp_holdamb_innovation_gate_m = 0.0;
     bool quiet = false;
 };
 
@@ -269,6 +271,12 @@ void printUsage(const char* program_name) {
         << "  --disable-ar            Disable PPP ambiguity fixing (default)\n"
         << "  --ar-ratio-threshold <value>\n"
         << "                          Ratio threshold for PPP ambiguity fixing (default: 3.0)\n"
+        << "  --enable-ppp-holdamb     Apply tight Kalman pseudo-obs update for fixed DD ambiguities\n"
+        << "                          on DD_IFLC / DD_PER_FREQ / DD_MADOCA_CASCADED (default: off)\n"
+        << "  --no-ppp-holdamb         Disable PPP holdamb (default)\n"
+        << "  --ppp-holdamb-innovation-gate <m>\n"
+        << "                          Per-pair innovation gate in meters before constraint is dropped\n"
+        << "                          (0 = no gate, default: 0)\n"
         << "  --quiet                  Suppress per-run summary output\n"
         << "  -h, --help               Show this help\n";
 }
@@ -750,6 +758,12 @@ Options parseArguments(int argc, char* argv[]) {
             options.code_phase_error_ratio_l1 = std::stod(argv[++i]);
         } else if (arg == "--code-phase-error-ratio-l2" && i + 1 < argc) {
             options.code_phase_error_ratio_l2 = std::stod(argv[++i]);
+        } else if (arg == "--enable-ppp-holdamb") {
+            options.enable_ppp_holdamb = true;
+        } else if (arg == "--no-ppp-holdamb") {
+            options.enable_ppp_holdamb = false;
+        } else if (arg == "--ppp-holdamb-innovation-gate" && i + 1 < argc) {
+            options.ppp_holdamb_innovation_gate_m = std::stod(argv[++i]);
         } else if (arg == "--quiet") {
             options.quiet = true;
         } else {
@@ -1820,6 +1834,9 @@ int main(int argc, char* argv[]) {
             options.kinematic_preconvergence_phase_residual_floor_m;
         ppp_config.low_dynamics_mode = options.low_dynamics_mode;
         ppp_config.enable_ambiguity_resolution = options.enable_ar;
+        ppp_config.enable_ppp_holdamb = options.enable_ppp_holdamb;
+        ppp_config.ppp_holdamb_innovation_gate_m =
+            options.ppp_holdamb_innovation_gate_m;
         ppp_config.convergence_min_epochs = options.convergence_min_epochs;
         ppp_config.phase_measurement_min_lock_count =
             options.phase_measurement_min_lock_count;

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -123,6 +123,15 @@ struct PPPConfig {
     enum class ARMethod { DD_IFLC, DD_WLNL, DD_PER_FREQ, DD_MADOCA_CASCADED };
     ARMethod ar_method = ARMethod::DD_IFLC;
     int wl_min_averaging_epochs = 20;
+    // PPP holdamb (experimental, default OFF): when true, fixed DD integer
+    // ambiguities are applied as a tight Kalman pseudo-observation update on
+    // tryDirectDdFix paths (DD_IFLC / DD_PER_FREQ / DD_MADOCA_CASCADED) instead
+    // of the per-pair zero-cross-cov hard pin. Preserves amb-pos cross-cov so
+    // the integer lock propagates through subsequent KF updates.
+    // ppp_holdamb_innovation_gate_m: per-pair max innovation in meters before
+    // the constraint is dropped. 0 = no gate.
+    bool enable_ppp_holdamb = false;
+    double ppp_holdamb_innovation_gate_m = 0.0;
 
     // Motion model
     bool kinematic_mode = false;

--- a/src/algorithms/ppp_ar.cpp
+++ b/src/algorithms/ppp_ar.cpp
@@ -721,26 +721,97 @@ DdFixAttempt tryDirectDdFix(
         ref_ambiguity.fixed_value = attempt.state.state(ref_state);
     }
 
-    for (int k = 0; k < attempt.nb; ++k) {
-        const int ri = dd_pairs[static_cast<size_t>(k)].ref_idx;
-        const int si = dd_pairs[static_cast<size_t>(k)].sat_idx;
-        const double ref_value_m =
-            attempt.state.state(state_indices[static_cast<size_t>(ri)]);
-        const double scale_si = scales[static_cast<size_t>(si)];
-        const double ref_cycles = ref_value_m / scales[static_cast<size_t>(ri)];
-        const double fixed_sat_cycles = ref_cycles - dd_fixed(k);
-        const double fixed_sat_m = fixed_sat_cycles * scale_si;
+    // Holdamb for DD_IFLC / DD_PER_FREQ / DD_MADOCA_CASCADED: apply tight Kalman
+    // pseudo-observation update on the DD ambiguity constraint instead of zeroing
+    // the per-satellite cross-cov. Preserves amb-pos cross-cov so subsequent
+    // epochs propagate the integer lock through the KF.
+    const bool use_holdamb_iflc =
+        config.enable_ppp_holdamb &&
+        config.ar_method != ppp_shared::PPPConfig::ARMethod::DD_WLNL;
 
-        const int sat_state = state_indices[static_cast<size_t>(si)];
-        attempt.state.state(sat_state) = fixed_sat_m;
-        attempt.state.covariance.row(sat_state).setZero();
-        attempt.state.covariance.col(sat_state).setZero();
-        attempt.state.covariance(sat_state, sat_state) = 1e-6;
+    if (use_holdamb_iflc) {
+        const int nx = filter_state.total_states;
+        constexpr double kHoldSigmaCycles = 1e-3;
+        constexpr double kHoldVar = kHoldSigmaCycles * kHoldSigmaCycles;
+        const double inn_gate_m = config.ppp_holdamb_innovation_gate_m > 0.0
+            ? config.ppp_holdamb_innovation_gate_m
+            : std::numeric_limits<double>::infinity();
+        MatrixXd H = MatrixXd::Zero(attempt.nb, nx);
+        VectorXd v = VectorXd::Zero(attempt.nb);
+        int nv = 0;
+        int gated = 0;
+        for (int k = 0; k < attempt.nb; ++k) {
+            const int ri = dd_pairs[static_cast<size_t>(k)].ref_idx;
+            const int si = dd_pairs[static_cast<size_t>(k)].sat_idx;
+            const int ref_state = state_indices[static_cast<size_t>(ri)];
+            const int sat_state = state_indices[static_cast<size_t>(si)];
+            const double scale_ri = scales[static_cast<size_t>(ri)];
+            const double scale_si = scales[static_cast<size_t>(si)];
+            if (scale_ri <= 0.0 || scale_si <= 0.0) continue;
+            const double current_dd_cyc =
+                attempt.state.state(ref_state) / scale_ri -
+                attempt.state.state(sat_state) / scale_si;
+            const double innovation = dd_fixed(k) - current_dd_cyc;
+            const double inn_m = innovation * 0.5 * (scale_ri + scale_si);
+            if (std::abs(inn_m) > inn_gate_m) { ++gated; continue; }
+            H(nv, ref_state) = 1.0 / scale_ri;
+            H(nv, sat_state) = -1.0 / scale_si;
+            v(nv) = innovation;
+            ++nv;
 
-        auto& ambiguity_state = attempt.ambiguities[satellites[static_cast<size_t>(si)]];
-        ambiguity_state.float_value = fixed_sat_m;
-        ambiguity_state.fixed_value = fixed_sat_m;
-        ambiguity_state.is_fixed = true;
+            auto& sat_amb = attempt.ambiguities[satellites[static_cast<size_t>(si)]];
+            const double ref_cycles = attempt.state.state(ref_state) / scale_ri;
+            const double fixed_sat_cycles = ref_cycles - dd_fixed(k);
+            const double fixed_sat_m = fixed_sat_cycles * scale_si;
+            sat_amb.float_value = fixed_sat_m;
+            sat_amb.fixed_value = fixed_sat_m;
+            sat_amb.is_fixed = true;
+        }
+        if (nv > 0) {
+            const MatrixXd Hcrop = H.topRows(nv);
+            const VectorXd vcrop = v.head(nv);
+            const MatrixXd Rcrop = MatrixXd::Identity(nv, nv) * kHoldVar;
+            const MatrixXd PHt = attempt.state.covariance * Hcrop.transpose();
+            const MatrixXd S = Hcrop * PHt + Rcrop;
+            Eigen::LLT<MatrixXd> llt(S);
+            if (llt.info() == Eigen::Success) {
+                const MatrixXd K = PHt * llt.solve(MatrixXd::Identity(nv, nv));
+                attempt.state.state += K * vcrop;
+                attempt.state.covariance.noalias() -= K * PHt.transpose();
+                attempt.state.covariance =
+                    0.5 * (attempt.state.covariance + attempt.state.covariance.transpose());
+                if (debug_enabled) {
+                    std::cerr << "[PPP-AR-HOLDAMB] DD_IFLC update nv=" << nv
+                              << " gated=" << gated
+                              << " ||v||=" << vcrop.norm()
+                              << " ||K*v||=" << (K * vcrop).norm() << "\n";
+                }
+            } else if (debug_enabled) {
+                std::cerr << "[PPP-AR-HOLDAMB] LLT failure, skipping update\n";
+            }
+        }
+    } else {
+        for (int k = 0; k < attempt.nb; ++k) {
+            const int ri = dd_pairs[static_cast<size_t>(k)].ref_idx;
+            const int si = dd_pairs[static_cast<size_t>(k)].sat_idx;
+            const double ref_value_m =
+                attempt.state.state(state_indices[static_cast<size_t>(ri)]);
+            const double scale_si = scales[static_cast<size_t>(si)];
+            const double ref_cycles = ref_value_m / scales[static_cast<size_t>(ri)];
+            const double fixed_sat_cycles = ref_cycles - dd_fixed(k);
+            const double fixed_sat_m = fixed_sat_cycles * scale_si;
+
+            const int sat_state = state_indices[static_cast<size_t>(si)];
+            attempt.state.state(sat_state) = fixed_sat_m;
+            attempt.state.covariance.row(sat_state).setZero();
+            attempt.state.covariance.col(sat_state).setZero();
+            attempt.state.covariance(sat_state, sat_state) = 1e-6;
+
+            auto& ambiguity_state = attempt.ambiguities[satellites[static_cast<size_t>(si)]];
+            ambiguity_state.float_value = fixed_sat_m;
+            ambiguity_state.fixed_value = fixed_sat_m;
+            ambiguity_state.is_fixed = true;
+        }
     }
 
     attempt.fixed = true;


### PR DESCRIPTION
## Summary

Wire holdamb (tight Kalman pseudo-observation update on the DD ambiguity constraint) into \`tryDirectDdFix\` for DD_IFLC / DD_PER_FREQ / DD_MADOCA_CASCADED. Existing per-pair zero-cross-cov + 1e-6 diag remains default; holdamb path is opt-in via the new knob.

## Why?

Per-pair zero-cross-cov hard-pins each fixed satellite's ambiguity but discards amb-position cross-covariance, so the integer lock does not propagate through subsequent KF updates. Holdamb instead applies a joint pseudo-observation update preserving the cross-cov so future epochs benefit from the lock.

Memory \`madoca_holdamb_breakthrough_2026_04_26\` documented this lever as effective on MADOCA: dN +118mm -> +55mm with 1m gate on MIZU sample.

(Note: the same lever was falsified for CLAS path in \`clas_iflc_holdamb_falsified_2026_05_03\` due to wrong-float-NL lock-in; CLAS bias is upstream of the AR layer. Knob is generic and useful for MADOCA experiments where it does help.)

## Implementation

- Build \`H\` row per fixed DD pair: \`H[ref] = +1/scale_ref\`, \`H[sat] = -1/scale_sat\`
- Innovation \`v = dd_fixed_cycles - current_dd_cycles\`
- \`R = (1mm cycles)^2\` diagonal, joint LLT-solved Kalman update on \`attempt.state\`
- Per-pair innovation gate (meters) drops constraints exceeding the threshold
- Symmetrize covariance after update

\`DD_WLNL\` is excluded from the new path (existing WLNL holdamb mechanism in tryWlnlFix is unchanged).

## CLI

- \`--enable-ppp-holdamb\` / \`--no-ppp-holdamb\` (default off)
- \`--ppp-holdamb-innovation-gate <m>\` (0 = no gate)

## Test plan

- [x] Build clean on origin/feat/rinex4-madoca base
- [x] CLI help registered (\`--help | grep holdamb\` shows entries)
- [x] Default OFF bit-identical to HEAD baseline (Tokyo run1 500ep md5 \`98f712475384b71fe19aa20b651deb93\` match)
- [ ] Knob ON regression on MADOCA dataset (referenced memory shows effectiveness; left for follow-up tuning session)