### PR TITLE
Fix IONEX 60-char window + Bias-SINEX SVN/PRN handling

### DIFF
--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -1824,7 +1824,13 @@ bool IONEXProducts::loadIONEXFile(const std::string& filename) {
                 line.find("LAT/LON1/LON2/DLON/H") != std::string::npos) {
                 break;
             }
-            std::istringstream value_stream(line.substr(0, std::min<size_t>(60U, line.size())));
+            // IONEX data values are 5-char wide (I5 in the spec) and
+            // packed up to 16 values per 80-character line. The
+            // previous 60-char window dropped the last 4 values on
+            // every line, leaving every TEC row 16-values short and
+            // every map empty — silently rejecting CODE / IGS final
+            // IONEX. Use the full line.
+            std::istringstream value_stream(line);
             double raw_value = 0.0;
             while (value_stream >> raw_value) {
                 if (std::abs(raw_value - 9999.0) < 1e-6) {
@@ -1967,8 +1973,31 @@ bool DCBProducts::loadFile(const std::string& filename) {
                 continue;
             }
 
+            // Bias-SINEX rows are `BIAS SVN PRN [STATION] OBS1 OBS2
+            // START END UNIT VALUE STDEV`. Some emitters omit the
+            // optional STATION column entirely; some include it as
+            // a 9-char field that whitespace-tokenization collapses
+            // away. After collapsing, the PRN column may therefore
+            // land at fields[1] (no SVN, e.g. CAS) or fields[2]
+            // (BSX with SVN, e.g. GFZ/GBM). Pick whichever parses
+            // as a valid PRN (3-char `<sys><digit><digit>`); SVNs
+            // are 4 chars (`<sys><digit><digit><digit>`) so
+            // length disambiguates without needing brittle field-
+            // count heuristics.
             SatelliteId satellite;
-            if (!parseSatelliteToken(fields[1], satellite)) {
+            std::size_t obs_offset = 0;
+            if (fields[1].size() == 3U &&
+                parseSatelliteToken(fields[1], satellite)) {
+                obs_offset = 2;
+            } else if (fields[2].size() == 3U &&
+                       parseSatelliteToken(fields[2], satellite)) {
+                obs_offset = 3;
+            } else {
+                continue;
+            }
+            // Required columns (relative to obs_offset): OBS1,
+            // OBS2, START, END, UNIT, VALUE, STDEV — 7 more.
+            if (fields.size() < obs_offset + 7U) {
                 continue;
             }
 
@@ -1976,11 +2005,11 @@ bool DCBProducts::loadFile(const std::string& filename) {
                 DCBEntry entry;
                 entry.bias_type = fields[0];
                 entry.satellite = satellite;
-                entry.observation_1 = fields[2];
-                entry.observation_2 = fields[3];
-                entry.unit = fields[6];
-                entry.bias = std::stod(fields[7]);
-                entry.sigma = std::stod(fields[8]);
+                entry.observation_1 = fields[obs_offset];
+                entry.observation_2 = fields[obs_offset + 1];
+                entry.unit = fields[obs_offset + 4];
+                entry.bias = std::stod(fields[obs_offset + 5]);
+                entry.sigma = std::stod(fields[obs_offset + 6]);
                 entry.valid = std::isfinite(entry.bias);
                 entries.push_back(entry);
                 loaded_any = true;

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -1114,6 +1114,83 @@ TEST(PPPTest, DCBProductsLoadBiasSinexAndLookupEntry) {
     std::filesystem::remove(dcb_path);
 }
 
+TEST(PPPTest, DCBProductsLoadBiasSinexWithSvnAndStationColumns) {
+    // GFZ / GBM emit Bias-SINEX rows with SVN before PRN and an
+    // empty STATION column collapsed by whitespace tokenization:
+    //   DSB G080 G01           C1W  C2W  ...
+    // With the old parser this was rejected (PRN expected at
+    // fields[1] but the SVN landed there) — silently dropping all
+    // GFZ DCB entries and breaking PPP init when --dcb pointed at
+    // a real GBM file. The parser now accepts both layouts.
+    const auto dcb_path = tempFilePath("libgnss_ppp_dcb_svn_test.bsx");
+    std::filesystem::remove(dcb_path);
+
+    const std::string dcb_text =
+        "%=BIA 1.00 GFZ 2026:106:56658 IGS 2026:105:00000 2026:105:89999 R 00000020\n"
+        "+BIAS/SOLUTION\n"
+        "*BIAS SVN_ PRN STATION__ OBS1 OBS2 BEGIN__________ END____________ UNIT VALUE_____ STD_DEV___\n"
+        " DSB  G080 G01           C1W  C2W  2026:105:00000 2026:105:89999 ns   1.234 0.100\n"
+        " OSB  E215 E11           C1C  C5Q  2026:105:00000 2026:105:89999 ns   0.321 0.050\n"
+        "-BIAS/SOLUTION\n";
+    writeTextFile(dcb_path, dcb_text);
+
+    DCBProducts dcb_products;
+    ASSERT_TRUE(dcb_products.loadFile(dcb_path.string()));
+    ASSERT_EQ(dcb_products.entries.size(), 2U);
+
+    double bias = 0.0;
+    double sigma = 0.0;
+    ASSERT_TRUE(dcb_products.getBias(
+        SatelliteId(GNSSSystem::GPS, 1), "DSB", "C1W", "C2W", bias, &sigma));
+    EXPECT_NEAR(bias, 1.234, 1e-12);
+    EXPECT_NEAR(sigma, 0.100, 1e-12);
+    ASSERT_TRUE(dcb_products.getBias(
+        SatelliteId(GNSSSystem::Galileo, 11), "OSB", "C1C", "C5Q", bias, &sigma));
+    EXPECT_NEAR(bias, 0.321, 1e-12);
+    EXPECT_NEAR(sigma, 0.050, 1e-12);
+
+    std::filesystem::remove(dcb_path);
+}
+
+TEST(PPPTest, IONEXProductsLoadFullWidthDataLines) {
+    // Real CODE / IGS final IONEX packs 16 TEC values per 80-char
+    // line (each value 5 chars wide). The previous parser truncated
+    // each line at 60 chars, dropping the trailing 4 values. With a
+    // 73-value-per-row map, the row never reached the expected
+    // value count and was discarded — silently rejecting every
+    // CODE / IGS final IONEX file. This test exercises the
+    // multi-line value collation: 16-value lines must reach the
+    // 19-value-per-row count for a (-180,180,20)-deg sweep.
+    const auto ionex_path = tempFilePath("libgnss_ppp_ionex_wide.inx");
+    std::filesystem::remove(ionex_path);
+
+    // 19 values across 16 + 3, exercising the line-spanning path.
+    const std::string ionex_text =
+        "     1.0           I                   G                   IONEX VERSION / TYPE\n"
+        "  3600                                                      INTERVAL\n"
+        "    -1                                                      EXPONENT\n"
+        "    0.0    0.0   10.0                                       LAT1 / LAT2 / DLAT\n"
+        " -180.0  180.0   20.0                                       LON1 / LON2 / DLON\n"
+        "  450.0  450.0    0.0                                       HGT1 / HGT2 / DHGT\n"
+        "                                                            END OF HEADER\n"
+        "    1                                                      START OF TEC MAP\n"
+        " 2026     4    15     0     0     0                        EPOCH OF CURRENT MAP\n"
+        "    0.0-180.0 180.0  20.0  450.0                            LAT/LON1/LON2/DLON/H\n"
+        "  100  101  102  103  104  105  106  107  108  109  110  111  112  113  114  115\n"
+        "  116  117  118\n"
+        "                                                            END OF TEC MAP\n";
+    writeTextFile(ionex_path, ionex_text);
+
+    IONEXProducts ionex_products;
+    ASSERT_TRUE(ionex_products.loadIONEXFile(ionex_path.string()));
+    ASSERT_EQ(ionex_products.tec_maps.size(), 1U);
+    ASSERT_EQ(ionex_products.tec_maps.front().rows.size(), 1U);
+    EXPECT_EQ(ionex_products.tec_maps.front().rows.front().values_tecu.size(),
+              19U);
+
+    std::filesystem::remove(ionex_path);
+}
+
 TEST(PPPTest, SSRProductsLoadCsvAndInterpolateMidpoint) {
     const auto ssr_path = tempFilePath("libgnss_ppp_ssr_test.csv");
     std::filesystem::remove(ssr_path);


### PR DESCRIPTION
## Summary

Two silent parser bugs in `src/core/navigation.cpp` that rejected real products from IGS analysis centers:

1. **IONEX 60-char window** (`IONEXProducts::loadIONEXFile`): each TEC value line was clipped to 60 chars; standard IONEX packs 16 `I5` values per 80-char line, so the parser dropped the trailing 4 values per line. With a 73-value-per-row map (5° longitude step), the row never reached the expected count and every map was discarded. CODE / IGS final IONEX (e.g. `COD0OPSFIN_*_GIM.INX`) hit this path, making `--ionex` unusable.
2. **Bias-SINEX SVN/PRN handling** (`DCBProducts::loadFile`): expected `BIAS PRN [STATION] OBS1 OBS2 ...` with PRN at `fields[1]`. GFZ / GBM Bias-SINEX uses `BIAS SVN PRN [STATION] OBS1 OBS2 ...`, putting the SVN (e.g. `G080`) at `fields[1]` and the PRN (e.g. `G01`) at `fields[2]`. `parseSatelliteToken` on `G080` failed and every entry was skipped. Disambiguate by token length (SVN = 4 chars, PRN = 3) and shift the OBS1/OBS2/UNIT/VALUE/STDEV indices.

## Discovery

The PR #77 IERS end-to-end truth bench surfaced both bugs the moment it was pointed at a real CODE `.INX` or GFZ `.BSX`: PPP init silently failed with `"failed to initialize PPP processor"`.

After the fix:
- 25 TEC + 25 RMS maps load from `COD0OPSFIN_20261050000_01D_01H_GIM.INX`
- All entries load from `GBM0MGXRAP_20261050000_01D_01D_DCB.BSX`
- PPP init succeeds with `--ionex` and `--dcb`

## Test plan

- [x] New `PPPTest.IONEXProductsLoadFullWidthDataLines` — 19-value row split across a 16-value line + 3-value continuation
- [x] New `PPPTest.DCBProductsLoadBiasSinexWithSvnAndStationColumns` — GFZ-style ` DSB G080 G01 ...` row
- [x] Existing IONEX / DCB tests still pass
- [x] PPP suite 22/22 green
- [ ] CI green

## Caveat (out of scope here)

Loading the products successfully does not yet improve PPP residual against ITRF — the TSKB 2026-04-15 residual went from 2.97 m (no IONEX) to 3.26 m (with `--ionex`). That's a separate downstream issue in the bias/iono application logic and is left for a follow-up.