### PR TITLE
PPP: opt-in IERS Conventions 2010 pole-tide model (Phase D-1, re-targeted from #62)

### DIFF
--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -53,6 +53,7 @@ struct Options {
     double ar_ratio_threshold = 3.0;
     bool use_iers_solid_tide = false;
     std::string eop_c04_file;
+    bool use_iers_pole_tide = false;
     bool quiet = false;
 };
 
@@ -125,6 +126,11 @@ void printUsage(const char* program_name) {
         << "                          (pole tide, sub-daily EOP). Phase D-0 scaffolding only — does\n"
         << "                          not change PPP output until D-1+ feature flags are enabled.\n"
         << "                          Source: https://hpiers.obspm.fr/iers/eop/eopc04/eopc04.1962-now\n"
+        << "  --use-iers-pole-tide     Apply the IERS Conventions 2010 §7.1.4 pole-tide station\n"
+        << "                          displacement (Phase D-1). Requires --eop-c04 to be set;\n"
+        << "                          otherwise the displacement is silently skipped because\n"
+        << "                          xp/yp are unknown. Opt-in pending truth-bench validation.\n"
+        << "  --no-iers-pole-tide      Skip the pole-tide model (default)\n"
         << "  --quiet                  Suppress per-run summary output\n"
         << "  -h, --help               Show this help\n";
 }
@@ -232,6 +238,10 @@ Options parseArguments(int argc, char* argv[]) {
             options.use_iers_solid_tide = false;
         } else if (arg == "--eop-c04" && i + 1 < argc) {
             options.eop_c04_file = argv[++i];
+        } else if (arg == "--use-iers-pole-tide") {
+            options.use_iers_pole_tide = true;
+        } else if (arg == "--no-iers-pole-tide") {
+            options.use_iers_pole_tide = false;
         } else if (arg == "--quiet") {
             options.quiet = true;
         } else {
@@ -581,6 +591,7 @@ int main(int argc, char* argv[]) {
         ppp_config.ar_ratio_threshold = options.ar_ratio_threshold;
         ppp_config.use_iers_solid_tide = options.use_iers_solid_tide;
         ppp_config.eop_path = options.eop_c04_file;
+        ppp_config.use_iers_pole_tide = options.use_iers_pole_tide;
         if (options.low_dynamics_mode) {
             ppp_config.reset_clock_to_spp_each_epoch = false;
             ppp_config.reset_kinematic_position_to_spp_each_epoch = false;

--- a/docs/iers-integration-plan.md
+++ b/docs/iers-integration-plan.md
@@ -253,9 +253,16 @@ does not block Phase C:
   the table yet — D-0 is a strictly additive scaffold for D-1+
   (pole tide and sub-daily EOP). Output is bit-identical to the
   no-EOP baseline.
-- **Phase D-1**: Pole tide (IERS Conventions 2010 §7.1.4). Closed-form
-  ~30 LOC, but requires the D-0 scaffold so per-epoch xp/yp/UT1-UTC
-  are available.
+- **Phase D-1** *(in progress)*: Pole tide (IERS Conventions 2010
+  §7.1.4) opt-in. Adds `libgnss::iers::poleTideDisplacement` (post-2018
+  IERS linear mean-pole secular drift + Sr/Sθ/Sλ Stokes formulation)
+  and `PPPConfig::use_iers_pole_tide` / `--use-iers-pole-tide` CLI
+  flag. Requires the D-0 EOP scaffold; gracefully degrades to a no-op
+  when no EOP table is loaded or the requested epoch is out of
+  coverage. At TSKB on 2026-04-15 (xp ≈ 0.149", yp ≈ 0.414") the
+  raw displacement is ~1.3 mm; the PPP estimate shifts by ~0.2 mm
+  in Z after the static-mode KF integrates across the arc. Default
+  off pending a real-data truth-bench validation cycle.
 - **Phase D-2**: Sub-daily EOP corrections (IERS §8.2). Shares the
   D-0 scaffold.
 - **Phase D-3**: Atmospheric loading. Smaller cm-level effect; needs

--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -418,6 +418,16 @@ private:
      */
     Vector3d calculateOceanLoading(const Vector3d& position,
                                  const GNSSTime& time) const;
+
+    /**
+     * @brief Calculate IERS pole-tide station displacement (Phase D-1).
+     *
+     * Returns Vector3d::Zero() when no EOP table is loaded, since the
+     * pole tide depends on instantaneous polar motion (xp, yp). Caller
+     * is responsible for gating on `ppp_config_.use_iers_pole_tide`.
+     */
+    Vector3d calculatePoleTide(const Vector3d& position,
+                               const GNSSTime& time) const;
     
     /**
      * @brief Form measurement equations

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -191,6 +191,13 @@ struct PPPConfig {
     // will read it. Empty string = no EOP table (current default).
     // Source: https://hpiers.obspm.fr/iers/eop/eopc04/eopc04.1962-now
     std::string eop_path;
+    // IERS Conventions 2010 §7.1.4 pole-tide displacement (opt-in).
+    // Requires an EOP table loaded via eop_path; otherwise the pole
+    // tide is silently skipped (instantaneous polar motion is
+    // unknown, so any non-zero displacement computed from the mean
+    // pole alone would be biased rather than zero). Default off
+    // pending Phase D-1 truth-bench validation.
+    bool use_iers_pole_tide = false;
     bool apply_relativity = true;
 
     // Convergence criteria

--- a/include/libgnss++/iers/tides.hpp
+++ b/include/libgnss++/iers/tides.hpp
@@ -14,6 +14,7 @@
 #include <Eigen/Dense>
 
 #include "libgnss++/core/types.hpp"
+#include "libgnss++/iers/earth_rotation.hpp"
 
 namespace libgnss::iers {
 
@@ -53,5 +54,48 @@ Eigen::Vector3d solidEarthTideDisplacement(
     const Eigen::Vector3d& xsta_itrs,
     const Eigen::Vector3d& xsun_icrs,
     const Eigen::Vector3d& xmon_icrs);
+
+/// @brief Pole-tide station displacement (IERS Conventions 2010 §7.1.4).
+///
+/// The pole tide is the centrifugal effect on the deformable Earth
+/// from the wandering of the rotation axis with respect to its mean
+/// position (m1 = xp - x_mean, m2 = -(yp - y_mean)). Peak amplitude
+/// is sub-cm in the horizontal and ~25 mm radial during large polar
+/// motion excursions.
+///
+/// Mean-pole secular model: this implementation uses the IERS 2018
+/// linear update (an outcome of the 2017 IERS conventions update —
+/// the cubic 1976-2010 polynomial in the original IERS 2010 Technical
+/// Note 36 was replaced because polar motion has actually drifted
+/// linearly post-2010):
+///
+///   x_mean(t) =  55.000 +   1.677 · (t - 2000.0)   mas
+///   y_mean(t) = 320.500 +   3.460 · (t - 2000.0)   mas
+///
+/// where t is the decimal year (Julian-year approximation suffices
+/// for the secular term).
+///
+/// Displacement formula (Sr = -33 mm, Stt = -9 mm, Stl = 9 mm in the
+/// IERS 2010 §7.1.4 conventions):
+///
+///   d_radial = -32 · sin(2θ) · (m1·cosλ + m2·sinλ)  mm
+///   d_north  =  -9 · cos(2θ) · (m1·cosλ + m2·sinλ)  mm
+///   d_east   =  +9 · cos(θ)  · (m1·sinλ - m2·cosλ)  mm
+///
+/// where θ is geocentric colatitude, λ is east longitude, both
+/// derived from `xsta_itrs`.
+///
+/// Returned displacement is in the local ITRS frame (East, North, Up
+/// rotated back into ECEF X/Y/Z) and should be ADDED to the station
+/// nominal ITRS position to obtain the tidally displaced position.
+///
+/// @param mjd_utc    UTC modified Julian date of the epoch.
+/// @param xsta_itrs  Station nominal ITRS / ECEF coordinates [m].
+/// @param eop        Earth orientation parameters at this epoch.
+/// @return Displacement vector [m] in ITRS / ECEF.
+Eigen::Vector3d poleTideDisplacement(
+    double mjd_utc,
+    const Eigen::Vector3d& xsta_itrs,
+    const EarthOrientationParams& eop);
 
 }  // namespace libgnss::iers

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -2705,6 +2705,9 @@ Vector3d PPPProcessor::applyGeophysicalCorrections(const Vector3d& position,
     if (ppp_config_.apply_ocean_loading) {
         corrected += calculateOceanLoading(position, time);
     }
+    if (ppp_config_.use_iers_pole_tide) {
+        corrected += calculatePoleTide(position, time);
+    }
     return corrected;
 }
 
@@ -2773,6 +2776,22 @@ Vector3d PPPProcessor::calculateOceanLoading(const Vector3d& position,
     ecef2geodetic(position, latitude_rad, longitude_rad, height_m);
     const Vector3d enu_offset(-west_m, -south_m, up_m);
     return enu2ecef(enu_offset, latitude_rad, longitude_rad);
+}
+
+Vector3d PPPProcessor::calculatePoleTide(const Vector3d& position,
+                                         const GNSSTime& time) const {
+    if (!eop_table_ || !position.allFinite() ||
+        position.norm() < constants::WGS84_A * 0.5) {
+        return Vector3d::Zero();
+    }
+    const double mjd_utc = libgnss::iers::gnssTimeToMjdUtc(time);
+    libgnss::iers::EarthOrientationParams eop;
+    try {
+        eop = eop_table_->interpolateAt(mjd_utc);
+    } catch (const std::out_of_range&) {
+        return Vector3d::Zero();
+    }
+    return libgnss::iers::poleTideDisplacement(mjd_utc, position, eop);
 }
 
 PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(

--- a/src/iers/tides.cpp
+++ b/src/iers/tides.cpp
@@ -58,4 +58,88 @@ Eigen::Vector3d solidEarthTideDisplacement(
     return xcor_vec.front();
 }
 
+namespace {
+
+// IERS 2018 Update of the Mean Pole Model (linear secular drift).
+// Replaces the cubic 1976–2010 polynomial that appeared in the
+// original IERS 2010 Technical Note 36. Outputs are in milli-arcseconds.
+//
+// References:
+//   - IERS Conventions 2010 §7.1.4 (post-2018 linear update)
+//   - https://hpiers.obspm.fr/iers/conv/conv2010/conv2010_c7.html
+void meanPoleMas(double decimal_year, double& xp_mean_mas, double& yp_mean_mas) {
+    const double dt = decimal_year - 2000.0;
+    xp_mean_mas =  55.0 + 1.677 * dt;
+    yp_mean_mas = 320.5 + 3.460 * dt;
+}
+
+double mjdUtcToDecimalYear(double mjd_utc) {
+    // J2000 = 2000-01-01.5 UTC ≈ MJD 51544.5; one Julian year is
+    // 365.25 days. Sub-day accuracy is unnecessary for the secular
+    // mean-pole term (its slope is ~mas/yr).
+    constexpr double kMjdJ2000Utc = 51544.5;
+    constexpr double kDaysPerYear = 365.25;
+    return 2000.0 + (mjd_utc - kMjdJ2000Utc) / kDaysPerYear;
+}
+
+}  // namespace
+
+Eigen::Vector3d poleTideDisplacement(
+    double mjd_utc,
+    const Eigen::Vector3d& xsta_itrs,
+    const EarthOrientationParams& eop) {
+    // Mean-pole reference position at this epoch (mas).
+    double xp_mean_mas = 0.0;
+    double yp_mean_mas = 0.0;
+    meanPoleMas(mjdUtcToDecimalYear(mjd_utc), xp_mean_mas, yp_mean_mas);
+
+    // m1, m2 in arcseconds — instantaneous polar motion offset from
+    // the mean pole (IERS 2010 §7.1.4 eq. 7.24).
+    constexpr double kMasPerArcsec = 1000.0;
+    const double m1 = eop.xp_arcsec - xp_mean_mas / kMasPerArcsec;
+    const double m2 = -(eop.yp_arcsec - yp_mean_mas / kMasPerArcsec);
+
+    // Geocentric latitude / longitude (no flattening — pole tide
+    // formulation is geocentric).
+    const double x = xsta_itrs.x();
+    const double y = xsta_itrs.y();
+    const double z = xsta_itrs.z();
+    const double r_xy = std::sqrt(x * x + y * y);
+    const double phi = std::atan2(z, r_xy);     // geocentric latitude
+    const double theta = M_PI / 2.0 - phi;      // colatitude
+    const double lambda = std::atan2(y, x);     // east longitude
+
+    const double sin_theta = std::sin(theta);
+    const double cos_theta = std::cos(theta);
+    const double sin_2theta = 2.0 * sin_theta * cos_theta;
+    const double cos_2theta = cos_theta * cos_theta - sin_theta * sin_theta;
+    const double sin_lambda = std::sin(lambda);
+    const double cos_lambda = std::cos(lambda);
+
+    // IERS 2010 eq. 7.25 (with conventions S_r = -33, S_θ = -9, S_λ = +9
+    // mm). All m1/m2 inputs in arcseconds.
+    const double m1_cosL_plus_m2_sinL = m1 * cos_lambda + m2 * sin_lambda;
+    const double m1_sinL_minus_m2_cosL = m1 * sin_lambda - m2 * cos_lambda;
+
+    const double d_radial_mm = -33.0 * sin_2theta * m1_cosL_plus_m2_sinL;
+    const double d_north_mm  =  -9.0 * cos_2theta * m1_cosL_plus_m2_sinL;
+    const double d_east_mm   =   9.0 * cos_theta  * m1_sinL_minus_m2_cosL;
+
+    constexpr double kMmToM = 1.0e-3;
+    const double dE = d_east_mm  * kMmToM;
+    const double dN = d_north_mm * kMmToM;
+    const double dU = d_radial_mm * kMmToM;
+
+    // Local ENU → ECEF rotation. Uses geocentric φ to match the
+    // formulation above (the IERS conventions explicitly compute the
+    // displacement in a geocentric local frame).
+    const double sin_phi = std::sin(phi);
+    const double cos_phi = std::cos(phi);
+    Eigen::Vector3d d_ecef;
+    d_ecef.x() = -sin_lambda * dE - sin_phi * cos_lambda * dN + cos_phi * cos_lambda * dU;
+    d_ecef.y() =  cos_lambda * dE - sin_phi * sin_lambda * dN + cos_phi * sin_lambda * dU;
+    d_ecef.z() =                     cos_phi * dN              + sin_phi * dU;
+    return d_ecef;
+}
+
 }  // namespace libgnss::iers

--- a/tests/test_iers_tides.cpp
+++ b/tests/test_iers_tides.cpp
@@ -65,3 +65,112 @@ TEST(IersTides, SolidEarthTideAmplitudeIsBounded) {
 
     EXPECT_LT(dxyz.cwiseAbs().maxCoeff(), 0.5);
 }
+
+// --- Pole tide (IERS Conventions 2010 §7.1.4) -----------------------
+
+using libgnss::iers::poleTideDisplacement;
+using libgnss::iers::EarthOrientationParams;
+
+namespace {
+
+// TSKB approx (Tsukuba, Japan): 36.106 N, 140.087 E, h ≈ 67 m → ECEF
+// roughly (-3957209, 3310326, 3737690) m. Used as a representative
+// mid-latitude site for amplitude/sanity tests.
+const Eigen::Vector3d kTskbEcef(-3957209.0, 3310326.0, 3737690.0);
+
+}  // namespace
+
+TEST(IersPoleTide, ZeroAtMeanPole) {
+    // 2026-04-15 UTC ≈ MJD 61145; mean pole at decimal year 2026.29
+    // is x_mean = 55.0 + 1.677*26.29 = 99.09 mas, y_mean = 320.5 +
+    // 3.460*26.29 = 411.46 mas. Setting xp/yp to those values exactly
+    // makes m1 = m2 = 0, so the displacement must be exactly zero
+    // at every station regardless of latitude/longitude.
+    const double mjd_utc = 61145.0;
+    const double dt = 2000.0 + (mjd_utc - 51544.5) / 365.25 - 2000.0;
+    const double xp_mean_arcsec = (55.0 + 1.677 * dt) / 1000.0;
+    const double yp_mean_arcsec = (320.5 + 3.460 * dt) / 1000.0;
+
+    EarthOrientationParams eop{};
+    eop.xp_arcsec = xp_mean_arcsec;
+    eop.yp_arcsec = yp_mean_arcsec;
+    eop.ut1_minus_utc_seconds = 0.0;
+
+    const Eigen::Vector3d disp = poleTideDisplacement(mjd_utc, kTskbEcef, eop);
+    EXPECT_NEAR(disp.x(), 0.0, 1e-12);
+    EXPECT_NEAR(disp.y(), 0.0, 1e-12);
+    EXPECT_NEAR(disp.z(), 0.0, 1e-12);
+}
+
+TEST(IersPoleTide, MagnitudeIsCmLevelForRealisticPolarMotion) {
+    // Realistic 2026-04-15 polar motion (TSKB-area, Phase D-1 bench
+    // case): xp ≈ 0.137 arcsec, yp ≈ 0.413 arcsec. m1, m2 are both
+    // tens of mas → displacement must be sub-cm in any component.
+    const double mjd_utc = 61145.0;
+    EarthOrientationParams eop{};
+    eop.xp_arcsec = 0.137;
+    eop.yp_arcsec = 0.413;
+    eop.ut1_minus_utc_seconds = 0.0;
+
+    const Eigen::Vector3d disp = poleTideDisplacement(mjd_utc, kTskbEcef, eop);
+    EXPECT_LT(disp.norm(), 0.05);   // < 5 cm
+    EXPECT_GT(disp.norm(), 1e-6);   // > 1 µm — non-trivial signal
+}
+
+TEST(IersPoleTide, EquatorRadialIsZero) {
+    // At φ = 0 (geocentric latitude = 0), sin(2θ) = sin(180°) = 0,
+    // so the pole-tide RADIAL component vanishes. cos(θ) = cos(90°)
+    // = 0 also kills the EAST component. Only NORTH remains.
+    const Eigen::Vector3d xsta_eq(6378137.0, 0.0, 0.0);  // equator, λ=0
+    EarthOrientationParams eop{};
+    eop.xp_arcsec = 0.5;   // arbitrary but non-zero polar motion
+    eop.yp_arcsec = 0.5;
+    eop.ut1_minus_utc_seconds = 0.0;
+
+    const Eigen::Vector3d disp = poleTideDisplacement(61145.0, xsta_eq, eop);
+    // Radial @ equator with λ=0 maps to the +X direction, but with
+    // sin(2θ)=0 and cos(θ)=0, only NORTH (+Z direction) survives.
+    EXPECT_NEAR(disp.x(), 0.0, 1e-9);   // east + radial both zero at λ=0
+    EXPECT_NEAR(disp.y(), 0.0, 1e-9);   // east axis at λ=0 maps to +Y; cos(θ)=0
+    EXPECT_GT(std::abs(disp.z()), 1e-6); // north component → +Z at the equator
+}
+
+TEST(IersPoleTide, NorthPoleEastAndRadialZero) {
+    // At φ = 90° (geographic North Pole), sin(2θ) = sin(0) = 0 and
+    // cos(2θ) = 1, cos(θ) = 1. Radial vanishes; east and north both
+    // exist as horizontal motions, mapping into ECEF X/Y depending
+    // on the (singular) longitude reference.
+    const Eigen::Vector3d xsta_np(0.0, 0.0, 6356752.0);
+    EarthOrientationParams eop{};
+    eop.xp_arcsec = 0.5;
+    eop.yp_arcsec = 0.5;
+    eop.ut1_minus_utc_seconds = 0.0;
+
+    const Eigen::Vector3d disp = poleTideDisplacement(61145.0, xsta_np, eop);
+    // Radial component vanishes at the pole (sin(2θ)=0).
+    EXPECT_NEAR(disp.z(), 0.0, 1e-9);
+    // Horizontal (X/Y) is non-zero — both north and east contribute.
+    EXPECT_GT(disp.head<2>().norm(), 1e-6);
+}
+
+TEST(IersPoleTide, SignReversesWhenPolarMotionFlips) {
+    // Linearity: flipping (xp, yp) about the mean pole flips m1, m2,
+    // and the displacement must flip sign at any station.
+    const double mjd_utc = 61145.0;
+    const double dt = 2000.0 + (mjd_utc - 51544.5) / 365.25 - 2000.0;
+    const double xp_mean = (55.0 + 1.677 * dt) / 1000.0;
+    const double yp_mean = (320.5 + 3.460 * dt) / 1000.0;
+
+    EarthOrientationParams ep{};
+    ep.xp_arcsec = xp_mean + 0.05;
+    ep.yp_arcsec = yp_mean + 0.05;
+
+    EarthOrientationParams en{};
+    en.xp_arcsec = xp_mean - 0.05;
+    en.yp_arcsec = yp_mean - 0.05;
+
+    const Eigen::Vector3d disp_p = poleTideDisplacement(mjd_utc, kTskbEcef, ep);
+    const Eigen::Vector3d disp_n = poleTideDisplacement(mjd_utc, kTskbEcef, en);
+
+    EXPECT_NEAR((disp_p + disp_n).norm(), 0.0, 1e-12);
+}


### PR DESCRIPTION
## Summary

Recreated from #62 after the base PR (#61, Phase D-0 EOP infra) was merged with `--delete-branch`, which auto-closed this PR. Content is identical — the rebased commit (now on top of develop) carries the pole-tide opt-in implementation.

## What's added

- `libgnss::iers::poleTideDisplacement(mjd_utc, xsta_itrs, eop)` → `Vector3d` (IERS Conventions 2010 §7.1.4)
- `PPPConfig::use_iers_pole_tide` (currently `false`; flipped to default-true downstream in #70 follow-up)
- `PPPProcessor::calculatePoleTide` with EOP-table guard (silent no-op without EOP)
- `gnss_ppp` CLI: `--use-iers-pole-tide` / `--no-iers-pole-tide`
- 5 unit tests (`IersPoleTide.*`)

## Bench evidence

TSKB 2026-04-15: raw displacement ECEF Δ = (−0.93, +0.57, +0.64) mm, |Δ| = 1.26 mm; PPP estimate ΔZ ~ −0.21 mm (KF-integrated, static mode).

See PR #62 for the original review thread.