### PR TITLE
EopTable: parse IERS Bulletin A finals2000A.daily (Phase D-0 ext, stacked on #63)

### DIFF
--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -121,11 +121,17 @@ void printUsage(const char* program_name) {
         << "                          Step-1-only built-in approximation. Opt-in pending\n"
         << "                          truth-bench validation. See docs/iers-integration-plan.md\n"
         << "  --no-iers-solid-tide    Use the built-in Step-1-only solid-earth-tide model (default)\n"
-        << "  --eop-c04 <eopc04.txt>   IERS 20 C04 Earth Orientation Parameter file (daily samples).\n"
-        << "                          Loaded into PPPProcessor for downstream IERS Phase D consumers\n"
-        << "                          (pole tide, sub-daily EOP). Phase D-0 scaffolding only — does\n"
-        << "                          not change PPP output until D-1+ feature flags are enabled.\n"
-        << "                          Source: https://hpiers.obspm.fr/iers/eop/eopc04/eopc04.1962-now\n"
+        << "  --eop-c04 <eop-file>     IERS Earth Orientation Parameter file (daily samples).\n"
+        << "                          Format auto-detected: IERS 20 C04 (final values, ~1-week\n"
+        << "                          publication lag) or IERS Bulletin A finals2000A.daily\n"
+        << "                          (combined observed + predicted, extends ~12 months ahead).\n"
+        << "                          Loaded into PPPProcessor for downstream IERS Phase D\n"
+        << "                          consumers (pole tide, sub-daily EOP).\n"
+        << "                          Sources:\n"
+        << "                            C04         https://hpiers.obspm.fr/iers/eop/eopc04/eopc04.1962-now\n"
+        << "                            Bulletin A  https://maia.usno.navy.mil/ser7/finals2000A.daily\n"
+        << "  --eop-bulletin-a <file>  Alias for --eop-c04 (the auto-detector accepts both formats\n"
+        << "                          via either flag; this alias clarifies intent at the call site).\n"
         << "  --use-iers-pole-tide     Apply the IERS Conventions 2010 §7.1.4 pole-tide station\n"
         << "                          displacement (Phase D-1). Requires --eop-c04 to be set;\n"
         << "                          otherwise the displacement is silently skipped because\n"
@@ -236,7 +242,8 @@ Options parseArguments(int argc, char* argv[]) {
             options.use_iers_solid_tide = true;
         } else if (arg == "--no-iers-solid-tide") {
             options.use_iers_solid_tide = false;
-        } else if (arg == "--eop-c04" && i + 1 < argc) {
+        } else if ((arg == "--eop-c04" || arg == "--eop-bulletin-a")
+                   && i + 1 < argc) {
             options.eop_c04_file = argv[++i];
         } else if (arg == "--use-iers-pole-tide") {
             options.use_iers_pole_tide = true;

--- a/docs/iers-integration-plan.md
+++ b/docs/iers-integration-plan.md
@@ -245,14 +245,23 @@ does not block Phase C:
   with native libgnss++ time-type adaptation. Re-uses the BLQ
   parser already present in libgnss++.
 - **Phase D-0** *(in progress)*: EOP plumbing scaffolding.
-  Adds `libgnss::iers::EopTable` (IERS 20 C04 daily series with
-  linear interpolation and leap-second snap on UT1-UTC) and a
-  `PPPConfig::eop_path` / `--eop-c04` CLI knob. PPPProcessor
-  loads the table on init and exposes
-  `getEarthOrientationParams(GNSSTime)`. No PPP code path consumes
-  the table yet — D-0 is a strictly additive scaffold for D-1+
-  (pole tide and sub-daily EOP). Output is bit-identical to the
-  no-EOP baseline.
+  Adds `libgnss::iers::EopTable` (daily series with linear
+  interpolation and leap-second snap on UT1-UTC) and a
+  `PPPConfig::eop_path` / `--eop-c04` CLI knob. PPPProcessor loads
+  the table on init and exposes `getEarthOrientationParams(GNSSTime)`.
+  No PPP code path consumes the table yet — D-0 is a strictly
+  additive scaffold for D-1+ (pole tide and sub-daily EOP). Output
+  is bit-identical to the no-EOP baseline.
+
+  Two upstream formats are supported, auto-detected at load time:
+  (1) **IERS 20 C04** (Paris Observatory `eopc04.1962-now`) — the
+  canonical final-values series, ITRF2020-consistent, ~1-week
+  publication lag. (2) **IERS Bulletin A** (`finals2000A.daily` from
+  USNO maia.usno.navy.mil) — combined observed (`I`) and predicted
+  (`P`) rows, the prediction extending ~12 months past the last
+  observed epoch and filling the C04 publication-lag gap. Bulletin A
+  is the recommended source for benches that need fresh real-data
+  EOP coverage of the previous month or two.
 - **Phase D-1** *(in progress)*: Pole tide (IERS Conventions 2010
   §7.1.4) opt-in. Adds `libgnss::iers::poleTideDisplacement` (post-2018
   IERS linear mean-pole secular drift + Sr/Sθ/Sλ Stokes formulation)

--- a/include/libgnss++/iers/eop_table.hpp
+++ b/include/libgnss++/iers/eop_table.hpp
@@ -2,15 +2,22 @@
 
 // libgnss++/iers/eop_table.hpp
 //
-// In-memory IERS Earth Orientation Parameter (EOP) series, loaded from
-// an IERS 20 C04 file (daily samples at 0h UTC, ITRF2020-consistent).
+// In-memory IERS Earth Orientation Parameter (EOP) series. Two
+// auth-free upstream formats are supported:
 //
-// The canonical auth-free source is the Paris Observatory:
-//   https://hpiers.obspm.fr/iers/eop/eopc04/eopc04.1962-now
+//   1. IERS 20 C04 daily series, IAU 2000 / ITRF2020-consistent.
+//      Source: https://hpiers.obspm.fr/iers/eop/eopc04/eopc04.1962-now
+//      Final values; published with ~1 week lag relative to the epoch.
 //
-// This is the Phase D-0 scaffolding piece of the IERS Conventions 2010
-// integration: PPP itself does not yet consume the table — that wiring
-// arrives in Phase D-1 (pole tide) and Phase D-2 (sub-daily EOP).
+//   2. IERS Bulletin A (USNO `finals2000A.daily`).
+//      Source: https://maia.usno.navy.mil/ser7/finals2000A.daily
+//      Combined observed (`I` flag) + predicted (`P` flag) rows;
+//      predictions extend ~12 months past the last observed epoch,
+//      filling the C04 publication-lag gap.
+//
+// `EopTable::fromFile()` auto-detects which format is on disk and
+// dispatches to the appropriate parser. Callers that want to be
+// explicit can use the format-specific factories.
 
 #include <cstddef>
 #include <string>
@@ -51,6 +58,27 @@ class EopTable {
 public:
     /// @brief Parse an IERS C04 fixed-width file. Comment lines (`#`) are skipped.
     static EopTable fromC04File(const std::string& path);
+
+    /// @brief Parse an IERS Bulletin A `finals2000A.daily` file.
+    ///
+    /// Per-row format (187-char fixed-width): year, month, day, MJD,
+    /// `I`/`P` flag, polar motion (xp, yp ± errors), `I`/`P` flag,
+    /// UT1-UTC ± error, LOD ± error, nutation flags + dX/dY...
+    /// libgnss::iers consumers only need MJD + xp + yp + UT1-UTC, so
+    /// LOD / dX / dY are dropped at parse time.
+    ///
+    /// Both observed (`I`) and predicted (`P`) rows are kept — the
+    /// prediction extension is the value-add over IERS 20 C04 here.
+    static EopTable fromBulletinAFile(const std::string& path);
+
+    /// @brief Auto-detect format and dispatch.
+    ///
+    /// Detection rule: if the first non-`#` non-empty data row has
+    /// an `I`/`P`/`b` flag character at column 17 (1-indexed), the
+    /// file is treated as Bulletin A; otherwise it is parsed as C04.
+    /// The two formats are unambiguous in practice — C04 has all
+    /// numeric columns where Bulletin A has its flag character.
+    static EopTable fromFile(const std::string& path);
 
     /// @brief Construct directly from a list of records (used by tests).
     /// Records do not need to be pre-sorted.

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -1251,8 +1251,12 @@ bool PPPProcessor::loadEopC04(const std::string& path) {
         return false;
     }
     try {
+        // Auto-detect IERS C04 vs Bulletin A. Both formats are
+        // accepted on the same `--eop-c04` CLI knob; the discriminator
+        // is the `I`/`P` flag character at fixed columns in Bulletin
+        // A (C04 has numeric data in those columns).
         eop_table_ = std::make_unique<libgnss::iers::EopTable>(
-            libgnss::iers::EopTable::fromC04File(path));
+            libgnss::iers::EopTable::fromFile(path));
     } catch (const std::exception&) {
         eop_table_.reset();
         return false;

--- a/src/iers/eop_table.cpp
+++ b/src/iers/eop_table.cpp
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdlib>
 #include <fstream>
 #include <sstream>
 #include <stdexcept>
@@ -32,6 +33,58 @@ bool tryParseC04Row(const std::string& line, EopRecord& out) {
     return true;
 }
 
+// Fixed-width column offsets (0-indexed) for IERS Bulletin A
+// `finals2000A.daily`. Lines are 187 chars; the value fields we
+// consume are stable across the IERS-published release history.
+constexpr std::size_t kBulletinAMinLineSize    = 78;
+constexpr std::size_t kBulletinAPoleFlagCol    = 16;
+constexpr std::size_t kBulletinAUt1FlagCol     = 57;
+constexpr std::size_t kBulletinAMjdCol         = 7;
+constexpr std::size_t kBulletinAMjdLen         = 8;
+constexpr std::size_t kBulletinAXpCol          = 18;
+constexpr std::size_t kBulletinAYpCol          = 37;
+constexpr std::size_t kBulletinAUt1Col         = 58;
+constexpr std::size_t kBulletinAFloatLen       = 10;
+
+bool isBulletinAFlag(char c) {
+    return c == 'I' || c == 'P' || c == ' ' || c == 'b';
+}
+
+bool tryParseBulletinARow(const std::string& line, EopRecord& out) {
+    if (line.size() < kBulletinAMinLineSize) {
+        return false;
+    }
+    const char pole_flag = line[kBulletinAPoleFlagCol];
+    const char ut1_flag = line[kBulletinAUt1FlagCol];
+    // Bulletin A uses `I` for IERS observed and `P` for predicted;
+    // a blank/`b` flag indicates a missing value, in which case we
+    // skip the row.
+    if (pole_flag != 'I' && pole_flag != 'P') return false;
+    if (ut1_flag != 'I' && ut1_flag != 'P') return false;
+
+    out.mjd_utc = std::atof(line.substr(kBulletinAMjdCol, kBulletinAMjdLen).c_str());
+    if (out.mjd_utc < 30000.0 || out.mjd_utc > 100000.0) {
+        return false;
+    }
+    out.xp_arcsec  = std::atof(line.substr(kBulletinAXpCol,  kBulletinAFloatLen).c_str());
+    out.yp_arcsec  = std::atof(line.substr(kBulletinAYpCol,  kBulletinAFloatLen).c_str());
+    out.ut1_minus_utc_seconds =
+        std::atof(line.substr(kBulletinAUt1Col, kBulletinAFloatLen).c_str());
+    out.lod_seconds = 0.0;
+    out.dx_arcsec   = 0.0;
+    out.dy_arcsec   = 0.0;
+    return true;
+}
+
+bool looksLikeBulletinA(const std::string& line) {
+    // Bulletin A lines are 187 chars and have an `I`/`P`/blank flag
+    // at column 17 (0-indexed 16). C04 lines are >= 100 chars but
+    // have a digit, sign, or decimal point in that column.
+    if (line.size() < kBulletinAMinLineSize) return false;
+    return isBulletinAFlag(line[kBulletinAPoleFlagCol])
+        && isBulletinAFlag(line[kBulletinAUt1FlagCol]);
+}
+
 }  // namespace
 
 EopTable EopTable::fromC04File(const std::string& path) {
@@ -52,6 +105,45 @@ EopTable EopTable::fromC04File(const std::string& path) {
             "EopTable::fromC04File: no data rows parsed from " + path);
     }
     return EopTable(std::move(records));
+}
+
+EopTable EopTable::fromBulletinAFile(const std::string& path) {
+    std::ifstream in(path);
+    if (!in) {
+        throw std::runtime_error(
+            "EopTable::fromBulletinAFile: cannot open " + path);
+    }
+    std::vector<EopRecord> records;
+    std::string line;
+    while (std::getline(in, line)) {
+        EopRecord rec{};
+        if (tryParseBulletinARow(line, rec)) {
+            records.push_back(rec);
+        }
+    }
+    if (records.empty()) {
+        throw std::runtime_error(
+            "EopTable::fromBulletinAFile: no data rows parsed from " + path);
+    }
+    return EopTable(std::move(records));
+}
+
+EopTable EopTable::fromFile(const std::string& path) {
+    std::ifstream in(path);
+    if (!in) {
+        throw std::runtime_error("EopTable::fromFile: cannot open " + path);
+    }
+    std::string line;
+    while (std::getline(in, line)) {
+        if (line.empty() || line[0] == '#') continue;
+        if (looksLikeBulletinA(line)) {
+            return fromBulletinAFile(path);
+        }
+        // First non-comment line did not match Bulletin A — assume C04.
+        return fromC04File(path);
+    }
+    throw std::runtime_error(
+        "EopTable::fromFile: file is empty or contains only comments: " + path);
 }
 
 EopTable::EopTable(std::vector<EopRecord> records) : records_(std::move(records)) {

--- a/tests/test_iers_eop.cpp
+++ b/tests/test_iers_eop.cpp
@@ -128,3 +128,99 @@ TEST(IersEopTable, FromC04FileMissingFileThrows) {
         EopTable::fromC04File("/this/path/does/not/exist/eopc04.txt"),
         std::runtime_error);
 }
+
+// --- Bulletin A finals2000A.daily parser ----------------------------
+
+TEST(IersEopTable, ParseBulletinAFixedWidthFixture) {
+    // Two real `finals2000A.daily` rows (USNO format, 187 chars each;
+    // the trailing portion past the UT1-UTC error is truncated for
+    // brevity — the parser only consumes the first ~78 cols).
+    const std::string fixture =
+        "26 2 8 61079.00 I  0.093941 0.000018  0.369169 0.000019  I 0.0671873 0.0000113\n"
+        "26 4 8 61138.00 I  0.137078 0.000086  0.413609 0.000080  I 0.0477569 0.0000158\n";
+    const std::string path = writeTempFile(fixture);
+    ASSERT_FALSE(path.empty());
+
+    auto table = EopTable::fromBulletinAFile(path);
+    std::remove(path.c_str());
+
+    ASSERT_EQ(table.size(), 2u);
+    EXPECT_DOUBLE_EQ(table.firstMjd(), 61079.0);
+    EXPECT_DOUBLE_EQ(table.lastMjd(), 61138.0);
+
+    auto eop_first = table.interpolateAt(61079.0);
+    EXPECT_NEAR(eop_first.xp_arcsec, 0.093941, 1e-9);
+    EXPECT_NEAR(eop_first.yp_arcsec, 0.369169, 1e-9);
+    EXPECT_NEAR(eop_first.ut1_minus_utc_seconds, 0.0671873, 1e-9);
+
+    auto eop_last = table.interpolateAt(61138.0);
+    EXPECT_NEAR(eop_last.xp_arcsec, 0.137078, 1e-9);
+    EXPECT_NEAR(eop_last.yp_arcsec, 0.413609, 1e-9);
+    EXPECT_NEAR(eop_last.ut1_minus_utc_seconds, 0.0477569, 1e-9);
+}
+
+TEST(IersEopTable, BulletinAKeepsObservedAndPredictedRows) {
+    // An `I`-flagged observed row immediately followed by a
+    // `P`-flagged predicted row. Both should make it into the table.
+    const std::string fixture =
+        "26 4 8 61138.00 I  0.137078 0.000086  0.413609 0.000080  I 0.0477569 0.0000158\n"
+        "26 4 9 61139.00 P  0.138900 0.000100  0.413700 0.000100  P 0.0476800 0.0000200\n";
+    const std::string path = writeTempFile(fixture);
+    ASSERT_FALSE(path.empty());
+
+    auto table = EopTable::fromBulletinAFile(path);
+    std::remove(path.c_str());
+
+    ASSERT_EQ(table.size(), 2u);
+    auto eop_pred = table.interpolateAt(61139.0);
+    EXPECT_NEAR(eop_pred.xp_arcsec, 0.138900, 1e-9);
+}
+
+TEST(IersEopTable, BulletinASkipsBlankFlagRows) {
+    // Some Bulletin A trailing lines have a blank flag (no value
+    // available yet). They must not be silently inserted as zeros.
+    const std::string fixture =
+        "26 4 8 61138.00 I  0.137078 0.000086  0.413609 0.000080  I 0.0477569 0.0000158\n"
+        "26 9 1 61285.00                                                                \n"
+        "26 9 2 61286.00 P  0.211000 0.008000  0.350000 0.011000  P 0.0700000 0.0090000\n";
+    const std::string path = writeTempFile(fixture);
+    ASSERT_FALSE(path.empty());
+
+    auto table = EopTable::fromBulletinAFile(path);
+    std::remove(path.c_str());
+    EXPECT_EQ(table.size(), 2u);  // blank-flag row dropped
+}
+
+TEST(IersEopTable, FromFileAutoDetectsBulletinA) {
+    const std::string fixture =
+        "26 4 8 61138.00 I  0.137078 0.000086  0.413609 0.000080  I 0.0477569 0.0000158\n"
+        "26 4 9 61139.00 P  0.138900 0.000100  0.413700 0.000100  P 0.0476800 0.0000200\n";
+    const std::string path = writeTempFile(fixture);
+    ASSERT_FALSE(path.empty());
+
+    auto table = EopTable::fromFile(path);
+    std::remove(path.c_str());
+    ASSERT_EQ(table.size(), 2u);
+    EXPECT_DOUBLE_EQ(table.firstMjd(), 61138.0);
+}
+
+TEST(IersEopTable, FromFileAutoDetectsC04) {
+    const std::string fixture =
+        "# EOP (IERS) 20 C04 TIME SERIES\n"
+        "1962   1   1   0  37665.00   -0.012700    0.213000   0.0326338"
+        "    0.000000    0.000000    0.000000    0.000000   0.0017230"
+        "    0.030000    0.030000   0.0020000    0.004774    0.002000\n";
+    const std::string path = writeTempFile(fixture);
+    ASSERT_FALSE(path.empty());
+
+    auto table = EopTable::fromFile(path);
+    std::remove(path.c_str());
+    ASSERT_EQ(table.size(), 1u);
+    EXPECT_DOUBLE_EQ(table.firstMjd(), 37665.0);
+}
+
+TEST(IersEopTable, FromBulletinAFileMissingFileThrows) {
+    EXPECT_THROW(
+        EopTable::fromBulletinAFile("/nonexistent/finals2000A.daily"),
+        std::runtime_error);
+}


### PR DESCRIPTION
## Summary

Phase D-0 extension. The IERS 20 C04 series has a ~1-week publication lag, which exceeded the 2026-04-15 TSKB bench window in #63 (the bench was driven by extrapolated EOP rather than real values). USNO `finals2000A.daily` (Bulletin A) carries observed and predicted rows side-by-side and is the standard auth-free way to fill the C04 publication-lag gap.

Stacked on #63.

## What's added

- `libgnss::iers::EopTable::fromBulletinAFile(path)` — explicit Bulletin A parser (187-char fixed-width format; drops blank-flag rows; keeps both observed `I` and predicted `P`).
- `libgnss::iers::EopTable::fromFile(path)` — auto-detecting factory. Discriminator: `I`/`P`/blank at col 17 of the first non-comment line.
- `PPPProcessor::loadEopC04` now calls `fromFile()`. Same `--eop-c04` CLI knob accepts either format.
- `--eop-bulletin-a <file>` CLI alias for clarity at the call site (no semantic change).
- 6 new unit tests.

## Bench evidence

Re-ran the PR #63 pole-tide bench harness on TSKB 2026-04-15, swapping the linearly-extrapolated C04 file (used in #63 because real C04 didn't cover the bench day) for the real Bulletin A `finals2000A.daily`:

| metric | real Bulletin A | extrapolated C04 | delta |
|---|---|---|---|
| max_displacement_m | 0.000893 | 0.000951 | −6% |
| p95_displacement_m | 0.000388 | 0.000416 | −7% |
| median_displacement_m | 0.000384 | 0.000411 | −7% |
| median_dx_m | +0.000280 | +0.000300 | −0.020 mm |
| median_dy_m | −0.000176 | −0.000186 | −0.010 mm |
| median_dz_m | −0.000196 | −0.000209 | −0.013 mm |
| aggregate_to_first_epoch_ratio | 216.5 | 230.5 | −14 |

The 5-7% magnitude shift is consistent with the synthetic xp slope being replaced by the real ~0.001-arcsec/day rate observed in Bulletin A. All component signs agree. Bulletin A is now the recommended source for D-1+ benches.

## Test plan

- [x] `IersEopTable.*` — 12/12 pass (6 existing + 6 new):
  - Bulletin A fixed-width parse
  - Bulletin A observed-and-predicted retention
  - Bulletin A blank-flag row rejection
  - `fromFile` auto-detects Bulletin A
  - `fromFile` auto-detects C04
  - Bulletin A missing-file error
- [x] Full `run_tests` green (253 pass, 35 skipped data-gated)
- [x] `gnss_ppp` end-to-end on TSKB 2026-04-15 with `--eop-c04 finals2000A.daily` → auto-detect kicks in, pole tide path activates correctly
- [ ] CI green (will appear after retarget to develop, since `pull_request: branches: [main, develop]` only triggers on direct PRs against develop)

## Source URL

- C04: `https://hpiers.obspm.fr/iers/eop/eopc04/eopc04.1962-now`
- Bulletin A: `https://maia.usno.navy.mil/ser7/finals2000A.daily`

Both are auth-free; CDDIS / IGN are unreachable from this network.