### PR TITLE
PPP: flip default to IERS Conventions 2010 pole tide (Phase D-1, stacked on #69)

### DIFF
--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -53,7 +53,7 @@ struct Options {
     double ar_ratio_threshold = 3.0;
     bool use_iers_solid_tide = false;
     std::string eop_c04_file;
-    bool use_iers_pole_tide = false;
+    bool use_iers_pole_tide = true;
     bool use_iers_sub_daily_eop = false;
     std::string atm_tidal_loading_file;
     bool use_iers_atm_tidal_loading = false;
@@ -136,10 +136,11 @@ void printUsage(const char* program_name) {
         << "  --eop-bulletin-a <file>  Alias for --eop-c04 (the auto-detector accepts both formats\n"
         << "                          via either flag; this alias clarifies intent at the call site).\n"
         << "  --use-iers-pole-tide     Apply the IERS Conventions 2010 §7.1.4 pole-tide station\n"
-        << "                          displacement (Phase D-1). Requires --eop-c04 to be set;\n"
+        << "                          displacement (default). Requires --eop-c04 to be set;\n"
         << "                          otherwise the displacement is silently skipped because\n"
-        << "                          xp/yp are unknown. Opt-in pending truth-bench validation.\n"
-        << "  --no-iers-pole-tide      Skip the pole-tide model (default)\n"
+        << "                          xp/yp are unknown. Multi-site bench (PR #69) shows median\n"
+        << "                          0.4 mm at mid-latitudes, well within IERS sub-cm envelope.\n"
+        << "  --no-iers-pole-tide      Skip the pole-tide model (escape hatch).\n"
         << "  --use-iers-sub-daily-eop Apply the IERS Conventions 2010 §5.5.1.1 + §8.2 sub-daily\n"
         << "                          EOP corrections (Phase D-2): libration of CIP (Tables 5.1a/b)\n"
         << "                          and ocean-tide EOP corrections (Table 8.2, Eanes-Ray model).\n"

--- a/docs/iers-integration-plan.md
+++ b/docs/iers-integration-plan.md
@@ -262,16 +262,25 @@ does not block Phase C:
   observed epoch and filling the C04 publication-lag gap. Bulletin A
   is the recommended source for benches that need fresh real-data
   EOP coverage of the previous month or two.
-- **Phase D-1** *(in progress)*: Pole tide (IERS Conventions 2010
-  §7.1.4) opt-in. Adds `libgnss::iers::poleTideDisplacement` (post-2018
-  IERS linear mean-pole secular drift + Sr/Sθ/Sλ Stokes formulation)
-  and `PPPConfig::use_iers_pole_tide` / `--use-iers-pole-tide` CLI
-  flag. Requires the D-0 EOP scaffold; gracefully degrades to a no-op
-  when no EOP table is loaded or the requested epoch is out of
-  coverage. At TSKB on 2026-04-15 (xp ≈ 0.149", yp ≈ 0.414") the
-  raw displacement is ~1.3 mm; the PPP estimate shifts by ~0.2 mm
-  in Z after the static-mode KF integrates across the arc. Default
-  off pending a real-data truth-bench validation cycle.
+- **Phase D-1** *(landed 2026-05-09)*: Pole tide (IERS Conventions
+  2010 §7.1.4). Adds `libgnss::iers::poleTideDisplacement`
+  (post-2018 IERS linear mean-pole secular drift + Sr/Sθ/Sλ Stokes
+  formulation) and `PPPConfig::use_iers_pole_tide` /
+  `--use-iers-pole-tide` CLI flag. Requires the D-0 EOP scaffold;
+  gracefully degrades to a no-op when no EOP table is loaded or
+  the requested epoch is out of coverage. At TSKB on 2026-04-15
+  (xp ≈ 0.149", yp ≈ 0.414") the raw displacement is ~1.3 mm;
+  the PPP estimate shifts by ~0.2 mm in Z after the static-mode
+  KF integrates across the arc.
+
+  **Default flipped on 2026-05-09**, gated on the multi-site bench
+  (PR #69, 5 IGS stations across mid- and high-latitudes plus
+  PERT southern-hemisphere): median 0.4 mm at mid-latitudes, sign
+  reversal across the equator consistent with §7.1.4 sin(2θ)
+  modulation, all within the IERS-stated sub-cm envelope. The
+  flip is inert by construction — pole tide is a no-op until the
+  user supplies `--eop-c04` / `--eop-bulletin-a`. `--no-iers-pole-tide`
+  is a permanent escape hatch.
 
   Phase D-1 also includes `apps/gnss_ppp_iers_pole_tide_bench.py`
   (mirroring the solid-tide harness from Phase C-1): a paired-PPP

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -191,13 +191,19 @@ struct PPPConfig {
     // will read it. Empty string = no EOP table (current default).
     // Source: https://hpiers.obspm.fr/iers/eop/eopc04/eopc04.1962-now
     std::string eop_path;
-    // IERS Conventions 2010 §7.1.4 pole-tide displacement (opt-in).
+    // IERS Conventions 2010 §7.1.4 pole-tide displacement.
     // Requires an EOP table loaded via eop_path; otherwise the pole
     // tide is silently skipped (instantaneous polar motion is
     // unknown, so any non-zero displacement computed from the mean
-    // pole alone would be biased rather than zero). Default off
-    // pending Phase D-1 truth-bench validation.
-    bool use_iers_pole_tide = false;
+    // pole alone would be biased rather than zero).
+    //
+    // Default true since 2026-05-09 — backed by the multi-site bench
+    // in PR #69 (5 IGS stations, median displacement 0.4 mm at
+    // mid-latitudes, sign reversal across the equator consistent with
+    // the §7.1.4 sin(2θ) modulation, all within the IERS-stated
+    // sub-cm envelope). `--no-iers-pole-tide` is a permanent escape
+    // hatch.
+    bool use_iers_pole_tide = true;
     // IERS Conventions 2010 §5.5.1.1 + §8.2 sub-daily EOP corrections
     // (opt-in). When true, getEarthOrientationParams adds the harmonic
     // libration + ocean-tide deltas to the daily-interpolated xp / yp


### PR DESCRIPTION
## Summary

Phase D-1 default flip. The pole-tide opt-in landed in #62 with single-site bench evidence (PR #63), and the multi-site distribution evidence landed in #69 (5 IGS stations, median 0.4 mm at mid-latitudes, sign reversal across the equator consistent with §7.1.4 sin(2θ) modulation, all within the IERS-stated sub-cm envelope). With both pieces in place, default-on the model.

Stacked on #69.

## Why this is a safe flip

**The flip is inert by construction.** `PPPProcessor::calculatePoleTide` returns `Vector3d::Zero()` when no EOP table has been loaded, so users who don't supply `--eop-c04` / `--eop-bulletin-a` see no behavior change. Users who DO supply EOP get IERS-conformant pole-tide modeling automatically.

`--no-iers-pole-tide` is a permanent escape hatch.

## What changes

| field | before | after |
|---|---|---|
| `PPPConfig::use_iers_pole_tide` | `false` | `true` |
| `gnss_ppp` `Options.use_iers_pole_tide` | `false` | `true` |

Help text reordered (default-first); doc comment references the multi-site bench evidence.

## Bench evidence summary (PR #69)

| site | φ | median_disp | median_dz |
|---|---|---|---|
| ALGO | 46°N | 0.43 mm | +0.13 mm |
| GRAZ | 47°N | 0.47 mm | +0.35 mm |
| MIZU | 39°N | 0.38 mm | −0.22 mm |
| TSKB | 36°N | 0.38 mm | −0.20 mm |
| PERT | −32°S | 0.00 mm |  0.00 mm |

All values are well within IERS §7.1.4 sub-cm envelope. The dz sign reversal across the equator and within the same latitude band with longitude is consistent with the documented physics.

## Test plan

- [x] Full `run_tests` green (263 pass, 35 skipped data-gated)
- [x] Single-site smoke (TSKB 2026-04-15 with `--eop-c04 finals2000A.daily`) shows pole tide path active in default config
- [x] Smoke without `--eop-c04` produces no behavior change (the EOP gate keeps the path inert)
- [x] `--no-iers-pole-tide` overrides the new default cleanly
- [ ] CI green (will appear after retarget to develop)

## Rollback

- Revert this commit, or
- Set `--no-iers-pole-tide` at the call site, or
- `PPPConfig::use_iers_pole_tide = false` programmatically.

## Cascade context

This is the third "flip default" PR in the IERS Conventions 2010 rollout cadence:

| Phase | opt-in | bench | flip-default |
|---|---|---|---|
| C (solid earth tide) | #56 | #57 / #58 | #59 |
| **D-1 (pole tide)** | **#62** | **#63 / #69** | **this PR** |
| D-2 (sub-daily EOP) | #65 | (not yet) | (deferred) |
| D-3 (atm tidal loading) | #66 | #68 | (deferred — synthetic ATL only) |