### PR TITLE
Add VMF ATL multisite PPP bench fixtures

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -86,6 +86,7 @@ install(PROGRAMS
     ${CMAKE_CURRENT_SOURCE_DIR}/gnss_ppp_iers_sub_daily_eop_bench.py
     ${CMAKE_CURRENT_SOURCE_DIR}/gnss_ppp_iers_sub_daily_eop_multisite_bench.py
     ${CMAKE_CURRENT_SOURCE_DIR}/gnss_ppp_iers_ocean_loading_bench.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/gnss_vmf_atl.py
     ${CMAKE_CURRENT_SOURCE_DIR}/gnss_ppp_products_signoff.py
     ${CMAKE_CURRENT_SOURCE_DIR}/gnss_ppc_demo.py
     ${CMAKE_CURRENT_SOURCE_DIR}/gnss_ppc_commercial.py
@@ -140,6 +141,15 @@ install(FILES
     ${CMAKE_SOURCE_DIR}/configs/ppc_rtk_signoff.example.toml
     ${CMAKE_SOURCE_DIR}/configs/ppp_products_ppc.example.toml
     ${CMAKE_SOURCE_DIR}/configs/moving_base_signoff.example.toml
+    ${CMAKE_SOURCE_DIR}/configs/iers_atl_multisite_smoke.example.json
+    ${CMAKE_SOURCE_DIR}/configs/iers_atl_multisite_vmf.example.json
     ${CMAKE_SOURCE_DIR}/configs/web.example.toml
     DESTINATION configs
+)
+
+install(FILES
+    ${CMAKE_SOURCE_DIR}/test_data/iers/pert_vmf.atl
+    ${CMAKE_SOURCE_DIR}/test_data/iers/tskb_synth.atl
+    ${CMAKE_SOURCE_DIR}/test_data/iers/tskb_vmf.atl
+    DESTINATION test_data/iers
 )

--- a/apps/gnss.py
+++ b/apps/gnss.py
@@ -269,6 +269,11 @@ COMMANDS = {
         "target": os.path.join(APPS_DIR, "gnss_ppp_iers_atm_tidal_loading_multisite_bench.py"),
         "summary": "Run the Phase D-3 atmospheric-tidal-loading bench across an arbitrary list of IGS stations and emit an aggregate per-site distribution summary.",
     },
+    "vmf-atl": {
+        "kind": "python",
+        "target": os.path.join(APPS_DIR, "gnss_vmf_atl.py"),
+        "summary": "Fetch or read VMF site-wise GNSS tidal APL coefficients and write libgnss++ ATL coefficient files.",
+    },
     "ppp-iers-pole-tide-multisite-bench": {
         "kind": "python",
         "target": os.path.join(APPS_DIR, "gnss_ppp_iers_pole_tide_multisite_bench.py"),

--- a/apps/gnss_ppp_iers_atm_tidal_loading_multisite_bench.py
+++ b/apps/gnss_ppp_iers_atm_tidal_loading_multisite_bench.py
@@ -1,59 +1,35 @@
 #!/usr/bin/env python3
 """Multi-site driver around ``gnss_ppp_iers_atm_tidal_loading_bench``.
 
-Runs the Phase D-3 atmospheric-tidal-loading truth-bench harness
-across an arbitrary list of IGS stations and aggregates the
-per-site comparison JSONs into one report. Mirrors
-``gnss_ppp_iers_pole_tide_multisite_bench`` (PR #69) and
-``gnss_ppp_iers_sub_daily_eop_multisite_bench`` (PR #75); only the
-underlying single-site harness differs.
+Runs the Phase D-3 atmospheric tidal-loading paired PPP harness across
+an arbitrary list of stations and aggregates the per-site comparison
+JSONs into one report. ATL coefficients are station-specific, so each
+site may provide its own ``atm_tidal_loading`` file; a common file may
+be supplied only for synthetic smoke benches.
 
-Atmospheric tidal loading is per-site: the S1 (24 h) and S2 (12 h)
-amplitudes/phases come from a station-specific coefficient file.
-A real campaign uses the per-site files distributed by the TU Wien
-atmospheric loading service. For bench harness fixtures (and as a
-default when only one synthetic fixture is at hand) the driver
-falls back to ``common.atm_tidal_loading`` when a site row does
-not provide its own ``atm_tidal_loading`` override — the same
-pattern PR #73 introduced for ``nav`` / ``sp3`` / ``clk`` /
-``eop_c04`` to support multi-day campaigns.
-
-The ATL coefficient file format (matches the single-site bench
-and ``PPPProcessor::loadAtmosphericTidalLoading``)::
-
-    $$ comment lines (any line starting with $ or #)
-    <station-name> line (any non-S1 / non-S2 / non-comment, ignored)
-    S1   <r_amp>   <w_amp>   <s_amp>   <r_pha>  <w_pha>  <s_pha>
-    S2   <r_amp>   <w_amp>   <s_amp>   <r_pha>  <w_pha>  <s_pha>
-
-Amplitudes in metres, phases in degrees. A representative
-mid-latitude coastal fixture (S1 = 0.8 mm radial, 0.2 mm
-horizontal; S2 = 0.4 mm radial, 0.1 mm horizontal) is suitable
-for order-of-magnitude bench checks until real per-site
-coefficients are wired in.
-
-Site list is supplied via ``--sites <site_config.json>``::
+Site list is supplied via ``--sites <site_config.json>`` whose schema is::
 
     {
       "common": {
         "nav": "data/igs_2026105/BRDC.rnx",
         "sp3": "data/igs_2026105/IGS_final.sp3",
-        "clk": "data/igs_2026105/IGS_final.clk",
-        "atm_tidal_loading": "data/iers/synth_midlat.atl"
+        "clk": "data/igs_2026105/IGS_final.clk"
       },
       "sites": [
-        { "name": "TSKB", "obs": "data/igs_2026105/TSKB.rnx" },
-        { "name": "GRAZ", "obs": "data/igs_2026105/GRAZ00AUT.rnx",
-          "atm_tidal_loading": "data/iers/graz_real.atl" },
+        {
+          "name": "TSKB",
+          "obs": "data/igs_2026105/TSKB.rnx",
+          "atm_tidal_loading": "data/iers/tskb.atl"
+        },
         ...
       ]
     }
 
 The script writes:
-    <output-dir>/per_site/<NAME>/legacy.pos     — single-site bench output
+    <output-dir>/per_site/<NAME>/legacy.pos       — single-site bench output
     <output-dir>/per_site/<NAME>/iers.pos
     <output-dir>/per_site/<NAME>/comparison.json
-    <output-dir>/multisite_summary.json         — aggregate report
+    <output-dir>/multisite_summary.json           — aggregate report
 
 See ``docs/iers-integration-plan.md`` for the rollout plan.
 """
@@ -88,55 +64,94 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def resolve_config_path(value: str | os.PathLike[str], config_dir: Path) -> Path:
+    """Resolve site-config paths relative to the JSON file or its parents."""
+    path = Path(value).expanduser()
+    if path.is_absolute():
+        return path
+    for base in (config_dir, *config_dir.parents, ROOT_DIR):
+        candidate = base / path
+        if candidate.exists():
+            return candidate
+    return config_dir / path
+
+
+def resolve_config_paths(config: dict, config_dir: Path) -> None:
+    common = config.get("common", {})
+    for key in (
+        "nav", "sp3", "clk", "ionex", "dcb", "antex", "blq",
+        "atm_tidal_loading",
+    ):
+        if key in common:
+            common[key] = resolve_config_path(common[key], config_dir)
+    for site in config.get("sites", []):
+        for key in ("obs", "atm_tidal_loading", "blq"):
+            if key in site:
+                site[key] = resolve_config_path(site[key], config_dir)
+
+
+def site_value(site: dict, common: dict, key: str):
+    return site[key] if key in site else common.get(key)
+
+
 def run_single_site(
-    config: dict,
     site: dict,
     common: dict,
     output_dir: Path,
     mode: str,
     max_epochs: int,
 ) -> dict | None:
-    """Invoke ppp-iers-atm-tidal-loading-bench for one site. Returns
-    the per-site comparison.json dict, or None on failure."""
+    """Invoke ppp-iers-atm-tidal-loading-bench for one site."""
     name = site["name"]
     site_dir = output_dir / "per_site" / name
     site_dir.mkdir(parents=True, exist_ok=True)
-    nav  = site.get("nav",  common.get("nav"))
-    sp3  = site.get("sp3",  common.get("sp3"))
-    clk  = site.get("clk",  common.get("clk"))
-    atl  = site.get("atm_tidal_loading", common.get("atm_tidal_loading"))
-    if atl is None:
-        print(f"[multisite] site {name} has no atm_tidal_loading "
-              f"(neither site row nor common provides one)",
+
+    atm_path = site_value(site, common, "atm_tidal_loading")
+    if atm_path is None:
+        print(f"[multisite-atl] site {name} has no atm_tidal_loading file",
               file=sys.stderr)
         return None
+
     cmd = [
         "python3",
         str(ROOT_DIR / "apps" / "gnss_ppp_iers_atm_tidal_loading_bench.py"),
         "--obs", str(site["obs"]),
-        "--atm-tidal-loading", str(atl),
+        "--atm-tidal-loading", str(atm_path),
         "--output-dir", str(site_dir),
         "--mode", mode,
     ]
-    if nav is not None: cmd += ["--nav", str(nav)]
-    if sp3 is not None: cmd += ["--sp3", str(sp3)]
-    if clk is not None: cmd += ["--clk", str(clk)]
+    for key, flag in (
+        ("nav", "--nav"),
+        ("sp3", "--sp3"),
+        ("clk", "--clk"),
+        ("ionex", "--ionex"),
+        ("dcb", "--dcb"),
+        ("antex", "--antex"),
+        ("blq", "--blq"),
+    ):
+        value = site_value(site, common, key)
+        if value is not None:
+            cmd += [flag, str(value)]
+
+    ocean_station = site_value(site, common, "ocean_loading_station")
+    if ocean_station is not None:
+        cmd += ["--ocean-loading-station", str(ocean_station)]
     if max_epochs > 0:
         cmd += ["--max-epochs", str(max_epochs)]
 
-    print(f"\n[multisite] === running site {name} ===", file=sys.stderr)
+    print(f"\n[multisite-atl] === running site {name} ===", file=sys.stderr)
     env = os.environ.copy()
     env["PYTHONPATH"] = (str(ROOT_DIR / "apps")
                         + os.pathsep + env.get("PYTHONPATH", ""))
     try:
         subprocess.run(cmd, check=True, env=env)
     except subprocess.CalledProcessError as exc:
-        print(f"[multisite] site {name} failed: {exc}", file=sys.stderr)
+        print(f"[multisite-atl] site {name} failed: {exc}", file=sys.stderr)
         return None
 
     cmp_path = site_dir / "comparison.json"
     if not cmp_path.exists():
-        print(f"[multisite] site {name} produced no comparison.json",
+        print(f"[multisite-atl] site {name} produced no comparison.json",
               file=sys.stderr)
         return None
     with cmp_path.open() as fh:
@@ -144,8 +159,6 @@ def run_single_site(
 
 
 def aggregate(per_site: dict[str, dict]) -> dict:
-    """Pull headline statistics from each per-site comparison.json into
-    a single distribution-level summary."""
     metrics = ("max_displacement_m",
                "p95_displacement_m",
                "median_displacement_m",
@@ -168,18 +181,17 @@ def aggregate(per_site: dict[str, dict]) -> dict:
         if not values:
             continue
         aggregate_summary["distribution"][m] = {
-            "min":    min(values),
-            "max":    max(values),
-            "mean":   statistics.fmean(values),
+            "min": min(values),
+            "max": max(values),
+            "mean": statistics.fmean(values),
             "median": statistics.median(values),
-            "abs_max":      max(abs(v) for v in values),
-            "abs_median":   statistics.median([abs(v) for v in values]),
+            "abs_max": max(abs(v) for v in values),
+            "abs_median": statistics.median([abs(v) for v in values]),
         }
     return aggregate_summary
 
 
 def render_table(per_site: dict[str, dict]) -> str:
-    """Plain-text per-site headline table for human-readable logs."""
     cols = ("max", "p95", "median", "first", "median_dz")
     keys = ("max_displacement_m",
             "p95_displacement_m",
@@ -212,6 +224,7 @@ def main() -> int:
     if not sites:
         print("sites config has no 'sites' list", file=sys.stderr)
         return 1
+    resolve_config_paths(config, args.sites.resolve().parent)
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
 
@@ -219,7 +232,7 @@ def main() -> int:
     for site in sites:
         name = site["name"]
         result = run_single_site(
-            config, site, common, args.output_dir, args.mode, args.max_epochs)
+            site, common, args.output_dir, args.mode, args.max_epochs)
         if result is not None:
             per_site[name] = result
 
@@ -232,7 +245,7 @@ def main() -> int:
 
     if per_site:
         print("\n" + render_table(per_site))
-    print(f"\n[multisite] aggregate written to {summary_path}",
+    print(f"\n[multisite-atl] aggregate written to {summary_path}",
           file=sys.stderr)
     return 0 if len(per_site) == len(sites) else 2
 

--- a/apps/gnss_ppp_iers_pole_tide_multisite_bench.py
+++ b/apps/gnss_ppp_iers_pole_tide_multisite_bench.py
@@ -83,6 +83,18 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
+def resolve_config_path(value: str | os.PathLike[str], config_dir: Path) -> Path:
+    """Resolve site-config paths relative to the JSON file or its parents."""
+    path = Path(value).expanduser()
+    if path.is_absolute():
+        return path
+    for base in (config_dir, *config_dir.parents, ROOT_DIR):
+        candidate = base / path
+        if candidate.exists():
+            return candidate
+    return config_dir / path
+
+
 def run_single_site(
     config: dict,
     site: dict,
@@ -206,6 +218,13 @@ def main() -> int:
     if not sites:
         print("sites config has no 'sites' list", file=sys.stderr)
         return 1
+    config_dir = args.sites.resolve().parent
+    for key in ("nav", "sp3", "clk", "eop_c04"):
+        if key in common:
+            common[key] = resolve_config_path(common[key], config_dir)
+    for site in sites:
+        if "obs" in site:
+            site["obs"] = resolve_config_path(site["obs"], config_dir)
 
     args.output_dir.mkdir(parents=True, exist_ok=True)
 

--- a/apps/gnss_vmf_atl.py
+++ b/apps/gnss_vmf_atl.py
@@ -1,0 +1,129 @@
+#!/usr/bin/env python3
+"""Convert VMF site-wise tidal APL coefficients to libgnss++ ATL files."""
+
+from __future__ import annotations
+
+import argparse
+import math
+import os
+from pathlib import Path
+import sys
+from urllib.request import urlopen
+
+
+DEFAULT_VMF_GNSS_TIDAL_URL = (
+    "https://vmf.geo.tuwien.ac.at/APL_products/TIDAL/"
+    "s1_s2_s3_cm_noib_gnss.dat"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog=os.environ.get("GNSS_CLI_NAME"))
+    parser.add_argument(
+        "--source",
+        default=DEFAULT_VMF_GNSS_TIDAL_URL,
+        help="VMF GNSS tidal APL file path or URL. Defaults to the VMF "
+             "site-wise GNSS tidal APL product.",
+    )
+    parser.add_argument(
+        "--station",
+        action="append",
+        required=True,
+        help="Four-character station code to extract. Repeat for multiple sites.",
+    )
+    parser.add_argument(
+        "--output-dir",
+        type=Path,
+        default=Path("test_data") / "iers",
+        help="Directory for generated .atl files.",
+    )
+    parser.add_argument(
+        "--suffix",
+        default="vmf",
+        help="Output filename suffix: <station>_<suffix>.atl.",
+    )
+    return parser.parse_args()
+
+
+def read_text(source: str) -> str:
+    if source.startswith(("http://", "https://")):
+        with urlopen(source, timeout=30) as response:
+            return response.read().decode("ascii")
+    return Path(source).read_text(encoding="ascii")
+
+
+def parse_vmf_rows(text: str) -> dict[str, list[float]]:
+    rows: dict[str, list[float]] = {}
+    for line in text.splitlines():
+        if not line.strip() or line.lstrip().startswith(("#", "$")):
+            continue
+        parts = line.split()
+        if len(parts) < 19:
+            continue
+        station = parts[0].upper()
+        try:
+            rows[station] = [float(value) for value in parts[1:19]]
+        except ValueError:
+            continue
+    return rows
+
+
+def amplitude_phase_m(cos_mm: float, sin_mm: float) -> tuple[float, float]:
+    """Return A, phi for A*cos(angle - phi) from C*cos(angle)+S*sin(angle)."""
+    amplitude_m = math.hypot(cos_mm, sin_mm) / 1000.0
+    phase_deg = math.degrees(math.atan2(sin_mm, cos_mm))
+    return amplitude_m, phase_deg
+
+
+def convert_row(station: str, values: list[float]) -> str:
+    # VMF columns after station:
+    # 0..5 radial S1/S2/S3 cos/sin, 6..11 east, 12..17 north, all in mm.
+    indices = {
+        "S1": (0, 1, 6, 7, 12, 13),
+        "S2": (2, 3, 8, 9, 14, 15),
+    }
+    lines = [
+        "$$ VMF site-wise GNSS tidal atmospheric pressure loading coefficients",
+        "$$ Source: " + DEFAULT_VMF_GNSS_TIDAL_URL,
+        "$$ Converted from VMF cos/sin mm coefficients to libgnss++",
+        "$$ amplitude/phase meters. East/north are stored as west/south.",
+        "$$ Format:",
+        "$$   <constituent>  radial_amp_m  west_amp_m  south_amp_m  "
+        "radial_phase_deg  west_phase_deg  south_phase_deg",
+        station.upper(),
+    ]
+    for constituent, (r_c, r_s, e_c, e_s, n_c, n_s) in indices.items():
+        radial_amp, radial_phase = amplitude_phase_m(values[r_c], values[r_s])
+        west_amp, west_phase = amplitude_phase_m(-values[e_c], -values[e_s])
+        south_amp, south_phase = amplitude_phase_m(-values[n_c], -values[n_s])
+        lines.append(
+            f"{constituent}  "
+            f"{radial_amp:.8f}  {west_amp:.8f}  {south_amp:.8f}  "
+            f"{radial_phase:.3f}  {west_phase:.3f}  {south_phase:.3f}"
+        )
+    lines.append("$$ END")
+    return "\n".join(lines) + "\n"
+
+
+def main() -> int:
+    args = parse_args()
+    rows = parse_vmf_rows(read_text(args.source))
+    args.output_dir.mkdir(parents=True, exist_ok=True)
+    missing: list[str] = []
+    for raw_station in args.station:
+        station = raw_station.upper()
+        values = rows.get(station)
+        if values is None:
+            missing.append(station)
+            continue
+        output = args.output_dir / f"{station.lower()}_{args.suffix}.atl"
+        output.write_text(convert_row(station, values), encoding="ascii")
+        print(output)
+    if missing:
+        print("missing stations: " + ", ".join(missing), file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/configs/iers_atl_multisite_smoke.example.json
+++ b/configs/iers_atl_multisite_smoke.example.json
@@ -1,0 +1,14 @@
+{
+  "common": {
+    "nav": "data/igs_2026105/BRDC.rnx",
+    "sp3": "data/igs_2026105/IGS_final.sp3",
+    "clk": "data/igs_2026105/IGS_final.clk"
+  },
+  "sites": [
+    {
+      "name": "TSKB",
+      "obs": "data/igs_2026105/TSKB.rnx",
+      "atm_tidal_loading": "test_data/iers/tskb_synth.atl"
+    }
+  ]
+}

--- a/configs/iers_atl_multisite_vmf.example.json
+++ b/configs/iers_atl_multisite_vmf.example.json
@@ -1,0 +1,19 @@
+{
+  "common": {
+    "nav": "data/igs_2026105/BRDC.rnx",
+    "sp3": "data/igs_2026105/IGS_final.sp3",
+    "clk": "data/igs_2026105/IGS_final.clk"
+  },
+  "sites": [
+    {
+      "name": "PERT",
+      "obs": "data/igs_2026105/PERT00AUS.rnx",
+      "atm_tidal_loading": "test_data/iers/pert_vmf.atl"
+    },
+    {
+      "name": "TSKB",
+      "obs": "data/igs_2026105/TSKB.rnx",
+      "atm_tidal_loading": "test_data/iers/tskb_vmf.atl"
+    }
+  ]
+}

--- a/docs/iers-integration-plan.md
+++ b/docs/iers-integration-plan.md
@@ -435,6 +435,30 @@ does not block Phase C:
   multi-site bench reports max = 0.30 / 0.35 mm, median = 0.21 /
   0.17 mm, median_dz = −83 / −89 µm — sub-mm at both stations,
   consistent with the IERS §7.1.5 envelope.
+
+  The checked smoke config
+  `configs/iers_atl_multisite_smoke.example.json` uses the small
+  synthetic fixture `test_data/iers/tskb_synth.atl` and reproduces
+  the single-site result exactly (`median = 0.169 mm`, `p95 =
+  0.358 mm`, `max = 0.901 mm`) when the 2026-04-15 TSKB PPP
+  products are available under `data/igs_2026105/`.
+
+  Real site-wise VMF tidal APL coefficients can be generated with
+  `gnss vmf-atl --station PERT --station TSKB`. The converter reads
+  the VMF Data Server GNSS site-wise tidal file
+  (`TIDAL/s1_s2_s3_cm_noib_gnss.dat`), converts the S1/S2 cos/sin
+  millimeter coefficients to libgnss++ amplitude/phase meter ATL
+  files, and flips VMF east/north into the west/south convention used
+  by `AtmosphericTidalLoadingCoefficients`. The checked fixtures
+  `test_data/iers/pert_vmf.atl` and `test_data/iers/tskb_vmf.atl`
+  came from that path.
+
+  On the 2026-04-15 IGS PPP data, the real VMF ATL multi-site smoke
+  for PERT/Australia + TSKB reports:
+  `PERT median = 0.000 mm`, `p95 = 0.007 mm`, `max = 0.022 mm`;
+  `TSKB median = 0.216 mm`, `p95 = 0.402 mm`, `max = 0.643 mm`.
+  PERT again shows the static-mode KF absorbing the sub-mm periodic
+  signal across the arc.
 - **`icrsToItrs` consumers**: when satellite-side processing
   (LEO orbits, external SP3 ingestion in non-ECEF frames, attitude
   for satellite antenna PCO/PCV) is wired up, the wrapper is

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -70,6 +70,7 @@ python3 apps/gnss.py replay \
 | `gnss scorpion-moving-base-signoff` | One-command prepare + BRDC fetch + replay validation for the public SCORPION bag with receiver side-by-side output |
 | `gnss fetch-products` | Fetch and cache `SP3`/`CLK`/`IONEX`/`DCB` files from local or remote sources |
 | `gnss ppp-products-signoff` | Run static, kinematic, or PPC PPP sign-off with fetched product presets or templates, plus comparison CSV/PNG artifacts |
+| `gnss vmf-atl` | Convert VMF site-wise GNSS tidal APL coefficients into libgnss++ ATL coefficient files |
 | `gnss stream` | Inspect and relay RTCM over file, NTRIP, TCP, or serial |
 | `gnss convert` | Convert RTCM or UBX into simple RINEX outputs |
 | `gnss ubx-info` | Inspect `NAV-PVT`, `RAWX`, `SFRBX` from file or serial |
@@ -179,6 +180,29 @@ python3 apps/gnss.py ppc-rtk-signoff \
   --realtime-profile sigma-demote \
   --summary-json output/ppc_tokyo_run1_sigma_demote_signoff.json
 ```
+
+## IERS PPP Loading Benches
+
+Atmospheric tidal loading (ATL) requires station-specific S1/S2
+coefficients. Convert VMF site-wise GNSS tidal APL coefficients to the
+libgnss++ `.atl` format, then run a paired PPP bench with ATL toggled:
+
+```bash
+python3 apps/gnss.py vmf-atl \
+  --station PERT \
+  --station TSKB \
+  --output-dir test_data/iers
+
+python3 apps/gnss.py ppp-iers-atm-tidal-loading-multisite-bench \
+  --sites configs/iers_atl_multisite_vmf.example.json \
+  --output-dir output/iers_atm_tidal_loading_multisite_bench_vmf
+```
+
+The example config expects the PPP observation/products under
+`data/igs_2026105/` and uses the tracked VMF-derived ATL fixtures for
+PERT and TSKB. Use site-specific real coefficients for production
+validation; `test_data/iers/tskb_synth.atl` is only a deterministic
+smoke fixture.
 
 ## Local docs
 

--- a/test_data/iers/pert_vmf.atl
+++ b/test_data/iers/pert_vmf.atl
@@ -1,0 +1,10 @@
+$$ VMF site-wise GNSS tidal atmospheric pressure loading coefficients
+$$ Source: https://vmf.geo.tuwien.ac.at/APL_products/TIDAL/s1_s2_s3_cm_noib_gnss.dat
+$$ Converted from VMF cos/sin mm coefficients to libgnss++
+$$ amplitude/phase meters. East/north are stored as west/south.
+$$ Format:
+$$   <constituent>  radial_amp_m  west_amp_m  south_amp_m  radial_phase_deg  west_phase_deg  south_phase_deg
+PERT
+S1  0.00059577  0.00043607  0.00013818  144.496  -127.921  -7.485
+S2  0.00098268  0.00021678  0.00006021  -131.411  -50.804  78.503
+$$ END

--- a/test_data/iers/tskb_synth.atl
+++ b/test_data/iers/tskb_synth.atl
@@ -1,0 +1,14 @@
+$$ Synthetic IERS Conventions 2010 7.1.5 atmospheric tidal-loading
+$$ coefficients (S1 + S2) for a mid-latitude coastal Japan IGS site.
+$$
+$$ This is not an official TSKB product. It is a small deterministic
+$$ fixture for exercising the PPP ATL dispatcher and bench harness when
+$$ real per-site loading coefficients are not available locally.
+$$
+$$ Format per row:
+$$   <constituent>  radial_amp_m  west_amp_m  south_amp_m  radial_phase_deg  west_phase_deg  south_phase_deg
+$$
+TSKB
+S1   0.00080  0.00020  0.00020   -30.0   -90.0    30.0
+S2   0.00040  0.00010  0.00010    60.0     0.0   -45.0
+$$ END

--- a/test_data/iers/tskb_vmf.atl
+++ b/test_data/iers/tskb_vmf.atl
@@ -1,0 +1,10 @@
+$$ VMF site-wise GNSS tidal atmospheric pressure loading coefficients
+$$ Source: https://vmf.geo.tuwien.ac.at/APL_products/TIDAL/s1_s2_s3_cm_noib_gnss.dat
+$$ Converted from VMF cos/sin mm coefficients to libgnss++
+$$ amplitude/phase meters. East/north are stored as west/south.
+$$ Format:
+$$   <constituent>  radial_amp_m  west_amp_m  south_amp_m  radial_phase_deg  west_phase_deg  south_phase_deg
+TSKB
+S1  0.00046991  0.00046441  0.00020425  120.713  -137.793  125.636
+S2  0.00080627  0.00023902  0.00011131  -173.448  -89.281  171.215
+$$ END

--- a/tests/test_benchmark_scripts.py
+++ b/tests/test_benchmark_scripts.py
@@ -40,6 +40,9 @@ import gnss_smartloc_adapter as smartloc_adapter  # noqa: E402
 import gnss_smartloc_signoff as smartloc_signoff  # noqa: E402
 import gnss_ppp_kinematic_signoff as ppp_kinematic_signoff  # noqa: E402
 import gnss_ppp_static_signoff as ppp_static_signoff  # noqa: E402
+import gnss_ppp_iers_atm_tidal_loading_multisite_bench as iers_atl_multisite_bench  # noqa: E402
+import gnss_ppp_iers_pole_tide_multisite_bench as iers_multisite_bench  # noqa: E402
+import gnss_vmf_atl as vmf_atl  # noqa: E402
 import gnss_short_baseline_signoff as short_signoff  # noqa: E402
 import generate_driving_comparison as comparison  # noqa: E402
 import generate_architecture_diagram as architecture_diagram  # noqa: E402
@@ -71,6 +74,195 @@ import apply_ppc_multi_candidate_selector as ppc_multi_candidate_selector  # noq
 import run_ppc_multi_candidate_selector_matrix as ppc_multi_selector_matrix  # noqa: E402
 import run_ppc_ratio_gating_selector_sweep as ppc_ratio_gating_sweep  # noqa: E402
 import run_ppc_realtime_guard_sweep as ppc_realtime_guard_sweep  # noqa: E402
+
+
+class IersMultisiteBenchHelpersTest(unittest.TestCase):
+    def test_resolve_config_path_uses_site_config_directory(self) -> None:
+        config_dir = Path("/tmp/gnsspp/site-config")
+
+        self.assertEqual(
+            iers_multisite_bench.resolve_config_path(
+                "data/igs_2026105/PERT00AUS.rnx", config_dir),
+            config_dir / "data/igs_2026105/PERT00AUS.rnx",
+        )
+        self.assertEqual(
+            iers_multisite_bench.resolve_config_path(
+                "/var/tmp/PERT00AUS.rnx", config_dir),
+            Path("/var/tmp/PERT00AUS.rnx"),
+        )
+
+    def test_resolve_config_path_falls_back_to_parent_relative_path(
+        self,
+    ) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnsspp_multisite_config_") as temp_dir:
+            root = Path(temp_dir)
+            config_dir = root / "data" / "igs_2026105"
+            obs = root / "data" / "igs_2026105" / "PERT00AUS.rnx"
+            obs.parent.mkdir(parents=True)
+            obs.touch()
+
+            self.assertEqual(
+                iers_multisite_bench.resolve_config_path(
+                    "data/igs_2026105/PERT00AUS.rnx", config_dir),
+                obs,
+            )
+
+    def test_resolve_config_path_falls_back_to_source_root(self) -> None:
+        self.assertEqual(
+            iers_multisite_bench.resolve_config_path(
+                "test_data/iers/tskb_synth.atl", Path("/tmp")),
+            ROOT_DIR / "test_data" / "iers" / "tskb_synth.atl",
+        )
+
+
+class IersAtmTidalLoadingMultisiteBenchHelpersTest(unittest.TestCase):
+    def test_smoke_example_config_references_tracked_synthetic_atl_fixture(self) -> None:
+        config_path = ROOT_DIR / "configs" / "iers_atl_multisite_smoke.example.json"
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+
+        self.assertEqual(config["sites"][0]["name"], "TSKB")
+        atl_path = ROOT_DIR / config["sites"][0]["atm_tidal_loading"]
+        self.assertTrue(atl_path.exists())
+        self.assertIn("S1", atl_path.read_text(encoding="ascii"))
+
+    def test_vmf_example_config_references_tracked_real_atl_fixtures(self) -> None:
+        config_path = ROOT_DIR / "configs" / "iers_atl_multisite_vmf.example.json"
+        config = json.loads(config_path.read_text(encoding="utf-8"))
+
+        self.assertEqual([site["name"] for site in config["sites"]], ["PERT", "TSKB"])
+        for site in config["sites"]:
+            atl_path = ROOT_DIR / site["atm_tidal_loading"]
+            text = atl_path.read_text(encoding="ascii")
+            self.assertTrue(atl_path.exists())
+            self.assertIn(site["name"], text)
+            self.assertIn("Source: https://vmf.geo.tuwien.ac.at", text)
+
+    def test_resolve_config_paths_resolves_common_and_site_paths(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnsspp_atl_multisite_") as temp_dir:
+            root = Path(temp_dir)
+            config_dir = root / "configs"
+            config_dir.mkdir()
+            nav = root / "data" / "BRDC.rnx"
+            obs = root / "data" / "PERT00AUS.rnx"
+            atl = root / "data" / "PERT.atl"
+            nav.parent.mkdir()
+            for path in (nav, obs, atl):
+                path.touch()
+            config = {
+                "common": {"nav": "data/BRDC.rnx"},
+                "sites": [
+                    {
+                        "name": "PERT",
+                        "obs": "data/PERT00AUS.rnx",
+                        "atm_tidal_loading": "data/PERT.atl",
+                    }
+                ],
+            }
+
+            iers_atl_multisite_bench.resolve_config_paths(config, config_dir)
+
+            self.assertEqual(config["common"]["nav"], nav)
+            self.assertEqual(config["sites"][0]["obs"], obs)
+            self.assertEqual(config["sites"][0]["atm_tidal_loading"], atl)
+
+    def test_site_value_prefers_site_over_common(self) -> None:
+        site = {"atm_tidal_loading": Path("site.atl")}
+        common = {"atm_tidal_loading": Path("common.atl")}
+
+        self.assertEqual(
+            iers_atl_multisite_bench.site_value(
+                site, common, "atm_tidal_loading"),
+            Path("site.atl"),
+        )
+        self.assertEqual(
+            iers_atl_multisite_bench.site_value(site, common, "nav"),
+            None,
+        )
+
+    def test_resolve_config_path_falls_back_to_source_root(self) -> None:
+        self.assertEqual(
+            iers_atl_multisite_bench.resolve_config_path(
+                "test_data/iers/tskb_synth.atl", Path("/tmp")),
+            ROOT_DIR / "test_data" / "iers" / "tskb_synth.atl",
+        )
+
+
+class VmfAtlHelpersTest(unittest.TestCase):
+    def sample_vmf_text(self) -> str:
+        values = " ".join(str(float(i)) for i in range(1, 19))
+        return f"PERT {values}\n"
+
+    def test_amplitude_phase_matches_cos_sin_form(self) -> None:
+        amplitude_m, phase_deg = vmf_atl.amplitude_phase_m(3.0, 4.0)
+
+        self.assertAlmostEqual(amplitude_m, 0.005)
+        self.assertAlmostEqual(phase_deg, 53.13010235415598)
+
+    def test_convert_row_flips_east_north_to_west_south(self) -> None:
+        # radial S1=(3,4), S2=(0,5); east S1=(1,0), S2=(0,2);
+        # north S1=(0,1), S2=(2,0). All values are VMF mm cos/sin.
+        values = [
+            3.0, 4.0, 0.0, 5.0, 0.0, 0.0,
+            1.0, 0.0, 0.0, 2.0, 0.0, 0.0,
+            0.0, 1.0, 2.0, 0.0, 0.0, 0.0,
+        ]
+
+        text = vmf_atl.convert_row("PERT", values)
+
+        self.assertIn("PERT", text)
+        self.assertIn("S1  0.00500000  0.00100000  0.00100000", text)
+        self.assertIn("S2  0.00500000  0.00200000  0.00200000", text)
+
+    def test_parse_vmf_rows_uppercases_station_names(self) -> None:
+        rows = vmf_atl.parse_vmf_rows("pert " + " ".join(["1"] * 18))
+
+        self.assertIn("PERT", rows)
+        self.assertEqual(len(rows["PERT"]), 18)
+
+    def test_main_writes_local_source_station_file(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnsspp_vmf_atl_") as temp_dir:
+            temp_root = Path(temp_dir)
+            source = temp_root / "vmf.dat"
+            out_dir = temp_root / "out"
+            source.write_text(self.sample_vmf_text(), encoding="ascii")
+
+            with mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "gnss_vmf_atl.py",
+                    "--source", str(source),
+                    "--station", "pert",
+                    "--output-dir", str(out_dir),
+                    "--suffix", "unit",
+                ],
+            ):
+                rc = vmf_atl.main()
+
+            output = out_dir / "pert_unit.atl"
+            self.assertEqual(rc, 0)
+            self.assertTrue(output.exists())
+            self.assertIn("PERT", output.read_text(encoding="ascii"))
+
+    def test_main_reports_missing_station(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnsspp_vmf_atl_missing_") as temp_dir:
+            temp_root = Path(temp_dir)
+            source = temp_root / "vmf.dat"
+            source.write_text(self.sample_vmf_text(), encoding="ascii")
+
+            with mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "gnss_vmf_atl.py",
+                    "--source", str(source),
+                    "--station", "NOPE",
+                    "--output-dir", str(temp_root / "out"),
+                ],
+            ):
+                rc = vmf_atl.main()
+
+            self.assertEqual(rc, 1)
 
 
 class ScorecardHelpersTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- add an ATL multi-site PPP bench wrapper and register it in the gnss CLI
- add a VMF site-wise tidal APL to libgnss++ ATL converter
- add PERT/TSKB VMF-derived ATL fixtures, example configs, docs, and helper tests

## Validation
- python3 tests/test_benchmark_scripts.py
- ctest --test-dir build -R python_benchmark_tests --output-on-failure
- python3 -m py_compile apps/gnss_vmf_atl.py apps/gnss_ppp_iers_atm_tidal_loading_multisite_bench.py apps/gnss_ppp_iers_pole_tide_multisite_bench.py apps/gnss.py
- python3 -m json.tool configs/iers_atl_multisite_smoke.example.json
- python3 -m json.tool configs/iers_atl_multisite_vmf.example.json
- git diff --check
- cmake --install build --prefix /tmp/gnsspp_atl_install_check

## Bench
- PERT VMF ATL: median 0.000 mm, p95 0.007 mm, max 0.022 mm
- TSKB VMF ATL: median 0.216 mm, p95 0.402 mm, max 0.643 mm