### PR TITLE
[codex] Add MADOCALIB parity harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,6 +319,52 @@ jobs:
           output/ppp_static_products_comparison.png
         if-no-files-found: ignore
 
+  madoca-parity:
+    needs: [changes, hygiene]
+    if: needs.changes.outputs.run_heavy == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Checkout MADOCALIB
+      uses: actions/checkout@v4
+      with:
+        repository: QZSS-Strategy-Office/madocalib
+        ref: 0089f7dc97e8e2ba283a40be2edf4b73a140df6c
+        path: external/madocalib
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libeigen3-dev libgtest-dev cmake build-essential python3-dev pybind11-dev
+
+    - name: Configure CMake with MADOCALIB parity link
+      run: |
+        cmake -B build-madoca-parity \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DMADOCALIB_PARITY_LINK=ON \
+          -DMADOCALIB_ROOT_DIR="${GITHUB_WORKSPACE}/external/madocalib"
+
+    - name: Build MadocaParity tests
+      run: cmake --build build-madoca-parity --config Release --parallel --target run_tests
+
+    - name: Run MadocaParity
+      working-directory: build-madoca-parity
+      run: ./tests/run_tests --gtest_filter='*MadocaParity*'
+
+    - name: Upload MadocaParity diagnostics
+      if: failure()
+      uses: actions/upload-artifact@v4
+      with:
+        name: madoca-parity-diagnostics
+        path: |
+          build-madoca-parity/CMakeCache.txt
+          build-madoca-parity/Testing/Temporary/LastTest.log
+          build-madoca-parity/Testing/Temporary/LastTestsFailed.log
+          build-madoca-parity/CMakeFiles/CMakeConfigureLog.yaml
+        if-no-files-found: ignore
+
   static-analysis:
     needs: [changes, hygiene]
     if: needs.changes.outputs.run_heavy == 'true'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ find_package(geometry_msgs QUIET)
 find_package(nav_msgs QUIET)
 find_package(std_msgs QUIET)
 find_package(OpenCV QUIET COMPONENTS core imgproc imgcodecs)
+option(MADOCALIB_PARITY_LINK "Link external MADOCALIB C sources for opt-in parity oracle tests" OFF)
+set(MADOCALIB_ROOT_DIR
+    ""
+    CACHE PATH "Path to the MADOCALIB checkout root")
 
 # Vendored third-party libraries.
 # These are built as STATIC sub-targets and consumed by gnss_lib through
@@ -47,6 +51,8 @@ set(GNSS_SOURCES
     src/algorithms/ppp_osr.cpp
     src/algorithms/ppp_wlnl.cpp
     src/algorithms/ppp_clas_epoch.cpp
+    src/algorithms/madoca_parity.cpp
+    src/algorithms/madocalib_oracle.cpp
     src/algorithms/ppp.cpp
     src/iers/earth_rotation.cpp
     src/iers/tides.cpp
@@ -83,6 +89,51 @@ target_link_libraries(gnss_lib PUBLIC Eigen3::Eigen)
 # include/libgnss++/iers/.
 target_link_libraries(gnss_lib PRIVATE sofa ginan_iers2010)
 
+if(MADOCALIB_PARITY_LINK)
+    set(MADOCALIB_SRC_DIR "${MADOCALIB_ROOT_DIR}/src")
+    if(NOT EXISTS "${MADOCALIB_SRC_DIR}/rtklib.h")
+        message(FATAL_ERROR "MADOCALIB source tree not found: ${MADOCALIB_SRC_DIR}")
+    endif()
+
+    add_library(madocalib STATIC
+        ${MADOCALIB_SRC_DIR}/rtkcmn.c
+    )
+    target_include_directories(madocalib
+        PUBLIC
+            $<BUILD_INTERFACE:${MADOCALIB_SRC_DIR}>
+    )
+    target_compile_definitions(madocalib
+        PRIVATE
+            TRACE
+            ENAGLO
+            ENAQZS
+            ENAGAL
+            ENACMP
+            ENAIRN
+            NFREQ=5
+            NEXOBS=5
+    )
+    target_link_libraries(madocalib PUBLIC m)
+
+    target_include_directories(gnss_lib PRIVATE ${MADOCALIB_SRC_DIR})
+    target_compile_definitions(gnss_lib
+        PUBLIC GNSSPP_HAS_MADOCALIB_ORACLE=1
+        PRIVATE
+            TRACE
+            ENAGLO
+            ENAQZS
+            ENAGAL
+            ENACMP
+            ENAIRN
+            NFREQ=5
+            NEXOBS=5
+            "GNSSPP_MADOCALIB_ROOT=\"${MADOCALIB_ROOT_DIR}\""
+    )
+    target_link_libraries(gnss_lib PUBLIC madocalib)
+else()
+    target_compile_definitions(gnss_lib PUBLIC GNSSPP_HAS_MADOCALIB_ORACLE=0)
+endif()
+
 # Create the no-optimization library
 add_library(gnss_lib_noopt STATIC ${GNSS_SOURCES_NO_OPTIMIZATION})
 target_compile_options(gnss_lib_noopt PRIVATE -O0)
@@ -92,12 +143,17 @@ target_include_directories(gnss_lib_noopt PUBLIC
 )
 target_link_libraries(gnss_lib_noopt PUBLIC Eigen3::Eigen)
 
+set(GNSS_INSTALL_TARGETS gnss_lib gnss_lib_noopt sofa ginan_iers2010)
+if(MADOCALIB_PARITY_LINK)
+    list(APPEND GNSS_INSTALL_TARGETS madocalib)
+endif()
+
 install(
     # Note: sofa and ginan_iers2010 are PRIVATE link deps of gnss_lib but
     # must still appear in the same export set because static archives do
     # not carry their dependency closure — downstream consumers of an
     # installed libgnsspp::gnss_lib need the vendor symbols at link time.
-    TARGETS gnss_lib gnss_lib_noopt sofa ginan_iers2010
+    TARGETS ${GNSS_INSTALL_TARGETS}
     EXPORT libgnssppTargets
     ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
     LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}

--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -234,6 +234,25 @@ Future oracle modules, test-only and opt-in:
 - `CLASLIB_PARITY_LINK` should not be reused blindly; use a MADOCA-specific
   CMake option if direct linking is added.
 
+## MADOCALIB License Notes
+
+`madocalib/readme.txt` identifies MADOCALIB as a MADOCA-PPP reference/test
+library derived from RTKLIB 2.4.3 b34, with PPP-AR and message-conversion
+functions copyrighted by third parties.  It is distributed under BSD 2-Clause
+terms with additional clauses.  Source redistributions must retain the upstream
+copyright notice, license conditions, and disclaimer; binary redistributions
+must reproduce those notices in documentation or other materials.  The upstream
+readme also notes companion Windows executables/shared libraries with their
+own original licenses, and the optional GUI has separate license information in
+`MADOCALIB_GUI_LICENSE.txt`.
+
+For CI parity use, checkout `QZSS-Strategy-Office/madocalib` into an
+`external/madocalib` directory and point `MADOCALIB_ROOT_DIR` there.  The
+opt-in oracle build links only the required source file(s), does not vendor
+MADOCALIB into the default build, and keeps the upstream checkout/readme
+available in the workflow workspace so the BSD notice and additional terms are
+retained.
+
 ## Roadmap
 
 Phase 0, iter1 foundation:

--- a/include/libgnss++/algorithms/madoca_parity.hpp
+++ b/include/libgnss++/algorithms/madoca_parity.hpp
@@ -4,4 +4,28 @@ namespace libgnss::algorithms::madoca_parity {
 
 inline constexpr double kOracleTolerance = 1e-6;
 
+inline constexpr int kSysNone = 0x000;
+inline constexpr int kSysGps = 0x001;
+inline constexpr int kSysSbs = 0x002;
+inline constexpr int kSysGlo = 0x004;
+inline constexpr int kSysGal = 0x008;
+inline constexpr int kSysQzs = 0x010;
+inline constexpr int kSysCmp = 0x020;
+inline constexpr int kSysIrn = 0x040;
+inline constexpr int kSysLeo = 0x080;
+inline constexpr int kSysBd2 = 0x100;
+
+inline constexpr int kMadocalibMaxSat = 221;
+
+bool satnoAvailable();
+bool satsysAvailable();
+bool ionmapfAvailable();
+bool geodistAvailable();
+
+int satno(int sys, int prn);
+int satsys(int sat, int* prn);
+
+double ionmapf(const double pos[3], const double azel[2]);
+double geodist(const double rs[3], const double rr[3], double e[3]);
+
 }  // namespace libgnss::algorithms::madoca_parity

--- a/include/libgnss++/external/madocalib_oracle.hpp
+++ b/include/libgnss++/external/madocalib_oracle.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace libgnss::external::madocalib_oracle {
+
+bool available();
+
+int satno(int sys, int prn);
+int satsys(int sat, int* prn);
+
+double ionmapf(const double pos[3], const double azel[2]);
+double geodist(const double rs[3], const double rr[3], double e[3]);
+
+}  // namespace libgnss::external::madocalib_oracle

--- a/src/algorithms/madoca_parity.cpp
+++ b/src/algorithms/madoca_parity.cpp
@@ -1,0 +1,184 @@
+#include <libgnss++/algorithms/madoca_parity.hpp>
+
+#include <libgnss++/core/constants.hpp>
+
+#include <cmath>
+
+namespace libgnss::algorithms::madoca_parity {
+namespace {
+
+constexpr double kIonosphereHeightM = 350000.0;
+constexpr double kPi = 3.141592653589793238462643383279502884;
+
+constexpr int kMinPrnGps = 1;
+constexpr int kMaxPrnGps = 32;
+constexpr int kNsatGps = kMaxPrnGps - kMinPrnGps + 1;
+
+constexpr int kMinPrnGlo = 1;
+constexpr int kMaxPrnGlo = 27;
+constexpr int kNsatGlo = kMaxPrnGlo - kMinPrnGlo + 1;
+
+constexpr int kMinPrnGal = 1;
+constexpr int kMaxPrnGal = 36;
+constexpr int kNsatGal = kMaxPrnGal - kMinPrnGal + 1;
+
+constexpr int kMinPrnQzs = 193;
+constexpr int kMaxPrnQzs = 202;
+constexpr int kNsatQzs = kMaxPrnQzs - kMinPrnQzs + 1;
+
+constexpr int kMinPrnCmp = 1;
+constexpr int kMaxPrnCmp = 63;
+constexpr int kMinPrnBds3 = 19;
+constexpr int kNsatCmp = kMaxPrnCmp - kMinPrnCmp + 1;
+
+constexpr int kMinPrnIrn = 1;
+constexpr int kMaxPrnIrn = 14;
+constexpr int kNsatIrn = kMaxPrnIrn - kMinPrnIrn + 1;
+
+constexpr int kNsatLeo = 0;
+
+constexpr int kMinPrnSbs = 120;
+constexpr int kMaxPrnSbs = 158;
+constexpr int kNsatSbs = kMaxPrnSbs - kMinPrnSbs + 1;
+
+double norm3(const double v[3]) {
+    return std::sqrt(v[0] * v[0] + v[1] * v[1] + v[2] * v[2]);
+}
+
+}  // namespace
+
+bool satnoAvailable() {
+    return true;
+}
+
+bool satsysAvailable() {
+    return true;
+}
+
+bool ionmapfAvailable() {
+    return true;
+}
+
+bool geodistAvailable() {
+    return true;
+}
+
+int satno(int sys, int prn) {
+    if (prn <= 0) {
+        return 0;
+    }
+
+    switch (sys) {
+        case kSysGps:
+            if (prn < kMinPrnGps || kMaxPrnGps < prn) {
+                return 0;
+            }
+            return prn - kMinPrnGps + 1;
+        case kSysGlo:
+            if (prn < kMinPrnGlo || kMaxPrnGlo < prn) {
+                return 0;
+            }
+            return kNsatGps + prn - kMinPrnGlo + 1;
+        case kSysGal:
+            if (prn < kMinPrnGal || kMaxPrnGal < prn) {
+                return 0;
+            }
+            return kNsatGps + kNsatGlo + prn - kMinPrnGal + 1;
+        case kSysQzs:
+            if (prn < kMinPrnQzs || kMaxPrnQzs < prn) {
+                return 0;
+            }
+            return kNsatGps + kNsatGlo + kNsatGal + prn - kMinPrnQzs + 1;
+        case kSysCmp:
+            if (prn < kMinPrnCmp || kMaxPrnCmp < prn) {
+                return 0;
+            }
+            return kNsatGps + kNsatGlo + kNsatGal + kNsatQzs + prn - kMinPrnCmp + 1;
+        case kSysBd2:
+            if (prn < kMinPrnCmp || kMinPrnBds3 <= prn) {
+                return 0;
+            }
+            return kNsatGps + kNsatGlo + kNsatGal + kNsatQzs + prn - kMinPrnCmp + 1;
+        case kSysIrn:
+            if (prn < kMinPrnIrn || kMaxPrnIrn < prn) {
+                return 0;
+            }
+            return kNsatGps + kNsatGlo + kNsatGal + kNsatQzs + kNsatCmp +
+                   prn - kMinPrnIrn + 1;
+        case kSysLeo:
+            return 0;
+        case kSysSbs:
+            if (prn < kMinPrnSbs || kMaxPrnSbs < prn) {
+                return 0;
+            }
+            return kNsatGps + kNsatGlo + kNsatGal + kNsatQzs + kNsatCmp +
+                   kNsatIrn + kNsatLeo + prn - kMinPrnSbs + 1;
+        default:
+            return 0;
+    }
+}
+
+int satsys(int sat, int* prn) {
+    int sys = kSysNone;
+    if (sat <= 0 || kMadocalibMaxSat < sat) {
+        sat = 0;
+    } else if (sat <= kNsatGps) {
+        sys = kSysGps;
+        sat += kMinPrnGps - 1;
+    } else if ((sat -= kNsatGps) <= kNsatGlo) {
+        sys = kSysGlo;
+        sat += kMinPrnGlo - 1;
+    } else if ((sat -= kNsatGlo) <= kNsatGal) {
+        sys = kSysGal;
+        sat += kMinPrnGal - 1;
+    } else if ((sat -= kNsatGal) <= kNsatQzs) {
+        sys = kSysQzs;
+        sat += kMinPrnQzs - 1;
+    } else if ((sat -= kNsatQzs) <= kNsatCmp) {
+        sys = kSysCmp;
+        sat += kMinPrnCmp - 1;
+    } else if ((sat -= kNsatCmp) <= kNsatIrn) {
+        sys = kSysIrn;
+        sat += kMinPrnIrn - 1;
+    } else if ((sat -= kNsatIrn) <= kNsatLeo) {
+        sys = kSysLeo;
+        sat += 0;
+    } else if ((sat -= kNsatLeo) <= kNsatSbs) {
+        sys = kSysSbs;
+        sat += kMinPrnSbs - 1;
+    } else {
+        sat = 0;
+    }
+
+    if (prn != nullptr) {
+        *prn = sat;
+    }
+    return sys;
+}
+
+double ionmapf(const double pos[3], const double azel[2]) {
+    if (pos[2] >= kIonosphereHeightM) {
+        return 1.0;
+    }
+    return 1.0 /
+           std::cos(std::asin((constants::WGS84_A + pos[2]) /
+                              (constants::WGS84_A + kIonosphereHeightM) *
+                              std::sin(kPi / 2.0 - azel[1])));
+}
+
+double geodist(const double rs[3], const double rr[3], double e[3]) {
+    if (norm3(rs) < constants::WGS84_A) {
+        return -1.0;
+    }
+    for (int i = 0; i < 3; ++i) {
+        e[i] = rs[i] - rr[i];
+    }
+    const double r = norm3(e);
+    for (int i = 0; i < 3; ++i) {
+        e[i] /= r;
+    }
+    return r + constants::OMEGA_E * (rs[0] * rr[1] - rs[1] * rr[0]) /
+                   constants::SPEED_OF_LIGHT;
+}
+
+}  // namespace libgnss::algorithms::madoca_parity

--- a/src/algorithms/madocalib_oracle.cpp
+++ b/src/algorithms/madocalib_oracle.cpp
@@ -1,0 +1,71 @@
+#include <libgnss++/external/madocalib_oracle.hpp>
+
+#ifndef GNSSPP_HAS_MADOCALIB_ORACLE
+#define GNSSPP_HAS_MADOCALIB_ORACLE 0
+#endif
+
+#if GNSSPP_HAS_MADOCALIB_ORACLE
+extern "C" {
+#include "rtklib.h"
+}
+#endif
+
+namespace libgnss::external::madocalib_oracle {
+namespace {
+
+void zero3(double out[3]) {
+    out[0] = 0.0;
+    out[1] = 0.0;
+    out[2] = 0.0;
+}
+
+}  // namespace
+
+bool available() {
+    return GNSSPP_HAS_MADOCALIB_ORACLE != 0;
+}
+
+int satno(int sys, int prn) {
+#if GNSSPP_HAS_MADOCALIB_ORACLE
+    return ::satno(sys, prn);
+#else
+    (void)sys;
+    (void)prn;
+    return 0;
+#endif
+}
+
+int satsys(int sat, int* prn) {
+#if GNSSPP_HAS_MADOCALIB_ORACLE
+    return ::satsys(sat, prn);
+#else
+    (void)sat;
+    if (prn != nullptr) {
+        *prn = 0;
+    }
+    return 0;
+#endif
+}
+
+double ionmapf(const double pos[3], const double azel[2]) {
+#if GNSSPP_HAS_MADOCALIB_ORACLE
+    return ::ionmapf(pos, azel);
+#else
+    (void)pos;
+    (void)azel;
+    return 0.0;
+#endif
+}
+
+double geodist(const double rs[3], const double rr[3], double e[3]) {
+#if GNSSPP_HAS_MADOCALIB_ORACLE
+    return ::geodist(rs, rr, e);
+#else
+    (void)rs;
+    (void)rr;
+    zero3(e);
+    return -1.0;
+#endif
+}
+
+}  // namespace libgnss::external::madocalib_oracle

--- a/tests/test_madoca_parity.cpp
+++ b/tests/test_madoca_parity.cpp
@@ -1,13 +1,182 @@
 #include <gtest/gtest.h>
 
 #include <libgnss++/algorithms/madoca_parity.hpp>
+#include <libgnss++/core/coordinates.hpp>
+#include <libgnss++/external/madocalib_oracle.hpp>
 
-namespace libgnss::algorithms::madoca_parity {
+#include <cmath>
+#include <string>
+#include <vector>
+
+#ifndef GNSSPP_HAS_MADOCALIB_ORACLE
+#define GNSSPP_HAS_MADOCALIB_ORACLE 0
+#endif
+
 namespace {
 
-TEST(MadocaParitySkeleton, OracleToleranceIsDefined) {
-    EXPECT_DOUBLE_EQ(kOracleTolerance, 1e-6);
+namespace madoca = libgnss::algorithms::madoca_parity;
+
+constexpr double kDegToRad = 3.141592653589793238462643383279502884 / 180.0;
+constexpr double kParityTolerance = madoca::kOracleTolerance;
+
+struct GeometrySample {
+    double rr[3] = {};
+    double pos[3] = {};
+    double rs[3] = {};
+    double azel[2] = {};
+};
+
+void copyVector3(const libgnss::Vector3d& value, double out[3]) {
+    out[0] = value(0);
+    out[1] = value(1);
+    out[2] = value(2);
 }
 
+GeometrySample makeSample(int index) {
+    GeometrySample sample;
+    const double lat = (35.681236 + 0.25 * static_cast<double>(index % 3)) * kDegToRad;
+    const double lon = (139.767125 + 0.40 * static_cast<double>(index % 4)) * kDegToRad;
+    const double height = 45.0 + 35.0 * static_cast<double>(index % 5);
+    sample.pos[0] = lat;
+    sample.pos[1] = lon;
+    sample.pos[2] = height;
+
+    const libgnss::Vector3d rr = libgnss::geodetic2ecef(lat, lon, height);
+    copyVector3(rr, sample.rr);
+
+    const double az = std::fmod((25.0 + 53.0 * static_cast<double>(index)) * kDegToRad,
+                                2.0 * 3.141592653589793238462643383279502884);
+    const double el = (12.0 + 9.0 * static_cast<double>(index % 7)) * kDegToRad;
+    sample.azel[0] = az;
+    sample.azel[1] = el;
+
+    const libgnss::Vector3d los_enu(std::sin(az) * std::cos(el),
+                                    std::cos(az) * std::cos(el),
+                                    std::sin(el));
+    const libgnss::Vector3d los_ecef = libgnss::enu2ecef(los_enu, lat, lon).normalized();
+    const double range_m = 21300000.0 + 475000.0 * static_cast<double>(index);
+    const libgnss::Vector3d rs = rr + range_m * los_ecef;
+    copyVector3(rs, sample.rs);
+    return sample;
+}
+
+std::vector<GeometrySample> makeSamples() {
+    std::vector<GeometrySample> samples;
+    for (int i = 0; i < 10; ++i) {
+        samples.push_back(makeSample(i));
+    }
+    return samples;
+}
+
+void expectNearArray(const std::string& label,
+                     const double* native,
+                     const double* oracle,
+                     int size) {
+    for (int i = 0; i < size; ++i) {
+        EXPECT_NEAR(native[i], oracle[i], kParityTolerance)
+            << label << " component=" << i
+            << " native=" << native[i]
+            << " oracle=" << oracle[i];
+    }
+}
+
+TEST(MadocaParityConfig, OracleToleranceIsDefined) {
+    EXPECT_DOUBLE_EQ(madoca::kOracleTolerance, 1e-6);
+}
+
+#if GNSSPP_HAS_MADOCALIB_ORACLE
+
+class MadocaParity : public ::testing::Test {
+protected:
+    void SetUp() override {
+        if (!libgnss::external::madocalib_oracle::available()) {
+            GTEST_SKIP() << "MADOCALIB oracle unavailable; configure with "
+                         << "-DMADOCALIB_PARITY_LINK=ON";
+        }
+    }
+};
+
+TEST_F(MadocaParity, SatnoSystemPrnMapping) {
+    ASSERT_TRUE(madoca::satnoAvailable());
+    struct SatnoCase {
+        int sys;
+        int prn;
+    };
+    const SatnoCase cases[] = {
+        {madoca::kSysGps, 1},   {madoca::kSysGps, 32},  {madoca::kSysGps, 33},
+        {madoca::kSysGlo, 1},   {madoca::kSysGlo, 27},  {madoca::kSysGal, 1},
+        {madoca::kSysGal, 36},  {madoca::kSysQzs, 193}, {madoca::kSysQzs, 202},
+        {madoca::kSysCmp, 1},   {madoca::kSysCmp, 63},  {madoca::kSysBd2, 18},
+        {madoca::kSysBd2, 19},  {madoca::kSysIrn, 1},   {madoca::kSysIrn, 14},
+        {madoca::kSysSbs, 120}, {madoca::kSysSbs, 158}, {madoca::kSysLeo, 1},
+        {madoca::kSysNone, 1},  {madoca::kSysGps, 0},
+    };
+
+    for (const auto& sample : cases) {
+        EXPECT_EQ(madoca::satno(sample.sys, sample.prn),
+                  libgnss::external::madocalib_oracle::satno(sample.sys, sample.prn))
+            << "sys=" << sample.sys << " prn=" << sample.prn;
+    }
+}
+
+TEST_F(MadocaParity, SatsysSatelliteNumberMapping) {
+    ASSERT_TRUE(madoca::satsysAvailable());
+    const int sats[] = {
+        0, 1, 32, 33, 59, 60, 95, 96, 105, 106, 168, 169, 182, 183, 221, 222,
+    };
+
+    for (int sat : sats) {
+        int native_prn = -1;
+        int oracle_prn = -2;
+        const int native_sys = madoca::satsys(sat, &native_prn);
+        const int oracle_sys =
+            libgnss::external::madocalib_oracle::satsys(sat, &oracle_prn);
+        EXPECT_EQ(native_sys, oracle_sys) << "sat=" << sat;
+        EXPECT_EQ(native_prn, oracle_prn) << "sat=" << sat;
+        EXPECT_EQ(madoca::satsys(sat, nullptr),
+                  libgnss::external::madocalib_oracle::satsys(sat, nullptr))
+            << "sat=" << sat << " nullptr";
+    }
+}
+
+TEST_F(MadocaParity, IonmapfSingleLayer) {
+    ASSERT_TRUE(madoca::ionmapfAvailable());
+    const auto samples = makeSamples();
+    for (size_t i = 0; i < samples.size(); ++i) {
+        const double native = madoca::ionmapf(samples[i].pos, samples[i].azel);
+        const double oracle =
+            libgnss::external::madocalib_oracle::ionmapf(samples[i].pos, samples[i].azel);
+        EXPECT_NEAR(native, oracle, kParityTolerance) << "sample=" << i;
+    }
+
+    const double high_pos[3] = {35.0 * kDegToRad, 139.0 * kDegToRad, 350000.0};
+    const double azel[2] = {75.0 * kDegToRad, 40.0 * kDegToRad};
+    EXPECT_NEAR(madoca::ionmapf(high_pos, azel),
+                libgnss::external::madocalib_oracle::ionmapf(high_pos, azel),
+                kParityTolerance);
+}
+
+TEST_F(MadocaParity, GeodistSagnacRangeAndLos) {
+    ASSERT_TRUE(madoca::geodistAvailable());
+    const auto samples = makeSamples();
+    for (size_t i = 0; i < samples.size(); ++i) {
+        double native_e[3] = {};
+        double oracle_e[3] = {};
+        const double native = madoca::geodist(samples[i].rs, samples[i].rr, native_e);
+        const double oracle =
+            libgnss::external::madocalib_oracle::geodist(samples[i].rs, samples[i].rr, oracle_e);
+        EXPECT_NEAR(native, oracle, kParityTolerance)
+            << "range sample=" << i;
+        expectNearArray("los sample=" + std::to_string(i), native_e, oracle_e, 3);
+    }
+}
+
+#else
+
+TEST(MadocaParityDefault, OracleDisabledInDefaultBuild) {
+    EXPECT_FALSE(libgnss::external::madocalib_oracle::available());
+}
+
+#endif
+
 }  // namespace
-}  // namespace libgnss::algorithms::madoca_parity


### PR DESCRIPTION
## Summary
- Extract the next reviewable slice from draft PR #49 onto current `develop`.
- Add an opt-in `MADOCALIB_PARITY_LINK` CMake path that links a pinned external MADOCALIB checkout only when requested.
- Add native MADOCA parity helpers for `satno`, `satsys`, `ionmapf`, and `geodist`, plus guarded oracle wrappers.
- Add CI coverage for the MADOCALIB linked parity path while keeping the default build oracle-free.

## Context
This follows #84, which landed the RINEX4/MADOCA foundation slice. The original #49 branch is still too large and stale to merge directly, so this continues the split-and-salvage approach from current `develop`.

## Validation
- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --target run_tests -j4`
- `./build/tests/run_tests --gtest_filter=MadocaParityConfig.*:MadocaParityDefault.*`
- `cmake -S . -B build-madoca-parity -DCMAKE_BUILD_TYPE=Release -DMADOCALIB_PARITY_LINK=ON -DMADOCALIB_ROOT_DIR=/tmp/gnsspp_madocalib_parity`
- `cmake --build build-madoca-parity --target run_tests -j4`
- `./build-madoca-parity/tests/run_tests --gtest_filter=*MadocaParity*`
- `ctest --test-dir build --output-on-failure`
- `git diff --check`