### PR TITLE
PPP: opt-in IERS Conventions 2010 atmospheric tidal loading (Phase D-3, stacked on #65)

### DIFF
--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -55,6 +55,8 @@ struct Options {
     std::string eop_c04_file;
     bool use_iers_pole_tide = false;
     bool use_iers_sub_daily_eop = false;
+    std::string atm_tidal_loading_file;
+    bool use_iers_atm_tidal_loading = false;
     bool quiet = false;
 };
 
@@ -145,6 +147,17 @@ void printUsage(const char* program_name) {
         << "                          Peak amplitudes ~0.5 mas in xp/yp and ~30 µs in UT1; PPP\n"
         << "                          receiver-position effect is sub-mm.\n"
         << "  --no-iers-sub-daily-eop  Skip the sub-daily EOP corrections (default)\n"
+        << "  --atm-tidal-loading <file>\n"
+        << "                          Per-site S1/S2 atmospheric tidal-loading coefficient file\n"
+        << "                          (Phase D-3). Custom format with $$ comment lines + S1 / S2\n"
+        << "                          rows of 6 numbers each (radial/west/south amplitudes in m,\n"
+        << "                          radial/west/south phases in deg). Required for the\n"
+        << "                          --use-iers-atm-tidal-loading flag to do anything.\n"
+        << "  --use-iers-atm-tidal-loading\n"
+        << "                          Apply the IERS Conventions 2010 §7.1.5 atmospheric tidal\n"
+        << "                          loading station displacement (S1 + S2). Peak ~1 mm radial.\n"
+        << "  --no-iers-atm-tidal-loading\n"
+        << "                          Skip atmospheric tidal loading (default).\n"
         << "  --quiet                  Suppress per-run summary output\n"
         << "  -h, --help               Show this help\n";
 }
@@ -261,6 +274,12 @@ Options parseArguments(int argc, char* argv[]) {
             options.use_iers_sub_daily_eop = true;
         } else if (arg == "--no-iers-sub-daily-eop") {
             options.use_iers_sub_daily_eop = false;
+        } else if (arg == "--atm-tidal-loading" && i + 1 < argc) {
+            options.atm_tidal_loading_file = argv[++i];
+        } else if (arg == "--use-iers-atm-tidal-loading") {
+            options.use_iers_atm_tidal_loading = true;
+        } else if (arg == "--no-iers-atm-tidal-loading") {
+            options.use_iers_atm_tidal_loading = false;
         } else if (arg == "--quiet") {
             options.quiet = true;
         } else {
@@ -612,6 +631,8 @@ int main(int argc, char* argv[]) {
         ppp_config.eop_path = options.eop_c04_file;
         ppp_config.use_iers_pole_tide = options.use_iers_pole_tide;
         ppp_config.use_iers_sub_daily_eop = options.use_iers_sub_daily_eop;
+        ppp_config.atm_tidal_loading_path = options.atm_tidal_loading_file;
+        ppp_config.use_iers_atm_tidal_loading = options.use_iers_atm_tidal_loading;
         if (options.low_dynamics_mode) {
             ppp_config.reset_clock_to_spp_each_epoch = false;
             ppp_config.reset_kinematic_position_to_spp_each_epoch = false;

--- a/docs/iers-integration-plan.md
+++ b/docs/iers-integration-plan.md
@@ -297,8 +297,22 @@ does not block Phase C:
   on top of the pole tide is RMS 1.5 µm in Z (0.17% relative
   perturbation, matching the daily-vs-sub-daily xp/yp amplitude
   ratio). Default off.
-- **Phase D-3**: Atmospheric loading. Smaller cm-level effect; needs
-  a separate gridded-data ingestion path, independent of EOP.
+- **Phase D-3** *(in progress)*: Atmospheric tidal loading (IERS
+  Conventions 2010 §7.1.5) opt-in. Adds
+  `libgnss::iers::atmosphericTidalLoadingDisplacement` and the
+  `AtmosphericTidalLoadingCoefficients` struct (S1 + S2 amplitudes
+  / phases × 3 components). PPP wires via
+  `PPPConfig::use_iers_atm_tidal_loading` + `atm_tidal_loading_path`
+  with `--use-iers-atm-tidal-loading` / `--atm-tidal-loading <file>`
+  CLI knobs. Per-site coefficient file format mirrors the BLQ
+  pattern but with only S1 / S2 rows (mid-latitude peak ~1 mm
+  radial). The non-tidal pressure-loading component (which
+  dominates at storm-driven sites) requires a gridded reanalysis
+  ingestion path and is deferred to a follow-up PR. At TSKB
+  2026-04-15 with synthetic mid-latitude coastal coefficients
+  (S1 = 0.8 mm radial, S2 = 0.4 mm radial), the PPP estimate
+  shifts by mean −10.6 µm / RMS 106 µm in Z. Default off pending
+  real TU Wien per-site coefficients.
 - **`icrsToItrs` consumers**: when satellite-side processing
   (LEO orbits, external SP3 ingestion in non-ECEF frames, attitude
   for satellite antenna PCO/PCV) is wired up, the wrapper is

--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -11,6 +11,7 @@
 #include "ppp_osr_types.hpp"
 #include "spp.hpp"
 #include "../iers/eop_table.hpp"
+#include "../iers/tides.hpp"
 #include <Eigen/Dense>
 #include <array>
 #include <memory>
@@ -216,6 +217,8 @@ private:
     OceanLoadingCoefficients ocean_loading_coefficients_{};
     bool ocean_loading_loaded_ = false;
     std::unique_ptr<iers::EopTable> eop_table_;
+    iers::AtmosphericTidalLoadingCoefficients atm_tidal_loading_coefficients_{};
+    bool atm_tidal_loading_loaded_ = false;
     std::map<std::string, std::map<SignalType, Vector3d>> receiver_antex_offsets_;
     bool receiver_antex_loaded_ = false;
     Vector3d static_anchor_position_ = Vector3d::Zero();
@@ -428,6 +431,29 @@ private:
      */
     Vector3d calculatePoleTide(const Vector3d& position,
                                const GNSSTime& time) const;
+
+    /**
+     * @brief Calculate IERS atmospheric tidal loading (Phase D-3).
+     *
+     * Returns Vector3d::Zero() when no atmospheric tidal-loading
+     * coefficient file is loaded. Caller is responsible for gating
+     * on `ppp_config_.use_iers_atm_tidal_loading`.
+     */
+    Vector3d calculateAtmosphericTidalLoading(const Vector3d& position,
+                                              const GNSSTime& time) const;
+
+    /**
+     * @brief Load per-site S1+S2 atmospheric tidal loading coefficients.
+     *
+     * File format: comment lines starting with `$$`; data block of
+     * one site:
+     *   <station_name>
+     *   S1 <radial_amp_m> <west_amp_m> <south_amp_m>
+     *      <radial_phase_deg> <west_phase_deg> <south_phase_deg>
+     *   S2 <radial_amp_m> <west_amp_m> <south_amp_m>
+     *      <radial_phase_deg> <west_phase_deg> <south_phase_deg>
+     */
+    bool loadAtmosphericTidalLoading(const std::string& path);
     
     /**
      * @brief Form measurement equations

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -205,6 +205,15 @@ struct PPPConfig {
     // so the receiver-position effect on PPP is sub-mm; flipping this
     // on tightens the modeled CIP location for IERS-conformant work.
     bool use_iers_sub_daily_eop = false;
+    // IERS Conventions 2010 §7.1.5 atmospheric tidal loading (S1/S2)
+    // station displacement (opt-in). Reads per-site amplitude / phase
+    // coefficients from `atm_tidal_loading_path` and adds the diurnal
+    // (S1) + semi-diurnal (S2) atmospheric pressure tide displacement
+    // to the receiver position. Peak ~1 mm radial at mid- and
+    // low-latitudes; sub-mm horizontal. Default off; requires the
+    // coefficient file. Without a loaded file, the path is a no-op.
+    bool use_iers_atm_tidal_loading = false;
+    std::string atm_tidal_loading_path;
     bool apply_relativity = true;
 
     // Convergence criteria

--- a/include/libgnss++/iers/tides.hpp
+++ b/include/libgnss++/iers/tides.hpp
@@ -11,6 +11,8 @@
 // ~30 cm radial, ~10 cm horizontal). Ignoring it sets a hard floor
 // on PPP positioning accuracy.
 
+#include <array>
+
 #include <Eigen/Dense>
 
 #include "libgnss++/core/types.hpp"
@@ -97,5 +99,48 @@ Eigen::Vector3d poleTideDisplacement(
     double mjd_utc,
     const Eigen::Vector3d& xsta_itrs,
     const EarthOrientationParams& eop);
+
+/// @brief Atmospheric tidal loading coefficients for one site (S1+S2).
+///
+/// Per IERS Conventions 2010 §7.1.5: the atmospheric tide loading
+/// signal is dominated by the diurnal S1 (24-h) and semi-diurnal S2
+/// (12-h) constituents. Per-site amplitudes / phase lags can be
+/// pre-computed from a global pressure model + site-specific Green's
+/// function (e.g. by the TU Wien atmospheric loading service).
+///
+/// Convention follows the legacy ocean-loading file format: amplitudes
+/// in metres, phases in degrees with the standard "lag" sign (a
+/// positive phase means the response lags the forcing).
+struct AtmosphericTidalLoadingCoefficients {
+    /// S1 (diurnal) and S2 (semidiurnal) amplitudes / phases.
+    /// Index 0 = S1, 1 = S2.
+    std::array<double, 2> radial_amplitudes_m{};
+    std::array<double, 2> west_amplitudes_m{};
+    std::array<double, 2> south_amplitudes_m{};
+    std::array<double, 2> radial_phases_deg{};
+    std::array<double, 2> west_phases_deg{};
+    std::array<double, 2> south_phases_deg{};
+};
+
+/// @brief Atmospheric tidal-loading station displacement (IERS §7.1.5).
+///
+/// Returns the station displacement due to the diurnal (S1) and
+/// semi-diurnal (S2) atmospheric pressure tide. Peak amplitude at
+/// mid- and low-latitudes is ~1 mm radial; horizontal is sub-mm.
+///
+/// Formula (per component): A_i · cos(2π · t / T_i − φ_i), summed
+/// over i ∈ {S1, S2} where T_S1 = 86400 s and T_S2 = 43200 s. The
+/// `t` argument is GPS-time-derived `seconds since Unix epoch`,
+/// which matches the legacy ocean-loading dispatcher's reference
+/// frame.
+///
+/// @param mjd_utc    UTC modified Julian date of the epoch.
+/// @param xsta_itrs  Station nominal ITRS / ECEF coordinates [m].
+/// @param coeffs     Per-site S1 + S2 amplitudes / phases.
+/// @return Displacement vector [m] in ITRS / ECEF; ADD to xsta_itrs.
+Eigen::Vector3d atmosphericTidalLoadingDisplacement(
+    double mjd_utc,
+    const Eigen::Vector3d& xsta_itrs,
+    const AtmosphericTidalLoadingCoefficients& coeffs);
 
 }  // namespace libgnss::iers

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -905,6 +905,12 @@ bool PPPProcessor::initialize(const ProcessorConfig& config) {
     if (!ppp_config_.eop_path.empty() && !loadEopC04(ppp_config_.eop_path)) {
         return false;
     }
+    atm_tidal_loading_loaded_ = false;
+    atm_tidal_loading_coefficients_ = libgnss::iers::AtmosphericTidalLoadingCoefficients{};
+    if (!ppp_config_.atm_tidal_loading_path.empty() &&
+        !loadAtmosphericTidalLoading(ppp_config_.atm_tidal_loading_path)) {
+        return false;
+    }
     return true;
 }
 
@@ -1263,6 +1269,54 @@ bool PPPProcessor::loadEopC04(const std::string& path) {
         return false;
     }
     return true;
+}
+
+bool PPPProcessor::loadAtmosphericTidalLoading(const std::string& path) {
+    atm_tidal_loading_coefficients_ =
+        libgnss::iers::AtmosphericTidalLoadingCoefficients{};
+    atm_tidal_loading_loaded_ = false;
+    if (path.empty()) {
+        return false;
+    }
+    std::ifstream in(path);
+    if (!in) {
+        return false;
+    }
+    bool have_s1 = false;
+    bool have_s2 = false;
+    std::string line;
+    while (std::getline(in, line)) {
+        if (line.empty() || line.front() == '$' || line.front() == '#') {
+            continue;
+        }
+        std::istringstream iss(line);
+        std::string tag;
+        iss >> tag;
+        std::size_t idx = 0;
+        if (tag == "S1") {
+            idx = 0;
+        } else if (tag == "S2") {
+            idx = 1;
+        } else {
+            // Anything that is not a comment and not an S1/S2 tag is
+            // assumed to be the station-name line; ignore.
+            continue;
+        }
+        double r_amp = 0.0, w_amp = 0.0, s_amp = 0.0;
+        double r_pha = 0.0, w_pha = 0.0, s_pha = 0.0;
+        if (!(iss >> r_amp >> w_amp >> s_amp >> r_pha >> w_pha >> s_pha)) {
+            return false;
+        }
+        atm_tidal_loading_coefficients_.radial_amplitudes_m[idx] = r_amp;
+        atm_tidal_loading_coefficients_.west_amplitudes_m[idx]   = w_amp;
+        atm_tidal_loading_coefficients_.south_amplitudes_m[idx]  = s_amp;
+        atm_tidal_loading_coefficients_.radial_phases_deg[idx]   = r_pha;
+        atm_tidal_loading_coefficients_.west_phases_deg[idx]     = w_pha;
+        atm_tidal_loading_coefficients_.south_phases_deg[idx]    = s_pha;
+        if (idx == 0) have_s1 = true; else have_s2 = true;
+    }
+    atm_tidal_loading_loaded_ = have_s1 && have_s2;
+    return atm_tidal_loading_loaded_;
 }
 
 libgnss::iers::EarthOrientationParams
@@ -2721,6 +2775,9 @@ Vector3d PPPProcessor::applyGeophysicalCorrections(const Vector3d& position,
     if (ppp_config_.use_iers_pole_tide) {
         corrected += calculatePoleTide(position, time);
     }
+    if (ppp_config_.use_iers_atm_tidal_loading) {
+        corrected += calculateAtmosphericTidalLoading(position, time);
+    }
     return corrected;
 }
 
@@ -2809,6 +2866,17 @@ Vector3d PPPProcessor::calculatePoleTide(const Vector3d& position,
         return Vector3d::Zero();
     }
     return libgnss::iers::poleTideDisplacement(mjd_utc, position, eop);
+}
+
+Vector3d PPPProcessor::calculateAtmosphericTidalLoading(
+    const Vector3d& position, const GNSSTime& time) const {
+    if (!atm_tidal_loading_loaded_ || !position.allFinite() ||
+        position.norm() < constants::WGS84_A * 0.5) {
+        return Vector3d::Zero();
+    }
+    const double mjd_utc = libgnss::iers::gnssTimeToMjdUtc(time);
+    return libgnss::iers::atmosphericTidalLoadingDisplacement(
+        mjd_utc, position, atm_tidal_loading_coefficients_);
 }
 
 PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(

--- a/src/iers/tides.cpp
+++ b/src/iers/tides.cpp
@@ -142,4 +142,70 @@ Eigen::Vector3d poleTideDisplacement(
     return d_ecef;
 }
 
+namespace {
+// MJD reference for converting UTC MJD → seconds since Unix epoch.
+// 1970-01-01 00:00:00 UTC = MJD 40587.
+constexpr double kMjdUnixEpoch        = 40587.0;
+constexpr double kSecondsPerDay       = 86400.0;
+constexpr double kAtmDegreesToRadians = M_PI / 180.0;
+}  // namespace
+
+Eigen::Vector3d atmosphericTidalLoadingDisplacement(
+    double mjd_utc,
+    const Eigen::Vector3d& xsta_itrs,
+    const AtmosphericTidalLoadingCoefficients& coeffs) {
+    // Time argument: seconds since Unix epoch (UTC). Mirrors the legacy
+    // ocean-loading dispatcher in PPPProcessor so the two paths share
+    // a single time reference for paired-comparison benches.
+    const double seconds_since_unix =
+        (mjd_utc - kMjdUnixEpoch) * kSecondsPerDay;
+
+    // S1 = 24 h, S2 = 12 h.
+    constexpr std::array<double, 2> kPeriodsSeconds = {
+        kSecondsPerDay,
+        kSecondsPerDay / 2.0,
+    };
+
+    double up_m = 0.0;
+    double west_m = 0.0;
+    double south_m = 0.0;
+    for (std::size_t i = 0; i < kPeriodsSeconds.size(); ++i) {
+        const double angle =
+            2.0 * M_PI * seconds_since_unix / kPeriodsSeconds[i];
+        up_m    += coeffs.radial_amplitudes_m[i] *
+                   std::cos(angle - coeffs.radial_phases_deg[i] *
+                                     kAtmDegreesToRadians);
+        west_m  += coeffs.west_amplitudes_m[i]   *
+                   std::cos(angle - coeffs.west_phases_deg[i] *
+                                     kAtmDegreesToRadians);
+        south_m += coeffs.south_amplitudes_m[i]  *
+                   std::cos(angle - coeffs.south_phases_deg[i] *
+                                     kAtmDegreesToRadians);
+    }
+
+    // Local (E, N, U) → ECEF; geocentric φ is accurate at sub-mm.
+    const double x = xsta_itrs.x();
+    const double y = xsta_itrs.y();
+    const double z = xsta_itrs.z();
+    const double r_xy = std::sqrt(x * x + y * y);
+    const double phi_g = std::atan2(z, r_xy);
+    const double lambda = std::atan2(y, x);
+    const double sin_phi    = std::sin(phi_g);
+    const double cos_phi    = std::cos(phi_g);
+    const double sin_lambda = std::sin(lambda);
+    const double cos_lambda = std::cos(lambda);
+    const double dE =  -west_m;
+    const double dN =  -south_m;
+    const double dU =   up_m;
+
+    Eigen::Vector3d d_ecef;
+    d_ecef.x() = -sin_lambda * dE - sin_phi * cos_lambda * dN +
+                  cos_phi    * cos_lambda * dU;
+    d_ecef.y() =  cos_lambda * dE - sin_phi * sin_lambda * dN +
+                  cos_phi    * sin_lambda * dU;
+    d_ecef.z() =                     cos_phi    * dN +
+                  sin_phi    * dU;
+    return d_ecef;
+}
+
 }  // namespace libgnss::iers

--- a/tests/test_iers_tides.cpp
+++ b/tests/test_iers_tides.cpp
@@ -174,3 +174,66 @@ TEST(IersPoleTide, SignReversesWhenPolarMotionFlips) {
 
     EXPECT_NEAR((disp_p + disp_n).norm(), 0.0, 1e-12);
 }
+
+// --- Atmospheric tidal loading (IERS Conventions 2010 §7.1.5) -------
+
+using libgnss::iers::atmosphericTidalLoadingDisplacement;
+using libgnss::iers::AtmosphericTidalLoadingCoefficients;
+
+TEST(IersAtmTidalLoading, ZeroCoefficientsProduceZeroDisplacement) {
+    AtmosphericTidalLoadingCoefficients coeffs{};
+    auto d = atmosphericTidalLoadingDisplacement(61145.0, kTskbEcef, coeffs);
+    EXPECT_DOUBLE_EQ(d.x(), 0.0);
+    EXPECT_DOUBLE_EQ(d.y(), 0.0);
+    EXPECT_DOUBLE_EQ(d.z(), 0.0);
+}
+
+TEST(IersAtmTidalLoading, MagnitudeIsBoundedForTypicalCoefficients) {
+    // Mid-latitude coastal site representative S1/S2 amplitudes,
+    // peak ~1 mm radial / sub-mm horizontal per IERS §7.1.5.
+    AtmosphericTidalLoadingCoefficients coeffs{};
+    coeffs.radial_amplitudes_m = {0.0008, 0.0004};
+    coeffs.west_amplitudes_m   = {0.0002, 0.0001};
+    coeffs.south_amplitudes_m  = {0.0002, 0.0001};
+    coeffs.radial_phases_deg   = {-30.0, 60.0};
+    coeffs.west_phases_deg     = {-90.0, 0.0};
+    coeffs.south_phases_deg    = {30.0, -45.0};
+
+    auto d = atmosphericTidalLoadingDisplacement(61145.0, kTskbEcef, coeffs);
+    EXPECT_LT(d.norm(), 0.005);  // < 5 mm is generous
+    EXPECT_GT(d.norm(), 1e-6);   // > 1 µm — non-trivial
+}
+
+TEST(IersAtmTidalLoading, S1IsDiurnalAtTwentyFourHourStep) {
+    // With ONLY an S1 amplitude, stepping 24 h should reproduce the
+    // signal exactly (24 h is the S1 period). We check |delta(t) -
+    // delta(t + 24h)| is well below the per-epoch amplitude scale.
+    AtmosphericTidalLoadingCoefficients coeffs{};
+    coeffs.radial_amplitudes_m[0] = 0.0010;  // 1 mm S1 only
+    coeffs.radial_phases_deg[0]   = 45.0;
+
+    auto a = atmosphericTidalLoadingDisplacement(61145.0,        kTskbEcef, coeffs);
+    auto b = atmosphericTidalLoadingDisplacement(61145.0 + 1.0, kTskbEcef, coeffs);
+    EXPECT_NEAR((a - b).norm(), 0.0, 1e-12);
+}
+
+TEST(IersAtmTidalLoading, S2IsSemidiurnalAtTwelveHourStep) {
+    AtmosphericTidalLoadingCoefficients coeffs{};
+    coeffs.radial_amplitudes_m[1] = 0.0010;  // 1 mm S2 only
+    coeffs.radial_phases_deg[1]   = -30.0;
+
+    auto a = atmosphericTidalLoadingDisplacement(61145.0,        kTskbEcef, coeffs);
+    auto b = atmosphericTidalLoadingDisplacement(61145.0 + 0.5, kTskbEcef, coeffs);
+    EXPECT_NEAR((a - b).norm(), 0.0, 1e-12);
+}
+
+TEST(IersAtmTidalLoading, AntiPeriodicAtHalfS1) {
+    // S1-only signal flips sign after half a period (12 h).
+    AtmosphericTidalLoadingCoefficients coeffs{};
+    coeffs.radial_amplitudes_m[0] = 0.0010;
+    coeffs.radial_phases_deg[0]   = 0.0;
+
+    auto a = atmosphericTidalLoadingDisplacement(61145.0,        kTskbEcef, coeffs);
+    auto b = atmosphericTidalLoadingDisplacement(61145.0 + 0.5, kTskbEcef, coeffs);
+    EXPECT_NEAR((a + b).norm(), 0.0, 1e-12);
+}


### PR DESCRIPTION
## Summary

Phase D-3 of the IERS Conventions 2010 integration: adds the §7.1.5 atmospheric tidal-loading station displacement model as an opt-in geophysical correction. Captures the diurnal (S1) and semi-diurnal (S2) atmospheric pressure tide that drives ~1 mm peak radial displacement at mid- and low-latitudes.

Stacked on #65.

## What's added

- `libgnss::iers::AtmosphericTidalLoadingCoefficients` — per-site struct (S1 + S2 × radial/west/south amplitudes/phases, 12 values total)
- `libgnss::iers::atmosphericTidalLoadingDisplacement(mjd_utc, xsta_itrs, coeffs)` — closed-form sum `∑ A_i · cos(2π·t/T_i − φ_i)` over `i ∈ {S1, S2}`, evaluated in local (E, N, U) and rotated back to ITRS / ECEF.
- `PPPConfig::use_iers_atm_tidal_loading` + `atm_tidal_loading_path`. Loaded by `PPPProcessor::loadAtmosphericTidalLoading` at init.
- File format: minimal `$$`-comment compatible (one site, `S1` + `S2` lines, six floats each — radial/west/south amplitudes in m and phases in degrees). Documented in `--help`.
- `gnss_ppp` CLI: `--atm-tidal-loading <file>`, `--use-iers-atm-tidal-loading`, `--no-iers-atm-tidal-loading`.
- 5 new unit tests (`IersAtmTidalLoading.*`).

## Bench evidence

TSKB 2026-04-15, IGS final SP3+CLK from BKG mirror, synthetic mid-latitude coastal ATL coefficients (S1 = 0.8 mm radial, S2 = 0.4 mm radial):

| metric | value |
|---|---|
| mean ΔZ | −10.6 µm |
| RMS ΔZ | 106.2 µm (0.11 mm) |

The KF-integrated PPP estimate shifts by ~10% of the peak instantaneous displacement, consistent with how the static-mode filter averages a time-varying signal across the arc — the same pattern observed for the pole-tide signal in #62/#63.

## Test plan

- [x] `IersAtmTidalLoading.*` — 5/5 pass
  - `ZeroCoefficientsProduceZeroDisplacement` — additive identity
  - `MagnitudeIsBoundedForTypicalCoefficients` — < 5 mm, > 1 µm
  - `S1IsDiurnalAtTwentyFourHourStep` — 24-h periodicity
  - `S2IsSemidiurnalAtTwelveHourStep` — 12-h periodicity
  - `AntiPeriodicAtHalfS1` — sign-flip at half-period
- [x] Full `run_tests` green (263 pass, 35 skipped data-gated)
- [x] PPP smoke run (TSKB 2026-04-15) shows ATL path activates with `--use-iers-atm-tidal-loading --atm-tidal-loading <synth>` and produces realistic ~0.1 mm Z shift
- [ ] CI green (will appear after retarget to develop)

## Rollout

- Default off. `--use-iers-atm-tidal-loading` is a no-op without `--atm-tidal-loading <file>` (silent).
- The non-tidal pressure-loading component (storm-driven, requires gridded reanalysis ingestion — typically NCEP / ERA5) is deferred to a separate PR. Tidal-only is the dominant signal at most sites.
- Real TU Wien atmospheric loading service per-site coefficients are a drop-in replacement for the synthetic file once the auth-free fetch path is found; the wrapper is data-source-agnostic.

## Why a stacked PR (Phase D-3)

Closes the EOP-side cascade. The full Phase D set:

| layer | status | PR |
|---|---|---|
| D-0 EOP infra (C04) | ✅ | #61 |
| D-0 ext (Bulletin A reader) | ✅ | #64 |
| D-1 pole tide opt-in | ✅ | #62 |
| D-1 pole-tide bench harness | ✅ | #63 |
| D-2 sub-daily EOP corrections | ✅ | #65 |
| **D-3 atmospheric tidal loading** | **this PR** | — |
| (D-4 non-tidal pressure loading) | deferred | — |

After merging this stack, libgnss++ implements the full IERS Conventions 2010 EOP / station-displacement chain except for non-tidal atmospheric loading and ICRS↔ITRS satellite-side consumers.