### PR TITLE
Add libgnss::iers wrapper API over SOFA + ginan-iers2010 (Phase B-1, stacked on #53)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,9 +23,8 @@ find_package(std_msgs QUIET)
 find_package(OpenCV QUIET COMPONENTS core imgproc imgcodecs)
 
 # Vendored third-party libraries.
-# These are built as STATIC sub-targets and are NOT yet linked into gnss_lib;
-# linking will be wired up in a follow-up PR once the API surface is exposed
-# through include/iers/.
+# These are built as STATIC sub-targets and consumed by gnss_lib through
+# the libgnss++/iers/ wrapper API (see include/libgnss++/iers/).
 add_subdirectory(third_party/sofa)
 add_subdirectory(third_party/ginan-iers2010)
 
@@ -48,6 +47,8 @@ set(GNSS_SOURCES
     src/algorithms/ppp_wlnl.cpp
     src/algorithms/ppp_clas_epoch.cpp
     src/algorithms/ppp.cpp
+    src/iers/earth_rotation.cpp
+    src/iers/tides.cpp
 )
 
 # List source files for the no-optimization library
@@ -72,6 +73,11 @@ target_include_directories(gnss_lib PUBLIC
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 target_link_libraries(gnss_lib PUBLIC Eigen3::Eigen)
+# IERS wrappers: SOFA + ginan-iers2010 are PRIVATE so the vendor types
+# (e.g. iauPV vector types, the iers2010:: namespace) do not leak into
+# the public libgnss++ API. Public consumers see only the wrappers in
+# include/libgnss++/iers/.
+target_link_libraries(gnss_lib PRIVATE sofa ginan_iers2010)
 
 # Create the no-optimization library
 add_library(gnss_lib_noopt STATIC ${GNSS_SOURCES_NO_OPTIMIZATION})
@@ -83,7 +89,11 @@ target_include_directories(gnss_lib_noopt PUBLIC
 target_link_libraries(gnss_lib_noopt PUBLIC Eigen3::Eigen)
 
 install(
-    TARGETS gnss_lib gnss_lib_noopt
+    # Note: sofa and ginan_iers2010 are PRIVATE link deps of gnss_lib but
+    # must still appear in the same export set because static archives do
+    # not carry their dependency closure — downstream consumers of an
+    # installed libgnsspp::gnss_lib need the vendor symbols at link time.
+    TARGETS gnss_lib gnss_lib_noopt sofa ginan_iers2010
     EXPORT libgnssppTargets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/include/libgnss++/iers/earth_rotation.hpp
+++ b/include/libgnss++/iers/earth_rotation.hpp
@@ -1,0 +1,90 @@
+#pragma once
+
+// libgnss++/iers/earth_rotation.hpp
+//
+// Thin C++ wrappers over the vendored IAU SOFA library (third_party/sofa/),
+// surfacing IAU 2006/2000A earth-rotation primitives in libgnss-native
+// types: MJD inputs (UTC), `Eigen::Matrix3d` rotation outputs.
+//
+// These primitives are required for cm-level PPP processing — earth
+// rotation, polar motion, and ICRS<->ITRS transforms cannot be ignored
+// at the centimeter level — and are not provided by the existing
+// libgnss++ codebase.
+//
+// Leap-second handling: the underlying SOFA functions consult their
+// internal leap-second table (current as of SOFA issue 2021-05-12).
+// Callers operating on epochs after the last leap second known to SOFA
+// will receive correct results until the next future leap second is
+// inserted; in that case a future SOFA refresh is required.
+
+#include <Eigen/Dense>
+
+#include "libgnss++/core/types.hpp"
+
+namespace libgnss::iers {
+
+/// @brief Earth orientation parameters (EOP) at a given epoch.
+///
+/// Values come from the IERS Bulletin A / Final EOP series. For
+/// consumers without access to a current EOP series, leaving all
+/// fields at zero produces a result equivalent to the rigid-body
+/// approximation: no UT1-UTC offset, no polar motion. The error
+/// from doing so is ~0.5 m at the equator (UT1) plus ~10 m of
+/// polar-motion-induced rotation, so EOP must be supplied for
+/// cm-level work.
+struct EarthOrientationParams {
+    /// UT1 - UTC, seconds. Range typically ±0.9 s.
+    double ut1_minus_utc_seconds = 0.0;
+
+    /// Polar motion x component, arcseconds (IERS x_p).
+    double xp_arcsec = 0.0;
+
+    /// Polar motion y component, arcseconds (IERS y_p).
+    double yp_arcsec = 0.0;
+};
+
+/// @brief Earth Rotation Angle (ERA), IAU 2000 model.
+///
+/// ERA is the angle between the Celestial Intermediate Origin (CIO)
+/// and the Terrestrial Intermediate Origin (TIO), measured around
+/// the Celestial Intermediate Pole. It replaces the older Greenwich
+/// Apparent Sidereal Time (GAST) in the IAU 2006/2000A framework.
+///
+/// @param mjd_utc        UTC modified Julian date.
+/// @param eop            Earth orientation parameters at this epoch.
+/// @return Earth rotation angle in the range [0, 2π) radians.
+double earthRotationAngle(double mjd_utc, const EarthOrientationParams& eop);
+
+/// @brief ICRS (~ECI / J2000) to ITRS (~ECEF) rotation matrix.
+///
+/// Computes the full IAU 2006/2000A celestial-to-terrestrial rotation
+/// matrix using the CIO-based formulation:
+///
+///     R(t) = R_pom(t) · R_era(t) · R_c2i(t)
+///
+/// where R_c2i is the precession-nutation-bias matrix at TT,
+/// R_era is the earth rotation matrix at UT1, and R_pom is the
+/// polar motion matrix at TT.
+///
+/// @param mjd_utc        UTC modified Julian date.
+/// @param eop            Earth orientation parameters at this epoch.
+/// @return 3x3 rotation matrix; if r_icrs is a vector in ICRS,
+///         then `icrsToItrs(...) * r_icrs` is the same vector in ITRS.
+Eigen::Matrix3d icrsToItrs(double mjd_utc, const EarthOrientationParams& eop);
+
+/// @brief Inverse of icrsToItrs (ITRS to ICRS).
+inline Eigen::Matrix3d itrsToIcrs(double mjd_utc, const EarthOrientationParams& eop) {
+    return icrsToItrs(mjd_utc, eop).transpose();
+}
+
+/// @brief Convert a libgnss::GNSSTime (GPS week + TOW) to UTC MJD.
+///
+/// Uses the SOFA leap-second table internally (current as of SOFA
+/// issue 2021-05-12). The GPS<->UTC offset is `leap_seconds - 19`
+/// seconds where leap_seconds is TAI-UTC at the requested epoch.
+///
+/// @param gps_time       GPS time (week, time-of-week).
+/// @return UTC modified Julian date.
+double gnssTimeToMjdUtc(const GNSSTime& gps_time);
+
+}  // namespace libgnss::iers

--- a/include/libgnss++/iers/tides.hpp
+++ b/include/libgnss++/iers/tides.hpp
@@ -1,0 +1,45 @@
+#pragma once
+
+// libgnss++/iers/tides.hpp
+//
+// Thin C++ wrappers over the vendored ginan-iers2010 library
+// (third_party/ginan-iers2010/), surfacing the IERS Conventions 2010
+// solid-earth-tide displacement model in libgnss-native types.
+//
+// At the centimeter level, the solid-earth tide is the largest single
+// non-trivial PPP correction (peak diurnal/semidiurnal amplitude is
+// ~30 cm radial, ~10 cm horizontal). Ignoring it sets a hard floor
+// on PPP positioning accuracy.
+
+#include <Eigen/Dense>
+
+#include "libgnss++/core/types.hpp"
+
+namespace libgnss::iers {
+
+/// @brief Solid-earth-tide station displacement.
+///
+/// Wraps `iers2010::dehanttideinel_impl`, which implements IERS
+/// Conventions 2010 §7.1.1 (Dehant et al.) — the standard model for
+/// solid-earth-tide displacement of a ground station due to lunisolar
+/// gravitational forcing. The result is a 3-vector (m) to be ADDED
+/// to the station's nominal ECEF coordinates to obtain the tidally
+/// displaced instantaneous position.
+///
+/// @param mjd_utc        UTC modified Julian date of the epoch.
+/// @param xsta_ecef      Station nominal ECEF coordinates [m].
+/// @param xsun_ecef      Sun ECEF coordinates [m] at this epoch.
+///                       Must be supplied by the caller; libgnss++
+///                       does not yet provide a built-in solar
+///                       ephemeris (planned for a follow-up PR).
+/// @param xmon_ecef      Moon ECEF coordinates [m] at this epoch.
+///                       Same caveat as xsun_ecef.
+/// @return Displacement vector [m]; add to xsta_ecef to obtain the
+///         instantaneously displaced station position.
+Eigen::Vector3d solidEarthTideDisplacement(
+    double mjd_utc,
+    const Eigen::Vector3d& xsta_ecef,
+    const Eigen::Vector3d& xsun_ecef,
+    const Eigen::Vector3d& xmon_ecef);
+
+}  // namespace libgnss::iers

--- a/src/iers/earth_rotation.cpp
+++ b/src/iers/earth_rotation.cpp
@@ -1,0 +1,100 @@
+#include "libgnss++/iers/earth_rotation.hpp"
+
+#include <cmath>
+
+extern "C" {
+#include "sofa.h"
+#include "sofam.h"
+}
+
+namespace libgnss::iers {
+
+namespace {
+constexpr double kMjdJ2000Epoch = 2400000.5;  // MJD <-> JD offset
+constexpr double kMjd0Gps       = 44244.0;    // MJD UTC of 1980-01-06 00:00:00
+constexpr double kArcsecToRad   = M_PI / (180.0 * 3600.0);
+}  // namespace
+
+double earthRotationAngle(double mjd_utc, const EarthOrientationParams& eop) {
+    const double utc1 = kMjdJ2000Epoch;
+    const double utc2 = mjd_utc;
+
+    double ut11 = 0.0;
+    double ut12 = 0.0;
+    iauUtcut1(utc1, utc2, eop.ut1_minus_utc_seconds, &ut11, &ut12);
+
+    return iauEra00(ut11, ut12);
+}
+
+Eigen::Matrix3d icrsToItrs(double mjd_utc, const EarthOrientationParams& eop) {
+    const double utc1 = kMjdJ2000Epoch;
+    const double utc2 = mjd_utc;
+
+    // UTC -> UT1 (for the earth rotation angle)
+    double ut11 = 0.0;
+    double ut12 = 0.0;
+    iauUtcut1(utc1, utc2, eop.ut1_minus_utc_seconds, &ut11, &ut12);
+
+    // UTC -> TAI -> TT (for precession-nutation and the TIO locator s')
+    double tai1 = 0.0;
+    double tai2 = 0.0;
+    double tt1  = 0.0;
+    double tt2  = 0.0;
+    iauUtctai(utc1, utc2, &tai1, &tai2);
+    iauTaitt(tai1, tai2, &tt1, &tt2);
+
+    // Celestial-to-intermediate matrix (CIO based, IAU 2006/2000A)
+    double rc2i[3][3];
+    iauC2i06a(tt1, tt2, rc2i);
+
+    // Earth rotation angle, evaluated at UT1
+    const double era = iauEra00(ut11, ut12);
+
+    // Polar motion: convert arcseconds to radians and pick up the TIO
+    // locator s' from the IAU 2006 model.
+    const double sp = iauSp00(tt1, tt2);
+    const double xp = eop.xp_arcsec * kArcsecToRad;
+    const double yp = eop.yp_arcsec * kArcsecToRad;
+
+    double rpom[3][3];
+    iauPom00(xp, yp, sp, rpom);
+
+    // Combine into the full celestial-to-terrestrial rotation
+    double rc2t[3][3];
+    iauC2tcio(rc2i, era, rpom, rc2t);
+
+    Eigen::Matrix3d R;
+    for (int i = 0; i < 3; ++i) {
+        for (int j = 0; j < 3; ++j) {
+            R(i, j) = rc2t[i][j];
+        }
+    }
+    return R;
+}
+
+double gnssTimeToMjdUtc(const GNSSTime& gps_time) {
+    // First-pass MJD UTC, treating GPS time as if it were UTC (off by
+    // ~30 s due to elapsed leap seconds since the GPS epoch).
+    const double total_seconds_gps =
+        static_cast<double>(gps_time.week) * 604800.0 + gps_time.tow;
+    const double mjd_approx = kMjd0Gps + total_seconds_gps / 86400.0;
+
+    // Look up TAI-UTC at this approximate UTC date so we can correct
+    // the offset. SOFA's iauDat returns ΔAT in seconds.
+    int iy = 0;
+    int im = 0;
+    int id = 0;
+    double fd = 0.0;
+    iauJd2cal(kMjdJ2000Epoch, mjd_approx, &iy, &im, &id, &fd);
+
+    double dat = 0.0;
+    iauDat(iy, im, id, fd, &dat);
+
+    // GPS time = TAI - 19 s = UTC + (ΔAT - 19).  Therefore
+    //   UTC seconds elapsed = GPS seconds elapsed - (ΔAT - 19).
+    // (At the GPS epoch ΔAT was 19, so this is exact at t = 0.)
+    const double total_seconds_utc = total_seconds_gps - (dat - 19.0);
+    return kMjd0Gps + total_seconds_utc / 86400.0;
+}
+
+}  // namespace libgnss::iers

--- a/src/iers/tides.cpp
+++ b/src/iers/tides.cpp
@@ -1,0 +1,61 @@
+#include "libgnss++/iers/tides.hpp"
+
+#include <cmath>
+#include <vector>
+
+#include "iers2010.hpp"
+
+extern "C" {
+#include "sofa.h"
+}
+
+namespace libgnss::iers {
+
+namespace {
+constexpr double kMjdJ2000Epoch  = 2400000.5;     // MJD <-> JD offset
+constexpr double kJdJ2000        = 2451545.0;     // J2000.0 in JD (TT)
+constexpr double kJulianCentury  = 36525.0;       // days per Julian century
+}  // namespace
+
+Eigen::Vector3d solidEarthTideDisplacement(
+    double mjd_utc,
+    const Eigen::Vector3d& xsta_ecef,
+    const Eigen::Vector3d& xsun_ecef,
+    const Eigen::Vector3d& xmon_ecef) {
+    // dehanttideinel_impl wants:
+    //   julian_centuries_tt — TT in Julian centuries from J2000
+    //   fhr_ut              — fractional hour UT of the day
+    //
+    // For TT we go through SOFA's leap-second-aware UTC -> TAI -> TT
+    // chain so the result is correct regardless of what leap-second
+    // table the caller has in mind.
+    double tai1 = 0.0;
+    double tai2 = 0.0;
+    double tt1  = 0.0;
+    double tt2  = 0.0;
+    iauUtctai(kMjdJ2000Epoch, mjd_utc, &tai1, &tai2);
+    iauTaitt(tai1, tai2, &tt1, &tt2);
+
+    const double centuries_tt =
+        ((tt1 - kJdJ2000) + tt2) / kJulianCentury;
+
+    // The Dehant model uses fhr_ut at the ~10 ms level only (it
+    // affects the diurnal Step-2 corrections), so taking UT ≈ UTC
+    // here introduces a sub-millimeter displacement error — well
+    // below the model's intrinsic accuracy.
+    const double fhr_ut = (mjd_utc - std::floor(mjd_utc)) * 24.0;
+
+    std::vector<Eigen::Vector3d> xsta_vec = { xsta_ecef };
+    std::vector<Eigen::Vector3d> xcor_vec;
+    xcor_vec.reserve(1);
+
+    iers2010::dehanttideinel_impl(
+        centuries_tt, fhr_ut, xsun_ecef, xmon_ecef, xsta_vec, xcor_vec);
+
+    if (xcor_vec.empty()) {
+        return Eigen::Vector3d::Zero();
+    }
+    return xcor_vec.front();
+}
+
+}  // namespace libgnss::iers

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -35,6 +35,8 @@ if(GTest_FOUND)
         test_ubx.cpp
         test_sofa_vendor.cpp
         test_ginan_iers2010_vendor.cpp
+        test_iers_earth_rotation.cpp
+        test_iers_tides.cpp
     )
 
     target_compile_options(run_tests PRIVATE -g)

--- a/tests/test_iers_earth_rotation.cpp
+++ b/tests/test_iers_earth_rotation.cpp
@@ -1,0 +1,107 @@
+// Tests for libgnss::iers::* earth-rotation primitives
+// (include/libgnss++/iers/earth_rotation.hpp).
+//
+// These tests validate the wrapper layer over the vendored IAU SOFA
+// library; SOFA itself is exercised by tests/test_sofa_vendor.cpp.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include <Eigen/Dense>
+
+#include "libgnss++/iers/earth_rotation.hpp"
+
+using libgnss::GNSSTime;
+using libgnss::iers::EarthOrientationParams;
+using libgnss::iers::earthRotationAngle;
+using libgnss::iers::gnssTimeToMjdUtc;
+using libgnss::iers::icrsToItrs;
+using libgnss::iers::itrsToIcrs;
+
+TEST(IersEarthRotation, GnssTimeToMjdUtcAtGpsEpoch) {
+    // GPS epoch = 1980-01-06 00:00:00 UTC = MJD 44244.0 exactly.
+    // At GPS epoch ΔAT was 19, so the leap-second correction is 0.
+    const GNSSTime epoch{0, 0.0};
+    EXPECT_NEAR(gnssTimeToMjdUtc(epoch), 44244.0, 1e-9);
+}
+
+TEST(IersEarthRotation, GnssTimeToMjdUtcRecentEpoch) {
+    // 2020-01-01 00:00:00 UTC = MJD 58849.0 (ΔAT = 37 since 2017).
+    // GPS time at this UTC instant:
+    //   GPS = TAI - 19 = UTC + (37 - 19) = UTC + 18 s.
+    // Days from 1980-01-06 to 2020-01-01 = 14605
+    //   week = 14605 / 7 = 2086.428..., week count = 2086, day = 3
+    //   (Wed). tow at 00:00:00 GPS on 2020-01-01:
+    //   day_of_week_at_2020_01_01 = (4 + 14605) mod 7 = 3 (Wed).
+    //   GPS week = 14605 / 7 = 2086 (rounding toward zero).
+    //   Actually: GPS week 2086 began 2020-01-05 (Sun); we want
+    //   2020-01-01 which is in GPS week 2085. Let's compute directly:
+    //   total GPS seconds since epoch =
+    //       14605 * 86400 + 18 = 1,261,872,018 s
+    //   week = floor(1261872018 / 604800) = 2086 (just barely; 2086 *
+    //   604800 = 1,261,612,800; remainder 259,218 s -> tow). Hmm,
+    //   that puts 2020-01-01 into GPS week 2086, day-of-week 3, which
+    //   matches Wed. Use this.
+    constexpr double kSecondsPerWeek = 604800.0;
+    const double gps_seconds = 14605.0 * 86400.0 + 18.0;
+    const int week = static_cast<int>(std::floor(gps_seconds / kSecondsPerWeek));
+    const double tow = gps_seconds - week * kSecondsPerWeek;
+    const GNSSTime t{week, tow};
+
+    EXPECT_NEAR(gnssTimeToMjdUtc(t), 58849.0, 1e-6);
+}
+
+TEST(IersEarthRotation, EarthRotationAngleIsInRange) {
+    // ERA must lie in [0, 2π). Sample a non-special epoch.
+    // 2020-01-01 12:00:00 UTC = MJD 58849.5
+    EarthOrientationParams eop;
+    const double era = earthRotationAngle(58849.5, eop);
+    EXPECT_GE(era, 0.0);
+    EXPECT_LT(era, 2.0 * M_PI);
+}
+
+TEST(IersEarthRotation, EarthRotationAngleAdvances) {
+    // Earth rotates ~360°/sidereal-day. After 12 sidereal hours
+    // (≈ 11h 58m of UT1), ERA should advance by ~π radians.
+    // Using exact UT1 days (12 sidereal hours = 12/24 sidereal days
+    // ≈ 0.4972695 UT1 days) takes us close to π.
+    EarthOrientationParams eop;
+    const double mjd_a = 58849.0;
+    const double mjd_b = 58849.5;
+    const double era_a = earthRotationAngle(mjd_a, eop);
+    const double era_b = earthRotationAngle(mjd_b, eop);
+    double diff = era_b - era_a;
+    if (diff < 0) diff += 2.0 * M_PI;
+    // Earth makes one rotation per sidereal day (~23h 56m), so 12 h
+    // of UT1 advances ERA by slightly more than π.
+    EXPECT_NEAR(diff, M_PI, 0.01);
+}
+
+TEST(IersEarthRotation, IcrsToItrsIsOrthogonal) {
+    // The full ICRS->ITRS rotation is an orthogonal matrix
+    // (proper rotation, det = +1).
+    EarthOrientationParams eop;
+    eop.xp_arcsec = 0.123;
+    eop.yp_arcsec = 0.456;
+    eop.ut1_minus_utc_seconds = -0.2;
+    const Eigen::Matrix3d R = icrsToItrs(58849.5, eop);
+
+    // R^T * R should be the identity.
+    const Eigen::Matrix3d ortho_residual =
+        R.transpose() * R - Eigen::Matrix3d::Identity();
+    EXPECT_LT(ortho_residual.cwiseAbs().maxCoeff(), 1e-12);
+
+    // det(R) = +1 (proper rotation).
+    EXPECT_NEAR(R.determinant(), 1.0, 1e-12);
+}
+
+TEST(IersEarthRotation, ItrsToIcrsIsInverse) {
+    EarthOrientationParams eop;
+    const Eigen::Matrix3d R_c2t = icrsToItrs(58849.5, eop);
+    const Eigen::Matrix3d R_t2c = itrsToIcrs(58849.5, eop);
+
+    const Eigen::Matrix3d roundtrip =
+        R_t2c * R_c2t - Eigen::Matrix3d::Identity();
+    EXPECT_LT(roundtrip.cwiseAbs().maxCoeff(), 1e-12);
+}

--- a/tests/test_iers_tides.cpp
+++ b/tests/test_iers_tides.cpp
@@ -1,0 +1,67 @@
+// Tests for libgnss::iers::solidEarthTideDisplacement
+// (include/libgnss++/iers/tides.hpp).
+//
+// The vendor-level smoke test (tests/test_ginan_iers2010_vendor.cpp)
+// already validates the underlying IERS Conventions 2010 reference
+// case at the iers2010::dehanttideinel_impl boundary. Here we
+// re-verify the SAME reference case through the libgnss wrapper to
+// catch any regression in the wrapper glue (time-scale conversions,
+// vector marshaling).
+
+#include <gtest/gtest.h>
+
+#include <Eigen/Dense>
+
+#include "libgnss++/iers/tides.hpp"
+
+using libgnss::iers::solidEarthTideDisplacement;
+
+TEST(IersTides, SolidEarthTideMatchesIersReference) {
+    // Canonical IERS Conventions 2010 reference case (DEHANTTIDEINEL):
+    //   Epoch 2009-04-13 0h UTC == MJD UTC 54934.0 exactly.
+    //   Expected DXYZ = (0.07700420357108126,
+    //                    0.06304056321824968,
+    //                    0.05516568152597247) m.
+    const double mjd_utc = 54934.0;
+
+    const Eigen::Vector3d xsta(4075578.385, 931852.890, 4801570.154);
+    const Eigen::Vector3d xsun(137859926952.015,
+                                54228127881.4350,
+                                23509422341.6960);
+    const Eigen::Vector3d xmon(-179996231.920342,
+                               -312468450.131567,
+                               -169288918.592160);
+
+    const Eigen::Vector3d dxyz =
+        solidEarthTideDisplacement(mjd_utc, xsta, xsun, xmon);
+
+    const Eigen::Vector3d expected(0.07700420357108126,
+                                   0.06304056321824968,
+                                   0.05516568152597247);
+
+    // 1 µm tolerance — same as the vendor smoke test. The wrapper
+    // adds only deterministic time-scale conversion glue.
+    EXPECT_NEAR(dxyz.x(), expected.x(), 1e-6);
+    EXPECT_NEAR(dxyz.y(), expected.y(), 1e-6);
+    EXPECT_NEAR(dxyz.z(), expected.z(), 1e-6);
+}
+
+TEST(IersTides, SolidEarthTideAmplitudeIsBounded) {
+    // Sanity check: the tidal displacement at any single epoch should
+    // fall well under 50 cm in any component (peak diurnal amplitude
+    // is ~30 cm radial). This guards against any catastrophic glue
+    // failure (wrong unit, swapped components, etc.) that does not
+    // hit the specific reference case.
+    const Eigen::Vector3d xsta(4075578.385, 931852.890, 4801570.154);
+    const Eigen::Vector3d xsun(137859926952.015,
+                                54228127881.4350,
+                                23509422341.6960);
+    const Eigen::Vector3d xmon(-179996231.920342,
+                               -312468450.131567,
+                               -169288918.592160);
+
+    const Eigen::Vector3d dxyz =
+        solidEarthTideDisplacement(54934.0, xsta, xsun, xmon);
+
+    EXPECT_LT(dxyz.cwiseAbs().maxCoeff(), 0.5);
+}


### PR DESCRIPTION
## Summary

Phase B-1 of the IERS2010 integration. **Stacked on #53** (which is stacked on #52); merge those first.

Surfaces the vendored SOFA and ginan-iers2010 libraries through libgnss-native types in `namespace libgnss::iers`, so PPP code can call earth-rotation, polar-motion, and solid-earth-tide primitives without touching IAU naming conventions or ginan's internal time machinery.

This PR exposes the API only — **no existing PPP source files are modified**. Actual consumption (Phase C) will land in a follow-up PR with feature flags and PPP truth-bench validation.

## Public API

### `include/libgnss++/iers/earth_rotation.hpp`

```cpp
namespace libgnss::iers {

struct EarthOrientationParams {
    double ut1_minus_utc_seconds = 0.0;
    double xp_arcsec             = 0.0;
    double yp_arcsec             = 0.0;
};

double          earthRotationAngle(double mjd_utc, const EarthOrientationParams& eop);
Eigen::Matrix3d icrsToItrs       (double mjd_utc, const EarthOrientationParams& eop);
Eigen::Matrix3d itrsToIcrs       (double mjd_utc, const EarthOrientationParams& eop);
double          gnssTimeToMjdUtc (const GNSSTime& gps_time);

}
```

`icrsToItrs` uses the IAU 2006/2000A CIO-based formulation `R_pom · R_era · R_c2i`, the modern definitive ICRS↔ITRS transform.

### `include/libgnss++/iers/tides.hpp`

```cpp
namespace libgnss::iers {

Eigen::Vector3d solidEarthTideDisplacement(
    double mjd_utc,
    const Eigen::Vector3d& xsta_ecef,
    const Eigen::Vector3d& xsun_ecef,
    const Eigen::Vector3d& xmon_ecef);

}
```

Sun/moon positions are caller-supplied for now; a SOFA-based ephemeris helper (`sunPositionEcef` / `moonPositionEcef`) is planned for Phase B-2.

## Build wiring

- 2 new `.cpp` files added to `gnss_lib`'s `GNSS_SOURCES`.
- `target_link_libraries(gnss_lib PRIVATE sofa ginan_iers2010)` — vendor types stay **PRIVATE** so they don't leak through public headers.
- `sofa` and `ginan_iers2010` added to the `libgnssppTargets` export set so downstream consumers of installed `libgnsspp::gnss_lib` pick up the vendor symbols at link time (static archives don't carry their dep closure).

## Leap seconds

Handled via SOFA's internal table (current as of issue 2021-05-12) — callers don't need a separate leap-second source. UT1-UTC and polar motion come from `EarthOrientationParams` supplied by the caller (zero defaults give the rigid-body approximation).

## Verification

- ✅ `libgnss_lib.a` links cleanly with `sofa` + `ginan_iers2010`.
- ✅ 8 / 8 new wrapper tests PASS:
  - 6 `IersEarthRotation`: GPS-epoch conversion (MJD 44244 exact), recent-epoch conversion (MJD 58849 ±1 µs), ERA in `[0, 2π)`, ERA advances ~π over 12 h UT, ICRS→ITRS orthogonality (`max|R^T R - I| < 1e-12`), ITRS↔ICRS roundtrip identity.
  - 2 `IersTides`: IERS Conventions 2010 reference case (2009-04-13 0h UT) re-validated **through the wrapper at 1 µm tolerance**; amplitude bound `< 50 cm` per component.
- ✅ 16 / 16 combined vendor + wrapper tests PASS; no regression in the existing test suite.

## Test plan

- [ ] CI build green on this branch (rebased to `develop` after #52 + #53 merge)
- [ ] CI test job (`run_tests`) passes the new `IersEarthRotation.*` and `IersTides.*` cases
- [ ] No regression in existing PPP / RTK tests

## Follow-up PRs (planned)

- **Phase A-2b**: vendor or re-implement HARDISP (ocean-tide-loading) — needs native libgnss++ time-type adaptation.
- **Phase B-2**: SOFA-based sun/moon ephemeris (`sunPositionEcef`, `moonPositionEcef`) so callers don't have to supply lunisolar positions manually.
- **Phase C**: actually use these wrappers from PPP — replace stubbed sun_pos in `calculateSatelliteAntennaPCO`, apply `solidEarthTideDisplacement` to receiver position, gate behind `--use-iers-earth-rotation` / `--use-iers-solid-tide` feature flags.
- **Phase D**: PPP truth-bench validation on Tokyo / Nagoya 6-run.