### PR TITLE
PPP: flip default to IERS Conventions 2010 sub-daily EOP (Phase D-2, stacked on #70)

### DIFF
--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -54,7 +54,7 @@ struct Options {
     bool use_iers_solid_tide = false;
     std::string eop_c04_file;
     bool use_iers_pole_tide = true;
-    bool use_iers_sub_daily_eop = false;
+    bool use_iers_sub_daily_eop = true;
     std::string atm_tidal_loading_file;
     bool use_iers_atm_tidal_loading = false;
     bool quiet = false;
@@ -142,12 +142,11 @@ void printUsage(const char* program_name) {
         << "                          0.4 mm at mid-latitudes, well within IERS sub-cm envelope.\n"
         << "  --no-iers-pole-tide      Skip the pole-tide model (escape hatch).\n"
         << "  --use-iers-sub-daily-eop Apply the IERS Conventions 2010 §5.5.1.1 + §8.2 sub-daily\n"
-        << "                          EOP corrections (Phase D-2): libration of CIP (Tables 5.1a/b)\n"
+        << "                          EOP corrections (default): libration of CIP (Tables 5.1a/b)\n"
         << "                          and ocean-tide EOP corrections (Table 8.2, Eanes-Ray model).\n"
-        << "                          Requires --eop-c04 to be set; ut1_utc is used as the input.\n"
-        << "                          Peak amplitudes ~0.5 mas in xp/yp and ~30 µs in UT1; PPP\n"
-        << "                          receiver-position effect is sub-mm.\n"
-        << "  --no-iers-sub-daily-eop  Skip the sub-daily EOP corrections (default)\n"
+        << "                          Requires --eop-c04; deterministic harmonic series with\n"
+        << "                          peak ~0.5 mas xp/yp and ~30 µs UT1, RMS 1.5 µm at receiver.\n"
+        << "  --no-iers-sub-daily-eop  Skip the sub-daily EOP corrections (escape hatch).\n"
         << "  --atm-tidal-loading <file>\n"
         << "                          Per-site S1/S2 atmospheric tidal-loading coefficient file\n"
         << "                          (Phase D-3). Custom format with $$ comment lines + S1 / S2\n"

--- a/docs/iers-integration-plan.md
+++ b/docs/iers-integration-plan.md
@@ -306,7 +306,7 @@ does not block Phase C:
   MIZU show transient max-displacement outliers from PPP convergence
   events that are unrelated to pole tide; the medians and dz values
   remain physical.
-- **Phase D-2** *(in progress)*: Sub-daily EOP corrections opt-in.
+- **Phase D-2** *(landed 2026-05-09)*: Sub-daily EOP corrections.
   Adds `libgnss::iers::subDailyEopCorrection(mjd_utc, ut1_utc)` →
   `{dxp, dyp, dut1, dlod}`, applying the full IERS Conventions 2010
   set: §5.5.1.1 Tables 5.1a/5.1b libration of CIP and UT1
@@ -320,7 +320,13 @@ does not block Phase C:
   dyp ≈ +255 µas, dut1 ≈ −24 µs; the PPP receiver-position effect
   on top of the pole tide is RMS 1.5 µm in Z (0.17% relative
   perturbation, matching the daily-vs-sub-daily xp/yp amplitude
-  ratio). Default off.
+  ratio).
+
+  **Default flipped on 2026-05-09** alongside D-1. The corrections
+  are pure deterministic harmonic series (no per-site data) and
+  produce sub-µm-level RMS effects on the receiver position;
+  inert without an EOP table loaded. `--no-iers-sub-daily-eop` is
+  a permanent escape hatch.
 - **Phase D-3** *(in progress)*: Atmospheric tidal loading (IERS
   Conventions 2010 §7.1.5) opt-in. Adds
   `libgnss::iers::atmosphericTidalLoadingDisplacement` and the

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -204,13 +204,19 @@ struct PPPConfig {
     // sub-cm envelope). `--no-iers-pole-tide` is a permanent escape
     // hatch.
     bool use_iers_pole_tide = true;
-    // IERS Conventions 2010 §5.5.1.1 + §8.2 sub-daily EOP corrections
-    // (opt-in). When true, getEarthOrientationParams adds the harmonic
-    // libration + ocean-tide deltas to the daily-interpolated xp / yp
-    // / UT1-UTC before returning. Peak amplitudes are sub-mas / few-µs,
-    // so the receiver-position effect on PPP is sub-mm; flipping this
-    // on tightens the modeled CIP location for IERS-conformant work.
-    bool use_iers_sub_daily_eop = false;
+    // IERS Conventions 2010 §5.5.1.1 + §8.2 sub-daily EOP corrections.
+    // When true, getEarthOrientationParams adds the harmonic libration
+    // + ocean-tide deltas to the daily-interpolated xp / yp / UT1-UTC
+    // before returning. Peak amplitudes are sub-mas / few-µs.
+    //
+    // Default true since 2026-05-09. The corrections are pure
+    // deterministic harmonic series (no per-site data) and produce
+    // RMS 1.5 µm at the receiver position over a static-mode
+    // pole-tide-on arc — well below the noise floor and within
+    // IERS-conformant cm-class CIP modeling. The flip is inert
+    // without an EOP table loaded (same gate as use_iers_pole_tide).
+    // `--no-iers-sub-daily-eop` is a permanent escape hatch.
+    bool use_iers_sub_daily_eop = true;
     // IERS Conventions 2010 §7.1.5 atmospheric tidal loading (S1/S2)
     // station displacement (opt-in). Reads per-site amplitude / phase
     // coefficients from `atm_tidal_loading_path` and adds the diurnal


### PR DESCRIPTION
## Summary

Phase D-2 default flip. The sub-daily EOP opt-in landed in #65 (deterministic harmonic series, Tables 5.1a/5.1b libration + Table 8.2 Eanes-Ray ocean-tide corrections — 92 terms total) with bench evidence of RMS 1.5 µm at the receiver position. With D-1 now default-on (#70) and the EOP infrastructure stable, default-on the sub-daily refinement too.

Stacked on #70.

## Why this is the safest flip in the cascade

1. **Pure deterministic harmonic series**, no per-site data dependency.
2. **Sub-µm receiver position effect** (1.5 µm RMS in #65 bench), well below the PPP noise floor.
3. **Inert without EOP loaded** — same gate as D-1 pole tide.
4. Tightens IERS-conformant CIP modeling for cm-class users without measurable risk at lower precision.

## What changes

| field | before | after |
|---|---|---|
| `PPPConfig::use_iers_sub_daily_eop` | `false` | `true` |
| `gnss_ppp` `Options.use_iers_sub_daily_eop` | `false` | `true` |

Help text reordered (default-first); doc comment references the #65 bench.

## Test plan

- [x] Full `run_tests` green (263 pass, 35 skipped data-gated)
- [x] No-EOP run is bit-identical (the EOP gate keeps the path inert)
- [x] `--no-iers-sub-daily-eop` overrides cleanly
- [ ] CI green (will appear after retarget to develop)

## Rollback

Revert this commit, or `--no-iers-sub-daily-eop`, or set `PPPConfig::use_iers_sub_daily_eop = false`.

## Cascade context

Now both EOP-side IERS Conventions 2010 components are default-on for cm-class users who supply EOP, with permanent CLI escape hatches:

| Phase | opt-in | bench | flip-default |
|---|---|---|---|
| C (solid earth tide) | #56 | #57 / #58 | #59 |
| D-1 (pole tide) | #62 | #63 / #69 | #70 |
| **D-2 (sub-daily EOP)** | **#65** | (in #65 commit) | **this PR** |
| D-3 (atm tidal loading) | #66 | #68 | (deferred — synthetic ATL only) |

Remaining deferred work documented in `docs/iers-integration-plan.md`:
- D-3 flip-default: blocked on real per-site ATL coefficients (TU Wien service is interactive, not auth-free batch).
- D-4 non-tidal pressure loading: substantial GRIB2 + Green's function scaffold, separate session.
- HARDISP flip-default: blocked on real Onsala BLQ (interactive queue only).