### PR TITLE
Document PPC ratio4 status profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,17 +125,16 @@ the run for scoring and Wrong-FIX labeling. The runtime selector itself is
 deployable-only: it uses solver diagnostics such as NIS per observation, ratio,
 residual/jump guards, and emitted status, not reference truth.
 
-On the six public PPC runs, the recommended `nis2` profile reaches **64.707%**
-weighted PPC official score with **7.046x** minimum realtime factor. Its purpose
-is not to maximize the number of emitted FIX epochs; it minimizes the measured
-Wrong/FIX rate while staying realtime:
+On the six public PPC runs, the recommended `nis2-ratio4` profile reaches
+**64.686%** weighted PPC official score with **6.188x** minimum realtime factor.
+Its purpose is not to maximize the number of emitted FIX epochs; it minimizes
+the measured Wrong/FIX rate while staying realtime:
 
 | Profile | Weighted official | FIX epochs | Wrong FIX | Wrong/FIX | Min realtime |
 |---|---:|---:|---:|---:|---:|
 | sigma profile, no status demotion | 64.750% | 41608 | 3078 | 7.398% | 6.883x |
 | `sigma-demote` (`--demote-fixed-status-nis-per-obs 2`) | 64.707% | 29705 | 563 | 1.895% | 7.046x |
-
-![PPC sigma-demote nis2 status trajectories](docs/ppc_sigma_demote_nis2_status_trajectories.png)
+| `sigma-demote` + ratio status demotion (`--demote-fixed-status-max-ratio 4`) | 64.686% | 27395 | 470 | 1.716% | 6.188x |
 
 This is a public-run replay result, not a hidden/private PPC leaderboard
 submission. The RTKLIB `demo5` comparison remains the open-observation baseline
@@ -152,7 +151,7 @@ into focused notes:
   experiments, IMU/dropout bridge diagnostics, scorecards, and reproduction
   commands.
 - [PPC realtime gate outputs](docs/ppc_realtime_gate_existing_outputs.md):
-  accepted `sigma-demote nis2` result plus rejected real-time gate candidates.
+  accepted `sigma-demote nis2-ratio4` result plus rejected real-time gate candidates.
 - [PPC smoother sanity report](docs/ppc_smoother_oracle_report.md): smoother
   and oracle/reference-selected checks kept as diagnostics only.
 

--- a/docs/ppc_realtime_gate_existing_outputs.md
+++ b/docs/ppc_realtime_gate_existing_outputs.md
@@ -8,22 +8,27 @@ Wrong FIX is `status == FIXED` with post-run 3D reference error above 0.50 m.
 ## Current recommendation
 
 The final deployable status profile is the sigma-profile replay with
-`--demote-fixed-status-nis-per-obs 2`. It minimizes the measured Wrong/FIX rate
-among the current real-time-only sweep:
+`--demote-fixed-status-nis-per-obs 2 --demote-fixed-status-max-ratio 4`.
+It minimizes the measured Wrong/FIX rate among the current real-time-only sweep
+while keeping the PPC official score effectively unchanged:
 
 | profile | official | FIX epochs | Wrong FIX | Wrong/FIX | min realtime | decision |
 |---|---:|---:|---:|---:|---:|---|
 | current_sigma | 64.750% | 41608 | 3078 | 7.398% | 6.883x | control |
-| current_sigma_demote_nis2 | 64.707% | 29705 | 563 | 1.895% | 7.046x | recommended when minimizing Wrong/FIX |
+| current_sigma_demote_nis2 | 64.707% | 29705 | 563 | 1.895% | 7.046x | previous recommendation |
+| current_sigma_demote_nis2_ratio4 | 64.686% | 27395 | 470 | 1.716% | 6.188x | recommended when minimizing Wrong/FIX |
 
-The tradeoff is explicit: `nis2` drops the weighted official score by 0.043 pp
-and emits 11903 fewer FIX epochs, but reduces Wrong FIX by 2515 epochs. The
-sections below are chronological rejected/diagnostic probes unless explicitly
-marked as the current recommendation.
+The tradeoff is explicit: `nis2-ratio4` drops the weighted official score by
+0.064 pp and emits 14213 fewer FIX epochs versus `current_sigma`, but reduces
+Wrong FIX by 2608 epochs. Relative to the previous `nis2` recommendation, it
+removes 93 additional Wrong FIX labels with a 0.021 pp official-score change.
+The sections below are chronological rejected/diagnostic probes unless
+explicitly marked as the current recommendation.
 
 ![PPC sigma-demote nis2 status trajectories](ppc_sigma_demote_nis2_status_trajectories.png)
 
-The red `WRONG_FIX` markers are post-run diagnostic labels at the 0.50 m 3D
+The checked-in trajectory image is the previous `nis2` diagnostic. The red
+`WRONG_FIX` markers are post-run diagnostic labels at the 0.50 m 3D
 reference-error threshold. The runtime selector itself uses only deployable
 fields and does not read reference truth.
 
@@ -39,6 +44,7 @@ fields and does not read reference truth.
 | snr_nis8_window | SNR weighting plus NIS gate in 7000-9000 m baseline window | 63.929% | -0.071 pp | 44393 | 7214 | 16.250% | reject, more wrong FIX |
 | secondary_window | SNR weighting plus primary/secondary fixed-update windows | 64.326% | +0.325 pp | 44355 | 7106 | 16.021% | reject, more wrong FIX |
 | secondary_window_reset12 | secondary_window plus non-FIX reset12 | 63.315% | -0.685 pp | 45089 | 9491 | 21.049% | reject |
+| current_sigma_demote_nis2_ratio4 | `--demote-fixed-status-nis-per-obs 2 --demote-fixed-status-max-ratio 4` | 64.686% | +0.685 pp | 27395 | 470 | 1.716% | recommended status profile |
 
 The current no-worse-Wrong-FIX policy rejects every profile that improves
 official score. The stricter `nis8_ratio6` experiment confirms that lowering the
@@ -262,10 +268,10 @@ cost of 4542 additional output FIX epochs.
 
 ## Ultra-conservative sigma-profile demotion
 
-Pushing Wrong/FIX lower requires dropping the ratio gate entirely and demoting
-every output FIX with `--demote-fixed-status-nis-per-obs 2`. This is the lowest
-Wrong/FIX runtime result in the current deployable sweep, but unlike the milder
-runtime-demotion profiles it gives up a small amount of official score.
+The earlier ultra-conservative profile demoted every output FIX with
+`--demote-fixed-status-nis-per-obs 2`. The current recommendation keeps that
+NIS demotion and adds `--demote-fixed-status-max-ratio 4`, which removes
+additional low-ratio wrong FIX labels with only a small official-score change.
 
 Full runtime replay:
 
@@ -273,20 +279,21 @@ Full runtime replay:
 |---|---:|---:|---:|---:|---:|---:|---:|---|
 | current_sigma | 64.750% | 41608 | 3078 | 7.398% | 0 | 0 | 6.883x | control |
 | current_sigma_demote_nis3_ratio15 | 64.750% | 35382 | 980 | 2.770% | 6226 | 2098 | 6.274x | sub-1000 Wrong FIX |
-| current_sigma_demote_nis2 | 64.707% | 29705 | 563 | 1.895% | 11903 | 2515 | 7.046x | lowest Wrong/FIX |
+| current_sigma_demote_nis2 | 64.707% | 29705 | 563 | 1.895% | 11903 | 2515 | 7.046x | previous recommendation |
+| current_sigma_demote_nis2_ratio4 | 64.686% | 27395 | 470 | 1.716% | 14213 | 2608 | 6.188x | current recommendation |
 
-Per-run Wrong FIX for `nis2`:
+Per-run Wrong FIX for `nis2-ratio4`:
 
-| run | current_sigma | nis3_ratio15 | nis2 |
-|---|---:|---:|---:|
-| tokyo_run1 | 936 | 442 | 271 |
-| tokyo_run2 | 160 | 75 | 65 |
-| tokyo_run3 | 870 | 218 | 123 |
-| nagoya_run1 | 124 | 27 | 6 |
-| nagoya_run2 | 537 | 157 | 69 |
-| nagoya_run3 | 451 | 61 | 29 |
+| run | current_sigma | nis3_ratio15 | nis2 | nis2-ratio4 |
+|---|---:|---:|---:|---:|
+| tokyo_run1 | 936 | 442 | 271 | 237 |
+| tokyo_run2 | 160 | 75 | 65 | 53 |
+| tokyo_run3 | 870 | 218 | 123 | 103 |
+| nagoya_run1 | 124 | 27 | 6 | 2 |
+| nagoya_run2 | 537 | 157 | 69 | 63 |
+| nagoya_run3 | 451 | 61 | 29 | 12 |
 
-`nis2` is the right headline status profile if the goal is to minimize Wrong/FIX
-as much as possible with deployable real-time fields. It reduces Wrong/FIX to
-1.895%, but the cost is high: 5677 fewer FIX epochs than `nis3_ratio15`, and a
-weighted official score drop of 0.043 pp.
+`nis2-ratio4` is the right headline status profile if the goal is to minimize
+Wrong/FIX as much as possible with deployable real-time fields. It reduces
+Wrong/FIX to 1.716%, at the cost of 7987 fewer FIX epochs than `nis3_ratio15`
+and a weighted official score drop of 0.064 pp from `current_sigma`.

--- a/docs/ppc_reproduction.md
+++ b/docs/ppc_reproduction.md
@@ -25,7 +25,7 @@ python3 apps/gnss.py ppc-rtk-signoff \
   --summary-json output/ppc_tokyo_run1_rtk_signoff.json
 ```
 
-Use `ppc-coverage-matrix` to replay the full six-run `sigma-demote nis2`
+Use `ppc-coverage-matrix` to replay the full six-run `sigma-demote nis2-ratio4`
 profile:
 
 ```bash
@@ -43,9 +43,10 @@ python3 apps/gnss.py ppc-coverage-matrix \
   --max-pos-jump-min 5.0 \
   --max-pos-jump-rate 25.0 \
   --demote-fixed-status-nis-per-obs 2 \
-  --output-dir output/ppc_sigma_profile_runtime_demote_nis2 \
-  --summary-json output/ppc_sigma_profile_runtime_demote_nis2/summary.json \
-  --markdown-output output/ppc_sigma_profile_runtime_demote_nis2/table.md
+  --demote-fixed-status-max-ratio 4 \
+  --output-dir output/ppc_sigma_profile_runtime_demote_nis2_ratio4 \
+  --summary-json output/ppc_sigma_profile_runtime_demote_nis2_ratio4/summary.json \
+  --markdown-output output/ppc_sigma_profile_runtime_demote_nis2_ratio4/table.md
 ```
 
 ## Coverage Matrix

--- a/docs/ppc_smoother_oracle_report.md
+++ b/docs/ppc_smoother_oracle_report.md
@@ -77,7 +77,7 @@ gate rather than more reference-selected smoothing.
 
 Existing full real-time gate outputs are summarized in
 [PPC existing real-time gate outputs](ppc_realtime_gate_existing_outputs.md).
-The current headline profile is the later deployable `sigma-demote nis2`
+The current headline profile is the later deployable `sigma-demote nis2-ratio4`
 runtime selector in that note. The images below are historical smoother/filter
 diagnostics, not the current PR performance claim.
 

--- a/docs/rtk_tuning_gates.md
+++ b/docs/rtk_tuning_gates.md
@@ -40,6 +40,7 @@ anchor bridge, and uses horizontal FIX-anchor speed for its motion gate. Use
 | `--min-fixed-update-gate-baseline <m>` + `--max-fixed-update-gate-baseline <m>` | Optional baseline-length window for the fixed-only NIS/post-RMS gates. | `0` / `0` disabled |
 | `--min-fixed-update-gate-speed <m/s>` + `--max-fixed-update-gate-speed <m/s>` | Optional speed window for the fixed-only NIS/post-RMS gates. | `0` / `0` disabled |
 | `--max-fixed-update-secondary-gate-ratio <v>` + baseline/speed secondary window flags | Optional second OR-window for fixed-only NIS/post-RMS gates. | `0` for all fields |
+| `--demote-fixed-status-max-ratio <v>` | Keep the position solution but output FIX as FLOAT when the AR ratio is finite and at or below N. PPC `nis2-ratio4` uses this to reduce measured Wrong/FIX while preserving official-score coverage. | `0` disabled |
 | `--rtk-snr-weighting` + `--rtk-snr-reference-dbhz <v>` + `--rtk-snr-max-variance-scale <v>` + `--rtk-snr-min-baseline <m>` | Low-cost observation model diagnostic. Uses the lower rover/base SNR for each SD link and inflates DD phase/code variance below the reference SNR, capped by the max scale. | `false` / `45` / `25` / `0` |
 | `--cycle-slip-threshold <m>` + `--doppler-slip-threshold <m>` + `--code-slip-threshold <m>` + `--strict-dynamic-slip-thresholds` + `--adaptive-dynamic-slip-thresholds` | Cycle-slip sensitivity sweep. Dynamic RTK keeps protective minimum thresholds by default; strict/adaptive modes are opt-in urban reacquisition experiments. | `0.05` / `0.20` / `5.0` / `false` / `false` |
 | `--adaptive-dynamic-slip-nonfix-count <N>` | Non-FIX epochs before adaptive dynamic slip thresholds activate. | `3` |
@@ -51,6 +52,7 @@ anchor bridge, and uses horizontal FIX-anchor speed for its motion gate. Use
 | `--max-postfix-rms <m>` | Reject fix if the L1 post-fix DD phase residual RMS exceeds N meters. | `0` disabled |
 | `--enable-wide-lane-ar` + `--wide-lane-threshold <cycle>` | Pre-compute MW wide-lane integers and inject them as Kalman constraints into the LAMBDA search. Odaiba's opt-in preset uses this to beat demo5 Hmed while still beating demo5 Fix count and tails. | `false` / `0.25` |
 | `--enable-wlnl-fallback` | Allow the experimental MW wide-lane / narrow-lane fallback after ordinary LAMBDA failure in non-IFLC runs. It reuses `--wide-lane-threshold` for both integer checks. | `false` |
+| `--enable-bsr-decimation` + `--bsr-worst-axes <N>` + `--bsr-max-drops <N>` | Add BSR-guided subset AR decimation candidates alongside the variance-drop subset family. PPC high-wrong probes preserved FIX count but did not reduce Wrong/FIX, so this remains diagnostic. | `false` / `3` / `6` |
 
 On PPC Tokyo and Nagoya, leave these off unless reproducing a specific sweep.
 On Odaiba or other urban multipath datasets, use `--preset odaiba` for the


### PR DESCRIPTION
## Summary
- update README PPC realtime profile to the merged nis2-ratio4 result
- update PPC reproduction command with --demote-fixed-status-max-ratio 4
- record ratio4 wrong-FIX tradeoff and new RTK tuning gate docs

## Validation
- rtk python3 -m mkdocs build --strict --site-dir /tmp/libgnsspp_mkdocs_ratio4_check
- rtk git diff --check -- README.md docs/ppc_reproduction.md docs/rtk_tuning_gates.md docs/ppc_realtime_gate_existing_outputs.md docs/ppc_smoother_oracle_report.md