### PR TITLE
PPP: use SP3 bracket for orbit when CLK-only entry aliases query time

### DIFF
--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -1981,6 +1981,36 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                 sat_velocity,
                 sat_clock_bias,
                 sat_clock_drift);
+            if (have_precise) {
+                // Light-travel-time iteration: the first SP3 sample is taken
+                // at reception time, so re-sample at the implied emission
+                // epoch (rcv − τ) to place sat_position on the orbit when the
+                // photon left the satellite. The downstream geodist() handles
+                // the Sagnac (frame-rotation) term.
+                const double initial_distance =
+                    (sat_position - receiver_position).norm();
+                if (std::isfinite(initial_distance) && initial_distance > 0.0) {
+                    const double travel_time =
+                        initial_distance / constants::SPEED_OF_LIGHT;
+                    const GNSSTime emission_time = time - travel_time;
+                    Vector3d em_position = sat_position;
+                    Vector3d em_velocity = sat_velocity;
+                    double em_clock_bias = sat_clock_bias;
+                    double em_clock_drift = sat_clock_drift;
+                    if (precise_products_.interpolateOrbitClock(
+                            observation.satellite,
+                            emission_time,
+                            em_position,
+                            em_velocity,
+                            em_clock_bias,
+                            em_clock_drift)) {
+                        sat_position = em_position;
+                        sat_velocity = em_velocity;
+                        sat_clock_bias = em_clock_bias;
+                        sat_clock_drift = em_clock_drift;
+                    }
+                }
+            }
         }
 
         if (!have_precise) {

--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -852,83 +852,90 @@ bool PreciseProducts::interpolateOrbitClock(const SatelliteId& sat,
     }
 
     const auto& entries = sat_it->second;
-    auto upper = std::lower_bound(
-        entries.begin(),
-        entries.end(),
-        time,
-        [](const PreciseOrbitClock& lhs, const GNSSTime& rhs) {
-            return lhs.time < rhs;
-        });
 
-    const PreciseOrbitClock* before = nullptr;
-    const PreciseOrbitClock* after = nullptr;
-    if (upper != entries.end()) {
-        after = &(*upper);
-        if (upper != entries.begin()) {
-            before = &(*(upper - 1));
+    // SP3 (orbit, ~15-min) and CLK (clock, ~30-s) merge into a single sorted
+    // entry list. Position-valid entries live on the SP3 grid only; CLK rows
+    // contribute clock-only entries between them. Search the bracketing
+    // position-valid pair separately from the bracketing clock-valid pair so
+    // an exact-match query at a CLK-only timestamp does not fail when SP3
+    // covers the surrounding 15-minute window.
+    const PreciseOrbitClock* pos_before = nullptr;
+    const PreciseOrbitClock* pos_after = nullptr;
+    const PreciseOrbitClock* clk_before = nullptr;
+    const PreciseOrbitClock* clk_after = nullptr;
+    for (const auto& entry : entries) {
+        if (entry.time <= time) {
+            if (entry.position_valid) {
+                pos_before = &entry;
+            }
+            if (entry.clock_valid) {
+                clk_before = &entry;
+            }
+        } else {
+            if (entry.position_valid && pos_after == nullptr) {
+                pos_after = &entry;
+            }
+            if (entry.clock_valid && clk_after == nullptr) {
+                clk_after = &entry;
+            }
+            if (pos_after != nullptr && clk_after != nullptr) {
+                break;
+            }
         }
-        if (upper->time == time) {
-            before = after;
-        }
-    } else {
-        before = &entries.back();
     }
 
-    if (before == nullptr && after == nullptr) {
-        return false;
-    }
-
-    if (before != nullptr && after != nullptr && before != after) {
-        const double dt_total = after->time - before->time;
-        const double dt_before = time - before->time;
-        if (std::abs(dt_total) < 1e-9 || std::abs(dt_total) > kPreciseInterpolationGapSeconds) {
+    auto interpolatePair = [&time](const PreciseOrbitClock* before,
+                                    const PreciseOrbitClock* after,
+                                    auto&& accessor,
+                                    auto& out_value,
+                                    auto& out_rate) -> bool {
+        if (before != nullptr && after != nullptr && before != after) {
+            const double dt_total = after->time - before->time;
+            if (std::abs(dt_total) < 1e-9 ||
+                std::abs(dt_total) > kPreciseInterpolationGapSeconds) {
+                return false;
+            }
+            const double dt_before = time - before->time;
+            const double alpha = dt_before / dt_total;
+            const auto before_value = accessor(*before);
+            const auto after_value = accessor(*after);
+            out_value = before_value + alpha * (after_value - before_value);
+            out_rate = (after_value - before_value) / dt_total;
+            return true;
+        }
+        const PreciseOrbitClock* sample = before != nullptr ? before : after;
+        if (sample == nullptr) {
             return false;
         }
-        const double alpha = dt_before / dt_total;
-        if ((before->position_valid || after->position_valid) &&
-            before->position_valid && after->position_valid) {
-            position = before->position + alpha * (after->position - before->position);
-            velocity = (after->position - before->position) / dt_total;
-        } else if (before->position_valid) {
-            position = before->position;
-            velocity = before->velocity;
-        } else if (after->position_valid) {
-            position = after->position;
-            velocity = after->velocity;
-        } else {
+        if (std::abs(sample->time - time) > kPreciseInterpolationGapSeconds) {
             return false;
         }
-
-        if (before->clock_valid && after->clock_valid) {
-            clock_bias = before->clock_bias + alpha * (after->clock_bias - before->clock_bias);
-            clock_drift = (after->clock_bias - before->clock_bias) / dt_total;
-        } else if (before->clock_valid) {
-            clock_bias = before->clock_bias;
-            clock_drift = before->clock_drift;
-        } else if (after->clock_valid) {
-            clock_bias = after->clock_bias;
-            clock_drift = after->clock_drift;
-        } else {
-            clock_bias = 0.0;
-            clock_drift = 0.0;
-        }
+        out_value = accessor(*sample);
+        out_rate = std::remove_reference_t<decltype(out_rate)>{};
         return true;
-    }
+    };
 
-    const PreciseOrbitClock* sample = before != nullptr ? before : after;
-    if (sample == nullptr) {
+    Vector3d interpolated_velocity = Vector3d::Zero();
+    if (!interpolatePair(
+            pos_before, pos_after,
+            [](const PreciseOrbitClock& e) { return e.position; },
+            position, interpolated_velocity)) {
         return false;
     }
-    if (std::abs(sample->time - time) > kPreciseInterpolationGapSeconds) {
-        return false;
+    velocity = interpolated_velocity;
+
+    double interpolated_drift = 0.0;
+    if (!interpolatePair(
+            clk_before, clk_after,
+            [](const PreciseOrbitClock& e) { return e.clock_bias; },
+            clock_bias, interpolated_drift)) {
+        // Fall back to a stationary clock if no CLK data is available; orbit
+        // alone is still useful for geometry.
+        clock_bias = 0.0;
+        clock_drift = 0.0;
+    } else {
+        clock_drift = interpolated_drift;
     }
-    if (!sample->position_valid) {
-        return false;
-    }
-    position = sample->position;
-    velocity = sample->velocity;
-    clock_bias = sample->clock_valid ? sample->clock_bias : 0.0;
-    clock_drift = sample->clock_valid ? sample->clock_drift : 0.0;
     return true;
 }
 

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -1026,6 +1026,64 @@ TEST(PPPTest, PreciseProductsLoadSp3AndClockAndInterpolateMidpoint) {
     std::filesystem::remove(clk_path);
 }
 
+TEST(PPPTest, PreciseProductsInterpolateAtClockOnlyTimestampUsesSP3Bracket) {
+    // Reproduces the silent SP3+CLK aliasing bug (2026-05-09): when the query
+    // time lands exactly on a CLK-only entry (added at 30 s spacing for IGS
+    // CLK files) that does not coincide with an SP3 epoch (15 min spacing),
+    // the interpolator was short-circuiting to a single-sample lookup whose
+    // position_valid was false, returning false. The PPP precise path then
+    // silently fell back to broadcast ephemeris for ~99% of receiver epochs.
+    const auto sp3_path = tempFilePath("libgnss_ppp_clk_only_query_test.sp3");
+    const auto clk_path = tempFilePath("libgnss_ppp_clk_only_query_test.clk");
+    std::filesystem::remove(sp3_path);
+    std::filesystem::remove(clk_path);
+
+    const std::string sp3_text =
+        "*  2026 03 26 00 00 00.00000000\n"
+        "PG01   20200.000000   14000.000000   21700.000000       123.000000\n"
+        "*  2026 03 26 00 15 00.00000000\n"
+        "PG01   20201.500000   14001.500000   21701.500000       223.000000\n";
+    // CLK with samples at 00:00, 00:00:30, and 00:15 (typical IGS 30 s grid).
+    // Query at 00:00:30 is *exactly* a CLK-only entry — pre-fix this returned
+    // false; post-fix it must interpolate the SP3 bracket.
+    const std::string clk_text =
+        "     3.00           C                   RINEX VERSION / TYPE\n"
+        "END OF HEADER\n"
+        "AS G01 2026 03 26 00 00 00.00000000  2  1.230000000000E-04  1.000000000000E-12\n"
+        "AS G01 2026 03 26 00 00 30.00000000  2  1.250000000000E-04  1.000000000000E-12\n"
+        "AS G01 2026 03 26 00 15 00.00000000  2  2.230000000000E-04  1.000000000000E-12\n";
+
+    writeTextFile(sp3_path, sp3_text);
+    writeTextFile(clk_path, clk_text);
+
+    PreciseProducts precise_products;
+    ASSERT_TRUE(precise_products.loadSP3File(sp3_path.string()));
+    ASSERT_TRUE(precise_products.loadClockFile(clk_path.string()));
+
+    Vector3d position = Vector3d::Zero();
+    Vector3d velocity = Vector3d::Zero();
+    double clock_bias = 0.0;
+    double clock_drift = 0.0;
+    const GNSSTime clk_only_query = makeTime(2026, 3, 26, 0, 0, 30.0);
+    ASSERT_TRUE(precise_products.interpolateOrbitClock(
+        SatelliteId(GNSSSystem::GPS, 1), clk_only_query,
+        position, velocity, clock_bias, clock_drift));
+
+    // Position interpolated from SP3 bracket at alpha = 30 / 900.
+    constexpr double kAlpha = 30.0 / 900.0;
+    EXPECT_NEAR(position.x(),
+                20'200'000.0 + kAlpha * 1500.0, 1e-3);
+    EXPECT_NEAR(position.y(),
+                14'000'000.0 + kAlpha * 1500.0, 1e-3);
+    EXPECT_NEAR(position.z(),
+                21'700'000.0 + kAlpha * 1500.0, 1e-3);
+    // Clock bias from the exact CLK sample at 00:00:30.
+    EXPECT_NEAR(clock_bias, 1.25e-4, 1e-12);
+
+    std::filesystem::remove(sp3_path);
+    std::filesystem::remove(clk_path);
+}
+
 TEST(PPPTest, IONEXProductsLoadAndInterpolateTecAndRms) {
     const auto ionex_path = tempFilePath("libgnss_ppp_ionex_test.ionex");
     std::filesystem::remove(ionex_path);


### PR DESCRIPTION
## Summary
- `PreciseProducts::interpolateOrbitClock` silently returned false whenever the query timestamp matched a CLK-only entry (the typical 30-s IGS CLK row that lives between two 15-min SP3 epochs). PPP's precise path then fell back to broadcast ephemeris for **all but the very first epoch**.
- Now searches the bracketing position-valid pair and the bracketing clock-valid pair independently, so position interpolates against the SP3 grid and clock interpolates against the CLK grid.
- Also iterates light-travel-time on the precise path so `sat_position` lies on the orbit at emission time. The existing `geodist()` already supplies the Sagnac correction analytically.
- New `PPPTest.PreciseProductsInterpolateAtClockOnlyTimestampUsesSP3Bracket` regression test fails on develop and passes on the fix.

## Root cause walkthrough
`lower_bound` for the query time landed on the CLK-only row (`upper->time == time`). The short-circuit `before = after` made `before == after`, the function fell through to the single-sample branch, and `if (!sample->position_valid) return false;` returned false because the CLK row carries no position.

Symptom: in TSKB DOY 105 PPP the precise path only fired for `tow=259200` (the first SP3 epoch). For every other epoch, `precise_products_loaded_=true` but `interpolateOrbitClock` returned false, so the fallback broadcast-eph path ran instead. The 3 m absolute residual investigation surfaced this only after instrumented LTT debug printed `have_precise=0` for 94/114 sat-call combinations.

## Bench impact (TSKB DOY 105, IGS final SP3+CLK, no ANTEX)
| | residual vs RINEX header XYZ | residual vs RTKLIB ppp-static |
|---|---|---|
| develop (broadcast eph fallback for 99% of epochs) | 3.23 m | 2.37 m |
| this fix (precise products active for all epochs) | 3.82 m | 2.96 m |
| RTKLIB rnx2rtkp `-p 7` with proper config (reference) | 1.12 m | — |

The +0.6 m drift is **not** a regression in the loader — it exposes a separate downstream model bias (likely clock-reference vs primary-signal mismatch) that the broken precise path was previously masking. Tracked as a follow-up; this PR is scoped to the loader bug.

## Test plan
- [x] `build/tests/run_tests` passes (268 PASSED, 0 FAILED)
- [x] New `PPPTest.PreciseProductsInterpolateAtClockOnlyTimestampUsesSP3Bracket` confirmed to fail on develop and pass on this branch
- [x] TSKB / GRAZ static bench reruns documented above