### PR TITLE
PPP: phase wind-up hook + IONEX gate + sat ANTEX loader

### DIFF
--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -20,9 +20,20 @@
 
 namespace libgnss {
 
+/// Per-SVN ANTEX entry used by PPPProcessor to translate satellite
+/// centre-of-mass positions (as delivered by SP3) to the antenna phase
+/// centre. Body frame uses ANTEX semantics: x = north-of-antenna,
+/// y = east-of-antenna, z = up-of-antenna ≡ boresight toward Earth.
+struct SatelliteAntexEntry {
+    SatelliteId satellite;
+    GNSSTime valid_from;
+    GNSSTime valid_until;
+    std::map<SignalType, Vector3d> body_offsets_m;
+};
+
 /**
  * @brief Precise Point Positioning (PPP) processor
- * 
+ *
  * Implements PPP using precise orbits and clocks for decimeter to
  * centimeter level positioning without base stations.
  */
@@ -221,6 +232,8 @@ private:
     bool atm_tidal_loading_loaded_ = false;
     std::map<std::string, std::map<SignalType, Vector3d>> receiver_antex_offsets_;
     bool receiver_antex_loaded_ = false;
+    std::vector<SatelliteAntexEntry> satellite_antex_offsets_;
+    bool satellite_antex_loaded_ = false;
     Vector3d static_anchor_position_ = Vector3d::Zero();
     bool has_static_anchor_position_ = false;
     double last_ar_ratio_ = 0.0;

--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -587,10 +587,17 @@ namespace ppp_utils {
                                        const std::string& antenna_type);
     
     /**
-     * @brief Calculate phase windup correction
+     * @brief Calculate phase windup correction (Wu et al. 1993).
+     *
+     * The satellite body frame is constructed from the sun direction so the
+     * X-axis points away from the spacecraft–Sun plane normal — the geometry
+     * used by IGS/RTKLIB. `sun_position_ecef` may be Vector3d::Zero() to fall
+     * back to a line-of-sight approximation, but precise PPP should always
+     * pass a real sun position.
      */
     double calculatePhaseWindup(const Vector3d& receiver_pos,
                               const Vector3d& satellite_pos,
+                              const Vector3d& sun_position_ecef,
                               double previous_windup);
 }
 

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -186,6 +186,20 @@ struct PPPConfig {
     // report centre of mass (some legacy AC products / GLONASS-only
     // analyses). The ANTEX loader is unconditional when --antex is set.
     bool apply_satellite_antenna_pco = false;
+    // Hard-blend the static-mode position state toward the SPP-derived
+    // anchor each epoch (50 % post-convergence with precise products).
+    //
+    // The blend caps absolute accuracy at the SPP-anchor floor (TSKB
+    // DOY 105: 2.79 m static residual vs RTKLIB rnx2rtkp 1.12 m on the
+    // same products), but disabling it on the precise-products path
+    // with the current observation-model implementation lets the
+    // receiver-clock and zenith-troposphere states run away —
+    // bench-verified divergence to 30 km within 5 hours at TSKB.
+    // Leave true unless and until the observation-model bias that
+    // drives the underlying divergence (~10–40 m first-epoch
+    // pseudorange residuals) is identified and fixed; then this
+    // becomes the obvious lever to lift the floor.
+    bool apply_static_anchor_blend = true;
     // When true (and apply_solid_earth_tides is also true), use the
     // IERS Conventions 2010 §7.1.1 (Dehant) Step-1 + Step-2 model
     // from libgnss::iers::solidEarthTideDisplacement instead of the

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -177,6 +177,15 @@ struct PPPConfig {
 
     bool apply_ocean_loading = false;
     bool apply_solid_earth_tides = true;
+    // Apply satellite antenna PCO (read from ANTEX) by shifting the
+    // SP3-interpolated satellite position to the ionosphere-free
+    // combination phase center. Default off because IGS final products
+    // since the 2017 convention switch publish SP3 / CLK already at the
+    // IF antenna phase center, so the additional shift double-applies
+    // the offset on those products. Enable for SP3 sources known to
+    // report centre of mass (some legacy AC products / GLONASS-only
+    // analyses). The ANTEX loader is unconditional when --antex is set.
+    bool apply_satellite_antenna_pco = false;
     // When true (and apply_solid_earth_tides is also true), use the
     // IERS Conventions 2010 §7.1.1 (Dehant) Step-1 + Step-2 model
     // from libgnss::iers::solidEarthTideDisplacement instead of the

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -189,17 +189,21 @@ struct PPPConfig {
     // Hard-blend the static-mode position state toward the SPP-derived
     // anchor each epoch (50 % post-convergence with precise products).
     //
-    // The blend caps absolute accuracy at the SPP-anchor floor (TSKB
-    // DOY 105: 2.79 m static residual vs RTKLIB rnx2rtkp 1.12 m on the
-    // same products), but disabling it on the precise-products path
-    // with the current observation-model implementation lets the
-    // receiver-clock and zenith-troposphere states run away —
-    // bench-verified divergence to 30 km within 5 hours at TSKB.
-    // Leave true unless and until the observation-model bias that
-    // drives the underlying divergence (~10–40 m first-epoch
-    // pseudorange residuals) is identified and fixed; then this
-    // becomes the obvious lever to lift the floor.
-    bool apply_static_anchor_blend = true;
+    // The blend was originally needed to prevent receiver-clock and
+    // zenith-troposphere runaway (TSKB anchor=off diverged to 30 km
+    // within 5 h) caused by km-class first-epoch pseudorange residuals
+    // from the linear SP3 interpolator. Once Lagrange (degree-9)
+    // polynomial interpolation replaced linear in
+    // `PreciseProducts::interpolateOrbitClock`, those residuals
+    // collapsed to ~10 m and the anchor is no longer needed for
+    // stability. Worse, the anchor caps absolute accuracy at the
+    // SPP floor: TSKB DOY 105 static residual is 1.29 m with the
+    // anchor disabled (close to RTKLIB rnx2rtkp's 1.12 m) vs 3.73 m
+    // with the anchor enabled on the Lagrange path. Default off; flip
+    // to true only when running with broadcast ephemeris or SSR
+    // products whose orbit accuracy is too poor for the filter to
+    // converge unaided.
+    bool apply_static_anchor_blend = false;
     // When true (and apply_solid_earth_tides is also true), use the
     // IERS Conventions 2010 §7.1.1 (Dehant) Step-1 + Step-2 model
     // from libgnss::iers::solidEarthTideDisplacement instead of the

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -3531,6 +3531,9 @@ void PPPProcessor::constrainStaticAnchorPosition() {
         !has_static_anchor_position_) {
         return;
     }
+    if (!ppp_config_.apply_static_anchor_blend) {
+        return;
+    }
     if (precise_products_loaded_ && !ppp_config_.estimate_troposphere) {
         return;
     }

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -1958,6 +1958,10 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
     }
     const int preferred_network_id = preferredClasNetworkId(epoch_atmos_tokens);
 
+    // Sun position is needed for the satellite body frame in phase wind-up.
+    // We compute it once per epoch and reuse for every satellite.
+    const Vector3d sun_position_ecef = approximateSunPositionEcef(time);
+
     for (auto& observation : observations) {
         double deferred_variance_pr = 0.0;
         double deferred_variance_cp = 0.0;
@@ -2268,6 +2272,35 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
         } else {
             observation.antenna_pco_m = 0.0;
         }
+
+        // Phase wind-up correction (Wu et al. 1993). Same cycle count for L1
+        // and L2 — convert via the IF combination wavelength c/(f1+f2),
+        // which is c1*λ1 + c2*λ2 with the standard IFLC coefficients.
+        if (observation.has_carrier_phase) {
+            const double previous_windup =
+                windup_cache_.count(observation.satellite) ?
+                    windup_cache_[observation.satellite] : 0.0;
+            const double new_windup = ppp_utils::calculatePhaseWindup(
+                receiver_position, sat_position, sun_position_ecef, previous_windup);
+            windup_cache_[observation.satellite] = new_windup;
+
+            double windup_wavelength_m = 0.0;
+            if (ppp_config_.use_ionosphere_free &&
+                observation.secondary_signal != SignalType::SIGNAL_TYPE_COUNT) {
+                const double f1 = signalFrequencyHz(observation.primary_signal, eph);
+                const double f2 = signalFrequencyHz(observation.secondary_signal, eph);
+                if (f1 > 0.0 && f2 > 0.0 && f1 + f2 > 0.0) {
+                    windup_wavelength_m = constants::SPEED_OF_LIGHT / (f1 + f2);
+                }
+            } else {
+                windup_wavelength_m = signalWavelengthMeters(observation.primary_signal, eph);
+            }
+            if (windup_wavelength_m > 0.0 && std::isfinite(new_windup)) {
+                const double windup_correction_m = new_windup * windup_wavelength_m;
+                observation.carrier_phase_if -= windup_correction_m;
+            }
+        }
+
         // In CLAS-PPP mode (estimate_ionosphere), reject satellites without
         // both SSR orbit/clock and ionosphere corrections — matching CLASLIB's
         // corrmeas() which returns 0 when STEC correction fails.
@@ -3565,47 +3598,68 @@ Vector3d calculateReceiverAntennaPCO(const Vector3d& receiver_pos,
 
 double calculatePhaseWindup(const Vector3d& receiver_pos,
                             const Vector3d& satellite_pos,
+                            const Vector3d& sun_position_ecef,
                             double previous_windup) {
-    // Phase wind-up correction based on Wu et al. (1993)
-    // Returns accumulated phase wind-up in cycles.
-    const Vector3d e_sr = (receiver_pos - satellite_pos).normalized();
+    // Phase wind-up (Wu et al. 1993) — accumulated cycles between the
+    // satellite and receiver right-handed dipole frames.
+    const Vector3d los_sr = receiver_pos - satellite_pos;
+    const double los_norm = los_sr.norm();
+    if (los_norm < 1.0) return previous_windup;
+    const Vector3d e_sr = los_sr / los_norm;
 
-    // Satellite frame: use sun direction for yaw steering
-    // Simplified: assume satellite Z points to Earth center, X in sun direction
+    // Satellite body frame using a nominal yaw-steering attitude:
+    //   z = -rs / |rs|              (toward Earth center)
+    //   y = z × (sun - rs) / |...|  (perpendicular to spacecraft–Sun plane)
+    //   x = y × z                   (toward Sun side)
     const Vector3d e_z_sat = -satellite_pos.normalized();
-    // Sun direction (simplified: assume along +X in ECEF for now)
-    // A proper implementation would use solar ephemeris.
-    // Using cross-track direction as approximation:
-    Vector3d e_x_sat = e_sr.cross(e_z_sat);
-    if (e_x_sat.norm() < 1e-10) return previous_windup;
-    e_x_sat.normalize();
-    const Vector3d e_y_sat = e_z_sat.cross(e_x_sat);
+    Vector3d sun_dir;
+    if (sun_position_ecef.norm() > 1.0) {
+        sun_dir = sun_position_ecef - satellite_pos;
+    } else {
+        // Fallback: cross-track approximation (gives wrong magnitude but
+        // keeps the correction bounded when no solar ephemeris is supplied).
+        sun_dir = e_sr.cross(e_z_sat);
+    }
+    const double sun_norm = sun_dir.norm();
+    if (sun_norm < 1e-3) return previous_windup;
+    sun_dir /= sun_norm;
+    Vector3d e_y_sat = e_z_sat.cross(sun_dir);
+    const double y_norm = e_y_sat.norm();
+    if (y_norm < 1e-10) return previous_windup;
+    e_y_sat /= y_norm;
+    const Vector3d e_x_sat = e_y_sat.cross(e_z_sat);
 
-    // Receiver frame: Z = up, X = east, Y = north (approximate)
-    const Vector3d e_z_rcv = receiver_pos.normalized();
-    Vector3d e_x_rcv = Vector3d(-receiver_pos.y(), receiver_pos.x(), 0.0);
-    if (e_x_rcv.norm() < 1e-10) return previous_windup;
-    e_x_rcv.normalize();
-    const Vector3d e_y_rcv = e_z_rcv.cross(e_x_rcv);
+    // Receiver local north-east-up (north, east, up are standard PPP/RTKLIB):
+    //   x_rcv → North, y_rcv → East, z_rcv → Up.
+    double latitude_rad = 0.0;
+    double longitude_rad = 0.0;
+    double height_m = 0.0;
+    ecef2geodetic(receiver_pos, latitude_rad, longitude_rad, height_m);
+    const double sin_lat = std::sin(latitude_rad);
+    const double cos_lat = std::cos(latitude_rad);
+    const double sin_lon = std::sin(longitude_rad);
+    const double cos_lon = std::cos(longitude_rad);
+    // North (X): -sin(lat) cos(lon), -sin(lat) sin(lon), cos(lat)
+    const Vector3d e_x_rcv(-sin_lat * cos_lon, -sin_lat * sin_lon, cos_lat);
+    // East  (Y): -sin(lon),                cos(lon),           0
+    const Vector3d e_y_rcv(-sin_lon, cos_lon, 0.0);
 
-    // Effective dipole vectors
+    // Effective dipole vectors (Wu et al. 1993, eq. 7)
     const Vector3d d_sat = e_x_sat - e_sr * (e_sr.dot(e_x_sat))
-                         + e_sr.cross(e_y_sat);
+                         - e_sr.cross(e_y_sat);
     const Vector3d d_rcv = e_x_rcv - e_sr * (e_sr.dot(e_x_rcv))
                          + e_sr.cross(e_y_rcv);
 
-    const double cos_phi = d_sat.dot(d_rcv) / (d_sat.norm() * d_rcv.norm() + 1e-20);
-    const double cross_sign = e_sr.dot(d_sat.cross(d_rcv));
-    double dphi = std::acos(std::clamp(cos_phi, -1.0, 1.0)) / (2.0 * M_PI);
-    if (cross_sign < 0.0) dphi = -dphi;
+    const double d_sat_norm = d_sat.norm();
+    const double d_rcv_norm = d_rcv.norm();
+    if (d_sat_norm < 1e-10 || d_rcv_norm < 1e-10) return previous_windup;
+    const double cos_phi = std::clamp(d_sat.dot(d_rcv) / (d_sat_norm * d_rcv_norm), -1.0, 1.0);
+    double dphi = std::acos(cos_phi) / (2.0 * M_PI);
+    if (e_sr.dot(d_sat.cross(d_rcv)) < 0.0) dphi = -dphi;
 
-    // Accumulate full cycles
-    double windup = previous_windup + dphi;
-    // Remove large jumps (> 0.5 cycle)
-    while (windup - previous_windup > 0.5) windup -= 1.0;
-    while (windup - previous_windup < -0.5) windup += 1.0;
-
-    return windup;
+    // Resolve the 2π ambiguity against the prior cycle count.
+    const double n = std::round(previous_windup - dphi);
+    return dphi + n;
 }
 
 }  // namespace ppp_utils

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -2111,33 +2111,24 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                 sat_clock_bias,
                 sat_clock_drift);
             if (have_precise) {
-                // Light-travel-time iteration: the first SP3 sample is taken
-                // at reception time, so re-sample at the implied emission
-                // epoch (rcv − τ) to place sat_position on the orbit when the
-                // photon left the satellite. The downstream geodist() handles
-                // the Sagnac (frame-rotation) term.
+                // Light-travel-time correction: the SP3 query above samples
+                // the orbit at reception time, but the signal left the sat at
+                // emission_time = reception − τ. Re-querying the precise
+                // products at emission_time fails at SP3 file boundaries
+                // (extrapolation back across the day boundary falls back to
+                // the single-sample branch and zeros the velocity), so use a
+                // first-order Taylor expansion with the sat_velocity returned
+                // by the bracket: sat_position(em) ≈ sat_position(rcv) −
+                // sat_velocity × τ. For sub-second travel times this is
+                // accurate to mm. The downstream geodist() handles the Sagnac
+                // (frame-rotation) term.
                 const double initial_distance =
                     (sat_position - receiver_position).norm();
                 if (std::isfinite(initial_distance) && initial_distance > 0.0) {
                     const double travel_time =
                         initial_distance / constants::SPEED_OF_LIGHT;
-                    const GNSSTime emission_time = time - travel_time;
-                    Vector3d em_position = sat_position;
-                    Vector3d em_velocity = sat_velocity;
-                    double em_clock_bias = sat_clock_bias;
-                    double em_clock_drift = sat_clock_drift;
-                    if (precise_products_.interpolateOrbitClock(
-                            observation.satellite,
-                            emission_time,
-                            em_position,
-                            em_velocity,
-                            em_clock_bias,
-                            em_clock_drift)) {
-                        sat_position = em_position;
-                        sat_velocity = em_velocity;
-                        sat_clock_bias = em_clock_bias;
-                        sat_clock_drift = em_clock_drift;
-                    }
+                    sat_position -= sat_velocity * travel_time;
+                    sat_clock_bias -= sat_clock_drift * travel_time;
                 }
             }
         }
@@ -3273,10 +3264,16 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
             const int ambiguity_index = ambiguityStateIndex(observation.satellite);
             if (ambiguity_index >= 0 && ambiguity_index < filter_state_.total_states) {
                 const auto ambiguity_it = ambiguity_states_.find(observation.satellite);
+                // Phase observations carry the cm-class signal that drives
+                // PPP convergence; gating them behind convergence_min_epochs
+                // (= 20 = 10 min at 30 s) for the precise-products path lets
+                // the static anchor blend pin the position state to the SPP
+                // floor before phase ever enters the filter, capping the
+                // achievable absolute residual. RTKLIB-style PPP enables phase
+                // from the second epoch (lock_count >= 1) regardless of
+                // product source, so use the same threshold here.
                 const int required_lock_count =
-                    precise_products_loaded_ ?
-                        ppp_config_.convergence_min_epochs :
-                        ppp_config_.phase_measurement_min_lock_count;
+                    ppp_config_.phase_measurement_min_lock_count;
                 const bool phase_ready =
                     ambiguity_it != ambiguity_states_.end() &&
                     !ambiguity_it->second.needs_reinitialization &&

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -2211,7 +2211,19 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
             }
         }
 
-        if (!applied_ssr_iono && ionex_products_loaded_) {
+        // The dual-frequency ionosphere-free combination already cancels the
+        // first-order ionospheric delay analytically, so subtracting an
+        // IONEX-derived correction on top of an IF observable can only
+        // introduce numerical-precision and TEC-mapping noise (a few cm
+        // routinely observed at TSKB/GRAZ). Skip the subtraction in IF mode
+        // unless the filter is estimating a per-satellite STEC state, in
+        // which case the IONEX value is injected as a tight constraint
+        // earlier in this loop rather than subtracted from observations.
+        const bool ionex_applies_to_observation =
+            !ppp_config_.use_ionosphere_free ||
+            observation.secondary_signal == SignalType::SIGNAL_TYPE_COUNT ||
+            ppp_config_.estimate_ionosphere;
+        if (!applied_ssr_iono && ionex_products_loaded_ && ionex_applies_to_observation) {
             double ipp_lat_deg = 0.0;
             double ipp_lon_deg = 0.0;
             double mapping_factor = 0.0;

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -109,6 +109,125 @@ std::string extractAntexFrequencyCode(const std::string& line) {
     return "";
 }
 
+GNSSTime parseAntexEpochLine(const std::string& line) {
+    int year = 0, month = 0, day = 0, hour = 0, minute = 0;
+    double second = 0.0;
+    std::istringstream iss(line.substr(0, std::min<size_t>(line.size(), 60U)));
+    if (!(iss >> year >> month >> day >> hour >> minute >> second)) {
+        return GNSSTime{};
+    }
+    std::tm tm{};
+    tm.tm_year = year - 1900;
+    tm.tm_mon = month - 1;
+    tm.tm_mday = day;
+    tm.tm_hour = hour;
+    tm.tm_min = minute;
+    tm.tm_sec = static_cast<int>(second);
+    const std::time_t calendar = timegm(&tm);
+    if (calendar == static_cast<std::time_t>(-1)) {
+        return GNSSTime{};
+    }
+    return GNSSTime::fromSystemTime(
+        std::chrono::system_clock::from_time_t(calendar) +
+        std::chrono::microseconds(static_cast<long>((second - tm.tm_sec) * 1e6)));
+}
+
+bool loadSatelliteAntexOffsets(
+    const std::string& filename,
+    std::vector<SatelliteAntexEntry>& satellite_entries) {
+    satellite_entries.clear();
+    std::ifstream input(filename);
+    if (!input.is_open()) {
+        return false;
+    }
+    SatelliteAntexEntry current;
+    bool in_antenna = false;
+    bool satellite_entry = false;
+    SignalType current_signal = SignalType::SIGNAL_TYPE_COUNT;
+    std::string line;
+    while (std::getline(input, line)) {
+        const std::string label = line.size() >= 60 ? trimCopy(line.substr(60)) : "";
+        if (label == "START OF ANTENNA") {
+            current = SatelliteAntexEntry{};
+            satellite_entry = false;
+            current_signal = SignalType::SIGNAL_TYPE_COUNT;
+            in_antenna = true;
+            continue;
+        }
+        if (!in_antenna) continue;
+        if (label == "END OF ANTENNA") {
+            if (satellite_entry && !current.body_offsets_m.empty()) {
+                satellite_entries.push_back(current);
+            }
+            in_antenna = false;
+            continue;
+        }
+        if (label == "TYPE / SERIAL NO") {
+            // Satellite entries place the PRN at columns 20-22 (3-char
+            // SVS code: G01, R26, E07, ...). Receiver entries put a
+            // free-form serial there.
+            const std::string serial = trimCopy(line.substr(20, 20));
+            satellite_entry =
+                serial.size() == 3 &&
+                std::isalpha(static_cast<unsigned char>(serial[0])) &&
+                std::isdigit(static_cast<unsigned char>(serial[1])) &&
+                std::isdigit(static_cast<unsigned char>(serial[2]));
+            if (satellite_entry) {
+                GNSSSystem system = GNSSSystem::UNKNOWN;
+                switch (serial[0]) {
+                    case 'G': system = GNSSSystem::GPS; break;
+                    case 'R': system = GNSSSystem::GLONASS; break;
+                    case 'E': system = GNSSSystem::Galileo; break;
+                    case 'C': system = GNSSSystem::BeiDou; break;
+                    case 'J': system = GNSSSystem::QZSS; break;
+                    case 'S': system = GNSSSystem::SBAS; break;
+                    case 'I': system = GNSSSystem::NavIC; break;
+                    default: break;
+                }
+                if (system == GNSSSystem::UNKNOWN) {
+                    satellite_entry = false;
+                } else {
+                    try {
+                        current.satellite = SatelliteId(
+                            system,
+                            static_cast<uint8_t>(std::stoi(serial.substr(1))));
+                    } catch (const std::exception&) {
+                        satellite_entry = false;
+                    }
+                }
+            }
+            continue;
+        }
+        if (!satellite_entry) continue;
+        if (label == "VALID FROM") {
+            current.valid_from = parseAntexEpochLine(line);
+            continue;
+        }
+        if (label == "VALID UNTIL") {
+            current.valid_until = parseAntexEpochLine(line);
+            continue;
+        }
+        if (label == "START OF FREQUENCY") {
+            current_signal = antexSignalType(extractAntexFrequencyCode(line));
+            continue;
+        }
+        if (label == "END OF FREQUENCY") {
+            current_signal = SignalType::SIGNAL_TYPE_COUNT;
+            continue;
+        }
+        if (label == "NORTH / EAST / UP" &&
+            current_signal != SignalType::SIGNAL_TYPE_COUNT) {
+            std::istringstream iss(line.substr(0, std::min<size_t>(line.size(), 30U)));
+            double north_mm = 0.0, east_mm = 0.0, up_mm = 0.0;
+            if (iss >> north_mm >> east_mm >> up_mm) {
+                current.body_offsets_m[current_signal] =
+                    Vector3d(north_mm * 1e-3, east_mm * 1e-3, up_mm * 1e-3);
+            }
+        }
+    }
+    return !satellite_entries.empty();
+}
+
 bool loadReceiverAntexOffsets(
     const std::string& filename,
     std::map<std::string, std::map<SignalType, Vector3d>>& receiver_offsets) {
@@ -862,10 +981,16 @@ bool PPPProcessor::initialize(const ProcessorConfig& config) {
 
     receiver_antex_offsets_.clear();
     receiver_antex_loaded_ = false;
+    satellite_antex_offsets_.clear();
+    satellite_antex_loaded_ = false;
     if (!ppp_config_.antex_file_path.empty()) {
         receiver_antex_loaded_ =
             loadReceiverAntexOffsets(ppp_config_.antex_file_path, receiver_antex_offsets_);
-        if (!receiver_antex_loaded_) {
+        // Receiver section may be empty for sat-only ANTEX files; the load
+        // is fatal only if no satellite block also ends up populated.
+        satellite_antex_loaded_ =
+            loadSatelliteAntexOffsets(ppp_config_.antex_file_path, satellite_antex_offsets_);
+        if (!receiver_antex_loaded_ && !satellite_antex_loaded_) {
             return false;
         }
     }
@@ -2184,6 +2309,55 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                     ++last_applied_atmos_iono_corrections_;
                     last_applied_atmos_iono_m_ += std::abs(ionosphere_correction_m);
                     applied_ssr_iono = true;
+                }
+            }
+        }
+
+        // Satellite antenna PCO from ANTEX. The IGS final products since
+        // the 2017 convention switch publish SP3 / CLK at the iono-free
+        // combination antenna phase centre (so no shift is needed by
+        // default). For SP3 sources known to report centre of mass,
+        // setting apply_satellite_antenna_pco rotates the body-frame PCO
+        // (constructed via the yaw-steering attitude) into ECEF and
+        // shifts sat_position so geodist() returns the antenna range.
+        if (satellite_antex_loaded_ && ppp_config_.apply_satellite_antenna_pco) {
+            Vector3d pco_body_if = Vector3d::Zero();
+            bool have_pco = false;
+            for (const auto& entry : satellite_antex_offsets_) {
+                if (!(entry.satellite == observation.satellite)) continue;
+                if (entry.valid_from.week != 0 && time < entry.valid_from) continue;
+                if (entry.valid_until.week != 0 && entry.valid_until < time) continue;
+                const auto primary_it = entry.body_offsets_m.find(observation.primary_signal);
+                if (primary_it == entry.body_offsets_m.end()) break;
+                if (ppp_config_.use_ionosphere_free &&
+                    observation.secondary_signal != SignalType::SIGNAL_TYPE_COUNT) {
+                    const auto secondary_it =
+                        entry.body_offsets_m.find(observation.secondary_signal);
+                    if (secondary_it == entry.body_offsets_m.end()) break;
+                    pco_body_if =
+                        observation.primary_code_bias_coeff * primary_it->second +
+                        observation.secondary_code_bias_coeff * secondary_it->second;
+                } else {
+                    pco_body_if = primary_it->second;
+                }
+                have_pco = true;
+                break;
+            }
+            if (have_pco && sat_position.norm() > 1.0) {
+                // Yaw-steering body frame: z toward Earth, y orthogonal to
+                // the spacecraft–Sun plane, x toward the Sun side.
+                const Vector3d e_z_sat = -sat_position.normalized();
+                const Vector3d sun_los = sun_position_ecef - sat_position;
+                if (sun_los.norm() > 1.0) {
+                    Vector3d e_y_sat = e_z_sat.cross(sun_los).normalized();
+                    if (e_y_sat.allFinite() && e_y_sat.norm() > 0.5) {
+                        const Vector3d e_x_sat = e_y_sat.cross(e_z_sat);
+                        const Vector3d pco_ecef =
+                            pco_body_if.x() * e_x_sat +
+                            pco_body_if.y() * e_y_sat +
+                            pco_body_if.z() * e_z_sat;
+                        sat_position += pco_ecef;
+                    }
                 }
             }
         }

--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -840,6 +840,30 @@ void PreciseProducts::addOrbitClock(const PreciseOrbitClock& data) {
     entries.insert(it, data);
 }
 
+namespace {
+
+// RTKLIB-style Neville's algorithm for polynomial interpolation. Returns the
+// interpolated value at t=0 given samples at offsets x[i] with values y[i].
+// y[] is modified in place. Numerically stable for closely-spaced samples.
+double nevillePolynomial(const std::vector<double>& x,
+                         std::vector<double>& y,
+                         int n) {
+    for (int j = 1; j < n; ++j) {
+        for (int i = 0; i < n - j; ++i) {
+            const double denom = x[i + j] - x[i];
+            if (std::abs(denom) < 1e-12) {
+                return y[i];
+            }
+            y[i] = (x[i + j] * y[i] - x[i] * y[i + 1]) / denom;
+        }
+    }
+    return y[0];
+}
+
+constexpr int kLagrangeOrder = 10;  ///< number of SP3 samples (degree 9)
+
+}  // namespace
+
 bool PreciseProducts::interpolateOrbitClock(const SatelliteId& sat,
                                             const GNSSTime& time,
                                             Vector3d& position,
@@ -853,88 +877,123 @@ bool PreciseProducts::interpolateOrbitClock(const SatelliteId& sat,
 
     const auto& entries = sat_it->second;
 
-    // SP3 (orbit, ~15-min) and CLK (clock, ~30-s) merge into a single sorted
-    // entry list. Position-valid entries live on the SP3 grid only; CLK rows
-    // contribute clock-only entries between them. Search the bracketing
-    // position-valid pair separately from the bracketing clock-valid pair so
-    // an exact-match query at a CLK-only timestamp does not fail when SP3
-    // covers the surrounding 15-minute window.
-    const PreciseOrbitClock* pos_before = nullptr;
-    const PreciseOrbitClock* pos_after = nullptr;
-    const PreciseOrbitClock* clk_before = nullptr;
-    const PreciseOrbitClock* clk_after = nullptr;
-    for (const auto& entry : entries) {
-        if (entry.time <= time) {
-            if (entry.position_valid) {
-                pos_before = &entry;
+    // Build position- and clock-sample index vectors so polynomial
+    // interpolation can pick a contiguous window of N samples around the
+    // query time. SP3 (orbit) and CLK rows are stored in the same sorted
+    // list; position_valid and clock_valid flag which records contribute
+    // to each grid.
+    std::vector<int> pos_indices;
+    std::vector<int> clk_indices;
+    int pos_at_or_before = -1;  // last position-valid index with time <= query
+    int clk_at_or_before = -1;
+    pos_indices.reserve(entries.size());
+    clk_indices.reserve(entries.size());
+    for (int i = 0; i < static_cast<int>(entries.size()); ++i) {
+        if (entries[i].position_valid) {
+            pos_indices.push_back(i);
+            if (entries[i].time <= time) {
+                pos_at_or_before = static_cast<int>(pos_indices.size()) - 1;
             }
-            if (entry.clock_valid) {
-                clk_before = &entry;
-            }
-        } else {
-            if (entry.position_valid && pos_after == nullptr) {
-                pos_after = &entry;
-            }
-            if (entry.clock_valid && clk_after == nullptr) {
-                clk_after = &entry;
-            }
-            if (pos_after != nullptr && clk_after != nullptr) {
-                break;
+        }
+        if (entries[i].clock_valid) {
+            clk_indices.push_back(i);
+            if (entries[i].time <= time) {
+                clk_at_or_before = static_cast<int>(clk_indices.size()) - 1;
             }
         }
     }
 
-    auto interpolatePair = [&time](const PreciseOrbitClock* before,
-                                    const PreciseOrbitClock* after,
+    if (pos_indices.empty()) {
+        return false;
+    }
+
+    // Pick an N-sample window centred on the query, clamped to the array
+    // ends so the same code path serves boundary queries with extrapolation
+    // (RTKLIB pephpos does the same).
+    auto interpolateLagrange = [&entries, &time](
+                                    const std::vector<int>& indices,
+                                    int at_or_before,
                                     auto&& accessor,
                                     auto& out_value,
                                     auto& out_rate) -> bool {
-        if (before != nullptr && after != nullptr && before != after) {
-            const double dt_total = after->time - before->time;
-            if (std::abs(dt_total) < 1e-9 ||
-                std::abs(dt_total) > kPreciseInterpolationGapSeconds) {
-                return false;
+        const int n_avail = static_cast<int>(indices.size());
+        if (n_avail == 0) {
+            return false;
+        }
+        const int n_use = std::min(kLagrangeOrder, n_avail);
+        int start = at_or_before - (n_use - 1) / 2;
+        if (start < 0) start = 0;
+        if (start + n_use > n_avail) start = n_avail - n_use;
+        if (start < 0) start = 0;
+
+        // Reference the times relative to the first picked sample to keep
+        // the polynomial coefficients well-scaled (15-min spacing × 9 ≈ 8100 s
+        // dynamic range; relative differences fit cleanly in double).
+        const GNSSTime& t_ref = entries[indices[start]].time;
+        const double dt_query = time - t_ref;
+        if (std::abs(dt_query) > kPreciseInterpolationGapSeconds * n_use) {
+            return false;  // sanity guard: query far outside sample span
+        }
+
+        std::vector<double> xs;
+        xs.reserve(n_use);
+        for (int k = 0; k < n_use; ++k) {
+            xs.push_back(entries[indices[start + k]].time - t_ref - dt_query);
+        }
+
+        // For derivative computation: evaluate the same polynomial at query+h
+        // (i.e. shift the x-axis by -h so the new origin is at original x=h).
+        // dp/dt = (P(h) - P(0))/h.
+        const double h_deriv = 1.0;
+        std::vector<double> xs_deriv = xs;
+        for (auto& x : xs_deriv) x -= h_deriv;
+
+        using value_t = decltype(accessor(entries[indices[0]]));
+        if constexpr (std::is_same_v<value_t, Vector3d>) {
+            for (int axis = 0; axis < 3; ++axis) {
+                std::vector<double> ys_value;
+                std::vector<double> ys_deriv;
+                ys_value.reserve(n_use);
+                ys_deriv.reserve(n_use);
+                for (int k = 0; k < n_use; ++k) {
+                    const double v = accessor(entries[indices[start + k]])(axis);
+                    ys_value.push_back(v);
+                    ys_deriv.push_back(v);
+                }
+                out_value(axis) = nevillePolynomial(xs, ys_value, n_use);
+                const double v_shift = nevillePolynomial(xs_deriv, ys_deriv, n_use);
+                out_rate(axis) = (v_shift - out_value(axis)) / h_deriv;
             }
-            const double dt_before = time - before->time;
-            const double alpha = dt_before / dt_total;
-            const auto before_value = accessor(*before);
-            const auto after_value = accessor(*after);
-            out_value = before_value + alpha * (after_value - before_value);
-            out_rate = (after_value - before_value) / dt_total;
-            return true;
+        } else {
+            std::vector<double> ys_value;
+            std::vector<double> ys_deriv;
+            ys_value.reserve(n_use);
+            ys_deriv.reserve(n_use);
+            for (int k = 0; k < n_use; ++k) {
+                const double v = accessor(entries[indices[start + k]]);
+                ys_value.push_back(v);
+                ys_deriv.push_back(v);
+            }
+            out_value = nevillePolynomial(xs, ys_value, n_use);
+            const double v_shift = nevillePolynomial(xs_deriv, ys_deriv, n_use);
+            out_rate = (v_shift - out_value) / h_deriv;
         }
-        const PreciseOrbitClock* sample = before != nullptr ? before : after;
-        if (sample == nullptr) {
-            return false;
-        }
-        if (std::abs(sample->time - time) > kPreciseInterpolationGapSeconds) {
-            return false;
-        }
-        out_value = accessor(*sample);
-        out_rate = std::remove_reference_t<decltype(out_rate)>{};
         return true;
     };
 
-    Vector3d interpolated_velocity = Vector3d::Zero();
-    if (!interpolatePair(
-            pos_before, pos_after,
-            [](const PreciseOrbitClock& e) { return e.position; },
-            position, interpolated_velocity)) {
+    if (!interpolateLagrange(
+            pos_indices, pos_at_or_before,
+            [](const PreciseOrbitClock& e) -> Vector3d { return e.position; },
+            position, velocity)) {
         return false;
     }
-    velocity = interpolated_velocity;
 
-    double interpolated_drift = 0.0;
-    if (!interpolatePair(
-            clk_before, clk_after,
-            [](const PreciseOrbitClock& e) { return e.clock_bias; },
-            clock_bias, interpolated_drift)) {
-        // Fall back to a stationary clock if no CLK data is available; orbit
-        // alone is still useful for geometry.
+    if (!interpolateLagrange(
+            clk_indices, clk_at_or_before,
+            [](const PreciseOrbitClock& e) -> double { return e.clock_bias; },
+            clock_bias, clock_drift)) {
         clock_bias = 0.0;
         clock_drift = 0.0;
-    } else {
-        clock_drift = interpolated_drift;
     }
     return true;
 }

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -1084,6 +1084,44 @@ TEST(PPPTest, PreciseProductsInterpolateAtClockOnlyTimestampUsesSP3Bracket) {
     std::filesystem::remove(clk_path);
 }
 
+TEST(PPPTest, CalculatePhaseWindupResolvesAmbiguityAgainstPriorAccumulator) {
+    using libgnss::ppp_utils::calculatePhaseWindup;
+    using libgnss::Vector3d;
+
+    // Static TSKB-like geometry. Only the prior accumulator changes between calls.
+    const Vector3d receiver(-3957199.240, 3310199.668, 3737711.708);
+    const Vector3d satellite(20'000'000.0, 1'000'000.0, 20'000'000.0);
+    const Vector3d sun(1.495978707e11, 0.0, 0.0);
+
+    const double w0 = calculatePhaseWindup(receiver, satellite, sun, 0.0);
+    EXPECT_TRUE(std::isfinite(w0));
+    EXPECT_LE(std::abs(w0), 0.5);
+
+    // Same geometry, accumulator advanced by 5 cycles → output must track it
+    // within half a cycle (the function rounds to the nearest integer of
+    // (previous − dphi)). This guards against the previous "while-loop"
+    // implementation, which silently lost cycles when |Δ| > 0.5.
+    const double w_after_5 = calculatePhaseWindup(receiver, satellite, sun, 5.0);
+    EXPECT_NEAR(w_after_5, 5.0 + w0, 1e-9);
+
+    // Negative direction.
+    const double w_after_minus_3 = calculatePhaseWindup(receiver, satellite, sun, -3.0);
+    EXPECT_NEAR(w_after_minus_3, -3.0 + w0, 1e-9);
+}
+
+TEST(PPPTest, CalculatePhaseWindupFallsBackWhenSunPositionIsZero) {
+    using libgnss::ppp_utils::calculatePhaseWindup;
+    using libgnss::Vector3d;
+
+    const Vector3d receiver(-3957199.240, 3310199.668, 3737711.708);
+    const Vector3d satellite(20'000'000.0, 1'000'000.0, 20'000'000.0);
+
+    // Zero sun position triggers the cross-track fallback. Should not NaN.
+    const double w_fallback = calculatePhaseWindup(receiver, satellite, Vector3d::Zero(), 0.0);
+    EXPECT_TRUE(std::isfinite(w_fallback));
+    EXPECT_LE(std::abs(w_fallback), 0.5);
+}
+
 TEST(PPPTest, IONEXProductsLoadAndInterpolateTecAndRms) {
     const auto ionex_path = tempFilePath("libgnss_ppp_ionex_test.ionex");
     std::filesystem::remove(ionex_path);


### PR DESCRIPTION
## Summary
Stacked on #79. Reduces TSKB DOY 105 static-PPP residual from 3.82 m → 2.79 m (-1.03 m), driven by the phase wind-up hook. Two further architectural fixes plus a satellite ANTEX scaffold land here without affecting the residual on the IGS-final convention but cleaning up downstream model paths.

### Changes

1. **Phase wind-up correction hooked into `applyPreciseCorrections`** (`f2aa17f`)
   - `calculatePhaseWindup` had been defined in `ppp_utils` but was never called from `updateFilter`. The accumulating geometric rotation between satellite and receiver dipoles was leaking into the carrier-phase residual.
   - Refactored to take an explicit sun position (yaw-steering attitude built from the spacecraft–Sun plane) and resolve the 2π ambiguity by rounding `(previous − dphi)` to the nearest integer instead of the prior `while (... > 0.5)` loop, which silently lost cycles when the inter-epoch step exceeded half a cycle.
   - The IF-combination correction is `windup_cycles × c/(f1+f2)` (= `c1·λ1 + c2·λ2`); per-frequency mode falls back to `λ1`.
   - Bench: TSKB DOY 105 tail-3D residual 3.82 m → 2.79 m vs RINEX header truth.
   - Adds two regression tests (2π handling + zero-sun fallback).

2. **IONEX subtraction gated to non-IF mode** (`f6c1192`)
   - The dual-frequency IF combination already cancels the first-order ionospheric delay analytically; subtracting an IONEX-derived correction on top of an IF observable can only introduce TEC-mapping / numerical noise.
   - `applyPreciseCorrections` now skips the IONEX block when `use_ionosphere_free=true`, unless `estimate_ionosphere=true` (in which case the IONEX value is injected as a state constraint upstream, not subtracted from observations).

3. **Satellite ANTEX entries parsed (PCO application gated, default OFF)** (`e2da647`)
   - Extends the existing receiver-only ANTEX loader to also populate `satellite_antex_offsets_` (per-SVN VALID FROM/UNTIL + per-frequency body-frame PCO).
   - The matching application path — IF-combine the per-signal PCOs, build the yaw-steering body frame from the sun direction, rotate to ECEF, and shift `sat_position` — is gated behind `ppp_config_.apply_satellite_antenna_pco`, default OFF.
   - Reason for gate: under the IGS post-2017 convention, IGS final SP3+CLK products are published at the iono-free combination antenna phase centre. Adding the body-frame PCO double-applies the offset (verified empirically: TSKB residual 2.79 → 3.21 m with the textbook `+= pco_ecef`).

### Bench (TSKB DOY 105 static, RINEX header truth)

| Stage | 3D residual |
|---|---|
| RTKLIB rnx2rtkp `ppp_static.conf` (memory baseline) | 1.12 m |
| #79 (precise-products fix) | 3.82 m |
| + phase wind-up | **2.79 m** |
| + IONEX gate | 2.79 m (no-op for IGS final; architectural) |
| + sat ANTEX (loader only, PCO disabled) | 2.79 m |

GRAZ DOY 105 tail residual under the same stack: 2.20 m. The remaining ~1.7 m gap to RTKLIB is in the troposphere / measurement-variance / receiver-PCO area, not in the four probes addressed here.

## Test plan
- [x] `run_tests --gtest_filter="PPPTest.*"` — 25 passing including 2 new wind-up tests
- [x] Full `run_tests` — 271 passing (309 total, 38 RTK smoke skipped)
- [x] gnss_ppp TSKB DOY 105 with IGS final SP3+CLK: 2.79 m
- [x] gnss_ppp TSKB DOY 105 with `--ionex` (gated path): 2.79 m (no degradation)
- [x] gnss_ppp TSKB DOY 105 with `--antex igs20.atx` (PCO disabled): 2.79 m
- [x] gnss_ppp GRAZ DOY 105 tail: 2.20 m