### PR TITLE
[codex] Add RINEX4 MADOCA foundation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ set(GNSS_SOURCES
     src/gnss.cpp
     src/io/ntrip.cpp
     src/io/rinex.cpp
+    src/io/rinex4.cpp
     src/io/rtcm.cpp
     src/io/rtcm_stream.cpp
     src/io/ubx.cpp

--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -1,0 +1,293 @@
+# MADOCA Port Plan
+
+This plan scopes a MADOCA foundation pass.  The goal is to capture what should
+be ported from MADOCALIB, what should be shared with the existing CLAS work,
+and how to build oracle parity without dragging reference code into production.
+
+## Reference Inputs
+
+Local MADOCALIB copy inspected for iter1:
+
+```text
+
+```
+
+Primary source files:
+
+- `src/mdccssr.c`
+- `src/mdciono.c`
+- `src/ppp.c`
+- `src/ppp_ar.c`
+- `sample_data/`
+- `readme.txt`
+
+Existing libgnss++ reference:
+
+- `docs/references/madocalib-gap.md`
+- `docs/clas_port_architecture.md`
+- `docs/clas_validated_datasets.md`
+- `include/libgnss++/io/qzss_l6.hpp`
+- `src/io/qzss_l6.cpp`
+- `include/libgnss++/algorithms/ppp.hpp`
+- `src/algorithms/ppp.cpp`
+- `include/libgnss++/algorithms/ppp_ar.hpp`
+- `src/algorithms/ppp_ar.cpp`
+
+## MADOCALIB License Note
+
+`readme.txt` states that MADOCALIB is distributed under a BSD 2-clause license
+with additional exclusive clauses.  It also states that users may develop,
+produce, or sell non-commercial or commercial products using MADOCALIB as long
+as they comply with the license.  The copyright notices list the Cabinet
+Office, Japan; Lighthouse Technology & Consulting; JAXA; Toshiba Electronic
+Technologies; and T. Takasu.
+
+The GUI license is separate in `MADOCALIB_GUI_LICENSE.txt`; the GUI should not
+be part of the C++ port scope.
+
+Porting rule for libgnss++:
+
+- Use MADOCALIB as a reference and oracle.
+- Prefer literal small-function ports only when the license header and
+  attribution are deliberately handled.
+- Keep any direct MADOCALIB-linked oracle code test-only and opt-in.
+- Do not create a production dependency on MADOCALIB.
+
+## CLASNAT Lessons To Carry Forward
+
+The CLASNAT work converged because it used a tight oracle loop:
+
+- Start with small deterministic helper parity, not whole-PPP parity.
+- Keep native code and external oracle code separated.
+- Target literal behavior first, cleanup second.
+- Use tight numerical tolerances, typically `1e-6` for helper-level values.
+- Add tests around one helper family at a time.
+- Preserve production behavior while oracle-linked builds are optional.
+- Use whole-run trajectory comparisons only after helper parity is stable.
+
+For MADOCA this means:
+
+- Add `madoca_parity` as a small, pure helper namespace first.
+- Add `test_madoca_parity.cpp` as an empty GoogleTest landing point.
+- Later add a MADOCALIB oracle layer that is linked only when explicitly
+  configured.
+- Gate initial helper ports against MADOCALIB outputs before wiring them into
+  PPP.
+
+## Current libgnss++ MADOCA/CLAS Baseline
+
+Already present:
+
+- A native PPP core with SSR product application.
+- A PPP-AR module.
+- A QZSS L6/CSSR decoder used for CLAS-style correction ingestion.
+- Compact sampled correction transport for CLI workflows.
+- `clas-ppp --profile madoca` CLI naming for profile-level runs.
+- Extensive synthetic QZSS L6 tests in `tests/test_cli_tools.py`.
+
+Important caveat:
+
+- The current `qzss_l6` decoder is CLAS-oriented.  It has useful building
+  blocks such as the bit reader, L6 frame handling, mask/orbit/clock/bias
+  concepts, and SSR product population, but it is not yet a MADOCALIB-equivalent
+  MADOCA L6E/L6D port.
+
+## MADOCALIB Key Functions
+
+`mdccssr.c` handles QZSS L6E MADOCA-PPP Compact SSR:
+
+- `init_mcssr(gt)` initializes the global MADOCA CSSR state.
+- `input_qzssl6e(rtcm, data)` synchronizes a byte stream on the L6 preamble.
+- `input_qzssl6ef(rtcm, fp)` reads L6E bytes from a file.
+- `decode_qzss_l6emsg(rtcm)` decodes a complete L6E frame/subframe sequence.
+- `decode_mcssr_mask()` decodes Compact SSR subtype 1 mask.
+- `decode_mcssr_oc()` decodes subtype 2 orbit correction.
+- `decode_mcssr_cc()` decodes subtype 3 clock correction.
+- `decode_mcssr_cb()` decodes subtype 4 code bias.
+- `decode_mcssr_pb()` decodes subtype 5 phase bias and discontinuity
+  indicator.
+- `decode_mcssr_ura()` decodes subtype 7 URA.
+- `mcssr_sel_biascode(sys, code)` maps observation codes to MADOCA bias codes.
+
+`mdciono.c` handles QZSS L6D wide-area ionospheric correction:
+
+- `init_miono(gt)` initializes L6D ionosphere decoder state.
+- `input_qzssl6d(mdcl6d, data)` synchronizes L6D byte input.
+- `input_qzssl6df(mdcl6d, fp)` reads L6D bytes from a file.
+- `decode_qzss_l6dmsg(mdcl6d)` decodes L6D frame/subframe content.
+- `decode_miono_coverage()` decodes coverage/region/area geometry.
+- `decode_miono_correction()` decodes STEC correction coefficients.
+- `miono_get_corr(rr, nav)` selects an ionosphere area for receiver ECEF
+  position and materializes per-satellite delay/std corrections.
+
+`ppp.c` contains the RTKLIB-derived PPP processing flow:
+
+- Measurement correction and combination: `corr_meas()`.
+- Slip detection: `detslp_ll()`, `detslp_gf()`, `detslp_mw()`, `detslp_ssr()`.
+- State updates: `udpos_ppp()`, `udclk_ppp()`, `udtrop_ppp()`,
+  `udiono_ppp()`, `udifb_ppp()`, `udbias_ppp()`, `udstate_ppp()`.
+- Atmospheric models: `trop_model_prec()`, `model_trop()`, `model_iono()`.
+- Residual construction: `ppp_res()`.
+- Main solver entry: `pppos()`.
+
+`ppp_ar.c` contains PPP ambiguity resolution:
+
+- Wavelength setup: `get_wavelength()`.
+- Single-difference satellite pair generation: `gen_sat_sd()`.
+- Extra-wide-lane and wide-lane searches: `search_amb_ewl()`,
+  `search_amb_wl()`.
+- LAMBDA search: `search_amb_lambda()`.
+- Fixed-state update: `update_states()`.
+- Partial ambiguity exclusion: `exc_sat_par()`.
+- Main AR entry: `ppp_ar()`.
+
+## MADOCA Message Scope
+
+MADOCA L6E in `mdccssr.c` is the immediate correction stream target:
+
+- L6 preamble: `0x1ACFFC1D`.
+- L6 message byte length without Reed-Solomon code: 218 bytes.
+- L6 data payload: 1695 bits.
+- MADOCA Compact SSR RTCM message number: 4073.
+- Supported subtypes in this decoder: 1, 2, 3, 4, 5, and 7.
+- Defined systems include GPS, GLONASS, Galileo, BeiDou, QZSS, and BeiDou-3.
+- Defined MADOCA L6E PRNs in the inspected code are 204, 205, 206, 207, 209,
+  210, and 211.
+
+MADOCA L6D in `mdciono.c` is the ionosphere stream target:
+
+- Coverage message type: 1.
+- Correction message type: 2.
+- Defined systems include GPS, GLONASS, Galileo, BeiDou, and QZSS.
+- Defined L6D PRNs in the inspected code are 200 and 201, with 197 retained
+  for testing.
+
+## Sample Data Inventory
+
+The inspected sample data includes:
+
+- Observation RINEX:
+  `sample_data/data/rinex/MIZU00JPN_R_20250910000_01D_30S_MO.rnx`
+- Observation RINEX:
+  `sample_data/data/rinex/ALIC00AUS_R_20250910000_01D_30S_MO.rnx`
+- Navigation RINEX:
+  `sample_data/data/rinex/BRDM00DLR_S_20250910000_01D_MN.rnx`
+- Antenna data:
+  `sample_data/data/igs20.atx`
+- L6 sample trees:
+  `sample_data/data/l6_is-qzss-mdc-003/2025/091/`
+- L6 sample trees:
+  `sample_data/data/l6_is-qzss-mdc-004/2025/091/`
+- Convenience L6 tree:
+  `sample_data/data/l6/2025/091/`
+
+Batch examples show the intended scenarios:
+
+- `exec_ppp.bat`: MADOCA-PPP with L6E PRNs 204 and 206.
+- `exec_pppar.bat`: MADOCA-PPP-AR with L6E PRNs 204 and 206.
+- `exec_pppar_ion.bat`: PPP-AR plus L6D ionosphere with PRNs 200 and 201.
+- `exec_cssr2ssr.bat`: `cssr2ssr` conversion from L6E to RTCM3/debug text.
+
+These sample files should become the first whole-run oracle candidates after
+helper parity exists.
+
+## Commonality With CLAS
+
+Likely shared pieces:
+
+- QZSS L6 byte synchronization and preamble handling.
+- Bit extraction utilities.
+- CSSR mask/orbit/clock/code-bias/phase-bias concepts.
+- SSR update interval table.
+- Conversion from decoded correction epochs to `SSRProducts`.
+- PPP application points for orbit, clock, code bias, phase bias, trop, and
+  ionosphere corrections.
+- CLI profile plumbing for CLAS/MADOCA family correction runs.
+
+Likely MADOCA-specific pieces:
+
+- L6E PRN set and message generation facility handling.
+- MADOCA Compact SSR signal masks and bias-code selection.
+- Subtype transmission pattern and frame assembly from `framelen[]`.
+- L6D wide-area ionosphere region/area selection.
+- STEC coefficient scaling and URA-to-standard-deviation conversion.
+- Triple/quad-frequency PPP and PPP-AR behavior described in MADOCALIB 2.0.
+- MADOCALIB-specific options such as alert ignoring and PRN selection.
+
+## Proposed Port Structure
+
+Initial foundation:
+
+- `include/libgnss++/algorithms/madoca_parity.hpp`
+- `tests/test_madoca_parity.cpp`
+
+Future production modules, not for iter1:
+
+- `include/libgnss++/io/madoca_l6.hpp`
+- `src/io/madoca_l6.cpp`
+- `include/libgnss++/algorithms/ppp_madoca.hpp`
+- `src/algorithms/ppp_madoca.cpp`
+
+Future oracle modules, test-only and opt-in:
+
+- `tests/madocalib_oracle/`
+- `CLASLIB_PARITY_LINK` should not be reused blindly; use a MADOCA-specific
+  CMake option if direct linking is added.
+
+## Roadmap
+
+Phase 0, iter1 foundation:
+
+- Add docs and compile-time skeleton files only.
+- Do not change PPP behavior.
+- Do not touch CLAS code.
+
+Phase 1, helper parity:
+
+- Port pure helpers with stable inputs first:
+  bit extraction expectations, system ID mapping, signal mask to code mapping,
+  update interval selection, and bias-code selection.
+- Add MADOCALIB oracle calls or generated fixture rows.
+- Use `1e-6` tolerance for scaled metric outputs.
+
+Phase 2, L6E decode:
+
+- Implement MADOCA L6E stream/frame assembly.
+- Decode subtypes 1, 2, 3, 4, 5, and 7 into a neutral correction epoch.
+- Compare decoded rows against MADOCALIB `cssr2ssr` or direct oracle output.
+- Only then map to `SSRProducts`.
+
+Phase 3, L6D ionosphere:
+
+- Implement coverage and correction message parsing.
+- Implement area selection and STEC delay/std calculation.
+- Add sample-driven tests for PRNs 200/201.
+
+Phase 4, PPP application:
+
+- Wire MADOCA correction products into the existing PPP pipeline.
+- Keep CLAS and MADOCA profiles explicit.
+- Compare sample `exec_ppp` and `exec_pppar` windows against MADOCALIB output.
+
+Phase 5, PPP-AR and multifrequency:
+
+- Audit MADOCALIB 2.0 triple/quad-frequency PPP-AR behavior.
+- Add fixture-level AR tests before enabling broad CLI behavior.
+
+## Acceptance Gates
+
+- Existing tests pass without MADOCALIB installed.
+- Oracle-linked tests are opt-in and clearly labeled.
+- Helper parity reaches `1e-6` for deterministic scaled values.
+- L6E decoded orbit/clock/bias rows match MADOCALIB for sample frames.
+- L6D decoded STEC delay/std rows match MADOCALIB for selected receiver
+  positions.
+- Whole-run PPP and PPP-AR sample windows are compared only after helper and
+  decoder parity are stable.
+
+## Non-Goals For Iter1
+
+- No MADOCA decoder implementation.
+- No MADOCALIB linking.
+- No PPP behavior change.
+- No CLAS source changes.

--- a/docs/rinex4_plan.md
+++ b/docs/rinex4_plan.md
@@ -1,0 +1,217 @@
+# RINEX 4.02 Plan
+
+This plan scopes the RINEX 4 work before implementation.  The intent for
+iter1 is to record the parser state, isolate the RINEX 4 surface area, and add
+only a compile-time skeleton.  Functional parsing changes should start in
+iter2.
+
+## Reference Sources
+
+- IGS RINEX 4.02 specification:
+  https://files.igs.org/pub/data/format/rinex_4.02.pdf
+- IGS release note for RINEX 4.02:
+  https://igs.org/news/rinex-4-02/
+- IGS formats page:
+  https://igs.org/formats-and-standards/
+- GSI RNXCMP / CompactRINEX note:
+  https://terras.gsi.go.jp/ja/crx2rnx.html
+
+## Current Parser State
+
+The active reader/writer lives in:
+
+- `include/libgnss++/io/rinex.hpp`
+- `src/io/rinex.cpp`
+
+Current behavior is mostly RINEX 2.x and 3.x:
+
+- `RINEXReader::readHeader()` reads fixed 80-column header lines until
+  `END OF HEADER`.
+- `parseHeaderLine()` detects the file version with `std::stod(line.substr(0, 9))`.
+- File type is inferred from `line[20]`, with observation, navigation,
+  meteorological, and clock mapped to `FileType`.
+- Observation headers support RINEX 2 `# / TYPES OF OBSERV` and RINEX 3
+  `SYS / # / OBS TYPES`.
+- The RINEX 3 observation type parser currently reads only the first line for a
+  system, up to 13 observation types.  Continuation lines are not accumulated.
+- `readObservationEpoch()` dispatches `version < 3.0` to the RINEX 2 epoch
+  parser and every `version >= 3.0` to the RINEX 3 epoch parser.
+- `parseObservationEpochV3()` assumes fixed epoch fields:
+  year at columns 2-5, seconds in `substr(18, 13)`, flag at columns 31-32,
+  and satellite count at columns 33-35.
+- RINEX 3 satellite observation rows are parsed as one line per satellite, with
+  16-character observation fields starting at column 4.
+- `readNavigationData()` treats every `version >= 3.0` navigation file as a
+  RINEX 3 navigation file.
+- Navigation record detection expects the first character of an ephemeris data
+  line to be a constellation identifier.
+- `supportsBroadcastNavigationSystem()` accepts GPS, GLONASS, Galileo, BeiDou,
+  and QZSS for broadcast navigation parsing.  SBAS and NavIC are not accepted.
+- `parseNavigationMessage()` handles RINEX 2 GPS-style records and RINEX 3
+  GPS/Galileo/BeiDou/QZSS eight-line Kepler records, plus four-line GLONASS
+  FDMA records.
+- Header-level RINEX 3 `IONOSPHERIC CORR` parsing is limited to GPSA/GPSB.
+- `RINEXWriter` can write simple RINEX 3-style headers and broadcast
+  navigation records, but it has no RINEX 4 data-record header support.
+
+The important conclusion is that RINEX 4 observation files may look close to
+RINEX 3, but RINEX 4 navigation files do not fit the current navigation parser.
+The current `version >= 3.0` branch is not a sufficient RINEX 4 compatibility
+story.
+
+## RINEX 4.02 Deltas
+
+The RINEX 4 line starts at RINEX 4.00:
+
+- Navigation files use a new data record header line beginning with `>`.
+- Navigation record types include `EPH`, `STO`, `EOP`, and `ION`.
+- The header line carries a data source and a navigation message type, for
+  example `LNAV`, `FDMA`, `FNAV`, `INAV`, `CNAV`, `CNV1`, `CNV2`, `CNV3`,
+  `L1NV`, `L1OC`, and `L3OC`.
+- System records such as `STO`, `EOP`, and `ION` are first-class data records,
+  not just legacy header fields.
+- RINEX 4.00 made system-dependent observation code lists required for
+  observation files.
+
+The RINEX 4.02 update adds or clarifies:
+
+- Observation epoch time tagging may carry extra second digits up to
+  picosecond resolution.
+- The observation epoch record can include an optional receiver clock offset
+  estimate.
+- NavIC L1 `L1NV` navigation messages are included.
+- GLONASS L1OC and L3OC CDMA navigation messages are included.
+- Navigation message subtypes are present in the navigation data record header.
+- ION subtypes are defined for QZSS and NavIC dual ionosphere models:
+  QZSS `CNVX WIDE`, QZSS `CNVX JAPN`, NavIC `L1NV KLOB`, and
+  NavIC `L1NV NEQN`.
+
+CompactRINEX / CRINEX is separate from the RINEX syntax itself:
+
+- Hatanaka CompactRINEX is a compressed representation for RINEX observation
+  files.
+- GSI RNXCMP advertises conversion for RINEX 2.xx, 3.xx, and 4.xx observation
+  files.
+- This repo currently has no native CRINEX reader.  Iter2 should treat CRINEX
+  as an input-preparation concern unless a native decompressor is explicitly
+  chosen.
+
+## Impact On Current Code
+
+Observation file impact:
+
+- Current RINEX 3 epoch parsing will not safely parse picosecond-width seconds,
+  because flag and satellite-count columns are fixed after a 13-character
+  seconds field.
+- The parser needs token-based epoch parsing after the `>` marker while still
+  preserving optional receiver clock offset parsing.
+- System observation type continuation lines must be supported before claiming
+  robust RINEX 4 observation support.
+- Time precision should be stored as `double` for now because `GNSSTime::tow`
+  is a `double`; picosecond text may be parsed but not represented losslessly.
+
+Navigation file impact:
+
+- Current RINEX 4 navigation files will begin records with `> EPH ...`,
+  `> STO ...`, `> EOP ...`, or `> ION ...`; the current parser will not treat
+  those lines as ephemeris starts.
+- Record metadata must be parsed before record-body dispatch.
+- Existing ephemeris parsing can be reused for selected `EPH` bodies after the
+  RINEX 4 header line is consumed, but the selected message type must be kept
+  in the resulting object or at least respected for line count and time-system
+  interpretation.
+- STO/EOP/ION require new data containers or an explicit skip policy.  Silent
+  misparse is not acceptable.
+- NavIC and GLONASS CDMA navigation messages need either new `Ephemeris`
+  fields or a generic navigation-message container.
+
+Writer impact:
+
+- RINEX 4 navigation writing must emit data record header lines.
+- Observation writing must preserve the expanded epoch second precision and the
+  optional receiver clock offset field.
+- Writer support can lag reader support; it should not block initial reader
+  acceptance.
+
+## Proposed Skeleton Ownership
+
+The new files introduced in iter1 are:
+
+- `include/libgnss++/io/rinex4.hpp`
+- `src/io/rinex4.cpp`
+
+They should remain small and separate until the compatibility boundary is
+clear.  The existing `RINEXReader` should remain the production path for
+RINEX 2/3.  RINEX 4 additions can later be folded into `RINEXReader` once the
+tests prove that no RINEX 2/3 behavior regressed.
+
+## Roadmap
+
+Phase 0, iter1 foundation:
+
+- Add empty RINEX 4 skeleton files and compile them.
+- Document current parser assumptions.
+- Do not change behavior in `src/io/rinex.cpp`.
+
+Phase 1, reader detection and safe dispatch:
+
+- Add explicit `isRinex4()` checks rather than relying on `version >= 3.0`.
+- Add tests with minimal RINEX 4.02 observation and navigation fixtures.
+- For RINEX 4 navigation records, parse the `>` data record header and route
+  unsupported record types to a deliberate skip path.
+- Keep RINEX 2/3 tests unchanged.
+
+Phase 2, observation support:
+
+- Replace fixed-column epoch parsing with token-based parsing for RINEX 4 epoch
+  lines.
+- Preserve optional receiver clock offset estimate when present.
+- Handle expanded second precision text without shifting flag/count parsing.
+- Accumulate `SYS / # / OBS TYPES` continuation lines.
+- Add CRINEX policy tests that verify `.crx`/`.crx.gz` is rejected with a clear
+  message or preprocessed through an external converter.
+
+Phase 3, `EPH` navigation support:
+
+- Parse RINEX 4 `EPH` data record headers.
+- Reuse current GPS/Galileo/BeiDou/QZSS/GLONASS FDMA bodies where compatible.
+- Add explicit skip/error handling for unsupported `L1NV`, `L1OC`, and `L3OC`
+  before implementing them.
+- Preserve message type metadata for Galileo `FNAV` vs `INAV`.
+
+Phase 4, system data records:
+
+- Add internal containers for `STO`, `EOP`, and `ION`.
+- Start with ION because QZSS/NavIC ION subtypes matter for MADOCA/RINEX 4
+  convergence.
+- Decide whether these containers live in `NavigationData` or a RINEX-specific
+  sidecar.
+
+Phase 5, new navigation messages:
+
+- Implement NavIC L1 `L1NV` parsing.
+- Implement GLONASS `L1OC` and `L3OC` parsing.
+- Add conformance fixtures from public RINEX 4.02 files before enabling these
+  records in production flows.
+
+Phase 6, writer support:
+
+- Emit RINEX 4 navigation data record headers.
+- Add writer round-trip tests only after reader behavior is stable.
+
+## Acceptance Gates
+
+- Existing RINEX 2/3 tests continue to pass.
+- RINEX 4 observation fixture parses header, epoch time, satellite count, and
+  at least GPS/QZSS observation rows.
+- RINEX 4 navigation fixture with `> EPH G.. LNAV` parses at parity with the
+  equivalent RINEX 3 record.
+- Unsupported RINEX 4 records fail or skip deterministically with diagnostics.
+- CRINEX input policy is explicit and tested.
+
+## Non-Goals For Iter1
+
+- No RINEX 4 parser behavior changes.
+- No native CRINEX decompressor.
+- No NavIC or GLONASS CDMA message implementation.
+- No writer behavior changes.

--- a/include/libgnss++/algorithms/madoca_parity.hpp
+++ b/include/libgnss++/algorithms/madoca_parity.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace libgnss::algorithms::madoca_parity {
+
+inline constexpr double kOracleTolerance = 1e-6;
+
+}  // namespace libgnss::algorithms::madoca_parity

--- a/include/libgnss++/io/rinex4.hpp
+++ b/include/libgnss++/io/rinex4.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+namespace libgnss::io::rinex4 {
+
+inline constexpr double kVersion = 4.02;
+
+}  // namespace libgnss::io::rinex4

--- a/src/io/rinex4.cpp
+++ b/src/io/rinex4.cpp
@@ -1,0 +1,1 @@
+#include <libgnss++/io/rinex4.hpp>

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ if(GTest_FOUND)
         test_gnss_live.cpp
         test_ppp.cpp
         test_rinex_writer.cpp
+        test_madoca_parity.cpp
         test_rtk_legacy.cpp
         test_spp.cpp
         test_rtk.cpp

--- a/tests/test_madoca_parity.cpp
+++ b/tests/test_madoca_parity.cpp
@@ -1,0 +1,13 @@
+#include <gtest/gtest.h>
+
+#include <libgnss++/algorithms/madoca_parity.hpp>
+
+namespace libgnss::algorithms::madoca_parity {
+namespace {
+
+TEST(MadocaParitySkeleton, OracleToleranceIsDefined) {
+    EXPECT_DOUBLE_EQ(kOracleTolerance, 1e-6);
+}
+
+}  // namespace
+}  // namespace libgnss::algorithms::madoca_parity


### PR DESCRIPTION
## Summary
- Extract the first reviewable slice from draft PR #49 onto current `develop`.
- Add RINEX 4.02 and MADOCA parity skeleton headers/sources wired into CMake.
- Add planning docs for RINEX4 and MADOCA port sequencing.
- Add a small skeleton test so the new MADOCA parity test target is exercised.

## Context
PR #49 is currently too large to merge directly and would revert large parts of current `develop` when compared as-is. This PR starts salvaging it as small, reviewable slices without carrying the stale branch history or unrelated deletions.

## Validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target run_tests -j4`
- `./build/tests/run_tests --gtest_filter=MadocaParitySkeleton.*`
- `ctest --test-dir build --output-on-failure`
- `git diff --check`