### PR TITLE
[codex] Add MADOCALIB bridge smoke slice

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -346,12 +346,35 @@ jobs:
           -DMADOCALIB_PARITY_LINK=ON \
           -DMADOCALIB_ROOT_DIR="${GITHUB_WORKSPACE}/external/madocalib"
 
-    - name: Build MadocaParity tests
+    - name: Build MadocaParity tests and bridge tool
       run: cmake --build build-madoca-parity --config Release --parallel --target run_tests
 
     - name: Run MadocaParity
       working-directory: build-madoca-parity
-      run: ./tests/run_tests --gtest_filter='*MadocaParity*'
+      run: ./tests/run_tests --gtest_filter='*MadocaParity*:MadocaBridgeConfig.*'
+
+    - name: Run MADOCALIB bridge smoke
+      working-directory: build-madoca-parity
+      run: |
+        ROOT="${GITHUB_WORKSPACE}/external/madocalib"
+        ./apps/gnss_ppp \
+          --madocalib-bridge \
+          --obs "$ROOT/sample_data/data/rinex/MIZU00JPN_R_20250910000_01D_30S_MO.rnx" \
+          --nav "$ROOT/sample_data/data/rinex/BRDM00DLR_S_20250910000_01D_MN.rnx" \
+          --madocalib-l6 "$ROOT/sample_data/data/l6_is-qzss-mdc-004/2025/091/2025091A.204.l6" \
+          --madocalib-l6 "$ROOT/sample_data/data/l6_is-qzss-mdc-004/2025/091/2025091A.206.l6" \
+          --antex "$ROOT/sample_data/data/igs20.atx" \
+          --madocalib-start "2025/04/01 00:00:00" \
+          --madocalib-end "2025/04/01 00:59:30" \
+          --madocalib-ti 30 \
+          --out madocalib_bridge_smoke.pos \
+          --summary-json madocalib_bridge_smoke.json \
+          --quiet
+        grep -q "MADOCALIB ver.2.1" madocalib_bridge_smoke.pos
+        rows="$(awk '$0 !~ /^%/ && NF > 0 {n++} END {print n+0}' madocalib_bridge_smoke.pos)"
+        test "$rows" -eq 118
+        non_q6="$(awk '$0 !~ /^%/ && NF > 0 && $6 != 6 {n++} END {print n+0}' madocalib_bridge_smoke.pos)"
+        test "$non_q6" -eq 0
 
     - name: Upload MadocaParity diagnostics
       if: failure()
@@ -363,6 +386,8 @@ jobs:
           build-madoca-parity/Testing/Temporary/LastTest.log
           build-madoca-parity/Testing/Temporary/LastTestsFailed.log
           build-madoca-parity/CMakeFiles/CMakeConfigureLog.yaml
+          build-madoca-parity/madocalib_bridge_smoke.pos
+          build-madoca-parity/madocalib_bridge_smoke.json
         if-no-files-found: ignore
 
   static-analysis:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ set(GNSS_SOURCES
     src/algorithms/ppp_clas_epoch.cpp
     src/algorithms/madoca_parity.cpp
     src/algorithms/madocalib_oracle.cpp
+    src/algorithms/madocalib_bridge.cpp
     src/algorithms/ppp.cpp
     src/iers/earth_rotation.cpp
     src/iers/tides.cpp
@@ -97,6 +98,28 @@ if(MADOCALIB_PARITY_LINK)
 
     add_library(madocalib STATIC
         ${MADOCALIB_SRC_DIR}/rtkcmn.c
+        ${MADOCALIB_SRC_DIR}/rinex.c
+        ${MADOCALIB_SRC_DIR}/rtkpos.c
+        ${MADOCALIB_SRC_DIR}/postpos.c
+        ${MADOCALIB_SRC_DIR}/solution.c
+        ${MADOCALIB_SRC_DIR}/lambda.c
+        ${MADOCALIB_SRC_DIR}/geoid.c
+        ${MADOCALIB_SRC_DIR}/sbas.c
+        ${MADOCALIB_SRC_DIR}/preceph.c
+        ${MADOCALIB_SRC_DIR}/pntpos.c
+        ${MADOCALIB_SRC_DIR}/ephemeris.c
+        ${MADOCALIB_SRC_DIR}/options.c
+        ${MADOCALIB_SRC_DIR}/ppp.c
+        ${MADOCALIB_SRC_DIR}/ppp_ar.c
+        ${MADOCALIB_SRC_DIR}/ppp_iono.c
+        ${MADOCALIB_SRC_DIR}/rtcm.c
+        ${MADOCALIB_SRC_DIR}/rtcm2.c
+        ${MADOCALIB_SRC_DIR}/rtcm3.c
+        ${MADOCALIB_SRC_DIR}/rtcm3e.c
+        ${MADOCALIB_SRC_DIR}/ionex.c
+        ${MADOCALIB_SRC_DIR}/tides.c
+        ${MADOCALIB_SRC_DIR}/mdccssr.c
+        ${MADOCALIB_SRC_DIR}/mdciono.c
     )
     target_include_directories(madocalib
         PUBLIC
@@ -113,11 +136,16 @@ if(MADOCALIB_PARITY_LINK)
             NFREQ=5
             NEXOBS=5
     )
-    target_link_libraries(madocalib PUBLIC m)
+    target_link_libraries(madocalib PUBLIC m Threads::Threads)
+    if(UNIX AND NOT APPLE)
+        target_link_libraries(madocalib PUBLIC rt)
+    endif()
 
     target_include_directories(gnss_lib PRIVATE ${MADOCALIB_SRC_DIR})
     target_compile_definitions(gnss_lib
-        PUBLIC GNSSPP_HAS_MADOCALIB_ORACLE=1
+        PUBLIC
+            GNSSPP_HAS_MADOCALIB_BRIDGE=1
+            GNSSPP_HAS_MADOCALIB_ORACLE=1
         PRIVATE
             TRACE
             ENAGLO
@@ -131,7 +159,10 @@ if(MADOCALIB_PARITY_LINK)
     )
     target_link_libraries(gnss_lib PUBLIC madocalib)
 else()
-    target_compile_definitions(gnss_lib PUBLIC GNSSPP_HAS_MADOCALIB_ORACLE=0)
+    target_compile_definitions(gnss_lib
+        PUBLIC
+            GNSSPP_HAS_MADOCALIB_BRIDGE=0
+            GNSSPP_HAS_MADOCALIB_ORACLE=0)
 endif()
 
 # Create the no-optimization library

--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -7,9 +7,11 @@
 #include <map>
 #include <sstream>
 #include <string>
+#include <vector>
 
 #include <libgnss++/algorithms/ppp.hpp>
 #include <libgnss++/core/solution.hpp>
+#include <libgnss++/external/madocalib_bridge.hpp>
 #include <libgnss++/io/rinex.hpp>
 
 namespace {
@@ -47,6 +49,14 @@ struct Options {
     std::string clas_residual_sampling = "indexed-or-mean";
     std::string clas_atmos_selection = "grid-first";
     double clas_atmos_stale_after_seconds = 15.0;
+    bool madocalib_bridge = false;
+    std::string madocalib_config_path;
+    std::vector<std::string> madocalib_l6_paths;
+    std::vector<std::string> madocalib_mdciono_paths;
+    std::string madocalib_start_time;
+    std::string madocalib_end_time;
+    double madocalib_time_interval_seconds = 0.0;
+    int madocalib_trace_level = 0;
     bool kinematic_mode = false;
     bool low_dynamics_mode = false;
     bool apply_static_anchor_blend = false;
@@ -113,6 +123,20 @@ void printUsage(const char* program_name) {
         << "                          CLAS atmosphere token selection policy (default: grid-first)\n"
         << "  --clas-atmos-stale-after-seconds <seconds>\n"
         << "                          Balanced policy stale threshold (default: 15.0)\n"
+        << "  --madocalib-bridge      Delegate this run to linked MADOCALIB postpos()\n"
+        << "                          (requires CMake -DMADOCALIB_PARITY_LINK=ON)\n"
+        << "  --madocalib-l6 <file>   Extra MADOCA L6 input file; repeat for two-channel L6E\n"
+        << "  --madocalib-mdciono <file>\n"
+        << "                          Extra MADOCA L6D ionosphere file; repeat up to three\n"
+        << "  --madocalib-config <file>\n"
+        << "                          MADOCALIB rnx2rtkp config (default: sample.conf)\n"
+        << "  --madocalib-start <time>\n"
+        << "                          MADOCALIB start time, e.g. '2025/04/01 00:00:00'\n"
+        << "  --madocalib-end <time>  MADOCALIB end time, e.g. '2025/04/01 00:59:30'\n"
+        << "  --madocalib-ti <seconds>\n"
+        << "                          MADOCALIB output interval passed to postpos()\n"
+        << "  --madocalib-trace <level>\n"
+        << "                          MADOCALIB trace level (default: 0)\n"
         << "  --static                Use a static PPP motion model (default)\n"
         << "  --kinematic             Use a kinematic PPP motion model\n"
         << "  --low-dynamics          Keep kinematic PPP anchored for quasi-static motion\n"
@@ -250,6 +274,22 @@ Options parseArguments(int argc, char* argv[]) {
             options.clas_atmos_selection = argv[++i];
         } else if (arg == "--clas-atmos-stale-after-seconds" && i + 1 < argc) {
             options.clas_atmos_stale_after_seconds = std::stod(argv[++i]);
+        } else if (arg == "--madocalib-bridge") {
+            options.madocalib_bridge = true;
+        } else if (arg == "--madocalib-l6" && i + 1 < argc) {
+            options.madocalib_l6_paths.push_back(argv[++i]);
+        } else if (arg == "--madocalib-mdciono" && i + 1 < argc) {
+            options.madocalib_mdciono_paths.push_back(argv[++i]);
+        } else if (arg == "--madocalib-config" && i + 1 < argc) {
+            options.madocalib_config_path = argv[++i];
+        } else if (arg == "--madocalib-start" && i + 1 < argc) {
+            options.madocalib_start_time = argv[++i];
+        } else if (arg == "--madocalib-end" && i + 1 < argc) {
+            options.madocalib_end_time = argv[++i];
+        } else if (arg == "--madocalib-ti" && i + 1 < argc) {
+            options.madocalib_time_interval_seconds = std::stod(argv[++i]);
+        } else if (arg == "--madocalib-trace" && i + 1 < argc) {
+            options.madocalib_trace_level = std::stoi(argv[++i]);
         } else if (arg == "--no-ionosphere-free") {
             options.use_ionosphere_free = false;
         } else if (arg == "--ionosphere-free") {
@@ -334,6 +374,12 @@ Options parseArguments(int argc, char* argv[]) {
     }
     if (options.ssr_step_seconds <= 0.0) {
         argumentError("--ssr-step-seconds must be positive", argv[0]);
+    }
+    if (options.madocalib_time_interval_seconds < 0.0) {
+        argumentError("--madocalib-ti must be non-negative", argv[0]);
+    }
+    if (options.madocalib_trace_level < 0) {
+        argumentError("--madocalib-trace must be non-negative", argv[0]);
     }
     if (options.clas_epoch_policy != "strict-osr" &&
         options.clas_epoch_policy != "hybrid-standard-ppp") {
@@ -572,6 +618,130 @@ parseClasSubtype12ValueConstructionPolicy(const std::string& value) {
 int main(int argc, char* argv[]) {
     try {
         const Options options = parseArguments(argc, argv);
+
+        if (options.madocalib_bridge) {
+            namespace madocalib = libgnss::external::madocalib;
+            if (!madocalib::isAvailable()) {
+                std::cerr << "Error: --madocalib-bridge requested, but this binary was not "
+                             "built with -DMADOCALIB_PARITY_LINK=ON\n";
+                return 1;
+            }
+
+            madocalib::PostposOptions bridge_options;
+            bridge_options.obs_path = options.obs_path;
+            bridge_options.nav_path = options.nav_path;
+            bridge_options.out_path = options.out_path;
+            bridge_options.config_path = options.madocalib_config_path;
+            bridge_options.antenna_path = options.antex_path;
+            bridge_options.start_time = options.madocalib_start_time;
+            bridge_options.end_time = options.madocalib_end_time;
+            bridge_options.time_interval_seconds =
+                options.madocalib_time_interval_seconds;
+            bridge_options.trace_level = options.madocalib_trace_level;
+            if (!options.sp3_path.empty()) {
+                bridge_options.auxiliary_input_paths.push_back(options.sp3_path);
+            }
+            if (!options.clk_path.empty()) {
+                bridge_options.auxiliary_input_paths.push_back(options.clk_path);
+            }
+            if (!options.ssr_path.empty()) {
+                bridge_options.auxiliary_input_paths.push_back(options.ssr_path);
+            }
+            for (const std::string& l6_path : options.madocalib_l6_paths) {
+                bridge_options.auxiliary_input_paths.push_back(l6_path);
+            }
+            bridge_options.mdciono_paths = options.madocalib_mdciono_paths;
+
+            const std::filesystem::path output_path(options.out_path);
+            if (output_path.has_parent_path()) {
+                std::filesystem::create_directories(output_path.parent_path());
+            }
+
+            std::string bridge_error;
+            const int bridge_status =
+                madocalib::runPostpos(bridge_options, &bridge_error);
+            if (bridge_status != 0) {
+                std::cerr << "Error: " << bridge_error << "\n";
+                return 1;
+            }
+            if (!std::filesystem::is_regular_file(options.out_path)) {
+                std::cerr << "Error: MADOCALIB bridge completed without output file: "
+                          << options.out_path << "\n";
+                return 1;
+            }
+
+            if (!options.summary_json_path.empty()) {
+                const std::filesystem::path summary_path(options.summary_json_path);
+                if (summary_path.has_parent_path()) {
+                    std::filesystem::create_directories(summary_path.parent_path());
+                }
+                std::ofstream summary(summary_path);
+                if (!summary.is_open()) {
+                    std::cerr << "Error: failed to write summary JSON: "
+                              << options.summary_json_path << "\n";
+                    return 1;
+                }
+                summary << "{\n"
+                        << "  \"obs\": \"" << jsonEscape(options.obs_path) << "\",\n"
+                        << "  \"nav\": "
+                        << (options.nav_path.empty() ?
+                                "null" :
+                                ("\"" + jsonEscape(options.nav_path) + "\""))
+                        << ",\n"
+                        << "  \"sp3\": "
+                        << (options.sp3_path.empty() ?
+                                "null" :
+                                ("\"" + jsonEscape(options.sp3_path) + "\""))
+                        << ",\n"
+                        << "  \"clk\": "
+                        << (options.clk_path.empty() ?
+                                "null" :
+                                ("\"" + jsonEscape(options.clk_path) + "\""))
+                        << ",\n"
+                        << "  \"ssr\": "
+                        << (options.ssr_path.empty() ?
+                                "null" :
+                                ("\"" + jsonEscape(options.ssr_path) + "\""))
+                        << ",\n"
+                        << "  \"out\": \"" << jsonEscape(options.out_path) << "\",\n"
+                        << "  \"madocalib_bridge\": true,\n"
+                        << "  \"madocalib_bridge_status\": " << bridge_status << ",\n"
+                        << "  \"madocalib_config\": "
+                        << (options.madocalib_config_path.empty() ?
+                                "null" :
+                                ("\"" + jsonEscape(options.madocalib_config_path) + "\""))
+                        << ",\n"
+                        << "  \"madocalib_start\": "
+                        << (options.madocalib_start_time.empty() ?
+                                "null" :
+                                ("\"" + jsonEscape(options.madocalib_start_time) + "\""))
+                        << ",\n"
+                        << "  \"madocalib_end\": "
+                        << (options.madocalib_end_time.empty() ?
+                                "null" :
+                                ("\"" + jsonEscape(options.madocalib_end_time) + "\""))
+                        << ",\n"
+                        << "  \"madocalib_time_interval_seconds\": "
+                        << options.madocalib_time_interval_seconds << ",\n"
+                        << "  \"madocalib_l6_inputs\": [";
+                bool first_l6 = true;
+                for (const std::string& l6_path : options.madocalib_l6_paths) {
+                    if (!first_l6) {
+                        summary << ", ";
+                    }
+                    summary << "\"" << jsonEscape(l6_path) << "\"";
+                    first_l6 = false;
+                }
+                summary << "]\n"
+                        << "}\n";
+            }
+
+            if (!options.quiet) {
+                std::cout << "MADOCALIB bridge: delegated run to linked MADOCALIB postpos()\n";
+                std::cout << "  output: " << options.out_path << "\n";
+            }
+            return 0;
+        }
 
         libgnss::io::RINEXReader obs_reader;
         if (!obs_reader.open(options.obs_path)) {

--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -231,8 +231,66 @@ Future production modules, not for iter1:
 Future oracle modules, test-only and opt-in:
 
 - `tests/madocalib_oracle/`
-- `CLASLIB_PARITY_LINK` should not be reused blindly; use a MADOCA-specific
-  CMake option if direct linking is added.
+- `include/libgnss++/external/madocalib_bridge.hpp`
+- `src/algorithms/madocalib_bridge.cpp`
+- `MADOCALIB_PARITY_LINK=ON` links the MADOCALIB C sources for direct helper
+  oracle calls and the whole-run `postpos()` bridge.  The default build keeps
+  this off.
+
+## Iter4 MADOCALIB Bridge Baseline
+
+The first whole-run oracle path is an opt-in static-link delegate:
+
+- Configure with `-DMADOCALIB_PARITY_LINK=ON`.
+- Run `gnss_ppp --madocalib-bridge` to delegate the whole run to MADOCALIB
+  `postpos()`.
+- Pass MADOCA L6E files with repeated `--madocalib-l6 <file>` arguments.
+- Pass L6D ionosphere files with repeated `--madocalib-mdciono <file>`
+  arguments when using the ionosphere scenario.
+- The default build does not link MADOCALIB and rejects `--madocalib-bridge`
+  before producing output.
+
+The public sample-data smoke case uses the `exec_ppp.bat` MIZU scenario with
+the two L6E channels from the `is-qzss-mdc-004` tree:
+
+```sh
+ROOT=${MADOCALIB_ROOT}
+
+./build_iter4_madocalib/apps/gnss_ppp \
+  --madocalib-bridge \
+  --obs "$ROOT/sample_data/data/rinex/MIZU00JPN_R_20250910000_01D_30S_MO.rnx" \
+  --nav "$ROOT/sample_data/data/rinex/BRDM00DLR_S_20250910000_01D_MN.rnx" \
+  --madocalib-l6 "$ROOT/sample_data/data/l6_is-qzss-mdc-004/2025/091/2025091A.204.l6" \
+  --madocalib-l6 "$ROOT/sample_data/data/l6_is-qzss-mdc-004/2025/091/2025091A.206.l6" \
+  --antex "$ROOT/sample_data/data/igs20.atx" \
+  --madocalib-start "2025/04/01 00:00:00" \
+  --madocalib-end "2025/04/01 00:59:30" \
+  --madocalib-ti 30 \
+  --out /tmp/madocalib_bridge_sample_0000.pos \
+  --summary-json /tmp/madocalib_bridge_sample_0000.json \
+  --quiet
+```
+
+Observed iter4 result:
+
+- Command exit status: `0`.
+- Output: `/tmp/madocalib_bridge_sample_0000.pos`, MADOCALIB format.
+- Header program line: `MADOCALIB ver.2.1`.
+- Time span in solution rows: `2025/04/01 00:01:00.000` through
+  `2025/04/01 00:59:30.000`.
+- Solution rows: `118`.
+- Quality counts: `Q=6` for all `118` rows.
+- Health-check RMS against the observation RINEX approximate-position header
+  `(-3857167.6484, 3108694.9138, 4004041.6876)`:
+  all rows `4.502422 m`, last 100 rows `4.461333 m`, last 60 rows
+  `4.453027 m`, last 30 rows `4.457820 m`.
+
+The RMS values above are not an accuracy acceptance gate.  No precise truth
+coordinate was found in the inspected public sample-data files, so the RINEX
+header approximate position is used only as a run-health check.  For the native
+MADOCA port, the reference baseline is the generated MADOCALIB bridge
+trajectory itself, starting with this MIZU one-hour PPP window and later adding
+the PPP-AR and L6D ionosphere sample windows.
 
 ## MADOCALIB License Notes
 

--- a/include/libgnss++/external/madocalib_bridge.hpp
+++ b/include/libgnss++/external/madocalib_bridge.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace libgnss::external::madocalib {
+
+struct PostposOptions {
+    std::string obs_path;
+    std::string nav_path;
+    std::vector<std::string> auxiliary_input_paths;
+    std::vector<std::string> mdciono_paths;
+    std::string out_path;
+    std::string config_path;
+    std::string antenna_path;
+    std::string start_time;
+    std::string end_time;
+    double time_interval_seconds = 0.0;
+    int trace_level = 0;
+};
+
+bool isAvailable();
+std::string defaultRootDir();
+std::string defaultSampleConfigPath();
+
+int runPostpos(const PostposOptions& options, std::string* error_message = nullptr);
+
+}  // namespace libgnss::external::madocalib

--- a/src/algorithms/madocalib_bridge.cpp
+++ b/src/algorithms/madocalib_bridge.cpp
@@ -1,0 +1,354 @@
+#include <libgnss++/external/madocalib_bridge.hpp>
+
+#include <cstdarg>
+#include <cstdio>
+#include <cstring>
+#include <filesystem>
+#include <sstream>
+#include <vector>
+
+#ifndef GNSSPP_HAS_MADOCALIB_BRIDGE
+#define GNSSPP_HAS_MADOCALIB_BRIDGE 0
+#endif
+
+#ifndef GNSSPP_MADOCALIB_ROOT
+#define GNSSPP_MADOCALIB_ROOT ""
+#endif
+
+#if GNSSPP_HAS_MADOCALIB_BRIDGE
+extern "C" {
+#include "rtklib.h"
+}
+
+#if defined(__GNUC__)
+#define GNSSPP_MADOCALIB_WEAK __attribute__((weak))
+#else
+#define GNSSPP_MADOCALIB_WEAK
+#endif
+
+extern "C" int GNSSPP_MADOCALIB_WEAK showmsg(const char* format, ...) {
+    if (format == nullptr || *format == '\0') {
+        return 0;
+    }
+    va_list args;
+    va_start(args, format);
+    std::vfprintf(stderr, format, args);
+    std::fprintf(stderr, "\n");
+    va_end(args);
+    return 0;
+}
+
+extern "C" void GNSSPP_MADOCALIB_WEAK settspan(gtime_t /*ts*/, gtime_t /*te*/) {}
+
+extern "C" void GNSSPP_MADOCALIB_WEAK settime(gtime_t /*time*/) {}
+#endif
+
+namespace libgnss::external::madocalib {
+namespace {
+
+std::string pathJoin(const std::string& base, const std::string& leaf) {
+    if (base.empty()) {
+        return "";
+    }
+    return (std::filesystem::path(base) / leaf).string();
+}
+
+bool requireRegularFile(const std::string& label,
+                        const std::string& path,
+                        std::string* error_message) {
+    if (!std::filesystem::is_regular_file(path)) {
+        if (error_message != nullptr) {
+            *error_message = label + " not found: " + path;
+        }
+        return false;
+    }
+    return true;
+}
+
+bool requireRegularFiles(const std::vector<std::string>& paths,
+                         const std::string& label,
+                         std::string* error_message) {
+    for (const std::string& path : paths) {
+        if (!requireRegularFile(label, path, error_message)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+#if GNSSPP_HAS_MADOCALIB_BRIDGE
+void copyPath(char* destination, size_t size, const std::string& source) {
+    if (size == 0) {
+        return;
+    }
+    std::strncpy(destination, source.c_str(), size - 1);
+    destination[size - 1] = '\0';
+}
+
+bool parseMadocalibTime(const std::string& value,
+                        gtime_t* out,
+                        std::string* error_message) {
+    *out = {};
+    if (value.empty()) {
+        return true;
+    }
+
+    double ep[6] = {};
+    if (std::sscanf(value.c_str(),
+                    "%lf/%lf/%lf %lf:%lf:%lf",
+                    &ep[0],
+                    &ep[1],
+                    &ep[2],
+                    &ep[3],
+                    &ep[4],
+                    &ep[5]) != 6 &&
+        std::sscanf(value.c_str(),
+                    "%lf-%lf-%lf %lf:%lf:%lf",
+                    &ep[0],
+                    &ep[1],
+                    &ep[2],
+                    &ep[3],
+                    &ep[4],
+                    &ep[5]) != 6 &&
+        std::sscanf(value.c_str(),
+                    "%lf %lf %lf %lf %lf %lf",
+                    &ep[0],
+                    &ep[1],
+                    &ep[2],
+                    &ep[3],
+                    &ep[4],
+                    &ep[5]) != 6) {
+        if (error_message != nullptr) {
+            *error_message =
+                "invalid MADOCALIB time, expected 'YYYY/MM/DD HH:MM:SS': " + value;
+        }
+        return false;
+    }
+    *out = epoch2time(ep);
+    return true;
+}
+
+void applySignalSelection(const prcopt_t& prcopt) {
+    const int freq_nums_l1l2[MAXFREQ] = {1, 2, 0, 0, 0};
+    const int freq_nums_l1l5[MAXFREQ] = {1, 5, 0, 0, 0};
+    const int freq_nums_l1l2l5[MAXFREQ] = {1, 2, 5, 0, 0};
+
+    const int freq_nums_e1e5a[MAXFREQ] = {1, 5, 0, 0, 0};
+    const int freq_nums_e1e5b[MAXFREQ] = {1, 7, 0, 0, 0};
+    const int freq_nums_e1e6[MAXFREQ] = {1, 6, 0, 0, 0};
+    const int freq_nums_e1e5ae5be6[MAXFREQ] = {1, 5, 7, 6, 0};
+    const int freq_nums_e1e5ae6e5b[MAXFREQ] = {1, 5, 6, 7, 0};
+
+    const int freq_nums_b1b3[MAXFREQ] = {2, 6, 0, 0, 0};
+    const int freq_nums_b1b2i[MAXFREQ] = {2, 7, 0, 0, 0};
+    const int freq_nums_b1b2a[MAXFREQ] = {2, 5, 0, 0, 0};
+    const int freq_nums_b1b3b2i[MAXFREQ] = {2, 6, 7, 0, 0};
+    const int freq_nums_b1b3b2a[MAXFREQ] = {2, 6, 5, 0, 0};
+
+    switch (prcopt.pppsig[0]) {
+    case 0:
+        set_obsdef(SYS_GPS, freq_nums_l1l2);
+        break;
+    case 1:
+        set_obsdef(SYS_GPS, freq_nums_l1l5);
+        break;
+    default:
+        set_obsdef(SYS_GPS, freq_nums_l1l2l5);
+        break;
+    }
+    switch (prcopt.pppsig[1]) {
+    case 0:
+        set_obsdef(SYS_QZS, freq_nums_l1l5);
+        break;
+    case 1:
+        set_obsdef(SYS_QZS, freq_nums_l1l2);
+        break;
+    default:
+        set_obsdef(SYS_QZS, freq_nums_l1l2l5);
+        break;
+    }
+    switch (prcopt.pppsig[2]) {
+    case 0:
+        set_obsdef(SYS_GAL, freq_nums_e1e5a);
+        break;
+    case 1:
+        set_obsdef(SYS_GAL, freq_nums_e1e5b);
+        break;
+    case 2:
+        set_obsdef(SYS_GAL, freq_nums_e1e6);
+        break;
+    case 4:
+        set_obsdef(SYS_GAL, freq_nums_e1e5ae6e5b);
+        break;
+    default:
+        set_obsdef(SYS_GAL, freq_nums_e1e5ae5be6);
+        break;
+    }
+    switch (prcopt.pppsig[3]) {
+    case 0:
+        set_obsdef(SYS_BD2, freq_nums_b1b3);
+        break;
+    case 1:
+        set_obsdef(SYS_BD2, freq_nums_b1b2i);
+        break;
+    default:
+        set_obsdef(SYS_BD2, freq_nums_b1b3b2i);
+        break;
+    }
+    switch (prcopt.pppsig[4]) {
+    case 0:
+        set_obsdef(SYS_CMP, freq_nums_b1b3);
+        break;
+    case 1:
+        set_obsdef(SYS_CMP, freq_nums_b1b2a);
+        break;
+    default:
+        set_obsdef(SYS_CMP, freq_nums_b1b3b2a);
+        break;
+    }
+}
+#endif
+
+}  // namespace
+
+bool isAvailable() {
+    return GNSSPP_HAS_MADOCALIB_BRIDGE != 0;
+}
+
+std::string defaultRootDir() {
+    return GNSSPP_MADOCALIB_ROOT;
+}
+
+std::string defaultSampleConfigPath() {
+    return pathJoin(defaultRootDir(), "app/consapp/rnx2rtkp/gcc_mingw/sample.conf");
+}
+
+int runPostpos(const PostposOptions& options, std::string* error_message) {
+#if !GNSSPP_HAS_MADOCALIB_BRIDGE
+    if (error_message != nullptr) {
+        *error_message =
+            "MADOCALIB bridge is not linked; reconfigure with -DMADOCALIB_PARITY_LINK=ON";
+    }
+    return -1;
+#else
+    if (!requireRegularFile("observation file", options.obs_path, error_message)) {
+        return -1;
+    }
+    if (!options.nav_path.empty() &&
+        !requireRegularFile("navigation file", options.nav_path, error_message)) {
+        return -1;
+    }
+    if (!requireRegularFiles(options.auxiliary_input_paths, "MADOCALIB input file", error_message) ||
+        !requireRegularFiles(options.mdciono_paths, "MADOCALIB L6D file", error_message)) {
+        return -1;
+    }
+    if (!options.antenna_path.empty() &&
+        !requireRegularFile("receiver ANTEX file", options.antenna_path, error_message)) {
+        return -1;
+    }
+    if (options.out_path.empty()) {
+        if (error_message != nullptr) {
+            *error_message = "output path is empty";
+        }
+        return -1;
+    }
+
+    const std::string config_path =
+        options.config_path.empty() ? defaultSampleConfigPath() : options.config_path;
+    if (!config_path.empty() &&
+        !requireRegularFile("MADOCALIB config", config_path, error_message)) {
+        return -1;
+    }
+
+    gtime_t start_time = {};
+    gtime_t end_time = {};
+    if (!parseMadocalibTime(options.start_time, &start_time, error_message) ||
+        !parseMadocalibTime(options.end_time, &end_time, error_message)) {
+        return -1;
+    }
+
+    prcopt_t prcopt = prcopt_default;
+    solopt_t solopt = solopt_default;
+    filopt_t filopt = {""};
+
+    prcopt.mode = PMODE_KINEMA;
+    prcopt.navsys = 0;
+    prcopt.refpos = 1;
+    prcopt.glomodear = 1;
+    for (int i = 0; i < MIONO_MAX_PRN; ++i) {
+        prcopt.l6dpath[i] = nullptr;
+    }
+    solopt.timef = 0;
+    std::snprintf(solopt.prog, sizeof(solopt.prog), "gnss_ppp MADOCALIB bridge");
+
+    if (!config_path.empty()) {
+        resetsysopts();
+        if (!loadopts(config_path.c_str(), sysopts)) {
+            if (error_message != nullptr) {
+                *error_message = "failed to load MADOCALIB config: " + config_path;
+            }
+            return -1;
+        }
+        getsysopts(&prcopt, &solopt, &filopt);
+    }
+
+    if (!prcopt.navsys) {
+        prcopt.navsys = SYS_GPS | SYS_GLO | SYS_QZS | SYS_GAL;
+    }
+    if (prcopt.ionocorr || prcopt.modear >= ARMODE_CONT) {
+        prcopt.ionoopt = IONOOPT_EST;
+    }
+    applySignalSelection(prcopt);
+
+    for (size_t i = 0; i < options.mdciono_paths.size() && i < MIONO_MAX_PRN; ++i) {
+        prcopt.l6dpath[i] = const_cast<char*>(options.mdciono_paths[i].c_str());
+    }
+
+    if (!options.antenna_path.empty()) {
+        copyPath(filopt.rcvantp, sizeof(filopt.rcvantp), options.antenna_path);
+        filopt.satantp[0] = '\0';
+    }
+    solopt.trace = options.trace_level;
+
+    std::vector<std::string> input_storage;
+    input_storage.push_back(options.obs_path);
+    if (!options.nav_path.empty()) {
+        input_storage.push_back(options.nav_path);
+    }
+    for (const std::string& input : options.auxiliary_input_paths) {
+        if (!input.empty()) {
+            input_storage.push_back(input);
+        }
+    }
+
+    std::vector<char*> input_files;
+    input_files.reserve(input_storage.size());
+    for (std::string& input : input_storage) {
+        input_files.push_back(input.data());
+    }
+
+    char output_path[1024] = "";
+    copyPath(output_path, sizeof(output_path), options.out_path);
+
+    const int ret = postpos(start_time,
+                            end_time,
+                            options.time_interval_seconds,
+                            0.0,
+                            &prcopt,
+                            &solopt,
+                            &filopt,
+                            input_files.data(),
+                            static_cast<int>(input_files.size()),
+                            output_path,
+                            "",
+                            "");
+    if (ret != 0 && error_message != nullptr) {
+        std::ostringstream oss;
+        oss << "MADOCALIB postpos failed with status " << ret;
+        *error_message = oss.str();
+    }
+    return ret;
+#endif
+}
+
+}  // namespace libgnss::external::madocalib

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -3531,6 +3531,13 @@ class CLIToolsTest(unittest.TestCase):
         self.assertIn("--window-size", result.stdout)
         self.assertIn("--output-csv", result.stdout)
 
+    def test_ppp_help_lists_madocalib_bridge_options(self) -> None:
+        result = self.run_gnss("ppp", "--help")
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("--madocalib-bridge", result.stdout)
+        self.assertIn("--madocalib-l6", result.stdout)
+        self.assertIn("--madocalib-mdciono", result.stdout)
+
     def test_public_rtk_benchmarks_cli_lists_matrix(self) -> None:
         result = self.run_gnss("public-rtk-benchmarks", "--format", "json")
         self.assertEqual(result.returncode, 0, msg=result.stderr)

--- a/tests/test_madoca_parity.cpp
+++ b/tests/test_madoca_parity.cpp
@@ -2,6 +2,7 @@
 
 #include <libgnss++/algorithms/madoca_parity.hpp>
 #include <libgnss++/core/coordinates.hpp>
+#include <libgnss++/external/madocalib_bridge.hpp>
 #include <libgnss++/external/madocalib_oracle.hpp>
 
 #include <cmath>
@@ -10,6 +11,10 @@
 
 #ifndef GNSSPP_HAS_MADOCALIB_ORACLE
 #define GNSSPP_HAS_MADOCALIB_ORACLE 0
+#endif
+
+#ifndef GNSSPP_HAS_MADOCALIB_BRIDGE
+#define GNSSPP_HAS_MADOCALIB_BRIDGE 0
 #endif
 
 namespace {
@@ -82,6 +87,18 @@ void expectNearArray(const std::string& label,
 
 TEST(MadocaParityConfig, OracleToleranceIsDefined) {
     EXPECT_DOUBLE_EQ(madoca::kOracleTolerance, 1e-6);
+}
+
+TEST(MadocaBridgeConfig, AvailabilityMatchesBuildFlag) {
+#if GNSSPP_HAS_MADOCALIB_BRIDGE
+    EXPECT_TRUE(libgnss::external::madocalib::isAvailable());
+    EXPECT_FALSE(libgnss::external::madocalib::defaultRootDir().empty());
+#else
+    EXPECT_FALSE(libgnss::external::madocalib::isAvailable());
+    std::string error_message;
+    EXPECT_EQ(libgnss::external::madocalib::runPostpos({}, &error_message), -1);
+    EXPECT_NE(error_message.find("MADOCALIB bridge is not linked"), std::string::npos);
+#endif
 }
 
 #if GNSSPP_HAS_MADOCALIB_ORACLE


### PR DESCRIPTION
## Summary
- Extract the next reviewable MADOCA slice from draft PR #49 onto current develop.
- Add an opt-in MADOCALIB postpos bridge behind MADOCALIB_PARITY_LINK=ON and gnss_ppp --madocalib-bridge.
- Wire MADOCA L6E/L6D bridge arguments, summary JSON output, and default-build unavailable guards.
- Extend the MADOCALIB CI job from helper parity into a one-hour public MIZU bridge smoke that asserts 118 solution rows and all Q=6.

## Context
This follows #85, which landed the helper parity harness. The original #49 branch is still too broad and stale to merge directly, so this keeps the next slice focused on an executable whole-run oracle path.

## Validation
- cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
- cmake --build build --target run_tests gnss_ppp -j4
- ./build/tests/run_tests --gtest_filter=MadocaBridgeConfig.*:MadocaParityConfig.*:MadocaParityDefault.*
- python3 -m unittest test_cli_tools.CLIToolsTest.test_ppp_help_lists_madocalib_bridge_options from tests/
- cmake -S . -B build-madoca-bridge -DCMAKE_BUILD_TYPE=Release -DMADOCALIB_PARITY_LINK=ON -DMADOCALIB_ROOT_DIR=<external/madocalib>
- cmake --build build-madoca-bridge --target run_tests gnss_ppp -j4
- ./build-madoca-bridge/tests/run_tests --gtest_filter=MadocaBridgeConfig.*:*MadocaParity*
- build-madoca-bridge/apps/gnss_ppp --madocalib-bridge public MIZU one-hour smoke: 118 solution rows, all Q=6
- ctest --test-dir build --output-on-failure
- git diff --check