### PR TITLE
Add modular DD residual diagnostics CLI

### DIFF
--- a/apps/gnss_dd_residuals.py
+++ b/apps/gnss_dd_residuals.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Summarize per-DD RTK residual diagnostics emitted by gnss solve.
+
+Thin CLI orchestrator: argument parsing, dispatch into the
+``gnss_dd_residuals_*`` helper modules, and result printing.  The actual
+record schema, statistics, and rendering live in the sibling modules so each
+layer can be unit-tested in isolation:
+
+| Concern                | Module                                |
+|------------------------|---------------------------------------|
+| Record schema helpers  | ``gnss_dd_residuals_records``         |
+| CSV I/O                | ``gnss_dd_residuals_io``              |
+| Filtering              | ``gnss_dd_residuals_filtering``       |
+| Statistics             | ``gnss_dd_residuals_statistics``      |
+| Summary assembly       | ``gnss_dd_residuals_summary``         |
+| HTML/SVG rendering     | ``gnss_dd_residuals_html``            |
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Any
+
+from gnss_dd_residuals_filtering import filter_records
+from gnss_dd_residuals_html import write_html_report
+from gnss_dd_residuals_io import read_records, write_top_pairs_csv
+from gnss_dd_residuals_summary import summarize_records
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog=os.environ.get("GNSS_CLI_NAME"))
+    parser.add_argument("input_csv", type=Path, help="Input --dd-residuals-csv file.")
+    parser.add_argument("--summary-json", type=Path, default=None, help="Optional summary JSON path.")
+    parser.add_argument("--top-pairs-csv", type=Path, default=None, help="Optional worst-pair CSV path.")
+    parser.add_argument(
+        "--html-report", type=Path, default=None, help="Optional self-contained HTML report path."
+    )
+    parser.add_argument("--top-n", type=int, default=10, help="Number of worst pairs to keep.")
+    parser.add_argument(
+        "--kind",
+        choices=("all", "phase", "code"),
+        default="all",
+        help="Filter measurements before summarizing.",
+    )
+    parser.add_argument(
+        "--frequency-index",
+        type=int,
+        default=None,
+        help="Filter one frequency index before summarizing.",
+    )
+    parser.add_argument(
+        "--require-phase-p95-max",
+        type=float,
+        default=None,
+        help="Fail if phase p95 absolute residual exceeds this value in meters.",
+    )
+    parser.add_argument(
+        "--require-code-p95-max",
+        type=float,
+        default=None,
+        help="Fail if code p95 absolute residual exceeds this value in meters.",
+    )
+    parser.add_argument(
+        "--require-max-abs-residual-max",
+        type=float,
+        default=None,
+        help="Fail if max absolute residual exceeds this value in meters.",
+    )
+    parser.add_argument(
+        "--require-suppressed-rows-max",
+        type=int,
+        default=None,
+        help="Fail if outlier-threshold suppressed row count exceeds this value.",
+    )
+    return parser.parse_args()
+
+
+def enforce_requirements(summary: dict[str, Any], args: argparse.Namespace) -> None:
+    """Validate the summary against the optional CI thresholds.
+
+    Raises ``SystemExit`` with the concatenated failure list when any of
+    the configured ``--require-*`` thresholds are exceeded.  Threshold
+    failures are reported as a single error block so CI surfaces all of
+    them in one shot instead of one-per-rerun.
+    """
+
+    failures: list[str] = []
+
+    phase_p95 = summary["by_kind"]["phase"]["p95_abs_residual_m"]
+    if args.require_phase_p95_max is not None:
+        if phase_p95 is None or float(phase_p95) > args.require_phase_p95_max:
+            observed = "n/a" if phase_p95 is None else f"{float(phase_p95):.6f}"
+            failures.append(
+                f"phase p95 abs residual {observed} m > {args.require_phase_p95_max:.6f} m"
+            )
+
+    code_p95 = summary["by_kind"]["code"]["p95_abs_residual_m"]
+    if args.require_code_p95_max is not None:
+        if code_p95 is None or float(code_p95) > args.require_code_p95_max:
+            observed = "n/a" if code_p95 is None else f"{float(code_p95):.6f}"
+            failures.append(
+                f"code p95 abs residual {observed} m > {args.require_code_p95_max:.6f} m"
+            )
+
+    max_abs = summary["overall"]["max_abs_residual_m"]
+    if args.require_max_abs_residual_max is not None:
+        if max_abs is None or float(max_abs) > args.require_max_abs_residual_max:
+            observed = "n/a" if max_abs is None else f"{float(max_abs):.6f}"
+            failures.append(
+                f"max abs residual {observed} m > {args.require_max_abs_residual_max:.6f} m"
+            )
+
+    suppressed = int(summary["overall"]["suppressed_rows"])
+    if args.require_suppressed_rows_max is not None and suppressed > args.require_suppressed_rows_max:
+        failures.append(
+            f"suppressed rows {suppressed} > {args.require_suppressed_rows_max}"
+        )
+
+    if failures:
+        raise SystemExit(
+            "DD residual checks failed:\n" + "\n".join(f"  - {item}" for item in failures)
+        )
+
+
+def main() -> int:
+    args = parse_args()
+    if args.top_n < 0:
+        raise SystemExit("--top-n must be non-negative")
+    records = filter_records(read_records(args.input_csv), args.kind, args.frequency_index)
+    if not records:
+        raise SystemExit(f"No DD residual rows matched {args.input_csv}")
+
+    summary = summarize_records(records, top_n=args.top_n)
+    if args.summary_json is not None:
+        args.summary_json.parent.mkdir(parents=True, exist_ok=True)
+        args.summary_json.write_text(
+            json.dumps(summary, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if args.top_pairs_csv is not None:
+        write_top_pairs_csv(args.top_pairs_csv, list(summary["top_pairs"]))
+    if args.html_report is not None:
+        write_html_report(args.html_report, summary)
+
+    enforce_requirements(summary, args)
+
+    print("DD residual summary")
+    print(f"  rows: {summary['overall']['rows']}")
+    print(f"  epochs: {summary['coverage']['epochs']}")
+    print(f"  satellite_pairs: {summary['coverage']['satellite_pairs']}")
+    print(f"  pair_frequency_kind_tracks: {summary['coverage']['pair_frequency_kind_tracks']}")
+    print(f"  phase_p95_abs_m: {summary['by_kind']['phase']['p95_abs_residual_m']}")
+    print(f"  code_p95_abs_m: {summary['by_kind']['code']['p95_abs_residual_m']}")
+    print(f"  phase_p95_sigma: {summary['by_kind']['phase']['p95_abs_normalized_residual']}")
+    print(f"  code_p95_sigma: {summary['by_kind']['code']['p95_abs_normalized_residual']}")
+    print(f"  max_abs_m: {summary['overall']['max_abs_residual_m']}")
+    if args.summary_json is not None:
+        print(f"  summary: {args.summary_json}")
+    if args.top_pairs_csv is not None:
+        print(f"  top_pairs: {args.top_pairs_csv}")
+    if args.html_report is not None:
+        print(f"  html_report: {args.html_report}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/gnss_dd_residuals_filtering.py
+++ b/apps/gnss_dd_residuals_filtering.py
@@ -1,0 +1,35 @@
+"""Per-row filters for DD residual records.
+
+Kept as a separate module because filtering is the one piece a downstream
+caller (e.g., an interactive notebook session) is most likely to want to
+import in isolation, without dragging in the statistics or HTML layers.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def filter_records(
+    records: list[dict[str, Any]],
+    kind: str = "all",
+    frequency_index: int | None = None,
+) -> list[dict[str, Any]]:
+    """Keep records matching the requested ``kind`` and ``frequency_index``.
+
+    ``kind`` of ``"all"`` is the documented no-op default; passing
+    ``"phase"`` / ``"code"`` filters to that DD family.  ``frequency_index``
+    of ``None`` keeps every band.
+    """
+
+    filtered = records
+    if kind != "all":
+        filtered = [record for record in filtered if record["kind"] == kind]
+    if frequency_index is not None:
+        filtered = [
+            record for record in filtered if int(record["frequency_index"]) == frequency_index
+        ]
+    return filtered
+
+
+__all__ = ["filter_records"]

--- a/apps/gnss_dd_residuals_html.py
+++ b/apps/gnss_dd_residuals_html.py
@@ -1,0 +1,574 @@
+"""HTML / SVG rendering for DD residual diagnostics.
+
+Consumes the summary dict produced by ``gnss_dd_residuals_summary`` and
+emits a self-contained HTML report (no external assets).  Pure rendering —
+no statistics or I/O beyond the final file write.
+"""
+
+from __future__ import annotations
+
+import html
+import math
+from pathlib import Path
+from typing import Any
+
+from gnss_dd_residuals_records import frequency_label
+
+
+def html_value(value: Any) -> str:
+    """Escape ``value`` for HTML output, mapping ``None`` to the literal ``n/a``."""
+
+    if value is None:
+        return "n/a"
+    return html.escape(str(value))
+
+
+def metric_cell(label: str, value: Any) -> str:
+    """Top-of-report KPI card."""
+
+    return (
+        "<div class=\"metric\">"
+        f"<div class=\"metric-label\">{html.escape(label)}</div>"
+        f"<div class=\"metric-value\">{html_value(value)}</div>"
+        "</div>"
+    )
+
+
+def stats_table(title: str, rows: list[dict[str, Any]], label_keys: list[str]) -> str:
+    """Render a labeled stats table; emits an empty placeholder for no-row inputs."""
+
+    if not rows:
+        return f"<section><h2>{html.escape(title)}</h2><p>No rows.</p></section>"
+    columns = [
+        *label_keys,
+        "rows",
+        "epochs",
+        "suppressed_rows",
+        "rms_residual_m",
+        "p95_abs_residual_m",
+        "max_abs_residual_m",
+        "rms_normalized_residual",
+        "p95_abs_normalized_residual",
+        "max_abs_normalized_residual",
+    ]
+    header = "".join(f"<th>{html.escape(column)}</th>" for column in columns)
+    body_rows = []
+    for row in rows:
+        cells = "".join(f"<td>{html_value(row.get(column))}</td>" for column in columns)
+        body_rows.append(f"<tr>{cells}</tr>")
+    return (
+        f"<section><h2>{html.escape(title)}</h2>"
+        f"<table><thead><tr>{header}</tr></thead><tbody>"
+        + "".join(body_rows)
+        + "</tbody></table></section>"
+    )
+
+
+def nice_max(values: list[float]) -> float:
+    """Round-up a chart's Y-axis upper bound to a ``{1, 2, 5} × 10^n`` step."""
+
+    if not values:
+        return 1.0
+    maximum = max(values)
+    if maximum <= 0.0:
+        return 1.0
+    exponent = math.floor(math.log10(maximum))
+    base = 10.0 ** exponent
+    for multiplier in (1.0, 2.0, 5.0, 10.0):
+        candidate = multiplier * base
+        if candidate >= maximum:
+            return candidate
+    return maximum
+
+
+def svg_line_chart(
+    title: str,
+    series: list[dict[str, Any]],
+    y_fields: list[tuple[str, str, str]],
+    height: int = 260,
+) -> str:
+    """Multi-line time-series chart used for the per-epoch residual trend.
+
+    ``y_fields`` is a list of ``(field_name, legend_label, stroke_color)``
+    tuples.  Rows missing the field are silently skipped so a partial input
+    still produces a chart.
+    """
+
+    width = 1080
+    left = 54
+    right = 18
+    top = 28
+    bottom = 38
+    plot_width = width - left - right
+    plot_height = height - top - bottom
+    points_by_field: dict[str, list[tuple[float, float, dict[str, Any]]]] = {}
+    all_values: list[float] = []
+    for field, _, _ in y_fields:
+        points: list[tuple[float, float, dict[str, Any]]] = []
+        for index, row in enumerate(series):
+            value = row.get(field)
+            if value is None:
+                continue
+            parsed = float(value)
+            if not math.isfinite(parsed):
+                continue
+            points.append((float(index), parsed, row))
+            all_values.append(parsed)
+        points_by_field[field] = points
+    if not all_values:
+        return f"<section><h2>{html.escape(title)}</h2><p>No chartable rows.</p></section>"
+
+    y_max = nice_max(all_values)
+    x_max = max(1, len(series) - 1)
+
+    def sx(index: float) -> float:
+        return left + (index / x_max) * plot_width
+
+    def sy(value: float) -> float:
+        return top + plot_height - (value / y_max) * plot_height
+
+    grid = []
+    for tick in range(5):
+        value = y_max * tick / 4.0
+        y = sy(value)
+        grid.append(
+            f"<line x1=\"{left}\" y1=\"{y:.2f}\" x2=\"{width - right}\" y2=\"{y:.2f}\" />"
+            f"<text x=\"8\" y=\"{y + 4:.2f}\">{value:.3g}</text>"
+        )
+    paths = []
+    legend = []
+    for field, label, color in y_fields:
+        points = points_by_field.get(field, [])
+        if not points:
+            continue
+        d = " ".join(f"{sx(index):.2f},{sy(value):.2f}" for index, value, _ in points)
+        paths.append(f"<polyline points=\"{d}\" stroke=\"{color}\" />")
+        if len(points) <= 240:
+            circles = []
+            for index, value, row in points:
+                circles.append(
+                    f"<circle cx=\"{sx(index):.2f}\" cy=\"{sy(value):.2f}\" r=\"2.8\" "
+                    f"fill=\"{color}\"><title>epoch {row['epoch_index']} tow {row['tow']} "
+                    f"{label}: {value:.6f} m</title></circle>"
+                )
+            paths.append("".join(circles))
+        legend.append(
+            f"<span><i style=\"background:{color}\"></i>{html.escape(label)}</span>"
+        )
+
+    x_labels = ""
+    if series:
+        first = series[0]
+        last = series[-1]
+        x_labels = (
+            f"<text class=\"x-label\" x=\"{left}\" y=\"{height - 8}\">"
+            f"epoch {first['epoch_index']}</text>"
+            f"<text class=\"x-label\" x=\"{width - right}\" y=\"{height - 8}\" text-anchor=\"end\">"
+            f"epoch {last['epoch_index']}</text>"
+        )
+    return (
+        f"<section><h2>{html.escape(title)}</h2>"
+        f"<div class=\"legend\">{''.join(legend)}</div>"
+        f"<svg class=\"chart\" viewBox=\"0 0 {width} {height}\" role=\"img\" "
+        f"aria-label=\"{html.escape(title)}\">"
+        f"<g class=\"grid\">{''.join(grid)}</g>"
+        f"<line class=\"axis\" x1=\"{left}\" y1=\"{top}\" x2=\"{left}\" y2=\"{height - bottom}\" />"
+        f"<line class=\"axis\" x1=\"{left}\" y1=\"{height - bottom}\" "
+        f"x2=\"{width - right}\" y2=\"{height - bottom}\" />"
+        f"{''.join(paths)}{x_labels}</svg></section>"
+    )
+
+
+def svg_bar_chart(
+    title: str, rows: list[dict[str, Any]], value_key: str, height: int = 320
+) -> str:
+    """Horizontal bar chart for the worst-pair summaries."""
+
+    if not rows:
+        return f"<section><h2>{html.escape(title)}</h2><p>No rows.</p></section>"
+    width = 1080
+    left = 240
+    right = 64
+    top = 18
+    row_height = 28
+    chart_height = max(height, top + row_height * len(rows) + 24)
+    max_value = max(float(row.get(value_key) or 0.0) for row in rows) or 1.0
+    max_value = nice_max([max_value])
+    bars = []
+    for index, row in enumerate(rows):
+        y = top + index * row_height
+        value = float(row.get(value_key) or 0.0)
+        bar_width = (value / max_value) * (width - left - right)
+        label = (
+            f"{row.get('kind')} {row.get('frequency_label')} "
+            f"{row.get('pair')}"
+        )
+        color = "#0f766e" if row.get("kind") == "phase" else "#2563eb"
+        bars.append(
+            f"<text x=\"8\" y=\"{y + 17}\">{html.escape(label)}</text>"
+            f"<rect x=\"{left}\" y=\"{y + 5}\" width=\"{bar_width:.2f}\" height=\"16\" "
+            f"fill=\"{color}\"><title>{html.escape(label)} {value:.6f} m</title></rect>"
+            f"<text x=\"{left + bar_width + 6:.2f}\" y=\"{y + 17}\">{value:.6f}</text>"
+        )
+    return (
+        f"<section><h2>{html.escape(title)}</h2>"
+        f"<svg class=\"bar-chart\" viewBox=\"0 0 {width} {chart_height}\" role=\"img\" "
+        f"aria-label=\"{html.escape(title)}\">{''.join(bars)}</svg></section>"
+    )
+
+
+def svg_residual_scatter(
+    title: str,
+    points: list[dict[str, Any]],
+    kind: str,
+    height: int = 340,
+) -> str:
+    """Per-epoch scatter of raw residuals coloured by frequency band."""
+
+    kind_points = [point for point in points if point.get("kind") == kind]
+    if not kind_points:
+        return f"<section><h2>{html.escape(title)}</h2><p>No {html.escape(kind)} rows.</p></section>"
+    width = 1080
+    left = 60
+    right = 20
+    top = 28
+    bottom = 42
+    plot_width = width - left - right
+    plot_height = height - top - bottom
+    epochs = [int(point["epoch_index"]) for point in kind_points]
+    min_epoch = min(epochs)
+    max_epoch = max(epochs)
+    x_span = max(1, max_epoch - min_epoch)
+    max_abs = max(abs(float(point["residual_m"])) for point in kind_points) or 1.0
+    y_limit = nice_max([max_abs])
+
+    def sx(epoch: int) -> float:
+        return left + ((epoch - min_epoch) / x_span) * plot_width
+
+    def sy(value: float) -> float:
+        return top + (y_limit - value) / (2.0 * y_limit) * plot_height
+
+    colors = {
+        0: "#0f766e" if kind == "phase" else "#2563eb",
+        1: "#b45309",
+        2: "#7c3aed",
+    }
+    grid = []
+    for tick in (-1.0, -0.5, 0.0, 0.5, 1.0):
+        value = y_limit * tick
+        y = sy(value)
+        klass = "zero-line" if abs(value) < 1e-12 else "grid-line"
+        grid.append(
+            f"<line class=\"{klass}\" x1=\"{left}\" y1=\"{y:.2f}\" "
+            f"x2=\"{width - right}\" y2=\"{y:.2f}\" />"
+            f"<text x=\"8\" y=\"{y + 4:.2f}\">{value:.3g}</text>"
+        )
+    rendered_points = []
+    for point in kind_points:
+        residual = float(point["residual_m"])
+        frequency = int(point["frequency_index"])
+        color = colors.get(frequency, "#64748b")
+        radius = 3.2 if int(point["suppressed_by_outlier_threshold"]) else 2.2
+        pair = str(point["pair"])
+        rendered_points.append(
+            f"<circle cx=\"{sx(int(point['epoch_index'])):.2f}\" cy=\"{sy(residual):.2f}\" "
+            f"r=\"{radius}\" fill=\"{color}\" fill-opacity=\"0.72\">"
+            f"<title>epoch {point['epoch_index']} tow {point['tow']} {pair} "
+            f"{point['frequency_label']} residual {residual:.6f} m</title></circle>"
+        )
+    legend_items = []
+    for frequency in sorted({int(point["frequency_index"]) for point in kind_points}):
+        color = colors.get(frequency, "#64748b")
+        legend_items.append(
+            f"<span><i style=\"background:{color}\"></i>{html.escape(frequency_label(frequency))}</span>"
+        )
+    return (
+        f"<section><h2>{html.escape(title)}</h2>"
+        f"<div class=\"legend\">{''.join(legend_items)}"
+        "<span><b class=\"suppressed-dot\"></b>threshold-suppressed rows use larger dots</span></div>"
+        f"<svg class=\"chart\" viewBox=\"0 0 {width} {height}\" role=\"img\" "
+        f"aria-label=\"{html.escape(title)}\">"
+        f"<g class=\"grid\">{''.join(grid)}</g>"
+        f"<line class=\"axis\" x1=\"{left}\" y1=\"{top}\" x2=\"{left}\" y2=\"{height - bottom}\" />"
+        f"<line class=\"axis\" x1=\"{left}\" y1=\"{height - bottom}\" "
+        f"x2=\"{width - right}\" y2=\"{height - bottom}\" />"
+        f"{''.join(rendered_points)}"
+        f"<text class=\"x-label\" x=\"{left}\" y=\"{height - 9}\">epoch {min_epoch}</text>"
+        f"<text class=\"x-label\" x=\"{width - right}\" y=\"{height - 9}\" text-anchor=\"end\">"
+        f"epoch {max_epoch}</text>"
+        "</svg></section>"
+    )
+
+
+def svg_pair_heatmap(
+    title: str,
+    points: list[dict[str, Any]],
+    pair_tracks: list[dict[str, Any]],
+    kind: str,
+    max_rows: int = 24,
+) -> str:
+    """Per-pair heatmap of worst residual magnitude across epochs."""
+
+    pair_rows = [row for row in pair_tracks if row.get("kind") == kind][:max_rows]
+    if not pair_rows:
+        return f"<section><h2>{html.escape(title)}</h2><p>No {html.escape(kind)} rows.</p></section>"
+    kind_points = [point for point in points if point.get("kind") == kind]
+    if not kind_points:
+        return f"<section><h2>{html.escape(title)}</h2><p>No {html.escape(kind)} points.</p></section>"
+
+    epochs = sorted({int(point["epoch_index"]) for point in kind_points})
+    min_epoch = epochs[0]
+    max_epoch = epochs[-1]
+    x_span = max(1, max_epoch - min_epoch)
+    width = 1080
+    left = 250
+    right = 24
+    top = 18
+    cell_height = 20
+    row_gap = 4
+    height = top + len(pair_rows) * (cell_height + row_gap) + 36
+    plot_width = width - left - right
+    max_abs = max(float(point["abs_residual_m"]) for point in kind_points) or 1.0
+
+    def sx(epoch: int) -> float:
+        return left + ((epoch - min_epoch) / x_span) * plot_width
+
+    def color(value: float, suppressed: int) -> str:
+        ratio = min(1.0, value / max_abs)
+        if suppressed:
+            return "#7f1d1d"
+        if kind == "phase":
+            green = int(229 - 119 * ratio)
+            blue = int(224 - 150 * ratio)
+            return f"rgb(15,{green},{blue})"
+        red = int(219 - 10 * ratio)
+        green = int(234 - 150 * ratio)
+        blue = int(254 - 190 * ratio)
+        return f"rgb({red},{green},{blue})"
+
+    grouped: dict[tuple[str, int, int], dict[str, Any]] = {}
+    for point in kind_points:
+        key = (str(point["pair"]), int(point["frequency_index"]), int(point["epoch_index"]))
+        current = grouped.get(key)
+        if current is None or float(point["abs_residual_m"]) > float(current["abs_residual_m"]):
+            grouped[key] = point
+
+    rows_html = []
+    for row_index, pair_row in enumerate(pair_rows):
+        y = top + row_index * (cell_height + row_gap)
+        pair = str(pair_row["pair"])
+        freq_index = int(pair_row["frequency_index"])
+        label = f"{pair} {pair_row['frequency_label']}"
+        rows_html.append(f"<text x=\"8\" y=\"{y + 14}\">{html.escape(label)}</text>")
+        for epoch in epochs:
+            point = grouped.get((pair, freq_index, epoch))
+            if point is None:
+                continue
+            x = sx(epoch)
+            residual = float(point["residual_m"])
+            abs_residual = float(point["abs_residual_m"])
+            suppressed = int(point["suppressed_by_outlier_threshold"])
+            rows_html.append(
+                f"<rect x=\"{x:.2f}\" y=\"{y}\" width=\"{max(2.0, plot_width / max(1, len(epochs))):.2f}\" "
+                f"height=\"{cell_height}\" fill=\"{color(abs_residual, suppressed)}\" "
+                f"fill-opacity=\"0.82\"><title>epoch {epoch} {label} residual "
+                f"{residual:.6f} m</title></rect>"
+            )
+    hidden_rows = max(
+        0,
+        len([row for row in pair_tracks if row.get("kind") == kind]) - len(pair_rows),
+    )
+    note = (
+        f"<p class=\"chart-note\">showing worst {len(pair_rows)} tracks"
+        + (
+            f"; {hidden_rows} lower-residual tracks are listed in the coverage table"
+            if hidden_rows
+            else ""
+        )
+        + "</p>"
+    )
+    return (
+        f"<section><h2>{html.escape(title)}</h2>"
+        f"{note}"
+        f"<svg class=\"heatmap\" viewBox=\"0 0 {width} {height}\" role=\"img\" "
+        f"aria-label=\"{html.escape(title)}\">"
+        f"{''.join(rows_html)}"
+        f"<text class=\"x-label\" x=\"{left}\" y=\"{height - 9}\">epoch {min_epoch}</text>"
+        f"<text class=\"x-label\" x=\"{width - right}\" y=\"{height - 9}\" text-anchor=\"end\">"
+        f"epoch {max_epoch}</text></svg></section>"
+    )
+
+
+_DOCUMENT_CSS = """\
+body { font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; margin: 0; color: #1f2933; background: #f7f8fa; }
+main { max-width: 1180px; margin: 0 auto; padding: 28px; }
+h1 { font-size: 28px; margin: 0 0 18px; }
+h2 { font-size: 18px; margin: 26px 0 10px; }
+.metrics { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 10px; }
+.metric { background: #fff; border: 1px solid #d9dee5; border-radius: 6px; padding: 12px; }
+.metric-label { color: #52616f; font-size: 12px; }
+.metric-value { font-size: 22px; font-weight: 650; margin-top: 4px; }
+table { width: 100%; border-collapse: collapse; background: #fff; border: 1px solid #d9dee5; }
+th, td { padding: 8px 10px; border-bottom: 1px solid #e5e9ef; text-align: right; font-size: 13px; }
+th { background: #eef2f6; color: #344150; }
+th:first-child, td:first-child { text-align: left; }
+.kv { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 8px; }
+.kv div { background: #fff; border: 1px solid #d9dee5; border-radius: 6px; padding: 10px; }
+.kv span { display: block; color: #52616f; font-size: 12px; }
+.kv strong { display: block; margin-top: 4px; font-size: 15px; }
+svg.chart, svg.bar-chart, svg.heatmap { width: 100%; height: auto; background: #fff; border: 1px solid #d9dee5; }
+.grid line { stroke: #e5e9ef; stroke-width: 1; }
+.grid .zero-line { stroke: #7b8794; stroke-width: 1.4; }
+.grid .grid-line { stroke: #e5e9ef; stroke-width: 1; }
+.grid text, .x-label { fill: #52616f; font-size: 12px; }
+.axis { stroke: #8b98a8; stroke-width: 1.2; }
+polyline { fill: none; stroke-width: 2.2; }
+.legend { display: flex; gap: 14px; flex-wrap: wrap; margin: 0 0 8px; color: #344150; font-size: 13px; }
+.legend i { display: inline-block; width: 18px; height: 3px; margin-right: 6px; vertical-align: middle; }
+.suppressed-dot { display: inline-block; width: 9px; height: 9px; border-radius: 50%; background: #1f2933; margin-right: 6px; vertical-align: middle; }
+.chart-note { color: #52616f; font-size: 13px; margin: -4px 0 8px; }
+"""
+
+
+def _worst_row_section(worst_row: Any) -> str:
+    if not isinstance(worst_row, dict):
+        return ""
+    return (
+        "<section><h2>Worst Row</h2>"
+        "<div class=\"kv\">"
+        + "".join(
+            f"<div><span>{html.escape(str(key))}</span><strong>{html_value(value)}</strong></div>"
+            for key, value in worst_row.items()
+        )
+        + "</div></section>"
+    )
+
+
+def write_html_report(
+    path: Path, summary: dict[str, Any], title: str = "DD Residual Report"
+) -> None:
+    """Render the full HTML document for ``summary`` to ``path``."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    by_kind = summary.get("by_kind", {})
+    phase = by_kind.get("phase", {})
+    code = by_kind.get("code", {})
+    coverage = summary.get("coverage", {})
+    cards = "".join(
+        [
+            metric_cell("rows", summary.get("overall", {}).get("rows")),
+            metric_cell("epochs", coverage.get("epochs")),
+            metric_cell("satellite pairs", coverage.get("satellite_pairs")),
+            metric_cell("pair/freq/kind tracks", coverage.get("pair_frequency_kind_tracks")),
+            metric_cell("phase p95 abs m", phase.get("p95_abs_residual_m")),
+            metric_cell("code p95 abs m", code.get("p95_abs_residual_m")),
+            metric_cell("phase p95 sigma", phase.get("p95_abs_normalized_residual")),
+            metric_cell("code p95 sigma", code.get("p95_abs_normalized_residual")),
+            metric_cell("max abs m", summary.get("overall", {}).get("max_abs_residual_m")),
+            metric_cell("suppressed rows", summary.get("overall", {}).get("suppressed_rows")),
+        ]
+    )
+    kind_rows = [
+        {"kind": kind, **stats}
+        for kind, stats in by_kind.items()
+        if isinstance(stats, dict)
+    ]
+    top_pairs = list(summary.get("top_pairs", []))
+    top_normalized_pairs = list(summary.get("top_normalized_pairs", []))
+    pair_tracks = list(summary.get("pair_tracks", []))
+    frequency_rows = list(summary.get("by_frequency", []))
+    time_series = list(summary.get("time_series", []))
+    residual_points = list(summary.get("residual_points", []))
+    residual_chart = svg_line_chart(
+        "Raw Prefit Residual Time Series",
+        time_series,
+        [
+            ("phase_p95_abs_residual_m", "phase p95", "#0f766e"),
+            ("code_p95_abs_residual_m", "code p95", "#2563eb"),
+            ("max_abs_residual_m", "max abs", "#b91c1c"),
+        ],
+    )
+    normalized_residual_chart = svg_line_chart(
+        "Normalized Prefit Residual Time Series",
+        time_series,
+        [
+            ("phase_p95_abs_normalized_residual", "phase p95 sigma", "#0f766e"),
+            ("code_p95_abs_normalized_residual", "code p95 sigma", "#2563eb"),
+            ("max_abs_normalized_residual", "max sigma", "#b91c1c"),
+        ],
+    )
+    suppressed_chart = svg_line_chart(
+        "Suppressed Rows Over Time",
+        time_series,
+        [("suppressed_rows", "suppressed rows", "#9333ea")],
+        height=210,
+    )
+    top_pairs_chart = svg_bar_chart("Worst Pair Raw P95", top_pairs, "p95_abs_residual_m")
+    top_normalized_pairs_chart = svg_bar_chart(
+        "Worst Pair Normalized P95", top_normalized_pairs, "p95_abs_normalized_residual"
+    )
+    phase_scatter = svg_residual_scatter(
+        "All Carrier Phase DD Residuals", residual_points, "phase"
+    )
+    code_scatter = svg_residual_scatter(
+        "All Pseudorange DD Residuals", residual_points, "code"
+    )
+    phase_heatmap = svg_pair_heatmap(
+        "Carrier Phase Residual Heatmap By Satellite Pair",
+        residual_points,
+        pair_tracks,
+        "phase",
+    )
+    code_heatmap = svg_pair_heatmap(
+        "Pseudorange Residual Heatmap By Satellite Pair",
+        residual_points,
+        pair_tracks,
+        "code",
+    )
+    worst_html = _worst_row_section(summary.get("overall", {}).get("worst_row"))
+    document = f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>{html.escape(title)}</title>
+  <style>
+{_DOCUMENT_CSS}  </style>
+</head>
+<body>
+<main>
+  <h1>{html.escape(title)}</h1>
+  <section class="metrics">{cards}</section>
+  {phase_scatter}
+  {code_scatter}
+  {phase_heatmap}
+  {code_heatmap}
+  {residual_chart}
+  {normalized_residual_chart}
+  {suppressed_chart}
+  {top_pairs_chart}
+  {top_normalized_pairs_chart}
+  {stats_table("By Kind", kind_rows, ["kind"])}
+  {stats_table("By Frequency", frequency_rows, ["frequency_label"])}
+  {stats_table("Worst Satellite Pairs By Raw Residual", top_pairs, ["kind", "frequency_label", "pair"])}
+  {stats_table("Worst Satellite Pairs By Normalized Residual", top_normalized_pairs, ["kind", "frequency_label", "pair"])}
+  {stats_table("All Satellite Pair Tracks", pair_tracks, ["kind", "frequency_label", "pair"])}
+  {worst_html}
+</main>
+</body>
+</html>
+"""
+    path.write_text(document, encoding="utf-8")
+
+
+__all__ = [
+    "html_value",
+    "metric_cell",
+    "nice_max",
+    "stats_table",
+    "svg_bar_chart",
+    "svg_line_chart",
+    "svg_pair_heatmap",
+    "svg_residual_scatter",
+    "write_html_report",
+]

--- a/apps/gnss_dd_residuals_io.py
+++ b/apps/gnss_dd_residuals_io.py
@@ -1,0 +1,129 @@
+"""CSV I/O for DD residual diagnostics.
+
+Reads ``--dd-residuals-csv`` files emitted by ``gnss solve`` into the
+dict-of-Python-primitives shape consumed by the rest of the pipeline, and
+writes the worst-pair CSV used in CI dashboards.  Pure I/O — no statistics
+or rendering happen here.
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+from pathlib import Path
+from typing import Any
+
+
+_REQUIRED_COLUMNS: frozenset[str] = frozenset(
+    {
+        "epoch_index",
+        "gps_week",
+        "tow",
+        "status",
+        "kind",
+        "frequency_index",
+        "reference_satellite",
+        "satellite",
+        "residual_m",
+        "abs_residual_m",
+        "suppressed_by_outlier_threshold",
+    }
+)
+
+
+_TOP_PAIRS_FIELDNAMES: tuple[str, ...] = (
+    "rank",
+    "kind",
+    "frequency_index",
+    "frequency_label",
+    "reference_satellite",
+    "satellite",
+    "pair",
+    "rows",
+    "epochs",
+    "suppressed_rows",
+    "rms_residual_m",
+    "p95_abs_residual_m",
+    "max_abs_residual_m",
+    "rms_normalized_residual",
+    "p95_abs_normalized_residual",
+    "max_abs_normalized_residual",
+)
+
+
+def optional_float(value: str | None) -> float | None:
+    """Parse a CSV cell into a float, returning ``None`` for empty/NaN cells.
+
+    Used for the ``*_variance_m2`` columns which may be omitted when the
+    solver did not emit per-measurement variance estimates.
+    """
+
+    if value is None or value == "":
+        return None
+    parsed = float(value)
+    return parsed if math.isfinite(parsed) else None
+
+
+def read_records(path: Path) -> list[dict[str, Any]]:
+    """Read a DD residual CSV into per-row dicts.
+
+    Raises ``SystemExit`` if any of the canonical columns are missing; this
+    matches the original script's contract so callers can rely on the
+    CLI-level error message.  Non-finite residual rows are silently
+    dropped because they would otherwise propagate NaNs into the summary
+    statistics.
+    """
+
+    records: list[dict[str, Any]] = []
+    with path.open(encoding="ascii", newline="") as handle:
+        reader = csv.DictReader(handle)
+        missing = _REQUIRED_COLUMNS.difference(reader.fieldnames or [])
+        if missing:
+            raise SystemExit(
+                f"Missing DD residual columns in {path}: {', '.join(sorted(missing))}"
+            )
+        for row in reader:
+            residual_m = float(row["residual_m"])
+            abs_residual_m = float(row["abs_residual_m"])
+            if not math.isfinite(residual_m) or not math.isfinite(abs_residual_m):
+                continue
+            records.append(
+                {
+                    "epoch_index": int(float(row["epoch_index"])),
+                    "gps_week": int(float(row["gps_week"])),
+                    "tow": float(row["tow"]),
+                    "status": int(float(row["status"])),
+                    "kind": row["kind"],
+                    "frequency_index": int(float(row["frequency_index"])),
+                    "reference_satellite": row["reference_satellite"],
+                    "satellite": row["satellite"],
+                    "residual_m": residual_m,
+                    "abs_residual_m": abs_residual_m,
+                    "reference_variance_m2": optional_float(row.get("reference_variance_m2")),
+                    "satellite_variance_m2": optional_float(row.get("satellite_variance_m2")),
+                    "suppressed_by_outlier_threshold": int(
+                        float(row["suppressed_by_outlier_threshold"])
+                    ),
+                }
+            )
+    return records
+
+
+def write_top_pairs_csv(path: Path, top_pairs: list[dict[str, Any]]) -> None:
+    """Persist the ranked worst-pair table to disk."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="ascii", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(_TOP_PAIRS_FIELDNAMES))
+        writer.writeheader()
+        for index, pair in enumerate(top_pairs, start=1):
+            row = {field: pair.get(field) for field in _TOP_PAIRS_FIELDNAMES if field != "rank"}
+            row["rank"] = index
+            writer.writerow(row)
+
+
+__all__ = [
+    "optional_float",
+    "read_records",
+    "write_top_pairs_csv",
+]

--- a/apps/gnss_dd_residuals_records.py
+++ b/apps/gnss_dd_residuals_records.py
@@ -1,0 +1,120 @@
+"""DD residual record schema helpers.
+
+This module owns the per-row transforms that mediate between the raw CSV
+dict and the higher-level statistics / rendering layers.  All functions are
+pure; there is no I/O or global state, so each predicate can be unit-tested
+with a hand-built dict literal.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+
+def frequency_label(frequency_index: int) -> str:
+    """Human-readable band label for a 0/1/2-indexed RINEX frequency slot."""
+
+    labels = {
+        0: "freq0 primary (L1/E1/B1)",
+        1: "freq1 secondary (L2/E5/B2)",
+        2: "freq2 L5-class (L5/E5a/B2a)",
+    }
+    return labels.get(frequency_index, f"freq{frequency_index}")
+
+
+def pair_label(reference_satellite: Any, satellite: Any) -> str:
+    """Canonical ``REF-SAT`` label used everywhere we group by DD pair."""
+
+    return f"{reference_satellite}-{satellite}"
+
+
+def residual_sigma_m(record: dict[str, Any]) -> float | None:
+    """Combined-variance σ for a DD record, or ``None`` if missing/non-finite.
+
+    The DD residual variance is the sum of the reference and satellite
+    measurement variances (independence assumption); when either is absent
+    or the sum is non-positive the σ is undefined and we return ``None``
+    so downstream summaries can skip the row.
+    """
+
+    reference_variance = record.get("reference_variance_m2")
+    satellite_variance = record.get("satellite_variance_m2")
+    if reference_variance is None or satellite_variance is None:
+        return None
+    variance = float(reference_variance) + float(satellite_variance)
+    if not math.isfinite(variance) or variance <= 0.0:
+        return None
+    return math.sqrt(variance)
+
+
+def normalized_residual(record: dict[str, Any]) -> float | None:
+    """Residual divided by its σ, or ``None`` if σ is undefined."""
+
+    sigma = residual_sigma_m(record)
+    if sigma is None:
+        return None
+    return float(record["residual_m"]) / sigma
+
+
+def abs_normalized_residual(record: dict[str, Any]) -> float | None:
+    """Magnitude of the normalized residual, ``None`` when σ is undefined."""
+
+    value = normalized_residual(record)
+    return abs(value) if value is not None else None
+
+
+def rounded(value: float | None) -> float | None:
+    """Round to 6 decimal places, propagating ``None``.
+
+    Centralised here so the choice of precision is one edit away if we
+    ever switch to a fixed-point output format.
+    """
+
+    if value is None:
+        return None
+    return round(value, 6)
+
+
+def compact_row(record: dict[str, Any]) -> dict[str, Any]:
+    """Lossy serialisation of a DD record into the renderer's row shape.
+
+    Drops the raw ``*_variance_m2`` fields (already folded into σ /
+    normalized residual) and adds the per-record annotations
+    (``frequency_label``, ``pair``, ``residual_sigma_m`` …) that the HTML
+    and CSV consumers reuse.
+    """
+
+    freq_index = int(record["frequency_index"])
+    pair = pair_label(record["reference_satellite"], record["satellite"])
+    sigma = residual_sigma_m(record)
+    normalized = normalized_residual(record)
+    return {
+        "epoch_index": int(record["epoch_index"]),
+        "gps_week": int(record["gps_week"]),
+        "tow": rounded(float(record["tow"])),
+        "status": int(record["status"]),
+        "kind": record["kind"],
+        "frequency_index": freq_index,
+        "frequency_label": frequency_label(freq_index),
+        "reference_satellite": record["reference_satellite"],
+        "satellite": record["satellite"],
+        "pair": pair,
+        "residual_m": rounded(float(record["residual_m"])),
+        "abs_residual_m": rounded(float(record["abs_residual_m"])),
+        "residual_sigma_m": rounded(sigma),
+        "normalized_residual": rounded(normalized),
+        "abs_normalized_residual": rounded(abs(normalized)) if normalized is not None else None,
+        "suppressed_by_outlier_threshold": int(record["suppressed_by_outlier_threshold"]),
+    }
+
+
+__all__ = [
+    "abs_normalized_residual",
+    "compact_row",
+    "frequency_label",
+    "normalized_residual",
+    "pair_label",
+    "residual_sigma_m",
+    "rounded",
+]

--- a/apps/gnss_dd_residuals_statistics.py
+++ b/apps/gnss_dd_residuals_statistics.py
@@ -1,0 +1,157 @@
+"""Pure statistical aggregations over DD residual records.
+
+Owns the percentile / RMS / worst-row computations and the
+``(epoch, pair, frequency)`` coverage stats.  All functions accept lists of
+dict-shaped records and return JSON-serialisable dicts so the summary and
+HTML layers can compose them without circular imports.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+from gnss_dd_residuals_records import (
+    abs_normalized_residual,
+    compact_row,
+    frequency_label,
+    normalized_residual,
+    pair_label,
+    rounded,
+)
+
+
+def percentile(values: list[float], q: float) -> float | None:
+    """Linear-interpolation percentile for ``q`` in ``[0, 1]``.
+
+    Matches numpy ``percentile(q*100)`` for finite inputs but avoids the
+    numpy dependency so this module stays portable across stripped-down
+    benchmark sandboxes.
+    """
+
+    if not values:
+        return None
+    sorted_values = sorted(values)
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+    rank = q * (len(sorted_values) - 1)
+    lower = math.floor(rank)
+    upper = math.ceil(rank)
+    if lower == upper:
+        return sorted_values[lower]
+    fraction = rank - lower
+    return sorted_values[lower] * (1.0 - fraction) + sorted_values[upper] * fraction
+
+
+def group_records(
+    records: list[dict[str, Any]],
+    keys: tuple[str, ...],
+) -> dict[tuple[Any, ...], list[dict[str, Any]]]:
+    """Group records by the requested record-dict ``keys`` tuple."""
+
+    groups: dict[tuple[Any, ...], list[dict[str, Any]]] = {}
+    for record in records:
+        key = tuple(record[name] for name in keys)
+        groups.setdefault(key, []).append(record)
+    return groups
+
+
+def residual_stats(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Per-group summary statistics (rms / p95 / max / worst row)."""
+
+    residuals = [float(record["residual_m"]) for record in records]
+    abs_residuals = [float(record["abs_residual_m"]) for record in records]
+    normalized_residuals = [
+        value
+        for value in (normalized_residual(record) for record in records)
+        if value is not None
+    ]
+    abs_normalized_residuals = [abs(value) for value in normalized_residuals]
+    suppressed_rows = sum(int(record["suppressed_by_outlier_threshold"]) for record in records)
+    worst = max(records, key=lambda record: float(record["abs_residual_m"])) if records else None
+    worst_normalized = max(
+        (record for record in records if abs_normalized_residual(record) is not None),
+        key=lambda record: float(abs_normalized_residual(record) or 0.0),
+        default=None,
+    )
+    return {
+        "rows": len(records),
+        "epochs": len({(int(record["gps_week"]), float(record["tow"])) for record in records}),
+        "suppressed_rows": suppressed_rows,
+        "mean_abs_residual_m": rounded(
+            sum(abs_residuals) / len(abs_residuals) if abs_residuals else None
+        ),
+        "rms_residual_m": rounded(
+            math.sqrt(sum(value * value for value in residuals) / len(residuals))
+            if residuals
+            else None
+        ),
+        "rms_normalized_residual": rounded(
+            math.sqrt(
+                sum(value * value for value in normalized_residuals)
+                / len(normalized_residuals)
+            )
+            if normalized_residuals
+            else None
+        ),
+        "p95_abs_residual_m": rounded(percentile(abs_residuals, 0.95)),
+        "p95_abs_normalized_residual": rounded(percentile(abs_normalized_residuals, 0.95)),
+        "max_abs_residual_m": rounded(max(abs_residuals) if abs_residuals else None),
+        "max_abs_normalized_residual": rounded(
+            max(abs_normalized_residuals) if abs_normalized_residuals else None
+        ),
+        "worst_row": compact_row(worst) if worst is not None else None,
+        "worst_normalized_row": (
+            compact_row(worst_normalized) if worst_normalized is not None else None
+        ),
+    }
+
+
+def coverage_stats(records: list[dict[str, Any]]) -> dict[str, Any]:
+    """Counts and band labels describing the records' DD coverage envelope."""
+
+    epochs = sorted(
+        {
+            (int(record["epoch_index"]), int(record["gps_week"]), float(record["tow"]))
+            for record in records
+        }
+    )
+    pairs = {
+        pair_label(record["reference_satellite"], record["satellite"])
+        for record in records
+    }
+    satellites = {
+        str(record[name])
+        for record in records
+        for name in ("reference_satellite", "satellite")
+    }
+    tracks = {
+        (
+            str(record["kind"]),
+            int(record["frequency_index"]),
+            str(record["reference_satellite"]),
+            str(record["satellite"]),
+        )
+        for record in records
+    }
+    frequencies = sorted({int(record["frequency_index"]) for record in records})
+    return {
+        "rows": len(records),
+        "epochs": len(epochs),
+        "first_epoch_index": epochs[0][0] if epochs else None,
+        "last_epoch_index": epochs[-1][0] if epochs else None,
+        "first_tow": rounded(epochs[0][2]) if epochs else None,
+        "last_tow": rounded(epochs[-1][2]) if epochs else None,
+        "satellites": len(satellites),
+        "satellite_pairs": len(pairs),
+        "pair_frequency_kind_tracks": len(tracks),
+        "frequency_labels": [frequency_label(frequency) for frequency in frequencies],
+    }
+
+
+__all__ = [
+    "coverage_stats",
+    "group_records",
+    "percentile",
+    "residual_stats",
+]

--- a/apps/gnss_dd_residuals_summary.py
+++ b/apps/gnss_dd_residuals_summary.py
@@ -1,0 +1,158 @@
+"""Top-level summary assembly for DD residual diagnostics.
+
+Composes the per-row, per-group, and per-epoch statistics into the
+JSON-serialisable ``summary`` dict consumed by the CLI, JSON dump, and HTML
+renderer.  No I/O or rendering here — those live in the io / html modules.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from gnss_dd_residuals_records import (
+    abs_normalized_residual,
+    compact_row,
+    frequency_label,
+    normalized_residual,
+    pair_label,
+    rounded,
+)
+from gnss_dd_residuals_statistics import (
+    coverage_stats,
+    group_records,
+    residual_stats,
+)
+
+
+def summarize_groups(
+    records: list[dict[str, Any]],
+    keys: tuple[str, ...],
+    top_n: int | None = None,
+) -> list[dict[str, Any]]:
+    """Group records by ``keys`` and return per-group summaries.
+
+    Adds the ``frequency_label`` / ``pair`` annotations expected by the
+    renderer when those keys are present in the grouping tuple.  Sorted by
+    descending ``p95_abs_residual_m`` so the first ``top_n`` rows are the
+    worst tracks for that grouping.
+    """
+
+    summaries: list[dict[str, Any]] = []
+    for key, group in group_records(records, keys).items():
+        entry = {keys[index]: key[index] for index in range(len(keys))}
+        if "frequency_index" in entry:
+            entry["frequency_label"] = frequency_label(int(entry["frequency_index"]))
+        if "reference_satellite" in entry and "satellite" in entry:
+            entry["pair"] = pair_label(entry["reference_satellite"], entry["satellite"])
+        entry.update(residual_stats(group))
+        summaries.append(entry)
+    summaries.sort(
+        key=lambda item: (
+            float(item["p95_abs_residual_m"] or -1.0),
+            float(item["max_abs_residual_m"] or -1.0),
+            int(item["rows"]),
+        ),
+        reverse=True,
+    )
+    return summaries[:top_n] if top_n is not None else summaries
+
+
+def summarize_time_series(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Per-epoch summary row used by the line-chart renderer."""
+
+    series: list[dict[str, Any]] = []
+    for key, group in group_records(
+        records, ("epoch_index", "gps_week", "tow", "status")
+    ).items():
+        phase_records = [record for record in group if record["kind"] == "phase"]
+        code_records = [record for record in group if record["kind"] == "code"]
+        group_stats = residual_stats(group)
+        phase_stats = residual_stats(phase_records)
+        code_stats = residual_stats(code_records)
+        series.append(
+            {
+                "epoch_index": int(key[0]),
+                "gps_week": int(key[1]),
+                "tow": rounded(float(key[2])),
+                "status": int(key[3]),
+                "rows": len(group),
+                "suppressed_rows": group_stats["suppressed_rows"],
+                "phase_p95_abs_residual_m": phase_stats["p95_abs_residual_m"],
+                "phase_max_abs_residual_m": phase_stats["max_abs_residual_m"],
+                "phase_p95_abs_normalized_residual": phase_stats[
+                    "p95_abs_normalized_residual"
+                ],
+                "phase_max_abs_normalized_residual": phase_stats[
+                    "max_abs_normalized_residual"
+                ],
+                "code_p95_abs_residual_m": code_stats["p95_abs_residual_m"],
+                "code_max_abs_residual_m": code_stats["max_abs_residual_m"],
+                "code_p95_abs_normalized_residual": code_stats[
+                    "p95_abs_normalized_residual"
+                ],
+                "code_max_abs_normalized_residual": code_stats[
+                    "max_abs_normalized_residual"
+                ],
+                "max_abs_residual_m": group_stats["max_abs_residual_m"],
+                "max_abs_normalized_residual": group_stats["max_abs_normalized_residual"],
+            }
+        )
+    series.sort(key=lambda item: (int(item["epoch_index"]), float(item["tow"] or 0.0)))
+    return series
+
+
+def compact_residual_points(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Renderer-shaped point list for the scatter / heatmap charts."""
+
+    points = [compact_row(record) for record in records]
+    points.sort(
+        key=lambda item: (
+            int(item["epoch_index"]),
+            float(item["tow"] or 0.0),
+            str(item["kind"]),
+            int(item["frequency_index"]),
+            str(item["reference_satellite"]),
+            str(item["satellite"]),
+        )
+    )
+    return points
+
+
+def summarize_records(records: list[dict[str, Any]], top_n: int = 10) -> dict[str, Any]:
+    """Assemble the full summary dict (overall + per-kind + per-track)."""
+
+    pair_keys = ("kind", "frequency_index", "reference_satellite", "satellite")
+    pair_tracks = summarize_groups(records, pair_keys, top_n=None)
+    top_pairs = summarize_groups(records, pair_keys, top_n=max(0, top_n))
+    top_normalized_pairs = sorted(
+        pair_tracks,
+        key=lambda item: (
+            float(item["p95_abs_normalized_residual"] or -1.0),
+            float(item["max_abs_normalized_residual"] or -1.0),
+            int(item["rows"]),
+        ),
+        reverse=True,
+    )[: max(0, top_n)]
+    return {
+        "rows": len(records),
+        "coverage": coverage_stats(records),
+        "overall": residual_stats(records),
+        "by_kind": {
+            kind: residual_stats([record for record in records if record["kind"] == kind])
+            for kind in ("phase", "code")
+        },
+        "by_frequency": summarize_groups(records, ("frequency_index",), top_n=None),
+        "pair_tracks": pair_tracks,
+        "top_pairs": top_pairs,
+        "top_normalized_pairs": top_normalized_pairs,
+        "time_series": summarize_time_series(records),
+        "residual_points": compact_residual_points(records),
+    }
+
+
+__all__ = [
+    "compact_residual_points",
+    "summarize_groups",
+    "summarize_records",
+    "summarize_time_series",
+]

--- a/tests/test_gnss_dd_residuals_filtering.py
+++ b/tests/test_gnss_dd_residuals_filtering.py
@@ -1,0 +1,64 @@
+"""Unit tests for ``apps/gnss_dd_residuals_filtering``."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+APPS_DIR = ROOT_DIR / "apps"
+sys.path.insert(0, str(APPS_DIR))
+
+import gnss_dd_residuals_filtering as filtering  # noqa: E402
+
+
+def _row(*, kind: str, freq: int) -> dict:
+    return {"kind": kind, "frequency_index": freq}
+
+
+class TestFilterRecords(unittest.TestCase):
+    def setUp(self) -> None:
+        self.records = [
+            _row(kind="phase", freq=0),
+            _row(kind="phase", freq=1),
+            _row(kind="code", freq=0),
+            _row(kind="code", freq=2),
+        ]
+
+    def test_all_kind_keeps_every_row(self):
+        self.assertEqual(len(filtering.filter_records(self.records)), 4)
+
+    def test_phase_kind_filters_code_out(self):
+        out = filtering.filter_records(self.records, kind="phase")
+        self.assertTrue(all(record["kind"] == "phase" for record in out))
+        self.assertEqual(len(out), 2)
+
+    def test_code_kind_filters_phase_out(self):
+        out = filtering.filter_records(self.records, kind="code")
+        self.assertTrue(all(record["kind"] == "code" for record in out))
+        self.assertEqual(len(out), 2)
+
+    def test_frequency_index_alone_filters(self):
+        out = filtering.filter_records(self.records, frequency_index=0)
+        self.assertEqual(len(out), 2)
+        self.assertTrue(all(record["frequency_index"] == 0 for record in out))
+
+    def test_kind_and_frequency_index_compose(self):
+        out = filtering.filter_records(self.records, kind="phase", frequency_index=1)
+        self.assertEqual(out, [_row(kind="phase", freq=1)])
+
+    def test_empty_input_returns_empty(self):
+        self.assertEqual(filtering.filter_records([], kind="phase", frequency_index=0), [])
+
+    def test_no_filter_returns_same_list_instance(self):
+        # Default arguments must short-circuit, not allocate a new list copy;
+        # this guards against accidental O(n) churn in CI runs with millions
+        # of rows.
+        out = filtering.filter_records(self.records)
+        self.assertIs(out, self.records)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gnss_dd_residuals_html.py
+++ b/tests/test_gnss_dd_residuals_html.py
@@ -1,0 +1,177 @@
+"""Unit tests for ``apps/gnss_dd_residuals_html``."""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+APPS_DIR = ROOT_DIR / "apps"
+sys.path.insert(0, str(APPS_DIR))
+
+import gnss_dd_residuals_html as html_mod  # noqa: E402
+
+
+class TestHtmlValue(unittest.TestCase):
+    def test_none_becomes_na(self):
+        self.assertEqual(html_mod.html_value(None), "n/a")
+
+    def test_escapes_special_characters(self):
+        self.assertEqual(html_mod.html_value("<script>"), "&lt;script&gt;")
+
+    def test_passes_through_numbers(self):
+        self.assertEqual(html_mod.html_value(42), "42")
+
+
+class TestMetricCell(unittest.TestCase):
+    def test_wraps_label_and_value(self):
+        out = html_mod.metric_cell("rows", 10)
+        self.assertIn("rows", out)
+        self.assertIn(">10<", out)
+        self.assertIn("metric-label", out)
+        self.assertIn("metric-value", out)
+
+
+class TestStatsTable(unittest.TestCase):
+    def test_empty_rows_renders_placeholder(self):
+        out = html_mod.stats_table("By Kind", [], ["kind"])
+        self.assertIn("No rows.", out)
+
+    def test_includes_label_keys_in_header(self):
+        rows = [
+            {
+                "kind": "phase",
+                "rows": 10,
+                "epochs": 5,
+                "suppressed_rows": 0,
+                "rms_residual_m": 0.01,
+                "p95_abs_residual_m": 0.02,
+                "max_abs_residual_m": 0.03,
+                "rms_normalized_residual": 0.5,
+                "p95_abs_normalized_residual": 1.0,
+                "max_abs_normalized_residual": 1.5,
+            }
+        ]
+        out = html_mod.stats_table("By Kind", rows, ["kind"])
+        self.assertIn("<th>kind</th>", out)
+        self.assertIn("phase", out)
+
+
+class TestNiceMax(unittest.TestCase):
+    def test_returns_one_for_empty_input(self):
+        self.assertEqual(html_mod.nice_max([]), 1.0)
+
+    def test_returns_one_for_nonpositive_maximum(self):
+        self.assertEqual(html_mod.nice_max([0.0, -1.0]), 1.0)
+
+    def test_rounds_up_to_125_decade_step(self):
+        # 1.7 → next nice step is 2.0; 4.3 → 5.0; 7.8 → 10.0
+        self.assertEqual(html_mod.nice_max([1.7]), 2.0)
+        self.assertEqual(html_mod.nice_max([4.3]), 5.0)
+        self.assertEqual(html_mod.nice_max([7.8]), 10.0)
+
+    def test_handles_subunit_inputs(self):
+        # 0.03 → 0.05 (next 5×10^-2 step)
+        self.assertAlmostEqual(html_mod.nice_max([0.03]), 0.05)
+
+
+class TestSvgRenderingNoData(unittest.TestCase):
+    """Each SVG renderer must degrade gracefully on empty input."""
+
+    def test_line_chart_empty(self):
+        out = html_mod.svg_line_chart("Empty", [], [("a", "A", "#000")])
+        self.assertIn("No chartable rows.", out)
+
+    def test_bar_chart_empty(self):
+        out = html_mod.svg_bar_chart("Empty", [], "value_key")
+        self.assertIn("No rows.", out)
+
+    def test_residual_scatter_empty(self):
+        out = html_mod.svg_residual_scatter("Empty", [], "phase")
+        self.assertIn("No phase rows.", out)
+
+    def test_pair_heatmap_empty(self):
+        out = html_mod.svg_pair_heatmap("Empty", [], [], "phase")
+        self.assertIn("No phase rows.", out)
+
+
+class TestSvgLineChartRendering(unittest.TestCase):
+    def test_renders_polyline_for_finite_series(self):
+        series = [
+            {"epoch_index": 1, "tow": 1.0, "value": 0.1},
+            {"epoch_index": 2, "tow": 2.0, "value": 0.2},
+            {"epoch_index": 3, "tow": 3.0, "value": 0.3},
+        ]
+        out = html_mod.svg_line_chart(
+            "T", series, [("value", "v", "#0f766e")]
+        )
+        self.assertIn("<polyline", out)
+        self.assertIn("v", out)
+
+
+class TestSvgResidualScatterRendering(unittest.TestCase):
+    def test_renders_circles_for_kind_match(self):
+        points = [
+            {
+                "epoch_index": 1,
+                "tow": 0.0,
+                "kind": "phase",
+                "frequency_index": 0,
+                "frequency_label": "freq0 primary (L1/E1/B1)",
+                "pair": "G01-G05",
+                "residual_m": 0.01,
+                "abs_residual_m": 0.01,
+                "suppressed_by_outlier_threshold": 0,
+            }
+        ]
+        out = html_mod.svg_residual_scatter("Phase", points, "phase")
+        self.assertIn("<circle", out)
+
+
+class TestWriteHtmlReport(unittest.TestCase):
+    def test_writes_self_contained_document(self):
+        summary = {
+            "rows": 0,
+            "coverage": {
+                "rows": 0,
+                "epochs": 0,
+                "first_epoch_index": None,
+                "last_epoch_index": None,
+                "first_tow": None,
+                "last_tow": None,
+                "satellites": 0,
+                "satellite_pairs": 0,
+                "pair_frequency_kind_tracks": 0,
+                "frequency_labels": [],
+            },
+            "overall": {
+                "rows": 0,
+                "suppressed_rows": 0,
+                "max_abs_residual_m": None,
+                "worst_row": None,
+            },
+            "by_kind": {"phase": {"p95_abs_residual_m": None, "p95_abs_normalized_residual": None},
+                        "code": {"p95_abs_residual_m": None, "p95_abs_normalized_residual": None}},
+            "by_frequency": [],
+            "pair_tracks": [],
+            "top_pairs": [],
+            "top_normalized_pairs": [],
+            "time_series": [],
+            "residual_points": [],
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_path = Path(tmpdir) / "report.html"
+            html_mod.write_html_report(out_path, summary)
+            content = out_path.read_text(encoding="utf-8")
+        # Must be a complete document with no external dependencies.
+        self.assertIn("<!doctype html>", content)
+        self.assertIn("<title>DD Residual Report</title>", content)
+        self.assertNotIn("<link ", content)  # no external stylesheets
+        self.assertNotIn("<script", content)  # no external scripts
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gnss_dd_residuals_io.py
+++ b/tests/test_gnss_dd_residuals_io.py
@@ -1,0 +1,213 @@
+"""Unit tests for ``apps/gnss_dd_residuals_io``."""
+
+from __future__ import annotations
+
+import csv
+import math
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+APPS_DIR = ROOT_DIR / "apps"
+sys.path.insert(0, str(APPS_DIR))
+
+import gnss_dd_residuals_io as dd_io  # noqa: E402
+
+
+_REQUIRED_COLUMNS = (
+    "epoch_index",
+    "gps_week",
+    "tow",
+    "status",
+    "kind",
+    "frequency_index",
+    "reference_satellite",
+    "satellite",
+    "residual_m",
+    "abs_residual_m",
+    "suppressed_by_outlier_threshold",
+)
+
+
+def _write_csv(path: Path, columns: list[str], rows: list[dict]) -> None:
+    with path.open("w", encoding="ascii", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=columns)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(row)
+
+
+class TestOptionalFloat(unittest.TestCase):
+    def test_parses_finite_string(self):
+        self.assertAlmostEqual(dd_io.optional_float("1.25"), 1.25)
+
+    def test_none_for_empty_or_missing(self):
+        self.assertIsNone(dd_io.optional_float(None))
+        self.assertIsNone(dd_io.optional_float(""))
+
+    def test_none_for_nonfinite(self):
+        self.assertIsNone(dd_io.optional_float("nan"))
+        self.assertIsNone(dd_io.optional_float("inf"))
+
+
+class TestReadRecords(unittest.TestCase):
+    def test_parses_minimal_row(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = Path(tmpdir) / "dd.csv"
+            _write_csv(
+                csv_path,
+                list(_REQUIRED_COLUMNS) + ["reference_variance_m2", "satellite_variance_m2"],
+                [
+                    {
+                        "epoch_index": "1",
+                        "gps_week": "2200",
+                        "tow": "120.0",
+                        "status": "4",
+                        "kind": "phase",
+                        "frequency_index": "0",
+                        "reference_satellite": "G01",
+                        "satellite": "G05",
+                        "residual_m": "0.012",
+                        "abs_residual_m": "0.012",
+                        "suppressed_by_outlier_threshold": "0",
+                        "reference_variance_m2": "0.0004",
+                        "satellite_variance_m2": "0.0004",
+                    }
+                ],
+            )
+            records = dd_io.read_records(csv_path)
+        self.assertEqual(len(records), 1)
+        self.assertEqual(records[0]["kind"], "phase")
+        self.assertAlmostEqual(records[0]["residual_m"], 0.012)
+        self.assertAlmostEqual(records[0]["reference_variance_m2"], 0.0004)
+
+    def test_rejects_missing_required_columns(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = Path(tmpdir) / "dd.csv"
+            _write_csv(csv_path, ["epoch_index", "gps_week"], [])
+            with self.assertRaises(SystemExit) as caught:
+                dd_io.read_records(csv_path)
+            self.assertIn("Missing DD residual columns", str(caught.exception))
+
+    def test_drops_nonfinite_residual_rows(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = Path(tmpdir) / "dd.csv"
+            _write_csv(
+                csv_path,
+                list(_REQUIRED_COLUMNS),
+                [
+                    {
+                        "epoch_index": "1",
+                        "gps_week": "2200",
+                        "tow": "120.0",
+                        "status": "4",
+                        "kind": "phase",
+                        "frequency_index": "0",
+                        "reference_satellite": "G01",
+                        "satellite": "G05",
+                        "residual_m": "nan",
+                        "abs_residual_m": "nan",
+                        "suppressed_by_outlier_threshold": "0",
+                    },
+                    {
+                        "epoch_index": "1",
+                        "gps_week": "2200",
+                        "tow": "120.0",
+                        "status": "4",
+                        "kind": "phase",
+                        "frequency_index": "0",
+                        "reference_satellite": "G01",
+                        "satellite": "G05",
+                        "residual_m": "0.05",
+                        "abs_residual_m": "0.05",
+                        "suppressed_by_outlier_threshold": "0",
+                    },
+                ],
+            )
+            records = dd_io.read_records(csv_path)
+        self.assertEqual(len(records), 1)
+        self.assertTrue(math.isfinite(records[0]["residual_m"]))
+
+    def test_optional_variance_columns_default_to_none(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            csv_path = Path(tmpdir) / "dd.csv"
+            _write_csv(
+                csv_path,
+                list(_REQUIRED_COLUMNS),
+                [
+                    {
+                        "epoch_index": "1",
+                        "gps_week": "2200",
+                        "tow": "120.0",
+                        "status": "4",
+                        "kind": "code",
+                        "frequency_index": "1",
+                        "reference_satellite": "G01",
+                        "satellite": "G05",
+                        "residual_m": "0.5",
+                        "abs_residual_m": "0.5",
+                        "suppressed_by_outlier_threshold": "0",
+                    }
+                ],
+            )
+            records = dd_io.read_records(csv_path)
+        self.assertIsNone(records[0]["reference_variance_m2"])
+        self.assertIsNone(records[0]["satellite_variance_m2"])
+
+
+class TestWriteTopPairsCsv(unittest.TestCase):
+    def test_emits_ranked_rows_with_header(self):
+        rows = [
+            {
+                "kind": "phase",
+                "frequency_index": 0,
+                "frequency_label": "freq0 primary (L1/E1/B1)",
+                "reference_satellite": "G01",
+                "satellite": "G05",
+                "pair": "G01-G05",
+                "rows": 100,
+                "epochs": 50,
+                "suppressed_rows": 0,
+                "rms_residual_m": 0.012,
+                "p95_abs_residual_m": 0.025,
+                "max_abs_residual_m": 0.040,
+                "rms_normalized_residual": 0.9,
+                "p95_abs_normalized_residual": 1.6,
+                "max_abs_normalized_residual": 2.4,
+            },
+            {
+                "kind": "code",
+                "frequency_index": 0,
+                "frequency_label": "freq0 primary (L1/E1/B1)",
+                "reference_satellite": "G01",
+                "satellite": "G07",
+                "pair": "G01-G07",
+                "rows": 90,
+                "epochs": 48,
+                "suppressed_rows": 1,
+                "rms_residual_m": 0.4,
+                "p95_abs_residual_m": 0.8,
+                "max_abs_residual_m": 1.2,
+                "rms_normalized_residual": 1.1,
+                "p95_abs_normalized_residual": 2.0,
+                "max_abs_normalized_residual": 3.5,
+            },
+        ]
+        with tempfile.TemporaryDirectory() as tmpdir:
+            out_path = Path(tmpdir) / "subdir" / "top_pairs.csv"
+            dd_io.write_top_pairs_csv(out_path, rows)
+            self.assertTrue(out_path.exists())
+            with out_path.open(encoding="ascii", newline="") as handle:
+                reader = csv.DictReader(handle)
+                written = list(reader)
+        self.assertEqual(written[0]["rank"], "1")
+        self.assertEqual(written[1]["rank"], "2")
+        self.assertEqual(written[0]["pair"], "G01-G05")
+        self.assertEqual(written[1]["pair"], "G01-G07")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gnss_dd_residuals_records.py
+++ b/tests/test_gnss_dd_residuals_records.py
@@ -1,0 +1,137 @@
+"""Unit tests for ``apps/gnss_dd_residuals_records``."""
+
+from __future__ import annotations
+
+import math
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+APPS_DIR = ROOT_DIR / "apps"
+sys.path.insert(0, str(APPS_DIR))
+
+import gnss_dd_residuals_records as records  # noqa: E402
+
+
+def _row(
+    *,
+    residual_m: float = 0.01,
+    reference_variance: float | None = 0.0004,
+    satellite_variance: float | None = 0.0004,
+    suppressed: int = 0,
+) -> dict:
+    return {
+        "epoch_index": 1,
+        "gps_week": 2200,
+        "tow": 123.0,
+        "status": 4,
+        "kind": "phase",
+        "frequency_index": 0,
+        "reference_satellite": "G01",
+        "satellite": "G05",
+        "residual_m": residual_m,
+        "abs_residual_m": abs(residual_m),
+        "reference_variance_m2": reference_variance,
+        "satellite_variance_m2": satellite_variance,
+        "suppressed_by_outlier_threshold": suppressed,
+    }
+
+
+class TestFrequencyLabel(unittest.TestCase):
+    def test_known_indexes(self):
+        self.assertEqual(records.frequency_label(0), "freq0 primary (L1/E1/B1)")
+        self.assertEqual(records.frequency_label(1), "freq1 secondary (L2/E5/B2)")
+        self.assertEqual(records.frequency_label(2), "freq2 L5-class (L5/E5a/B2a)")
+
+    def test_unknown_index_falls_back_to_generic_label(self):
+        self.assertEqual(records.frequency_label(7), "freq7")
+
+
+class TestPairLabel(unittest.TestCase):
+    def test_concatenates_with_hyphen(self):
+        self.assertEqual(records.pair_label("G01", "G05"), "G01-G05")
+
+    def test_accepts_non_string_inputs(self):
+        self.assertEqual(records.pair_label(1, 5), "1-5")
+
+
+class TestResidualSigma(unittest.TestCase):
+    def test_returns_sqrt_of_sum(self):
+        sigma = records.residual_sigma_m(_row(reference_variance=0.04, satellite_variance=0.09))
+        self.assertAlmostEqual(sigma, math.sqrt(0.13), places=9)
+
+    def test_returns_none_when_either_variance_missing(self):
+        self.assertIsNone(records.residual_sigma_m(_row(reference_variance=None)))
+        self.assertIsNone(records.residual_sigma_m(_row(satellite_variance=None)))
+
+    def test_returns_none_for_nonpositive_total_variance(self):
+        self.assertIsNone(
+            records.residual_sigma_m(_row(reference_variance=0.0, satellite_variance=0.0))
+        )
+        self.assertIsNone(
+            records.residual_sigma_m(_row(reference_variance=-0.1, satellite_variance=0.05))
+        )
+
+    def test_returns_none_for_nonfinite_inputs(self):
+        self.assertIsNone(
+            records.residual_sigma_m(
+                _row(reference_variance=float("nan"), satellite_variance=0.04)
+            )
+        )
+
+
+class TestNormalizedResidual(unittest.TestCase):
+    def test_divides_residual_by_sigma(self):
+        row = _row(residual_m=0.03, reference_variance=0.0009, satellite_variance=0.0)
+        # sigma = sqrt(0.0009) = 0.03 → normalized = 1.0
+        self.assertAlmostEqual(records.normalized_residual(row), 1.0, places=9)
+
+    def test_returns_none_when_sigma_undefined(self):
+        self.assertIsNone(records.normalized_residual(_row(reference_variance=None)))
+
+
+class TestAbsNormalizedResidual(unittest.TestCase):
+    def test_returns_magnitude(self):
+        row = _row(residual_m=-0.03, reference_variance=0.0009, satellite_variance=0.0)
+        self.assertAlmostEqual(records.abs_normalized_residual(row), 1.0, places=9)
+
+    def test_propagates_none(self):
+        self.assertIsNone(records.abs_normalized_residual(_row(reference_variance=None)))
+
+
+class TestRounded(unittest.TestCase):
+    def test_rounds_to_six_decimals(self):
+        self.assertAlmostEqual(records.rounded(1.0 / 3.0), 0.333333)
+
+    def test_passes_through_none(self):
+        self.assertIsNone(records.rounded(None))
+
+
+class TestCompactRow(unittest.TestCase):
+    def test_adds_pair_and_label_annotations(self):
+        compact = records.compact_row(_row())
+        self.assertEqual(compact["pair"], "G01-G05")
+        self.assertEqual(compact["frequency_label"], "freq0 primary (L1/E1/B1)")
+
+    def test_carries_normalized_residual_when_sigma_finite(self):
+        compact = records.compact_row(
+            _row(residual_m=0.03, reference_variance=0.0009, satellite_variance=0.0)
+        )
+        self.assertAlmostEqual(compact["normalized_residual"], 1.0, places=6)
+        self.assertAlmostEqual(compact["abs_normalized_residual"], 1.0, places=6)
+
+    def test_returns_none_for_normalized_when_sigma_missing(self):
+        compact = records.compact_row(_row(reference_variance=None))
+        self.assertIsNone(compact["normalized_residual"])
+        self.assertIsNone(compact["abs_normalized_residual"])
+
+    def test_drops_raw_variance_fields(self):
+        compact = records.compact_row(_row())
+        self.assertNotIn("reference_variance_m2", compact)
+        self.assertNotIn("satellite_variance_m2", compact)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gnss_dd_residuals_statistics.py
+++ b/tests/test_gnss_dd_residuals_statistics.py
@@ -1,0 +1,136 @@
+"""Unit tests for ``apps/gnss_dd_residuals_statistics``."""
+
+from __future__ import annotations
+
+import math
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+APPS_DIR = ROOT_DIR / "apps"
+sys.path.insert(0, str(APPS_DIR))
+
+import gnss_dd_residuals_statistics as stats  # noqa: E402
+
+
+def _row(
+    *,
+    epoch_index: int = 1,
+    gps_week: int = 2200,
+    tow: float = 120.0,
+    status: int = 4,
+    kind: str = "phase",
+    frequency_index: int = 0,
+    reference_satellite: str = "G01",
+    satellite: str = "G05",
+    residual_m: float = 0.01,
+    reference_variance: float | None = 0.0001,
+    satellite_variance: float | None = 0.0001,
+    suppressed: int = 0,
+) -> dict:
+    return {
+        "epoch_index": epoch_index,
+        "gps_week": gps_week,
+        "tow": tow,
+        "status": status,
+        "kind": kind,
+        "frequency_index": frequency_index,
+        "reference_satellite": reference_satellite,
+        "satellite": satellite,
+        "residual_m": residual_m,
+        "abs_residual_m": abs(residual_m),
+        "reference_variance_m2": reference_variance,
+        "satellite_variance_m2": satellite_variance,
+        "suppressed_by_outlier_threshold": suppressed,
+    }
+
+
+class TestPercentile(unittest.TestCase):
+    def test_returns_none_for_empty(self):
+        self.assertIsNone(stats.percentile([], 0.5))
+
+    def test_single_value_returns_value(self):
+        self.assertEqual(stats.percentile([3.0], 0.5), 3.0)
+
+    def test_median_of_evenly_spaced(self):
+        self.assertAlmostEqual(stats.percentile([1.0, 2.0, 3.0, 4.0, 5.0], 0.5), 3.0)
+
+    def test_p95_interpolates_between_neighbours(self):
+        values = list(range(1, 21))  # 1..20
+        # numpy default: 19th element = 20 → p95 = 19 + 0.05 * (20 - 19) = 19.05
+        self.assertAlmostEqual(stats.percentile(values, 0.95), 19.05)
+
+
+class TestGroupRecords(unittest.TestCase):
+    def test_groups_by_single_key(self):
+        rows = [_row(kind="phase"), _row(kind="phase"), _row(kind="code")]
+        groups = stats.group_records(rows, ("kind",))
+        self.assertEqual(len(groups[("phase",)]), 2)
+        self.assertEqual(len(groups[("code",)]), 1)
+
+    def test_groups_by_multiple_keys(self):
+        rows = [
+            _row(kind="phase", frequency_index=0),
+            _row(kind="phase", frequency_index=1),
+            _row(kind="phase", frequency_index=0),
+        ]
+        groups = stats.group_records(rows, ("kind", "frequency_index"))
+        self.assertEqual(len(groups[("phase", 0)]), 2)
+        self.assertEqual(len(groups[("phase", 1)]), 1)
+
+
+class TestResidualStats(unittest.TestCase):
+    def test_empty_records_produce_none_aggregates(self):
+        out = stats.residual_stats([])
+        self.assertEqual(out["rows"], 0)
+        self.assertIsNone(out["rms_residual_m"])
+        self.assertIsNone(out["worst_row"])
+
+    def test_rms_matches_manual_computation(self):
+        rows = [_row(residual_m=value) for value in (0.01, -0.02, 0.03)]
+        out = stats.residual_stats(rows)
+        expected_rms = math.sqrt((0.0001 + 0.0004 + 0.0009) / 3)
+        self.assertAlmostEqual(out["rms_residual_m"], round(expected_rms, 6))
+
+    def test_worst_row_picks_largest_abs_residual(self):
+        rows = [_row(residual_m=0.01), _row(residual_m=-0.05), _row(residual_m=0.02)]
+        out = stats.residual_stats(rows)
+        self.assertAlmostEqual(out["worst_row"]["abs_residual_m"], 0.05)
+
+    def test_suppressed_rows_sum(self):
+        rows = [
+            _row(suppressed=0),
+            _row(suppressed=1),
+            _row(suppressed=1),
+        ]
+        out = stats.residual_stats(rows)
+        self.assertEqual(out["suppressed_rows"], 2)
+
+
+class TestCoverageStats(unittest.TestCase):
+    def test_counts_unique_epochs_and_pairs(self):
+        rows = [
+            _row(epoch_index=1, tow=10.0, reference_satellite="G01", satellite="G05"),
+            _row(epoch_index=2, tow=11.0, reference_satellite="G01", satellite="G05"),
+            _row(epoch_index=2, tow=11.0, reference_satellite="G01", satellite="G07"),
+        ]
+        out = stats.coverage_stats(rows)
+        self.assertEqual(out["rows"], 3)
+        self.assertEqual(out["epochs"], 2)
+        self.assertEqual(out["satellite_pairs"], 2)
+
+    def test_first_and_last_epoch_indices(self):
+        rows = [
+            _row(epoch_index=5, tow=50.0),
+            _row(epoch_index=2, tow=20.0),
+            _row(epoch_index=3, tow=30.0),
+        ]
+        out = stats.coverage_stats(rows)
+        self.assertEqual(out["first_epoch_index"], 2)
+        self.assertEqual(out["last_epoch_index"], 5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_gnss_dd_residuals_summary.py
+++ b/tests/test_gnss_dd_residuals_summary.py
@@ -1,0 +1,134 @@
+"""Unit tests for ``apps/gnss_dd_residuals_summary``."""
+
+from __future__ import annotations
+
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+APPS_DIR = ROOT_DIR / "apps"
+sys.path.insert(0, str(APPS_DIR))
+
+import gnss_dd_residuals_summary as summary_mod  # noqa: E402
+
+
+def _row(
+    *,
+    epoch_index: int = 1,
+    kind: str = "phase",
+    freq: int = 0,
+    ref: str = "G01",
+    sat: str = "G05",
+    residual_m: float = 0.01,
+    suppressed: int = 0,
+) -> dict:
+    return {
+        "epoch_index": epoch_index,
+        "gps_week": 2200,
+        "tow": float(epoch_index) * 1.0,
+        "status": 4,
+        "kind": kind,
+        "frequency_index": freq,
+        "reference_satellite": ref,
+        "satellite": sat,
+        "residual_m": residual_m,
+        "abs_residual_m": abs(residual_m),
+        "reference_variance_m2": 0.0001,
+        "satellite_variance_m2": 0.0001,
+        "suppressed_by_outlier_threshold": suppressed,
+    }
+
+
+class TestSummarizeGroups(unittest.TestCase):
+    def test_decorates_groups_with_pair_label(self):
+        rows = [_row(ref="G01", sat="G05"), _row(ref="G01", sat="G05")]
+        groups = summary_mod.summarize_groups(
+            rows, ("kind", "frequency_index", "reference_satellite", "satellite")
+        )
+        self.assertEqual(groups[0]["pair"], "G01-G05")
+        self.assertEqual(groups[0]["frequency_label"], "freq0 primary (L1/E1/B1)")
+
+    def test_top_n_truncates_after_descending_sort(self):
+        rows = [
+            _row(sat=f"G{index:02d}", residual_m=index * 0.01)
+            for index in range(2, 12)  # G02..G11, residuals 0.02..0.11
+        ]
+        top = summary_mod.summarize_groups(
+            rows,
+            ("kind", "frequency_index", "reference_satellite", "satellite"),
+            top_n=3,
+        )
+        self.assertEqual(len(top), 3)
+        # Sorted by descending p95 — largest residual at index 0.
+        self.assertEqual(top[0]["satellite"], "G11")
+
+
+class TestSummarizeTimeSeries(unittest.TestCase):
+    def test_one_row_per_unique_epoch_status(self):
+        rows = [
+            _row(epoch_index=1, kind="phase", residual_m=0.01),
+            _row(epoch_index=1, kind="code", residual_m=0.30),
+            _row(epoch_index=2, kind="phase", residual_m=0.03),
+        ]
+        series = summary_mod.summarize_time_series(rows)
+        self.assertEqual(len(series), 2)
+        self.assertEqual(series[0]["epoch_index"], 1)
+        self.assertEqual(series[1]["epoch_index"], 2)
+
+    def test_phase_and_code_aggregates_split(self):
+        rows = [
+            _row(epoch_index=1, kind="phase", residual_m=0.01),
+            _row(epoch_index=1, kind="code", residual_m=0.50),
+        ]
+        series = summary_mod.summarize_time_series(rows)
+        self.assertAlmostEqual(series[0]["phase_max_abs_residual_m"], 0.01)
+        self.assertAlmostEqual(series[0]["code_max_abs_residual_m"], 0.50)
+
+
+class TestCompactResidualPoints(unittest.TestCase):
+    def test_sorted_by_epoch_then_kind_then_pair(self):
+        rows = [
+            _row(epoch_index=2, kind="code", sat="G10", residual_m=0.5),
+            _row(epoch_index=1, kind="phase", sat="G05", residual_m=0.01),
+            _row(epoch_index=1, kind="phase", sat="G03", residual_m=0.02),
+        ]
+        points = summary_mod.compact_residual_points(rows)
+        self.assertEqual(
+            [(point["epoch_index"], point["kind"], point["satellite"]) for point in points],
+            [(1, "phase", "G03"), (1, "phase", "G05"), (2, "code", "G10")],
+        )
+
+
+class TestSummarizeRecords(unittest.TestCase):
+    def test_returns_canonical_top_level_keys(self):
+        rows = [_row(kind="phase"), _row(kind="code", residual_m=0.5)]
+        out = summary_mod.summarize_records(rows, top_n=5)
+        for key in (
+            "rows",
+            "coverage",
+            "overall",
+            "by_kind",
+            "by_frequency",
+            "pair_tracks",
+            "top_pairs",
+            "top_normalized_pairs",
+            "time_series",
+            "residual_points",
+        ):
+            self.assertIn(key, out)
+        self.assertEqual(out["rows"], 2)
+        self.assertIn("phase", out["by_kind"])
+        self.assertIn("code", out["by_kind"])
+
+    def test_top_pairs_capped_at_top_n(self):
+        rows = [
+            _row(sat=f"G{index:02d}", residual_m=index * 0.01) for index in range(2, 8)
+        ]
+        out = summary_mod.summarize_records(rows, top_n=3)
+        self.assertLessEqual(len(out["top_pairs"]), 3)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Splits the original 1050-line ``apps/gnss_dd_residuals.py`` into one thin CLI orchestrator plus six single-responsibility helper modules so each layer can be unit-tested in isolation and reused by future tools that need only a subset of the pipeline.

### Module layout

| Module | Responsibility |
|--------|----------------|
| `apps/gnss_dd_residuals.py` | Thin CLI: ``parse_args`` / ``enforce_requirements`` / ``main`` |
| `apps/gnss_dd_residuals_records.py` | Record schema helpers (label / σ / normalized residual / compact row) |
| `apps/gnss_dd_residuals_io.py` | CSV read + worst-pair CSV write |
| `apps/gnss_dd_residuals_filtering.py` | `filter_records(kind=, frequency_index=)` |
| `apps/gnss_dd_residuals_statistics.py` | percentile / group / residual_stats / coverage_stats |
| `apps/gnss_dd_residuals_summary.py` | Summary assembly (top-N pairs, time-series, residual points) |
| `apps/gnss_dd_residuals_html.py` | HTML / SVG renderer (line / bar / scatter / heatmap charts) |

### CLI surface unchanged

The `gnss_dd_residuals` script keeps the same `--input_csv` / `--summary-json` / `--top-pairs-csv` / `--html-report` / `--top-n` / `--kind` / `--frequency-index` / `--require-*` surface so downstream callers and CI scripts continue to work without changes. End-to-end smoke against a synthetic CSV reproduces the same summary dict and a self-contained HTML report.

### Tests

Six unittest modules, **69 cases total**, all pass in <10 ms:

| Module | Cases |
|---|---|
| `tests/test_gnss_dd_residuals_records.py` | 14 |
| `tests/test_gnss_dd_residuals_io.py` | 9 |
| `tests/test_gnss_dd_residuals_filtering.py` | 7 |
| `tests/test_gnss_dd_residuals_statistics.py` | 11 |
| `tests/test_gnss_dd_residuals_summary.py` | 9 |
| `tests/test_gnss_dd_residuals_html.py` | 14 |

```
python3 -m unittest discover -s tests -p test_gnss_dd_residuals_*.py -v
...
Ran 69 tests in 0.005s
OK
```

## Test plan
- [x] All 69 new unittest cases pass
- [x] End-to-end smoke generates identical summary + HTML output from synthetic CSV
- [ ] CI verifies on the canonical DD residual fixture (ship via CI workflow if available)

## Follow-ups
- Promote `_DOCUMENT_CSS` to an external static file once the HTML report grows beyond a single-page document.