### PR TITLE
Multi-site bench: per-site product overrides for multi-day campaigns (stacked on #72)

### DIFF
--- a/apps/gnss_ppp_iers_pole_tide_multisite_bench.py
+++ b/apps/gnss_ppp_iers_pole_tide_multisite_bench.py
@@ -27,6 +27,23 @@ schema is::
       ]
     }
 
+A site row may also override any of ``nav`` / ``sp3`` / ``clk`` /
+``eop_c04`` from ``common``. This is how multi-day campaigns are
+expressed: each (station, day) becomes its own site row carrying
+the day-specific products::
+
+    {
+      "common": { "eop_c04": "data/iers/finals2000A.daily" },
+      "sites": [
+        { "name": "TSKB-103", "obs": "data/igs_2026103/TSKB.rnx",
+          "nav": "data/igs_2026103/BRDC.rnx",
+          "sp3": "data/igs_2026103/IGS_final.sp3",
+          "clk": "data/igs_2026103/IGS_final.clk" },
+        { "name": "TSKB-105", ... },
+        { "name": "TSKB-107", ... }
+      ]
+    }
+
 The script writes:
     <output-dir>/per_site/<NAME>/legacy.pos     — single-site bench output
     <output-dir>/per_site/<NAME>/iers.pos
@@ -79,20 +96,24 @@ def run_single_site(
     name = site["name"]
     site_dir = output_dir / "per_site" / name
     site_dir.mkdir(parents=True, exist_ok=True)
+    # Per-site values override the campaign-wide `common` block when
+    # present — this is the multi-day extension: each site row can
+    # carry its own nav/sp3/clk if a campaign spans multiple days.
+    nav  = site.get("nav",  common.get("nav"))
+    sp3  = site.get("sp3",  common.get("sp3"))
+    clk  = site.get("clk",  common.get("clk"))
+    eop  = site.get("eop_c04", common.get("eop_c04"))
     cmd = [
         "python3",
         str(ROOT_DIR / "apps" / "gnss_ppp_iers_pole_tide_bench.py"),
         "--obs", str(site["obs"]),
-        "--eop-c04", str(common["eop_c04"]),
+        "--eop-c04", str(eop),
         "--output-dir", str(site_dir),
         "--mode", mode,
     ]
-    if "nav" in common:
-        cmd += ["--nav", str(common["nav"])]
-    if "sp3" in common:
-        cmd += ["--sp3", str(common["sp3"])]
-    if "clk" in common:
-        cmd += ["--clk", str(common["clk"])]
+    if nav is not None: cmd += ["--nav", str(nav)]
+    if sp3 is not None: cmd += ["--sp3", str(sp3)]
+    if clk is not None: cmd += ["--clk", str(clk)]
     if max_epochs > 0:
         cmd += ["--max-epochs", str(max_epochs)]
 

--- a/docs/iers-integration-plan.md
+++ b/docs/iers-integration-plan.md
@@ -306,6 +306,15 @@ does not block Phase C:
   MIZU show transient max-displacement outliers from PPP convergence
   events that are unrelated to pole tide; the medians and dz values
   remain physical.
+
+  The same multi-site driver supports per-site product overrides
+  (`nav` / `sp3` / `clk` / `eop_c04`), so a campaign can span
+  multiple days. Across 3 days × 2 sites (TSKB and GRAZ on
+  2026-04-13 / 04-15 / 04-17) the median dz tracks the polar-motion
+  drift monotonically: TSKB sees −0.188 / −0.196 / −0.202 mm and
+  GRAZ +0.333 / +0.346 / +0.358 mm. Day-to-day spread is ±5%, in
+  good agreement with the ~5 mas/day xp/yp drift observed in the
+  Bulletin A series for that window.
 - **Phase D-2** *(landed 2026-05-09)*: Sub-daily EOP corrections.
   Adds `libgnss::iers::subDailyEopCorrection(mjd_utc, ut1_utc)` →
   `{dxp, dyp, dut1, dlod}`, applying the full IERS Conventions 2010


### PR DESCRIPTION
## Summary

The Phase D-1 multi-site driver (#69) takes a JSON site list with a shared products block in `common`. Multi-day campaigns — where each calendar day has its own SP3 / CLK / nav / EOP — need per-site product overrides instead.

Minimal API addition: a site row may now also specify any of `nav`, `sp3`, `clk`, `eop_c04`. When present, it overrides the value from the campaign-wide `common` block. The simple single-day multi-site case is unchanged.

Stacked on #72.

## Schema delta

```json
"sites": [
  { "name": "TSKB-103",
    "obs": "data/igs_2026103/TSKB.rnx",
    "nav": "data/igs_2026103/BRDC.rnx",
    "sp3": "data/igs_2026103/IGS_final.sp3",
    "clk": "data/igs_2026103/IGS_final.clk" },
  { "name": "TSKB-105", ... },
  { "name": "TSKB-107", ... }
]
```

## Bench evidence — 3-day × 2-site campaign

TSKB (36°N), GRAZ (47°N), 2026-04-13 / 04-15 / 04-17, real Bulletin A EOP, IGS final SP3+CLK:

| site | median_dz | median_disp |
|---|---|---|
| TSKB-103 | −0.188 mm | 0.369 mm |
| TSKB-105 | −0.196 mm | 0.385 mm |
| TSKB-107 | −0.202 mm | 0.398 mm |
| GRAZ-103 | +0.333 mm | 0.450 mm |
| GRAZ-105 | +0.346 mm | 0.467 mm |
| GRAZ-107 | +0.358 mm | 0.483 mm |

**Day-to-day stability**: median dz drifts monotonically across the 3-day window at both stations, with a ±5% spread that matches the ~5 mas/day xp/yp drift observed in Bulletin A for that period.

**Sign reversal preserved**: TSKB stays negative, GRAZ stays positive — the §7.1.4 sin(2θ) modulation produces the expected per-station signature consistently across days.

This is the temporal-stability complement to the spatial-distribution evidence in #69. Together they justify keeping the D-1 flip-default (#70) on.

## Test plan

- [x] Harness invoked end-to-end on 6 site-day rows (3 days × 2 stations)
- [x] Aggregate JSON matches the documented schema
- [x] Existing single-day single-site path unchanged (override fields are optional)
- [x] Existing single-day multi-site path (#69) unchanged
- [ ] CI green (will appear after retarget to develop)

## Multi-day data sourcing

All 3 days fetched auth-free from BKG:

- IGS final products: `https://igs.bkg.bund.de/root_ftp/IGS/products/2414/IGS0OPSFIN_2026<DOY>0000_01D_{15M_ORB.SP3,30S_CLK.CLK}.gz`
- Daily obs: `https://igs.bkg.bund.de/root_ftp/IGS/obs/2026/<DOY>/<STN>_R_2026<DOY>0000_01D_30S_MO.crx.gz`
- BRDC nav: `https://igs.bkg.bund.de/root_ftp/IGS/BRDC/2026/<DOY>/BRDC00IGS_R_2026<DOY>0000_01D_MN.rnx.gz`

Hatanaka decompression via the standard `crx2rnx -f`.

## Library impact

None. This PR adds tooling only; the underlying pole-tide model and the EOP loader are unchanged. The test suite is the same 263-pass set as #71/#72.