### PR TITLE
Add IERS 20 C04 EOP table loader (Phase D-0 scaffolding)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,6 +50,7 @@ set(GNSS_SOURCES
     src/iers/earth_rotation.cpp
     src/iers/tides.cpp
     src/iers/ephemeris.cpp
+    src/iers/eop_table.cpp
 )
 
 # List source files for the no-optimization library

--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -52,6 +52,7 @@ struct Options {
     bool enable_ar = false;
     double ar_ratio_threshold = 3.0;
     bool use_iers_solid_tide = false;
+    std::string eop_c04_file;
     bool quiet = false;
 };
 
@@ -119,6 +120,11 @@ void printUsage(const char* program_name) {
         << "                          Step-1-only built-in approximation. Opt-in pending\n"
         << "                          truth-bench validation. See docs/iers-integration-plan.md\n"
         << "  --no-iers-solid-tide    Use the built-in Step-1-only solid-earth-tide model (default)\n"
+        << "  --eop-c04 <eopc04.txt>   IERS 20 C04 Earth Orientation Parameter file (daily samples).\n"
+        << "                          Loaded into PPPProcessor for downstream IERS Phase D consumers\n"
+        << "                          (pole tide, sub-daily EOP). Phase D-0 scaffolding only — does\n"
+        << "                          not change PPP output until D-1+ feature flags are enabled.\n"
+        << "                          Source: https://hpiers.obspm.fr/iers/eop/eopc04/eopc04.1962-now\n"
         << "  --quiet                  Suppress per-run summary output\n"
         << "  -h, --help               Show this help\n";
 }
@@ -224,6 +230,8 @@ Options parseArguments(int argc, char* argv[]) {
             options.use_iers_solid_tide = true;
         } else if (arg == "--no-iers-solid-tide") {
             options.use_iers_solid_tide = false;
+        } else if (arg == "--eop-c04" && i + 1 < argc) {
+            options.eop_c04_file = argv[++i];
         } else if (arg == "--quiet") {
             options.quiet = true;
         } else {
@@ -572,6 +580,7 @@ int main(int argc, char* argv[]) {
         ppp_config.convergence_min_epochs = options.convergence_min_epochs;
         ppp_config.ar_ratio_threshold = options.ar_ratio_threshold;
         ppp_config.use_iers_solid_tide = options.use_iers_solid_tide;
+        ppp_config.eop_path = options.eop_c04_file;
         if (options.low_dynamics_mode) {
             ppp_config.reset_clock_to_spp_each_epoch = false;
             ppp_config.reset_kinematic_position_to_spp_each_epoch = false;

--- a/docs/iers-integration-plan.md
+++ b/docs/iers-integration-plan.md
@@ -244,8 +244,22 @@ does not block Phase C:
 - **Phase A-2b**: Vendor or re-implement HARDISP (ocean-tide-loading)
   with native libgnss++ time-type adaptation. Re-uses the BLQ
   parser already present in libgnss++.
-- **Phase D**: Pole tide, sub-daily EOP corrections, atmospheric
-  loading. Smaller cm-level effects.
+- **Phase D-0** *(in progress)*: EOP plumbing scaffolding.
+  Adds `libgnss::iers::EopTable` (IERS 20 C04 daily series with
+  linear interpolation and leap-second snap on UT1-UTC) and a
+  `PPPConfig::eop_path` / `--eop-c04` CLI knob. PPPProcessor
+  loads the table on init and exposes
+  `getEarthOrientationParams(GNSSTime)`. No PPP code path consumes
+  the table yet — D-0 is a strictly additive scaffold for D-1+
+  (pole tide and sub-daily EOP). Output is bit-identical to the
+  no-EOP baseline.
+- **Phase D-1**: Pole tide (IERS Conventions 2010 §7.1.4). Closed-form
+  ~30 LOC, but requires the D-0 scaffold so per-epoch xp/yp/UT1-UTC
+  are available.
+- **Phase D-2**: Sub-daily EOP corrections (IERS §8.2). Shares the
+  D-0 scaffold.
+- **Phase D-3**: Atmospheric loading. Smaller cm-level effect; needs
+  a separate gridded-data ingestion path, independent of EOP.
 - **`icrsToItrs` consumers**: when satellite-side processing
   (LEO orbits, external SP3 ingestion in non-ECEF frames, attitude
   for satellite antenna PCO/PCV) is wired up, the wrapper is

--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -10,8 +10,10 @@
 #include "ppp_clas_sd.hpp"
 #include "ppp_osr_types.hpp"
 #include "spp.hpp"
+#include "../iers/eop_table.hpp"
 #include <Eigen/Dense>
 #include <array>
+#include <memory>
 #include <mutex>
 #include <string>
 
@@ -69,6 +71,31 @@ public:
      * @brief Load DCB / Bias-SINEX products for future PPP hooks.
      */
     bool loadDCBProducts(const std::string& dcb_file);
+
+    /**
+     * @brief Load an IERS 20 C04 Earth Orientation Parameter file.
+     *
+     * The series is stored in-memory and consumed by per-epoch
+     * earth-rotation / pole-tide / sub-daily-EOP code paths in
+     * subsequent IERS phases. Phase D-0 wires the loader and
+     * lookup; consumers arrive in Phase D-1+.
+     */
+    bool loadEopC04(const std::string& path);
+
+    /**
+     * @brief Whether an EOP series has been loaded successfully.
+     */
+    bool hasEopTable() const { return static_cast<bool>(eop_table_); }
+
+    /**
+     * @brief Look up EOP at a GNSS epoch.
+     *
+     * Returns the zero EarthOrientationParams (i.e. rigid-body
+     * approximation) when no EOP series has been loaded. Throws
+     * std::out_of_range when the requested epoch falls outside the
+     * loaded series — callers should keep their EOP file current.
+     */
+    iers::EarthOrientationParams getEarthOrientationParams(const GNSSTime& time) const;
 
     /**
      * @brief Load RTCM SSR orbit/clock corrections and convert them to sampled PPP corrections.
@@ -188,6 +215,7 @@ private:
     };
     OceanLoadingCoefficients ocean_loading_coefficients_{};
     bool ocean_loading_loaded_ = false;
+    std::unique_ptr<iers::EopTable> eop_table_;
     std::map<std::string, std::map<SignalType, Vector3d>> receiver_antex_offsets_;
     bool receiver_antex_loaded_ = false;
     Vector3d static_anchor_position_ = Vector3d::Zero();

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -184,6 +184,13 @@ struct PPPConfig {
     // Default off; opt-in for safe rollout pending truth-bench
     // validation. See docs/iers-integration-plan.md.
     bool use_iers_solid_tide = false;
+    // Optional IERS 20 C04 EOP file path (Phase D-0 scaffolding).
+    // When set, PPPProcessor loads the series at construction and
+    // exposes per-epoch xp/yp/UT1-UTC via getEarthOrientationParams();
+    // downstream Phase D-1 (pole tide) / D-2 (sub-daily EOP) consumers
+    // will read it. Empty string = no EOP table (current default).
+    // Source: https://hpiers.obspm.fr/iers/eop/eopc04/eopc04.1962-now
+    std::string eop_path;
     bool apply_relativity = true;
 
     // Convergence criteria

--- a/include/libgnss++/iers/eop_table.hpp
+++ b/include/libgnss++/iers/eop_table.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+// libgnss++/iers/eop_table.hpp
+//
+// In-memory IERS Earth Orientation Parameter (EOP) series, loaded from
+// an IERS 20 C04 file (daily samples at 0h UTC, ITRF2020-consistent).
+//
+// The canonical auth-free source is the Paris Observatory:
+//   https://hpiers.obspm.fr/iers/eop/eopc04/eopc04.1962-now
+//
+// This is the Phase D-0 scaffolding piece of the IERS Conventions 2010
+// integration: PPP itself does not yet consume the table — that wiring
+// arrives in Phase D-1 (pole tide) and Phase D-2 (sub-daily EOP).
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+#include "libgnss++/iers/earth_rotation.hpp"
+
+namespace libgnss::iers {
+
+/// @brief A single daily row from an IERS 20 C04 series.
+///
+/// xp/yp/dx/dy are arcseconds, ut1_minus_utc and lod are seconds.
+/// Rates and formal errors from the source file are dropped at parse
+/// time — libgnss::iers consumers only need the value columns.
+struct EopRecord {
+    double mjd_utc{0.0};
+    double xp_arcsec{0.0};
+    double yp_arcsec{0.0};
+    double ut1_minus_utc_seconds{0.0};
+    double lod_seconds{0.0};
+    double dx_arcsec{0.0};
+    double dy_arcsec{0.0};
+};
+
+/// @brief Daily-sampled EOP series with linear interpolation.
+///
+/// Linear interpolation between adjacent daily samples is well below
+/// the cm-level PPP requirement during periods covered by the final
+/// EOP series. Around a UT1-UTC leap-second insertion the ut1_minus_utc
+/// column has a 1-second step at 0h UTC; interpolateAt() detects this
+/// and snaps to the nearer sample for ut1_minus_utc only (xp/yp are
+/// continuous and are still interpolated).
+///
+/// For epochs outside [firstMjd(), lastMjd()], interpolateAt() throws
+/// std::out_of_range — callers are expected to keep the EOP file
+/// current. The C04 series is updated daily.
+class EopTable {
+public:
+    /// @brief Parse an IERS C04 fixed-width file. Comment lines (`#`) are skipped.
+    static EopTable fromC04File(const std::string& path);
+
+    /// @brief Construct directly from a list of records (used by tests).
+    /// Records do not need to be pre-sorted.
+    explicit EopTable(std::vector<EopRecord> records);
+
+    /// @brief Interpolate the series at the given UTC MJD.
+    EarthOrientationParams interpolateAt(double mjd_utc) const;
+
+    double firstMjd() const;
+    double lastMjd() const;
+    std::size_t size() const { return records_.size(); }
+
+    const std::vector<EopRecord>& records() const { return records_; }
+
+private:
+    std::vector<EopRecord> records_;  // sorted ascending by mjd_utc
+};
+
+}  // namespace libgnss::iers

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -18,6 +18,7 @@
 #include <array>
 #include <chrono>
 #include <fstream>
+#include <memory>
 #include <cmath>
 #include <ctime>
 #include <cctype>
@@ -900,6 +901,9 @@ bool PPPProcessor::initialize(const ProcessorConfig& config) {
         !loadDCBProducts(ppp_config_.dcb_file_path)) {
         return false;
     }
+    if (!ppp_config_.eop_path.empty() && !loadEopC04(ppp_config_.eop_path)) {
+        return false;
+    }
     return true;
 }
 
@@ -1239,6 +1243,30 @@ bool PPPProcessor::loadDCBProducts(const std::string& dcb_file) {
     }
     dcb_products_loaded_ = dcb_products_.loadFile(dcb_file);
     return dcb_products_loaded_;
+}
+
+bool PPPProcessor::loadEopC04(const std::string& path) {
+    eop_table_.reset();
+    if (path.empty()) {
+        return false;
+    }
+    try {
+        eop_table_ = std::make_unique<libgnss::iers::EopTable>(
+            libgnss::iers::EopTable::fromC04File(path));
+    } catch (const std::exception&) {
+        eop_table_.reset();
+        return false;
+    }
+    return true;
+}
+
+libgnss::iers::EarthOrientationParams
+PPPProcessor::getEarthOrientationParams(const GNSSTime& time) const {
+    if (!eop_table_) {
+        return libgnss::iers::EarthOrientationParams{};
+    }
+    const double mjd_utc = libgnss::iers::gnssTimeToMjdUtc(time);
+    return eop_table_->interpolateAt(mjd_utc);
 }
 
 bool PPPProcessor::loadRTCMSSRProducts(const std::string& rtcm_file,

--- a/src/iers/eop_table.cpp
+++ b/src/iers/eop_table.cpp
@@ -1,0 +1,111 @@
+#include "libgnss++/iers/eop_table.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <fstream>
+#include <sstream>
+#include <stdexcept>
+
+namespace libgnss::iers {
+
+namespace {
+
+bool tryParseC04Row(const std::string& line, EopRecord& out) {
+    if (line.empty() || line[0] == '#') {
+        return false;
+    }
+    std::istringstream iss(line);
+    int yr = 0, mm = 0, dd = 0, hh = 0;
+    double mjd = 0.0, xp = 0.0, yp = 0.0, dut1 = 0.0;
+    double dx = 0.0, dy = 0.0, xrt = 0.0, yrt = 0.0, lod = 0.0;
+    if (!(iss >> yr >> mm >> dd >> hh >> mjd >> xp >> yp >> dut1
+              >> dx >> dy >> xrt >> yrt >> lod)) {
+        return false;
+    }
+    out.mjd_utc = mjd;
+    out.xp_arcsec = xp;
+    out.yp_arcsec = yp;
+    out.ut1_minus_utc_seconds = dut1;
+    out.lod_seconds = lod;
+    out.dx_arcsec = dx;
+    out.dy_arcsec = dy;
+    return true;
+}
+
+}  // namespace
+
+EopTable EopTable::fromC04File(const std::string& path) {
+    std::ifstream in(path);
+    if (!in) {
+        throw std::runtime_error("EopTable::fromC04File: cannot open " + path);
+    }
+    std::vector<EopRecord> records;
+    std::string line;
+    while (std::getline(in, line)) {
+        EopRecord rec{};
+        if (tryParseC04Row(line, rec)) {
+            records.push_back(rec);
+        }
+    }
+    if (records.empty()) {
+        throw std::runtime_error(
+            "EopTable::fromC04File: no data rows parsed from " + path);
+    }
+    return EopTable(std::move(records));
+}
+
+EopTable::EopTable(std::vector<EopRecord> records) : records_(std::move(records)) {
+    if (records_.empty()) {
+        throw std::invalid_argument("EopTable: must contain at least one record");
+    }
+    std::sort(records_.begin(), records_.end(),
+              [](const EopRecord& a, const EopRecord& b) {
+                  return a.mjd_utc < b.mjd_utc;
+              });
+}
+
+EarthOrientationParams EopTable::interpolateAt(double mjd_utc) const {
+    if (mjd_utc < records_.front().mjd_utc || mjd_utc > records_.back().mjd_utc) {
+        std::ostringstream msg;
+        msg << "EopTable::interpolateAt: mjd_utc " << mjd_utc
+            << " outside coverage [" << records_.front().mjd_utc
+            << ", " << records_.back().mjd_utc << "]";
+        throw std::out_of_range(msg.str());
+    }
+
+    auto upper = std::lower_bound(
+        records_.begin(), records_.end(), mjd_utc,
+        [](const EopRecord& r, double v) { return r.mjd_utc < v; });
+
+    if (upper == records_.begin() || upper->mjd_utc == mjd_utc) {
+        const auto& r = *upper;
+        return EarthOrientationParams{
+            r.ut1_minus_utc_seconds, r.xp_arcsec, r.yp_arcsec};
+    }
+    const auto lower = upper - 1;
+    const double t1 = lower->mjd_utc;
+    const double t2 = upper->mjd_utc;
+    const double w = (mjd_utc - t1) / (t2 - t1);
+
+    EarthOrientationParams eop;
+    eop.xp_arcsec = lower->xp_arcsec + w * (upper->xp_arcsec - lower->xp_arcsec);
+    eop.yp_arcsec = lower->yp_arcsec + w * (upper->yp_arcsec - lower->yp_arcsec);
+
+    // UT1-UTC has a 1-second discontinuity at a leap-second day. Detect
+    // and snap to the nearest sample instead of interpolating across.
+    const double ddut1 =
+        upper->ut1_minus_utc_seconds - lower->ut1_minus_utc_seconds;
+    if (std::abs(ddut1) > 0.5) {
+        eop.ut1_minus_utc_seconds = (w < 0.5)
+            ? lower->ut1_minus_utc_seconds
+            : upper->ut1_minus_utc_seconds;
+    } else {
+        eop.ut1_minus_utc_seconds = lower->ut1_minus_utc_seconds + w * ddut1;
+    }
+    return eop;
+}
+
+double EopTable::firstMjd() const { return records_.front().mjd_utc; }
+double EopTable::lastMjd() const { return records_.back().mjd_utc; }
+
+}  // namespace libgnss::iers

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -38,6 +38,7 @@ if(GTest_FOUND)
         test_iers_earth_rotation.cpp
         test_iers_tides.cpp
         test_iers_ephemeris.cpp
+        test_iers_eop.cpp
     )
 
     target_compile_options(run_tests PRIVATE -g)

--- a/tests/test_iers_eop.cpp
+++ b/tests/test_iers_eop.cpp
@@ -1,0 +1,130 @@
+#include "libgnss++/iers/eop_table.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <fstream>
+#include <stdexcept>
+#include <string>
+
+namespace {
+
+using libgnss::iers::EopRecord;
+using libgnss::iers::EopTable;
+
+std::string writeTempFile(const std::string& contents) {
+    char path_template[] = "/tmp/libgnss_eop_XXXXXX";
+    int fd = mkstemp(path_template);
+    if (fd < 0) {
+        ADD_FAILURE() << "mkstemp failed";
+        return {};
+    }
+    std::string path(path_template);
+    close(fd);
+    std::ofstream out(path);
+    out << contents;
+    return path;
+}
+
+}  // namespace
+
+TEST(IersEopTable, ConstructFromRecordsAndExactLookup) {
+    std::vector<EopRecord> recs;
+    recs.push_back(EopRecord{
+        /*mjd_utc=*/60800.0,
+        /*xp_arcsec=*/0.10,
+        /*yp_arcsec=*/0.30,
+        /*ut1_minus_utc_seconds=*/-0.20,
+        /*lod_seconds=*/0.0,
+        /*dx_arcsec=*/0.0,
+        /*dy_arcsec=*/0.0});
+    recs.push_back(EopRecord{60801.0, 0.12, 0.31, -0.19, 0.0, 0.0, 0.0});
+    EopTable table(std::move(recs));
+
+    EXPECT_EQ(table.size(), 2u);
+    EXPECT_DOUBLE_EQ(table.firstMjd(), 60800.0);
+    EXPECT_DOUBLE_EQ(table.lastMjd(), 60801.0);
+
+    auto eop = table.interpolateAt(60800.0);
+    EXPECT_DOUBLE_EQ(eop.xp_arcsec, 0.10);
+    EXPECT_DOUBLE_EQ(eop.yp_arcsec, 0.30);
+    EXPECT_DOUBLE_EQ(eop.ut1_minus_utc_seconds, -0.20);
+}
+
+TEST(IersEopTable, LinearInterpolationAtMidpoint) {
+    std::vector<EopRecord> recs = {
+        EopRecord{60800.0, 0.10, 0.30, -0.20, 0.0, 0.0, 0.0},
+        EopRecord{60801.0, 0.12, 0.32, -0.18, 0.0, 0.0, 0.0},
+    };
+    EopTable table(std::move(recs));
+
+    auto eop = table.interpolateAt(60800.5);
+    EXPECT_NEAR(eop.xp_arcsec, 0.11, 1e-12);
+    EXPECT_NEAR(eop.yp_arcsec, 0.31, 1e-12);
+    EXPECT_NEAR(eop.ut1_minus_utc_seconds, -0.19, 1e-12);
+}
+
+TEST(IersEopTable, OutOfRangeThrows) {
+    std::vector<EopRecord> recs = {
+        EopRecord{60800.0, 0.10, 0.30, -0.20, 0.0, 0.0, 0.0},
+        EopRecord{60801.0, 0.12, 0.32, -0.18, 0.0, 0.0, 0.0},
+    };
+    EopTable table(std::move(recs));
+    EXPECT_THROW(table.interpolateAt(60799.5), std::out_of_range);
+    EXPECT_THROW(table.interpolateAt(60802.0), std::out_of_range);
+}
+
+TEST(IersEopTable, LeapSecondSnapForUt1Minus) {
+    // Pre-leap dut1 = +0.4 s, post-leap dut1 = -0.6 s (1-s step).
+    // xp/yp are continuous and should still interpolate.
+    std::vector<EopRecord> recs = {
+        EopRecord{60800.0, 0.10, 0.30, +0.4, 0.0, 0.0, 0.0},
+        EopRecord{60801.0, 0.20, 0.40, -0.6, 0.0, 0.0, 0.0},
+    };
+    EopTable table(std::move(recs));
+
+    // Slightly before midpoint → snap to lower (pre-leap).
+    auto a = table.interpolateAt(60800.49);
+    EXPECT_DOUBLE_EQ(a.ut1_minus_utc_seconds, +0.4);
+    EXPECT_NEAR(a.xp_arcsec, 0.10 + 0.49 * 0.10, 1e-12);
+
+    // Past midpoint → snap to upper (post-leap).
+    auto b = table.interpolateAt(60800.6);
+    EXPECT_DOUBLE_EQ(b.ut1_minus_utc_seconds, -0.6);
+    EXPECT_NEAR(b.xp_arcsec, 0.10 + 0.60 * 0.10, 1e-12);
+}
+
+TEST(IersEopTable, ParseC04FixedWidthFixture) {
+    // Real IERS 20 C04 lines (header comments + two daily samples).
+    const std::string fixture =
+        "# EARTH ORIENTATION PARAMETER (EOP) PRODUCT CENTER ...\n"
+        "# EOP (IERS) 20 C04 TIME SERIES  consistent with ITRF 2020\n"
+        "# YR  MM  DD  HH       MJD        x(\")        y(\")  UT1-UTC(s) "
+        "      dX(\")       dY(\")  xrt(\"/day)  yrt(\"/day)      LOD(s)\n"
+        "1962   1   1   0  37665.00   -0.012700    0.213000   0.0326338"
+        "    0.000000    0.000000    0.000000    0.000000   0.0017230"
+        "    0.030000    0.030000   0.0020000    0.004774    0.002000\n"
+        "1962   1   2   0  37666.00   -0.015900    0.214100   0.0320547"
+        "    0.000000    0.000000    0.000000    0.000000   0.0016690"
+        "    0.030000    0.030000   0.0020000    0.004774    0.002000\n";
+    const std::string path = writeTempFile(fixture);
+    ASSERT_FALSE(path.empty());
+
+    auto table = EopTable::fromC04File(path);
+    std::remove(path.c_str());
+
+    ASSERT_EQ(table.size(), 2u);
+    EXPECT_DOUBLE_EQ(table.firstMjd(), 37665.0);
+    EXPECT_DOUBLE_EQ(table.lastMjd(), 37666.0);
+
+    auto eop = table.interpolateAt(37665.0);
+    EXPECT_NEAR(eop.xp_arcsec, -0.012700, 1e-9);
+    EXPECT_NEAR(eop.yp_arcsec, 0.213000, 1e-9);
+    EXPECT_NEAR(eop.ut1_minus_utc_seconds, 0.0326338, 1e-9);
+}
+
+TEST(IersEopTable, FromC04FileMissingFileThrows) {
+    EXPECT_THROW(
+        EopTable::fromC04File("/this/path/does/not/exist/eopc04.txt"),
+        std::runtime_error);
+}


### PR DESCRIPTION
## Summary

Phase D-0 of the IERS Conventions 2010 integration: a strictly additive scaffold that lets PPPProcessor load an IERS 20 C04 EOP series and look up interpolated `EarthOrientationParams` at any GNSSTime epoch.

**No PPP code path consumes the table yet** — that wiring arrives in Phase D-1 (pole tide) and D-2 (sub-daily EOP), each gated by their own opt-in feature flag. This PR exists so D-1 / D-2 can land as small, focused PRs without bundling EOP-loading infrastructure into them.

## What's added

- `libgnss::iers::EopRecord` / `EopTable` (`iers/eop_table.{hpp,cpp}`)
  - Linear interpolation between daily samples
  - UT1-UTC leap-second step (|Δ| > 0.5 s) detected → snaps to the nearer sample for UT1-UTC only; xp/yp stay continuously interpolated
  - Out-of-range epochs throw `std::out_of_range`
- `PPPConfig::eop_path` (string, default empty). When non-empty, `PPPProcessor::initialize()` loads the file.
- `PPPProcessor::loadEopC04(path)`, `hasEopTable()`, `getEarthOrientationParams(GNSSTime)`. The getter returns a zero-EOP struct (rigid-body approximation) when no table is loaded, so existing callers stay source-compatible.
- `gnss_ppp` CLI flag `--eop-c04 <eopc04.txt>`. `apps/gnss.py`'s "binary" dispatch forwards it transparently.
- 6 new unit tests (`test_iers_eop.cpp`)

## Bench evidence

TSKB 2026-04-15, IGS final SP3+CLK from BKG mirror, real `eopc04.1962-now` from `hpiers.obspm.fr`:

```
md5sum  no_eop.pos  c2db4cb3cd5629d9a9fdcc981819266d
md5sum  with_eop.pos c2db4cb3cd5629d9a9fdcc981819266d   ← identical
diff -q no_eop.pos with_eop.pos  → IDENTICAL
```

Confirms the scaffold does not perturb existing PPP behavior.

## EOP source for users

  https://hpiers.obspm.fr/iers/eop/eopc04/eopc04.1962-now

Auth-free, IAU 2000 / ITRF2020-consistent, daily samples 1962-now.

## Test plan

- [x] `IersEopTable.*` — 6/6 pass (exact lookup, midpoint interpolation, out-of-range throws, leap-second snap, real C04 fixed-width parse, missing-file handles)
- [x] Full `run_tests` green (242 pass, 35 skipped data-gated)
- [x] `gnss_ppp` `--help` shows `--eop-c04` with scaffold scope note
- [x] PPP smoke run: TSKB 2026-04-15 with vs without `--eop-c04` → bit-identical
- [x] Bogus `--eop-c04 /nonexistent` → init fails with clear message (no crash)
- [ ] CI green (will appear after push)

## Follow-ups (not in this PR)

- **Phase D-1**: pole tide opt-in (closed-form ~30 LOC + selector flag, consumes this scaffold)
- **Phase D-2**: sub-daily EOP corrections (consumes this scaffold)
- **Phase D-3**: atmospheric loading (independent — gridded data, not EOP)