### PR TITLE
Add libgnss::iers Sun/Moon ephemeris helpers (Phase B-2, stacked on #54)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ set(GNSS_SOURCES
     src/algorithms/ppp.cpp
     src/iers/earth_rotation.cpp
     src/iers/tides.cpp
+    src/iers/ephemeris.cpp
 )
 
 # List source files for the no-optimization library

--- a/docs/iers-integration-plan.md
+++ b/docs/iers-integration-plan.md
@@ -1,0 +1,226 @@
+# IERS Conventions 2010 integration — Phase C design
+
+This document describes the planned integration of the
+`libgnss::iers::*` wrapper API (introduced by PRs #52–#55) into the
+existing PPP solver, and the truth-bench validation strategy that
+gates the change.
+
+It is **not** a description of the wrapper API itself; for that, see
+the headers under `include/libgnss++/iers/` and the per-PR
+descriptions of the four foundation PRs:
+
+| PR  | Branch              | Foundation work |
+|-----|---------------------|-----------------|
+| #52 | `feat/vendor-sofa`         | IAU SOFA vendoring under `third_party/sofa/`. |
+| #53 | `feat/vendor-iers2010`     | ginan-iers2010 subset (`fcul_a`, `fcul_zd_hpa`, `dehanttideinel`). |
+| #54 | `feat/iers-wrappers`       | `libgnss::iers::{earthRotationAngle, icrsToItrs, gnssTimeToMjdUtc, solidEarthTideDisplacement, EarthOrientationParams}`. |
+| #55 | `feat/iers-ephemeris`      | `libgnss::iers::{sunPositionIcrs, moonPositionIcrs}`. |
+
+## 1. Goal
+
+Replace the simplified IERS Conventions 2010 **Step-1** body-tide
+approximation currently used by `PPPProcessor::calculateSolidEarthTides`
+with the full IERS Conventions 2010 §7.1.1 (Dehant) **Step-1 + Step-2**
+solid-earth-tide displacement model surfaced by the wrapper API,
+gated behind an opt-in feature flag for safe rollout.
+
+The change is expected to produce a few-millimeter periodic refinement
+to the receiver-position correction, primarily during peak diurnal /
+semidiurnal tidal phases. The cm-level PPP truth-bench targets
+(Tokyo / Nagoya 6-run) are the validation oracle.
+
+## 2. Non-goals (deferred)
+
+- **Earth rotation matrix wiring (`icrsToItrs`)**. The PPP solver is
+  currently entirely ECEF-native; satellite ephemerides arrive in
+  ECEF, observation residuals are formed in ECEF, the Kalman state
+  is in ECEF. There is no consumer for `icrsToItrs` yet. It is
+  available in the wrapper API for future work (e.g., LEO satellite
+  position, attitude, or external ephemeris ingestion) but Phase C
+  does not consume it.
+- **`calculateSatelliteAntennaPCO`** at `src/algorithms/ppp.cpp:3331`
+  is fully stubbed and has zero call sites in the PPP code today.
+  Phase C does not wire it up; revisiting satellite antenna
+  PCO/PCV handling is its own scope.
+- **Ocean tide loading (HARDISP)**. Vendored separately as a future
+  Phase A-2b PR; not consumed here.
+- **Pole tide**. Out of scope for this PR; covered by a possible
+  Phase E.
+
+## 3. Concrete change
+
+### 3.1 PPPConfig flag
+
+`include/libgnss++/algorithms/ppp_shared.hpp` currently has, near
+line 178:
+
+```cpp
+bool apply_ocean_loading      = false;
+bool apply_solid_earth_tides  = true;
+bool apply_relativity         = true;
+```
+
+Phase C adds, alongside the existing flags:
+
+```cpp
+/// When true (and apply_solid_earth_tides is also true), use the
+/// IERS Conventions 2010 §7.1.1 (Dehant) Step-1 + Step-2 model from
+/// libgnss::iers::solidEarthTideDisplacement instead of the built-in
+/// simplified Step-1-only approximation. Default off; opt-in for
+/// safe rollout pending truth-bench validation.
+bool use_iers_solid_tide = false;
+```
+
+Reading the flag inside the existing dispatcher:
+
+```cpp
+// src/algorithms/ppp.cpp:2680 (current)
+Vector3d PPPProcessor::calculateSolidEarthTides(
+    const Vector3d& position, const GNSSTime& time) const {
+    constexpr double kSunGM = 1.32712440018e20;
+    constexpr double kMoonGM = 4.902801e12;
+    if (!position.allFinite() ||
+        position.norm() < constants::WGS84_A * 0.5) {
+        return Vector3d::Zero();
+    }
+    const Vector3d sun_position  = approximateSunPositionEcef(time);
+    const Vector3d moon_position = approximateMoonPositionEcef(time);
+    return bodyTideDisplacement(position, sun_position, kSunGM) +
+           bodyTideDisplacement(position, moon_position, kMoonGM);
+}
+```
+
+becomes:
+
+```cpp
+// src/algorithms/ppp.cpp:2680 (Phase C)
+Vector3d PPPProcessor::calculateSolidEarthTides(
+    const Vector3d& position, const GNSSTime& time) const {
+    if (!position.allFinite() ||
+        position.norm() < constants::WGS84_A * 0.5) {
+        return Vector3d::Zero();
+    }
+
+    if (ppp_config_.use_iers_solid_tide) {
+        const double mjd_utc = libgnss::iers::gnssTimeToMjdUtc(time);
+        const Vector3d sun_icrs  = libgnss::iers::sunPositionIcrs(mjd_utc);
+        const Vector3d moon_icrs = libgnss::iers::moonPositionIcrs(mjd_utc);
+        return libgnss::iers::solidEarthTideDisplacement(
+            mjd_utc, position, sun_icrs, moon_icrs);
+    }
+
+    // Existing Step-1-only Love-number formula (default path).
+    constexpr double kSunGM  = 1.32712440018e20;
+    constexpr double kMoonGM = 4.902801e12;
+    const Vector3d sun_position  = approximateSunPositionEcef(time);
+    const Vector3d moon_position = approximateMoonPositionEcef(time);
+    return bodyTideDisplacement(position, sun_position, kSunGM) +
+           bodyTideDisplacement(position, moon_position, kMoonGM);
+}
+```
+
+The dispatcher upstream at `src/algorithms/ppp.cpp:2671` is
+unchanged — it still gates the entire correction on the existing
+`apply_solid_earth_tides` flag, so users who have disabled solid
+tides altogether see no change.
+
+### 3.2 CLI plumbing
+
+`apps/gnss_ppp.cpp` follows the canonical "three-line" pattern from
+the recent `--enable-ppp-holdamb` change (commit `0293f54`):
+
+1. Add field to local `Options` struct.
+2. Add `--use-iers-solid-tide` / `--no-iers-solid-tide` to
+   `printUsage()`.
+3. Parse in `parseArguments()` and copy to `ppp_config` in `main()`.
+
+No other CLI tools require updates: `gnss_solve` and the Python
+benchmark scripts pass through `PPPConfig` directly.
+
+### 3.3 Build wiring
+
+Already in place from PR #54:
+`target_link_libraries(gnss_lib PRIVATE sofa ginan_iers2010)`. The
+new `ppp.cpp` consumers of `libgnss::iers::*` symbols compile and
+link without further CMake changes.
+
+## 4. Tests
+
+### 4.1 Unit / golden tests
+
+Add `tests/test_ppp_iers_solid_tide.cpp` exercising the dispatch:
+
+- With `use_iers_solid_tide = false` (default): displacement
+  matches the existing Step-1 result to 1 µm. Guards against
+  accidental breakage of the legacy path.
+- With `use_iers_solid_tide = true` at the IERS Conventions 2010
+  reference epoch (2009-04-13 0h UT), displacement matches the
+  published reference (0.077, 0.063, 0.055) m to 1 mm — the same
+  bound already validated by `IersEphemeris.SolidEarthTideUsingComputedEphemeris`,
+  but now exercised through the PPP processor's dispatcher rather
+  than the wrapper directly.
+- Both paths return zero for invalid receiver positions
+  (`!allFinite()`, sub-Earth-radius), preserving existing behavior.
+
+### 4.2 Truth-bench validation (Tokyo / Nagoya 6-run)
+
+Driver: `apps/gnss_ppc_rtk_signoff.py`. The bench already exercises
+both cities (`PROFILE_DEFAULTS` keyed on `tokyo` / `nagoya`, runs
+`run1` / `run2` / `run3` for each).
+
+Phase C adds a paired comparison harness:
+
+1. Run each of the 6 PPC datasets twice — once with the legacy
+   Step-1 model (`use_iers_solid_tide = false`) and once with the
+   IERS Step-1+Step-2 model (`use_iers_solid_tide = true`).
+2. Compare against `reference.csv` ground truth on the headline
+   metrics already used by `gnss_ppc_rtk_signoff.py`:
+   `coverage`, `fix_rate`, `fix95_h_m`, `wrong_fix_rate`, and
+   `median_h_m`.
+3. **Acceptance criterion**: opt-in must not regress any metric
+   beyond noise (defined as ±2× the run-to-run standard deviation
+   measured from the existing v237 baseline ledger). Improvements
+   are expected at the few-mm level on `median_h_m` and `fix95_h_m`
+   during peak-tide epochs but are not required for merge.
+
+The opt-in flag means even a regression on the IERS path leaves the
+default behavior intact, so the go/no-go for the flip-default
+(below) is bench evidence only — no live-system risk.
+
+## 5. Rollout
+
+1. Land Phase C as drafted: opt-in, default off.
+2. Run truth-bench on the 6 PPC datasets, attach the comparison
+   table to the PR for review.
+3. If the bench shows neutral-or-better results, follow up with a
+   small "flip default" PR that flips `use_iers_solid_tide = true`
+   in `PPPConfig`. Rollback path: revert that single-line PR.
+
+This two-PR rollout (opt-in, then flip-default) is preferred over a
+single big-bang change because the bench result is the only honest
+oracle for "did we improve?" and we want it on record before the
+change becomes the default for downstream consumers.
+
+## 6. Risks & mitigations
+
+| Risk | Mitigation |
+|------|------------|
+| Frame mismatch in `dehanttideinel_impl`. The IERS routine takes the station in ITRS but Sun/Moon in ICRS (see `tides.hpp` "FRAME NOTE"). PPP currently passes ECEF sun/moon to the legacy path; the new IERS path uses ICRS via `sunPositionIcrs` / `moonPositionIcrs`. | Wrapper API enforces correct types at the call site; the Phase C code passes whatever each path expects. The 1-mm-tolerance reference test in `IersTides` and `IersEphemeris` validate the wrapper end-to-end through the same dispatcher pattern Phase C uses. |
+| `iauUtctai` warning for epochs after 2026 (last leap second known to vendored SOFA issue 2021-05-12). | SOFA returns the warning code but the result remains correct as long as no leap second has been inserted since the SOFA snapshot. Future leap seconds (currently none scheduled) require a SOFA refresh. PPP receives no warning in normal flow. |
+| The two-iteration leap-second handshake in `gnssTimeToMjdUtc` has a single-iteration approximation that is wrong by up to 30 s on a leap-second day's midnight boundary. | Documented in the wrapper. PPP epochs do not sit on leap-second-midnight boundaries in the truth-bench data; if this becomes a concern (real-time on a leap-second day), promote `gnssTimeToMjdUtc` to a true Newton iteration. |
+| Truth-bench shows regression on a specific run. | Default-off opt-in means no production impact. Investigate bench specifics (which metric, which epochs) before flipping default. |
+
+## 7. Out-of-band follow-ups (separate scope)
+
+These are tracked here for context but are independent work that
+does not block Phase C:
+
+- **Phase A-2b**: Vendor or re-implement HARDISP (ocean-tide-loading)
+  with native libgnss++ time-type adaptation. Re-uses the BLQ
+  parser already present in libgnss++.
+- **Phase D**: Pole tide, sub-daily EOP corrections, atmospheric
+  loading. Smaller cm-level effects.
+- **`icrsToItrs` consumers**: when satellite-side processing
+  (LEO orbits, external SP3 ingestion in non-ECEF frames, attitude
+  for satellite antenna PCO/PCV) is wired up, the wrapper is
+  ready.

--- a/include/libgnss++/iers/ephemeris.hpp
+++ b/include/libgnss++/iers/ephemeris.hpp
@@ -1,0 +1,42 @@
+#pragma once
+
+// libgnss++/iers/ephemeris.hpp
+//
+// Geocentric Sun and Moon positions in the ICRS / GCRS, computed
+// from the vendored IAU SOFA library (`iauEpv00` for the Earth-Sun
+// heliocentric vector, `iauMoon98` for the geocentric Moon vector).
+// These two positions are the lunisolar inputs required by the IERS
+// Conventions 2010 solid-earth-tide model implemented in
+// libgnss::iers::solidEarthTideDisplacement.
+//
+// Frame note: the IERS Conventions 2010 routine (dehanttideinel)
+// expects the station in ITRS but takes Sun and Moon in the ICRS /
+// GCRS — see the comment block at the top of tides.hpp for details.
+// The functions in this header therefore return ICRS positions; if
+// you need ITRS Sun/Moon vectors for an unrelated purpose, multiply
+// by libgnss::iers::icrsToItrs().
+//
+// Accuracy: SOFA's iauEpv00 has ~15 km positional error vs. JPL DE405
+// (~1e-7 of the Sun-Earth distance); iauMoon98 has ~1 km positional
+// error vs. high-precision lunar ephemerides. Both are far below the
+// noise floor for tidal displacement calculations (which scale as
+// 1/r^3) and adequate for any GNSS application that does not require
+// JPL-grade planetary tables.
+
+#include <Eigen/Dense>
+
+namespace libgnss::iers {
+
+/// @brief Sun geocentric position in ICRS / GCRS [m].
+///
+/// @param mjd_utc UTC modified Julian date.
+/// @return Sun position vector in the ICRS frame [m].
+Eigen::Vector3d sunPositionIcrs(double mjd_utc);
+
+/// @brief Moon geocentric position in ICRS / GCRS [m].
+///
+/// @param mjd_utc UTC modified Julian date.
+/// @return Moon position vector in the ICRS frame [m].
+Eigen::Vector3d moonPositionIcrs(double mjd_utc);
+
+}  // namespace libgnss::iers

--- a/include/libgnss++/iers/tides.hpp
+++ b/include/libgnss++/iers/tides.hpp
@@ -23,23 +23,35 @@ namespace libgnss::iers {
 /// Conventions 2010 §7.1.1 (Dehant et al.) — the standard model for
 /// solid-earth-tide displacement of a ground station due to lunisolar
 /// gravitational forcing. The result is a 3-vector (m) to be ADDED
-/// to the station's nominal ECEF coordinates to obtain the tidally
+/// to the station's nominal ITRS coordinates to obtain the tidally
 /// displaced instantaneous position.
 ///
+/// FRAME NOTE: although the IERS Conventions 2010 routine
+/// documentation describes all inputs as "ECEF", the published
+/// reference test case actually uses ICRS positions for Sun and Moon
+/// while keeping the station in ITRS. The libgnss::iers wrapper
+/// follows the *test-case convention* (which defines the routine's
+/// behavior in practice), so:
+///
+///   - `xsta_itrs` should be the station's ITRS / ECEF position.
+///   - `xsun_icrs` and `xmon_icrs` should be Sun / Moon positions in
+///     the ICRS / GCRS — *not* rotated to ITRS.
+///
+/// `libgnss::iers::sunPositionIcrs` and `moonPositionIcrs` (in
+/// libgnss++/iers/ephemeris.hpp) return values in the correct frame
+/// for direct use here.
+///
 /// @param mjd_utc        UTC modified Julian date of the epoch.
-/// @param xsta_ecef      Station nominal ECEF coordinates [m].
-/// @param xsun_ecef      Sun ECEF coordinates [m] at this epoch.
-///                       Must be supplied by the caller; libgnss++
-///                       does not yet provide a built-in solar
-///                       ephemeris (planned for a follow-up PR).
-/// @param xmon_ecef      Moon ECEF coordinates [m] at this epoch.
-///                       Same caveat as xsun_ecef.
-/// @return Displacement vector [m]; add to xsta_ecef to obtain the
-///         instantaneously displaced station position.
+/// @param xsta_itrs      Station nominal ITRS / ECEF coordinates [m].
+/// @param xsun_icrs      Sun ICRS / GCRS coordinates [m] at this epoch.
+/// @param xmon_icrs      Moon ICRS / GCRS coordinates [m] at this epoch.
+/// @return Displacement vector [m] in the station's ITRS frame; add
+///         to `xsta_itrs` to obtain the instantaneously displaced
+///         station position.
 Eigen::Vector3d solidEarthTideDisplacement(
     double mjd_utc,
-    const Eigen::Vector3d& xsta_ecef,
-    const Eigen::Vector3d& xsun_ecef,
-    const Eigen::Vector3d& xmon_ecef);
+    const Eigen::Vector3d& xsta_itrs,
+    const Eigen::Vector3d& xsun_icrs,
+    const Eigen::Vector3d& xmon_icrs);
 
 }  // namespace libgnss::iers

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,7 @@ nav:
   - Interfaces: interfaces.md
   - Experiments: experiments.md
   - Decisions: decisions.md
+  - IERS Integration Plan: iers-integration-plan.md
   - References:
       - Overview: references/index.md
       - MADOCALIB Gap: references/madocalib-gap.md

--- a/src/iers/ephemeris.cpp
+++ b/src/iers/ephemeris.cpp
@@ -1,0 +1,60 @@
+#include "libgnss++/iers/ephemeris.hpp"
+
+extern "C" {
+#include "sofa.h"
+#include "sofam.h"
+}
+
+namespace libgnss::iers {
+
+namespace {
+
+constexpr double kMjdJ2000Epoch = 2400000.5;  // MJD <-> JD offset
+
+/// Convert MJD UTC to TT 2-part Julian Date via SOFA's leap-second-aware
+/// chain. Output: (tt1, tt2) such that tt1 + tt2 == JD(TT).
+inline void mjdUtcToTt2(double mjd_utc, double& tt1, double& tt2) {
+    double tai1 = 0.0;
+    double tai2 = 0.0;
+    iauUtctai(kMjdJ2000Epoch, mjd_utc, &tai1, &tai2);
+    iauTaitt(tai1, tai2, &tt1, &tt2);
+}
+
+}  // namespace
+
+Eigen::Vector3d sunPositionIcrs(double mjd_utc) {
+    double tt1 = 0.0;
+    double tt2 = 0.0;
+    mjdUtcToTt2(mjd_utc, tt1, tt2);
+
+    // iauEpv00 returns Earth's position-velocity in two reference
+    // frames at the requested TT epoch:
+    //   pvh: heliocentric ([0] = position, [1] = velocity), AU
+    //   pvb: barycentric  ([0] = position, [1] = velocity), AU
+    // The Sun's geocentric position in the ICRS is obtained by
+    // negating Earth's heliocentric position vector.
+    double pvh[2][3];
+    double pvb[2][3];
+    iauEpv00(tt1, tt2, pvh, pvb);
+
+    return Eigen::Vector3d(-pvh[0][0] * DAU,
+                           -pvh[0][1] * DAU,
+                           -pvh[0][2] * DAU);
+}
+
+Eigen::Vector3d moonPositionIcrs(double mjd_utc) {
+    double tt1 = 0.0;
+    double tt2 = 0.0;
+    mjdUtcToTt2(mjd_utc, tt1, tt2);
+
+    // iauMoon98 returns the Moon's geocentric position-velocity in
+    // the ICRS at the requested TT epoch, in AU and AU/day.
+    double pv[2][3];
+    iauMoon98(tt1, tt2, pv);
+
+    return Eigen::Vector3d(pv[0][0] * DAU,
+                           pv[0][1] * DAU,
+                           pv[0][2] * DAU);
+}
+
+}  // namespace libgnss::iers

--- a/src/iers/tides.cpp
+++ b/src/iers/tides.cpp
@@ -19,9 +19,9 @@ constexpr double kJulianCentury  = 36525.0;       // days per Julian century
 
 Eigen::Vector3d solidEarthTideDisplacement(
     double mjd_utc,
-    const Eigen::Vector3d& xsta_ecef,
-    const Eigen::Vector3d& xsun_ecef,
-    const Eigen::Vector3d& xmon_ecef) {
+    const Eigen::Vector3d& xsta_itrs,
+    const Eigen::Vector3d& xsun_icrs,
+    const Eigen::Vector3d& xmon_icrs) {
     // dehanttideinel_impl wants:
     //   julian_centuries_tt — TT in Julian centuries from J2000
     //   fhr_ut              — fractional hour UT of the day
@@ -45,12 +45,12 @@ Eigen::Vector3d solidEarthTideDisplacement(
     // below the model's intrinsic accuracy.
     const double fhr_ut = (mjd_utc - std::floor(mjd_utc)) * 24.0;
 
-    std::vector<Eigen::Vector3d> xsta_vec = { xsta_ecef };
+    std::vector<Eigen::Vector3d> xsta_vec = { xsta_itrs };
     std::vector<Eigen::Vector3d> xcor_vec;
     xcor_vec.reserve(1);
 
     iers2010::dehanttideinel_impl(
-        centuries_tt, fhr_ut, xsun_ecef, xmon_ecef, xsta_vec, xcor_vec);
+        centuries_tt, fhr_ut, xsun_icrs, xmon_icrs, xsta_vec, xcor_vec);
 
     if (xcor_vec.empty()) {
         return Eigen::Vector3d::Zero();

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ if(GTest_FOUND)
         test_ginan_iers2010_vendor.cpp
         test_iers_earth_rotation.cpp
         test_iers_tides.cpp
+        test_iers_ephemeris.cpp
     )
 
     target_compile_options(run_tests PRIVATE -g)

--- a/tests/test_iers_ephemeris.cpp
+++ b/tests/test_iers_ephemeris.cpp
@@ -1,0 +1,106 @@
+// Tests for libgnss::iers::* sun/moon ephemeris helpers
+// (include/libgnss++/iers/ephemeris.hpp).
+//
+// We use a mix of:
+//   - Magnitude bounds (Earth-Sun ~1 AU ± 2%, Earth-Moon ~384,400 km
+//     ± 14%) — frame-independent, only assumes physical orbit ranges.
+//   - Direction sweep over a quarter / half year so the Sun's
+//     ICRS angular position advances as expected.
+//   - Integration smoke: feeding our SOFA-derived sun/moon vectors
+//     into solidEarthTideDisplacement at the IERS reference epoch
+//     should produce a displacement close to the published reference
+//     (~7 cm magnitude), validating the wrapper as a self-contained
+//     unit.
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include <Eigen/Dense>
+
+#include "libgnss++/iers/ephemeris.hpp"
+#include "libgnss++/iers/tides.hpp"
+
+using libgnss::iers::moonPositionIcrs;
+using libgnss::iers::solidEarthTideDisplacement;
+using libgnss::iers::sunPositionIcrs;
+
+namespace {
+constexpr double kAuMeters = 149597870700.0;
+}  // namespace
+
+TEST(IersEphemeris, SunIcrsMagnitudeIsOneAU) {
+    // 2020-01-01 12:00:00 UTC = MJD 58849.5
+    const Eigen::Vector3d sun = sunPositionIcrs(58849.5);
+    const double r = sun.norm();
+    // Earth's orbit eccentricity is ~0.0167, so |Earth-Sun| varies
+    // between ~0.983 AU and ~1.017 AU over the year. Allow 3%.
+    EXPECT_GT(r, 0.97 * kAuMeters);
+    EXPECT_LT(r, 1.03 * kAuMeters);
+}
+
+TEST(IersEphemeris, MoonIcrsMagnitudeNearLunarOrbit) {
+    // Lunar orbit eccentricity is ~0.055; perigee ~363,000 km,
+    // apogee ~406,000 km.
+    const Eigen::Vector3d moon = moonPositionIcrs(58849.5);
+    const double r = moon.norm();
+    EXPECT_GT(r, 350.0e6);
+    EXPECT_LT(r, 410.0e6);
+}
+
+TEST(IersEphemeris, SunDirectionSweepsOverHalfYear) {
+    // The Sun's geocentric direction in ICRS sweeps 360° per year.
+    // Sample at 0 / 90 / 180 days from MJD 58849.5 (2020-01-01 12 UT)
+    // and check the angular separation from the start point. We
+    // restrict the check to the [0, 180°] range so the angle-between
+    // -vectors metric (always in that range) is unambiguous.
+    auto angle_deg = [](const Eigen::Vector3d& a, const Eigen::Vector3d& b) {
+        const double cosang = a.normalized().dot(b.normalized());
+        return std::acos(std::min(1.0, std::max(-1.0, cosang))) * 180.0 / M_PI;
+    };
+
+    const Eigen::Vector3d s0  = sunPositionIcrs(58849.5);
+    const Eigen::Vector3d s90 = sunPositionIcrs(58849.5 + 90.0);
+    const Eigen::Vector3d s180 = sunPositionIcrs(58849.5 + 180.0);
+
+    // After 90 days the Sun's ICRS direction has advanced by
+    // ~90 * 360/365.25 ≈ 88.7°.
+    EXPECT_NEAR(angle_deg(s0, s90), 90.0 * 360.0 / 365.25, 5.0);
+    // After 180 days, ~177.4°.
+    EXPECT_NEAR(angle_deg(s0, s180), 180.0 * 360.0 / 365.25, 5.0);
+}
+
+TEST(IersEphemeris, SolidEarthTideUsingComputedEphemeris) {
+    // Integration test: at the IERS Conventions 2010 reference epoch
+    // (2009-04-13 0h UTC, MJD 54934.0) feed our SOFA-computed sun and
+    // moon ICRS vectors into solidEarthTideDisplacement. Compare to
+    // the published reference value.
+    //
+    // The IERS reference test in test_iers_tides.cpp uses hand-supplied
+    // sun/moon vectors (also in ICRS, despite the IERS routine docs
+    // calling it "ECEF"). Here we replace those hand-supplied vectors
+    // with SOFA-computed ones; small differences arise because:
+    //   - iauEpv00 vs. JPL DE405 differ by ~15 km at the Sun.
+    //   - iauMoon98 vs. JPL DE405 differ by ~1 km at the Moon.
+    //   - Inverse-cube weighting in the tide formula amplifies any
+    //     position error to ~3× relative error in displacement.
+    // Net expected drift: well under 1 mm in the final displacement,
+    // far below the model's intrinsic accuracy. Tolerance set to
+    // 1 mm.
+    const double mjd_utc = 54934.0;
+
+    const Eigen::Vector3d xsta(4075578.385, 931852.890, 4801570.154);
+    const Eigen::Vector3d xsun = sunPositionIcrs(mjd_utc);
+    const Eigen::Vector3d xmon = moonPositionIcrs(mjd_utc);
+
+    const Eigen::Vector3d dxyz =
+        solidEarthTideDisplacement(mjd_utc, xsta, xsun, xmon);
+
+    const Eigen::Vector3d expected(0.07700420357108126,
+                                   0.06304056321824968,
+                                   0.05516568152597247);
+
+    EXPECT_NEAR(dxyz.x(), expected.x(), 1e-3);
+    EXPECT_NEAR(dxyz.y(), expected.y(), 1e-3);
+    EXPECT_NEAR(dxyz.z(), expected.z(), 1e-3);
+}


### PR DESCRIPTION
## Summary

Phase B-2 of the IERS2010 integration. **Stacked on #54** (which is stacked on #53 → #52); merge those first.

Provides SOFA-based geocentric Sun and Moon positions in the ICRS / GCRS, completing the lunisolar input surface needed by `libgnss::iers::solidEarthTideDisplacement`. With this PR landed, callers no longer need to supply Sun/Moon vectors manually for solid-earth-tide computation — they can just call the helpers.

## New API

```cpp
namespace libgnss::iers {

Eigen::Vector3d sunPositionIcrs (double mjd_utc);
Eigen::Vector3d moonPositionIcrs(double mjd_utc);

}
```

Implementation: `iauEpv00` (Earth heliocentric) negated for the Sun's geocentric vector; `iauMoon98` direct for the Moon. Accuracy ~15 km (Sun) and ~1 km (Moon) vs. JPL DE405 — far below the noise floor for solid-earth-tide displacement, which scales as 1/r³.

## Frame discovery

While building this PR I discovered that the IERS Conventions 2010 documentation for `dehanttideinel` describes all inputs as "ECEF", but the published reference test case actually uses **ICRS** positions for Sun and Moon while keeping the station in ITRS. The routine implicitly follows that test-case convention.

Consequence:
1. **Ephemeris helpers are ICRS-only.** An earlier draft of this PR also offered `sunPositionEcef` / `moonPositionEcef` (pre-rotated to ITRS); those would have produced numerically wrong tide displacements when fed into `solidEarthTideDisplacement`, so they're omitted.
2. **`tides.hpp` documentation updated** with a `FRAME NOTE` block making this explicit, and parameters renamed from `xsun_ecef` → `xsun_icrs` (etc.) so consumer code reads correctly. No behavioral change.

## Verification

- ✅ 4 / 4 new `IersEphemeris` tests PASS:
  - Sun ICRS magnitude is 1 AU ± 3% (Earth orbit eccentricity).
  - Moon ICRS magnitude is in [350,000 km, 410,000 km] (lunar orbit perigee/apogee bounds).
  - Sun ICRS direction sweeps ~89° in 90 days, ~177° in 180 days.
  - **`SolidEarthTideUsingComputedEphemeris`**: at the IERS 2010 reference epoch (2009-04-13 0h UT), feeding our SOFA-computed Sun/Moon ICRS vectors into `solidEarthTideDisplacement` reproduces the IERS reference (0.077, 0.063, 0.055) m result **within 1 mm** — confirming the wrapper stack is internally consistent and the ephemeris helpers are drop-in compatible.
- ✅ 20 / 20 combined SOFA + ginan-iers2010 + IERS wrapper + ephemeris tests PASS; no regression.

## Test plan

- [ ] CI build green (will run after rebase to `develop` once #52–#54 merge)
- [ ] CI test job passes new `IersEphemeris.*` cases

## Follow-up PRs (planned)

- **Phase A-2b**: vendor or re-implement HARDISP (ocean-tide-loading) with native libgnss++ time-type adaptation.
- **Phase C**: actually use these wrappers from PPP — apply `solidEarthTideDisplacement` to receiver position, replace stubbed sun_pos in `calculateSatelliteAntennaPCO` with `sunPositionIcrs` (rotated as needed). Gate behind `--use-iers-earth-rotation` / `--use-iers-solid-tide` feature flags.
- **Phase D**: PPP truth-bench validation on Tokyo / Nagoya 6-run.