### PR TITLE
PPP opt-in IERS solid-earth-tide (Phase C-1, stacked on #55)

### DIFF
--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -51,6 +51,7 @@ struct Options {
     bool low_dynamics_mode = false;
     bool enable_ar = false;
     double ar_ratio_threshold = 3.0;
+    bool use_iers_solid_tide = false;
     bool quiet = false;
 };
 
@@ -113,6 +114,11 @@ void printUsage(const char* program_name) {
         << "  --disable-ar            Disable PPP ambiguity fixing (default)\n"
         << "  --ar-ratio-threshold <value>\n"
         << "                          Ratio threshold for PPP ambiguity fixing (default: 3.0)\n"
+        << "  --use-iers-solid-tide   Use the IERS Conventions 2010 (Dehant) Step-1+Step-2\n"
+        << "                          solid-earth-tide model instead of the simplified\n"
+        << "                          Step-1-only built-in approximation. Opt-in pending\n"
+        << "                          truth-bench validation. See docs/iers-integration-plan.md\n"
+        << "  --no-iers-solid-tide    Use the built-in Step-1-only solid-earth-tide model (default)\n"
         << "  --quiet                  Suppress per-run summary output\n"
         << "  -h, --help               Show this help\n";
 }
@@ -214,6 +220,10 @@ Options parseArguments(int argc, char* argv[]) {
             options.enable_ar = false;
         } else if (arg == "--ar-ratio-threshold" && i + 1 < argc) {
             options.ar_ratio_threshold = std::stod(argv[++i]);
+        } else if (arg == "--use-iers-solid-tide") {
+            options.use_iers_solid_tide = true;
+        } else if (arg == "--no-iers-solid-tide") {
+            options.use_iers_solid_tide = false;
         } else if (arg == "--quiet") {
             options.quiet = true;
         } else {
@@ -561,6 +571,7 @@ int main(int argc, char* argv[]) {
         ppp_config.enable_ambiguity_resolution = options.enable_ar;
         ppp_config.convergence_min_epochs = options.convergence_min_epochs;
         ppp_config.ar_ratio_threshold = options.ar_ratio_threshold;
+        ppp_config.use_iers_solid_tide = options.use_iers_solid_tide;
         if (options.low_dynamics_mode) {
             ppp_config.reset_clock_to_spp_each_epoch = false;
             ppp_config.reset_kinematic_position_to_spp_each_epoch = false;

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -177,6 +177,13 @@ struct PPPConfig {
 
     bool apply_ocean_loading = false;
     bool apply_solid_earth_tides = true;
+    // When true (and apply_solid_earth_tides is also true), use the
+    // IERS Conventions 2010 §7.1.1 (Dehant) Step-1 + Step-2 model
+    // from libgnss::iers::solidEarthTideDisplacement instead of the
+    // built-in simplified Step-1-only Love-number approximation.
+    // Default off; opt-in for safe rollout pending truth-bench
+    // validation. See docs/iers-integration-plan.md.
+    bool use_iers_solid_tide = false;
     bool apply_relativity = true;
 
     // Convergence criteria

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -7,6 +7,9 @@
 #include <libgnss++/core/constants.hpp>
 #include <libgnss++/core/coordinates.hpp>
 #include <libgnss++/core/signals.hpp>
+#include <libgnss++/iers/earth_rotation.hpp>
+#include <libgnss++/iers/ephemeris.hpp>
+#include <libgnss++/iers/tides.hpp>
 #include <libgnss++/io/qzss_l6.hpp>
 #include <libgnss++/io/rtcm.hpp>
 #include <libgnss++/models/troposphere.hpp>
@@ -2679,12 +2682,30 @@ Vector3d PPPProcessor::applyGeophysicalCorrections(const Vector3d& position,
 
 Vector3d PPPProcessor::calculateSolidEarthTides(const Vector3d& position,
                                                 const GNSSTime& time) const {
-    constexpr double kSunGM = 1.32712440018e20;
-    constexpr double kMoonGM = 4.902801e12;
     if (!position.allFinite() || position.norm() < constants::WGS84_A * 0.5) {
         return Vector3d::Zero();
     }
-    const Vector3d sun_position = approximateSunPositionEcef(time);
+
+    if (ppp_config_.use_iers_solid_tide) {
+        // IERS Conventions 2010 §7.1.1 (Dehant) Step-1 + Step-2 model
+        // via the libgnss::iers wrapper. Sun and Moon are supplied in
+        // ICRS — see the FRAME NOTE in libgnss++/iers/tides.hpp for
+        // why this is the correct frame for the IERS routine despite
+        // its public documentation calling it "ECEF".
+        const double mjd_utc = libgnss::iers::gnssTimeToMjdUtc(time);
+        const Vector3d sun_icrs  = libgnss::iers::sunPositionIcrs(mjd_utc);
+        const Vector3d moon_icrs = libgnss::iers::moonPositionIcrs(mjd_utc);
+        return libgnss::iers::solidEarthTideDisplacement(
+            mjd_utc, position, sun_icrs, moon_icrs);
+    }
+
+    // Default path: simplified Step-1-only Love-number body-tide
+    // approximation kept for behavioral compatibility while the
+    // IERS path stays opt-in pending truth-bench validation. See
+    // docs/iers-integration-plan.md.
+    constexpr double kSunGM  = 1.32712440018e20;
+    constexpr double kMoonGM = 4.902801e12;
+    const Vector3d sun_position  = approximateSunPositionEcef(time);
     const Vector3d moon_position = approximateMoonPositionEcef(time);
     return bodyTideDisplacement(position, sun_position, kSunGM) +
            bodyTideDisplacement(position, moon_position, kMoonGM);

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -739,6 +739,94 @@ TEST(PPPTest, SolidEarthTidesChangeSyntheticPrecisePppSolutionWithoutBreakingIt)
     std::filesystem::remove(clk_path);
 }
 
+TEST(PPPTest, IersSolidTideOptInDispatchProducesDistinctSolution) {
+    // Phase C-1 dispatch test: with `apply_solid_earth_tides = true`,
+    // toggling `use_iers_solid_tide` between false (legacy Step-1
+    // body-tide approximation) and true (IERS Conventions 2010
+    // Step-1+Step-2 Dehant via libgnss::iers::solidEarthTideDisplacement)
+    // must produce two distinct converged solutions, both close to
+    // the true receiver position. This proves the dispatcher picks
+    // different code paths and that neither path is broken.
+    const auto sp3_path = tempFilePath("libgnss_ppp_iers_tide_test.sp3");
+    const auto clk_path = tempFilePath("libgnss_ppp_iers_tide_test.clk");
+    std::filesystem::remove(sp3_path);
+    std::filesystem::remove(clk_path);
+
+    const Vector3d true_receiver_position =
+        geodetic2ecef(35.0 * M_PI / 180.0, 139.0 * M_PI / 180.0, 45.0);
+    const Vector3d approximate_receiver_position =
+        true_receiver_position + Vector3d(8.0, -5.0, 3.0);
+    const auto satellites = makeSyntheticSatellites(true_receiver_position);
+
+    const GNSSTime first_time = makeTime(2026, 3, 26, 6, 0, 0.0);
+    const GNSSTime last_precise_time = first_time + 600.0;
+    writeTextFile(sp3_path, buildSp3Text(satellites, first_time, last_precise_time));
+    writeTextFile(clk_path, buildClockText(satellites, first_time, last_precise_time));
+
+    PPPProcessor::PPPConfig base_config;
+    base_config.use_precise_orbits = true;
+    base_config.use_precise_clocks = true;
+    base_config.orbit_file_path = sp3_path.string();
+    base_config.clock_file_path = clk_path.string();
+    base_config.convergence_min_epochs = 5;
+    base_config.convergence_threshold_horizontal = 0.2;
+    base_config.estimate_troposphere = false;
+    base_config.enable_ambiguity_resolution = false;
+    base_config.kinematic_mode = false;
+    base_config.apply_ocean_loading = false;
+    base_config.apply_solid_earth_tides = true;
+
+    PPPProcessor::PPPConfig legacy_config = base_config;
+    legacy_config.use_iers_solid_tide = false;
+    PPPProcessor::PPPConfig iers_config = base_config;
+    iers_config.use_iers_solid_tide = true;
+
+    PPPProcessor legacy_processor(legacy_config);
+    PPPProcessor iers_processor(iers_config);
+
+    ProcessorConfig processor_config;
+    processor_config.mode = PositioningMode::PPP;
+    processor_config.min_satellites = 4;
+    processor_config.use_precise_orbits = true;
+    processor_config.use_precise_clocks = true;
+    processor_config.orbit_file_path = sp3_path.string();
+    processor_config.clock_file_path = clk_path.string();
+    ASSERT_TRUE(legacy_processor.initialize(processor_config));
+    ASSERT_TRUE(iers_processor.initialize(processor_config));
+
+    NavigationData nav_data;
+    PositionSolution legacy_solution;
+    PositionSolution iers_solution;
+    for (int i = 0; i < 8; ++i) {
+        const ObservationData epoch = makeSyntheticEpoch(
+            first_time + 30.0 * static_cast<double>(i),
+            true_receiver_position,
+            approximate_receiver_position,
+            satellites);
+        legacy_solution = legacy_processor.processEpoch(epoch, nav_data);
+        iers_solution   = iers_processor.processEpoch(epoch, nav_data);
+    }
+
+    ASSERT_TRUE(legacy_solution.isValid());
+    ASSERT_TRUE(iers_solution.isValid());
+    // Both paths should converge to within 1 m of truth — neither is
+    // catastrophically wrong.
+    EXPECT_LT((legacy_solution.position_ecef - true_receiver_position).norm(), 1.0);
+    EXPECT_LT((iers_solution.position_ecef - true_receiver_position).norm(), 1.0);
+
+    // The two solutions must differ — if they don't, the dispatch is
+    // not actually picking different code paths. The tide model
+    // difference at any single epoch is a few mm to a few cm; we
+    // require non-zero separation but bound it loosely.
+    const double position_delta_m =
+        (legacy_solution.position_ecef - iers_solution.position_ecef).norm();
+    EXPECT_GT(position_delta_m, 1e-5);
+    EXPECT_LT(position_delta_m, 0.5);
+
+    std::filesystem::remove(sp3_path);
+    std::filesystem::remove(clk_path);
+}
+
 TEST(PPPTest, ReceiverAntexPcoChangesSyntheticPrecisePppSolutionWithoutBreakingIt) {
     const auto sp3_path = tempFilePath("libgnss_ppp_antex_test.sp3");
     const auto clk_path = tempFilePath("libgnss_ppp_antex_test.clk");


### PR DESCRIPTION
## Summary

Phase C-1 of the IERS integration. **Stacked on #55** (which is stacked on #54 → #53 → #52); merge those first.

Adds a `use_iers_solid_tide` flag to `PPPProcessor::PPPConfig` (default **off**) that swaps the existing simplified Step-1-only Love-number body-tide approximation in `PPPProcessor::calculateSolidEarthTides` for the full IERS Conventions 2010 §7.1.1 (Dehant) Step-1 + Step-2 model, via the libgnss::iers wrapper API landed by the foundation PRs #52–#55.

This is the implementation of the design captured in `docs/iers-integration-plan.md`.

## Why opt-in / default off

- No production consumer sees a behavior change unless they explicitly opt in.
- Truth-bench validation on the Tokyo / Nagoya 6-run is the next step (`docs/iers-integration-plan.md` §4.2). Until bench evidence lands, the safe default is unchanged behavior.
- Flipping the default to `true` will be a separate one-line PR, gated on bench results.

## Code change at a glance

### `include/libgnss++/algorithms/ppp_shared.hpp`

```cpp
bool apply_solid_earth_tides = true;
+ // When true (and apply_solid_earth_tides is also true), use the
+ // IERS Conventions 2010 (Dehant) Step-1+Step-2 model via
+ // libgnss::iers::solidEarthTideDisplacement. Default off; opt-in.
+ bool use_iers_solid_tide = false;
bool apply_relativity = true;
```

### `src/algorithms/ppp.cpp::PPPProcessor::calculateSolidEarthTides`

```cpp
if (ppp_config_.use_iers_solid_tide) {
    const double mjd_utc = libgnss::iers::gnssTimeToMjdUtc(time);
    const Vector3d sun_icrs  = libgnss::iers::sunPositionIcrs(mjd_utc);
    const Vector3d moon_icrs = libgnss::iers::moonPositionIcrs(mjd_utc);
    return libgnss::iers::solidEarthTideDisplacement(
        mjd_utc, position, sun_icrs, moon_icrs);
}
// Existing Step-1 body-tide path unchanged below.
```

### `apps/gnss_ppp.cpp`

Canonical three-line pattern (Options field, parseArguments branch, ppp_config copy). Adds `--use-iers-solid-tide` / `--no-iers-solid-tide` CLI flags. Other CLI tools pick up the change via `PPPConfig` automatically.

## Verification

- ✅ `gnss_lib`, `gnss_ppp` build cleanly with the new flag.
- ✅ `gnss_ppp --help` shows the new `--use-iers-solid-tide` / `--no-iers-solid-tide` lines.
- ✅ New `PPPTest.IersSolidTideOptInDispatchProducesDistinctSolution` runs the synthetic PPP harness twice (once per dispatch path), confirms both converge to within 1 m of truth, and verifies their solutions differ (1e-5 m < |Δr| < 0.5 m) — proving the flag actually picks different code paths.
- ✅ Existing `PPPTest.SolidEarthTidesChangeSyntheticPrecisePppSolutionWithoutBreakingIt` still passes — no regression on the legacy path.
- ✅ 22 / 22 combined PPP tide + IERS wrapper + vendor tests PASS.

## Test plan

- [ ] CI build green on this branch (after rebase to develop, post #52–#55 merge).
- [ ] CI test job passes new `PPPTest.IersSolidTideOptInDispatchProducesDistinctSolution` case.
- [ ] No regression in existing PPP tests.

## Follow-up PRs (planned)

- **Phase C-2 (truth-bench)**: Add a paired Tokyo / Nagoya 6-run comparison harness driven by `apps/gnss_ppc_rtk_signoff.py` (`use_iers_solid_tide=true` vs default), with ±2σ-noise acceptance.
- **Flip-default**: One-line PR flipping `use_iers_solid_tide = true` in `PPPConfig`, gated on bench results from C-2.
- **Phase A-2b**: Vendor or re-implement HARDISP (ocean-tide-loading) with native libgnss++ time-type adaptation.

See `docs/iers-integration-plan.md` for the full Phase C design context.