### PR TITLE
Add ppp-iers-sub-daily-eop-bench harnesses (Phase D-2 multi-site)

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -80,6 +80,8 @@ install(PROGRAMS
     ${CMAKE_CURRENT_SOURCE_DIR}/gnss_ppp_iers_pole_tide_bench.py
     ${CMAKE_CURRENT_SOURCE_DIR}/gnss_ppp_iers_atm_tidal_loading_bench.py
     ${CMAKE_CURRENT_SOURCE_DIR}/gnss_ppp_iers_pole_tide_multisite_bench.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/gnss_ppp_iers_sub_daily_eop_bench.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/gnss_ppp_iers_sub_daily_eop_multisite_bench.py
     ${CMAKE_CURRENT_SOURCE_DIR}/gnss_ppp_iers_ocean_loading_bench.py
     ${CMAKE_CURRENT_SOURCE_DIR}/gnss_ppp_products_signoff.py
     ${CMAKE_CURRENT_SOURCE_DIR}/gnss_ppc_demo.py

--- a/apps/gnss.py
+++ b/apps/gnss.py
@@ -269,6 +269,16 @@ COMMANDS = {
         "target": os.path.join(APPS_DIR, "gnss_ppp_iers_pole_tide_multisite_bench.py"),
         "summary": "Run the Phase D-1 pole-tide bench across an arbitrary list of IGS stations and emit an aggregate per-site distribution summary (gates the use_iers_pole_tide flip-default).",
     },
+    "ppp-iers-sub-daily-eop-bench": {
+        "kind": "python",
+        "target": os.path.join(APPS_DIR, "gnss_ppp_iers_sub_daily_eop_bench.py"),
+        "summary": "Run the same PPP setup with and without --use-iers-sub-daily-eop (pole-tide ON in both runs) and summarize the per-epoch displacement (Phase D-2 truth-bench harness; requires --eop-c04).",
+    },
+    "ppp-iers-sub-daily-eop-multisite-bench": {
+        "kind": "python",
+        "target": os.path.join(APPS_DIR, "gnss_ppp_iers_sub_daily_eop_multisite_bench.py"),
+        "summary": "Run the Phase D-2 sub-daily-EOP bench across an arbitrary list of IGS stations and emit an aggregate per-site distribution summary.",
+    },
     "ppp-iers-ocean-loading-bench": {
         "kind": "python",
         "target": os.path.join(APPS_DIR, "gnss_ppp_iers_ocean_loading_bench.py"),

--- a/apps/gnss_ppp_iers_sub_daily_eop_bench.py
+++ b/apps/gnss_ppp_iers_sub_daily_eop_bench.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Paired PPP run with the IERS Conventions 2010 sub-daily EOP
+correction toggled, summarizing the per-epoch displacement between
+the two solutions.
+
+This is the truth-bench harness for Phase D-2 (PR #65/#71). It runs
+``gnss_ppp`` twice on the same input observations / navigation /
+products with ``--use-iers-pole-tide`` enabled in BOTH runs, and
+toggles only ``--use-iers-sub-daily-eop`` (on vs off). The
+sub-daily EOP correction modifies xp / yp / UT1-UTC at the sub-mas
+/ µs level via the §5.5.1.1 libration tables and §8.2 ocean-tide
+EOP series, and only enters the receiver position through the
+pole-tide displacement (which consumes xp / yp). Toggling
+sub-daily-EOP without pole-tide on therefore gives an identity
+result; this bench keeps pole-tide on in both runs to expose the
+isolated sub-daily contribution.
+
+The bench takes ``--eop-c04`` as a mandatory argument — the
+pole-tide path is a no-op when the EOP table is unavailable, so
+the bench would otherwise silently report zero displacement.
+
+Typical use::
+
+    python apps/gnss_ppp_iers_sub_daily_eop_bench.py \\
+        --obs path/to/rover.obs \\
+        --nav path/to/nav.rnx \\
+        --sp3 path/to/orbit.sp3 \\
+        --clk path/to/clock.clk \\
+        --eop-c04 data/iers/finals2000A.daily \\
+        --output-dir output/iers_sub_daily_eop_bench \\
+        --max-epochs 600
+
+The script writes:
+    <output-dir>/legacy.pos       — gnss_ppp with pole-tide ON, sub-daily OFF
+    <output-dir>/iers.pos         — gnss_ppp with pole-tide ON, sub-daily ON
+    <output-dir>/comparison.json  — paired-epoch displacement stats
+
+See docs/iers-integration-plan.md for the rollout plan this harness
+participates in.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+from gnss_runtime import ensure_input_exists, resolve_gnss_command
+
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog=os.environ.get("GNSS_CLI_NAME"))
+    parser.add_argument("--obs", type=Path, required=True,
+                        help="Rover RINEX observation file.")
+    parser.add_argument("--nav", type=Path, default=None,
+                        help="Optional broadcast navigation file.")
+    parser.add_argument("--sp3", type=Path, default=None,
+                        help="Optional precise orbit file (SP3).")
+    parser.add_argument("--clk", type=Path, default=None,
+                        help="Optional precise clock file (CLK).")
+    parser.add_argument("--ionex", type=Path, default=None,
+                        help="Optional IONEX TEC map.")
+    parser.add_argument("--dcb", type=Path, default=None,
+                        help="Optional DCB / Bias-SINEX product.")
+    parser.add_argument("--antex", type=Path, default=None,
+                        help="Optional ANTEX antenna file.")
+    parser.add_argument("--blq", type=Path, default=None,
+                        help="Optional BLQ ocean-loading coefficient file.")
+    parser.add_argument("--ocean-loading-station", default=None,
+                        help="Station name to select from the BLQ file.")
+    parser.add_argument(
+        "--eop-c04", type=Path, required=True,
+        help="IERS 20 C04 or Bulletin A EOP file (mandatory). The "
+             "sub-daily EOP correction enters PPP only via the "
+             "pole-tide displacement, which is a no-op without an "
+             "EOP table loaded. "
+             "Source: https://hpiers.obspm.fr/iers/eop/eopc04/eopc04.1962-now")
+    parser.add_argument(
+        "--mode", choices=("static", "kinematic"), default="static",
+        help="PPP motion model. (default: static)")
+    parser.add_argument(
+        "--max-epochs", type=int, default=0,
+        help="Limit processed epochs in each PPP run (default: 0 == all).")
+    parser.add_argument(
+        "--output-dir", type=Path,
+        default=ROOT_DIR / "output" / "iers_sub_daily_eop_bench",
+        help="Directory for paired .pos outputs and the comparison summary.")
+    parser.add_argument(
+        "--require-max-displacement-m", type=float, default=None,
+        help="Optional acceptance gate: fail if the maximum per-epoch "
+             "ECEF displacement between the two paths (after the "
+             "convergence-gate filter is applied) exceeds this many "
+             "meters. The sub-daily delta is sub-mas xp/yp on top of "
+             "the daily-interpolated value, producing µm-level static "
+             "PPP receiver-position effects, so values in the "
+             "0.0001-0.001 m range are reasonable upper bounds.")
+    parser.add_argument(
+        "--outlier-threshold-m", type=float, default=0.1,
+        help="Convergence-gate threshold (default 0.1 m). Per-epoch "
+             "displacements above this are dropped from the filtered "
+             "stats — they are dominated by transient PPP convergence "
+             "noise rather than the sub-mas sub-daily-EOP signal. The "
+             "unfiltered distribution is also kept in the JSON for "
+             "transparency.")
+    return parser.parse_args()
+
+
+def read_pos_records(path: Path) -> list[dict[str, float | int]]:
+    """Parse a libgnss++ ``.pos`` solution file into a list of
+    per-epoch dicts. Mirrors the parser pattern used by the
+    pole-tide bench (#63) so the field semantics are consistent."""
+    records: list[dict[str, float | int]] = []
+    with path.open(encoding="ascii") as handle:
+        for line in handle:
+            if not line.strip() or line.startswith("%"):
+                continue
+            parts = line.split()
+            if len(parts) < 10:
+                continue
+            records.append({
+                "week": int(float(parts[0])),
+                "tow": float(parts[1]),
+                "x": float(parts[2]),
+                "y": float(parts[3]),
+                "z": float(parts[4]),
+                "status": int(parts[8]),
+                "satellites": int(parts[9]),
+            })
+    return records
+
+
+def run_ppp(
+    base_command: list[str],
+    args: argparse.Namespace,
+    out_pos: Path,
+    use_sub_daily: bool,
+) -> None:
+    """Invoke ``gnss ppp`` for one of the two paired runs. Pole tide
+    is enabled in both runs; the toggle is on the sub-daily EOP
+    correction only."""
+    cmd = [
+        *base_command, "ppp",
+        "--obs", str(args.obs),
+        "--out", str(out_pos),
+        "--quiet",
+        "--eop-c04", str(args.eop_c04),
+        "--use-iers-pole-tide",
+    ]
+    if args.nav is not None:
+        cmd += ["--nav", str(args.nav)]
+    if args.sp3 is not None:
+        cmd += ["--sp3", str(args.sp3)]
+    if args.clk is not None:
+        cmd += ["--clk", str(args.clk)]
+    if args.ionex is not None:
+        cmd += ["--ionex", str(args.ionex)]
+    if args.dcb is not None:
+        cmd += ["--dcb", str(args.dcb)]
+    if args.antex is not None:
+        cmd += ["--antex", str(args.antex)]
+    if args.blq is not None:
+        cmd += ["--blq", str(args.blq)]
+        if args.ocean_loading_station is not None:
+            cmd += ["--ocean-loading-station", args.ocean_loading_station]
+    if args.mode == "kinematic":
+        cmd += ["--kinematic"]
+    if args.max_epochs > 0:
+        cmd += ["--max-epochs", str(args.max_epochs)]
+    cmd += ["--use-iers-sub-daily-eop" if use_sub_daily
+            else "--no-iers-sub-daily-eop"]
+
+    label = "iers" if use_sub_daily else "legacy"
+    print(f"[bench] running {label} PPP -> {out_pos}", file=sys.stderr)
+    subprocess.run(cmd, check=True)
+
+
+def epoch_key(record: dict) -> tuple[int, int]:
+    """Match epochs across the two paired runs by (week, tow_microseconds).
+    Microsecond-rounding the TOW absorbs the ``.pos`` writer's printf
+    formatting so we don't double-match on float comparison."""
+    return (int(record["week"]), int(round(float(record["tow"]) * 1e6)))
+
+
+def _stats_block(displacements_m: list[float],
+                 dx_m: list[float], dy_m: list[float],
+                 dz_m: list[float]) -> dict:
+    """Compute the displacement-statistics block for one set of
+    paired-epoch deltas. Used twice — once for the unfiltered set
+    and once after the convergence-gate filter is applied."""
+    if not displacements_m:
+        return {"n": 0}
+    sorted_d = sorted(displacements_m)
+    out: dict = {
+        "n": len(displacements_m),
+        "max_displacement_m":     sorted_d[-1],
+        "min_displacement_m":     sorted_d[0],
+        "mean_displacement_m":    statistics.fmean(displacements_m),
+        "median_displacement_m":  statistics.median(displacements_m),
+        "p95_displacement_m":     sorted_d[int(0.95 * (len(sorted_d) - 1))],
+        "first_epoch_displacement_m": displacements_m[0],
+        "median_dx_m":            statistics.median(dx_m),
+        "median_dy_m":            statistics.median(dy_m),
+        "median_dz_m":            statistics.median(dz_m),
+    }
+    if displacements_m[0] > 1e-9:
+        out["aggregate_to_first_epoch_ratio"] = (
+            sorted_d[-1] / displacements_m[0])
+    return out
+
+
+def summarize(legacy_pos: Path, iers_pos: Path,
+              outlier_threshold_m: float = 0.1) -> dict:
+    """Paired-epoch displacement summary with a transient-PPP filter.
+    Identical structure to the pole-tide harness — see that file's
+    docstring for the rationale."""
+    legacy = {epoch_key(r): r for r in read_pos_records(legacy_pos)}
+    iers = {epoch_key(r): r for r in read_pos_records(iers_pos)}
+    matched_keys = sorted(set(legacy) & set(iers))
+
+    raw_d, raw_dx, raw_dy, raw_dz = [], [], [], []
+    flt_d, flt_dx, flt_dy, flt_dz = [], [], [], []
+    n_status_mismatch = 0
+    n_threshold_exceeded = 0
+    for key in matched_keys:
+        l = legacy[key]
+        i = iers[key]
+        dx = float(i["x"]) - float(l["x"])
+        dy = float(i["y"]) - float(l["y"])
+        dz = float(i["z"]) - float(l["z"])
+        d = math.sqrt(dx * dx + dy * dy + dz * dz)
+        raw_d.append(d); raw_dx.append(dx); raw_dy.append(dy); raw_dz.append(dz)
+
+        status_match = (int(l["status"]) == int(i["status"]))
+        if not status_match:
+            n_status_mismatch += 1
+            continue
+        if d > outlier_threshold_m:
+            n_threshold_exceeded += 1
+            continue
+        flt_d.append(d); flt_dx.append(dx); flt_dy.append(dy); flt_dz.append(dz)
+
+    summary: dict = {
+        "matched_epochs": len(matched_keys),
+        "legacy_total_epochs": len(legacy),
+        "iers_total_epochs": len(iers),
+        "filter": {
+            "outlier_threshold_m":   outlier_threshold_m,
+            "status_mismatch":       n_status_mismatch,
+            "threshold_exceeded":    n_threshold_exceeded,
+            "n_kept":                len(flt_d),
+            "n_dropped":             len(matched_keys) - len(flt_d),
+        },
+        "unfiltered": _stats_block(raw_d, raw_dx, raw_dy, raw_dz),
+    }
+    summary.update(_stats_block(flt_d, flt_dx, flt_dy, flt_dz))
+    return summary
+
+
+def main() -> int:
+    args = parse_args()
+
+    ensure_input_exists(args.obs, "observation file", ROOT_DIR)
+    if args.nav is not None:
+        ensure_input_exists(args.nav, "navigation file", ROOT_DIR)
+    if args.sp3 is not None:
+        ensure_input_exists(args.sp3, "SP3 orbit file", ROOT_DIR)
+    if args.clk is not None:
+        ensure_input_exists(args.clk, "clock file", ROOT_DIR)
+    ensure_input_exists(args.eop_c04, "IERS C04 EOP file", ROOT_DIR)
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    legacy_pos = args.output_dir / "legacy.pos"
+    iers_pos = args.output_dir / "iers.pos"
+    comparison_json = args.output_dir / "comparison.json"
+
+    base_command = resolve_gnss_command(ROOT_DIR)
+    run_ppp(base_command, args, legacy_pos, use_sub_daily=False)
+    run_ppp(base_command, args, iers_pos, use_sub_daily=True)
+
+    summary = summarize(
+        legacy_pos, iers_pos,
+        outlier_threshold_m=args.outlier_threshold_m)
+    summary["legacy_pos"] = str(legacy_pos)
+    summary["iers_pos"] = str(iers_pos)
+
+    comparison_json.write_text(
+        json.dumps(summary, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+    if (args.require_max_displacement_m is not None
+            and "max_displacement_m" in summary
+            and summary["max_displacement_m"] >
+                args.require_max_displacement_m):
+        print(
+            f"FAIL: max displacement {summary['max_displacement_m']:.6f} m "
+            f"exceeds gate {args.require_max_displacement_m} m",
+            file=sys.stderr,
+        )
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/apps/gnss_ppp_iers_sub_daily_eop_multisite_bench.py
+++ b/apps/gnss_ppp_iers_sub_daily_eop_multisite_bench.py
@@ -1,0 +1,223 @@
+#!/usr/bin/env python3
+"""Multi-site driver around ``gnss_ppp_iers_sub_daily_eop_bench``.
+
+Runs the Phase D-2 sub-daily-EOP truth-bench harness across an
+arbitrary list of IGS stations and aggregates the per-site
+comparison JSONs into one report. Mirrors
+``gnss_ppp_iers_pole_tide_multisite_bench`` exactly — only the
+underlying single-site harness differs (sub-daily EOP toggle vs
+pole-tide toggle) and the default output directory name.
+
+The single-site harness keeps ``--use-iers-pole-tide`` enabled in
+both runs and toggles only ``--use-iers-sub-daily-eop``: the
+sub-daily correction enters PPP only via the pole-tide
+displacement (which consumes xp / yp), so this isolates the
+sub-daily harmonic delta on top of the daily-interpolated
+pole-tide signal.
+
+Site list is supplied via ``--sites <site_config.json>`` whose
+schema is::
+
+    {
+      "common": {
+        "nav": "data/igs_2026105/BRDC.rnx",
+        "sp3": "data/igs_2026105/IGS_final.sp3",
+        "clk": "data/igs_2026105/IGS_final.clk",
+        "eop_c04": "data/iers/finals2000A.daily"
+      },
+      "sites": [
+        { "name": "TSKB", "obs": "data/igs_2026105/TSKB.rnx" },
+        { "name": "ALGO", "obs": "data/igs_2026105/ALGO00CAN.rnx" },
+        ...
+      ]
+    }
+
+A site row may also override any of ``nav`` / ``sp3`` / ``clk`` /
+``eop_c04`` from ``common`` (the same multi-day extension used by
+the pole-tide multi-site driver — see PR #73).
+
+The script writes:
+    <output-dir>/per_site/<NAME>/legacy.pos     — single-site bench output
+    <output-dir>/per_site/<NAME>/iers.pos
+    <output-dir>/per_site/<NAME>/comparison.json
+    <output-dir>/multisite_summary.json         — aggregate report
+
+See ``docs/iers-integration-plan.md`` for the rollout plan.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import statistics
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog=os.environ.get("GNSS_CLI_NAME"))
+    parser.add_argument("--sites", type=Path, required=True,
+                        help="JSON site configuration (see module doc).")
+    parser.add_argument("--output-dir", type=Path,
+                        default=ROOT_DIR / "output" /
+                                "iers_sub_daily_eop_multisite_bench",
+                        help="Directory for per-site outputs and the "
+                             "aggregate summary.")
+    parser.add_argument("--max-epochs", type=int, default=0,
+                        help="Per-site PPP epoch cap (0 == all).")
+    parser.add_argument("--mode", choices=("static", "kinematic"),
+                        default="static",
+                        help="PPP motion model. (default: static)")
+    return parser.parse_args()
+
+
+def run_single_site(
+    config: dict,
+    site: dict,
+    common: dict,
+    output_dir: Path,
+    mode: str,
+    max_epochs: int,
+) -> dict | None:
+    """Invoke ppp-iers-sub-daily-eop-bench for one site. Returns the
+    per-site comparison.json dict, or None on failure."""
+    name = site["name"]
+    site_dir = output_dir / "per_site" / name
+    site_dir.mkdir(parents=True, exist_ok=True)
+    nav  = site.get("nav",  common.get("nav"))
+    sp3  = site.get("sp3",  common.get("sp3"))
+    clk  = site.get("clk",  common.get("clk"))
+    eop  = site.get("eop_c04", common.get("eop_c04"))
+    cmd = [
+        "python3",
+        str(ROOT_DIR / "apps" / "gnss_ppp_iers_sub_daily_eop_bench.py"),
+        "--obs", str(site["obs"]),
+        "--eop-c04", str(eop),
+        "--output-dir", str(site_dir),
+        "--mode", mode,
+    ]
+    if nav is not None: cmd += ["--nav", str(nav)]
+    if sp3 is not None: cmd += ["--sp3", str(sp3)]
+    if clk is not None: cmd += ["--clk", str(clk)]
+    if max_epochs > 0:
+        cmd += ["--max-epochs", str(max_epochs)]
+
+    print(f"\n[multisite] === running site {name} ===", file=sys.stderr)
+    env = os.environ.copy()
+    env["PYTHONPATH"] = (str(ROOT_DIR / "apps")
+                        + os.pathsep + env.get("PYTHONPATH", ""))
+    try:
+        subprocess.run(cmd, check=True, env=env)
+    except subprocess.CalledProcessError as exc:
+        print(f"[multisite] site {name} failed: {exc}", file=sys.stderr)
+        return None
+
+    cmp_path = site_dir / "comparison.json"
+    if not cmp_path.exists():
+        print(f"[multisite] site {name} produced no comparison.json",
+              file=sys.stderr)
+        return None
+    with cmp_path.open() as fh:
+        return json.load(fh)
+
+
+def aggregate(per_site: dict[str, dict]) -> dict:
+    """Pull headline statistics from each per-site comparison.json into
+    a single distribution-level summary."""
+    metrics = ("max_displacement_m",
+               "p95_displacement_m",
+               "median_displacement_m",
+               "first_epoch_displacement_m",
+               "median_dx_m", "median_dy_m", "median_dz_m")
+    aggregate_summary: dict = {
+        "n_sites": len(per_site),
+        "site_names": sorted(per_site.keys()),
+        "per_site_headline": {},
+        "distribution": {},
+    }
+    for name in sorted(per_site):
+        rec = per_site[name]
+        aggregate_summary["per_site_headline"][name] = {
+            m: rec.get(m) for m in metrics
+        }
+    for m in metrics:
+        values = [per_site[n].get(m) for n in per_site]
+        values = [v for v in values if v is not None]
+        if not values:
+            continue
+        aggregate_summary["distribution"][m] = {
+            "min":    min(values),
+            "max":    max(values),
+            "mean":   statistics.fmean(values),
+            "median": statistics.median(values),
+            "abs_max":      max(abs(v) for v in values),
+            "abs_median":   statistics.median([abs(v) for v in values]),
+        }
+    return aggregate_summary
+
+
+def render_table(per_site: dict[str, dict]) -> str:
+    """Plain-text per-site headline table for human-readable logs."""
+    cols = ("max", "p95", "median", "first", "median_dz")
+    keys = ("max_displacement_m",
+            "p95_displacement_m",
+            "median_displacement_m",
+            "first_epoch_displacement_m",
+            "median_dz_m")
+    lines = ["{:<10}  {:>10}  {:>10}  {:>10}  {:>10}  {:>10}".format(
+        "site", *cols)]
+    for name in sorted(per_site):
+        rec = per_site[name]
+        row = [name]
+        for k in keys:
+            v = rec.get(k)
+            row.append(f"{v*1e3:+.3f}mm" if isinstance(v, (int, float))
+                       else "    n/a")
+        lines.append("{:<10}  {:>10}  {:>10}  {:>10}  {:>10}  {:>10}".format(
+            *row))
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.sites.exists():
+        print(f"sites config not found: {args.sites}", file=sys.stderr)
+        return 1
+    with args.sites.open() as fh:
+        config = json.load(fh)
+    common = config.get("common", {})
+    sites = config.get("sites", [])
+    if not sites:
+        print("sites config has no 'sites' list", file=sys.stderr)
+        return 1
+
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+
+    per_site: dict[str, dict] = {}
+    for site in sites:
+        name = site["name"]
+        result = run_single_site(
+            config, site, common, args.output_dir, args.mode, args.max_epochs)
+        if result is not None:
+            per_site[name] = result
+
+    summary = aggregate(per_site)
+    summary["output_dir"] = str(args.output_dir)
+    summary_path = args.output_dir / "multisite_summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True)
+                             + "\n", encoding="utf-8")
+    print(json.dumps(summary, indent=2, sort_keys=True))
+
+    if per_site:
+        print("\n" + render_table(per_site))
+    print(f"\n[multisite] aggregate written to {summary_path}",
+          file=sys.stderr)
+    return 0 if len(per_site) == len(sites) else 2
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/iers-integration-plan.md
+++ b/docs/iers-integration-plan.md
@@ -345,6 +345,19 @@ does not block Phase C:
   produce sub-µm-level RMS effects on the receiver position;
   inert without an EOP table loaded. `--no-iers-sub-daily-eop` is
   a permanent escape hatch.
+
+  Phase D-2 also includes a paired-PPP single-site bench
+  `apps/gnss_ppp_iers_sub_daily_eop_bench.py` and a multi-site
+  driver `apps/gnss_ppp_iers_sub_daily_eop_multisite_bench.py`
+  (mirroring the pole-tide harnesses from Phase D-1). Both keep
+  `--use-iers-pole-tide` enabled in both runs and toggle only
+  `--use-iers-sub-daily-eop`, so the reported displacement is the
+  isolated sub-daily-harmonic contribution on top of the
+  daily-interpolated pole tide. On TSKB and GRAZ at 2026-04-15
+  (DOY 105, 600-epoch caps) the multi-site bench reports max =
+  4.1 / 5.1 µm, median = 2.4 / 2.8 µm, p95 = 3.5 / 5.1 µm — sub-µm
+  to single-µm, matching the documented sub-mas xp/yp wobble at
+  ~1/100-of-pole-tide amplitude.
 - **Phase D-3** *(in progress)*: Atmospheric tidal loading (IERS
   Conventions 2010 §7.1.5) opt-in. Adds
   `libgnss::iers::atmosphericTidalLoadingDisplacement` and the


### PR DESCRIPTION
## Summary

- Adds `apps/gnss_ppp_iers_sub_daily_eop_bench.py` — paired-PPP truth-bench harness for IERS §5.5.1.1 CIP libration + §8.2 Eanes-Ray ocean-tide EOP corrections.
- Adds `apps/gnss_ppp_iers_sub_daily_eop_multisite_bench.py` — multi-site driver mirroring the Phase D-1 pole-tide multi-site harness (PR #69 / #73 lineage).
- Registers both in `apps/CMakeLists.txt` + `apps/gnss.py`. Updates docs/iers-integration-plan.md §7 Phase D-2 with multi-site bench evidence.

## Design

Both harnesses keep `--use-iers-pole-tide` enabled in legacy and IERS runs and toggle only `--use-iers-sub-daily-eop`. Sub-daily EOP only enters PPP through the pole-tide xp/yp consumer, so toggling sub-daily without pole-tide ON would produce identity output. The reported displacement therefore isolates the sub-daily-harmonic contribution on top of the daily-interpolated pole-tide signal.

The multi-site driver inherits the per-site product overrides added in PR #73 (each site row may override `nav` / `sp3` / `clk` / `eop_c04` from `common`), so a campaign can span multiple days using the same JSON site config schema.

## Bench evidence

TSKB + GRAZ at 2026-04-15 (DOY 105, 600-epoch cap, IGS final SP3 + CLK from BKG mirror, `finals2000A.daily` for EOP):

| site | max | p95 | median | median_dz |
|------|-----|-----|--------|-----------|
| TSKB | 4.1 µm | 3.5 µm | 2.4 µm | +1.0 µm |
| GRAZ | 5.1 µm | 5.1 µm | 2.8 µm | −2.0 µm |

Both mid-latitude northern hemisphere stations show single-µm-level signals, matching the documented sub-mas xp/yp wobble (PR #65 reported RMS 1.5 µm in Z at TSKB). The median_dz signs differ between TSKB and GRAZ, as expected — the sub-daily xp/yp wobble enters via the pole-tide `sin(2θ)·(m1·cosλ + m2·sinλ)` projection, which depends on station longitude.

## Test plan

- [x] `python3 -m py_compile` on both new harnesses + apps/gnss.py
- [x] Single-site bench on TSKB DOY 105 — works, max=4.1µm
- [x] Multi-site bench on TSKB+GRAZ DOY 105 — works, both sites in µm-envelope
- [ ] CI green (no C++ changes; only Python harnesses + CMakeLists.txt install registration)