### PR TITLE
Vendor ginan-iers2010 subset under third_party/ (Phase A-2a, stacked on #52)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ find_package(OpenCV QUIET COMPONENTS core imgproc imgcodecs)
 # linking will be wired up in a follow-up PR once the API surface is exposed
 # through include/iers/.
 add_subdirectory(third_party/sofa)
+add_subdirectory(third_party/ginan-iers2010)
 
 # List source files for the main library
 set(GNSS_SOURCES

--- a/LICENSE-third-party.md
+++ b/LICENSE-third-party.md
@@ -11,6 +11,7 @@ project root `NOTICE` file.
 | Component | Path | Upstream | License | License File |
 |-----------|------|----------|---------|--------------|
 | IAU SOFA  | `third_party/sofa/`  | http://www.iausofa.org/ | SOFA Software License | `third_party/sofa/LICENSE` |
+| ginan-iers2010 | `third_party/ginan-iers2010/` | https://github.com/GeoscienceAustralia/ginan (commit `535ef0a`) | Apache License 2.0 | `third_party/ginan-iers2010/LICENSE` |
 
 ## Compatibility
 
@@ -30,3 +31,11 @@ clauses for downstream users:
   libgnss++'s own symbol naming. Downstream users who modify the SOFA
   copy in `third_party/sofa/` must observe this clause.
 - **Clauses 5–6**: SOFA is provided "as is" with no warranty.
+
+The Apache License 2.0 (used by `third_party/ginan-iers2010/`) is
+OSI-approved and broadly compatible with MIT redistribution. Per Apache
+2.0 §4(b), the modifications libgnss++ has made relative to the
+upstream ginan sources are documented in
+`third_party/ginan-iers2010/README.md`. Per §4(d), upstream
+attribution and the original NOTICE are preserved at
+`third_party/ginan-iers2010/NOTICE`.

--- a/NOTICE
+++ b/NOTICE
@@ -25,3 +25,30 @@ reproduced in `third_party/sofa/LICENSE`.
 
 This product does not itself constitute software provided by and/or
 endorsed by SOFA.
+
+----
+
+ginan-iers2010 (IERS Conventions 2010 routines, subset)
+-------------------------------------------------------
+
+Location in this repository: `third_party/ginan-iers2010/`
+
+This product includes C++ wrappers around IERS Conventions (2010)
+routines, adapted from:
+
+    Geoscience Australia - Ginan
+    https://github.com/GeoscienceAustralia/ginan
+    Copyright 2020 Geoscience Australia
+    Licensed under Apache License, Version 2.0
+
+The wrapper code is itself derived from IERS Conventions 2010 software
+distributed by the International Earth Rotation and Reference Systems
+Service (https://iers-conventions.obspm.fr/).
+
+Modifications made to the upstream ginan sources are documented per
+Apache License 2.0 §4(b) in
+`third_party/ginan-iers2010/README.md` ("Modifications" section).
+Only the GTime-independent subset of ginan's iers2010 wrappers (FCUL
+tropospheric mapping and Dehant solid-earth-tide displacement) is
+included; the HARDISP ocean-tide-loading routines are not vendored
+here and will land in a follow-up integration.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -34,6 +34,7 @@ if(GTest_FOUND)
         test_rtcm_stream.cpp
         test_ubx.cpp
         test_sofa_vendor.cpp
+        test_ginan_iers2010_vendor.cpp
     )
 
     target_compile_options(run_tests PRIVATE -g)
@@ -44,6 +45,7 @@ if(GTest_FOUND)
     target_link_libraries(run_tests
         gnss_lib gnss_lib_noopt
         sofa
+        ginan_iers2010
         GTest::GTest
         GTest::Main
         Threads::Threads

--- a/tests/test_ginan_iers2010_vendor.cpp
+++ b/tests/test_ginan_iers2010_vendor.cpp
@@ -1,0 +1,128 @@
+// Smoke tests for the vendored ginan-iers2010 library
+// (third_party/ginan-iers2010/).
+//
+// Reference values for dehanttideinel come from the IERS Conventions
+// 2010 software distribution test case for routine DEHANTTIDEINEL
+// (https://iers-conventions.obspm.fr/content/chapter7/software/dehanttideinel)
+// — the same test case ginan itself uses upstream.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <vector>
+
+#include <Eigen/Dense>
+
+#include "iers2010.hpp"
+
+TEST(GinanIers2010Vendor, FculaZenithIsUnity) {
+    // At elevation = 90° the FCULa total mapping function is 1/sin(90°) = 1.
+    // Use a typical mid-latitude station, modest height, ambient temperature.
+    const double dlat = 35.6586;     // degrees N (Tokyo Tower latitude — arbitrary)
+    const double dhgt = 333.0;       // m
+    const double t_kelvin = 288.15;  // K (15 °C)
+    const double elev_deg = 90.0;
+
+    const double mf = iers2010::fcul_a(dlat, dhgt, t_kelvin, elev_deg);
+    EXPECT_NEAR(mf, 1.0, 1e-6);
+}
+
+TEST(GinanIers2010Vendor, FculaIncreasesAsElevationDrops) {
+    // The mapping function should grow monotonically as elevation drops
+    // (the slant path through the atmosphere lengthens). This is a basic
+    // sanity check that does not depend on a specific reference value.
+    const double dlat = 35.6586;
+    const double dhgt = 333.0;
+    const double t_kelvin = 288.15;
+
+    const double mf90 = iers2010::fcul_a(dlat, dhgt, t_kelvin, 90.0);
+    const double mf30 = iers2010::fcul_a(dlat, dhgt, t_kelvin, 30.0);
+    const double mf10 = iers2010::fcul_a(dlat, dhgt, t_kelvin, 10.0);
+
+    EXPECT_GT(mf30, mf90);
+    EXPECT_GT(mf10, mf30);
+    // 1/sin(30°) ≈ 2 is the dominant geometric factor at this elevation.
+    EXPECT_NEAR(mf30, 2.0, 0.05);
+}
+
+TEST(GinanIers2010Vendor, FculZdHpaSucceeds) {
+    // Just verify that the zenith-delay routine returns success status
+    // and produces non-pathological hydrostatic / wet zenith delays.
+    const double dlat = 35.6586;     // degrees N
+    const double dhgt = 333.0;       // m
+    const double pressure = 1013.25; // hPa
+    const double e_water = 12.0;     // hPa partial pressure of water vapor
+    const double t_kelvin = 288.15;  // K
+
+    double fcul_ztd = 0.0;
+    double fcul_zhd = 0.0;
+    double fcul_zwd = 0.0;
+    const int rc = iers2010::fcul_zd_hpa(
+        dlat, dhgt, pressure, e_water, t_kelvin,
+        fcul_ztd, fcul_zhd, fcul_zwd);
+
+    EXPECT_EQ(rc, 0);
+    // Standard sea-level hydrostatic zenith delay is ~2.3 m;
+    // wet delay is typically a few cm to tens of cm.
+    EXPECT_GT(fcul_zhd, 2.0);
+    EXPECT_LT(fcul_zhd, 2.6);
+    EXPECT_GE(fcul_zwd, 0.0);
+    EXPECT_LT(fcul_zwd, 0.5);
+    EXPECT_NEAR(fcul_ztd, fcul_zhd + fcul_zwd, 1e-9);
+}
+
+TEST(GinanIers2010Vendor, DehanttideinelIersReferenceCase) {
+    // Canonical IERS Conventions 2010 software reference test case for
+    // DEHANTTIDEINEL (epoch 2009-04-13 0h UT). Inputs and expected
+    // outputs are documented in the original FORTRAN routine header.
+    //
+    //   XSTA = (4075578.385, 931852.890, 4801570.154)  [m]
+    //   XSUN = (137859926952.015,  54228127881.4350,  23509422341.6960) [m]
+    //   XMON = (-179996231.920342, -312468450.131567, -169288918.592160) [m]
+    //   YR=2009 MONTH=4 DAY=13 FHR=0.00
+    //
+    // Expected DXYZ = (0.07700420357108126,
+    //                  0.06304056321824968,
+    //                  0.05516568152597247) [m]
+    //
+    // Time argument computation:
+    //   MJD(UTC) = 54934.0
+    //   TT - UTC = 66.184 s (UTC+34 leap + 32.184 TAI->TT)
+    //   MJD(TT) = 54934 + 66.184/86400
+    //   J2000 epoch (TT) = MJD 51544.5
+    //   julian_centuries_tt = (MJD(TT) - 51544.5) / 36525
+    const double mjd_utc        = 54934.0;
+    const double tt_minus_utc_s = 66.184;
+    const double mjd_tt         = mjd_utc + tt_minus_utc_s / 86400.0;
+    const double t              = (mjd_tt - 51544.5) / 36525.0;
+    const double fhr_ut         = 0.0;
+
+    Eigen::Vector3d xsun(137859926952.015,
+                          54228127881.4350,
+                          23509422341.6960);
+    Eigen::Vector3d xmon(-179996231.920342,
+                         -312468450.131567,
+                         -169288918.592160);
+
+    std::vector<Eigen::Vector3d> xsta_vec = {
+        Eigen::Vector3d(4075578.385, 931852.890, 4801570.154)
+    };
+    std::vector<Eigen::Vector3d> xcor_vec;
+
+    const int rc = iers2010::dehanttideinel_impl(
+        t, fhr_ut, xsun, xmon, xsta_vec, xcor_vec);
+
+    ASSERT_EQ(rc, 0);
+    ASSERT_EQ(xcor_vec.size(), 1u);
+
+    // Loose tolerance of 1e-6 m (1 µm) absorbs the small bias from our
+    // approximate ΔT (66.184 s is a constant; the IERS reference uses
+    // tabulated leap seconds + TAI-TT). The displacement itself is ~7 cm
+    // so this is a tight functional gate without being overly fragile.
+    const Eigen::Vector3d expected(0.07700420357108126,
+                                   0.06304056321824968,
+                                   0.05516568152597247);
+    EXPECT_NEAR(xcor_vec[0].x(), expected.x(), 1e-6);
+    EXPECT_NEAR(xcor_vec[0].y(), expected.y(), 1e-6);
+    EXPECT_NEAR(xcor_vec[0].z(), expected.z(), 1e-6);
+}

--- a/third_party/README.md
+++ b/third_party/README.md
@@ -12,6 +12,7 @@ modifications.
 | Directory | Upstream | License | Purpose |
 |-----------|----------|---------|---------|
 | `sofa/`   | IAU SOFA (Standards Of Fundamental Astronomy), issue 2021-05-12 | SOFA Software License | Earth rotation, polar motion, time scales, astronomical computations for PPP cm-level positioning |
+| `ginan-iers2010/` | GeoscienceAustralia/ginan (`535ef0a`) — IERS Conventions 2010 wrappers, GTime-independent subset | Apache License 2.0 | Solid-earth-tide displacement (Dehant) and Mendes-Pavlis tropospheric mapping (FCUL) |
 
 ## Conventions
 

--- a/third_party/ginan-iers2010/CMakeLists.txt
+++ b/third_party/ginan-iers2010/CMakeLists.txt
@@ -1,0 +1,36 @@
+# ginan-iers2010 — IERS Conventions 2010 routines (subset)
+#
+# Vendored from GeoscienceAustralia/ginan@535ef0a (Apache License 2.0).
+# See ./README.md for provenance, scope, and the list of modifications
+# made relative to upstream. The wrapper code is licensed under Apache
+# License 2.0 (./LICENSE); this CMakeLists.txt is part of libgnss++ and
+# is licensed under MIT.
+
+cmake_minimum_required(VERSION 3.14)
+project(ginan_iers2010 CXX)
+
+find_package(Eigen3 REQUIRED)
+
+set(GINAN_IERS2010_SOURCES
+    ch9/fcul_a.cpp
+    ch9/fcul_zd_hpa.cpp
+    dehanttideinel/dehanttide_all.cpp
+)
+
+add_library(ginan_iers2010 STATIC ${GINAN_IERS2010_SOURCES})
+
+# Public include path: the vendor root, so consumers can write
+#     #include "iers2010.hpp"
+# Internal (PRIVATE) include path: shim/, so the vendored .cpp files
+# resolve their `common/eigenIncluder.hpp` and `common/constants.hpp`
+# includes against the minimal libgnss++ stand-ins (see ./README.md).
+target_include_directories(ginan_iers2010
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/shim
+)
+
+target_link_libraries(ginan_iers2010 PUBLIC Eigen3::Eigen)
+
+set_target_properties(ginan_iers2010 PROPERTIES POSITION_INDEPENDENT_CODE ON)

--- a/third_party/ginan-iers2010/LICENSE
+++ b/third_party/ginan-iers2010/LICENSE
@@ -1,0 +1,14 @@
+## Copyright 2020 Geoscience Australia
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+

--- a/third_party/ginan-iers2010/NOTICE
+++ b/third_party/ginan-iers2010/NOTICE
@@ -1,0 +1,24 @@
+ginan-iers2010 (libgnss++ vendored subset)
+==========================================
+
+This directory contains C++ wrappers around IERS Conventions (2010)
+routines, adapted from:
+
+    Geoscience Australia - Ginan
+    https://github.com/GeoscienceAustralia/ginan
+    Copyright 2020 Geoscience Australia
+    Licensed under Apache License, Version 2.0
+
+The wrapper code is itself a translation/wrapper of FORTRAN routines
+distributed by the IERS as part of the IERS Conventions 2010 software:
+
+    https://iers-conventions.obspm.fr/
+
+The IERS Conventions 2010 routines are public-domain scientific software
+produced under the auspices of the International Earth Rotation and
+Reference Systems Service. The C++ wrappers in this directory are
+licensed under Apache License, Version 2.0 (see ./LICENSE).
+
+A list of modifications made by libgnss++ to the upstream ginan sources
+is recorded in ./README.md ("Modifications" section), as required by
+Apache License 2.0 §4(b).

--- a/third_party/ginan-iers2010/README.md
+++ b/third_party/ginan-iers2010/README.md
@@ -1,0 +1,73 @@
+# ginan-iers2010 — IERS Conventions 2010 routines (subset)
+
+C++ wrappers around IERS Conventions 2010 routines, vendored from
+Geoscience Australia's Ginan project for use by libgnss++ to provide
+solid-earth-tide displacement and Mendes-Pavlis tropospheric mapping.
+
+## Provenance
+
+- **Origin**: GeoscienceAustralia/ginan, commit `535ef0a` (release v4.1.1),
+  path `src/cpp/3rdparty/iers2010/`.
+- **Underlying scientific source**: IERS Conventions (2010) software, see
+  https://iers-conventions.obspm.fr/. The C++ wrappers in ginan are
+  translations/wrappers of the original FORTRAN routines distributed by
+  the IERS.
+- **License**: Apache License, Version 2.0 — see `./LICENSE` in this
+  directory and `./NOTICE` for attribution.
+
+## Scope of this vendoring
+
+Only the **GTime-independent** subset of ginan's iers2010 wrappers is
+vendored here. Specifically:
+
+| Routine | File | Purpose |
+|---------|------|---------|
+| `iers2010::fcul_a` | `ch9/fcul_a.cpp` | Mendes-Pavlis FCULa total mapping function (latitude, height, surface temperature, elevation) |
+| `iers2010::fcul_zd_hpa` | `ch9/fcul_zd_hpa.cpp` | Mendes-Pavlis total zenith delay (lat, height, pressure, water-vapor pressure, temperature) |
+| `iers2010::dehanttideinel_impl` | `dehanttideinel/dehanttide_all.cpp` | Solid-earth-tide station displacement (Dehant et al., IERS Conventions 2010 §7.1.1) |
+
+The HARDISP ocean-tide-loading routines (`hardisp/`) are **deliberately
+not included** in this PR because their public APIs depend on ginan's
+internal `GTime` / `MjDateUtc` / `MjDateTT` time types. That subset
+will land in a follow-up PR with native libgnss++ time-type adaptation,
+or via a fresh re-implementation on top of SOFA's Julian Date primitives.
+
+## Modifications
+
+Per Apache License 2.0 §4(b), the following modifications were made
+relative to the upstream ginan sources in
+`GeoscienceAustralia/ginan@535ef0a:src/cpp/3rdparty/iers2010/`:
+
+1. **`iers2010.hpp`** — adapted from the upstream header:
+   - Removed `#include "common/gTime.hpp"` (no longer required because
+     of (3) below).
+   - Removed the `namespace hisp { ... }` block (HARDISP routines not
+     vendored — see "Scope" above).
+   - Replaced `#include "common/eigenIncluder.hpp"` with a direct
+     `#include <Eigen/Dense>` so this public header is self-contained
+     and does not depend on the internal `shim/` directory (which is
+     PRIVATE to the vendored `.cpp` files only).
+   - Added `#include <vector>` (was previously pulled in transitively
+     via `gTime.hpp`).
+   - Added a header banner describing the modifications and pointing
+     readers to this README.
+
+2. **`ch9/fcul_a.cpp`, `ch9/fcul_zd_hpa.cpp`,
+   `dehanttideinel/dehanttide_all.cpp`** — single-line include path
+   adjustment:
+   - `#include "3rdparty/iers2010/iers2010.hpp"` →
+     `#include "iers2010.hpp"`
+   - Reason: the libgnss++ vendor layout places this header alongside
+     the source files rather than under a `3rdparty/iers2010/` prefix.
+   - No algorithmic or behavioral change.
+
+3. **`shim/common/constants.hpp`** — *new* minimal stand-in header
+   added by libgnss++. It satisfies the single `common/constants.hpp`
+   include that survives in `dehanttideinel/dehanttide_all.cpp`
+   (providing the `D2R` degrees-to-radians constant) without pulling
+   in ginan's full `common/` tree (which depends on
+   boost/serialization, custom EigenDenseBase plugins, ginan time
+   types, etc.). The value is bit-identical to ginan's equivalent.
+
+No algorithmic, numerical, or behavioral modifications were made to any
+of the vendored `.cpp` source files.

--- a/third_party/ginan-iers2010/ch9/fcul_a.cpp
+++ b/third_party/ginan-iers2010/ch9/fcul_a.cpp
@@ -1,0 +1,73 @@
+#include "iers2010.hpp"
+#ifdef USE_EXTERNAL_CONSTS
+#include "iersc.hpp"
+#endif
+
+/// @details  This function computes the global total FCULa mapping function
+///           (Mendes et al. 2002). It is dependent on latitude, height, and
+///           surface temperature.
+///           This function is a translation/wrapper for the fortran FCUL_A
+///           subroutine, found here :
+///           http://maia.usno.navy.mil/conv2010/software.html
+///
+/// @param[in]  dlat  Latitude given in degrees (North Latitude)
+/// @param[in]  dhgt  Height given in meters (mean sea level)
+/// @param[in]  t     Surface temperature given in Kelvin
+/// @param[in]  elev  Elevation angle in degrees
+/// @return           Mapping function to scale total delay (Note 1)
+///
+/// @note
+///    -# These coefficients are based on a LS adjustment of 87766 (cleaned)
+///    set of traces, based on Ciddor routines to compute refractivity,
+///    according to IUGG recommendations (1999).
+///    -# Status: Class 1 model
+///
+/// @version 13.08.2009
+///
+/// @cite iers2010
+/// Mendes, V.B., G. Prates, E.C. Pavlis, D.E. Pavlis,
+/// and R.B. Langley (2002). "Improved mapping functions for
+/// atmospheric refraction correction in SLR", Geophysical
+/// Res. Lett., 29(10), 1414, doi:10.1029/2001GL014394, 2002
+double iers2010::fcul_a(double dlat, double dhgt, double t,
+                        double elev) noexcept {
+#ifdef USE_EXTERNAL_CONSTS
+  constexpr double PI(iers2010::DPI);
+#else
+  constexpr double PI(3.14159265358979323846e0);
+#endif
+
+  // Convert elevation angle to radians
+  const double epsilon = elev * (PI / 180e0);
+  const double sine = std::sin(epsilon);
+  // Convert temperature to Celsius
+  const double t_c = t - 273.15e0;
+  const double cosphi = std::cos(dlat * (PI / 180e0));
+
+  // Define coefficients used in the model
+  constexpr double a10 = 0.121008e-02;
+  constexpr double a11 = 0.17295e-05;
+  constexpr double a12 = 0.3191e-04;
+  constexpr double a13 = -0.18478e-07;
+
+  constexpr double a20 = 0.304965e-02;
+  constexpr double a21 = 0.2346e-05;
+  constexpr double a22 = -0.1035e-03;
+  constexpr double a23 = -0.1856e-07;
+
+  constexpr double a30 = 0.68777e-01;
+  constexpr double a31 = 0.1972e-04;
+  constexpr double a32 = -0.3458e-02;
+  constexpr double a33 = 0.1060e-06;
+
+  // a, b, and c in Marini continued fraction (Eq. 5)
+  double a1{a10 + a11 * t_c + a12 * cosphi + a13 * dhgt};
+  double a2{a20 + a21 * t_c + a22 * cosphi + a23 * dhgt};
+  double a3{a30 + a31 * t_c + a32 * cosphi + a33 * dhgt};
+
+  // numerator in continued fraction
+  double map_zen = (1e0 + a1 / (1e0 + a2 / (1e0 + a3)));
+
+  // result
+  return map_zen / (sine + a1 / (sine + a2 / (sine + a3)));
+}

--- a/third_party/ginan-iers2010/ch9/fcul_zd_hpa.cpp
+++ b/third_party/ginan-iers2010/ch9/fcul_zd_hpa.cpp
@@ -1,0 +1,106 @@
+#include "iers2010.hpp"
+#ifdef USE_EXTERNAL_CONSTS
+#include "iersc.hpp"
+#endif
+
+/// @details  This function determines the total zenith delay following
+///           (Mendes and Pavlis, 2004).
+///           This function is a translation/wrapper for the fortran FCUL_A
+///           subroutine, found here :
+///           http://maia.usno.navy.mil/conv2010/software.html
+///
+/// @param[in]  dlat   Geodetic Latitude given in degrees (North Latitude)
+/// @param[in]  dhgt   Height above ellipsoid given in meters
+/// @param[in]  pres   Surface pressure given in hPa (mbars) (Note 1)
+/// @param[in]  wvp    Water vapor pressure in hPa (mbars) (Note 1)
+/// @param[in]  lambda Laser wavelength (micrometers)
+/// @param[out] f_ztd  Zenith total delay in meters
+/// @param[out] f_zhd  Zenith hydrostatic delay in meters
+/// @param[out] f_zwd  Zenith non-hydrostatic delay in meters
+/// @return            An integer, always zero
+///
+/// @note
+///    -# The surface pressure provided was converted from inches Hg.
+///       The water vapor pressure was calculated from the surface
+///       temperature (Celsius) and Relative Humidity (% R.H.) at the station.
+///    -# Status: Class 1 model
+///
+/// @verbatim
+///     given input: LATITUDE  = 30.67166667D0 degrees (McDonald Observatory)
+///                  ELLIP_HT  = 2010.344D0 meters
+///                  PRESSURE  = 798.4188D0 hPa (August 14, 2009)
+///                  WVP       = 14.322D0 hPa (August 14, 2009)
+///                  LAMBDA_UM = 0.532D0 micrometers (See Mendes et al.)
+///     expected output: FCUL_ZTD = 1.935225924846803114D0 m
+///                      FCUL_ZHD = 1.932992176591644462D0 m
+///                      FCUL_ZWD = 0.2233748255158703871D-02 m
+/// @endverbatim
+///
+/// @version 14.08.2009
+///
+/// @cite iers2010
+///    Mendes, V.B. and E.C. Pavlis, 2004,
+///     "High-accuracy zenith delay prediction at optical wavelengths,"
+///     Geophysical Res. Lett., 31, L14602, doi:10.1029/2004GL020308, 2004
+int iers2010::fcul_zd_hpa(double dlat, double dhgt, double pres, double wvp,
+                          double lambda, double &f_ztd, double &f_zhd,
+                          double &f_zwd) noexcept {
+#ifdef USE_EXTERNAL_CONSTS
+  constexpr double PI(iers2010::DPI);
+  // constexpr double C    (DC);
+#else
+  constexpr double PI(3.14159265358979323846e0);
+  // speed of light in vacuum (m/s)
+  // constexpr double C    (2.99792458e8);
+#endif
+
+  // CO2 content in ppm
+  constexpr double xc = 375e0;
+  // constant values to be used in Equation (20)
+  // k1 and k3 are k1* and k3*
+  constexpr double k0 = 238.0185e0;
+  constexpr double k1 = 19990.975e0;
+  constexpr double k2 = 57.362e0;
+  constexpr double k3 = 579.55174e0;
+
+  // constant values to be used in Equation (32)
+  constexpr double w0 = 295.235e0;
+  constexpr double w1 = 2.6422e0;
+  constexpr double w2 = -0.032380e0;
+  constexpr double w3 = 0.004028e0;
+
+  //  Wave number
+  const double sigma = 1e0 / lambda;
+
+  // correction factor - Equation (24)
+  const double f =
+      1e0 - 0.00266e0 * std::cos(2e0 * PI / 180e0 * dlat) - 0.00028e-3 * dhgt;
+
+  // correction for CO2 content
+  const double corr = 1e0 + 0.534e-6 * (xc - 450e0);
+
+  // dispersion equation for the hydrostatic component - Equation (20)
+  const double sigma2 = sigma * sigma;
+  const double fh = 0.01e0 * corr *
+                    ((k1 * (k0 + sigma2)) / (std::pow((k0 - sigma2), 2)) +
+                     k3 * (k2 + sigma2) / (std::pow((k2 - sigma2), 2)));
+
+  // computation of the hydrostatic component - Equation (26)
+  // caution: pressure in hectoPascal units
+  f_zhd = 2.416579e-3 * fh * pres / f;
+
+  // dispersion equation for the non-hydrostatic component - Equation (32)
+  const double fnh =
+      0.003101e0 * (w0 + 3e0 * w1 * sigma2 + 5e0 * w2 * (sigma2 * sigma2) +
+                    7e0 * w3 * std::pow(sigma, 6));
+
+  // computation of the non-hydrostatic component - Equation (38)
+  // caution: pressure in hectoPascal units
+  f_zwd = 1.e-4 * (5.316e0 * fnh - 3.759e0 * fh) * wvp / f;
+
+  // compute the zenith total delay
+  f_ztd = f_zhd + f_zwd;
+
+  // return
+  return 0;
+}

--- a/third_party/ginan-iers2010/dehanttideinel/dehanttide_all.cpp
+++ b/third_party/ginan-iers2010/dehanttideinel/dehanttide_all.cpp
@@ -1,0 +1,762 @@
+#include "common/constants.hpp"
+#include "iers2010.hpp"
+// #include <datetime/dtfund.hpp>
+
+namespace {
+// Set constants
+// constexpr const double DEG2RAD = iers2010::D2PI / 360e0;
+constexpr const double DEG2RAD = D2R;
+
+// coefficients for computations in step2diu
+const double s2d_datdi[][9] = {
+    {-3e0, 0e0, 2e0, 0e0, 0e0, -0.01e0, 0e0, 0e0, 0e0},
+    {-3e0, 2e0, 0e0, 0e0, 0e0, -0.01e0, 0e0, 0e0, 0e0},
+    {-2e0, 0e0, 1e0, -1e0, 0e0, -0.02e0, 0e0, 0e0, 0e0},
+    {-2e0, 0e0, 1e0, 0e0, 0e0, -0.08e0, 0e0, -0.01e0, 0.01e0},
+    {-2e0, 2e0, -1e0, 0e0, 0e0, -0.02e0, 0e0, 0e0, 0e0},
+    {-1e0, 0e0, 0e0, -1e0, 0e0, -0.10e0, 0e0, 0e0, 0e0},
+    {-1e0, 0e0, 0e0, 0e0, 0e0, -0.51e0, 0e0, -0.02e0, 0.03e0},
+    {-1e0, 2e0, 0e0, 0e0, 0e0, 0.01e0, 0e0, 0e0, 0e0},
+    {0e0, -2e0, 1e0, 0e0, 0e0, 0.01e0, 0e0, 0e0, 0e0},
+    {0e0, 0e0, -1e0, 0e0, 0e0, 0.02e0, 0e0, 0e0, 0e0},
+    {0e0, 0e0, 1e0, 0e0, 0e0, 0.06e0, 0e0, 0e0, 0e0},
+    {0e0, 0e0, 1e0, 1e0, 0e0, 0.01e0, 0e0, 0e0, 0e0},
+    {0e0, 2e0, -1e0, 0e0, 0e0, 0.01e0, 0e0, 0e0, 0e0},
+    {1e0, -3e0, 0e0, 0e0, 1e0, -0.06e0, 0e0, 0e0, 0e0},
+    {1e0, -2e0, 0e0, -1e0, 0e0, 0.01e0, 0e0, 0e0, 0e0},
+    {1e0, -2e0, 0e0, 0e0, 0e0, -1.23e0, -0.07e0, 0.06e0, 0.01e0},
+    {1e0, -1e0, 0e0, 0e0, -1e0, 0.02e0, 0e0, 0e0, 0e0},
+    {1e0, -1e0, 0e0, 0e0, 1e0, 0.04e0, 0e0, 0e0, 0e0},
+    {1e0, 0e0, 0e0, -1e0, 0e0, -0.22e0, 0.01e0, 0.01e0, 0e0},
+    {1e0, 0e0, 0e0, 0e0, 0e0, 12.00e0, -0.80e0, -0.67e0, -0.03e0},
+    {1e0, 0e0, 0e0, 1e0, 0e0, 1.73e0, -0.12e0, -0.10e0, 0e0},
+    {1e0, 0e0, 0e0, 2e0, 0e0, -0.04e0, 0e0, 0e0, 0e0},
+    {1e0, 1e0, 0e0, 0e0, -1e0, -0.50e0, -0.01e0, 0.03e0, 0e0},
+    {1e0, 1e0, 0e0, 0e0, 1e0, 0.01e0, 0e0, 0e0, 0e0},
+    {0e0, 1e0, 0e0, 1e0, -1e0, -0.01e0, 0e0, 0e0, 0e0},
+    {1e0, 2e0, -2e0, 0e0, 0e0, -0.01e0, 0e0, 0e0, 0e0},
+    {1e0, 2e0, 0e0, 0e0, 0e0, -0.11e0, 0.01e0, 0.01e0, 0e0},
+    {2e0, -2e0, 1e0, 0e0, 0e0, -0.01e0, 0e0, 0e0, 0e0},
+    {2e0, 0e0, -1e0, 0e0, 0e0, -0.02e0, 0e0, 0e0, 0e0},
+    {3e0, 0e0, 0e0, 0e0, 0e0, 0e0, 0e0, 0e0, 0e0},
+    {3e0, 0e0, 0e0, 1e0, 0e0, 0e0, 0e0, 0e0, 0e0}};
+
+/// @brief Structure to hold a number of angles used to compute the Step 2
+///        tidal displacement for a point on earth. See function step2diu and
+///        step2lon. Instead of computing them within these functions, they are
+///        computed once, and stored in a Step2Angles instance.
+struct Step2Angles {
+  /// @param[in] tms Datetime in milliseond resolution, TT
+  Step2Angles(double julian_centuries_tt, double fhr_ut) noexcept {
+    const double t = julian_centuries_tt;
+    const double fhr = fhr_ut;
+
+    //printf("targ = %.12f\n", t);
+    //printf("tfhr = %.12f\n", fhr);
+
+    // Compute the phase angles in degrees.
+    s = 218.31664563e0 +
+        (481267.88194e0 + (-0.0014663889e0 + (0.00000185139e0) * t) * t) * t;
+
+    tau = fhr * 15e0 + 280.4606184e0 +
+          (36000.7700536e0 + (0.00038793e0 + (-0.0000000258e0) * t) * t) * t +
+          (-s);
+
+    const double pr =
+        (1.396971278e0 +
+         (0.000308889e0 + (0.000000021e0 + (0.000000007e0) * t) * t) * t) *
+        t;
+
+    s += pr;
+
+    h = 280.46645e0 +
+        (36000.7697489e0 +
+         (0.00030322222e0 + (0.000000020e0 + (-0.00000000654e0) * t) * t) * t) *
+            t;
+
+    p = 83.35324312e0 +
+        (4069.01363525e0 +
+         (-0.01032172222e0 + (-0.0000124991e0 + (0.00000005263e0) * t) * t) *
+             t) *
+            t;
+
+    zns = 234.95544499e0 +
+          (1934.13626197e0 +
+           (-0.00207561111e0 + (-0.00000213944e0 + (0.00000001650e0) * t) * t) *
+               t) *
+              t;
+
+    ps = 282.93734098e0 +
+         (1.71945766667e0 +
+          (0.00045688889e0 + (-0.00000001778e0 + (-0.00000000334e0) * t) * t) *
+              t) *
+             t;
+
+    // Reduce angles to between the range 0 and 360.
+    s = std::fmod(s, 360e0);
+    tau = std::fmod(tau, 360e0);
+    h = std::fmod(h, 360e0);
+    p = std::fmod(p, 360e0);
+    zns = std::fmod(zns, 360e0);
+    ps = std::fmod(ps, 360e0);
+  }
+  double s, tau, h, p, zns, ps;
+}; // Step2Angles
+
+/// @brief A list of auxiliary quantities used to compute Step-1 and Step-2
+///        tidal displacement. Originaly, they are performed within each of the
+///        step-1 functions (st1l1, st1isem, st1diu) and step-1 functions (
+///        step2diu and step2lon) but we can only compute them once and store
+///        the in a TideAux instance.
+struct TideAux {
+  TideAux(const Eigen::Matrix<double, 3, 1> &ixsta,
+          const Eigen::Matrix<double, 3, 1> &ixsun,
+          const Eigen::Matrix<double, 3, 1> &ixmon) noexcept
+      : xsta(&ixsta), xsun(&ixsun), xmon(&ixmon), rsta(ixsta.norm()),
+        sinphi(ixsta(2) / rsta),
+        cosphi(std::sqrt(ixsta(0) * ixsta(0) + ixsta(1) * ixsta(1)) / rsta),
+        sinla(ixsta(1) / cosphi / rsta), cosla(ixsta(0) / cosphi / rsta),
+        rsun(ixsun.norm()), rmon(ixmon.norm()) {
+    planet_factors();
+  }
+
+  // set member variables fac2sun and fac2mon using IERS constants
+  void planet_factors() noexcept {
+    constexpr double mass_ratio_sun = 332946.0482e0;
+    constexpr double mass_ratio_moon = 0.0123000371e0;
+    constexpr double re = iers2010::Re;
+    fac2sun = mass_ratio_sun * re * std::pow(re / rsun, 3);
+    fac2mon = mass_ratio_moon * re * std::pow(re / rmon, 3);
+  }
+
+  void set_site(const Eigen::Matrix<double, 3, 1> &ixsta) noexcept {
+    xsta = &ixsta;
+    rsta = ixsta.norm();
+    sinphi = ixsta(2) / rsta;
+    cosphi = std::sqrt(ixsta(0) * ixsta(0) + ixsta(1) * ixsta(1)) / rsta;
+    sinla = ixsta(1) / cosphi / rsta;
+    cosla = ixsta(0) / cosphi / rsta;
+  }
+
+  const Eigen::Matrix<double, 3, 1> *xsta, *xsun, *xmon;
+  double rsta;
+  double sinphi;
+  double cosphi;
+  double sinla;
+  double cosla;
+  double rsun;
+  double rmon;
+  double fac2sun;
+  double fac2mon;
+}; // TideAux
+
+} // namespace
+
+/// @details This function gives the corrections induced by the latitude
+///          dependence given by L^1 in Mathews et al. 1991
+///
+///          This function is a translation/wrapper for the fortran ST1L1
+///          subroutine, found here :
+///          http://maia.usno.navy.mil/conv2010/software.html
+///
+/// @param[in] aux An instance of type TideAux, containing information for the
+///            site and "planets" (xsta in ECEF [m]), xsun in ECEF [m] and
+///            xmon ECEF [m]), as well as the fac2sun and fac2mon (degree 2
+///            TGP factor for the Sun and Moon respectively)
+/// @return  xcorsta Out of phase station corrections for semi-diurnal band
+///
+/// @note This fucnction is part of the package dehanttideinel, see
+///       ftp://maia.usno.navy.mil/conv2010/convupdt/chapter7/dehanttideinel/
+///
+/// @version 31.07.2009
+Eigen::Matrix<double, 3, 1> st1l1(const TideAux &aux) noexcept {
+  constexpr const double l1d = 0.0012e0;
+  constexpr const double l1sd = 0.0024e0;
+
+  // Compute the normalized position vector of the station.
+  // const double rsta = aux.rsta;
+  const double sinphi = aux.sinphi;
+  const double sinphi2 = sinphi * sinphi;
+  const double cosphi = aux.cosphi;
+  const double cosphi2 = cosphi * cosphi;
+  const double sinla = aux.sinla;
+  const double cosla = aux.cosla;
+
+  // Compute the normalized position vector of the Moon.
+  const double rmon2 = aux.rmon * aux.rmon;
+
+  // Compute the normalized position vector of the Sun.
+  const double rsun2 = aux.rsun * aux.rsun;
+
+  // Compute the station corrections for the diurnal band.
+  double l1 = l1d;
+  const double fac2sun = aux.fac2sun;
+  const double fac2mon = aux.fac2mon;
+  double dnsun =
+      -l1 * sinphi2 * fac2sun * aux.xsun->operator()(2) *
+      (aux.xsun->operator()(0) * cosla + aux.xsun->operator()(1) * sinla) /
+      rsun2;
+  double dnmon =
+      -l1 * sinphi2 * fac2mon * aux.xmon->operator()(2) *
+      (aux.xmon->operator()(0) * cosla + aux.xmon->operator()(1) * sinla) /
+      rmon2;
+  double desun =
+      l1 * sinphi * (cosphi2 - sinphi2) * fac2sun * aux.xsun->operator()(2) *
+      (aux.xsun->operator()(0) * sinla - aux.xsun->operator()(1) * cosla) /
+      rsun2;
+  double demon =
+      l1 * sinphi * (cosphi2 - sinphi2) * fac2mon * aux.xmon->operator()(2) *
+      (aux.xmon->operator()(0) * sinla - aux.xmon->operator()(1) * cosla) /
+      rmon2;
+
+  double de = 3e0 * (desun + demon);
+  double dn = 3e0 * (dnsun + dnmon);
+
+  const double xcorsta_[] = {-de * sinla - dn * sinphi * cosla,
+                             de * cosla - dn * sinphi * sinla, dn * cosphi};
+  Eigen::Matrix<double, 3, 1> xcorsta(xcorsta_);
+
+  // Compute the station corrections for the semi-diurnal band.
+  l1 = l1sd;
+  const double costwola = cosla * cosla - sinla * sinla;
+  const double sintwola = 2e0 * cosla * sinla;
+  const double xsun_x2 = std::pow(aux.xsun->operator()(0), 2);
+  const double xsun_y2 = std::pow(aux.xsun->operator()(1), 2);
+  const double xmon_x2 = std::pow(aux.xmon->operator()(0), 2);
+  const double xmon_y2 = std::pow(aux.xmon->operator()(1), 2);
+
+  dnsun = -l1 / 2e0 * sinphi * cosphi * fac2sun *
+          ((xsun_x2 - xsun_y2) * costwola +
+           2e0 * aux.xsun->operator()(0) * aux.xsun->operator()(1) * sintwola) /
+          rsun2;
+
+  dnmon = -l1 / 2e0 * sinphi * cosphi * fac2mon *
+          ((xmon_x2 - xmon_y2) * costwola +
+           2e0 * aux.xmon->operator()(0) * aux.xmon->operator()(1) * sintwola) /
+          rmon2;
+
+  desun = -l1 / 2e0 * sinphi2 * cosphi * fac2sun *
+          ((xsun_x2 - xsun_y2) * sintwola -
+           2e0 * aux.xsun->operator()(0) * aux.xsun->operator()(1) * costwola) /
+          rsun2;
+
+  demon = -l1 / 2e0 * sinphi2 * cosphi * fac2mon *
+          ((xmon_x2 - xmon_y2) * sintwola -
+           2e0 * aux.xmon->operator()(0) * aux.xmon->operator()(1) * costwola) /
+          rmon2;
+
+  de = 3e0 * (desun + demon);
+  dn = 3e0 * (dnsun + dnmon);
+
+  xcorsta(0) += (-de * sinla - dn * sinphi * cosla);
+  xcorsta(1) += (de * cosla - dn * sinphi * sinla);
+  xcorsta(2) += (dn * cosphi);
+
+  // Finished
+  return xcorsta;
+}
+
+/// @details This function gives the out-of-phase corrections induced by
+///          mantle anelasticity in the semi-diurnal band.
+///
+///          This function is a translation/wrapper for the fortran ST1ISEM
+///          subroutine, found here :
+///          http://maia.usno.navy.mil/conv2010/software.html
+///
+/// @param[in] aux An instance of type TideAux, containing information for the
+///            site and "planets" (xsta in ECEF [m]), xsun in ECEF [m] and
+///            xmon ECEF [m]), as well as the fac2sun and fac2mon (degree 2
+///            TGP factor for the Sun and Moon respectively)
+/// @return xcorsta Out of phase station corrections for semi-diurnal band
+///
+/// @note This fucnction is part of the package dehanttideinel, see
+///       ftp://maia.usno.navy.mil/conv2010/convupdt/chapter7/dehanttideinel/
+///
+/// @version 31.07.2009
+Eigen::Matrix<double, 3, 1> st1isem(const TideAux &aux) noexcept {
+
+  constexpr const double dhi = -0.0022e0;
+  constexpr const double dli = -0.0007e0;
+
+  const double sinphi = aux.sinphi;
+  const double cosphi = aux.cosphi;
+  const double sinla = aux.sinla;
+  const double cosla = aux.cosla;
+  const double costwola = cosla * cosla - sinla * sinla;
+  const double sintwola = 2e0 * cosla * sinla;
+
+  // Compute the normalized position vector of the Moon.
+  const double rmon2 = aux.rmon * aux.rmon;
+
+  // Compute the normalized position vector of the Sun.
+  const double rsun2 = aux.rsun * aux.rsun;
+
+  // (minor modification) compute some helpfull intermediate quantities,
+  // to reduce the following computation lines.
+  const double xs0m1 = aux.xsun->operator()(0) * aux.xsun->operator()(0) -
+                       aux.xsun->operator()(1) * aux.xsun->operator()(1);
+  const double xm0m1 = aux.xmon->operator()(0) * aux.xmon->operator()(0) -
+                       aux.xmon->operator()(1) * aux.xmon->operator()(1);
+  const double fac2sun = aux.fac2sun;
+  const double fac2mon = aux.fac2mon;
+
+  const double drsun =
+      -3e0 / 4e0 * dhi * cosphi * cosphi * fac2sun *
+      (xs0m1 * sintwola -
+       2e0 * aux.xsun->operator()(0) * aux.xsun->operator()(1) * costwola) /
+      rsun2;
+
+  const double drmon =
+      -3e0 / 4e0 * dhi * cosphi * cosphi * fac2mon *
+      (xm0m1 * sintwola -
+       2e0 * aux.xmon->operator()(0) * aux.xmon->operator()(1) * costwola) /
+      rmon2;
+
+  const double dnsun =
+      3e0 / 2e0 * dli * sinphi * cosphi * fac2sun *
+      (xs0m1 * sintwola -
+       2e0 * aux.xsun->operator()(0) * aux.xsun->operator()(1) * costwola) /
+      rsun2;
+
+  const double dnmon =
+      3e0 / 2e0 * dli * sinphi * cosphi * fac2mon *
+      (xm0m1 * sintwola -
+       2e0 * aux.xmon->operator()(0) * aux.xmon->operator()(1) * costwola) /
+      rmon2;
+
+  const double desun =
+      -3e0 / 2e0 * dli * cosphi * fac2sun *
+      (xs0m1 * costwola +
+       2e0 * aux.xsun->operator()(0) * aux.xsun->operator()(1) * sintwola) /
+      rsun2;
+
+  const double demon =
+      -3e0 / 2e0 * dli * cosphi * fac2mon *
+      (xm0m1 * costwola +
+       2e0 * aux.xmon->operator()(0) * aux.xmon->operator()(1) * sintwola) /
+      rmon2;
+
+  const double dr = drsun + drmon;
+  const double dn = dnsun + dnmon;
+  const double de = desun + demon;
+
+  // Compute the corrections for the station.
+  const double _data[] = {
+      dr * cosla * cosphi - de * sinla - dn * sinphi * cosla,
+      dr * sinla * cosphi + de * cosla - dn * sinphi * sinla,
+      dr * sinphi + dn * cosphi};
+  return Eigen::Matrix<double, 3, 1>(_data);
+
+  // Finished
+}
+
+/// @details This function gives the out-of-phase corrections induced by
+///          mantle anelasticity in the diurnal band.
+///
+///          This function is a translation/wrapper for the fortran ST1IDIU
+///          subroutine, found here :
+///          http://maia.usno.navy.mil/conv2010/software.html
+///
+/// @param[in] aux An instance of type TideAux, containing information for the
+///            site and "planets" (xsta in ECEF [m]), xsun in ECEF [m] and
+///            xmon ECEF [m]), as well as the fac2sun and fac2mon (degree 2
+///            TGP factor for the Sun and Moon respectively)
+/// @return xcorsta Out of phase station corrections for diurnal band
+///            (3d vector)
+///
+/// @note This fucnction is part of the package dehanttideinel, see
+///       ftp://maia.usno.navy.mil/conv2010/convupdt/chapter7/dehanttideinel/
+///
+/// @version 31.07.2009
+Eigen::Matrix<double, 3, 1> st1idiu(const TideAux &aux) noexcept {
+  constexpr const double dhi = -0.0025e0;
+  constexpr const double dli = -0.0007e0;
+
+  // Compute the normalized position vector of the station.
+  // const double rsta = aux.rsta;
+  const double sinphi = aux.sinphi;
+  const double cosphi = aux.cosphi;
+  const double cos2phi = cosphi * cosphi - sinphi * sinphi;
+  const double sinla = aux.sinla;
+  const double cosla = aux.cosla;
+
+  // Compute the normalized position vector of the Moon.
+  const double rmon2 = aux.rmon * aux.rmon;
+
+  // Compute the normalized position vector of the Sun.
+  const double rsun2 = aux.rsun * aux.rsun;
+  const double fac2sun = aux.fac2sun;
+  const double fac2mon = aux.fac2mon;
+
+  const double drsun =
+      -3e0 * dhi * sinphi * cosphi * fac2sun * aux.xsun->operator()(2) *
+      (aux.xsun->operator()(0) * sinla - aux.xsun->operator()(1) * cosla) /
+      rsun2;
+  //printf("drsun: %.9f %.9f %.9f %.9f %.9f\n", sinphi, cosphi, fac2sun, sinla, cosla);
+  //printf("drsun: %.9f %.9f %.9f\n", aux.xsun->operator()(0), aux.xsun->operator()(1), aux.xsun->operator()(2));
+  //printf("drsun: %.9f\n", drsun);
+
+  const double drmon =
+      -3e0 * dhi * sinphi * cosphi * fac2mon * aux.xmon->operator()(2) *
+      (aux.xmon->operator()(0) * sinla - aux.xmon->operator()(1) * cosla) /
+      rmon2;
+  //printf("drmon: %.9f\n", drmon);
+
+  const double dnsun =
+      -3e0 * dli * cos2phi * fac2sun * aux.xsun->operator()(2) *
+      (aux.xsun->operator()(0) * sinla - aux.xsun->operator()(1) * cosla) /
+      rsun2;
+
+  const double dnmon =
+      -3e0 * dli * cos2phi * fac2mon * aux.xmon->operator()(2) *
+      (aux.xmon->operator()(0) * sinla - aux.xmon->operator()(1) * cosla) /
+      rmon2;
+
+  const double desun =
+      -3e0 * dli * sinphi * fac2sun * aux.xsun->operator()(2) *
+      (aux.xsun->operator()(0) * cosla + aux.xsun->operator()(1) * sinla) /
+      rsun2;
+
+  const double demon =
+      -3e0 * dli * sinphi * fac2mon * aux.xmon->operator()(2) *
+      (aux.xmon->operator()(0) * cosla + aux.xmon->operator()(1) * sinla) /
+      rmon2;
+
+  const double dr = drsun + drmon;
+  const double dn = dnsun + dnmon;
+  const double de = desun + demon;
+
+  // Compute the corrections for the station.
+  return Eigen::Matrix<double, 3, 1>(
+      dr * cosla * cosphi - de * sinla - dn * sinphi * cosla,
+      dr * sinla * cosphi + de * cosla - dn * sinphi * sinla,
+      dr * sinphi + dn * cosphi);
+
+  // Finished
+}
+
+/// @details This function gives the in-phase and out-of-phase corrections
+///          induced by mantle anelasticity in the diurnal band.
+///          This function is a translation/wrapper for the fortran STEP2DIU
+///          subroutine, found here at
+///          http://maia.usno.navy.mil/conv2010/software.html
+///
+/// @param[in] aux An instance of type TideAux, containing information for the
+///            site and "planets" (xsta in ECEF [m]), xsun in ECEF [m] and
+///            xmon ECEF [m]), as well as the fac2sun and fac2mon (degree 2
+///            TGP factor for the Sun and Moon respectively)
+/// @param[in] angles An instance of type Step2Angles where all relevant
+///            angles/variables to be used are store, for the passed in
+///            datetime
+/// @return xcorsta In phase and out of phase station corrections
+///            for diurnal band
+///
+/// @note This fucnction is part of the package dehanttideinel, see
+///       ftp://maia.usno.navy.mil/conv2010/convupdt/chapter7/dehanttideinel/
+///
+/// @version 20.10.2010
+Eigen::Matrix<double, 3, 1> step2diu(const Step2Angles &angles,
+                                     const TideAux &aux) noexcept {
+
+  // Compute the phase angles in degrees.
+  const double s = angles.s;
+  const double tau = angles.tau;
+  const double h = angles.h;
+  const double p = angles.p;
+  const double zns = angles.zns;
+  const double ps = angles.ps;
+
+  // const double rsta = aux.rsta;
+  const double sinphi = aux.sinphi;
+  const double cosphi = aux.cosphi;
+  const double cosla = aux.cosla;
+  const double sinla = aux.sinla;
+  const double zla =
+      std::atan2(aux.xsta->operator()(1), aux.xsta->operator()(0));
+
+  Eigen::Matrix<double, 3, 1> xcorsta = Eigen::Matrix<double, 3, 1>::Zero();
+
+  double thetaf, dr, dn, de;
+  const double f1 = 2e0 * sinphi * cosphi;
+  const double g1 = cosphi * cosphi - sinphi * sinphi;
+  for (int j = 0; j < 31; j++) {
+    // Convert from degrees to radians.
+    thetaf =
+        (tau + s2d_datdi[j][0] * s + s2d_datdi[j][1] * h + s2d_datdi[j][2] * p +
+         s2d_datdi[j][3] * zns + s2d_datdi[j][4] * ps) *
+        DEG2RAD;
+
+    const double stz = std::sin(thetaf + zla);
+    const double ctz = std::cos(thetaf + zla);
+    dr = s2d_datdi[j][5] * f1 * stz + s2d_datdi[j][6] * f1 * ctz;
+
+    dn = s2d_datdi[j][7] * g1 * stz + s2d_datdi[j][8] * g1 * ctz;
+
+    // DE=DATDI(8,J)*SINPHI*COS(THETAF+ZLA)+
+    // Modified 20 June 2007
+    de = s2d_datdi[j][7] * sinphi * ctz - s2d_datdi[j][8] * sinphi * stz;
+
+    xcorsta(0) += dr * cosla * cosphi - de * sinla - dn * sinphi * cosla;
+    xcorsta(1) += dr * sinla * cosphi + de * cosla - dn * sinphi * sinla;
+    xcorsta(2) += dr * sinphi + dn * cosphi;
+  }
+
+  // Finished
+  return xcorsta * 1e-3;
+}
+
+/// @details This function gives the in-phase and out-of-phase corrections
+///          induced by mantle anelasticity in the long period band.
+///
+///          This function is a translation/wrapper for the fortran STEP2LON
+///          subroutine, found here :
+///          http://maia.usno.navy.mil/conv2010/software.html
+///
+/// @param[in] aux An instance of type TideAux, containing information for the
+///            site and "planets" (xsta in ECEF [m]), xsun in ECEF [m] and
+///            xmon ECEF [m]), as well as the fac2sun and fac2mon (degree 2
+///            TGP factor for the Sun and Moon respectively)
+/// @param[in] angles An instance of type Step2Angles where all relevant
+///            angles/variables to be used are store, for the passed in
+///            datetime
+/// @param[out] xcorsta In phase and out of phase station corrections
+///            for diurnal band
+///
+/// @note This fucnction is part of the package dehanttideinel, see
+///       ftp://maia.usno.navy.mil/conv2010/convupdt/chapter7/dehanttideinel/
+///
+/// @version 20.10.2010
+Eigen::Matrix<double, 3, 1> step2lon(const Step2Angles &angles,
+                                     const TideAux &aux) noexcept {
+
+  constexpr double datdi[][9] = {
+      {0e0, 0e0, 0e0, 1e0, 0e0, 0.47e0, 0.23e0, 0.16e0, 0.07e0},
+      {0e0, 2e0, 0e0, 0e0, 0e0, -0.20e0, -0.12e0, -0.11e0, -0.05e0},
+      {1e0, 0e0, -1e0, 0e0, 0e0, -0.11e0, -0.08e0, -0.09e0, -0.04e0},
+      {2e0, 0e0, 0e0, 0e0, 0e0, -0.13e0, -0.11e0, -0.15e0, -0.07e0},
+      {2e0, 0e0, 0e0, 1e0, 0e0, -0.05e0, -0.05e0, -0.06e0, -0.03e0}};
+
+  // Compute the phase angles in degrees.
+  // Compute the phase angles in degrees.
+  const double s = angles.s;
+  // const double tau = angles.tau;
+  const double h = angles.h;
+  const double p = angles.p;
+  const double zns = angles.zns;
+  const double ps = angles.ps;
+
+  // const double rsta = aux.rsta;
+  const double sinphi = aux.sinphi;
+  const double cosphi = aux.cosphi;
+  const double cosla = aux.cosla;
+  const double sinla = aux.sinla;
+
+  // double dr_tot = 0e0, dn_tot = 0e0;
+  Eigen::Matrix<double, 3, 1> xcorsta = Eigen::Matrix<double, 3, 1>::Zero();
+
+  double thetaf, dr, dn, de;
+  const double f1 = (3e0 * sinphi * sinphi - 1e0) / 2e0;
+  const double f2 = cosphi * sinphi * 2e0;
+  for (int j = 0; j < 5; j++) {
+
+    thetaf = (datdi[j][0] * s + datdi[j][1] * h + datdi[j][2] * p +
+              datdi[j][3] * zns + datdi[j][4] * ps) *
+             DEG2RAD;
+
+    const double ct = std::cos(thetaf);
+    const double st = std::sin(thetaf);
+
+    dr = datdi[j][5] * f1 * ct + datdi[j][7] * f1 * st;
+
+    dn = datdi[j][6] * f2 * ct + datdi[j][8] * f2 * st;
+
+    de = 0e0;
+
+    // dr_tot += dr;
+    // dn_tot += dn;
+
+    xcorsta(0) += dr * cosla * cosphi - de * sinla - dn * sinphi * cosla;
+    xcorsta(1) += dr * sinla * cosphi + de * cosla - dn * sinphi * sinla;
+    xcorsta(2) += dr * sinphi + dn * cosphi;
+  }
+
+  // Finished.
+  return xcorsta * 1e-3;
+}
+
+/// @details This function computes the station tidal displacement
+///          caused by lunar and solar gravitational attraction (see
+///          References). The computations are calculated by the following
+///          steps:<br> <b>Step 1):</b> General degree 2 and degree 3
+///          corrections
+///          + CALL ST1IDIU + CALL ST1ISEM + CALL ST1L1.<br>
+///          <b>Step 2):</b> CALL STEP2DIU + CALL STEP2LON<br>
+///          It has been decided that the <b>Step 3</b> non-correction for
+///          permanent tide would not be applied in order to avoid a jump in the
+///          reference frame. This Step 3 must be added in order to get the
+///          non-tidal station position and to conform with the IAG Resolution.
+///          This function is a translation/wrapper for the fortran
+///          DEHANTTIDEINEL subroutine, found here :
+///          http://maia.usno.navy.mil/conv2010/software.html
+///
+/// @param[in]  xsta   Geocentric position of the station (Note 1)
+/// @param[in]  xsun   Geocentric position of the Sun (Note 2)
+/// @param[in]  xmon   Geocentric position of the Moon (Note 2)
+/// @param[in]  t      Datetime in TT
+/// @return dxtide Displacement vector (Note 3)
+/// @return            Always 0.
+///
+/// @note
+///     -# The station is in ITRF co-rotating frame.  All coordinates,
+///        X, Y, and Z, are expressed in meters.
+///     -# The position is in Earth Centered Earth Fixed (ECEF) frame.  All
+///        coordinates are expressed in meters.
+///     -# The displacement vector is in the geocentric ITRF.  All components
+///        are expressed in meters.
+///     -# Parameters jc1 and jc2 constitute the date as Julian Centuries in TT
+///        time scale. The actual date is given by the addition jc1+jc2.
+///        Either jc1 or jc2 can be set to zero.
+///     -# Status: Class 1
+///     -# This fucnction is part of the package dehanttideinel, see
+///        ftp://maia.usno.navy.mil/conv2010/convupdt/chapter7/dehanttideinel/
+///
+/// @version 19.12.2016
+///
+/// @cite iers2010,
+///
+///     Groten, E., 2000, Geodesists Handbook 2000, Part 4,
+///     http://www.gfy.ku.dk/~iag/HB2000/part4/groten.htm. See also
+///     ''Parameters of Common Relevance of Astronomy, Geodesy, and
+///     Geodynamics," J. Geod., 74, pp. 134-140
+///
+///     Mathews, P. M., Dehant, V., and Gipson, J. M., 1997, ''Tidal station
+///     displacements," J. Geophys. Res., 102(B9), pp. 20,469-20,477
+///
+///     Petit, G. and Luzum, B. (eds.), IERS Conventions (2010),
+///     IERS Technical Note No. 36, BKG (2010)
+///
+///     Pitjeva, E. and Standish, E. M., 2009, ''Proposals for the masses
+///     of the three largest asteroids, the Moon-Earth mass ratio and the
+///     Astronomical Unit," Celest. Mech. Dyn. Astr., 103, pp. 365-372
+///
+///     Ries, J. C., Eanes, R. J., Shum, C. K. and Watkins, M. M., 1992,
+///     ''Progress in the Determination of the Gravitational Coefficient
+///     of the Earth," Geophys. Res. Lett., 19(6), pp. 529-531
+int iers2010::dehanttideinel_impl(
+    double julian_centuries_tt, double fhr_ut,
+    const Eigen::Matrix<double, 3, 1> &xsun,
+    const Eigen::Matrix<double, 3, 1> &xmon,
+    const std::vector<Eigen::Matrix<double, 3, 1>> &xsta_vec,
+    std::vector<Eigen::Matrix<double, 3, 1>> &xcor_vec) noexcept {
+
+  // clear result vector and allocate
+  if (xcor_vec.capacity() < xsta_vec.size())
+    xcor_vec.reserve(xsta_vec.size());
+  xcor_vec.clear();
+
+  // nominal second degree and third degree love numbers and shida numbers
+  constexpr const double h20 = 0.6078e0;
+  constexpr const double l20 = 0.0847e0;
+  constexpr const double h3 = 0.292e0;
+  constexpr const double l3 = 0.015e0;
+
+  // compute angles/variables dependent (only) on datetime (used in Step 2
+  // corrections)
+  const Step2Angles angles(julian_centuries_tt, fhr_ut);
+
+  for (const auto &xsta : xsta_vec) {
+
+    // scalar product of station vector with sun/moon vector
+    TideAux aux(xsta, xsun, xmon);
+    const double rmon = aux.rmon;
+    const double rsta = aux.rsta;
+    const double rsun = aux.rsun;
+    const double scm = xsta.dot(xmon);
+    const double scs = xsta.dot(xsun);
+    const double scsun = scs / rsta / rsun;
+    const double scmon = scm / rsta / rmon;
+
+    // computation of new h2 and l2 (Equation 2, Chapter 7)
+    const double cosphi = aux.cosphi;
+    const double h2 = h20 - 0.0006e0 * (1e0 - 3e0 / 2e0 * cosphi * cosphi);
+    const double l2 = l20 + 0.0002e0 * (1e0 - 3e0 / 2e0 * cosphi * cosphi);
+
+    // P2 term (Equation 5, Chapter 7)
+    const double p2sun = 3e0 * (h2 / 2e0 - l2) * scsun * scsun - h2 / 2e0;
+    const double p2mon = 3e0 * (h2 / 2e0 - l2) * scmon * scmon - h2 / 2e0;
+
+    // P3 term (Equation 6, Chapter 7)
+    const double p3sun = 5e0 / 2e0 * (h3 - 3e0 * l3) * std::pow(scsun, 3) +
+                         3e0 / 2e0 * (l3 - h3) * scsun;
+    const double p3mon = 5e0 / 2e0 * (h3 - 3e0 * l3) * std::pow(scmon, 3) +
+                         3e0 / 2e0 * (l3 - h3) * scmon;
+
+    // term in direction of sun/moon vector
+    const double x2sun = 3e0 * l2 * scsun;
+    const double x2mon = 3e0 * l2 * scmon;
+    const double x3sun = 3e0 * l3 / 2e0 * (5e0 * scsun * scsun - 1e0);
+    const double x3mon = 3e0 * l3 / 2e0 * (5e0 * scmon * scmon - 1e0);
+
+    // total displacement
+    const double fac3sun = aux.fac2sun * (iers2010::Re / rsun);
+    const double fac3mon = aux.fac2mon * (iers2010::Re / rmon);
+    Eigen::Matrix<double, 3, 1> dxtide =
+        aux.fac2sun * (x2sun * xsun / rsun + p2sun * xsta / rsta) +
+        aux.fac2mon * (x2mon * xmon / rmon + p2mon * xsta / rsta) +
+        fac3sun * (x3sun * xsun / rsun + p3sun * xsta / rsta) +
+        fac3mon * (x3mon * xmon / rmon + p3mon * xsta / rsta);
+    //printf("dxtide initial: %12.9f%12.9f%12.9f\n", dxtide(0), dxtide(1), dxtide(2));
+
+    // corrections for the out-of-phase part of love numbers (part h_2^(0)i
+    // and l_2^(0)i )
+
+    // first, for the diurnal band
+    //Eigen::Matrix<double,3,1> dxtide_tmp = st1idiu(aux);
+    //printf("step1 diu corr: %12.9f%12.9f%12.9f\n", dxtide_tmp(0), dxtide_tmp(1), dxtide_tmp(2));
+    dxtide += st1idiu(aux);
+    // second, for the semi-diurnal band
+    //dxtide_tmp = st1isem(aux);
+    //printf("step1 sem corr: %12.9f%12.9f%12.9f\n", dxtide_tmp(0), dxtide_tmp(1), dxtide_tmp(2));
+    dxtide += st1isem(aux);
+    // corrections for the latitude dependence of love numbers (part l^(1) )
+    //dxtide_tmp = st1l1(aux);
+    //printf("step1  li corr: %12.9f%12.9f%12.9f\n", dxtide_tmp(0), dxtide_tmp(1), dxtide_tmp(2));
+    dxtide += st1l1(aux);
+
+    // CONSIDER CORRECTIONS FOR STEP 2
+    // -------------------------------------------------------------------------
+
+    //  second, we can call the subroutine step2diu, for the diurnal band
+    //+ corrections, (in-phase and out-of-phase frequency dependence):
+    //dxtide_tmp = step2diu(angles, aux);
+    //printf("step2 diu corr: %12.9f%12.9f%12.9f\n", dxtide_tmp(0), dxtide_tmp(1), dxtide_tmp(2));
+    dxtide += step2diu(angles, aux);
+
+    //  corrections for the long-period band,
+    //+ (in-phase and out-of-phase frequency dependence):
+    //dxtide_tmp = step2lon(angles, aux);
+    //printf("step2 lon corr: %12.9f%12.9f%12.9f\n", dxtide_tmp(0), dxtide_tmp(1), dxtide_tmp(2));
+    dxtide += step2lon(angles, aux);
+
+    // CONSIDER CORRECTIONS FOR STEP 3
+    // --------------------------------------------------------------------------
+
+    // uncorrect for the permanent tide
+    /*
+     * double sinphi = xsta[2]/rsta;
+     * double cosphi = sqrt( xsta[0]*xsta[0]+xsta[1]*xsta[1] ) / rsta;
+     * double cosla  = xsta[0]/cosphi/rsta;
+     * double sinla  = xsta[1]/cosphi/rsta;
+     * double dr     =
+     * -sqrt(5e0/4e0/PI)*h2*0.31460e0*(3e0/2e0*sinphi*sinphi-0.5e0); double dn =
+     * -sqrt(5e0/4e0/PI)*l2*0.31460e0*3e0*cosphi*sinphi; dxtide[0]    +=
+     * -dr*cosla*cosphi+dn*cosla*sinphi; dxtide[1]    +=
+     * -dr*sinla*cosphi+dn*sinla*sinphi; dxtide[2]    += -dr*sinphi -dn*cosphi;
+     */
+
+    xcor_vec.push_back(dxtide);
+  }
+
+  // Finished.
+  return 0;
+}

--- a/third_party/ginan-iers2010/iers2010.hpp
+++ b/third_party/ginan-iers2010/iers2010.hpp
@@ -1,0 +1,52 @@
+// IERS2010 wrapper header.
+//
+// Adapted from GeoscienceAustralia/ginan@535ef0a (release v4.1.1):
+//     src/cpp/3rdparty/iers2010/iers2010.hpp
+//
+// Modifications from upstream (per Apache License 2.0 attribution
+// requirements; see ./README.md for the full list):
+//   - Removed `#include "common/gTime.hpp"` (HARDISP / GTime-dependent
+//     declarations not vendored in this PR).
+//   - Removed the `namespace hisp { ... }` section (HARDISP ocean tide
+//     loading routines not vendored; will land in a separate PR with
+//     native libgnss++ time-type adaptation).
+//   - Replaced `#include "common/eigenIncluder.hpp"` with a direct
+//     `#include <Eigen/Dense>` so this public header does not depend on
+//     the libgnss++ internal `shim/` (which is PRIVATE to the vendored
+//     .cpp files only).
+//
+// Original ginan code is licensed under Apache License 2.0; see
+// ./LICENSE in this directory.
+
+#pragma once
+
+#include <vector>
+
+#include <Eigen/Dense>
+
+namespace iers2010
+{
+/// @brief Equatorial radius of the Earth [m].
+/// @see Table 1.1: IERS numerical standards, IERS 2010
+constexpr const double Re = 6'378'136.6e0;
+
+/// Compute the global total FCULa mapping function.
+double fcul_a(double, double, double, double) noexcept;
+/*
+/// Computes the global total FCULb mapping function.
+double fcul_b(double, double, double, double) noexcept;
+*/
+// Determine the total zenith delay following Mendes and Pavlis, 2004.
+int fcul_zd_hpa(double, double, double, double, double, double &, double &, double &) noexcept;
+
+/// @brief Compute tidal corrections of station displacements caused by lunar
+/// and solar gravitational attraction. This is just the implementation, use the
+/// generic template function instead.
+int dehanttideinel_impl(
+    double julian_centuries_tt, double fhr_ut,
+    const Eigen::Matrix<double, 3, 1> &xsun,
+    const Eigen::Matrix<double, 3, 1> &xmon,
+    const std::vector<Eigen::Matrix<double, 3, 1>> &xsta_vec,
+    std::vector<Eigen::Matrix<double, 3, 1>> &xcor_vec) noexcept;
+
+};

--- a/third_party/ginan-iers2010/shim/common/constants.hpp
+++ b/third_party/ginan-iers2010/shim/common/constants.hpp
@@ -1,0 +1,12 @@
+// Minimal stand-in for ginan's `common/constants.hpp`, supplied so that the
+// vendored iers2010 wrappers in this directory compile without pulling in
+// ginan's full common/ tree.
+//
+// The vendored iers2010 sources only reference D2R (degrees-to-radians).
+// Definitions here match ginan's values exactly so behavior is bit-identical.
+
+#pragma once
+
+#include <cmath>
+
+constexpr double D2R = (M_PI / 180.0);


### PR DESCRIPTION
## Summary

Phase A-2a of the libgnss++ vs. ginan PPP gap-closure work. **Stacked on top of #52** (SOFA vendoring); merge that first.

Vendors the GTime-independent subset of GeoscienceAustralia/ginan's iers2010 C++ wrappers under `third_party/ginan-iers2010/`, providing three IERS Conventions 2010 routines that libgnss++ needs for cm-level PPP:

| Routine | Purpose |
|---------|---------|
| `iers2010::dehanttideinel_impl` | Solid-earth-tide station displacement (IERS Conv. 2010 §7.1.1, Dehant et al.) |
| `iers2010::fcul_a` | Mendes-Pavlis FCULa total mapping function (ch.9) |
| `iers2010::fcul_zd_hpa` | Mendes-Pavlis total zenith delay |

## Scope

The HARDISP ocean-tide-loading routines (`hardisp/`) are **intentionally not vendored here** because their public APIs depend on ginan's internal `GTime` / `MjDateUtc` / `MjDateTT` time types. They'll land in a follow-up PR with native libgnss++ time-type adaptation (or a re-implementation on top of SOFA's Julian Date primitives).

## Source

- **Upstream**: `GeoscienceAustralia/ginan@535ef0a` (release v4.1.1)
- **Path**: `src/cpp/3rdparty/iers2010/{ch9,dehanttideinel}/`
- **License**: Apache 2.0 (the upstream code is itself a C++ translation of the IERS Conventions 2010 FORTRAN distribution at https://iers-conventions.obspm.fr/)

## Modifications (per Apache License 2.0 §4(b))

Enumerated in `third_party/ginan-iers2010/README.md`. Summary:

1. **`iers2010.hpp`** — removed `gTime` / `hisp` dependencies; replaced `#include "common/eigenIncluder.hpp"` with `#include <Eigen/Dense>` so the public header is self-contained; added `#include <vector>`.
2. **3 `.cpp` files** — include path adjustment `"3rdparty/iers2010/iers2010.hpp"` → `"iers2010.hpp"` to match libgnss++ vendor layout. No algorithmic change.
3. **`shim/common/constants.hpp`** — new minimal stand-in providing the `D2R` constant used by `dehanttide_all.cpp` (PRIVATE include path, not exposed to consumers).

## Build wiring

- New STATIC target `ginan_iers2010` built via `add_subdirectory(third_party/ginan-iers2010)` alongside the existing `sofa` target.
- Linked into `run_tests` for smoke testing.
- **NOT yet linked into `gnss_lib`** — that wiring lands in the follow-up `iers/` wrapper PR (Phase B) along with the SOFA wrapper.

## Verification

- ✅ `libginan_iers2010.a` builds cleanly (3 `.cpp` files, no warnings)
- ✅ Symbol table exports `iers2010::fcul_a`, `iers2010::fcul_zd_hpa`, `iers2010::dehanttideinel_impl` as expected
- ✅ 4 / 4 `GinanIers2010Vendor.*` smoke tests PASS, including the canonical **IERS Conventions 2010 reference test case for DEHANTTIDEINEL** (epoch 2009-04-13 0h UT) matched to within **1 µm**
- ✅ Existing `gnss_lib` / `gnss_lib_noopt` / SOFA smoke tests build and link with no regression

## Test plan

- [ ] CI build green on this branch (stacked diff vs. `feat/vendor-sofa`)
- [ ] CI test job (`run_tests`) passes the new `GinanIers2010Vendor.*` GTest cases
- [ ] No regression in the existing test suite

## Follow-up PRs (planned)

- **Phase B**: `include/iers/earth_rotation.hpp` thin C++ wrapper over SOFA + `include/iers/tides.hpp` over `dehanttideinel_impl`. Wire `gnss_lib` → `sofa` + `ginan_iers2010`. Add `--use-iers-earth-rotation` / `--use-iers-solid-tide` feature flags.
- **Phase A-2b** (out of band): vendor or re-implement HARDISP ocean-tide-loading on libgnss++ time types.
- **Phase C**: replace skeleton solid-earth-tide in PPP with `dehanttideinel_impl`; wire BLQ parser → HARDISP for actual displacement.
- **Phase D**: PPP truth-bench validation on Tokyo / Nagoya 6-run.