### PR TITLE
Add taroz FGO solver and PPC validation workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,14 @@
 # Build artifacts
 build/
 build_local/
+build-codex/
 bin/
 *.a
 *.o
+
+# ROS 2 generated artifacts
+ros2/install/
+ros2/log/
 
 # Data (large RINEX files)
 data/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,26 @@ find_package(geometry_msgs QUIET)
 find_package(nav_msgs QUIET)
 find_package(std_msgs QUIET)
 find_package(OpenCV QUIET COMPONENTS core imgproc imgcodecs)
+find_package(GTSAM QUIET CONFIG PATHS /usr/local/lib/cmake/GTSAM)
+if(GTSAM_FOUND)
+    message(STATUS "GTSAM found; enabling optional FGO GTSAM backend")
+else()
+    message(STATUS "GTSAM not found; optional FGO GTSAM backend disabled")
+endif()
+option(GNSSPP_USE_CHOLMOD "Use CHOLMOD for optional FGO sparse covariance solves" ON)
+if(GNSSPP_USE_CHOLMOD)
+    find_path(CHOLMOD_INCLUDE_DIR
+        NAMES cholmod.h
+        PATH_SUFFIXES suitesparse)
+    find_library(CHOLMOD_LIBRARY NAMES cholmod)
+    if(CHOLMOD_INCLUDE_DIR AND CHOLMOD_LIBRARY)
+        message(STATUS "CHOLMOD found; enabling optional FGO covariance solver")
+    else()
+        message(STATUS "CHOLMOD not found; using Eigen sparse covariance solver")
+    endif()
+else()
+    message(STATUS "CHOLMOD disabled; using Eigen sparse covariance solver")
+endif()
 option(MADOCALIB_PARITY_LINK "Link external MADOCALIB C sources for opt-in parity oracle tests" OFF)
 set(MADOCALIB_ROOT_DIR
     ""
@@ -72,6 +92,7 @@ set(GNSS_SOURCES_NO_OPTIMIZATION
     src/algorithms/rtk_selection.cpp
     src/algorithms/rtk_update.cpp
     src/algorithms/rtk_validation.cpp
+    src/algorithms/fgo.cpp
     src/algorithms/rtk.cpp
     src/algorithms/spp.cpp
     src/algorithms/lambda.cpp
@@ -175,6 +196,11 @@ target_include_directories(gnss_lib_noopt PUBLIC
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 target_link_libraries(gnss_lib_noopt PUBLIC Eigen3::Eigen)
+if(CHOLMOD_INCLUDE_DIR AND CHOLMOD_LIBRARY)
+    target_include_directories(gnss_lib_noopt PRIVATE ${CHOLMOD_INCLUDE_DIR})
+    target_compile_definitions(gnss_lib_noopt PRIVATE GNSSPP_HAS_CHOLMOD=1)
+    target_link_libraries(gnss_lib_noopt PRIVATE ${CHOLMOD_LIBRARY})
+endif()
 
 set(GNSS_INSTALL_TARGETS gnss_lib gnss_lib_noopt sofa ginan_iers2010)
 if(MADOCALIB_PARITY_LINK)

--- a/README.md
+++ b/README.md
@@ -431,6 +431,33 @@ Full replay, RTKLIB comparison, and historical diagnostic commands are in
 [PPC reproduction commands](docs/ppc_reproduction.md). Dataset source:
 [taroz/PPC-Dataset](https://github.com/taroz/PPC-Dataset).
 
+The taroz ambiguity PDC FGO port has a separate PPC dogfood harness. Keep the
+20-epoch form for lightweight smoke, and use the longer form locally when
+checking public-run behavior or shifted windows:
+
+```bash
+python3 apps/gnss.py ppc-taroz-amb-pdc-smoke \
+  --dataset-root /datasets/PPC-Dataset \
+  --max-epochs 20 \
+  --summary-json output/dogfood/ppc_taroz_amb_pdc_smoke/summary.json
+
+python3 apps/gnss.py ppc-taroz-amb-pdc-smoke \
+  --dataset-root /datasets/PPC-Dataset \
+  --max-epochs 200 \
+  --generate-spp-seed \
+  --require-valid-p95-3d-max 2.0 \
+  --summary-json output/dogfood/ppc_taroz_amb_pdc_smoke_200/summary.json
+
+python3 apps/gnss.py ppc-taroz-amb-pdc-smoke \
+  --dataset-root /datasets/PPC-Dataset \
+  --run nagoya/run3 \
+  --skip-epochs 400 \
+  --max-epochs 200 \
+  --generate-spp-seed \
+  --require-valid-p95-3d-max 2.0 \
+  --summary-json output/dogfood/ppc_taroz_amb_pdc_nagoya_run3_shifted/summary.json
+```
+
 Other benchmark artifacts and checked sign-offs are documented in
 [Benchmarks](docs/benchmarks.md) and [Validation](docs/validation.md).
 

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -1,5 +1,11 @@
 set(GNSS_APP_TARGETS
     gnss_spp
+    gnss_fgo
+    gnss_vel_d
+    gnss_pos_pdc
+    gnss_pos_pd
+    gnss_pos_vel_pdc
+    gnss_pos_vel_pd
     gnss_solve
     gnss_ppp
     gnss_visibility
@@ -14,6 +20,28 @@ set(GNSS_APP_TARGETS
 
 add_executable(gnss_spp gnss_spp.cpp)
 target_link_libraries(gnss_spp PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)
+
+add_executable(gnss_fgo gnss_fgo.cpp)
+target_link_libraries(gnss_fgo PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)
+if(GTSAM_FOUND)
+    target_compile_definitions(gnss_fgo PRIVATE GNSS_WITH_GTSAM=1)
+    target_link_libraries(gnss_fgo PRIVATE gtsam)
+endif()
+
+add_executable(gnss_vel_d gnss_vel_d.cpp)
+target_link_libraries(gnss_vel_d PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)
+
+add_executable(gnss_pos_pdc gnss_pos_pdc.cpp)
+target_link_libraries(gnss_pos_pdc PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)
+
+add_executable(gnss_pos_pd gnss_pos_pd.cpp)
+target_link_libraries(gnss_pos_pd PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)
+
+add_executable(gnss_pos_vel_pdc gnss_pos_vel_pdc.cpp)
+target_link_libraries(gnss_pos_vel_pdc PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)
+
+add_executable(gnss_pos_vel_pd gnss_pos_vel_pd.cpp)
+target_link_libraries(gnss_pos_vel_pd PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)
 
 add_executable(gnss_solve gnss_solve.cpp)
 target_link_libraries(gnss_solve PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)
@@ -60,6 +88,12 @@ install(PROGRAMS
     ${CMAKE_CURRENT_SOURCE_DIR}/gnss_web.py
     ${CMAKE_CURRENT_SOURCE_DIR}/gnss_runtime.py
     ${CMAKE_CURRENT_SOURCE_DIR}/gnss_toml_config.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/gnss_mode_compare.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/gnss_ppc_taroz_amb_pdc_smoke.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/gnss_taroz_p_dogfood.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/gnss_taroz_pd_dogfood.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/gnss_taroz_pc_dogfood.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/gnss_taroz_pos_vel_amb_pdc_dogfood.py
     ${CMAKE_CURRENT_SOURCE_DIR}/gnss_live_signoff.py
     ${CMAKE_CURRENT_SOURCE_DIR}/gnss_moving_base_signoff.py
     ${CMAKE_CURRENT_SOURCE_DIR}/gnss_scorpion_moving_base_signoff.py
@@ -126,6 +160,13 @@ install(PROGRAMS
     ${CMAKE_SOURCE_DIR}/scripts/generate_ppc_rtk_scorecard.py
     ${CMAKE_SOURCE_DIR}/scripts/generate_ppc_tail_cleanup_scorecard.py
     ${CMAKE_SOURCE_DIR}/scripts/generate_ppc_rtk_trajectory.py
+    ${CMAKE_SOURCE_DIR}/scripts/dump_taroz_p_debug.m
+    ${CMAKE_SOURCE_DIR}/scripts/dump_taroz_d_debug.m
+    ${CMAKE_SOURCE_DIR}/scripts/dump_taroz_pos_pdc_debug.m
+    ${CMAKE_SOURCE_DIR}/scripts/dump_taroz_pos_pd_debug.m
+    ${CMAKE_SOURCE_DIR}/scripts/dump_taroz_pos_vel_pdc_debug.m
+    ${CMAKE_SOURCE_DIR}/scripts/dump_taroz_pos_vel_ambiguity_pdc_debug.m
+    ${CMAKE_SOURCE_DIR}/scripts/dump_taroz_pd_debug.m
     ${CMAKE_SOURCE_DIR}/scripts/analyze_ppc_dual_profile_selector_matrix.py
     ${CMAKE_SOURCE_DIR}/scripts/apply_ppc_dual_profile_selector.py
     ${CMAKE_SOURCE_DIR}/scripts/analyze_ppc_profile_segment_delta.py

--- a/apps/gnss.py
+++ b/apps/gnss.py
@@ -19,6 +19,66 @@ COMMANDS = {
         "target": "gnss_spp",
         "summary": "Batch SPP post-processing from rover/nav RINEX files.",
     },
+    "fgo": {
+        "kind": "binary",
+        "target": "gnss_fgo",
+        "summary": "Batch factor-graph post-processing from rover/nav RINEX files.",
+    },
+    "vel-d": {
+        "kind": "binary",
+        "target": "gnss_vel_d",
+        "summary": "Taroz-style batch velocity and clock-drift estimation from Doppler.",
+    },
+    "pos-pd": {
+        "kind": "binary",
+        "target": "gnss_pos_pd",
+        "summary": "Taroz-style batch position and clock estimation from pseudorange plus Doppler between epochs.",
+    },
+    "pos-pdc": {
+        "kind": "binary",
+        "target": "gnss_pos_pdc",
+        "summary": "Taroz-style batch position and clock estimation from pseudorange, Doppler, and TDCP.",
+    },
+    "pos-vel-pd": {
+        "kind": "binary",
+        "target": "gnss_pos_vel_pd",
+        "summary": "Taroz-style batch position, velocity, clock, and drift estimation from pseudorange plus Doppler.",
+    },
+    "pos-vel-pdc": {
+        "kind": "binary",
+        "target": "gnss_pos_vel_pdc",
+        "summary": "Taroz-style batch position, velocity, clock, and drift estimation from pseudorange, Doppler, and TDCP.",
+    },
+    "compare-modes": {
+        "kind": "python",
+        "target": os.path.join(APPS_DIR, "gnss_mode_compare.py"),
+        "summary": "Run SPP/FGO/RTK on shared RINEX inputs and emit a mode-comparison JSON summary.",
+    },
+    "taroz-pc-dogfood": {
+        "kind": "python",
+        "target": os.path.join(APPS_DIR, "gnss_taroz_pc_dogfood.py"),
+        "summary": "Regenerate taroz PC FGO outputs and verify intermediate/final parity.",
+    },
+    "taroz-p-dogfood": {
+        "kind": "python",
+        "target": os.path.join(APPS_DIR, "gnss_taroz_p_dogfood.py"),
+        "summary": "Regenerate taroz P FGO smoke outputs and verify raw-pseudorange configuration.",
+    },
+    "taroz-pd-dogfood": {
+        "kind": "python",
+        "target": os.path.join(APPS_DIR, "gnss_taroz_pd_dogfood.py"),
+        "summary": "Regenerate taroz position/velocity PD outputs and verify internal parity.",
+    },
+    "taroz-pos-vel-amb-pdc-dogfood": {
+        "kind": "python",
+        "target": os.path.join(APPS_DIR, "gnss_taroz_pos_vel_amb_pdc_dogfood.py"),
+        "summary": "Regenerate taroz position/velocity ambiguity PDC FGO outputs and verify parity.",
+    },
+    "ppc-taroz-amb-pdc-smoke": {
+        "kind": "python",
+        "target": os.path.join(APPS_DIR, "gnss_ppc_taroz_amb_pdc_smoke.py"),
+        "summary": "Run taroz ambiguity PDC FGO checks on PPC-Dataset runs.",
+    },
     "solve": {
         "kind": "binary",
         "target": "gnss_solve",
@@ -366,6 +426,20 @@ def usage() -> str:
             "Examples:",
             "  python3 apps/gnss.py solve --data-dir data/driving --out output/rtk_solution.pos",
             "  python3 apps/gnss.py spp --obs data/rover_static.obs --nav data/navigation_static.nav --out output/spp_solution.pos",
+            "  python3 apps/gnss.py fgo --preset real-data-fixed --obs data/rover_static.obs --nav data/navigation_static.nav --out output/fgo_solution.pos --summary-json output/fgo_summary.json",
+            "  python3 apps/gnss.py vel-d --obs data/rover_1Hz.obs --nav data/base.nav --seed-pos data/rover_1Hz_spp.pos --out-csv output/velocity.csv",
+            "  python3 apps/gnss.py pos-pd --obs data/rover_1Hz.obs --nav data/base.nav --seed-pos data/rover_1Hz_spp.pos --out-csv output/pos_pd_state.csv",
+            "  python3 apps/gnss.py pos-pdc --obs data/rover_1Hz.obs --nav data/base.nav --seed-pos data/rover_1Hz_spp.pos --out-csv output/pos_pdc_state.csv",
+            "  python3 apps/gnss.py pos-vel-pd --obs data/rover_1Hz.obs --nav data/base.nav --seed-pos data/rover_1Hz_spp.pos --out-csv output/pd_state.csv",
+            "  python3 apps/gnss.py pos-vel-pdc --obs data/rover_1Hz.obs --nav data/base.nav --seed-pos data/rover_1Hz_spp.pos --out-csv output/pdc_state.csv",
+            "  python3 apps/gnss.py compare-modes --fgo-preset real-data --obs data/rover_kinematic.obs --base data/base_kinematic.obs --nav data/navigation_kinematic.nav --reference-csv data/reference.csv --max-epochs 120",
+            "  python3 apps/gnss.py taroz-p-dogfood --out-dir output/dogfood/taroz_p_dogfood_current",
+            "  python3 apps/gnss.py taroz-pd-dogfood --out-dir output/dogfood/taroz_pd_dogfood_current",
+            "  python3 apps/gnss.py taroz-pc-dogfood --out-dir output/dogfood/taroz_pc_dogfood_current",
+            "  python3 apps/gnss.py taroz-pos-vel-amb-pdc-dogfood --out-dir output/dogfood/taroz_pos_vel_amb_pdc_dogfood_current",
+            "  python3 apps/gnss.py ppc-taroz-amb-pdc-smoke --dataset-root /datasets/PPC-Dataset --max-epochs 200 --generate-spp-seed",
+            "  python3 apps/gnss.py compare-modes --modes spp,fgo,rtk --spp-pos output/spp.pos --fgo-pos output/fgo.pos --rtk-pos output/rtk.pos",
+            "  python3 apps/gnss.py compare-modes --modes fgo,rtk --fgo-pos output/fgo.pos --rtk-pos output/rtk.pos --require-pair-p95-3d-max fgo:rtk=2.0",
             "  python3 apps/gnss.py visibility --obs data/rover_static.obs --nav data/navigation_static.nav --csv output/visibility.csv --summary-json output/visibility.json --max-epochs 60",
             "  python3 apps/gnss.py visibility-plot output/visibility.csv output/visibility.png",
             "  python3 apps/gnss.py solve --rover data/rover_kinematic.obs --base data/base_kinematic.obs --nav data/navigation_kinematic.nav --iono est --max-epochs 5",
@@ -444,23 +518,35 @@ def usage() -> str:
 
 def find_binary(target_name: str) -> str | None:
     filename = target_name + EXE_SUFFIX
+    build_roots = [
+        path for path in sorted(glob.glob(os.path.join(ROOT_DIR, "build*")))
+        if os.path.isdir(path)
+    ]
+    default_build = os.path.join(ROOT_DIR, "build")
+    if default_build not in build_roots:
+        build_roots.insert(0, default_build)
+
     candidates = [
         os.path.join(APPS_DIR, filename),
-        os.path.join(ROOT_DIR, "build", "apps", filename),
     ]
-    for config in BUILD_CONFIGS:
-        candidates.append(os.path.join(ROOT_DIR, "build", "apps", config, filename))
-        candidates.append(os.path.join(ROOT_DIR, "build", config, "apps", filename))
-        candidates.append(os.path.join(ROOT_DIR, "build", config, filename))
+    for build_root in build_roots:
+        candidates.append(os.path.join(build_root, "apps", filename))
+        for config in BUILD_CONFIGS:
+            candidates.append(os.path.join(build_root, "apps", config, filename))
+            candidates.append(os.path.join(build_root, config, "apps", filename))
+            candidates.append(os.path.join(build_root, config, filename))
 
     for candidate in candidates:
         if os.path.isfile(candidate):
             return candidate
 
-    recursive_hits = sorted(
-        path for path in glob.glob(os.path.join(ROOT_DIR, "build", "**", filename), recursive=True)
-        if os.path.isfile(path)
-    )
+    recursive_hits: list[str] = []
+    for build_root in build_roots:
+        recursive_hits.extend(
+            path for path in glob.glob(os.path.join(build_root, "**", filename), recursive=True)
+            if os.path.isfile(path)
+        )
+    recursive_hits.sort()
     return recursive_hits[0] if recursive_hits else None
 
 

--- a/apps/gnss_fgo.cpp
+++ b/apps/gnss_fgo.cpp
@@ -1,0 +1,3406 @@
+#include <libgnss++/algorithms/fgo.hpp>
+#include <libgnss++/algorithms/lambda.hpp>
+#include <libgnss++/core/constants.hpp>
+#include <libgnss++/core/coordinates.hpp>
+#include <libgnss++/core/navigation.hpp>
+#include <libgnss++/core/signals.hpp>
+#include <libgnss++/io/rinex.hpp>
+#include <libgnss++/models/ionosphere.hpp>
+#include <libgnss++/models/troposphere.hpp>
+
+#ifdef GNSS_WITH_GTSAM
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam/nonlinear/Marginals.h>
+#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/nonlinear/PriorFactor.h>
+#include <gtsam/nonlinear/Values.h>
+#include <gtsam/slam/dataset.h>
+#endif
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstdlib>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace {
+
+struct Options {
+    std::string obs_path;
+    std::string base_path;
+    std::string nav_path;
+    std::string out_path;
+    std::string summary_json_path;
+    std::string epoch_debug_csv_path;
+    std::string factor_debug_csv_path;
+    std::string sd_factor_debug_csv_path;
+    std::string lambda_debug_csv_path;
+    std::string seed_pos_path;
+    std::string preset = "default";
+    std::string backend = "eigen";
+    int max_epochs = 0;
+    int skip_epochs = 0;
+    int max_iterations = 8;
+    double relative_cost_convergence_threshold = 0.0;
+    double absolute_cost_convergence_threshold = 0.0;
+    double pseudorange_sigma_m = 3.0;
+    double pseudorange_elevation_sigma_power = 1.0;
+    double motion_sigma_m = 50.0;
+    double clock_motion_sigma_m = 300.0;
+    double velocity_prior_sigma_mps = 100.0;
+    double velocity_motion_sigma_m = 0.01;
+    double ambiguity_between_sigma_cycles = 0.001;
+    double position_prior_sigma_m = 0.0;
+    double clock_prior_sigma_m = 0.0;
+    double tdcp_sigma_m = 0.03;
+    double carrier_phase_sigma_m = 0.01;
+    double double_difference_pseudorange_sigma_m = 1.0;
+    double double_difference_carrier_sigma_m = 0.02;
+    double ambiguity_prior_sigma_m = 1000.0;
+    double pseudorange_huber_threshold_sigma = 4.0;
+    double carrier_phase_huber_threshold_sigma = 4.0;
+    double tdcp_huber_threshold_sigma = 4.0;
+    double fixed_ambiguity_sigma_m = 0.003;
+    double ambiguity_fix_threshold_cycles = 0.15;
+    double lambda_ratio_threshold = 3.0;
+    double max_tdcp_gap_s = 2.0;
+    double base_match_tolerance_s = 0.02;
+    double base_interpolation_max_gap_s = 1.2;
+    double seed_match_tolerance_s = 0.01;
+    double seed_interpolation_max_gap_s = 0.0;
+    double tdcp_slip_threshold_m = 10.0;
+    double min_elevation_deg = 10.0;
+    double min_snr_dbhz = 0.0;
+    double double_difference_reference_min_snr_dbhz = -1.0;
+    double double_difference_base_min_snr_dbhz = -1.0;
+    int min_satellites_per_epoch = 4;
+    int min_output_dd_carrier_factors_per_epoch = 0;
+    int min_fixed_ambiguities = 4;
+    int max_lambda_ambiguities = 12;
+    bool use_carrier_phase_factors = false;
+    bool fix_ambiguities = false;
+    bool fix_all_ambiguities = false;
+    bool use_lambda_ambiguity_fix = true;
+    bool use_epoch_lambda_fixed_output = false;
+    bool use_partial_lambda_ambiguity_fix = true;
+    bool use_robust_loss = true;
+    bool no_pseudorange_factors = false;
+    bool no_double_difference_factors = false;
+    bool use_single_difference_doppler_factors = false;
+    bool use_single_difference_tdcp_factors = false;
+    bool use_velocity_states = false;
+    bool use_velocity_motion_factors = false;
+    bool use_ambiguity_between_factors = false;
+    bool linearize_double_difference_factors_at_seed = false;
+    bool dd_ambiguity_per_epoch = false;
+    bool no_ambiguity_priors = false;
+    bool no_spp_seed = false;
+    bool no_motion_factors = false;
+    bool clock_only_motion_factors = false;
+    bool no_tdcp_factors = false;
+    bool no_tdcp_slip_reject = false;
+    bool reject_rover_carrier_lli = false;
+    bool exclude_glonass_qzss_sbas = false;
+    bool insert_fixed_interval_gaps = false;
+    bool use_ionosphere_model = true;
+    bool use_troposphere_model = true;
+    bool debug_problem_only = false;
+    bool quiet = false;
+};
+
+void printUsage(const char* program_name) {
+    std::cout
+        << "Usage: " << program_name << " --obs <rover.obs> --nav <nav.rnx> --out <solution.pos>\n"
+        << "Options:\n"
+        << "  --obs <rover.obs>             RINEX observation file\n"
+        << "  --base <base.obs>             Optional base RINEX for double-difference carrier factors\n"
+        << "  --nav <nav.rnx>               RINEX navigation file\n"
+        << "  --out <solution.pos>          Output position file\n"
+        << "  --summary-json <summary.json> Write machine-readable run summary\n"
+        << "  --epoch-debug-csv <debug.csv> Write per-epoch FGO diagnostics\n"
+        << "  --factor-debug-csv <debug.csv>\n"
+        << "                                Write per-DD-factor residual diagnostics\n"
+        << "  --sd-factor-debug-csv <debug.csv>\n"
+        << "                                Write taroz SD Doppler/TDCP diagnostics\n"
+        << "  --lambda-debug-csv <debug.csv>\n"
+        << "                                Write per-LAMBDA ambiguity/covariance diagnostics\n"
+        << "  --debug-problem-only          Build factors and debug outputs without optimizing\n"
+        << "  --seed-pos <solution.pos>     Use LibGNSS++/RTKLIB POS rows as epoch initial positions\n"
+        << "  --backend <name>              Optimizer backend: eigen, gtsam-pc (if built with GTSAM)\n"
+        << "  --preset <name>               Defaults: default, real-data, real-data-float,\n"
+        << "                                real-data-fixed, tdcp-only, taroz-p,\n"
+        << "                                taroz-pc, taroz-amb-pdc\n"
+        << "  --skip-epochs <n>             Skip the first n rover epochs before solving\n"
+        << "  --max-epochs <n>              Stop after n epochs\n"
+        << "  --max-iterations <n>          Batch Gauss-Newton iterations (default: 8)\n"
+        << "  --relative-cost-threshold <v> Stop when relative cost decrease is below v\n"
+        << "  --absolute-cost-threshold <v> Stop when absolute cost decrease is below v\n"
+        << "  --pseudorange-sigma <m>       Code factor sigma in meters (default: 3)\n"
+        << "  --pseudorange-elevation-power <p>\n"
+        << "                                Code sigma elevation exponent (default: 1)\n"
+        << "  --motion-sigma <m>            Adjacent position smoothness sigma (default: 50)\n"
+        << "  --clock-motion-sigma <m>      Adjacent clock smoothness sigma (default: 300)\n"
+        << "  --velocity-prior-sigma <m/s>  Velocity prior sigma (default: 100)\n"
+        << "  --velocity-motion-sigma <m>   Taroz XXVV motion factor sigma (default: 0.01)\n"
+        << "  --ambiguity-between-sigma <cycles>\n"
+        << "                                Taroz ambiguity between sigma (default: 0.001)\n"
+        << "  --position-prior-sigma <m>    Weak position prior sigma; 0 disables (default: 0)\n"
+        << "  --clock-prior-sigma <m>       Weak clock prior sigma; 0 disables (default: 0)\n"
+        << "  --tdcp-sigma <m>              TDCP factor sigma in meters (default: 0.03)\n"
+        << "  --carrier-phase-sigma <m>     Carrier phase sigma in meters (default: 0.01)\n"
+        << "  --dd-pseudorange-sigma <m>    Double-difference code sigma in meters (default: 1)\n"
+        << "  --dd-carrier-sigma <m>        Double-difference carrier sigma in meters (default: 0.02)\n"
+        << "  --ambiguity-prior-sigma <m>   Weak float ambiguity prior sigma (default: 1000)\n"
+        << "  --pseudorange-huber-threshold <s>\n"
+        << "                                Code Huber threshold in sigma units (default: 4)\n"
+        << "  --carrier-phase-huber-threshold <s>\n"
+        << "                                Carrier Huber threshold in sigma units (default: 4)\n"
+        << "  --tdcp-huber-threshold <s>    TDCP Huber threshold in sigma units (default: 4)\n"
+        << "  --fixed-ambiguity-sigma <m>   Fixed ambiguity constraint sigma (default: 0.003)\n"
+        << "  --ambiguity-fix-threshold <c> Max fractional cycles for nearest-int fix (default: 0.15)\n"
+        << "  --min-fixed-ambiguities <n>   Min accepted ambiguities before fixed pass (default: 4)\n"
+        << "  --lambda-ratio-threshold <v>  LAMBDA ratio threshold (default: 3)\n"
+        << "  --max-lambda-ambiguities <n>  Max ambiguity states passed to LAMBDA (default: 12)\n"
+        << "  --max-tdcp-gap <s>            Max adjacent epoch gap for TDCP (default: 2)\n"
+        << "  --base-match-tolerance <s>    Max rover/base epoch gap for DD factors (default: 0.02)\n"
+        << "  --base-interpolation-max-gap <s>\n"
+        << "                                Max bracketing base epoch gap for interpolation (default: 1.2)\n"
+        << "  --seed-match-tolerance <s>    Max rover/seed POS epoch gap (default: 0.01)\n"
+        << "  --seed-interpolation-max-gap <s>\n"
+        << "                                Interpolate seed POS across gaps up to this length (default: 0)\n"
+        << "  --tdcp-slip-threshold <m>     Max TDCP/code delta mismatch (default: 10)\n"
+        << "  --min-elevation <deg>         Elevation mask in degrees (default: 10)\n"
+        << "  --min-snr <dbhz>              SNR mask in dB-Hz (default: 0)\n"
+        << "  --min-satellites-per-epoch <n>\n"
+        << "                                Minimum usable measurements before keeping epoch (default: 4)\n"
+        << "  --min-output-dd-carrier-factors-per-epoch <n>\n"
+        << "                                Mark DD-only output epochs NONE below this carrier factor count\n"
+        << "  --dd-reference-min-snr <dbhz> Rover reference SNR mask for DD (-1 inherits --min-snr)\n"
+        << "  --dd-base-min-snr <dbhz>      Base SNR mask for DD factors (-1 inherits --min-snr)\n"
+        << "  --carrier-phase-factors       Enable float ambiguity carrier phase factors\n"
+        << "  --fix-ambiguities             Enable ambiguity fixed pass\n"
+        << "  --fix-all-ambiguities         Include non-DD carrier ambiguities in fixed pass\n"
+        << "  --no-lambda-ambiguity-fix     Use nearest-integer fixed pass instead of LAMBDA\n"
+        << "  --epoch-lambda-fixed-output   Apply per-epoch LAMBDA fixed position output\n"
+        << "  --no-epoch-lambda-fixed-output\n"
+        << "                                Keep optimized float positions in output\n"
+        << "  --no-partial-lambda-ambiguity-fix\n"
+        << "                                Disable partial LAMBDA retry with fewer candidates\n"
+        << "  --no-pseudorange-factors      Do not add raw pseudorange factors\n"
+        << "  --no-dd-factors               Ignore --base for FGO double-difference factors\n"
+        << "  --sd-doppler-factors          Add taroz-style SD Doppler factors\n"
+        << "  --sd-tdcp-factors             Add taroz-style SD TDCP factors\n"
+        << "  --velocity-states             Add per-epoch 3D velocity states\n"
+        << "  --velocity-motion-factors     Add taroz XXVV position/velocity motion factors\n"
+        << "  --ambiguity-between-factors   Add taroz epoch-to-epoch ambiguity constraints\n"
+        << "  --dd-ambiguity-per-epoch      Do not carry DD ambiguity states across epochs\n"
+        << "  --no-ambiguity-priors         Disable weak ambiguity prior factors\n"
+        << "  --reject-rover-carrier-lli    Drop rover carrier observations with LLI=1\n"
+        << "  --no-spp-seed                 Use receiver/seed POS initial positions instead of per-epoch SPP\n"
+        << "  --no-robust-loss              Disable Huber robust weighting\n"
+        << "  --no-motion-factors           Disable adjacent epoch smoothness factors\n"
+        << "  --clock-only-motion-factors   Keep clock smoothness but disable position smoothness\n"
+        << "  --no-tdcp-factors             Disable time-differenced carrier phase factors\n"
+        << "  --no-tdcp-slip-reject         Keep TDCP factors even when code/phase jump check fails\n"
+        << "  --ionosphere-model            Enable broadcast ionosphere correction\n"
+        << "  --no-ionosphere-model         Disable broadcast ionosphere correction\n"
+        << "  --troposphere-model           Enable Saastamoinen troposphere correction\n"
+        << "  --no-troposphere-model        Disable Saastamoinen troposphere correction\n"
+        << "  --exclude-glo-qzs-sbs         Exclude GLONASS, QZSS, and SBAS observations\n"
+        << "  --insert-fixed-interval-gaps  Insert empty fixed-interval epochs before building factors\n"
+        << "  --quiet                       Suppress run summary\n"
+        << "  -h, --help                    Show this help\n";
+}
+
+[[noreturn]] void argumentError(const std::string& message, const char* program_name) {
+    std::cerr << "Argument error: " << message << "\n\n";
+    printUsage(program_name);
+    std::exit(1);
+}
+
+void applyRealDataFloatPreset(Options& options) {
+    options.max_iterations = 12;
+    options.pseudorange_sigma_m = 4.0;
+    options.motion_sigma_m = 100.0;
+    options.clock_motion_sigma_m = 600.0;
+    options.tdcp_sigma_m = 0.05;
+    options.carrier_phase_sigma_m = 0.02;
+    options.double_difference_pseudorange_sigma_m = 1.0;
+    options.double_difference_carrier_sigma_m = 0.02;
+    options.ambiguity_prior_sigma_m = 2000.0;
+    options.pseudorange_huber_threshold_sigma = 3.0;
+    options.carrier_phase_huber_threshold_sigma = 3.0;
+    options.tdcp_huber_threshold_sigma = 3.0;
+    options.max_tdcp_gap_s = 1.5;
+    options.base_match_tolerance_s = 0.02;
+    options.base_interpolation_max_gap_s = 1.2;
+    options.tdcp_slip_threshold_m = 6.0;
+    options.min_elevation_deg = 15.0;
+    options.use_carrier_phase_factors = false;
+    options.fix_ambiguities = false;
+    options.use_lambda_ambiguity_fix = true;
+    options.use_partial_lambda_ambiguity_fix = true;
+    options.use_robust_loss = true;
+    options.no_motion_factors = false;
+    options.no_tdcp_factors = false;
+    options.no_tdcp_slip_reject = false;
+}
+
+void applyTarozPcPreset(Options& options) {
+    options.backend = "gtsam-pc";
+    options.max_iterations = 1000;
+    options.double_difference_pseudorange_sigma_m = 1.0;
+    options.double_difference_carrier_sigma_m = 0.003;
+    options.ambiguity_prior_sigma_m = 1e6;
+    options.pseudorange_huber_threshold_sigma = 1.234;
+    options.carrier_phase_huber_threshold_sigma = 1.234;
+    options.lambda_ratio_threshold = 2.0;
+    options.min_fixed_ambiguities = 5;
+    options.min_elevation_deg = 15.0;
+    options.min_snr_dbhz = 35.0;
+    options.double_difference_reference_min_snr_dbhz = 0.0;
+    options.double_difference_base_min_snr_dbhz = 0.0;
+    options.seed_interpolation_max_gap_s = 30.0;
+    options.no_spp_seed = true;
+    options.use_carrier_phase_factors = false;
+    options.fix_ambiguities = false;
+    options.use_lambda_ambiguity_fix = true;
+    options.use_partial_lambda_ambiguity_fix = true;
+    options.use_robust_loss = true;
+    options.no_pseudorange_factors = true;
+    options.no_motion_factors = true;
+    options.no_tdcp_factors = true;
+    options.dd_ambiguity_per_epoch = true;
+    options.no_ambiguity_priors = true;
+    options.reject_rover_carrier_lli = true;
+    options.exclude_glonass_qzss_sbas = true;
+    options.use_ionosphere_model = false;
+    options.use_troposphere_model = false;
+}
+
+void applyTarozAmbPdcPreset(Options& options) {
+    applyTarozPcPreset(options);
+    options.backend = "eigen";
+    options.min_satellites_per_epoch = 0;
+    options.min_output_dd_carrier_factors_per_epoch = 6;
+    options.insert_fixed_interval_gaps = true;
+    options.fix_ambiguities = false;
+    options.no_motion_factors = true;
+    options.no_tdcp_factors = true;
+    options.use_single_difference_doppler_factors = true;
+    options.use_single_difference_tdcp_factors = true;
+    options.tdcp_huber_threshold_sigma = 1.234;
+    options.use_velocity_states = true;
+    options.use_velocity_motion_factors = true;
+    options.velocity_prior_sigma_mps = 100.0;
+    options.velocity_motion_sigma_m = 0.01;
+    options.use_ambiguity_between_factors = true;
+    options.linearize_double_difference_factors_at_seed = true;
+    options.ambiguity_between_sigma_cycles = 0.001;
+    options.use_epoch_lambda_fixed_output = true;
+    options.relative_cost_convergence_threshold = 1e-5;
+    options.absolute_cost_convergence_threshold = 1e-5;
+    options.no_ambiguity_priors = true;
+}
+
+void applyTarozPPreset(Options& options) {
+    options.backend = "eigen";
+    options.max_iterations = 1000;
+    options.pseudorange_sigma_m = 3.0;
+    options.pseudorange_elevation_sigma_power = 0.5;
+    options.position_prior_sigma_m = 1e3;
+    options.clock_prior_sigma_m = 1e6;
+    options.clock_motion_sigma_m = 100.0;
+    options.pseudorange_huber_threshold_sigma = 1.234;
+    options.min_elevation_deg = 15.0;
+    options.min_snr_dbhz = 35.0;
+    options.seed_interpolation_max_gap_s = 30.0;
+    options.no_spp_seed = true;
+    options.use_carrier_phase_factors = false;
+    options.fix_ambiguities = false;
+    options.use_lambda_ambiguity_fix = true;
+    options.use_partial_lambda_ambiguity_fix = true;
+    options.use_robust_loss = true;
+    options.no_pseudorange_factors = false;
+    options.no_double_difference_factors = true;
+    options.no_motion_factors = false;
+    options.clock_only_motion_factors = true;
+    options.no_tdcp_factors = true;
+    options.no_ambiguity_priors = true;
+    options.reject_rover_carrier_lli = false;
+    options.exclude_glonass_qzss_sbas = false;
+    options.use_ionosphere_model = true;
+    options.use_troposphere_model = true;
+}
+
+void applyPresetDefaults(Options& options, const char* program_name) {
+    if (options.preset == "default") {
+        return;
+    }
+    if (options.preset == "real-data" ||
+        options.preset == "real-data-float") {
+        applyRealDataFloatPreset(options);
+        return;
+    }
+    if (options.preset == "real-data-fixed") {
+        applyRealDataFloatPreset(options);
+        options.fix_ambiguities = true;
+        options.lambda_ratio_threshold = 1.5;
+        options.min_fixed_ambiguities = 6;
+        options.max_lambda_ambiguities = 16;
+        options.fixed_ambiguity_sigma_m = 0.005;
+        return;
+    }
+    if (options.preset == "tdcp-only") {
+        options.max_iterations = 12;
+        options.pseudorange_sigma_m = 4.0;
+        options.motion_sigma_m = 100.0;
+        options.clock_motion_sigma_m = 600.0;
+        options.tdcp_sigma_m = 0.05;
+        options.double_difference_pseudorange_sigma_m = 1.0;
+        options.double_difference_carrier_sigma_m = 0.02;
+        options.pseudorange_huber_threshold_sigma = 3.0;
+        options.tdcp_huber_threshold_sigma = 3.0;
+        options.max_tdcp_gap_s = 1.5;
+        options.base_match_tolerance_s = 0.02;
+        options.base_interpolation_max_gap_s = 1.2;
+        options.tdcp_slip_threshold_m = 6.0;
+        options.min_elevation_deg = 15.0;
+        options.use_carrier_phase_factors = false;
+        options.fix_ambiguities = false;
+        options.use_robust_loss = true;
+        options.no_motion_factors = false;
+        options.no_tdcp_factors = false;
+        options.no_tdcp_slip_reject = false;
+        return;
+    }
+    if (options.preset == "taroz-p") {
+        applyTarozPPreset(options);
+        return;
+    }
+    if (options.preset == "taroz-pc") {
+        applyTarozPcPreset(options);
+        return;
+    }
+    if (options.preset == "taroz-amb-pdc") {
+        applyTarozAmbPdcPreset(options);
+        return;
+    }
+    argumentError("unsupported --preset value: " + options.preset, program_name);
+}
+
+Options parseArguments(int argc, char* argv[]) {
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "-h" || arg == "--help") {
+            printUsage(argv[0]);
+            std::exit(0);
+        }
+        if (arg == "--preset" && i + 1 < argc) {
+            options.preset = argv[++i];
+        } else if (arg == "--preset") {
+            argumentError("unknown or incomplete argument: " + arg, argv[0]);
+        }
+    }
+    applyPresetDefaults(options, argv[0]);
+
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "-h" || arg == "--help") {
+            printUsage(argv[0]);
+            std::exit(0);
+        } else if (arg == "--obs" && i + 1 < argc) {
+            options.obs_path = argv[++i];
+        } else if (arg == "--base" && i + 1 < argc) {
+            options.base_path = argv[++i];
+        } else if (arg == "--nav" && i + 1 < argc) {
+            options.nav_path = argv[++i];
+        } else if (arg == "--out" && i + 1 < argc) {
+            options.out_path = argv[++i];
+        } else if (arg == "--summary-json" && i + 1 < argc) {
+            options.summary_json_path = argv[++i];
+        } else if (arg == "--epoch-debug-csv" && i + 1 < argc) {
+            options.epoch_debug_csv_path = argv[++i];
+        } else if (arg == "--factor-debug-csv" && i + 1 < argc) {
+            options.factor_debug_csv_path = argv[++i];
+        } else if (arg == "--sd-factor-debug-csv" && i + 1 < argc) {
+            options.sd_factor_debug_csv_path = argv[++i];
+        } else if (arg == "--lambda-debug-csv" && i + 1 < argc) {
+            options.lambda_debug_csv_path = argv[++i];
+        } else if (arg == "--seed-pos" && i + 1 < argc) {
+            options.seed_pos_path = argv[++i];
+        } else if (arg == "--backend" && i + 1 < argc) {
+            options.backend = argv[++i];
+        } else if (arg == "--preset" && i + 1 < argc) {
+            ++i;
+        } else if (arg == "--skip-epochs" && i + 1 < argc) {
+            options.skip_epochs = std::stoi(argv[++i]);
+        } else if (arg == "--max-epochs" && i + 1 < argc) {
+            options.max_epochs = std::stoi(argv[++i]);
+        } else if (arg == "--max-iterations" && i + 1 < argc) {
+            options.max_iterations = std::stoi(argv[++i]);
+        } else if (arg == "--relative-cost-threshold" && i + 1 < argc) {
+            options.relative_cost_convergence_threshold = std::stod(argv[++i]);
+        } else if (arg == "--absolute-cost-threshold" && i + 1 < argc) {
+            options.absolute_cost_convergence_threshold = std::stod(argv[++i]);
+        } else if (arg == "--pseudorange-sigma" && i + 1 < argc) {
+            options.pseudorange_sigma_m = std::stod(argv[++i]);
+        } else if (arg == "--pseudorange-elevation-power" && i + 1 < argc) {
+            options.pseudorange_elevation_sigma_power = std::stod(argv[++i]);
+        } else if (arg == "--motion-sigma" && i + 1 < argc) {
+            options.motion_sigma_m = std::stod(argv[++i]);
+        } else if (arg == "--clock-motion-sigma" && i + 1 < argc) {
+            options.clock_motion_sigma_m = std::stod(argv[++i]);
+        } else if (arg == "--velocity-prior-sigma" && i + 1 < argc) {
+            options.velocity_prior_sigma_mps = std::stod(argv[++i]);
+        } else if (arg == "--velocity-motion-sigma" && i + 1 < argc) {
+            options.velocity_motion_sigma_m = std::stod(argv[++i]);
+        } else if (arg == "--ambiguity-between-sigma" && i + 1 < argc) {
+            options.ambiguity_between_sigma_cycles = std::stod(argv[++i]);
+        } else if (arg == "--position-prior-sigma" && i + 1 < argc) {
+            options.position_prior_sigma_m = std::stod(argv[++i]);
+        } else if (arg == "--clock-prior-sigma" && i + 1 < argc) {
+            options.clock_prior_sigma_m = std::stod(argv[++i]);
+        } else if (arg == "--tdcp-sigma" && i + 1 < argc) {
+            options.tdcp_sigma_m = std::stod(argv[++i]);
+        } else if (arg == "--carrier-phase-sigma" && i + 1 < argc) {
+            options.carrier_phase_sigma_m = std::stod(argv[++i]);
+        } else if (arg == "--dd-pseudorange-sigma" && i + 1 < argc) {
+            options.double_difference_pseudorange_sigma_m = std::stod(argv[++i]);
+        } else if (arg == "--dd-carrier-sigma" && i + 1 < argc) {
+            options.double_difference_carrier_sigma_m = std::stod(argv[++i]);
+        } else if (arg == "--ambiguity-prior-sigma" && i + 1 < argc) {
+            options.ambiguity_prior_sigma_m = std::stod(argv[++i]);
+        } else if (arg == "--pseudorange-huber-threshold" && i + 1 < argc) {
+            options.pseudorange_huber_threshold_sigma = std::stod(argv[++i]);
+        } else if (arg == "--carrier-phase-huber-threshold" && i + 1 < argc) {
+            options.carrier_phase_huber_threshold_sigma = std::stod(argv[++i]);
+        } else if (arg == "--tdcp-huber-threshold" && i + 1 < argc) {
+            options.tdcp_huber_threshold_sigma = std::stod(argv[++i]);
+        } else if (arg == "--fixed-ambiguity-sigma" && i + 1 < argc) {
+            options.fixed_ambiguity_sigma_m = std::stod(argv[++i]);
+        } else if (arg == "--ambiguity-fix-threshold" && i + 1 < argc) {
+            options.ambiguity_fix_threshold_cycles = std::stod(argv[++i]);
+        } else if (arg == "--min-fixed-ambiguities" && i + 1 < argc) {
+            options.min_fixed_ambiguities = std::stoi(argv[++i]);
+        } else if (arg == "--lambda-ratio-threshold" && i + 1 < argc) {
+            options.lambda_ratio_threshold = std::stod(argv[++i]);
+        } else if (arg == "--max-lambda-ambiguities" && i + 1 < argc) {
+            options.max_lambda_ambiguities = std::stoi(argv[++i]);
+        } else if (arg == "--max-tdcp-gap" && i + 1 < argc) {
+            options.max_tdcp_gap_s = std::stod(argv[++i]);
+        } else if (arg == "--base-match-tolerance" && i + 1 < argc) {
+            options.base_match_tolerance_s = std::stod(argv[++i]);
+        } else if (arg == "--base-interpolation-max-gap" && i + 1 < argc) {
+            options.base_interpolation_max_gap_s = std::stod(argv[++i]);
+        } else if (arg == "--seed-match-tolerance" && i + 1 < argc) {
+            options.seed_match_tolerance_s = std::stod(argv[++i]);
+        } else if (arg == "--seed-interpolation-max-gap" && i + 1 < argc) {
+            options.seed_interpolation_max_gap_s = std::stod(argv[++i]);
+        } else if (arg == "--tdcp-slip-threshold" && i + 1 < argc) {
+            options.tdcp_slip_threshold_m = std::stod(argv[++i]);
+        } else if (arg == "--min-elevation" && i + 1 < argc) {
+            options.min_elevation_deg = std::stod(argv[++i]);
+        } else if (arg == "--min-snr" && i + 1 < argc) {
+            options.min_snr_dbhz = std::stod(argv[++i]);
+        } else if (arg == "--min-satellites-per-epoch" && i + 1 < argc) {
+            options.min_satellites_per_epoch = std::stoi(argv[++i]);
+        } else if (arg == "--min-output-dd-carrier-factors-per-epoch" &&
+                   i + 1 < argc) {
+            options.min_output_dd_carrier_factors_per_epoch =
+                std::stoi(argv[++i]);
+        } else if (arg == "--dd-reference-min-snr" && i + 1 < argc) {
+            options.double_difference_reference_min_snr_dbhz = std::stod(argv[++i]);
+        } else if (arg == "--dd-base-min-snr" && i + 1 < argc) {
+            options.double_difference_base_min_snr_dbhz = std::stod(argv[++i]);
+        } else if (arg == "--carrier-phase-factors") {
+            options.use_carrier_phase_factors = true;
+        } else if (arg == "--fix-ambiguities") {
+            options.fix_ambiguities = true;
+        } else if (arg == "--fix-all-ambiguities") {
+            options.fix_all_ambiguities = true;
+        } else if (arg == "--no-lambda-ambiguity-fix") {
+            options.use_lambda_ambiguity_fix = false;
+        } else if (arg == "--epoch-lambda-fixed-output") {
+            options.use_epoch_lambda_fixed_output = true;
+        } else if (arg == "--no-epoch-lambda-fixed-output") {
+            options.use_epoch_lambda_fixed_output = false;
+        } else if (arg == "--no-partial-lambda-ambiguity-fix") {
+            options.use_partial_lambda_ambiguity_fix = false;
+        } else if (arg == "--no-pseudorange-factors") {
+            options.no_pseudorange_factors = true;
+        } else if (arg == "--no-dd-factors") {
+            options.no_double_difference_factors = true;
+        } else if (arg == "--sd-doppler-factors") {
+            options.use_single_difference_doppler_factors = true;
+        } else if (arg == "--sd-tdcp-factors") {
+            options.use_single_difference_tdcp_factors = true;
+        } else if (arg == "--velocity-states") {
+            options.use_velocity_states = true;
+        } else if (arg == "--velocity-motion-factors") {
+            options.use_velocity_motion_factors = true;
+            options.use_velocity_states = true;
+        } else if (arg == "--ambiguity-between-factors") {
+            options.use_ambiguity_between_factors = true;
+        } else if (arg == "--dd-ambiguity-per-epoch") {
+            options.dd_ambiguity_per_epoch = true;
+        } else if (arg == "--no-ambiguity-priors") {
+            options.no_ambiguity_priors = true;
+        } else if (arg == "--reject-rover-carrier-lli") {
+            options.reject_rover_carrier_lli = true;
+        } else if (arg == "--no-spp-seed") {
+            options.no_spp_seed = true;
+        } else if (arg == "--no-robust-loss") {
+            options.use_robust_loss = false;
+        } else if (arg == "--no-motion-factors") {
+            options.no_motion_factors = true;
+        } else if (arg == "--clock-only-motion-factors") {
+            options.clock_only_motion_factors = true;
+        } else if (arg == "--no-tdcp-factors") {
+            options.no_tdcp_factors = true;
+        } else if (arg == "--no-tdcp-slip-reject") {
+            options.no_tdcp_slip_reject = true;
+        } else if (arg == "--ionosphere-model") {
+            options.use_ionosphere_model = true;
+        } else if (arg == "--no-ionosphere-model") {
+            options.use_ionosphere_model = false;
+        } else if (arg == "--troposphere-model") {
+            options.use_troposphere_model = true;
+        } else if (arg == "--no-troposphere-model") {
+            options.use_troposphere_model = false;
+        } else if (arg == "--debug-problem-only") {
+            options.debug_problem_only = true;
+        } else if (arg == "--exclude-glo-qzs-sbs") {
+            options.exclude_glonass_qzss_sbas = true;
+        } else if (arg == "--insert-fixed-interval-gaps") {
+            options.insert_fixed_interval_gaps = true;
+        } else if (arg == "--quiet") {
+            options.quiet = true;
+        } else {
+            argumentError("unknown or incomplete argument: " + arg, argv[0]);
+        }
+    }
+
+    if (options.obs_path.empty()) {
+        argumentError("--obs is required", argv[0]);
+    }
+    if (options.nav_path.empty()) {
+        argumentError("--nav is required", argv[0]);
+    }
+    if (options.out_path.empty()) {
+        argumentError("--out is required", argv[0]);
+    }
+    if (options.backend != "eigen" && options.backend != "gtsam-pc") {
+        argumentError("--backend must be eigen or gtsam-pc", argv[0]);
+    }
+    if (options.max_epochs < 0) {
+        argumentError("--max-epochs must be non-negative", argv[0]);
+    }
+    if (options.skip_epochs < 0) {
+        argumentError("--skip-epochs must be non-negative", argv[0]);
+    }
+    if (options.max_iterations <= 0) {
+        argumentError("--max-iterations must be positive", argv[0]);
+    }
+    if (options.relative_cost_convergence_threshold < 0.0 ||
+        options.absolute_cost_convergence_threshold < 0.0) {
+        argumentError("cost convergence thresholds must be non-negative", argv[0]);
+    }
+    if (options.pseudorange_sigma_m <= 0.0 ||
+        options.motion_sigma_m <= 0.0 ||
+        options.clock_motion_sigma_m <= 0.0 ||
+        options.velocity_prior_sigma_mps <= 0.0 ||
+        options.velocity_motion_sigma_m <= 0.0 ||
+        options.ambiguity_between_sigma_cycles <= 0.0 ||
+        options.tdcp_sigma_m <= 0.0 ||
+        options.carrier_phase_sigma_m <= 0.0 ||
+        options.double_difference_pseudorange_sigma_m <= 0.0 ||
+        options.double_difference_carrier_sigma_m <= 0.0 ||
+        options.ambiguity_prior_sigma_m <= 0.0 ||
+        options.fixed_ambiguity_sigma_m <= 0.0) {
+        argumentError("sigma values must be positive", argv[0]);
+    }
+    if (options.pseudorange_elevation_sigma_power < 0.0) {
+        argumentError("--pseudorange-elevation-power must be non-negative", argv[0]);
+    }
+    if (options.position_prior_sigma_m < 0.0 ||
+        options.clock_prior_sigma_m < 0.0) {
+        argumentError("prior sigma values must be non-negative", argv[0]);
+    }
+    if (options.ambiguity_fix_threshold_cycles < 0.0) {
+        argumentError("--ambiguity-fix-threshold must be non-negative", argv[0]);
+    }
+    if (options.pseudorange_huber_threshold_sigma < 0.0 ||
+        options.carrier_phase_huber_threshold_sigma < 0.0 ||
+        options.tdcp_huber_threshold_sigma < 0.0) {
+        argumentError("Huber thresholds must be non-negative", argv[0]);
+    }
+    if (options.lambda_ratio_threshold < 0.0) {
+        argumentError("--lambda-ratio-threshold must be non-negative", argv[0]);
+    }
+    if (options.min_fixed_ambiguities <= 0) {
+        argumentError("--min-fixed-ambiguities must be positive", argv[0]);
+    }
+    if (options.min_satellites_per_epoch < 0) {
+        argumentError("--min-satellites-per-epoch must be non-negative", argv[0]);
+    }
+    if (options.min_output_dd_carrier_factors_per_epoch < 0) {
+        argumentError(
+            "--min-output-dd-carrier-factors-per-epoch must be non-negative",
+            argv[0]);
+    }
+    if (options.max_lambda_ambiguities < 0) {
+        argumentError("--max-lambda-ambiguities must be non-negative", argv[0]);
+    }
+    if (options.max_tdcp_gap_s < 0.0) {
+        argumentError("--max-tdcp-gap must be non-negative", argv[0]);
+    }
+    if (options.base_match_tolerance_s < 0.0) {
+        argumentError("--base-match-tolerance must be non-negative", argv[0]);
+    }
+    if (options.base_interpolation_max_gap_s < 0.0) {
+        argumentError("--base-interpolation-max-gap must be non-negative", argv[0]);
+    }
+    if (options.seed_match_tolerance_s < 0.0) {
+        argumentError("--seed-match-tolerance must be non-negative", argv[0]);
+    }
+    if (options.seed_interpolation_max_gap_s < 0.0) {
+        argumentError("--seed-interpolation-max-gap must be non-negative", argv[0]);
+    }
+    if (options.tdcp_slip_threshold_m < 0.0) {
+        argumentError("--tdcp-slip-threshold must be non-negative", argv[0]);
+    }
+    if (options.double_difference_base_min_snr_dbhz < -1.0) {
+        argumentError("--dd-base-min-snr must be >= -1", argv[0]);
+    }
+    if (options.double_difference_reference_min_snr_dbhz < -1.0) {
+        argumentError("--dd-reference-min-snr must be >= -1", argv[0]);
+    }
+    return options;
+}
+
+double ratePercent(std::size_t numerator, std::size_t denominator) {
+    if (denominator == 0) {
+        return 0.0;
+    }
+    return 100.0 * static_cast<double>(numerator) /
+           static_cast<double>(denominator);
+}
+
+std::string formatPercent(double value) {
+    std::ostringstream formatted;
+    formatted << std::fixed << std::setprecision(2) << value;
+    return formatted.str();
+}
+
+bool isTarozExcludedSystem(libgnss::GNSSSystem system) {
+    return system == libgnss::GNSSSystem::GLONASS ||
+           system == libgnss::GNSSSystem::QZSS ||
+           system == libgnss::GNSSSystem::SBAS;
+}
+
+void applySystemFilter(libgnss::ObservationData& epoch, const Options& options) {
+    if (!options.exclude_glonass_qzss_sbas) {
+        return;
+    }
+    epoch.observations.erase(
+        std::remove_if(epoch.observations.begin(),
+                       epoch.observations.end(),
+                       [](const libgnss::Observation& observation) {
+                           return isTarozExcludedSystem(
+                               observation.satellite.system);
+                       }),
+        epoch.observations.end());
+}
+
+std::string jsonEscape(const std::string& value) {
+    std::ostringstream escaped;
+    for (char ch : value) {
+        switch (ch) {
+            case '\\': escaped << "\\\\"; break;
+            case '"': escaped << "\\\""; break;
+            case '\n': escaped << "\\n"; break;
+            case '\r': escaped << "\\r"; break;
+            case '\t': escaped << "\\t"; break;
+            default: escaped << ch; break;
+        }
+    }
+    return escaped.str();
+}
+
+const char* jsonBool(bool value) {
+    return value ? "true" : "false";
+}
+
+struct SeedPosition {
+    libgnss::GNSSTime time;
+    libgnss::Vector3d position_ecef = libgnss::Vector3d::Zero();
+};
+
+bool parseSeparatedIntegers(std::string value,
+                            char separator,
+                            int& first,
+                            int& second,
+                            int& third) {
+    std::replace(value.begin(), value.end(), separator, ' ');
+    std::istringstream input(value);
+    return static_cast<bool>(input >> first >> second >> third);
+}
+
+bool parseRtklibTime(std::string value,
+                     int& hour,
+                     int& minute,
+                     double& second) {
+    std::replace(value.begin(), value.end(), ':', ' ');
+    std::istringstream input(value);
+    return static_cast<bool>(input >> hour >> minute >> second);
+}
+
+bool isLeapYear(int year) {
+    return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+}
+
+libgnss::GNSSTime gpstCalendarToTime(int year,
+                                     int month,
+                                     int day,
+                                     int hour,
+                                     int minute,
+                                     double second) {
+    int days_since_gps_epoch = 0;
+    for (int current_year = 1980; current_year < year; ++current_year) {
+        days_since_gps_epoch += isLeapYear(current_year) ? 366 : 365;
+    }
+
+    int days_in_month[] = {
+        31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    if (isLeapYear(year)) {
+        days_in_month[1] = 29;
+    }
+    for (int current_month = 1; current_month < month; ++current_month) {
+        days_since_gps_epoch += days_in_month[current_month - 1];
+    }
+    days_since_gps_epoch += day;
+    days_since_gps_epoch -= 6;
+
+    const int gps_week = days_since_gps_epoch / 7;
+    const int day_of_week = days_since_gps_epoch % 7;
+    const double tow = static_cast<double>(day_of_week) * 86400.0 +
+                       static_cast<double>(hour) * 3600.0 +
+                       static_cast<double>(minute) * 60.0 + second;
+    return libgnss::GNSSTime(gps_week, tow);
+}
+
+bool parseRtklibSeedPositionLine(const std::string& line, SeedPosition& seed) {
+    std::istringstream input(line);
+    std::string date_token;
+    std::string time_token;
+    if (!(input >> date_token >> time_token)) {
+        return false;
+    }
+
+    int year = 0;
+    int month = 0;
+    int day = 0;
+    int hour = 0;
+    int minute = 0;
+    double second = 0.0;
+    if (!parseSeparatedIntegers(date_token, '/', year, month, day) ||
+        !parseRtklibTime(time_token, hour, minute, second)) {
+        return false;
+    }
+
+    double latitude_deg = 0.0;
+    double longitude_deg = 0.0;
+    double height_m = 0.0;
+    if (!(input >> latitude_deg >> longitude_deg >> height_m)) {
+        return false;
+    }
+    if (!std::isfinite(latitude_deg) || !std::isfinite(longitude_deg) ||
+        !std::isfinite(height_m)) {
+        return false;
+    }
+
+    constexpr double kDegreesToRadians = 0.017453292519943295769;
+    seed.time = gpstCalendarToTime(year, month, day, hour, minute, second);
+    seed.position_ecef = libgnss::geodetic2ecef(latitude_deg * kDegreesToRadians,
+                                                longitude_deg * kDegreesToRadians,
+                                                height_m);
+    return seed.position_ecef.norm() > 1e6;
+}
+
+bool parseSeedPositionLine(const std::string& line, SeedPosition& seed) {
+    std::istringstream input(line);
+    std::string first_token;
+    if (!(input >> first_token)) {
+        return false;
+    }
+    if (first_token[0] == '%' || first_token[0] == '#') {
+        return false;
+    }
+    if (first_token.find('/') != std::string::npos) {
+        return parseRtklibSeedPositionLine(line, seed);
+    }
+
+    int week = 0;
+    try {
+        std::size_t consumed = 0;
+        week = std::stoi(first_token, &consumed);
+        if (consumed != first_token.size()) {
+            return false;
+        }
+    } catch (const std::exception&) {
+        return false;
+    }
+
+    double tow = 0.0;
+    double x = 0.0;
+    double y = 0.0;
+    double z = 0.0;
+    if (!(input >> tow >> x >> y >> z)) {
+        return false;
+    }
+    if (!std::isfinite(tow) || !std::isfinite(x) ||
+        !std::isfinite(y) || !std::isfinite(z)) {
+        return false;
+    }
+
+    seed.time = libgnss::GNSSTime(week, tow);
+    seed.position_ecef = libgnss::Vector3d(x, y, z);
+    return seed.position_ecef.norm() > 1e6;
+}
+
+std::vector<SeedPosition> readSeedPositions(const std::string& path) {
+    std::ifstream input(path);
+    if (!input.is_open()) {
+        throw std::runtime_error("failed to open seed POS file: " + path);
+    }
+
+    std::vector<SeedPosition> seeds;
+    std::string line;
+    while (std::getline(input, line)) {
+        SeedPosition seed;
+        if (parseSeedPositionLine(line, seed)) {
+            seeds.push_back(seed);
+        }
+    }
+    if (seeds.empty()) {
+        throw std::runtime_error(
+            "seed POS file has no readable LibGNSS++ or RTKLIB POS rows: " + path);
+    }
+
+    std::sort(seeds.begin(),
+              seeds.end(),
+              [](const SeedPosition& lhs, const SeedPosition& rhs) {
+                  return lhs.time < rhs.time;
+              });
+    return seeds;
+}
+
+bool findSeedPosition(const std::vector<SeedPosition>& seeds,
+                      const libgnss::GNSSTime& time,
+                      double tolerance_s,
+                      double interpolation_max_gap_s,
+                      std::size_t& cursor,
+                      libgnss::Vector3d& position_ecef,
+                      bool& interpolated) {
+    interpolated = false;
+    while (cursor < seeds.size() && seeds[cursor].time - time < -tolerance_s) {
+        ++cursor;
+    }
+
+    std::size_t best_index = seeds.size();
+    double best_abs_dt = tolerance_s;
+    if (cursor < seeds.size()) {
+        const double abs_dt = std::abs(seeds[cursor].time - time);
+        if (abs_dt <= best_abs_dt) {
+            best_index = cursor;
+            best_abs_dt = abs_dt;
+        }
+    }
+    if (cursor > 0) {
+        const std::size_t previous_index = cursor - 1;
+        const double abs_dt = std::abs(seeds[previous_index].time - time);
+        if (abs_dt <= best_abs_dt) {
+            best_index = previous_index;
+        }
+    }
+    if (best_index == seeds.size()) {
+        if (interpolation_max_gap_s <= 0.0 || cursor == 0 ||
+            cursor >= seeds.size()) {
+            return false;
+        }
+        const SeedPosition& lower = seeds[cursor - 1];
+        const SeedPosition& upper = seeds[cursor];
+        const double gap_s = upper.time - lower.time;
+        const double lower_dt_s = time - lower.time;
+        if (gap_s <= 0.0 || gap_s > interpolation_max_gap_s ||
+            lower_dt_s < 0.0 || lower_dt_s > gap_s) {
+            return false;
+        }
+        const double alpha = lower_dt_s / gap_s;
+        position_ecef =
+            lower.position_ecef +
+            alpha * (upper.position_ecef - lower.position_ecef);
+        interpolated = true;
+        return position_ecef.norm() > 1e6;
+    }
+
+    position_ecef = seeds[best_index].position_ecef;
+    return true;
+}
+
+#ifndef GNSS_WITH_GTSAM
+double ddGeometry(const libgnss::Vector3d& rover_position,
+                  const libgnss::Vector3d& base_position,
+                  const libgnss::Vector3d& rover_satellite_position,
+                  const libgnss::Vector3d& rover_reference_position,
+                  const libgnss::Vector3d& base_satellite_position,
+                  const libgnss::Vector3d& base_reference_position) {
+    return (rover_satellite_position - rover_position).norm() -
+           (base_satellite_position - base_position).norm() -
+           ((rover_reference_position - rover_position).norm() -
+            (base_reference_position - base_position).norm());
+}
+#endif
+
+#ifdef GNSS_WITH_GTSAM
+class GtsamPseudorangeFactorX
+    : public gtsam::NoiseModelFactorN<gtsam::Vector> {
+public:
+    GtsamPseudorangeFactorX(gtsam::Key key_x,
+                            const gtsam::Vector& los,
+                            double residual_m,
+                            const gtsam::Vector& initial_x,
+                            const gtsam::SharedNoiseModel& model)
+        : gtsam::NoiseModelFactorN<gtsam::Vector>(model, key_x),
+          los_(los),
+          residual_m_(residual_m),
+          initial_x_(initial_x) {}
+
+    gtsam::Vector evaluateError(const gtsam::Vector& x,
+                                gtsam::OptionalMatrixType hx) const override {
+        gtsam::Vector error(1);
+        error(0) = los_.dot(x - initial_x_) - residual_m_;
+        if (hx) {
+            *hx = los_.transpose();
+        }
+        return error;
+    }
+
+private:
+    gtsam::Vector los_;
+    double residual_m_ = 0.0;
+    gtsam::Vector initial_x_;
+};
+
+class GtsamCarrierPhaseFactorXB
+    : public gtsam::NoiseModelFactorN<gtsam::Vector, gtsam::Vector> {
+public:
+    GtsamCarrierPhaseFactorXB(gtsam::Key key_x,
+                              gtsam::Key key_b,
+                              const gtsam::Vector& los,
+                              double residual_m,
+                              int bias_index,
+                              double wavelength_m,
+                              const gtsam::Vector& initial_x,
+                              const gtsam::SharedNoiseModel& model)
+        : gtsam::NoiseModelFactorN<gtsam::Vector, gtsam::Vector>(
+              model, key_x, key_b),
+          los_(los),
+          residual_m_(residual_m),
+          bias_index_(bias_index),
+          wavelength_m_(wavelength_m),
+          initial_x_(initial_x) {}
+
+    gtsam::Vector evaluateError(const gtsam::Vector& x,
+                                const gtsam::Vector& b,
+                                gtsam::OptionalMatrixType hx,
+                                gtsam::OptionalMatrixType hb) const override {
+        gtsam::Vector error(1);
+        error(0) = los_.dot(x - initial_x_) -
+                   (residual_m_ - wavelength_m_ * b(bias_index_));
+        if (hx) {
+            *hx = los_.transpose();
+        }
+        if (hb) {
+            *hb = gtsam::Matrix::Zero(1, b.size());
+            (*hb)(0, bias_index_) = wavelength_m_;
+        }
+        return error;
+    }
+
+private:
+    gtsam::Vector los_;
+    double residual_m_ = 0.0;
+    int bias_index_ = 0;
+    double wavelength_m_ = 0.0;
+    gtsam::Vector initial_x_;
+};
+
+gtsam::Vector vector3ToGtsam(const libgnss::Vector3d& value) {
+    gtsam::Vector converted(3);
+    converted << value(0), value(1), value(2);
+    return converted;
+}
+
+gtsam::Vector scalarSigma(double sigma) {
+    gtsam::Vector sigmas(1);
+    sigmas(0) = sigma;
+    return sigmas;
+}
+
+gtsam::SharedNoiseModel robustScalarNoise(double sigma,
+                                          double huber_threshold_sigma,
+                                          bool use_robust_loss) {
+    auto gaussian =
+        gtsam::noiseModel::Diagonal::Sigmas(scalarSigma(std::max(1e-6, sigma)));
+    if (!use_robust_loss || huber_threshold_sigma <= 0.0) {
+        return gaussian;
+    }
+    return gtsam::noiseModel::Robust::Create(
+        gtsam::noiseModel::mEstimator::Huber::Create(huber_threshold_sigma),
+        gaussian);
+}
+
+libgnss::Vector3d ddPositionJacobian(
+    const libgnss::Vector3d& rover_position,
+    const libgnss::Vector3d& satellite_position,
+    const libgnss::Vector3d& reference_position) {
+    const libgnss::Vector3d satellite_delta =
+        satellite_position - rover_position;
+    const libgnss::Vector3d reference_delta =
+        reference_position - rover_position;
+    return -satellite_delta.normalized() + reference_delta.normalized();
+}
+
+double ddGeometry(const libgnss::Vector3d& rover_position,
+                  const libgnss::Vector3d& base_position,
+                  const libgnss::Vector3d& rover_satellite_position,
+                  const libgnss::Vector3d& rover_reference_position,
+                  const libgnss::Vector3d& base_satellite_position,
+                  const libgnss::Vector3d& base_reference_position) {
+    return (rover_satellite_position - rover_position).norm() -
+           (base_satellite_position - base_position).norm() -
+           ((rover_reference_position - rover_position).norm() -
+            (base_reference_position - base_position).norm());
+}
+
+double elevationRad(const libgnss::Vector3d& receiver_position,
+                    const libgnss::Vector3d& satellite_position) {
+    double lat = 0.0;
+    double lon = 0.0;
+    double height = 0.0;
+    libgnss::ecef2geodetic(receiver_position, lat, lon, height);
+    const libgnss::Vector3d enu =
+        libgnss::ecef2enu(satellite_position - receiver_position, lat, lon);
+    const double range = enu.norm();
+    if (range <= 0.0) {
+        return 0.0;
+    }
+    return std::asin(std::max(-1.0, std::min(1.0, enu(2) / range)));
+}
+
+libgnss::FGOProcessor::FGOResult optimizeGtsamPcProblem(
+    const libgnss::FGOProcessor::FGOProblem& problem,
+    const libgnss::FGOProcessor::FGOConfig& config) {
+    using FGOProcessor = libgnss::FGOProcessor;
+
+    struct LocalBiasInfo {
+        int local_index = 0;
+        double initial_cycles = 0.0;
+        double wavelength_m = 0.0;
+        double prior_sigma_cycles = 1e6;
+    };
+
+    FGOProcessor::FGOResult result;
+    result.diagnostics.epochs = problem.epochs.size();
+    result.diagnostics.pseudorange_factors = problem.pseudorange_factors.size();
+    result.diagnostics.tdcp_factors = problem.tdcp_factors.size();
+    result.diagnostics.carrier_phase_factors =
+        problem.carrier_phase_factors.size();
+    result.diagnostics.double_difference_pseudorange_factors =
+        problem.double_difference_pseudorange_factors.size();
+    result.diagnostics.double_difference_carrier_factors =
+        problem.double_difference_carrier_factors.size();
+    result.diagnostics.ambiguity_states = problem.ambiguity_states.size();
+    result.diagnostics.double_difference_matched_base_epochs =
+        problem.diagnostics.double_difference_matched_base_epochs;
+    result.diagnostics.double_difference_interpolated_base_epochs =
+        problem.diagnostics.double_difference_interpolated_base_epochs;
+    result.diagnostics.double_difference_candidate_pairs =
+        problem.diagnostics.double_difference_candidate_pairs;
+    result.diagnostics.double_difference_rejected_no_base_epoch =
+        problem.diagnostics.double_difference_rejected_no_base_epoch;
+    result.diagnostics.double_difference_rejected_no_reference =
+        problem.diagnostics.double_difference_rejected_no_reference;
+
+    if (problem.epochs.empty() ||
+        problem.double_difference_pseudorange_factors.empty()) {
+        return result;
+    }
+
+    std::map<std::size_t, std::map<libgnss::SatelliteId, LocalBiasInfo>>
+        local_bias_by_epoch;
+    std::map<std::size_t, std::set<libgnss::SatelliteId>>
+        dd_satellites_by_epoch;
+    std::map<std::size_t, std::map<libgnss::SatelliteId, libgnss::SatelliteId>>
+        reference_by_epoch_satellite;
+
+    const auto ensure_bias =
+        [&local_bias_by_epoch](std::size_t epoch_index,
+                               const libgnss::SatelliteId& satellite,
+                               double initial_cycles,
+                               double wavelength_m,
+                               double prior_sigma_cycles) {
+            auto& local_biases = local_bias_by_epoch[epoch_index];
+            auto existing_it = local_biases.find(satellite);
+            if (existing_it != local_biases.end()) {
+                existing_it->second.prior_sigma_cycles =
+                    std::min(existing_it->second.prior_sigma_cycles,
+                             prior_sigma_cycles);
+                return;
+            }
+            const int local_index = static_cast<int>(local_biases.size());
+            local_biases.emplace(
+                satellite,
+                LocalBiasInfo{local_index,
+                              initial_cycles,
+                              wavelength_m,
+                              prior_sigma_cycles});
+        };
+
+    for (const auto& factor : problem.double_difference_carrier_factors) {
+        double initial_cycles = 0.0;
+        double wavelength_m = 0.0;
+        if (factor.ambiguity_index < problem.ambiguity_states.size()) {
+            const auto& ambiguity =
+                problem.ambiguity_states[factor.ambiguity_index];
+            wavelength_m = ambiguity.wavelength_m;
+            if (ambiguity.wavelength_m > 0.0) {
+                initial_cycles =
+                    ambiguity.initial_ambiguity_m / ambiguity.wavelength_m;
+            }
+        }
+        ensure_bias(factor.epoch_index,
+                    factor.satellite,
+                    initial_cycles,
+                    wavelength_m,
+                    std::max(1e6, config.ambiguity_prior_sigma_m));
+        ensure_bias(factor.epoch_index,
+                    factor.reference_satellite,
+                    0.0,
+                    wavelength_m,
+                    1.0);
+        reference_by_epoch_satellite[factor.epoch_index][factor.satellite] =
+            factor.reference_satellite;
+        dd_satellites_by_epoch[factor.epoch_index].insert(factor.satellite);
+        dd_satellites_by_epoch[factor.epoch_index].insert(
+            factor.reference_satellite);
+    }
+    for (const auto& factor : problem.double_difference_pseudorange_factors) {
+        dd_satellites_by_epoch[factor.epoch_index].insert(factor.satellite);
+        dd_satellites_by_epoch[factor.epoch_index].insert(
+            factor.reference_satellite);
+    }
+
+    gtsam::NonlinearFactorGraph graph;
+    gtsam::Values initials;
+    const gtsam::Vector x_prior_sigmas =
+        (gtsam::Vector(3) << 100.0, 100.0, 100.0).finished();
+    const auto x_prior_noise =
+        gtsam::noiseModel::Diagonal::Sigmas(x_prior_sigmas);
+
+    for (std::size_t epoch_index = 0; epoch_index < problem.epochs.size();
+         ++epoch_index) {
+        const gtsam::Key key_x = gtsam::symbol('x', epoch_index);
+        const gtsam::Vector initial_x =
+            vector3ToGtsam(problem.epochs[epoch_index].position_ecef);
+        initials.insert(key_x, initial_x);
+        graph.push_back(std::make_shared<gtsam::PriorFactor<gtsam::Vector>>(
+            key_x, initial_x, x_prior_noise));
+
+        const auto local_it = local_bias_by_epoch.find(epoch_index);
+        if (local_it != local_bias_by_epoch.end()) {
+            gtsam::Vector initial_b =
+                gtsam::Vector::Zero(local_it->second.size());
+            gtsam::Vector ambiguity_prior_sigmas =
+                gtsam::Vector::Ones(local_it->second.size());
+            for (const auto& [satellite, bias] : local_it->second) {
+                initial_b(bias.local_index) = bias.initial_cycles;
+                ambiguity_prior_sigmas(bias.local_index) =
+                    std::max(1.0, bias.prior_sigma_cycles);
+            }
+            const gtsam::Key key_b = gtsam::symbol('b', epoch_index);
+            initials.insert(key_b, initial_b);
+            graph.push_back(std::make_shared<gtsam::PriorFactor<gtsam::Vector>>(
+                key_b,
+                initial_b,
+                gtsam::noiseModel::Diagonal::Sigmas(ambiguity_prior_sigmas)));
+        }
+    }
+
+    for (const auto& factor : problem.double_difference_pseudorange_factors) {
+        if (factor.epoch_index >= problem.epochs.size()) {
+            continue;
+        }
+        const libgnss::Vector3d seed_position =
+            problem.epochs[factor.epoch_index].position_ecef;
+        const double geometry = ddGeometry(seed_position,
+                                           factor.base_position_ecef,
+                                           factor.rover_satellite_position_ecef,
+                                           factor.rover_reference_position_ecef,
+                                           factor.base_satellite_position_ecef,
+                                           factor.base_reference_position_ecef);
+        const double residual = factor.observed_dd_pseudorange_m - geometry;
+        const libgnss::Vector3d jacobian =
+            ddPositionJacobian(seed_position,
+                               factor.rover_satellite_position_ecef,
+                               factor.rover_reference_position_ecef);
+        graph.push_back(std::make_shared<GtsamPseudorangeFactorX>(
+            gtsam::symbol('x', factor.epoch_index),
+            vector3ToGtsam(jacobian),
+            residual,
+            vector3ToGtsam(seed_position),
+            robustScalarNoise(factor.sigma_m,
+                              config.pseudorange_huber_threshold_sigma,
+                              config.use_robust_loss)));
+    }
+
+    for (const auto& factor : problem.double_difference_carrier_factors) {
+        if (factor.epoch_index >= problem.epochs.size() ||
+            factor.ambiguity_index >= problem.ambiguity_states.size()) {
+            continue;
+        }
+        const auto local_epoch_it =
+            local_bias_by_epoch.find(factor.epoch_index);
+        if (local_epoch_it == local_bias_by_epoch.end()) {
+            continue;
+        }
+        const auto local_it =
+            local_epoch_it->second.find(factor.satellite);
+        if (local_it == local_epoch_it->second.end()) {
+            continue;
+        }
+        const auto reference_bias_it =
+            local_epoch_it->second.find(factor.reference_satellite);
+        if (reference_bias_it == local_epoch_it->second.end()) {
+            continue;
+        }
+        const auto& ambiguity =
+            problem.ambiguity_states[factor.ambiguity_index];
+        if (ambiguity.wavelength_m <= 0.0) {
+            continue;
+        }
+
+        const libgnss::Vector3d seed_position =
+            problem.epochs[factor.epoch_index].position_ecef;
+        const double geometry = ddGeometry(seed_position,
+                                           factor.base_position_ecef,
+                                           factor.rover_satellite_position_ecef,
+                                           factor.rover_reference_position_ecef,
+                                           factor.base_satellite_position_ecef,
+                                           factor.base_reference_position_ecef);
+        const double residual = factor.observed_dd_carrier_m - geometry;
+        const libgnss::Vector3d jacobian =
+            ddPositionJacobian(seed_position,
+                               factor.rover_satellite_position_ecef,
+                               factor.rover_reference_position_ecef);
+        graph.push_back(std::make_shared<GtsamCarrierPhaseFactorXB>(
+            gtsam::symbol('x', factor.epoch_index),
+            gtsam::symbol('b', factor.epoch_index),
+            vector3ToGtsam(jacobian),
+            residual,
+            local_it->second.local_index,
+            ambiguity.wavelength_m,
+            vector3ToGtsam(seed_position),
+            robustScalarNoise(factor.sigma_m,
+                              config.carrier_phase_huber_threshold_sigma,
+                              config.use_robust_loss)));
+    }
+
+    auto start_time = std::chrono::high_resolution_clock::now();
+    result.diagnostics.graph_factors = graph.size();
+    result.diagnostics.graph_values = initials.size();
+    result.diagnostics.initial_cost = graph.error(initials);
+    gtsam::LevenbergMarquardtParams params;
+    params.setMaxIterations(std::max(1, config.max_iterations));
+    params.setVerbosity("SILENT");
+    gtsam::LevenbergMarquardtOptimizer optimizer(graph, initials, params);
+    const gtsam::Values optimized = optimizer.optimize();
+    auto end_time = std::chrono::high_resolution_clock::now();
+
+    result.diagnostics.iterations = optimizer.iterations();
+    result.diagnostics.final_cost = graph.error(optimized);
+    result.diagnostics.converged = true;
+    result.diagnostics.processing_time_ms =
+        std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(
+            end_time - start_time)
+            .count();
+
+    std::unique_ptr<gtsam::Marginals> marginals;
+    if (config.fix_ambiguities) {
+        marginals = std::make_unique<gtsam::Marginals>(graph, optimized);
+    }
+    result.ambiguity_candidate_satellites_by_epoch.resize(problem.epochs.size());
+    result.ambiguity_reference_satellites_by_epoch.resize(problem.epochs.size());
+    result.ambiguity_estimate_cycles_by_epoch.resize(problem.epochs.size());
+
+    for (std::size_t epoch_index = 0; epoch_index < problem.epochs.size();
+         ++epoch_index) {
+        const gtsam::Vector x =
+            optimized.at<gtsam::Vector>(gtsam::symbol('x', epoch_index));
+        libgnss::Vector3d position_ecef(x(0), x(1), x(2));
+        double ratio = 0.0;
+        int fixed_ambiguities = 0;
+        bool fixed_epoch = false;
+
+        const auto local_epoch_it =
+            local_bias_by_epoch.find(epoch_index);
+        gtsam::Vector float_ambiguities;
+        std::vector<int> candidate_indices;
+        std::vector<libgnss::SatelliteId> satellite_by_local;
+        bool has_float_ambiguities = false;
+        if (local_epoch_it != local_bias_by_epoch.end()) {
+            const gtsam::Key key_b = gtsam::symbol('b', epoch_index);
+            float_ambiguities = optimized.at<gtsam::Vector>(key_b);
+            if (float_ambiguities.size() ==
+                static_cast<int>(local_epoch_it->second.size())) {
+                has_float_ambiguities = true;
+                candidate_indices.reserve(
+                    static_cast<std::size_t>(float_ambiguities.size()));
+                satellite_by_local.assign(
+                    static_cast<std::size_t>(float_ambiguities.size()),
+                    libgnss::SatelliteId());
+                for (const auto& [satellite, bias] : local_epoch_it->second) {
+                    if (bias.local_index >= 0 &&
+                        bias.local_index < float_ambiguities.size()) {
+                        satellite_by_local[static_cast<std::size_t>(
+                            bias.local_index)] = satellite;
+                        if (std::isfinite(float_ambiguities(bias.local_index))) {
+                            result.ambiguity_estimate_cycles_by_epoch[epoch_index]
+                                [satellite] = float_ambiguities(bias.local_index);
+                        }
+                    }
+                }
+                const auto reference_it =
+                    reference_by_epoch_satellite.find(epoch_index);
+                for (int i = 0; i < float_ambiguities.size(); ++i) {
+                    if (std::isfinite(float_ambiguities(i)) &&
+                        std::abs(float_ambiguities(i)) > 1e-9) {
+                        candidate_indices.push_back(i);
+                        const auto& satellite =
+                            satellite_by_local[static_cast<std::size_t>(i)];
+                        result.ambiguity_candidate_satellites_by_epoch[epoch_index]
+                            .insert(satellite);
+                        if (reference_it != reference_by_epoch_satellite.end()) {
+                            const auto sat_ref_it =
+                                reference_it->second.find(satellite);
+                            if (sat_ref_it != reference_it->second.end()) {
+                                result
+                                    .ambiguity_reference_satellites_by_epoch
+                                        [epoch_index]
+                                    .insert(sat_ref_it->second);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        if (config.fix_ambiguities && marginals &&
+            local_epoch_it != local_bias_by_epoch.end() &&
+            has_float_ambiguities &&
+            static_cast<int>(candidate_indices.size()) >
+                config.min_fixed_ambiguities) {
+            const gtsam::Key key_b = gtsam::symbol('b', epoch_index);
+            const gtsam::Key key_x = gtsam::symbol('x', epoch_index);
+                try {
+                    gtsam::KeyVector keys;
+                    keys.push_back(key_b);
+                    keys.push_back(key_x);
+                    const gtsam::Matrix covariance =
+                        marginals->jointMarginalCovariance(keys).fullMatrix();
+                    const int bias_count =
+                        static_cast<int>(float_ambiguities.size());
+                    if (covariance.rows() == bias_count + 3 &&
+                        covariance.cols() == bias_count + 3) {
+                        const int ambiguity_count =
+                            static_cast<int>(candidate_indices.size());
+                        if (ambiguity_count > config.min_fixed_ambiguities) {
+                            Eigen::VectorXd ambiguity_float =
+                                Eigen::VectorXd::Zero(ambiguity_count);
+                            Eigen::MatrixXd ambiguity_covariance =
+                                Eigen::MatrixXd::Zero(ambiguity_count, ambiguity_count);
+                            for (int row = 0; row < ambiguity_count; ++row) {
+                                const int source_row = candidate_indices[row];
+                                ambiguity_float(row) = float_ambiguities(source_row);
+                                for (int col = 0; col < ambiguity_count; ++col) {
+                                    const int source_col = candidate_indices[col];
+                                    ambiguity_covariance(row, col) =
+                                        covariance(source_row, source_col);
+                                }
+                            }
+                            ambiguity_covariance =
+                                0.5 * (ambiguity_covariance +
+                                       ambiguity_covariance.transpose());
+                            for (int i = 0; i < ambiguity_count; ++i) {
+                                const double diagonal =
+                                    std::abs(ambiguity_covariance(i, i));
+                                ambiguity_covariance(i, i) +=
+                                    std::max(1e-12, diagonal * 1e-9);
+                            }
+
+                            Eigen::VectorXd fixed_ambiguities_vector;
+                            ++result.diagnostics.lambda_ambiguity_attempts;
+                            const bool solved =
+                                libgnss::lambdaSearch(ambiguity_float,
+                                                       ambiguity_covariance,
+                                                       fixed_ambiguities_vector,
+                                                       ratio);
+                            const bool accepted =
+                                solved && std::isfinite(ratio) &&
+                                ratio > config.lambda_ratio_threshold;
+                            if (config.collect_lambda_debug) {
+                                result.lambda_debug_entries.reserve(
+                                    result.lambda_debug_entries.size() +
+                                    static_cast<std::size_t>(ambiguity_count *
+                                                             ambiguity_count));
+                                for (int row = 0; row < ambiguity_count; ++row) {
+                                    const int source_row = candidate_indices[row];
+                                    for (int col = 0; col < ambiguity_count; ++col) {
+                                        const int source_col = candidate_indices[col];
+                                        libgnss::FGOProcessor::LambdaDebugEntry entry;
+                                        entry.epoch_index = epoch_index;
+                                        entry.time = problem.epochs[epoch_index].time;
+                                        entry.solved = solved;
+                                        entry.fixed_epoch = accepted;
+                                        entry.ratio = ratio;
+                                        entry.candidate_count = ambiguity_count;
+                                        entry.row = row;
+                                        entry.col = col;
+                                        entry.local_index = source_row;
+                                        entry.other_local_index = source_col;
+                                        entry.satellite =
+                                            satellite_by_local[static_cast<std::size_t>(
+                                                source_row)];
+                                        entry.other_satellite =
+                                            satellite_by_local[static_cast<std::size_t>(
+                                                source_col)];
+                                        entry.ambiguity_float =
+                                            ambiguity_float(row);
+                                        entry.fixed_ambiguity =
+                                            solved &&
+                                                    fixed_ambiguities_vector.size() >
+                                                        row
+                                                ? fixed_ambiguities_vector(row)
+                                                : std::numeric_limits<double>::quiet_NaN();
+                                        entry.covariance =
+                                            ambiguity_covariance(row, col);
+                                        entry.position_covariance_x =
+                                            covariance(bias_count, source_row);
+                                        entry.position_covariance_y =
+                                            covariance(bias_count + 1, source_row);
+                                        entry.position_covariance_z =
+                                            covariance(bias_count + 2, source_row);
+                                        result.lambda_debug_entries.push_back(entry);
+                                    }
+                                }
+                            }
+                            if (solved) {
+                                result.diagnostics.lambda_ambiguity_fix_solved = true;
+                            }
+                            if (solved && std::isfinite(ratio)) {
+                                result.diagnostics.lambda_ambiguity_ratio =
+                                    std::max(result.diagnostics.lambda_ambiguity_ratio,
+                                             ratio);
+                            }
+                            result.diagnostics.lambda_ambiguity_candidates +=
+                                static_cast<std::size_t>(ambiguity_count);
+                            result.diagnostics.ambiguity_fix_candidates +=
+                                static_cast<std::size_t>(ambiguity_count);
+                            if (accepted) {
+                                const Eigen::VectorXd ambiguity_delta =
+                                    ambiguity_float - fixed_ambiguities_vector;
+                                const Eigen::MatrixXd position_ambiguity_covariance =
+                                    [&]() {
+                                        Eigen::MatrixXd covariance_block =
+                                            Eigen::MatrixXd::Zero(3, ambiguity_count);
+                                        for (int col = 0; col < ambiguity_count; ++col) {
+                                            covariance_block.col(col) =
+                                                covariance.block(bias_count,
+                                                                 candidate_indices[col],
+                                                                 3,
+                                                                 1);
+                                        }
+                                        return covariance_block;
+                                    }();
+                                const Eigen::Vector3d position_update =
+                                    position_ambiguity_covariance *
+                                    ambiguity_covariance.ldlt().solve(
+                                        ambiguity_delta);
+                                position_ecef -= position_update;
+                                fixed_epoch = true;
+                                fixed_ambiguities = ambiguity_count;
+                                result.diagnostics.fixed_solution = true;
+                                result.diagnostics.lambda_ambiguity_fix_used = true;
+                                result.diagnostics.lambda_ambiguity_used_candidates +=
+                                    static_cast<std::size_t>(ambiguity_count);
+                                result.diagnostics.fixed_ambiguities +=
+                                    static_cast<std::size_t>(ambiguity_count);
+                            }
+                        }
+                    }
+                } catch (const std::exception&) {
+                    // Keep the float solution when covariance extraction fails.
+                }
+        }
+
+        libgnss::PositionSolution solution;
+        solution.time = problem.epochs[epoch_index].time;
+        solution.status =
+            fixed_epoch ? libgnss::SolutionStatus::FIXED
+                        : libgnss::SolutionStatus::FLOAT;
+        solution.position_ecef = position_ecef;
+        solution.num_frequencies = 1;
+        solution.ratio = ratio;
+        solution.num_fixed_ambiguities = fixed_ambiguities;
+        solution.processing_time_ms =
+            result.diagnostics.processing_time_ms /
+            static_cast<double>(std::max<std::size_t>(1, problem.epochs.size()));
+        solution.iterations = result.diagnostics.iterations;
+        solution.position_covariance = libgnss::Matrix3d::Identity() * 9999.0;
+
+        double lat = 0.0;
+        double lon = 0.0;
+        double height = 0.0;
+        libgnss::ecef2geodetic(solution.position_ecef, lat, lon, height);
+        solution.position_geodetic = libgnss::GeodeticCoord(lat, lon, height);
+
+        const auto dd_satellite_it = dd_satellites_by_epoch.find(epoch_index);
+        if (dd_satellite_it != dd_satellites_by_epoch.end()) {
+            solution.num_satellites =
+                static_cast<int>(dd_satellite_it->second.size());
+            solution.satellites_used.assign(dd_satellite_it->second.begin(),
+                                            dd_satellite_it->second.end());
+        }
+        result.solution.addSolution(solution);
+    }
+
+    return result;
+}
+#endif
+
+void writeSummaryJson(const Options& options,
+                      const libgnss::FGOProcessor::FGOResult& result,
+                      const libgnss::Solution::SolutionStatistics& stats,
+                      std::size_t input_epochs,
+                      std::size_t seed_matched_epochs,
+                      std::size_t seed_interpolated_epochs,
+                      double availability_rate_percent,
+                      double fix_rate_percent,
+                      double float_rate_percent) {
+    if (options.summary_json_path.empty()) {
+        return;
+    }
+
+    std::ofstream output(options.summary_json_path);
+    if (!output.is_open()) {
+        throw std::runtime_error(
+            "failed to open summary JSON for writing: " +
+            options.summary_json_path);
+    }
+
+    const auto& diagnostics = result.diagnostics;
+    output << std::setprecision(10);
+    output << "{\n";
+    output << "  \"obs\": \"" << jsonEscape(options.obs_path) << "\",\n";
+    output << "  \"base\": \"" << jsonEscape(options.base_path) << "\",\n";
+    output << "  \"nav\": \"" << jsonEscape(options.nav_path) << "\",\n";
+    output << "  \"out\": \"" << jsonEscape(options.out_path) << "\",\n";
+    output << "  \"preset\": \"" << jsonEscape(options.preset) << "\",\n";
+    output << "  \"backend\": \"" << jsonEscape(options.backend) << "\",\n";
+    output << "  \"skip_epochs\": " << options.skip_epochs << ",\n";
+    output << "  \"max_epochs\": " << options.max_epochs << ",\n";
+    output << "  \"max_iterations\": " << options.max_iterations << ",\n";
+    output << "  \"relative_cost_convergence_threshold\": "
+           << options.relative_cost_convergence_threshold << ",\n";
+    output << "  \"absolute_cost_convergence_threshold\": "
+           << options.absolute_cost_convergence_threshold << ",\n";
+    output << "  \"seed_pos\": \"" << jsonEscape(options.seed_pos_path) << "\",\n";
+    output << "  \"epoch_debug_csv\": \""
+           << jsonEscape(options.epoch_debug_csv_path) << "\",\n";
+    output << "  \"factor_debug_csv\": \""
+           << jsonEscape(options.factor_debug_csv_path) << "\",\n";
+    output << "  \"sd_factor_debug_csv\": \""
+           << jsonEscape(options.sd_factor_debug_csv_path) << "\",\n";
+    output << "  \"lambda_debug_csv\": \""
+           << jsonEscape(options.lambda_debug_csv_path) << "\",\n";
+    output << "  \"seed_match_tolerance_s\": "
+           << options.seed_match_tolerance_s << ",\n";
+    output << "  \"seed_interpolation_max_gap_s\": "
+           << options.seed_interpolation_max_gap_s << ",\n";
+    output << "  \"use_spp_seed\": " << jsonBool(!options.no_spp_seed) << ",\n";
+    output << "  \"use_pseudorange_factors\": "
+           << jsonBool(!options.no_pseudorange_factors) << ",\n";
+    output << "  \"use_single_difference_doppler_factors\": "
+           << jsonBool(options.use_single_difference_doppler_factors) << ",\n";
+    output << "  \"use_single_difference_tdcp_factors\": "
+           << jsonBool(options.use_single_difference_tdcp_factors) << ",\n";
+    output << "  \"use_velocity_states\": "
+           << jsonBool(options.use_velocity_states) << ",\n";
+    output << "  \"use_velocity_motion_factors\": "
+           << jsonBool(options.use_velocity_motion_factors) << ",\n";
+    output << "  \"use_ambiguity_between_factors\": "
+           << jsonBool(options.use_ambiguity_between_factors) << ",\n";
+    output << "  \"linearize_double_difference_factors_at_seed\": "
+           << jsonBool(options.linearize_double_difference_factors_at_seed)
+           << ",\n";
+    output << "  \"use_epoch_lambda_fixed_output\": "
+           << jsonBool(options.use_epoch_lambda_fixed_output) << ",\n";
+    output << "  \"pseudorange_sigma_m\": "
+           << options.pseudorange_sigma_m << ",\n";
+    output << "  \"pseudorange_elevation_sigma_power\": "
+           << options.pseudorange_elevation_sigma_power << ",\n";
+    output << "  \"pseudorange_huber_threshold_sigma\": "
+           << options.pseudorange_huber_threshold_sigma << ",\n";
+    output << "  \"carrier_phase_huber_threshold_sigma\": "
+           << options.carrier_phase_huber_threshold_sigma << ",\n";
+    output << "  \"tdcp_huber_threshold_sigma\": "
+           << options.tdcp_huber_threshold_sigma << ",\n";
+    output << "  \"position_prior_sigma_m\": "
+           << options.position_prior_sigma_m << ",\n";
+    output << "  \"clock_prior_sigma_m\": "
+           << options.clock_prior_sigma_m << ",\n";
+    output << "  \"motion_sigma_m\": " << options.motion_sigma_m << ",\n";
+    output << "  \"clock_motion_sigma_m\": "
+           << options.clock_motion_sigma_m << ",\n";
+    output << "  \"velocity_prior_sigma_mps\": "
+           << options.velocity_prior_sigma_mps << ",\n";
+    output << "  \"velocity_motion_sigma_m\": "
+           << options.velocity_motion_sigma_m << ",\n";
+    output << "  \"ambiguity_between_sigma_cycles\": "
+           << options.ambiguity_between_sigma_cycles << ",\n";
+    output << "  \"use_position_motion_factors\": "
+           << jsonBool(!options.no_motion_factors &&
+                       !options.clock_only_motion_factors) << ",\n";
+    output << "  \"use_clock_motion_factors\": "
+           << jsonBool(!options.no_motion_factors) << ",\n";
+    output << "  \"dd_ambiguity_per_epoch\": "
+           << jsonBool(options.dd_ambiguity_per_epoch) << ",\n";
+    output << "  \"use_ambiguity_priors\": "
+           << jsonBool(!options.no_ambiguity_priors) << ",\n";
+    output << "  \"reject_rover_carrier_lli\": "
+           << jsonBool(options.reject_rover_carrier_lli) << ",\n";
+    output << "  \"min_snr_dbhz\": " << options.min_snr_dbhz << ",\n";
+    output << "  \"min_satellites_per_epoch\": "
+           << options.min_satellites_per_epoch << ",\n";
+    output << "  \"min_output_dd_carrier_factors_per_epoch\": "
+           << options.min_output_dd_carrier_factors_per_epoch << ",\n";
+    output << "  \"insert_fixed_interval_gaps\": "
+           << jsonBool(options.insert_fixed_interval_gaps) << ",\n";
+    output << "  \"double_difference_reference_min_snr_dbhz\": "
+           << options.double_difference_reference_min_snr_dbhz << ",\n";
+    output << "  \"double_difference_base_min_snr_dbhz\": "
+           << options.double_difference_base_min_snr_dbhz << ",\n";
+    output << "  \"exclude_glonass_qzss_sbas\": "
+           << jsonBool(options.exclude_glonass_qzss_sbas) << ",\n";
+    output << "  \"use_ionosphere_model\": "
+           << jsonBool(options.use_ionosphere_model) << ",\n";
+    output << "  \"use_troposphere_model\": "
+           << jsonBool(options.use_troposphere_model) << ",\n";
+    output << "  \"debug_problem_only\": "
+           << jsonBool(options.debug_problem_only) << ",\n";
+    output << "  \"seed_matched_epochs\": " << seed_matched_epochs << ",\n";
+    output << "  \"seed_interpolated_epochs\": "
+           << seed_interpolated_epochs << ",\n";
+    output << "  \"input_epochs\": " << input_epochs << ",\n";
+    output << "  \"optimized_epochs\": " << diagnostics.epochs << ",\n";
+    output << "  \"valid_solutions\": " << stats.valid_solutions << ",\n";
+    output << "  \"fixed_solutions\": " << stats.fixed_solutions << ",\n";
+    output << "  \"float_solutions\": " << stats.float_solutions << ",\n";
+    output << "  \"availability_rate_percent\": " << availability_rate_percent << ",\n";
+    output << "  \"fix_rate_percent\": " << fix_rate_percent << ",\n";
+    output << "  \"float_rate_percent\": " << float_rate_percent << ",\n";
+    output << "  \"pseudorange_factors\": " << diagnostics.pseudorange_factors << ",\n";
+    output << "  \"tdcp_factors\": " << diagnostics.tdcp_factors << ",\n";
+    output << "  \"single_difference_doppler_factors\": "
+           << diagnostics.single_difference_doppler_factors << ",\n";
+    output << "  \"single_difference_tdcp_factors\": "
+           << diagnostics.single_difference_tdcp_factors << ",\n";
+    output << "  \"carrier_phase_factors\": " << diagnostics.carrier_phase_factors << ",\n";
+    output << "  \"double_difference_pseudorange_factors\": "
+           << diagnostics.double_difference_pseudorange_factors << ",\n";
+    output << "  \"double_difference_carrier_factors\": "
+           << diagnostics.double_difference_carrier_factors << ",\n";
+    output << "  \"ambiguity_states\": " << diagnostics.ambiguity_states << ",\n";
+    output << "  \"ambiguity_fix_candidates\": " << diagnostics.ambiguity_fix_candidates << ",\n";
+    output << "  \"lambda_ambiguity_candidates\": "
+           << diagnostics.lambda_ambiguity_candidates << ",\n";
+    output << "  \"lambda_ambiguity_used_candidates\": "
+           << diagnostics.lambda_ambiguity_used_candidates << ",\n";
+    output << "  \"lambda_ambiguity_attempts\": "
+           << diagnostics.lambda_ambiguity_attempts << ",\n";
+    output << "  \"lambda_ambiguity_fix_solved\": "
+           << jsonBool(diagnostics.lambda_ambiguity_fix_solved) << ",\n";
+    output << "  \"lambda_ambiguity_fix_used\": "
+           << jsonBool(diagnostics.lambda_ambiguity_fix_used) << ",\n";
+    output << "  \"partial_lambda_ambiguity_fix_used\": "
+           << jsonBool(diagnostics.partial_lambda_ambiguity_fix_used) << ",\n";
+    output << "  \"lambda_ambiguity_ratio\": "
+           << diagnostics.lambda_ambiguity_ratio << ",\n";
+    output << "  \"fixed_ambiguities\": " << diagnostics.fixed_ambiguities << ",\n";
+    output << "  \"fixed_solution\": " << jsonBool(diagnostics.fixed_solution) << ",\n";
+    output << "  \"tdcp_candidate_pairs\": " << diagnostics.tdcp_candidate_pairs << ",\n";
+    output << "  \"tdcp_rejected_gap\": " << diagnostics.tdcp_rejected_gap << ",\n";
+    output << "  \"tdcp_rejected_missing_previous\": "
+           << diagnostics.tdcp_rejected_missing_previous << ",\n";
+    output << "  \"tdcp_rejected_loss_of_lock\": "
+           << diagnostics.tdcp_rejected_loss_of_lock << ",\n";
+    output << "  \"tdcp_rejected_code_phase_jump\": "
+           << diagnostics.tdcp_rejected_code_phase_jump << ",\n";
+    output << "  \"double_difference_matched_base_epochs\": "
+           << diagnostics.double_difference_matched_base_epochs << ",\n";
+    output << "  \"double_difference_interpolated_base_epochs\": "
+           << diagnostics.double_difference_interpolated_base_epochs << ",\n";
+    output << "  \"double_difference_candidate_pairs\": "
+           << diagnostics.double_difference_candidate_pairs << ",\n";
+    output << "  \"double_difference_rejected_no_base_epoch\": "
+           << diagnostics.double_difference_rejected_no_base_epoch << ",\n";
+    output << "  \"double_difference_rejected_no_reference\": "
+           << diagnostics.double_difference_rejected_no_reference << ",\n";
+    output << "  \"motion_factors\": " << diagnostics.motion_factors << ",\n";
+    output << "  \"ambiguity_between_factors\": "
+           << diagnostics.ambiguity_between_factors << ",\n";
+    output << "  \"robust_pseudorange_factors\": "
+           << diagnostics.robust_pseudorange_factors << ",\n";
+    output << "  \"robust_carrier_phase_factors\": "
+           << diagnostics.robust_carrier_phase_factors << ",\n";
+    output << "  \"robust_double_difference_pseudorange_factors\": "
+           << diagnostics.robust_double_difference_pseudorange_factors << ",\n";
+    output << "  \"robust_double_difference_carrier_factors\": "
+           << diagnostics.robust_double_difference_carrier_factors << ",\n";
+    output << "  \"robust_tdcp_factors\": " << diagnostics.robust_tdcp_factors << ",\n";
+    output << "  \"graph_factors\": " << diagnostics.graph_factors << ",\n";
+    output << "  \"graph_values\": " << diagnostics.graph_values << ",\n";
+    output << "  \"iterations\": " << diagnostics.iterations << ",\n";
+    output << "  \"converged\": " << jsonBool(diagnostics.converged) << ",\n";
+    output << "  \"initial_cost\": " << diagnostics.initial_cost << ",\n";
+    output << "  \"final_cost\": " << diagnostics.final_cost << ",\n";
+    output << "  \"processing_time_ms\": " << diagnostics.processing_time_ms << ",\n";
+    output << "  \"epoch_lambda_processing_time_ms\": "
+           << diagnostics.epoch_lambda_processing_time_ms << ",\n";
+    output << "  \"epoch_lambda_setup_time_ms\": "
+           << diagnostics.epoch_lambda_setup_time_ms << ",\n";
+    output << "  \"epoch_lambda_factorization_time_ms\": "
+           << diagnostics.epoch_lambda_factorization_time_ms << ",\n";
+    output << "  \"epoch_lambda_covariance_solve_time_ms\": "
+           << diagnostics.epoch_lambda_covariance_solve_time_ms << ",\n";
+    output << "  \"epoch_lambda_search_time_ms\": "
+           << diagnostics.epoch_lambda_search_time_ms << ",\n";
+    output << "  \"epoch_lambda_fixed_output_time_ms\": "
+           << diagnostics.epoch_lambda_fixed_output_time_ms << ",\n";
+    output << "  \"epoch_lambda_debug_record_time_ms\": "
+           << diagnostics.epoch_lambda_debug_record_time_ms << ",\n";
+    output << "  \"postprocessing_time_ms\": "
+           << diagnostics.postprocessing_time_ms << ",\n";
+    output << "  \"total_processing_time_ms\": "
+           << diagnostics.total_processing_time_ms << ",\n";
+    output << "  \"last_update_norm_m\": " << diagnostics.last_update_norm_m << ",\n";
+    output << "  \"residual_rms_m\": " << diagnostics.residual_rms_m << ",\n";
+    output << "  \"tdcp_residual_rms_m\": " << diagnostics.tdcp_residual_rms_m << ",\n";
+    output << "  \"single_difference_doppler_residual_rms_mps\": "
+           << diagnostics.single_difference_doppler_residual_rms_mps << ",\n";
+    output << "  \"single_difference_tdcp_residual_rms_m\": "
+           << diagnostics.single_difference_tdcp_residual_rms_m << ",\n";
+    output << "  \"carrier_phase_residual_rms_m\": "
+           << diagnostics.carrier_phase_residual_rms_m << ",\n";
+    output << "  \"double_difference_pseudorange_residual_rms_m\": "
+           << diagnostics.double_difference_pseudorange_residual_rms_m << ",\n";
+    output << "  \"double_difference_carrier_residual_rms_m\": "
+           << diagnostics.double_difference_carrier_residual_rms_m << ",\n";
+    output << "  \"fixed_ambiguity_residual_rms_cycles\": "
+           << diagnostics.fixed_ambiguity_residual_rms_cycles << "\n";
+    output << "}\n";
+}
+
+libgnss::FGOProcessor::FGOResult makeProblemOnlyResult(
+    const libgnss::FGOProcessor::FGOProblem& problem,
+    const libgnss::FGOProcessor::FGOConfig& config) {
+    libgnss::FGOProcessor::FGOResult result;
+    auto& diagnostics = result.diagnostics;
+    diagnostics.epochs = problem.epochs.size();
+    diagnostics.pseudorange_factors = problem.pseudorange_factors.size();
+    diagnostics.tdcp_factors = problem.tdcp_factors.size();
+    diagnostics.single_difference_doppler_factors =
+        problem.single_difference_doppler_factors.size();
+    diagnostics.single_difference_tdcp_factors =
+        problem.single_difference_tdcp_factors.size();
+    diagnostics.carrier_phase_factors = problem.carrier_phase_factors.size();
+    diagnostics.double_difference_pseudorange_factors =
+        problem.double_difference_pseudorange_factors.size();
+    diagnostics.double_difference_carrier_factors =
+        problem.double_difference_carrier_factors.size();
+    diagnostics.ambiguity_between_factors =
+        problem.ambiguity_between_factors.size();
+    diagnostics.ambiguity_states = problem.ambiguity_states.size();
+    diagnostics.tdcp_candidate_pairs =
+        problem.diagnostics.tdcp_candidate_pairs;
+    diagnostics.tdcp_rejected_gap = problem.diagnostics.tdcp_rejected_gap;
+    diagnostics.tdcp_rejected_missing_previous =
+        problem.diagnostics.tdcp_rejected_missing_previous;
+    diagnostics.tdcp_rejected_loss_of_lock =
+        problem.diagnostics.tdcp_rejected_loss_of_lock;
+    diagnostics.tdcp_rejected_code_phase_jump =
+        problem.diagnostics.tdcp_rejected_code_phase_jump;
+    diagnostics.double_difference_matched_base_epochs =
+        problem.diagnostics.double_difference_matched_base_epochs;
+    diagnostics.double_difference_interpolated_base_epochs =
+        problem.diagnostics.double_difference_interpolated_base_epochs;
+    diagnostics.double_difference_candidate_pairs =
+        problem.diagnostics.double_difference_candidate_pairs;
+    diagnostics.double_difference_rejected_no_base_epoch =
+        problem.diagnostics.double_difference_rejected_no_base_epoch;
+    diagnostics.double_difference_rejected_no_reference =
+        problem.diagnostics.double_difference_rejected_no_reference;
+    diagnostics.motion_factors =
+        (config.use_motion_factors || config.use_velocity_motion_factors) &&
+                problem.epochs.size() >= 2
+            ? problem.epochs.size() - 1
+            : 0;
+
+    const std::size_t position_prior_factors =
+        config.position_prior_sigma_m > 0.0 ? problem.epochs.size() : 0;
+    const std::size_t clock_prior_factors =
+        config.clock_prior_sigma_m > 0.0 ? problem.epochs.size() : 0;
+    const std::size_t velocity_prior_factors =
+        config.use_velocity_states && config.velocity_prior_sigma_mps > 0.0
+            ? problem.epochs.size()
+            : 0;
+    const std::size_t ambiguity_prior_factors =
+        config.use_ambiguity_priors && config.ambiguity_prior_sigma_m > 0.0
+            ? problem.ambiguity_states.size()
+            : 0;
+    diagnostics.graph_factors =
+        diagnostics.pseudorange_factors +
+        diagnostics.tdcp_factors +
+        diagnostics.single_difference_doppler_factors +
+        diagnostics.single_difference_tdcp_factors +
+        diagnostics.carrier_phase_factors +
+        diagnostics.double_difference_pseudorange_factors +
+        diagnostics.double_difference_carrier_factors +
+        diagnostics.ambiguity_between_factors +
+        diagnostics.motion_factors +
+        position_prior_factors +
+        clock_prior_factors +
+        velocity_prior_factors +
+        ambiguity_prior_factors;
+    diagnostics.graph_values =
+        problem.epochs.size() * (config.use_velocity_states ? 3 : 2) +
+        problem.ambiguity_states.size();
+
+    std::map<std::size_t, std::vector<const libgnss::FGOProcessor::PseudorangeFactor*>>
+        pseudorange_factors_by_epoch;
+    for (const auto& factor : problem.pseudorange_factors) {
+        pseudorange_factors_by_epoch[factor.epoch_index].push_back(&factor);
+    }
+    std::map<std::size_t, std::set<libgnss::SatelliteId>>
+        dd_satellites_by_epoch;
+    for (const auto& factor : problem.double_difference_pseudorange_factors) {
+        dd_satellites_by_epoch[factor.epoch_index].insert(factor.satellite);
+        dd_satellites_by_epoch[factor.epoch_index].insert(
+            factor.reference_satellite);
+    }
+    for (const auto& factor : problem.double_difference_carrier_factors) {
+        dd_satellites_by_epoch[factor.epoch_index].insert(factor.satellite);
+        dd_satellites_by_epoch[factor.epoch_index].insert(
+            factor.reference_satellite);
+    }
+    std::map<std::size_t, std::size_t> dd_carrier_factors_by_epoch;
+    for (const auto& factor : problem.double_difference_carrier_factors) {
+        ++dd_carrier_factors_by_epoch[factor.epoch_index];
+    }
+
+    result.solution.solutions.reserve(problem.epochs.size());
+    for (std::size_t epoch_index = 0; epoch_index < problem.epochs.size();
+         ++epoch_index) {
+        const auto& epoch = problem.epochs[epoch_index];
+        libgnss::PositionSolution solution;
+        solution.time = epoch.time;
+        solution.status = libgnss::SolutionStatus::SPP;
+        solution.position_ecef = epoch.position_ecef;
+        solution.receiver_clock_bias =
+            epoch.receiver_clock_bias_m / libgnss::constants::SPEED_OF_LIGHT;
+        solution.position_covariance =
+            libgnss::Matrix3d::Identity() * 9999.0;
+        solution.num_frequencies = 1;
+
+        double lat = 0.0;
+        double lon = 0.0;
+        double height = 0.0;
+        libgnss::ecef2geodetic(solution.position_ecef, lat, lon, height);
+        solution.position_geodetic = libgnss::GeodeticCoord(lat, lon, height);
+
+        const auto pseudorange_it =
+            pseudorange_factors_by_epoch.find(epoch_index);
+        bool has_epoch_pseudorange_solution = false;
+        if (pseudorange_it != pseudorange_factors_by_epoch.end()) {
+            has_epoch_pseudorange_solution = true;
+            solution.num_satellites =
+                static_cast<int>(pseudorange_it->second.size());
+            solution.satellites_used.reserve(pseudorange_it->second.size());
+            solution.satellite_elevations.reserve(pseudorange_it->second.size());
+            solution.satellite_residuals.reserve(pseudorange_it->second.size());
+            for (const auto* factor : pseudorange_it->second) {
+                solution.satellites_used.push_back(factor->satellite);
+                solution.satellite_elevations.push_back(factor->elevation_rad);
+                solution.satellite_residuals.push_back(
+                    std::numeric_limits<double>::quiet_NaN());
+            }
+        } else {
+            const auto dd_it = dd_satellites_by_epoch.find(epoch_index);
+            if (dd_it != dd_satellites_by_epoch.end()) {
+                solution.num_satellites = static_cast<int>(dd_it->second.size());
+                solution.satellites_used.assign(dd_it->second.begin(),
+                                                dd_it->second.end());
+            }
+        }
+        if (!has_epoch_pseudorange_solution &&
+            config.min_output_double_difference_carrier_factors_per_epoch > 0) {
+            const auto dd_carrier_count_it =
+                dd_carrier_factors_by_epoch.find(epoch_index);
+            const std::size_t dd_carrier_count =
+                dd_carrier_count_it == dd_carrier_factors_by_epoch.end()
+                    ? 0
+                    : dd_carrier_count_it->second;
+            if (dd_carrier_count <
+                static_cast<std::size_t>(
+                    config
+                        .min_output_double_difference_carrier_factors_per_epoch)) {
+                solution.status = libgnss::SolutionStatus::NONE;
+            }
+        }
+        result.solution.addSolution(solution);
+    }
+
+    return result;
+}
+
+std::string joinSatellites(const std::set<libgnss::SatelliteId>& satellites) {
+    std::ostringstream joined;
+    bool first = true;
+    for (const auto& satellite : satellites) {
+        if (!first) {
+            joined << ';';
+        }
+        joined << satellite.toString();
+        first = false;
+    }
+    return joined.str();
+}
+
+bool writeEpochDebugCsv(
+    const std::string& path,
+    const libgnss::FGOProcessor::FGOProblem& problem,
+    const libgnss::FGOProcessor::FGOResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+
+    std::map<std::size_t, std::set<std::size_t>> ambiguity_indices_by_epoch;
+    std::map<std::size_t, std::set<libgnss::SatelliteId>> dd_satellites_by_epoch;
+    std::map<std::size_t, std::set<libgnss::SatelliteId>> reference_satellites_by_epoch;
+
+    for (const auto& factor : problem.double_difference_carrier_factors) {
+        ambiguity_indices_by_epoch[factor.epoch_index].insert(
+            factor.ambiguity_index);
+        dd_satellites_by_epoch[factor.epoch_index].insert(factor.satellite);
+        dd_satellites_by_epoch[factor.epoch_index].insert(
+            factor.reference_satellite);
+        reference_satellites_by_epoch[factor.epoch_index].insert(
+            factor.reference_satellite);
+    }
+    for (const auto& factor : problem.double_difference_pseudorange_factors) {
+        dd_satellites_by_epoch[factor.epoch_index].insert(factor.satellite);
+        dd_satellites_by_epoch[factor.epoch_index].insert(
+            factor.reference_satellite);
+        reference_satellites_by_epoch[factor.epoch_index].insert(
+            factor.reference_satellite);
+    }
+
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+
+    output << "epoch_index,gps_week,gps_tow,status,ratio,num_fixed_ambiguities,"
+              "ambiguity_candidates,dd_satellites,reference_satellites,"
+              "position_x_m,position_y_m,position_z_m,"
+              "velocity_x_mps,velocity_y_mps,velocity_z_mps\n";
+    output << std::fixed << std::setprecision(6);
+    const auto& solution = result.solution;
+    const std::size_t rows =
+        std::min(problem.epochs.size(), solution.solutions.size());
+    const bool has_result_candidates =
+        result.ambiguity_candidate_satellites_by_epoch.size() >= rows &&
+        result.ambiguity_reference_satellites_by_epoch.size() >= rows;
+    for (std::size_t epoch_index = 0; epoch_index < rows; ++epoch_index) {
+        const auto& epoch = problem.epochs[epoch_index];
+        const auto& sol = solution.solutions[epoch_index];
+        const auto ambiguity_it = ambiguity_indices_by_epoch.find(epoch_index);
+        std::size_t ambiguity_candidates =
+            ambiguity_it == ambiguity_indices_by_epoch.end()
+                ? 0
+                : ambiguity_it->second.size();
+        const auto satellites_it = dd_satellites_by_epoch.find(epoch_index);
+        const auto references_it =
+            reference_satellites_by_epoch.find(epoch_index);
+        const std::set<libgnss::SatelliteId> empty_satellites;
+        std::set<libgnss::SatelliteId> result_satellites;
+        const std::set<libgnss::SatelliteId>* output_satellites =
+            satellites_it == dd_satellites_by_epoch.end()
+                ? &empty_satellites
+                : &satellites_it->second;
+        const std::set<libgnss::SatelliteId>* output_references =
+            references_it == reference_satellites_by_epoch.end()
+                ? &empty_satellites
+                : &references_it->second;
+        if (has_result_candidates) {
+            const auto& candidates =
+                result.ambiguity_candidate_satellites_by_epoch[epoch_index];
+            const auto& references =
+                result.ambiguity_reference_satellites_by_epoch[epoch_index];
+            ambiguity_candidates = candidates.size();
+            result_satellites = candidates;
+            result_satellites.insert(references.begin(), references.end());
+            output_satellites = &result_satellites;
+            output_references = &references;
+        }
+
+        const double nan = std::numeric_limits<double>::quiet_NaN();
+        libgnss::Vector3d velocity_mps =
+            libgnss::Vector3d::Constant(nan);
+        if (result.epoch_velocities_ecef_mps.size() > epoch_index) {
+            velocity_mps = result.epoch_velocities_ecef_mps[epoch_index];
+        }
+        auto velocityBetween = [&](std::size_t begin_index,
+                                   std::size_t end_index) -> libgnss::Vector3d {
+            const double dt =
+                solution.solutions[end_index].time -
+                solution.solutions[begin_index].time;
+            if (dt <= 0.0) {
+                return libgnss::Vector3d::Constant(nan);
+            }
+            return (solution.solutions[end_index].position_ecef -
+                    solution.solutions[begin_index].position_ecef) /
+                   dt;
+        };
+        if (rows >= 2 && !velocity_mps.allFinite()) {
+            if (epoch_index > 0 && epoch_index + 1 < rows) {
+                velocity_mps = velocityBetween(epoch_index - 1, epoch_index + 1);
+            } else if (epoch_index + 1 < rows) {
+                velocity_mps = velocityBetween(epoch_index, epoch_index + 1);
+            } else {
+                velocity_mps = velocityBetween(epoch_index - 1, epoch_index);
+            }
+        }
+
+        output << epoch_index << ','
+               << epoch.time.week << ','
+               << epoch.time.tow << ','
+               << static_cast<int>(sol.status) << ','
+               << sol.ratio << ','
+               << sol.num_fixed_ambiguities << ','
+               << ambiguity_candidates << ','
+               << joinSatellites(*output_satellites)
+               << ','
+               << joinSatellites(*output_references)
+               << ','
+               << sol.position_ecef(0) << ','
+               << sol.position_ecef(1) << ','
+               << sol.position_ecef(2) << ','
+               << velocity_mps(0) << ','
+               << velocity_mps(1) << ','
+               << velocity_mps(2)
+               << '\n';
+    }
+    return true;
+}
+
+void writeCsvDouble(std::ostream& output, double value);
+
+bool writeLambdaDebugCsv(
+    const std::string& path,
+    const std::vector<libgnss::FGOProcessor::LambdaDebugEntry>& entries) {
+    if (path.empty()) {
+        return true;
+    }
+
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+
+    output << "epoch_index,gps_week,gps_tow,solved,fixed_epoch,ratio,"
+              "candidate_count,row,col,satellite,other_satellite,local_index,"
+              "other_local_index,ambiguity_float,fixed_ambiguity,covariance,"
+              "position_covariance_x,position_covariance_y,position_covariance_z\n";
+    output << std::fixed << std::setprecision(15);
+    for (const auto& entry : entries) {
+        output << entry.epoch_index << ','
+               << entry.time.week << ','
+               << entry.time.tow << ','
+               << (entry.solved ? 1 : 0) << ','
+               << (entry.fixed_epoch ? 1 : 0) << ',';
+        writeCsvDouble(output, entry.ratio);
+        output << ','
+               << entry.candidate_count << ','
+               << entry.row << ','
+               << entry.col << ','
+               << entry.satellite.toString() << ','
+               << entry.other_satellite.toString() << ','
+               << entry.local_index << ','
+               << entry.other_local_index << ',';
+        writeCsvDouble(output, entry.ambiguity_float);
+        output << ',';
+        writeCsvDouble(output, entry.fixed_ambiguity);
+        output << ',';
+        writeCsvDouble(output, entry.covariance);
+        output << ',';
+        writeCsvDouble(output, entry.position_covariance_x);
+        output << ',';
+        writeCsvDouble(output, entry.position_covariance_y);
+        output << ',';
+        writeCsvDouble(output, entry.position_covariance_z);
+        output << '\n';
+    }
+    return true;
+}
+
+struct FactorDebugKey {
+    std::size_t epoch_index = 0;
+    libgnss::SatelliteId satellite;
+    libgnss::SatelliteId reference_satellite;
+    libgnss::SignalType signal = libgnss::SignalType::GPS_L1CA;
+
+    bool operator<(const FactorDebugKey& other) const {
+        return std::tie(epoch_index,
+                        satellite,
+                        reference_satellite,
+                        signal) <
+               std::tie(other.epoch_index,
+                        other.satellite,
+                        other.reference_satellite,
+                        other.signal);
+    }
+};
+
+void writeCsvDouble(std::ostream& output, double value) {
+    if (std::isfinite(value)) {
+        output << value;
+    } else {
+        output << "NaN";
+    }
+}
+
+double ddDebugTerm(double rover_satellite,
+                   double base_satellite,
+                   double rover_reference,
+                   double base_reference) {
+    return (rover_satellite - base_satellite) -
+           (rover_reference - base_reference);
+}
+
+bool isPrimaryFgoDebugSignal(libgnss::SignalType signal) {
+    switch (signal) {
+        case libgnss::SignalType::GPS_L1CA:
+        case libgnss::SignalType::GLO_L1CA:
+        case libgnss::SignalType::GAL_E1:
+        case libgnss::SignalType::BDS_B1I:
+        case libgnss::SignalType::BDS_B1C:
+        case libgnss::SignalType::QZS_L1CA:
+            return true;
+        default:
+            return false;
+    }
+}
+
+bool isHealthyForFgoDebug(const libgnss::Observation& observation,
+                          const libgnss::Ephemeris& eph) {
+    int sv_health = static_cast<int>(eph.health);
+    if (observation.satellite.system == libgnss::GNSSSystem::QZSS) {
+        sv_health &= 0xFE;
+    }
+    return sv_health == 0;
+}
+
+double groupDelayCorrectionMeters(const libgnss::Observation& observation,
+                                  const libgnss::Ephemeris& eph) {
+    switch (observation.satellite.system) {
+        case libgnss::GNSSSystem::GPS:
+        case libgnss::GNSSSystem::QZSS:
+        case libgnss::GNSSSystem::Galileo:
+            return eph.tgd * libgnss::constants::SPEED_OF_LIGHT;
+        case libgnss::GNSSSystem::BeiDou:
+            switch (observation.signal) {
+                case libgnss::SignalType::BDS_B1I:
+                case libgnss::SignalType::BDS_B1C:
+                    return eph.tgd * libgnss::constants::SPEED_OF_LIGHT;
+                case libgnss::SignalType::BDS_B2I:
+                case libgnss::SignalType::BDS_B2A:
+                    return eph.tgd_secondary *
+                           libgnss::constants::SPEED_OF_LIGHT;
+                default:
+                    return 0.0;
+            }
+        default:
+            return 0.0;
+    }
+}
+
+libgnss::Vector3d earthRotationCorrected(
+    const libgnss::Vector3d& satellite_position,
+    const libgnss::Vector3d& receiver_position) {
+    const double signal_travel_time =
+        (satellite_position - receiver_position).norm() /
+        libgnss::constants::SPEED_OF_LIGHT;
+    const double angle = libgnss::constants::OMEGA_E * signal_travel_time;
+
+    Eigen::Matrix3d earth_rotation;
+    earth_rotation << std::cos(angle),  std::sin(angle), 0.0,
+                     -std::sin(angle),  std::cos(angle), 0.0,
+                      0.0,              0.0,             1.0;
+    return earth_rotation * satellite_position;
+}
+
+struct SdReferenceKey {
+    std::size_t epoch_index = 0;
+    libgnss::GNSSSystem system = libgnss::GNSSSystem::UNKNOWN;
+    libgnss::SignalType signal = libgnss::SignalType::GPS_L1CA;
+
+    bool operator<(const SdReferenceKey& other) const {
+        return std::tie(epoch_index, system, signal) <
+               std::tie(other.epoch_index, other.system, other.signal);
+    }
+};
+
+struct SdDefaultReferenceKey {
+    libgnss::GNSSSystem system = libgnss::GNSSSystem::UNKNOWN;
+    libgnss::SignalType signal = libgnss::SignalType::GPS_L1CA;
+
+    bool operator<(const SdDefaultReferenceKey& other) const {
+        return std::tie(system, signal) <
+               std::tie(other.system, other.signal);
+    }
+};
+
+using SdObservationKey =
+    std::pair<libgnss::SatelliteId, libgnss::SignalType>;
+
+struct SdObservationModel {
+    libgnss::SatelliteId satellite;
+    libgnss::SignalType signal = libgnss::SignalType::GPS_L1CA;
+    double snr_dbhz = 0.0;
+    double elevation_rad = 0.0;
+    double raw_doppler_hz = std::numeric_limits<double>::quiet_NaN();
+    double raw_carrier_cycles = std::numeric_limits<double>::quiet_NaN();
+    double wavelength_m = std::numeric_limits<double>::quiet_NaN();
+    double doppler_residual_mps = std::numeric_limits<double>::quiet_NaN();
+    double carrier_residual_m = std::numeric_limits<double>::quiet_NaN();
+    double sigma_d_mps = std::numeric_limits<double>::quiet_NaN();
+    double sigma_l_m = std::numeric_limits<double>::quiet_NaN();
+    bool has_doppler_residual = false;
+    bool has_carrier_residual = false;
+    libgnss::Vector3d los = libgnss::Vector3d::Zero();
+};
+
+bool prepareSdObservationModel(const libgnss::ObservationData& epoch,
+                               const libgnss::Observation& observation,
+                               const libgnss::NavigationData& nav,
+                               const libgnss::Vector3d& receiver_position,
+                               const Options& options,
+                               SdObservationModel& model) {
+    if (receiver_position.norm() <= 1e6 ||
+        !isPrimaryFgoDebugSignal(observation.signal) ||
+        !observation.valid ||
+        !observation.has_pseudorange ||
+        observation.pseudorange <= 0.0 ||
+        observation.snr < options.min_snr_dbhz) {
+        return false;
+    }
+
+    libgnss::Vector3d satellite_position;
+    libgnss::Vector3d satellite_velocity;
+    double satellite_clock_bias = 0.0;
+    double satellite_clock_drift = 0.0;
+
+    libgnss::GNSSTime transmit_time =
+        epoch.time -
+        observation.pseudorange / libgnss::constants::SPEED_OF_LIGHT;
+    if (!nav.calculateSatelliteState(observation.satellite,
+                                     transmit_time,
+                                     satellite_position,
+                                     satellite_velocity,
+                                     satellite_clock_bias,
+                                     satellite_clock_drift)) {
+        return false;
+    }
+
+    transmit_time = transmit_time - satellite_clock_bias;
+    if (!nav.calculateSatelliteState(observation.satellite,
+                                     transmit_time,
+                                     satellite_position,
+                                     satellite_velocity,
+                                     satellite_clock_bias,
+                                     satellite_clock_drift)) {
+        return false;
+    }
+
+    const libgnss::Ephemeris* eph =
+        nav.getEphemeris(observation.satellite, transmit_time);
+    if (!eph || !isHealthyForFgoDebug(observation, *eph)) {
+        return false;
+    }
+
+    const libgnss::Vector3d corrected_satellite_position =
+        earthRotationCorrected(satellite_position, receiver_position);
+    const auto geometry =
+        nav.calculateGeometry(receiver_position, corrected_satellite_position);
+    const double min_elevation_rad = options.min_elevation_deg * M_PI / 180.0;
+    if (geometry.elevation < min_elevation_rad) {
+        return false;
+    }
+
+    double receiver_lat = 0.0;
+    double receiver_lon = 0.0;
+    double receiver_height = 0.0;
+    libgnss::ecef2geodetic(receiver_position,
+                           receiver_lat,
+                           receiver_lon,
+                           receiver_height);
+
+    double ionosphere_delay = 0.0;
+    if (options.use_ionosphere_model && nav.ionosphere_model.valid) {
+        ionosphere_delay = libgnss::models::ionoDelayKlobuchar(
+            receiver_lat,
+            receiver_lon,
+            geometry.azimuth,
+            geometry.elevation,
+            epoch.time.tow,
+            nav.ionosphere_model.alpha,
+            nav.ionosphere_model.beta);
+
+        const double frequency_hz =
+            libgnss::signalFrequencyHz(observation.signal, eph);
+        if (frequency_hz > 0.0) {
+            const double scale =
+                libgnss::constants::GPS_L1_FREQ / frequency_hz;
+            ionosphere_delay *= scale * scale;
+        }
+    }
+
+    double troposphere_delay = 0.0;
+    if (options.use_troposphere_model) {
+        troposphere_delay =
+            libgnss::models::tropDelaySaastamoinen(receiver_position,
+                                                   geometry.elevation);
+    }
+
+    double wavelength = libgnss::signalWavelengthMeters(observation);
+    if (wavelength <= 0.0) {
+        wavelength = libgnss::signalWavelengthMeters(observation.signal, eph);
+    }
+    if (wavelength <= 0.0) {
+        return false;
+    }
+
+    const double sin_el = std::sin(geometry.elevation);
+    if (sin_el <= 0.0) {
+        return false;
+    }
+    const double sqrt_sin_el = std::sqrt(sin_el);
+    const double satellite_clock_m =
+        satellite_clock_bias * libgnss::constants::SPEED_OF_LIGHT;
+    const double corrected_range =
+        (corrected_satellite_position - receiver_position).norm();
+    const libgnss::Vector3d corrected_delta =
+        corrected_satellite_position - receiver_position;
+    if (corrected_range <= 0.0) {
+        return false;
+    }
+
+    model = SdObservationModel{};
+    model.satellite = observation.satellite;
+    model.signal = observation.signal;
+    model.snr_dbhz = observation.snr;
+    model.elevation_rad = geometry.elevation;
+    model.wavelength_m = wavelength;
+    model.sigma_d_mps = 0.2 / sqrt_sin_el;
+    model.sigma_l_m =
+        options.double_difference_carrier_sigma_m / sqrt_sin_el;
+    model.los = -corrected_delta / corrected_range;
+
+    if (observation.has_doppler) {
+        const libgnss::Vector3d doppler_delta =
+            satellite_position - receiver_position;
+        const double doppler_range = doppler_delta.norm();
+        if (doppler_range > 0.0) {
+            const libgnss::Vector3d ex = doppler_delta / doppler_range;
+            const double sagnac_rate =
+                libgnss::constants::OMEGA_E /
+                libgnss::constants::SPEED_OF_LIGHT *
+                (satellite_velocity(1) * receiver_position(0) -
+                 satellite_velocity(0) * receiver_position(1));
+            const double modeled_range_rate =
+                satellite_velocity.dot(ex) + sagnac_rate;
+            const double satellite_clock_drift_mps =
+                satellite_clock_drift *
+                libgnss::constants::SPEED_OF_LIGHT;
+            const double measured_range_rate =
+                -observation.doppler * wavelength;
+            model.raw_doppler_hz = observation.doppler;
+            model.doppler_residual_mps =
+                measured_range_rate -
+                (modeled_range_rate - satellite_clock_drift_mps);
+            model.has_doppler_residual =
+                std::isfinite(model.doppler_residual_mps);
+        }
+    }
+
+    const bool has_carrier =
+        observation.has_carrier_phase && observation.carrier_phase != 0.0;
+    const bool loss_of_lock =
+        observation.loss_of_lock || ((observation.lli & 0x01U) != 0U);
+    if (has_carrier && !loss_of_lock) {
+        const double corrected_carrier =
+            observation.carrier_phase * wavelength +
+            satellite_clock_m -
+            troposphere_delay +
+            ionosphere_delay;
+        model.raw_carrier_cycles = observation.carrier_phase;
+        model.carrier_residual_m = corrected_carrier - corrected_range;
+        model.has_carrier_residual =
+            std::isfinite(model.carrier_residual_m);
+    }
+
+    return model.has_doppler_residual || model.has_carrier_residual;
+}
+
+bool writeSdFactorDebugCsv(
+    const std::string& path,
+    const std::vector<libgnss::ObservationData>& rover_epochs,
+    const libgnss::NavigationData& nav,
+    const libgnss::FGOProcessor::FGOProblem& problem,
+    const Options& options) {
+    if (path.empty()) {
+        return true;
+    }
+
+    std::map<SdReferenceKey, libgnss::SatelliteId> reference_by_group;
+    std::map<SdDefaultReferenceKey,
+             std::map<libgnss::SatelliteId, std::size_t>>
+        default_reference_counts;
+    auto remember_reference =
+        [&reference_by_group](std::size_t epoch_index,
+                              const libgnss::SatelliteId& satellite,
+                              const libgnss::SatelliteId& reference,
+                              libgnss::SignalType signal) {
+            reference_by_group[SdReferenceKey{
+                epoch_index,
+                satellite.system,
+                signal,
+            }] = reference;
+        };
+    for (const auto& factor : problem.double_difference_pseudorange_factors) {
+        remember_reference(factor.epoch_index,
+                           factor.satellite,
+                           factor.reference_satellite,
+                           factor.signal);
+        ++default_reference_counts[SdDefaultReferenceKey{
+            factor.satellite.system,
+            factor.signal,
+        }][factor.reference_satellite];
+    }
+    for (const auto& factor : problem.double_difference_carrier_factors) {
+        remember_reference(factor.epoch_index,
+                           factor.satellite,
+                           factor.reference_satellite,
+                           factor.signal);
+        ++default_reference_counts[SdDefaultReferenceKey{
+            factor.satellite.system,
+            factor.signal,
+        }][factor.reference_satellite];
+    }
+    std::map<SdDefaultReferenceKey, libgnss::SatelliteId>
+        default_reference_by_group;
+    for (const auto& [group_key, counts] : default_reference_counts) {
+        const auto best_it =
+            std::max_element(counts.begin(),
+                             counts.end(),
+                             [](const auto& lhs, const auto& rhs) {
+                                 return lhs.second < rhs.second;
+                             });
+        if (best_it != counts.end()) {
+            default_reference_by_group[group_key] = best_it->first;
+        }
+    }
+
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    output << "epoch_index,gps_week,gps_tow,satellite,reference,signal,"
+              "elevation_deg,reference_elevation_deg,sigma_dsd_mps,"
+              "sigma_tdcp_m,res_dsd_mps,res_lsd_m,tdcp_sd_m,"
+              "raw_d_rover_hz,raw_l_rover_cycles,wavelength_m,"
+              "valid_doppler_sd,valid_tdcp_sd,los_x,los_y,los_z\n";
+    output << std::fixed << std::setprecision(12);
+
+    std::map<SdObservationKey, double> previous_res_lsd_by_key;
+    const std::size_t rows = std::min(problem.epochs.size(), rover_epochs.size());
+    for (std::size_t epoch_index = 0; epoch_index < rows; ++epoch_index) {
+        const auto& problem_epoch = problem.epochs[epoch_index];
+        const auto& rover_epoch = rover_epochs[epoch_index];
+        std::map<SdObservationKey, SdObservationModel> models_by_key;
+        for (const auto& observation : rover_epoch.observations) {
+            SdObservationModel model;
+            if (prepareSdObservationModel(rover_epoch,
+                                          observation,
+                                          nav,
+                                          problem_epoch.position_ecef,
+                                          options,
+                                          model)) {
+                models_by_key[{model.satellite, model.signal}] = model;
+            }
+        }
+
+        std::map<SdObservationKey, double> current_res_lsd_by_key;
+        for (const auto& [key, model] : models_by_key) {
+            const auto reference_it = reference_by_group.find(SdReferenceKey{
+                epoch_index,
+                model.satellite.system,
+                model.signal,
+            });
+            libgnss::SatelliteId reference_satellite;
+            if (reference_it != reference_by_group.end()) {
+                reference_satellite = reference_it->second;
+            } else {
+                const auto default_reference_it =
+                    default_reference_by_group.find(SdDefaultReferenceKey{
+                        model.satellite.system,
+                        model.signal,
+                    });
+                if (default_reference_it ==
+                        default_reference_by_group.end() ||
+                    !(model.satellite == default_reference_it->second)) {
+                    continue;
+                }
+                reference_satellite = default_reference_it->second;
+            }
+            const auto reference_model_it =
+                models_by_key.find({reference_satellite, model.signal});
+            if (reference_model_it == models_by_key.end()) {
+                continue;
+            }
+            const SdObservationModel& reference_model =
+                reference_model_it->second;
+
+            double res_dsd =
+                std::numeric_limits<double>::quiet_NaN();
+            const bool valid_doppler =
+                model.has_doppler_residual &&
+                reference_model.has_doppler_residual;
+            if (valid_doppler) {
+                res_dsd =
+                    model.doppler_residual_mps -
+                    reference_model.doppler_residual_mps;
+            }
+
+            double res_lsd =
+                std::numeric_limits<double>::quiet_NaN();
+            double tdcp_sd =
+                std::numeric_limits<double>::quiet_NaN();
+            bool valid_tdcp = false;
+            if (model.has_carrier_residual &&
+                reference_model.has_carrier_residual) {
+                res_lsd =
+                    model.carrier_residual_m -
+                    reference_model.carrier_residual_m;
+                current_res_lsd_by_key[key] = res_lsd;
+                const auto previous_it =
+                    previous_res_lsd_by_key.find(key);
+                if (previous_it != previous_res_lsd_by_key.end()) {
+                    tdcp_sd = res_lsd - previous_it->second;
+                    valid_tdcp =
+                        std::isfinite(tdcp_sd) && tdcp_sd != 0.0;
+                }
+            }
+
+            if (!valid_doppler &&
+                !std::isfinite(res_lsd) &&
+                !valid_tdcp) {
+                continue;
+            }
+
+            const libgnss::Vector3d dd_los =
+                model.los - reference_model.los;
+            output << epoch_index << ','
+                   << problem_epoch.time.week << ','
+                   << problem_epoch.time.tow << ','
+                   << model.satellite.toString() << ','
+                   << reference_satellite.toString() << ','
+                   << static_cast<int>(model.signal) << ','
+                   << model.elevation_rad * 180.0 / M_PI << ','
+                   << reference_model.elevation_rad * 180.0 / M_PI << ',';
+            writeCsvDouble(output, model.sigma_d_mps);
+            output << ',';
+            writeCsvDouble(output, model.sigma_l_m);
+            output << ',';
+            writeCsvDouble(output, res_dsd);
+            output << ',';
+            writeCsvDouble(output, res_lsd);
+            output << ',';
+            writeCsvDouble(output, tdcp_sd);
+            output << ',';
+            writeCsvDouble(output, model.raw_doppler_hz);
+            output << ',';
+            writeCsvDouble(output, model.raw_carrier_cycles);
+            output << ',';
+            writeCsvDouble(output, model.wavelength_m);
+            output << ','
+                   << (valid_doppler ? 1 : 0) << ','
+                   << (valid_tdcp ? 1 : 0) << ',';
+            writeCsvDouble(output, dd_los(0));
+            output << ',';
+            writeCsvDouble(output, dd_los(1));
+            output << ',';
+            writeCsvDouble(output, dd_los(2));
+            output << '\n';
+        }
+
+        previous_res_lsd_by_key = std::move(current_res_lsd_by_key);
+    }
+
+    return true;
+}
+
+bool writeFactorDebugCsv(
+    const std::string& path,
+    const libgnss::FGOProcessor::FGOProblem& problem,
+    const libgnss::FGOProcessor::FGOResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+
+    std::map<FactorDebugKey,
+             const libgnss::FGOProcessor::DoubleDifferenceCarrierFactor*>
+        carrier_factor_by_key;
+    for (const auto& factor : problem.double_difference_carrier_factors) {
+        carrier_factor_by_key[FactorDebugKey{
+            factor.epoch_index,
+            factor.satellite,
+            factor.reference_satellite,
+            factor.signal,
+        }] = &factor;
+    }
+
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    if (problem.double_difference_pseudorange_factors.empty() &&
+        !problem.pseudorange_factors.empty()) {
+        output << "epoch_index,gps_week,gps_tow,satellite,clock_group,"
+                  "elevation_deg,sigma_p_m,corrected_pseudorange_m,"
+                  "seed_range_m,initial_res_pc_m,final_residual_m,"
+                  "los_x,los_y,los_z\n";
+        output << std::fixed << std::setprecision(12);
+
+        for (const auto& factor : problem.pseudorange_factors) {
+            if (factor.epoch_index >= problem.epochs.size()) {
+                continue;
+            }
+            const auto& epoch = problem.epochs[factor.epoch_index];
+            const libgnss::Vector3d delta =
+                factor.satellite_position_ecef - epoch.position_ecef;
+            const double range = delta.norm();
+            if (range <= 0.0) {
+                continue;
+            }
+            const libgnss::Vector3d los = delta / range;
+            const double initial_residual =
+                factor.corrected_pseudorange_m - range -
+                epoch.receiver_clock_bias_m;
+            double final_residual =
+                std::numeric_limits<double>::quiet_NaN();
+            if (result.solution.solutions.size() > factor.epoch_index) {
+                const auto& solution =
+                    result.solution.solutions[factor.epoch_index];
+                for (std::size_t i = 0;
+                     i < solution.satellites_used.size() &&
+                     i < solution.satellite_residuals.size();
+                     ++i) {
+                    if (solution.satellites_used[i] == factor.satellite) {
+                        final_residual = solution.satellite_residuals[i];
+                        break;
+                    }
+                }
+            }
+
+            output << factor.epoch_index << ','
+                   << epoch.time.week << ','
+                   << epoch.time.tow << ','
+                   << factor.satellite.toString() << ','
+                   << static_cast<int>(factor.clock_group) << ','
+                   << factor.elevation_rad * 180.0 / M_PI << ',';
+            writeCsvDouble(output, factor.sigma_m);
+            output << ',';
+            writeCsvDouble(output, factor.corrected_pseudorange_m);
+            output << ',';
+            writeCsvDouble(output, range);
+            output << ',';
+            writeCsvDouble(output, initial_residual);
+            output << ',';
+            writeCsvDouble(output, final_residual);
+            output << ',';
+            writeCsvDouble(output, -los(0));
+            output << ',';
+            writeCsvDouble(output, -los(1));
+            output << ',';
+            writeCsvDouble(output, -los(2));
+            output << '\n';
+        }
+        return true;
+    }
+
+    output << "epoch_index,gps_week,gps_tow,satellite,reference,signal,"
+              "elevation_deg,sigma_pdd_m,sigma_ldd_m,res_pdd,res_ldd,ambiguity_initial,"
+              "ambiguity_estimate,geometry_m,rover_satellite_range_m,"
+              "base_satellite_range_m,rover_reference_range_m,"
+              "base_reference_range_m,observed_dd_pseudorange_m,"
+              "observed_dd_carrier_m,dd_raw_pseudorange_m,"
+              "dd_raw_carrier_m,dd_code_correction_m,"
+              "dd_carrier_correction_m,dd_satellite_clock_m,"
+              "dd_ionosphere_delay_m,dd_troposphere_delay_m,"
+              "dd_group_delay_m\n";
+    output << std::fixed << std::setprecision(12);
+
+    for (const auto& factor : problem.double_difference_pseudorange_factors) {
+        if (factor.epoch_index >= problem.epochs.size()) {
+            continue;
+        }
+        const auto& epoch = problem.epochs[factor.epoch_index];
+        const double geometry = ddGeometry(epoch.position_ecef,
+                                           factor.base_position_ecef,
+                                           factor.rover_satellite_position_ecef,
+                                           factor.rover_reference_position_ecef,
+                                           factor.base_satellite_position_ecef,
+                                           factor.base_reference_position_ecef);
+        const FactorDebugKey key{
+            factor.epoch_index,
+            factor.satellite,
+            factor.reference_satellite,
+            factor.signal,
+        };
+        const double pseudorange_residual =
+            factor.observed_dd_pseudorange_m - geometry;
+        double carrier_residual = std::numeric_limits<double>::quiet_NaN();
+        double initial_cycles = std::numeric_limits<double>::quiet_NaN();
+        double estimated_cycles = std::numeric_limits<double>::quiet_NaN();
+        double observed_dd_carrier =
+            std::numeric_limits<double>::quiet_NaN();
+        double carrier_sigma = std::numeric_limits<double>::quiet_NaN();
+        double raw_carrier_dd = std::numeric_limits<double>::quiet_NaN();
+        double carrier_correction_dd =
+            std::numeric_limits<double>::quiet_NaN();
+
+        const double rover_satellite_range =
+            factor.rover_satellite_model.geometric_range_m;
+        const double base_satellite_range =
+            factor.base_satellite_model.geometric_range_m;
+        const double rover_reference_range =
+            factor.rover_reference_model.geometric_range_m;
+        const double base_reference_range =
+            factor.base_reference_model.geometric_range_m;
+        const double raw_pseudorange_dd =
+            ddDebugTerm(factor.rover_satellite_model.raw_pseudorange_m,
+                        factor.base_satellite_model.raw_pseudorange_m,
+                        factor.rover_reference_model.raw_pseudorange_m,
+                        factor.base_reference_model.raw_pseudorange_m);
+        const double code_correction_dd =
+            factor.observed_dd_pseudorange_m - raw_pseudorange_dd;
+        const double satellite_clock_dd =
+            ddDebugTerm(factor.rover_satellite_model.satellite_clock_m,
+                        factor.base_satellite_model.satellite_clock_m,
+                        factor.rover_reference_model.satellite_clock_m,
+                        factor.base_reference_model.satellite_clock_m);
+        const double ionosphere_dd =
+            ddDebugTerm(factor.rover_satellite_model.ionosphere_delay_m,
+                        factor.base_satellite_model.ionosphere_delay_m,
+                        factor.rover_reference_model.ionosphere_delay_m,
+                        factor.base_reference_model.ionosphere_delay_m);
+        const double troposphere_dd =
+            ddDebugTerm(factor.rover_satellite_model.troposphere_delay_m,
+                        factor.base_satellite_model.troposphere_delay_m,
+                        factor.rover_reference_model.troposphere_delay_m,
+                        factor.base_reference_model.troposphere_delay_m);
+        const double group_delay_dd =
+            ddDebugTerm(factor.rover_satellite_model.group_delay_m,
+                        factor.base_satellite_model.group_delay_m,
+                        factor.rover_reference_model.group_delay_m,
+                        factor.base_reference_model.group_delay_m);
+
+        const auto carrier_it = carrier_factor_by_key.find(key);
+        if (carrier_it != carrier_factor_by_key.end()) {
+            const auto& carrier_factor = *carrier_it->second;
+            if (carrier_factor.ambiguity_index < problem.ambiguity_states.size()) {
+                const auto& ambiguity =
+                    problem.ambiguity_states[carrier_factor.ambiguity_index];
+                observed_dd_carrier = carrier_factor.observed_dd_carrier_m;
+                carrier_sigma = carrier_factor.sigma_m;
+                carrier_residual =
+                    carrier_factor.observed_dd_carrier_m - geometry;
+                raw_carrier_dd =
+                    ddDebugTerm(
+                        carrier_factor.rover_satellite_model.raw_carrier_m,
+                        carrier_factor.base_satellite_model.raw_carrier_m,
+                        carrier_factor.rover_reference_model.raw_carrier_m,
+                        carrier_factor.base_reference_model.raw_carrier_m);
+                carrier_correction_dd =
+                    carrier_factor.observed_dd_carrier_m - raw_carrier_dd;
+                initial_cycles =
+                    ambiguity.wavelength_m > 0.0
+                        ? ambiguity.initial_ambiguity_m / ambiguity.wavelength_m
+                        : std::numeric_limits<double>::quiet_NaN();
+                if (result.ambiguity_estimate_cycles_by_epoch.size() >
+                    factor.epoch_index) {
+                    const auto estimate_it =
+                        result
+                            .ambiguity_estimate_cycles_by_epoch[factor.epoch_index]
+                            .find(factor.satellite);
+                    if (estimate_it !=
+                        result
+                            .ambiguity_estimate_cycles_by_epoch[factor.epoch_index]
+                            .end()) {
+                        estimated_cycles = estimate_it->second;
+                    }
+                }
+            }
+        }
+
+        output << factor.epoch_index << ','
+               << epoch.time.week << ','
+               << epoch.time.tow << ','
+               << factor.satellite.toString() << ','
+               << factor.reference_satellite.toString() << ','
+               << static_cast<int>(factor.signal) << ','
+               << factor.elevation_rad * 180.0 / M_PI << ',';
+        writeCsvDouble(output, factor.sigma_m);
+        output << ',';
+        writeCsvDouble(output, carrier_sigma);
+        output << ',';
+        writeCsvDouble(output, pseudorange_residual);
+        output << ',';
+        writeCsvDouble(output, carrier_residual);
+        output << ',';
+        writeCsvDouble(output, initial_cycles);
+        output << ',';
+        writeCsvDouble(output, estimated_cycles);
+        output << ',';
+        writeCsvDouble(output, geometry);
+        output << ',';
+        writeCsvDouble(output, rover_satellite_range);
+        output << ',';
+        writeCsvDouble(output, base_satellite_range);
+        output << ',';
+        writeCsvDouble(output, rover_reference_range);
+        output << ',';
+        writeCsvDouble(output, base_reference_range);
+        output << ',';
+        writeCsvDouble(output, factor.observed_dd_pseudorange_m);
+        output << ',';
+        writeCsvDouble(output, observed_dd_carrier);
+        output << ',';
+        writeCsvDouble(output, raw_pseudorange_dd);
+        output << ',';
+        writeCsvDouble(output, raw_carrier_dd);
+        output << ',';
+        writeCsvDouble(output, code_correction_dd);
+        output << ',';
+        writeCsvDouble(output, carrier_correction_dd);
+        output << ',';
+        writeCsvDouble(output, satellite_clock_dd);
+        output << ',';
+        writeCsvDouble(output, ionosphere_dd);
+        output << ',';
+        writeCsvDouble(output, troposphere_dd);
+        output << ',';
+        writeCsvDouble(output, group_delay_dd);
+        output << '\n';
+    }
+
+    return true;
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+    try {
+        const Options options = parseArguments(argc, argv);
+
+        libgnss::io::RINEXReader obs_reader;
+        if (!obs_reader.open(options.obs_path)) {
+            std::cerr << "Error: failed to open observation file: " << options.obs_path << "\n";
+            return 1;
+        }
+        libgnss::io::RINEXReader::RINEXHeader obs_header;
+        if (!obs_reader.readHeader(obs_header)) {
+            std::cerr << "Error: failed to read observation header: " << options.obs_path << "\n";
+            return 1;
+        }
+
+        libgnss::io::RINEXReader nav_reader;
+        if (!nav_reader.open(options.nav_path)) {
+            std::cerr << "Error: failed to open navigation file: " << options.nav_path << "\n";
+            return 1;
+        }
+        libgnss::NavigationData nav_data;
+        if (!nav_reader.readNavigationData(nav_data)) {
+            std::cerr << "Error: failed to read navigation data: " << options.nav_path << "\n";
+            return 1;
+        }
+
+        const std::vector<SeedPosition> seed_positions =
+            options.seed_pos_path.empty()
+                ? std::vector<SeedPosition>()
+                : readSeedPositions(options.seed_pos_path);
+        std::size_t seed_cursor = 0;
+        std::size_t seed_matched_epochs = 0;
+        std::size_t seed_interpolated_epochs = 0;
+
+        std::vector<libgnss::ObservationData> epochs;
+        const double fixed_interval_s =
+            obs_header.interval > 0.0 ? obs_header.interval : 1.0;
+        const double fixed_gap_tolerance_s =
+            std::max(0.01, 0.5 * fixed_interval_s);
+        bool have_last_output_time = false;
+        libgnss::GNSSTime last_output_time;
+
+        auto append_rover_epoch =
+            [&](libgnss::ObservationData epoch_to_append) -> bool {
+            if (options.max_epochs > 0 &&
+                static_cast<int>(epochs.size()) >= options.max_epochs) {
+                return false;
+            }
+            libgnss::Vector3d seed_position = libgnss::Vector3d::Zero();
+            bool seed_interpolated = false;
+            if (!seed_positions.empty() &&
+                findSeedPosition(seed_positions,
+                                 epoch_to_append.time,
+                                 options.seed_match_tolerance_s,
+                                 options.seed_interpolation_max_gap_s,
+                                 seed_cursor,
+                                 seed_position,
+                                 seed_interpolated)) {
+                epoch_to_append.receiver_position = seed_position;
+                epoch_to_append.receiver_clock_bias = 0.0;
+                ++seed_matched_epochs;
+                if (seed_interpolated) {
+                    ++seed_interpolated_epochs;
+                }
+            } else if (obs_header.approximate_position.norm() > 0.0) {
+                epoch_to_append.receiver_position = obs_header.approximate_position;
+            }
+            applySystemFilter(epoch_to_append, options);
+            epochs.push_back(std::move(epoch_to_append));
+            return true;
+        };
+
+        libgnss::ObservationData epoch;
+        int rover_epoch_index = 0;
+        while (obs_reader.readObservationEpoch(epoch)) {
+            if (rover_epoch_index++ < options.skip_epochs) {
+                continue;
+            }
+
+            if (options.insert_fixed_interval_gaps && have_last_output_time) {
+                libgnss::GNSSTime expected_time =
+                    last_output_time + fixed_interval_s;
+                while (epoch.time - expected_time > fixed_gap_tolerance_s) {
+                    libgnss::ObservationData empty_epoch(expected_time);
+                    if (!append_rover_epoch(empty_epoch)) {
+                        break;
+                    }
+                    last_output_time = expected_time;
+                    expected_time = last_output_time + fixed_interval_s;
+                    if (options.max_epochs > 0 &&
+                        static_cast<int>(epochs.size()) >= options.max_epochs) {
+                        break;
+                    }
+                }
+                if (options.max_epochs > 0 &&
+                    static_cast<int>(epochs.size()) >= options.max_epochs) {
+                    break;
+                }
+            }
+
+            if (!append_rover_epoch(epoch)) {
+                break;
+            }
+            last_output_time = epoch.time;
+            have_last_output_time = true;
+        }
+
+        std::vector<libgnss::ObservationData> base_epochs;
+        libgnss::Vector3d base_position = libgnss::Vector3d::Zero();
+        if (!options.base_path.empty() && !options.no_double_difference_factors) {
+            libgnss::io::RINEXReader base_reader;
+            if (!base_reader.open(options.base_path)) {
+                std::cerr << "Error: failed to open base observation file: "
+                          << options.base_path << "\n";
+                return 1;
+            }
+            libgnss::io::RINEXReader::RINEXHeader base_header;
+            if (!base_reader.readHeader(base_header)) {
+                std::cerr << "Error: failed to read base observation header: "
+                          << options.base_path << "\n";
+                return 1;
+            }
+            if (base_header.approximate_position.norm() <= 1e6) {
+                std::cerr << "Error: base approximate position is unavailable in: "
+                          << options.base_path << "\n";
+                return 1;
+            }
+            base_position = base_header.approximate_position;
+
+            libgnss::ObservationData base_epoch;
+            while (base_reader.readObservationEpoch(base_epoch)) {
+                base_epoch.receiver_position = base_position;
+                applySystemFilter(base_epoch, options);
+                base_epochs.push_back(base_epoch);
+            }
+            if (base_epochs.empty()) {
+                std::cerr << "Error: base observation file has no epochs: "
+                          << options.base_path << "\n";
+                return 1;
+            }
+        }
+
+        libgnss::FGOProcessor::FGOConfig config;
+        config.max_iterations = options.max_iterations;
+        config.relative_cost_convergence_threshold =
+            options.relative_cost_convergence_threshold;
+        config.absolute_cost_convergence_threshold =
+            options.absolute_cost_convergence_threshold;
+        config.pseudorange_sigma_m = options.pseudorange_sigma_m;
+        config.pseudorange_elevation_sigma_power =
+            options.pseudorange_elevation_sigma_power;
+        config.motion_sigma_m = options.motion_sigma_m;
+        config.clock_motion_sigma_m = options.clock_motion_sigma_m;
+        config.velocity_prior_sigma_mps = options.velocity_prior_sigma_mps;
+        config.velocity_motion_sigma_m = options.velocity_motion_sigma_m;
+        config.ambiguity_between_sigma_cycles =
+            options.ambiguity_between_sigma_cycles;
+        config.position_prior_sigma_m = options.position_prior_sigma_m;
+        config.clock_prior_sigma_m = options.clock_prior_sigma_m;
+        config.tdcp_sigma_m = options.tdcp_sigma_m;
+        config.carrier_phase_sigma_m = options.carrier_phase_sigma_m;
+        config.double_difference_pseudorange_sigma_m =
+            options.double_difference_pseudorange_sigma_m;
+        config.double_difference_carrier_sigma_m =
+            options.double_difference_carrier_sigma_m;
+        config.ambiguity_prior_sigma_m = options.ambiguity_prior_sigma_m;
+        config.pseudorange_huber_threshold_sigma =
+            options.pseudorange_huber_threshold_sigma;
+        config.carrier_phase_huber_threshold_sigma =
+            options.carrier_phase_huber_threshold_sigma;
+        config.tdcp_huber_threshold_sigma = options.tdcp_huber_threshold_sigma;
+        config.fixed_ambiguity_sigma_m = options.fixed_ambiguity_sigma_m;
+        config.ambiguity_fix_max_fractional_cycles =
+            options.ambiguity_fix_threshold_cycles;
+        config.lambda_ratio_threshold = options.lambda_ratio_threshold;
+        config.use_epoch_lambda_fixed_output =
+            options.use_epoch_lambda_fixed_output;
+        config.min_fixed_ambiguities = options.min_fixed_ambiguities;
+        config.max_lambda_ambiguities = options.max_lambda_ambiguities;
+        config.max_tdcp_gap_s = options.max_tdcp_gap_s;
+        config.base_epoch_match_tolerance_s = options.base_match_tolerance_s;
+        config.base_interpolation_max_gap_s =
+            options.base_interpolation_max_gap_s;
+        config.tdcp_code_phase_jump_threshold_m = options.tdcp_slip_threshold_m;
+        config.min_elevation_deg = options.min_elevation_deg;
+        config.min_snr_dbhz = options.min_snr_dbhz;
+        config.min_satellites_per_epoch = options.min_satellites_per_epoch;
+        config.min_output_double_difference_carrier_factors_per_epoch =
+            options.min_output_dd_carrier_factors_per_epoch;
+        config.double_difference_reference_min_snr_dbhz =
+            options.double_difference_reference_min_snr_dbhz;
+        config.double_difference_base_min_snr_dbhz =
+            options.double_difference_base_min_snr_dbhz;
+        config.use_spp_seed = !options.no_spp_seed;
+        config.use_pseudorange_factors = !options.no_pseudorange_factors;
+        config.use_motion_factors = !options.no_motion_factors;
+        config.use_position_motion_factors =
+            config.use_motion_factors && !options.clock_only_motion_factors;
+        config.use_clock_motion_factors = config.use_motion_factors;
+        config.use_tdcp_factors = !options.no_tdcp_factors;
+        config.use_double_difference_factors =
+            !options.base_path.empty() && !options.no_double_difference_factors;
+        config.use_single_difference_doppler_factors =
+            options.use_single_difference_doppler_factors;
+        config.use_single_difference_tdcp_factors =
+            options.use_single_difference_tdcp_factors;
+        config.use_velocity_states = options.use_velocity_states;
+        config.use_velocity_motion_factors =
+            options.use_velocity_motion_factors && options.use_velocity_states;
+        config.use_ambiguity_between_factors =
+            options.use_ambiguity_between_factors;
+        config.linearize_double_difference_factors_at_seed =
+            options.linearize_double_difference_factors_at_seed;
+        config.reset_double_difference_ambiguities_each_epoch =
+            options.dd_ambiguity_per_epoch;
+        config.use_carrier_phase_factors =
+            options.use_carrier_phase_factors ||
+            (options.fix_ambiguities && !config.use_double_difference_factors);
+        config.fix_ambiguities = options.fix_ambiguities;
+        config.prefer_double_difference_ambiguity_fixing =
+            !options.fix_all_ambiguities;
+        config.use_lambda_ambiguity_fix = options.use_lambda_ambiguity_fix;
+        config.use_partial_lambda_ambiguity_fix =
+            options.use_partial_lambda_ambiguity_fix;
+        config.use_robust_loss = options.use_robust_loss;
+        config.use_ambiguity_priors = !options.no_ambiguity_priors;
+        config.reject_rover_carrier_loss_of_lock =
+            options.reject_rover_carrier_lli;
+        config.reject_tdcp_code_phase_jump = !options.no_tdcp_slip_reject;
+        config.use_ionosphere_model = options.use_ionosphere_model;
+        config.use_troposphere_model = options.use_troposphere_model;
+        config.collect_lambda_debug = !options.lambda_debug_csv_path.empty();
+
+        const libgnss::FGOProcessor processor(config);
+        const libgnss::FGOProcessor::FGOProblem problem =
+            config.use_double_difference_factors
+                ? processor.buildDoubleDifferenceProblem(
+                      epochs, base_epochs, nav_data, base_position)
+                : processor.buildPseudorangeProblem(epochs, nav_data);
+        libgnss::FGOProcessor::FGOResult result;
+        if (options.debug_problem_only) {
+            result = makeProblemOnlyResult(problem, config);
+        } else if (options.backend == "gtsam-pc") {
+#ifdef GNSS_WITH_GTSAM
+            if (!config.use_double_difference_factors) {
+                std::cerr << "Error: --backend gtsam-pc requires --base and DD factors\n";
+                return 1;
+            }
+            result = optimizeGtsamPcProblem(problem, config);
+#else
+            std::cerr << "Error: --backend gtsam-pc is not available in this build\n";
+            return 1;
+#endif
+        } else {
+            result = processor.optimizeProblem(problem);
+        }
+
+        if (result.solution.isEmpty()) {
+            std::cerr << "Error: FGO produced no valid epochs\n";
+            return 1;
+        }
+        if (!result.solution.writeToFile(options.out_path)) {
+            std::cerr << "Error: failed to write solution file: " << options.out_path << "\n";
+            return 1;
+        }
+        if (!writeEpochDebugCsv(options.epoch_debug_csv_path, problem, result)) {
+            std::cerr << "Error: failed to write epoch debug CSV: "
+                      << options.epoch_debug_csv_path << "\n";
+            return 1;
+        }
+        if (!writeFactorDebugCsv(options.factor_debug_csv_path, problem, result)) {
+            std::cerr << "Error: failed to write factor debug CSV: "
+                      << options.factor_debug_csv_path << "\n";
+            return 1;
+        }
+        if (!writeSdFactorDebugCsv(options.sd_factor_debug_csv_path,
+                                   epochs,
+                                   nav_data,
+                                   problem,
+                                   options)) {
+            std::cerr << "Error: failed to write SD factor debug CSV: "
+                      << options.sd_factor_debug_csv_path << "\n";
+            return 1;
+        }
+        if (!writeLambdaDebugCsv(options.lambda_debug_csv_path,
+                                 result.lambda_debug_entries)) {
+            std::cerr << "Error: failed to write lambda debug CSV: "
+                      << options.lambda_debug_csv_path << "\n";
+            return 1;
+        }
+
+        const auto stats = result.solution.calculateStatistics();
+        const double availability_rate =
+            ratePercent(stats.valid_solutions, epochs.size());
+        const double fix_rate =
+            ratePercent(stats.fixed_solutions, stats.valid_solutions);
+        const double float_rate =
+            ratePercent(stats.float_solutions, stats.valid_solutions);
+        writeSummaryJson(options,
+                         result,
+                         stats,
+                         epochs.size(),
+                         seed_matched_epochs,
+                         seed_interpolated_epochs,
+                         availability_rate,
+                         fix_rate,
+                         float_rate);
+
+        if (!options.quiet) {
+            std::cout << "Preset: " << options.preset << "\n";
+            std::cout << "Backend: " << options.backend << "\n";
+            std::cout << "Input epochs: " << epochs.size() << "\n";
+            if (!options.seed_pos_path.empty()) {
+                std::cout << "Seed POS matched epochs: "
+                          << seed_matched_epochs << "\n";
+                std::cout << "Seed POS interpolated epochs: "
+                          << seed_interpolated_epochs << "\n";
+                std::cout << "SPP seed: "
+                          << (config.use_spp_seed ? "enabled" : "disabled")
+                          << "\n";
+            }
+            std::cout << "Optimized epochs: " << result.diagnostics.epochs << "\n";
+            std::cout << "Valid solutions: " << stats.valid_solutions << "\n";
+            std::cout << "Fixed solutions: " << stats.fixed_solutions << "\n";
+            std::cout << "Float solutions: " << stats.float_solutions << "\n";
+            std::cout << "Availability rate [%]: "
+                      << formatPercent(availability_rate) << "\n";
+            std::cout << "Fix rate [%]: "
+                      << formatPercent(fix_rate) << "\n";
+            std::cout << "Float rate [%]: "
+                      << formatPercent(float_rate) << "\n";
+            std::cout << "Pseudorange factors: " << result.diagnostics.pseudorange_factors << "\n";
+            std::cout << "TDCP factors: " << result.diagnostics.tdcp_factors << "\n";
+            std::cout << "SD Doppler factors: "
+                      << result.diagnostics.single_difference_doppler_factors
+                      << "\n";
+            std::cout << "SD TDCP factors: "
+                      << result.diagnostics.single_difference_tdcp_factors
+                      << "\n";
+            std::cout << "Carrier phase factors: "
+                      << result.diagnostics.carrier_phase_factors << "\n";
+            std::cout << "Double-difference pseudorange factors: "
+                      << result.diagnostics.double_difference_pseudorange_factors
+                      << "\n";
+            std::cout << "Double-difference carrier factors: "
+                      << result.diagnostics.double_difference_carrier_factors << "\n";
+            std::cout << "Ambiguity states: " << result.diagnostics.ambiguity_states << "\n";
+            std::cout << "Ambiguity fix candidates: "
+                      << result.diagnostics.ambiguity_fix_candidates << "\n";
+            std::cout << "LAMBDA ambiguity candidates: "
+                      << result.diagnostics.lambda_ambiguity_candidates << "\n";
+            std::cout << "LAMBDA used candidates: "
+                      << result.diagnostics.lambda_ambiguity_used_candidates << "\n";
+            std::cout << "LAMBDA attempts: "
+                      << result.diagnostics.lambda_ambiguity_attempts << "\n";
+            std::cout << "LAMBDA solved: "
+                      << (result.diagnostics.lambda_ambiguity_fix_solved ? "yes" : "no")
+                      << "\n";
+            std::cout << "LAMBDA used: "
+                      << (result.diagnostics.lambda_ambiguity_fix_used ? "yes" : "no")
+                      << "\n";
+            std::cout << "Partial LAMBDA used: "
+                      << (result.diagnostics.partial_lambda_ambiguity_fix_used ? "yes" : "no")
+                      << "\n";
+            std::cout << "LAMBDA ratio: "
+                      << result.diagnostics.lambda_ambiguity_ratio << "\n";
+            std::cout << "Fixed ambiguities: "
+                      << result.diagnostics.fixed_ambiguities << "\n";
+            std::cout << "Fixed solution: "
+                      << (result.diagnostics.fixed_solution ? "yes" : "no") << "\n";
+            std::cout << "TDCP candidate pairs: " << result.diagnostics.tdcp_candidate_pairs << "\n";
+            std::cout << "TDCP rejected by gap: " << result.diagnostics.tdcp_rejected_gap << "\n";
+            std::cout << "TDCP rejected missing previous: "
+                      << result.diagnostics.tdcp_rejected_missing_previous << "\n";
+            std::cout << "TDCP rejected by loss of lock: "
+                      << result.diagnostics.tdcp_rejected_loss_of_lock << "\n";
+            std::cout << "TDCP rejected by code/phase jump: "
+                      << result.diagnostics.tdcp_rejected_code_phase_jump << "\n";
+            std::cout << "DD matched base epochs: "
+                      << result.diagnostics.double_difference_matched_base_epochs << "\n";
+            std::cout << "DD interpolated base epochs: "
+                      << result.diagnostics.double_difference_interpolated_base_epochs << "\n";
+            std::cout << "DD candidate pairs: "
+                      << result.diagnostics.double_difference_candidate_pairs << "\n";
+            std::cout << "DD rejected no base epoch: "
+                      << result.diagnostics.double_difference_rejected_no_base_epoch << "\n";
+            std::cout << "DD rejected no reference: "
+                      << result.diagnostics.double_difference_rejected_no_reference << "\n";
+            std::cout << "Motion factors: " << result.diagnostics.motion_factors << "\n";
+            std::cout << "Ambiguity between factors: "
+                      << result.diagnostics.ambiguity_between_factors << "\n";
+            std::cout << "Robust pseudorange factors: "
+                      << result.diagnostics.robust_pseudorange_factors << "\n";
+            std::cout << "Robust carrier phase factors: "
+                      << result.diagnostics.robust_carrier_phase_factors << "\n";
+            std::cout << "Robust DD pseudorange factors: "
+                      << result.diagnostics.robust_double_difference_pseudorange_factors
+                      << "\n";
+            std::cout << "Robust DD carrier factors: "
+                      << result.diagnostics.robust_double_difference_carrier_factors << "\n";
+            std::cout << "Robust TDCP factors: "
+                      << result.diagnostics.robust_tdcp_factors << "\n";
+            std::cout << "Iterations: " << result.diagnostics.iterations << "\n";
+            std::cout << "Converged: " << (result.diagnostics.converged ? "yes" : "no") << "\n";
+            std::cout << "Processing time [ms]: "
+                      << result.diagnostics.processing_time_ms << "\n";
+            std::cout << "Last update norm [m]: "
+                      << result.diagnostics.last_update_norm_m << "\n";
+            std::cout << "Residual RMS [m]: " << result.diagnostics.residual_rms_m << "\n";
+            std::cout << "TDCP residual RMS [m]: " << result.diagnostics.tdcp_residual_rms_m << "\n";
+            std::cout << "SD Doppler residual RMS [m/s]: "
+                      << result.diagnostics.single_difference_doppler_residual_rms_mps
+                      << "\n";
+            std::cout << "SD TDCP residual RMS [m]: "
+                      << result.diagnostics.single_difference_tdcp_residual_rms_m
+                      << "\n";
+            std::cout << "Carrier phase residual RMS [m]: "
+                      << result.diagnostics.carrier_phase_residual_rms_m << "\n";
+            std::cout << "DD pseudorange residual RMS [m]: "
+                      << result.diagnostics.double_difference_pseudorange_residual_rms_m
+                      << "\n";
+            std::cout << "DD carrier residual RMS [m]: "
+                      << result.diagnostics.double_difference_carrier_residual_rms_m << "\n";
+            std::cout << "Fixed ambiguity residual RMS [cycles]: "
+                      << result.diagnostics.fixed_ambiguity_residual_rms_cycles << "\n";
+            if (!options.summary_json_path.empty()) {
+                std::cout << "Summary JSON: " << options.summary_json_path << "\n";
+            }
+            if (!options.epoch_debug_csv_path.empty()) {
+                std::cout << "Epoch debug CSV: "
+                          << options.epoch_debug_csv_path << "\n";
+            }
+            if (!options.factor_debug_csv_path.empty()) {
+                std::cout << "Factor debug CSV: "
+                          << options.factor_debug_csv_path << "\n";
+            }
+            if (!options.lambda_debug_csv_path.empty()) {
+                std::cout << "LAMBDA debug CSV: "
+                          << options.lambda_debug_csv_path << "\n";
+            }
+            std::cout << "Output: " << options.out_path << "\n";
+        }
+
+        return 0;
+    } catch (const std::exception& e) {
+        std::cerr << "Error: " << e.what() << "\n";
+        return 1;
+    }
+}

--- a/apps/gnss_mode_compare.py
+++ b/apps/gnss_mode_compare.py
@@ -1,0 +1,888 @@
+#!/usr/bin/env python3
+"""Run SPP/FGO/RTK modes on the same RINEX inputs and summarize outputs."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import math
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+from typing import Any
+
+from gnss_runtime import ensure_input_exists, resolve_gnss_command
+
+
+ROOT_DIR = Path(__file__).resolve().parent.parent
+
+STATUS_NAMES = {
+    0: "NONE",
+    1: "SPP",
+    2: "DGPS",
+    3: "FLOAT",
+    4: "FIXED",
+    5: "PPP_FLOAT",
+    6: "PPP_FIXED",
+}
+FIXED_STATUSES = {4, 6}
+FLOAT_STATUSES = {3, 5}
+
+
+@dataclass(frozen=True)
+class PosRecord:
+    week: int
+    tow: float
+    x: float
+    y: float
+    z: float
+    status: int
+    satellites: int
+    ratio: float | None
+
+
+@dataclass(frozen=True)
+class ModePlan:
+    name: str
+    pos_path: Path
+    summary_path: Path | None
+    command: list[str]
+    external: bool = False
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(prog=os.environ.get("GNSS_CLI_NAME"))
+    parser.add_argument("--obs", type=Path, help="Rover RINEX observation file.")
+    parser.add_argument("--nav", type=Path, help="Navigation RINEX file.")
+    parser.add_argument("--base", type=Path, help="Optional base RINEX observation file for RTK.")
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=ROOT_DIR / "output/gnss_mode_compare",
+        help="Directory for per-mode POS files and summaries.",
+    )
+    parser.add_argument(
+        "--summary-json",
+        type=Path,
+        help="Output path for the aggregate JSON summary. Defaults to <out-dir>/summary.json.",
+    )
+    parser.add_argument(
+        "--modes",
+        default="auto",
+        help=(
+            "Comma-separated modes: auto, spp, fgo, rtk. Auto runs spp/fgo and "
+            "rtk when --base or --rtk-pos is set."
+        ),
+    )
+    parser.add_argument(
+        "--max-epochs",
+        type=int,
+        default=0,
+        help="Stop each solver after N epochs. Use 0 for the full input.",
+    )
+    parser.add_argument(
+        "--fgo-skip-epochs",
+        type=int,
+        default=0,
+        help="Skip the first N rover epochs when running FGO.",
+    )
+    parser.add_argument(
+        "--match-tolerance-s",
+        type=float,
+        default=0.01,
+        help="Epoch matching tolerance for pairwise mode deltas.",
+    )
+    parser.add_argument(
+        "--reference-csv",
+        type=Path,
+        help="Optional PPC-style reference.csv used to compute per-mode reference errors.",
+    )
+    parser.add_argument(
+        "--reference-match-tolerance-s",
+        type=float,
+        default=0.25,
+        help="Epoch matching tolerance for --reference-csv metrics.",
+    )
+    parser.add_argument(
+        "--rtk-mode",
+        default="auto",
+        choices=("auto", "kinematic", "static", "moving-base"),
+        help="Mode passed to gnss solve when RTK is enabled.",
+    )
+    parser.add_argument(
+        "--spp-pos",
+        type=Path,
+        help="Existing SPP POS file to summarize instead of running gnss spp.",
+    )
+    parser.add_argument(
+        "--fgo-pos",
+        type=Path,
+        help="Existing FGO POS file to summarize instead of running gnss fgo.",
+    )
+    parser.add_argument(
+        "--fgo-preset",
+        choices=(
+            "default",
+            "real-data",
+            "real-data-float",
+            "real-data-fixed",
+            "tdcp-only",
+            "taroz-pc",
+        ),
+        help="Preset passed to gnss fgo when FGO is run by this tool.",
+    )
+    parser.add_argument(
+        "--fgo-summary-json",
+        type=Path,
+        help="Existing FGO native summary JSON to include when --fgo-pos is used.",
+    )
+    parser.add_argument(
+        "--rtk-pos",
+        type=Path,
+        help="Existing RTK POS file to summarize instead of running gnss solve.",
+    )
+    parser.add_argument(
+        "--spp-extra-arg",
+        action="append",
+        default=[],
+        help="Extra single argument passed to gnss spp. Repeat for multiple tokens.",
+    )
+    parser.add_argument(
+        "--fgo-extra-arg",
+        action="append",
+        default=[],
+        help="Extra single argument passed to gnss fgo. Repeat for multiple tokens.",
+    )
+    parser.add_argument(
+        "--rtk-extra-arg",
+        action="append",
+        default=[],
+        help="Extra single argument passed to gnss solve. Repeat for multiple tokens.",
+    )
+    parser.add_argument(
+        "--require-mode-epochs-min",
+        action="append",
+        default=[],
+        metavar="MODE=N",
+        help="Fail if MODE has fewer than N solution epochs. Repeatable.",
+    )
+    parser.add_argument(
+        "--require-mode-fix-rate-min",
+        action="append",
+        default=[],
+        metavar="MODE=PCT",
+        help="Fail if MODE fix rate is below PCT. Repeatable.",
+    )
+    parser.add_argument(
+        "--require-mode-float-rate-min",
+        action="append",
+        default=[],
+        metavar="MODE=PCT",
+        help="Fail if MODE float rate is below PCT. Repeatable.",
+    )
+    parser.add_argument(
+        "--require-pair-common-min",
+        action="append",
+        default=[],
+        metavar="LEFT:RIGHT=N",
+        help="Fail if a mode pair has fewer than N common epochs. Repeatable.",
+    )
+    parser.add_argument(
+        "--require-pair-mean-3d-max",
+        action="append",
+        default=[],
+        metavar="LEFT:RIGHT=M",
+        help="Fail if pair mean 3D delta exceeds M meters. Repeatable.",
+    )
+    parser.add_argument(
+        "--require-pair-p95-3d-max",
+        action="append",
+        default=[],
+        metavar="LEFT:RIGHT=M",
+        help="Fail if pair p95 3D delta exceeds M meters. Repeatable.",
+    )
+    parser.add_argument(
+        "--keep-going",
+        action="store_true",
+        help="Continue running later modes if one mode exits with a non-zero status.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Write the planned commands and summary without executing solvers.",
+    )
+    return parser.parse_args()
+
+
+def parse_modes(raw_modes: str, has_rtk_input: bool) -> list[str]:
+    if raw_modes.strip().lower() == "auto":
+        modes = ["spp", "fgo"]
+        if has_rtk_input:
+            modes.append("rtk")
+        return modes
+
+    modes: list[str] = []
+    for token in raw_modes.split(","):
+        mode = token.strip().lower()
+        if not mode:
+            continue
+        if mode == "auto":
+            for auto_mode in parse_modes("auto", has_rtk_input):
+                if auto_mode not in modes:
+                    modes.append(auto_mode)
+            continue
+        if mode not in {"spp", "fgo", "rtk"}:
+            raise SystemExit(f"Unsupported mode `{mode}`; expected auto, spp, fgo, or rtk")
+        if mode == "rtk" and not has_rtk_input:
+            raise SystemExit("Mode `rtk` requires --base or --rtk-pos")
+        if mode not in modes:
+            modes.append(mode)
+    if not modes:
+        raise SystemExit("--modes did not select any modes")
+    return modes
+
+
+def build_mode_plans(args: argparse.Namespace, gnss_command: list[str]) -> list[ModePlan]:
+    out_dir = args.out_dir
+    modes = parse_modes(args.modes, args.base is not None or args.rtk_pos is not None)
+    plans: list[ModePlan] = []
+    for mode in modes:
+        pos_path = out_dir / f"{mode}.pos"
+        if mode == "spp":
+            if args.spp_pos is not None:
+                plans.append(ModePlan(mode, args.spp_pos, None, [], external=True))
+                continue
+            command = [
+                *gnss_command,
+                "spp",
+                "--obs",
+                str(args.obs),
+                "--nav",
+                str(args.nav),
+                "--out",
+                str(pos_path),
+                "--quiet",
+                *args.spp_extra_arg,
+            ]
+            if args.max_epochs > 0:
+                command.extend(["--max-epochs", str(args.max_epochs)])
+            plans.append(ModePlan(mode, pos_path, None, command))
+        elif mode == "fgo":
+            fgo_summary_path = out_dir / "fgo_summary.json"
+            if args.fgo_pos is not None:
+                plans.append(
+                    ModePlan(
+                        mode,
+                        args.fgo_pos,
+                        args.fgo_summary_json,
+                        [],
+                        external=True,
+                    )
+                )
+                continue
+            command = [
+                *gnss_command,
+                "fgo",
+                "--obs",
+                str(args.obs),
+                "--nav",
+                str(args.nav),
+                "--out",
+                str(pos_path),
+                "--summary-json",
+                str(fgo_summary_path),
+                "--quiet",
+            ]
+            if args.fgo_preset is not None:
+                command.extend(["--preset", args.fgo_preset])
+                if args.fgo_preset == "taroz-pc":
+                    command.extend(["--backend", "gtsam-pc"])
+            if args.base is not None:
+                command.extend(["--base", str(args.base)])
+            command.extend(args.fgo_extra_arg)
+            if args.fgo_skip_epochs > 0:
+                command.extend(["--skip-epochs", str(args.fgo_skip_epochs)])
+            if args.max_epochs > 0:
+                command.extend(["--max-epochs", str(args.max_epochs)])
+            plans.append(ModePlan(mode, pos_path, fgo_summary_path, command))
+        elif mode == "rtk":
+            if args.rtk_pos is not None:
+                plans.append(ModePlan(mode, args.rtk_pos, None, [], external=True))
+                continue
+            command = [
+                *gnss_command,
+                "solve",
+                "--rover",
+                str(args.obs),
+                "--base",
+                str(args.base),
+                "--nav",
+                str(args.nav),
+                "--out",
+                str(pos_path),
+                "--mode",
+                args.rtk_mode,
+                "--no-kml",
+                *args.rtk_extra_arg,
+            ]
+            if args.max_epochs > 0:
+                command.extend(["--max-epochs", str(args.max_epochs)])
+            plans.append(ModePlan(mode, pos_path, None, command))
+    return plans
+
+
+def read_pos_records(path: Path) -> list[PosRecord]:
+    records: list[PosRecord] = []
+    with path.open(encoding="ascii", errors="ignore") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            line = raw_line.strip()
+            if not line or line.startswith("%"):
+                continue
+            parts = line.split()
+            if len(parts) < 10:
+                raise ValueError(f"{path}:{line_number}: expected at least 10 POS columns")
+            ratio = None
+            if len(parts) > 11:
+                try:
+                    parsed_ratio = float(parts[11])
+                except ValueError:
+                    parsed_ratio = math.nan
+                if math.isfinite(parsed_ratio):
+                    ratio = parsed_ratio
+            records.append(
+                PosRecord(
+                    week=int(float(parts[0])),
+                    tow=float(parts[1]),
+                    x=float(parts[2]),
+                    y=float(parts[3]),
+                    z=float(parts[4]),
+                    status=int(float(parts[8])),
+                    satellites=int(float(parts[9])),
+                    ratio=ratio,
+                )
+            )
+    return records
+
+
+def percentile(values: list[float], percent: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = (len(ordered) - 1) * percent / 100.0
+    lower = int(math.floor(position))
+    upper = int(math.ceil(position))
+    if lower == upper:
+        return ordered[lower]
+    fraction = position - lower
+    return ordered[lower] * (1.0 - fraction) + ordered[upper] * fraction
+
+
+def rate_percent(numerator: int, denominator: int) -> float | None:
+    if denominator <= 0:
+        return None
+    return 100.0 * numerator / denominator
+
+
+def summarize_records(records: list[PosRecord]) -> dict[str, Any]:
+    status_counts_by_code: dict[str, int] = {}
+    status_counts_by_name: dict[str, int] = {}
+    for record in records:
+        status_counts_by_code[str(record.status)] = status_counts_by_code.get(str(record.status), 0) + 1
+        status_name = STATUS_NAMES.get(record.status, f"UNKNOWN_{record.status}")
+        status_counts_by_name[status_name] = status_counts_by_name.get(status_name, 0) + 1
+
+    fixed_epochs = sum(1 for record in records if record.status in FIXED_STATUSES)
+    float_epochs = sum(1 for record in records if record.status in FLOAT_STATUSES)
+    spp_epochs = sum(1 for record in records if record.status == 1)
+    ratios = [record.ratio for record in records if record.ratio is not None]
+    satellites = [record.satellites for record in records]
+    payload: dict[str, Any] = {
+        "epochs": len(records),
+        "fixed_epochs": fixed_epochs,
+        "float_epochs": float_epochs,
+        "spp_epochs": spp_epochs,
+        "fix_rate_percent": rate_percent(fixed_epochs, len(records)),
+        "float_rate_percent": rate_percent(float_epochs, len(records)),
+        "spp_rate_percent": rate_percent(spp_epochs, len(records)),
+        "status_counts": status_counts_by_name,
+        "status_counts_by_code": status_counts_by_code,
+        "mean_satellites": sum(satellites) / len(satellites) if satellites else None,
+        "mean_ratio": sum(ratios) / len(ratios) if ratios else None,
+        "first_epoch": None,
+        "last_epoch": None,
+    }
+    if records:
+        first = min(records, key=lambda record: (record.week, record.tow))
+        last = max(records, key=lambda record: (record.week, record.tow))
+        payload["first_epoch"] = {"week": first.week, "tow": first.tow}
+        payload["last_epoch"] = {"week": last.week, "tow": last.tow}
+    return payload
+
+
+def match_records(
+    left_records: list[PosRecord],
+    right_records: list[PosRecord],
+    tolerance_s: float,
+) -> list[tuple[PosRecord, PosRecord]]:
+    left = sorted(left_records, key=lambda record: (record.week, record.tow))
+    right = sorted(right_records, key=lambda record: (record.week, record.tow))
+    matches: list[tuple[PosRecord, PosRecord]] = []
+    i = 0
+    j = 0
+    while i < len(left) and j < len(right):
+        left_record = left[i]
+        right_record = right[j]
+        if left_record.week == right_record.week:
+            dt = left_record.tow - right_record.tow
+            if abs(dt) <= tolerance_s:
+                matches.append((left_record, right_record))
+                i += 1
+                j += 1
+            elif dt < 0.0:
+                i += 1
+            else:
+                j += 1
+        elif left_record.week < right_record.week:
+            i += 1
+        else:
+            j += 1
+    return matches
+
+
+def summarize_pairwise(
+    left_name: str,
+    left_records: list[PosRecord],
+    right_name: str,
+    right_records: list[PosRecord],
+    tolerance_s: float,
+) -> dict[str, Any]:
+    matches = match_records(left_records, right_records, tolerance_s)
+    deltas = [
+        math.dist((left.x, left.y, left.z), (right.x, right.y, right.z))
+        for left, right in matches
+    ]
+    return {
+        "left": left_name,
+        "right": right_name,
+        "common_epochs": len(matches),
+        "mean_3d_delta_m": sum(deltas) / len(deltas) if deltas else None,
+        "median_3d_delta_m": percentile(deltas, 50.0),
+        "p95_3d_delta_m": percentile(deltas, 95.0),
+        "max_3d_delta_m": max(deltas) if deltas else None,
+    }
+
+
+def rounded(value: Any) -> Any:
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return None
+        return round(value, 6)
+    if isinstance(value, list):
+        return [rounded(item) for item in value]
+    if isinstance(value, dict):
+        return {key: rounded(item) for key, item in value.items()}
+    return value
+
+
+def run_plan(plan: ModePlan, keep_going: bool) -> tuple[subprocess.CompletedProcess[str], float]:
+    print("+", " ".join(plan.command), flush=True)
+    start_time = time.perf_counter()
+    completed = subprocess.run(
+        plan.command,
+        cwd=ROOT_DIR,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    solver_wall_time_s = time.perf_counter() - start_time
+    if completed.stdout:
+        print(completed.stdout, end="")
+    if completed.stderr:
+        print(completed.stderr, end="", file=sys.stderr)
+    if completed.returncode != 0 and not keep_going:
+        raise SystemExit(f"{plan.name} failed with exit code {completed.returncode}")
+    return completed, solver_wall_time_s
+
+
+def load_json_if_present(path: Path | None) -> dict[str, Any] | None:
+    if path is None or not path.exists():
+        return None
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return payload if isinstance(payload, dict) else None
+
+
+def load_reference_epochs(reference_csv: Path) -> list[Any]:
+    scripts_dir = ROOT_DIR / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    import generate_driving_comparison as comparison
+
+    return comparison.read_reference_csv(reference_csv)
+
+
+def summarize_reference_metrics(
+    reference_epochs: list[Any],
+    pos_path: Path,
+    mode_name: str,
+    tolerance_s: float,
+    solver_wall_time_s: float | None,
+) -> dict[str, Any]:
+    scripts_dir = ROOT_DIR / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    import generate_driving_comparison as comparison
+    import gnss_ppc_metrics as ppc_metrics
+
+    solution_epochs = comparison.read_libgnss_pos(pos_path)
+    try:
+        return ppc_metrics.summarize_solution_epochs(
+            reference_epochs,
+            solution_epochs,
+            fixed_status=4,
+            label=mode_name,
+            match_tolerance_s=tolerance_s,
+            solver_wall_time_s=solver_wall_time_s,
+        )
+    except SystemExit as exc:
+        return {"error": str(exc)}
+
+
+def parse_requirement_spec(raw_spec: str) -> tuple[str, float]:
+    if "=" not in raw_spec:
+        raise SystemExit(f"Requirement `{raw_spec}` must use NAME=VALUE syntax")
+    key, raw_value = raw_spec.split("=", 1)
+    key = key.strip().lower()
+    if not key:
+        raise SystemExit(f"Requirement `{raw_spec}` has an empty name")
+    try:
+        value = float(raw_value)
+    except ValueError as exc:
+        raise SystemExit(f"Requirement `{raw_spec}` has a non-numeric value") from exc
+    if not math.isfinite(value):
+        raise SystemExit(f"Requirement `{raw_spec}` must be finite")
+    return key, value
+
+
+def parse_pair_requirement_spec(raw_spec: str) -> tuple[str, str, float]:
+    pair_name, value = parse_requirement_spec(raw_spec)
+    if ":" not in pair_name:
+        raise SystemExit(f"Requirement `{raw_spec}` must use LEFT:RIGHT=VALUE syntax")
+    left, right = (token.strip().lower() for token in pair_name.split(":", 1))
+    if not left or not right:
+        raise SystemExit(f"Requirement `{raw_spec}` has an empty pair side")
+    return left, right, value
+
+
+def find_pair_summary(payload: dict[str, Any], left: str, right: str) -> dict[str, Any] | None:
+    raw_pairwise = payload.get("pairwise")
+    if not isinstance(raw_pairwise, list):
+        return None
+    for raw_entry in raw_pairwise:
+        if not isinstance(raw_entry, dict):
+            continue
+        entry_left = str(raw_entry.get("left", "")).lower()
+        entry_right = str(raw_entry.get("right", "")).lower()
+        if (entry_left == left and entry_right == right) or (
+            entry_left == right and entry_right == left
+        ):
+            return raw_entry
+    return None
+
+
+def evaluate_requirements(payload: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    failures: list[str] = []
+    raw_modes = payload.get("modes")
+    modes = raw_modes if isinstance(raw_modes, dict) else {}
+
+    def mode_summary(mode: str, raw_spec: str) -> dict[str, Any] | None:
+        raw_entry = modes.get(mode)
+        if not isinstance(raw_entry, dict):
+            failures.append(f"{raw_spec}: mode `{mode}` is missing")
+            return None
+        raw_summary = raw_entry.get("summary")
+        if not isinstance(raw_summary, dict):
+            failures.append(f"{raw_spec}: mode `{mode}` has no POS summary")
+            return None
+        return raw_summary
+
+    for raw_spec in args.require_mode_epochs_min:
+        mode, threshold = parse_requirement_spec(raw_spec)
+        summary = mode_summary(mode, raw_spec)
+        if summary is None:
+            continue
+        epochs = int(summary.get("epochs", 0))
+        if epochs < threshold:
+            failures.append(f"{raw_spec}: {mode} epochs {epochs} < {threshold:g}")
+
+    for raw_spec in args.require_mode_fix_rate_min:
+        mode, threshold = parse_requirement_spec(raw_spec)
+        summary = mode_summary(mode, raw_spec)
+        if summary is None:
+            continue
+        value = summary.get("fix_rate_percent")
+        if value is None or float(value) < threshold:
+            shown = "n/a" if value is None else f"{float(value):.6f}"
+            failures.append(f"{raw_spec}: {mode} fix rate {shown}% < {threshold:g}%")
+
+    for raw_spec in args.require_mode_float_rate_min:
+        mode, threshold = parse_requirement_spec(raw_spec)
+        summary = mode_summary(mode, raw_spec)
+        if summary is None:
+            continue
+        value = summary.get("float_rate_percent")
+        if value is None or float(value) < threshold:
+            shown = "n/a" if value is None else f"{float(value):.6f}"
+            failures.append(f"{raw_spec}: {mode} float rate {shown}% < {threshold:g}%")
+
+    for raw_spec in args.require_pair_common_min:
+        left, right, threshold = parse_pair_requirement_spec(raw_spec)
+        pair = find_pair_summary(payload, left, right)
+        if pair is None:
+            failures.append(f"{raw_spec}: pair `{left}:{right}` is missing")
+            continue
+        common_epochs = int(pair.get("common_epochs", 0))
+        if common_epochs < threshold:
+            failures.append(
+                f"{raw_spec}: {left}:{right} common epochs {common_epochs} < {threshold:g}"
+            )
+
+    for raw_spec in args.require_pair_mean_3d_max:
+        left, right, threshold = parse_pair_requirement_spec(raw_spec)
+        pair = find_pair_summary(payload, left, right)
+        if pair is None:
+            failures.append(f"{raw_spec}: pair `{left}:{right}` is missing")
+            continue
+        value = pair.get("mean_3d_delta_m")
+        if value is None or float(value) > threshold:
+            shown = "n/a" if value is None else f"{float(value):.6f}"
+            failures.append(f"{raw_spec}: {left}:{right} mean 3D {shown} m > {threshold:g} m")
+
+    for raw_spec in args.require_pair_p95_3d_max:
+        left, right, threshold = parse_pair_requirement_spec(raw_spec)
+        pair = find_pair_summary(payload, left, right)
+        if pair is None:
+            failures.append(f"{raw_spec}: pair `{left}:{right}` is missing")
+            continue
+        value = pair.get("p95_3d_delta_m")
+        if value is None or float(value) > threshold:
+            shown = "n/a" if value is None else f"{float(value):.6f}"
+            failures.append(f"{raw_spec}: {left}:{right} p95 3D {shown} m > {threshold:g} m")
+
+    return {
+        "passed": not failures,
+        "failures": failures,
+    }
+
+
+def build_payload(
+    args: argparse.Namespace,
+    plans: list[ModePlan],
+    completed_by_mode: dict[str, subprocess.CompletedProcess[str] | None],
+    wall_time_by_mode: dict[str, float | None],
+) -> dict[str, Any]:
+    mode_payloads: dict[str, Any] = {}
+    records_by_mode: dict[str, list[PosRecord]] = {}
+    reference_epochs = load_reference_epochs(args.reference_csv) if args.reference_csv else None
+    for plan in plans:
+        completed = completed_by_mode.get(plan.name)
+        mode_payload: dict[str, Any] = {
+            "command": plan.command,
+            "output_pos": str(plan.pos_path),
+            "native_summary_json": str(plan.summary_path) if plan.summary_path is not None else None,
+            "returncode": completed.returncode if completed is not None else None,
+            "solver_wall_time_s": wall_time_by_mode.get(plan.name),
+            "status": (
+                "external"
+                if plan.external
+                else ("planned" if completed is None else ("ok" if completed.returncode == 0 else "failed"))
+            ),
+            "summary": None,
+            "native_summary": load_json_if_present(plan.summary_path),
+        }
+        if plan.pos_path.exists():
+            records = read_pos_records(plan.pos_path)
+            records_by_mode[plan.name] = records
+            mode_payload["summary"] = summarize_records(records)
+            if reference_epochs is not None:
+                mode_payload["reference_summary"] = summarize_reference_metrics(
+                    reference_epochs,
+                    plan.pos_path,
+                    plan.name,
+                    args.reference_match_tolerance_s,
+                    wall_time_by_mode.get(plan.name),
+                )
+        mode_payloads[plan.name] = rounded(mode_payload)
+
+    pairwise: list[dict[str, Any]] = []
+    mode_names = [plan.name for plan in plans if plan.name in records_by_mode]
+    for left_index, left_name in enumerate(mode_names):
+        for right_name in mode_names[left_index + 1:]:
+            pairwise.append(
+                rounded(
+                    summarize_pairwise(
+                        left_name,
+                        records_by_mode[left_name],
+                        right_name,
+                        records_by_mode[right_name],
+                        args.match_tolerance_s,
+                    )
+                )
+            )
+
+    return {
+        "obs": str(args.obs) if args.obs is not None else None,
+        "nav": str(args.nav) if args.nav is not None else None,
+        "base": str(args.base) if args.base is not None else None,
+        "reference_csv": str(args.reference_csv) if args.reference_csv is not None else None,
+        "out_dir": str(args.out_dir),
+        "max_epochs": args.max_epochs,
+        "fgo_skip_epochs": args.fgo_skip_epochs,
+        "match_tolerance_s": args.match_tolerance_s,
+        "reference_match_tolerance_s": args.reference_match_tolerance_s,
+        "modes": mode_payloads,
+        "pairwise": pairwise,
+    }
+
+
+def print_text_summary(payload: dict[str, Any]) -> None:
+    print("Mode comparison summary")
+    modes = payload["modes"]
+    assert isinstance(modes, dict)
+    for name, raw_entry in modes.items():
+        assert isinstance(raw_entry, dict)
+        summary = raw_entry.get("summary")
+        status = raw_entry.get("status")
+        if not isinstance(summary, dict):
+            print(f"  {name}: {status}")
+            continue
+        epochs = int(summary["epochs"])
+        fixed = int(summary["fixed_epochs"])
+        floats = int(summary["float_epochs"])
+        spp = int(summary["spp_epochs"])
+        mean_satellites = summary["mean_satellites"]
+        mean_satellites_text = (
+            f"{float(mean_satellites):.2f}" if mean_satellites is not None else "n/a"
+        )
+        line = (
+            f"  {name}: epochs={epochs} fixed={fixed} float={floats} "
+            f"spp={spp} mean_sats={mean_satellites_text}"
+        )
+        solver_wall_time_s = raw_entry.get("solver_wall_time_s")
+        if solver_wall_time_s is not None:
+            line += f" wall={float(solver_wall_time_s):.3f}s"
+        reference_summary = raw_entry.get("reference_summary")
+        if isinstance(reference_summary, dict):
+            if "error" in reference_summary:
+                line += f" ref_error={reference_summary['error']}"
+            else:
+                mean_h = reference_summary.get("mean_h_m")
+                p95_h = reference_summary.get("p95_h_m")
+                score_matched = reference_summary.get("ppc_score_3d_50cm_matched_pct")
+                score_ref = reference_summary.get("ppc_score_3d_50cm_ref_pct")
+                mean_h_text = f"{float(mean_h):.3f}" if mean_h is not None else "n/a"
+                p95_h_text = f"{float(p95_h):.3f}" if p95_h is not None else "n/a"
+                score_matched_text = (
+                    f"{float(score_matched):.2f}" if score_matched is not None else "n/a"
+                )
+                score_ref_text = f"{float(score_ref):.2f}" if score_ref is not None else "n/a"
+                line += (
+                    f" ref_mean_h={mean_h_text}m"
+                    f" ref_p95_h={p95_h_text}m"
+                    f" ref_3d50_matched={score_matched_text}%"
+                    f" ref_3d50_ref={score_ref_text}%"
+                )
+        print(line)
+    pairwise = payload["pairwise"]
+    assert isinstance(pairwise, list)
+    for entry in pairwise:
+        if not isinstance(entry, dict):
+            continue
+        mean_delta = entry["mean_3d_delta_m"]
+        p95_delta = entry["p95_3d_delta_m"]
+        mean_text = f"{float(mean_delta):.3f}" if mean_delta is not None else "n/a"
+        p95_text = f"{float(p95_delta):.3f}" if p95_delta is not None else "n/a"
+        print(
+            f"  {entry['left']} vs {entry['right']}: common={entry['common_epochs']} "
+            f"mean_3d={mean_text}m p95_3d={p95_text}m"
+        )
+
+
+def main() -> int:
+    args = parse_args()
+    if args.max_epochs < 0:
+        raise SystemExit("--max-epochs must be >= 0")
+    if args.fgo_skip_epochs < 0:
+        raise SystemExit("--fgo-skip-epochs must be >= 0")
+    if args.match_tolerance_s < 0.0:
+        raise SystemExit("--match-tolerance-s must be >= 0")
+    if args.reference_match_tolerance_s < 0.0:
+        raise SystemExit("--reference-match-tolerance-s must be >= 0")
+
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+    summary_json = args.summary_json or args.out_dir / "summary.json"
+    summary_json.parent.mkdir(parents=True, exist_ok=True)
+
+    gnss_command = resolve_gnss_command(ROOT_DIR)
+    plans = build_mode_plans(args, gnss_command)
+    needs_solver_inputs = any(not plan.external for plan in plans)
+    if needs_solver_inputs:
+        if args.obs is None:
+            raise SystemExit("--obs is required when running a solver")
+        if args.nav is None:
+            raise SystemExit("--nav is required when running a solver")
+        ensure_input_exists(args.obs, "rover observation file", ROOT_DIR)
+        ensure_input_exists(args.nav, "navigation file", ROOT_DIR)
+    if args.reference_csv is not None:
+        ensure_input_exists(args.reference_csv, "reference CSV", ROOT_DIR)
+    for plan in plans:
+        if plan.external:
+            ensure_input_exists(plan.pos_path, f"{plan.name} POS file", ROOT_DIR)
+            if plan.summary_path is not None:
+                ensure_input_exists(plan.summary_path, f"{plan.name} summary JSON", ROOT_DIR)
+        elif plan.name == "rtk":
+            if args.base is None:
+                raise SystemExit("Mode `rtk` requires --base when --rtk-pos is not provided")
+            ensure_input_exists(args.base, "base observation file", ROOT_DIR)
+    completed_by_mode: dict[str, subprocess.CompletedProcess[str] | None] = {}
+    wall_time_by_mode: dict[str, float | None] = {}
+    if args.dry_run:
+        for plan in plans:
+            completed_by_mode[plan.name] = None
+            wall_time_by_mode[plan.name] = None
+            if plan.external:
+                print(f"# {plan.name}: using existing POS {plan.pos_path}")
+            else:
+                print("+", " ".join(plan.command))
+    else:
+        for plan in plans:
+            if plan.external:
+                completed_by_mode[plan.name] = None
+                wall_time_by_mode[plan.name] = None
+                continue
+            completed, solver_wall_time_s = run_plan(plan, args.keep_going)
+            completed_by_mode[plan.name] = completed
+            wall_time_by_mode[plan.name] = solver_wall_time_s
+
+    payload = rounded(build_payload(args, plans, completed_by_mode, wall_time_by_mode))
+    payload["requirements"] = evaluate_requirements(payload, args)
+    summary_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print_text_summary(payload)
+    print(f"Summary JSON: {summary_json}")
+    requirements = payload["requirements"]
+    assert isinstance(requirements, dict)
+    failures = requirements.get("failures")
+    if isinstance(failures, list) and failures:
+        print("Requirement checks failed:", file=sys.stderr)
+        for failure in failures:
+            print(f"  - {failure}", file=sys.stderr)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/gnss_pos_pd.cpp
+++ b/apps/gnss_pos_pd.cpp
@@ -1,0 +1,1698 @@
+#include <libgnss++/core/constants.hpp>
+#include <libgnss++/core/coordinates.hpp>
+#include <libgnss++/core/navigation.hpp>
+#include <libgnss++/core/observation.hpp>
+#include <libgnss++/core/signals.hpp>
+#include <libgnss++/io/rinex.hpp>
+#include <libgnss++/models/ionosphere.hpp>
+#include <libgnss++/models/troposphere.hpp>
+
+#include <Eigen/Sparse>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace {
+
+constexpr double kPi = 3.141592653589793238462643383279502884;
+constexpr double kDegreesToRadians = kPi / 180.0;
+constexpr double kRadiansToDegrees = 180.0 / kPi;
+constexpr std::size_t kClockGroups = 5;
+constexpr std::size_t kStateStride = 8;
+
+struct Options {
+    std::string obs_path;
+    std::string nav_path;
+    std::string seed_pos_path;
+    std::string out_csv_path;
+    std::string factor_debug_csv_path;
+    std::string graph_csv_path;
+    std::string summary_json_path;
+    int skip_epochs = 0;
+    int max_epochs = 0;
+    int max_iterations = 1000;
+    double seed_match_tolerance_s = 0.51;
+    double seed_interpolation_max_gap_s = 60.0;
+    double min_snr_dbhz = 35.0;
+    double min_elevation_deg = 15.0;
+    double pseudorange_sigma_zenith_m = 3.0;
+    double doppler_sigma_zenith_mps = 0.2;
+    double position_prior_sigma_m = 1000.0;
+    double clock_prior_sigma_m = 1e6;
+    double clock_motion_sigma_m = 100.0;
+    double clock_jump_sigma_m = 1e6;
+    double inter_system_clock_motion_sigma_m = 1e-6;
+    double huber_threshold_sigma = 1.234;
+    bool debug_problem_only = false;
+    bool quiet = false;
+};
+
+struct SeedPosition {
+    libgnss::GNSSTime time;
+    libgnss::Vector3d position_ecef = libgnss::Vector3d::Zero();
+};
+
+struct DopplerFactor {
+    std::size_t epoch_index = 0;
+    std::size_t previous_epoch_index = 0;
+    libgnss::GNSSTime time;
+    libgnss::GNSSTime midpoint_time;
+    libgnss::SatelliteId satellite;
+    libgnss::SignalType signal = libgnss::SignalType::GPS_L1CA;
+    double snr_dbhz = 0.0;
+    double elevation_rad = 0.0;
+    double midpoint_elevation_rad = 0.0;
+    double dt_s = 1.0;
+    double sigma_mps = 1.0;
+    double residual_mps = 0.0;
+    double measured_range_rate_mps = 0.0;
+    double modeled_range_rate_mps = 0.0;
+    double satellite_clock_drift_mps = 0.0;
+    double wavelength_m = 0.0;
+    libgnss::Vector3d los = libgnss::Vector3d::Zero();
+};
+
+struct PseudorangeFactor {
+    std::size_t epoch_index = 0;
+    libgnss::GNSSTime time;
+    libgnss::SatelliteId satellite;
+    libgnss::SignalType signal = libgnss::SignalType::GPS_L1CA;
+    std::size_t clock_group = 0;
+    double snr_dbhz = 0.0;
+    double elevation_rad = 0.0;
+    double sigma_m = 1.0;
+    double residual_m = 0.0;
+    double corrected_pseudorange_m = 0.0;
+    double modeled_range_m = 0.0;
+    double ionosphere_delay_m = 0.0;
+    double troposphere_delay_m = 0.0;
+    double satellite_clock_m = 0.0;
+    double group_delay_m = 0.0;
+    libgnss::Vector3d los = libgnss::Vector3d::Zero();
+};
+
+struct Problem {
+    std::vector<libgnss::ObservationData> epochs;
+    std::vector<libgnss::Vector3d> seed_positions;
+    std::vector<PseudorangeFactor> pseudorange_factors;
+    std::vector<DopplerFactor> factors;
+    std::vector<bool> clock_jumps;
+    std::size_t nsat = 0;
+    std::size_t seed_matched_epochs = 0;
+    std::size_t seed_interpolated_epochs = 0;
+};
+
+struct SolveResult {
+    Eigen::VectorXd state;
+    double initial_cost = 0.0;
+    double final_cost = 0.0;
+    double residual_rms_mps = 0.0;
+    int iterations = 0;
+    bool converged = false;
+};
+
+[[noreturn]] void usageError(const std::string& message, const char* argv0) {
+    std::cerr << "Error: " << message << "\n\n"
+              << "Usage: " << argv0 << " --obs rover.obs --nav base.nav "
+              << "--seed-pos rover_1Hz_spp.pos [options]\n\n"
+              << "Options:\n"
+              << "  --out-csv PATH                 Write per-epoch position/clock CSV.\n"
+              << "  --factor-debug-csv PATH        Write per-factor debug CSV.\n"
+              << "  --graph-csv PATH               Write taroz-like graph detail CSV.\n"
+              << "  --summary-json PATH            Write JSON summary.\n"
+              << "  --max-epochs N                 Limit processed epochs; 0 means all.\n"
+              << "  --skip-epochs N                Skip leading observation epochs.\n"
+              << "  --max-iterations N             IRLS iteration limit.\n"
+              << "  --debug-problem-only           Build factors and skip optimization.\n"
+              << "  --quiet                        Suppress human-readable summary.\n";
+    throw std::invalid_argument(message);
+}
+
+int parseIntArg(const std::string& value, const std::string& name, const char* argv0) {
+    try {
+        std::size_t consumed = 0;
+        const int parsed = std::stoi(value, &consumed);
+        if (consumed == value.size()) {
+            return parsed;
+        }
+    } catch (const std::exception&) {
+    }
+    usageError("invalid integer for " + name + ": " + value, argv0);
+}
+
+double parseDoubleArg(const std::string& value, const std::string& name, const char* argv0) {
+    try {
+        std::size_t consumed = 0;
+        const double parsed = std::stod(value, &consumed);
+        if (consumed == value.size() && std::isfinite(parsed)) {
+            return parsed;
+        }
+    } catch (const std::exception&) {
+    }
+    usageError("invalid number for " + name + ": " + value, argv0);
+}
+
+Options parseArguments(int argc, char* argv[]) {
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        auto require_value = [&](const std::string& name) -> std::string {
+            if (i + 1 >= argc) {
+                usageError("missing value for " + name, argv[0]);
+            }
+            return argv[++i];
+        };
+
+        if (arg == "--obs") {
+            options.obs_path = require_value(arg);
+        } else if (arg == "--nav") {
+            options.nav_path = require_value(arg);
+        } else if (arg == "--seed-pos") {
+            options.seed_pos_path = require_value(arg);
+        } else if (arg == "--out-csv") {
+            options.out_csv_path = require_value(arg);
+        } else if (arg == "--factor-debug-csv") {
+            options.factor_debug_csv_path = require_value(arg);
+        } else if (arg == "--graph-csv") {
+            options.graph_csv_path = require_value(arg);
+        } else if (arg == "--summary-json") {
+            options.summary_json_path = require_value(arg);
+        } else if (arg == "--skip-epochs") {
+            options.skip_epochs = parseIntArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--max-epochs") {
+            options.max_epochs = parseIntArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--max-iterations") {
+            options.max_iterations = parseIntArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--seed-match-tolerance") {
+            options.seed_match_tolerance_s = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--seed-interpolation-max-gap") {
+            options.seed_interpolation_max_gap_s = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--min-snr") {
+            options.min_snr_dbhz = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--min-elevation") {
+            options.min_elevation_deg = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--pseudorange-sigma-zenith") {
+            options.pseudorange_sigma_zenith_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--doppler-sigma-zenith") {
+            options.doppler_sigma_zenith_mps = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--position-prior-sigma") {
+            options.position_prior_sigma_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--clock-prior-sigma") {
+            options.clock_prior_sigma_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--clock-motion-sigma") {
+            options.clock_motion_sigma_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--clock-jump-sigma") {
+            options.clock_jump_sigma_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--isb-motion-sigma") {
+            options.inter_system_clock_motion_sigma_m =
+                parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--huber-threshold") {
+            options.huber_threshold_sigma = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--debug-problem-only") {
+            options.debug_problem_only = true;
+        } else if (arg == "--quiet") {
+            options.quiet = true;
+        } else if (arg == "--help" || arg == "-h") {
+            usageError("help requested", argv[0]);
+        } else {
+            usageError("unknown argument: " + arg, argv[0]);
+        }
+    }
+
+    if (options.obs_path.empty()) {
+        usageError("--obs is required", argv[0]);
+    }
+    if (options.nav_path.empty()) {
+        usageError("--nav is required", argv[0]);
+    }
+    if (options.seed_pos_path.empty()) {
+        usageError("--seed-pos is required", argv[0]);
+    }
+    if (options.skip_epochs < 0 || options.max_epochs < 0 ||
+        options.max_iterations < 0) {
+        usageError("epoch and iteration limits must be non-negative", argv[0]);
+    }
+    if (options.seed_match_tolerance_s < 0.0 ||
+        options.seed_interpolation_max_gap_s < 0.0 ||
+        options.pseudorange_sigma_zenith_m <= 0.0 ||
+        options.doppler_sigma_zenith_mps <= 0.0 ||
+        options.position_prior_sigma_m <= 0.0 ||
+        options.clock_prior_sigma_m <= 0.0 ||
+        options.clock_motion_sigma_m <= 0.0 ||
+        options.clock_jump_sigma_m <= 0.0 ||
+        options.inter_system_clock_motion_sigma_m <= 0.0 ||
+        options.huber_threshold_sigma <= 0.0) {
+        usageError("sigma, threshold, and tolerance values must be positive", argv[0]);
+    }
+    return options;
+}
+
+bool isPrimaryPdSignal(libgnss::SignalType signal) {
+    switch (signal) {
+        case libgnss::SignalType::GPS_L1CA:
+        case libgnss::SignalType::GLO_L1CA:
+        case libgnss::SignalType::GAL_E1:
+        case libgnss::SignalType::BDS_B1I:
+        case libgnss::SignalType::BDS_B1C:
+        case libgnss::SignalType::QZS_L1CA:
+            return true;
+        default:
+            return false;
+    }
+}
+
+std::string signalName(libgnss::SignalType signal) {
+    switch (signal) {
+        case libgnss::SignalType::GPS_L1CA: return "GPS_L1CA";
+        case libgnss::SignalType::GLO_L1CA: return "GLO_L1CA";
+        case libgnss::SignalType::GAL_E1: return "GAL_E1";
+        case libgnss::SignalType::BDS_B1I: return "BDS_B1I";
+        case libgnss::SignalType::BDS_B1C: return "BDS_B1C";
+        case libgnss::SignalType::QZS_L1CA: return "QZS_L1CA";
+        default: return "UNKNOWN";
+    }
+}
+
+bool isHealthyForPositioning(const libgnss::Observation& observation,
+                             const libgnss::Ephemeris& eph) {
+    int sv_health = static_cast<int>(eph.health);
+    if (observation.satellite.system == libgnss::GNSSSystem::QZSS) {
+        sv_health &= 0xFE;
+    }
+    return sv_health == 0;
+}
+
+std::size_t clockGroup(libgnss::GNSSSystem system) {
+    switch (system) {
+        case libgnss::GNSSSystem::GPS:
+            return 0U;
+        case libgnss::GNSSSystem::GLONASS:
+            return 1U;
+        case libgnss::GNSSSystem::Galileo:
+            return 2U;
+        case libgnss::GNSSSystem::QZSS:
+            return 3U;
+        case libgnss::GNSSSystem::BeiDou:
+            return 4U;
+        default:
+            return 0U;
+    }
+}
+
+double groupDelayCorrectionMeters(const libgnss::Observation& observation,
+                                  const libgnss::Ephemeris& eph) {
+    switch (observation.satellite.system) {
+        case libgnss::GNSSSystem::GPS:
+        case libgnss::GNSSSystem::QZSS:
+        case libgnss::GNSSSystem::Galileo:
+            return eph.tgd * libgnss::constants::SPEED_OF_LIGHT;
+        case libgnss::GNSSSystem::BeiDou:
+            switch (observation.signal) {
+                case libgnss::SignalType::BDS_B1I:
+                case libgnss::SignalType::BDS_B1C:
+                    return eph.tgd * libgnss::constants::SPEED_OF_LIGHT;
+                case libgnss::SignalType::BDS_B2I:
+                case libgnss::SignalType::BDS_B2A:
+                    return eph.tgd_secondary * libgnss::constants::SPEED_OF_LIGHT;
+                default:
+                    return 0.0;
+            }
+        default:
+            return 0.0;
+    }
+}
+
+double sagnacRangeCorrection(const libgnss::Vector3d& satellite_position,
+                             const libgnss::Vector3d& receiver_position) {
+    return libgnss::constants::OMEGA_E / libgnss::constants::SPEED_OF_LIGHT *
+           (satellite_position(0) * receiver_position(1) -
+            satellite_position(1) * receiver_position(0));
+}
+
+bool parseSeparatedIntegers(std::string value,
+                            char separator,
+                            int& first,
+                            int& second,
+                            int& third) {
+    std::replace(value.begin(), value.end(), separator, ' ');
+    std::istringstream input(value);
+    return static_cast<bool>(input >> first >> second >> third);
+}
+
+bool parseRtklibTime(std::string value,
+                     int& hour,
+                     int& minute,
+                     double& second) {
+    std::replace(value.begin(), value.end(), ':', ' ');
+    std::istringstream input(value);
+    return static_cast<bool>(input >> hour >> minute >> second);
+}
+
+bool isLeapYear(int year) {
+    return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+}
+
+libgnss::GNSSTime gpstCalendarToTime(int year,
+                                     int month,
+                                     int day,
+                                     int hour,
+                                     int minute,
+                                     double second) {
+    int days_since_gps_epoch = 0;
+    for (int current_year = 1980; current_year < year; ++current_year) {
+        days_since_gps_epoch += isLeapYear(current_year) ? 366 : 365;
+    }
+
+    int days_in_month[] = {
+        31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    if (isLeapYear(year)) {
+        days_in_month[1] = 29;
+    }
+    for (int current_month = 1; current_month < month; ++current_month) {
+        days_since_gps_epoch += days_in_month[current_month - 1];
+    }
+    days_since_gps_epoch += day;
+    days_since_gps_epoch -= 6;
+
+    const int gps_week = days_since_gps_epoch / 7;
+    const int day_of_week = days_since_gps_epoch % 7;
+    const double tow = static_cast<double>(day_of_week) * 86400.0 +
+                       static_cast<double>(hour) * 3600.0 +
+                       static_cast<double>(minute) * 60.0 + second;
+    return libgnss::GNSSTime(gps_week, tow);
+}
+
+bool parseRtklibSeedPositionLine(const std::string& line, SeedPosition& seed) {
+    std::istringstream input(line);
+    std::string date_token;
+    std::string time_token;
+    if (!(input >> date_token >> time_token)) {
+        return false;
+    }
+
+    int year = 0;
+    int month = 0;
+    int day = 0;
+    int hour = 0;
+    int minute = 0;
+    double second = 0.0;
+    if (!parseSeparatedIntegers(date_token, '/', year, month, day) ||
+        !parseRtklibTime(time_token, hour, minute, second)) {
+        return false;
+    }
+
+    double latitude_deg = 0.0;
+    double longitude_deg = 0.0;
+    double height_m = 0.0;
+    if (!(input >> latitude_deg >> longitude_deg >> height_m)) {
+        return false;
+    }
+    if (!std::isfinite(latitude_deg) || !std::isfinite(longitude_deg) ||
+        !std::isfinite(height_m)) {
+        return false;
+    }
+
+    seed.time = gpstCalendarToTime(year, month, day, hour, minute, second);
+    seed.position_ecef = libgnss::geodetic2ecef(latitude_deg * kDegreesToRadians,
+                                                longitude_deg * kDegreesToRadians,
+                                                height_m);
+    return seed.position_ecef.norm() > 1e6;
+}
+
+bool parseSeedPositionLine(const std::string& line, SeedPosition& seed) {
+    std::istringstream input(line);
+    std::string first_token;
+    if (!(input >> first_token)) {
+        return false;
+    }
+    if (first_token[0] == '%' || first_token[0] == '#') {
+        return false;
+    }
+    if (first_token.find('/') != std::string::npos) {
+        return parseRtklibSeedPositionLine(line, seed);
+    }
+
+    int week = 0;
+    try {
+        std::size_t consumed = 0;
+        week = std::stoi(first_token, &consumed);
+        if (consumed != first_token.size()) {
+            return false;
+        }
+    } catch (const std::exception&) {
+        return false;
+    }
+
+    double tow = 0.0;
+    double x = 0.0;
+    double y = 0.0;
+    double z = 0.0;
+    if (!(input >> tow >> x >> y >> z)) {
+        return false;
+    }
+    if (!std::isfinite(tow) || !std::isfinite(x) ||
+        !std::isfinite(y) || !std::isfinite(z)) {
+        return false;
+    }
+
+    seed.time = libgnss::GNSSTime(week, tow);
+    seed.position_ecef = libgnss::Vector3d(x, y, z);
+    return seed.position_ecef.norm() > 1e6;
+}
+
+std::vector<SeedPosition> readSeedPositions(const std::string& path) {
+    std::ifstream input(path);
+    if (!input.is_open()) {
+        throw std::runtime_error("failed to open seed POS file: " + path);
+    }
+
+    std::vector<SeedPosition> seeds;
+    std::string line;
+    while (std::getline(input, line)) {
+        SeedPosition seed;
+        if (parseSeedPositionLine(line, seed)) {
+            seeds.push_back(seed);
+        }
+    }
+    if (seeds.empty()) {
+        throw std::runtime_error(
+            "seed POS file has no readable LibGNSS++ or RTKLIB POS rows: " + path);
+    }
+
+    std::sort(seeds.begin(),
+              seeds.end(),
+              [](const SeedPosition& lhs, const SeedPosition& rhs) {
+                  return lhs.time < rhs.time;
+              });
+    return seeds;
+}
+
+bool findSeedPosition(const std::vector<SeedPosition>& seeds,
+                      const libgnss::GNSSTime& time,
+                      double tolerance_s,
+                      double interpolation_max_gap_s,
+                      std::size_t& cursor,
+                      libgnss::Vector3d& position_ecef,
+                      bool& interpolated) {
+    interpolated = false;
+    while (cursor < seeds.size() && seeds[cursor].time - time < -tolerance_s) {
+        ++cursor;
+    }
+
+    std::size_t best_index = seeds.size();
+    double best_abs_dt = tolerance_s;
+    if (cursor < seeds.size()) {
+        const double abs_dt = std::abs(seeds[cursor].time - time);
+        if (abs_dt <= best_abs_dt) {
+            best_index = cursor;
+            best_abs_dt = abs_dt;
+        }
+    }
+    if (cursor > 0) {
+        const std::size_t previous_index = cursor - 1;
+        const double abs_dt = std::abs(seeds[previous_index].time - time);
+        if (abs_dt <= best_abs_dt) {
+            best_index = previous_index;
+        }
+    }
+    if (best_index == seeds.size()) {
+        if (interpolation_max_gap_s <= 0.0 || cursor == 0 ||
+            cursor >= seeds.size()) {
+            return false;
+        }
+        const SeedPosition& lower = seeds[cursor - 1];
+        const SeedPosition& upper = seeds[cursor];
+        const double gap_s = upper.time - lower.time;
+        const double lower_dt_s = time - lower.time;
+        if (gap_s <= 0.0 || gap_s > interpolation_max_gap_s ||
+            lower_dt_s < 0.0 || lower_dt_s > gap_s) {
+            return false;
+        }
+        const double alpha = lower_dt_s / gap_s;
+        position_ecef =
+            lower.position_ecef +
+            alpha * (upper.position_ecef - lower.position_ecef);
+        interpolated = true;
+        return position_ecef.norm() > 1e6;
+    }
+
+    position_ecef = seeds[best_index].position_ecef;
+    return true;
+}
+
+void writeCsvDouble(std::ostream& output, double value) {
+    if (std::isfinite(value)) {
+        output << value;
+    } else {
+        output << "NaN";
+    }
+}
+
+double robustHuberLoss(double whitened_error, double threshold) {
+    const double abs_error = std::abs(whitened_error);
+    if (abs_error <= threshold) {
+        return 0.5 * whitened_error * whitened_error;
+    }
+    return threshold * (abs_error - 0.5 * threshold);
+}
+
+double robustHuberWeight(double whitened_error, double threshold) {
+    const double abs_error = std::abs(whitened_error);
+    if (abs_error <= threshold || abs_error <= 0.0) {
+        return 1.0;
+    }
+    return threshold / abs_error;
+}
+
+int positionColumn(std::size_t epoch_index, int component) {
+    return static_cast<int>(kStateStride * epoch_index +
+                            static_cast<std::size_t>(component));
+}
+
+int clockColumn(std::size_t epoch_index, std::size_t group) {
+    return static_cast<int>(kStateStride * epoch_index + 3U + group);
+}
+
+double pseudorangePrediction(const Eigen::VectorXd& state,
+                             const PseudorangeFactor& factor) {
+    const std::size_t i = factor.epoch_index;
+    double prediction =
+        factor.los(0) * state(positionColumn(i, 0)) +
+        factor.los(1) * state(positionColumn(i, 1)) +
+        factor.los(2) * state(positionColumn(i, 2)) +
+        state(clockColumn(i, 0));
+    if (factor.clock_group != 0U) {
+        prediction += state(clockColumn(i, factor.clock_group));
+    }
+    return prediction;
+}
+
+double dopplerPrediction(const Eigen::VectorXd& state, const DopplerFactor& factor) {
+    const std::size_t i = factor.epoch_index;
+    const std::size_t previous = factor.previous_epoch_index;
+    return factor.los(0) *
+               (state(positionColumn(i, 0)) -
+                state(positionColumn(previous, 0))) / factor.dt_s +
+           factor.los(1) *
+               (state(positionColumn(i, 1)) -
+                state(positionColumn(previous, 1))) / factor.dt_s +
+           factor.los(2) *
+               (state(positionColumn(i, 2)) -
+                state(positionColumn(previous, 2))) / factor.dt_s +
+           (state(clockColumn(i, 0)) -
+            state(clockColumn(previous, 0))) / factor.dt_s;
+}
+
+double computeCost(const Problem& problem,
+                   const Options& options,
+                   const Eigen::VectorXd& state) {
+    double cost = 0.0;
+    for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
+        for (int component = 0; component < 3; ++component) {
+            const double e =
+                state(positionColumn(i, component)) /
+                options.position_prior_sigma_m;
+            cost += 0.5 * e * e;
+        }
+        for (std::size_t group = 0; group < kClockGroups; ++group) {
+            const double e =
+                state(clockColumn(i, group)) / options.clock_prior_sigma_m;
+            cost += 0.5 * e * e;
+        }
+        if (i > 0) {
+            for (std::size_t group = 0; group < kClockGroups; ++group) {
+                const double sigma =
+                    group == 0U
+                        ? (problem.clock_jumps[i]
+                               ? options.clock_jump_sigma_m
+                               : options.clock_motion_sigma_m)
+                        : options.inter_system_clock_motion_sigma_m;
+                const double prediction =
+                    state(clockColumn(i, group)) -
+                    state(clockColumn(i - 1U, group));
+                const double e = prediction / sigma;
+                cost += 0.5 * e * e;
+            }
+        }
+    }
+
+    for (const PseudorangeFactor& factor : problem.pseudorange_factors) {
+        const double error =
+            (pseudorangePrediction(state, factor) - factor.residual_m) /
+            factor.sigma_m;
+        cost += robustHuberLoss(error, options.huber_threshold_sigma);
+    }
+
+    for (const DopplerFactor& factor : problem.factors) {
+        const double error =
+            (dopplerPrediction(state, factor) - factor.residual_mps) /
+            factor.sigma_mps;
+        cost += robustHuberLoss(error, options.huber_threshold_sigma);
+    }
+    return cost;
+}
+
+struct NormalEquation {
+    Eigen::SparseMatrix<double> hessian;
+    Eigen::VectorXd rhs;
+};
+
+void addWeightedRow(std::vector<Eigen::Triplet<double>>& triplets,
+                    Eigen::VectorXd& rhs,
+                    const std::vector<int>& columns,
+                    const std::vector<double>& coefficients,
+                    double residual,
+                    double sigma,
+                    double robust_weight) {
+    const double inv_variance = robust_weight / (sigma * sigma);
+    for (std::size_t a = 0; a < columns.size(); ++a) {
+        const double weighted_a = inv_variance * coefficients[a];
+        rhs(columns[a]) += weighted_a * residual;
+        for (std::size_t b = 0; b < columns.size(); ++b) {
+            triplets.emplace_back(columns[a],
+                                  columns[b],
+                                  weighted_a * coefficients[b]);
+        }
+    }
+}
+
+NormalEquation buildNormalEquation(const Problem& problem,
+                                   const Options& options,
+                                   const Eigen::VectorXd& state) {
+    const int state_size = static_cast<int>(kStateStride * problem.epochs.size());
+    std::vector<Eigen::Triplet<double>> triplets;
+    triplets.reserve((problem.pseudorange_factors.size() + problem.factors.size()) * 16U +
+                     problem.epochs.size() * 48U);
+    Eigen::VectorXd rhs = Eigen::VectorXd::Zero(state_size);
+
+    for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
+        for (int component = 0; component < 3; ++component) {
+            const int col = positionColumn(i, component);
+            addWeightedRow(triplets,
+                           rhs,
+                           {col},
+                           {1.0},
+                           -state(col),
+                           options.position_prior_sigma_m,
+                           1.0);
+        }
+        for (std::size_t group = 0; group < kClockGroups; ++group) {
+            const int col = clockColumn(i, group);
+            addWeightedRow(triplets,
+                           rhs,
+                           {col},
+                           {1.0},
+                           -state(col),
+                           options.clock_prior_sigma_m,
+                           1.0);
+        }
+
+        if (i > 0) {
+            for (std::size_t group = 0; group < kClockGroups; ++group) {
+                const int previous = clockColumn(i - 1U, group);
+                const int current = clockColumn(i, group);
+                const double sigma =
+                    group == 0U
+                        ? (problem.clock_jumps[i]
+                               ? options.clock_jump_sigma_m
+                               : options.clock_motion_sigma_m)
+                        : options.inter_system_clock_motion_sigma_m;
+                const double prediction = state(current) - state(previous);
+                addWeightedRow(triplets,
+                               rhs,
+                               {previous, current},
+                               {-1.0, 1.0},
+                               -prediction,
+                               sigma,
+                               1.0);
+            }
+        }
+    }
+
+    for (const PseudorangeFactor& factor : problem.pseudorange_factors) {
+        const std::size_t i = factor.epoch_index;
+        const double prediction = pseudorangePrediction(state, factor);
+        const double residual = factor.residual_m - prediction;
+        const double whitened_error = -residual / factor.sigma_m;
+        const double robust_weight =
+            robustHuberWeight(whitened_error, options.huber_threshold_sigma);
+        std::vector<int> columns{
+            positionColumn(i, 0),
+            positionColumn(i, 1),
+            positionColumn(i, 2),
+            clockColumn(i, 0),
+        };
+        std::vector<double> coeffs{
+            factor.los(0),
+            factor.los(1),
+            factor.los(2),
+            1.0,
+        };
+        if (factor.clock_group != 0U) {
+            columns.push_back(clockColumn(i, factor.clock_group));
+            coeffs.push_back(1.0);
+        }
+        addWeightedRow(triplets,
+                       rhs,
+                       columns,
+                       coeffs,
+                       residual,
+                       factor.sigma_m,
+                       robust_weight);
+    }
+
+    for (const DopplerFactor& factor : problem.factors) {
+        const std::size_t i = factor.epoch_index;
+        const std::size_t previous = factor.previous_epoch_index;
+        const double prediction = dopplerPrediction(state, factor);
+        const double residual = factor.residual_mps - prediction;
+        const double whitened_error = -residual / factor.sigma_mps;
+        const double robust_weight =
+            robustHuberWeight(whitened_error, options.huber_threshold_sigma);
+        addWeightedRow(triplets,
+                       rhs,
+                       {positionColumn(previous, 0),
+                        positionColumn(i, 0),
+                        positionColumn(previous, 1),
+                        positionColumn(i, 1),
+                        positionColumn(previous, 2),
+                        positionColumn(i, 2),
+                        clockColumn(previous, 0),
+                        clockColumn(i, 0)},
+                       {-factor.los(0) / factor.dt_s,
+                        factor.los(0) / factor.dt_s,
+                        -factor.los(1) / factor.dt_s,
+                        factor.los(1) / factor.dt_s,
+                        -factor.los(2) / factor.dt_s,
+                        factor.los(2) / factor.dt_s,
+                        -1.0 / factor.dt_s,
+                        1.0 / factor.dt_s},
+                       residual,
+                       factor.sigma_mps,
+                       robust_weight);
+    }
+
+    NormalEquation normal;
+    normal.hessian.resize(state_size, state_size);
+    normal.hessian.setFromTriplets(triplets.begin(), triplets.end());
+    normal.rhs = std::move(rhs);
+    return normal;
+}
+
+double residualRms(const Problem& problem, const Eigen::VectorXd& state) {
+    const std::size_t count =
+        problem.pseudorange_factors.size() + problem.factors.size();
+    if (count == 0U) {
+        return 0.0;
+    }
+    double sum_sq = 0.0;
+    for (const PseudorangeFactor& factor : problem.pseudorange_factors) {
+        const double residual =
+            pseudorangePrediction(state, factor) - factor.residual_m;
+        sum_sq += residual * residual;
+    }
+    for (const DopplerFactor& factor : problem.factors) {
+        const double residual =
+            dopplerPrediction(state, factor) - factor.residual_mps;
+        sum_sq += residual * residual;
+    }
+    return std::sqrt(sum_sq / static_cast<double>(count));
+}
+
+SolveResult solveProblem(const Problem& problem, const Options& options) {
+    SolveResult result;
+    result.state =
+        Eigen::VectorXd::Zero(static_cast<int>(kStateStride * problem.epochs.size()));
+    result.initial_cost = computeCost(problem, options, result.state);
+
+    if (options.debug_problem_only || options.max_iterations == 0 ||
+        problem.epochs.empty()) {
+        result.final_cost = result.initial_cost;
+        result.residual_rms_mps = residualRms(problem, result.state);
+        return result;
+    }
+
+    double previous_cost = result.initial_cost;
+    for (int iteration = 1; iteration <= options.max_iterations; ++iteration) {
+        NormalEquation normal = buildNormalEquation(problem, options, result.state);
+        Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> solver;
+        solver.compute(normal.hessian);
+        if (solver.info() != Eigen::Success) {
+            throw std::runtime_error("failed to factor Doppler normal equation");
+        }
+        const Eigen::VectorXd delta = solver.solve(normal.rhs);
+        if (solver.info() != Eigen::Success || !delta.allFinite()) {
+            throw std::runtime_error("failed to solve Doppler normal equation");
+        }
+
+        result.state += delta;
+        result.iterations = iteration;
+
+        const double cost = computeCost(problem, options, result.state);
+        const double absolute_decrease = previous_cost - cost;
+        const double relative_decrease =
+            absolute_decrease / std::max(1.0, std::abs(previous_cost));
+        previous_cost = cost;
+
+        if (delta.norm() < 1e-10 ||
+            (iteration > 1 && absolute_decrease >= 0.0 &&
+             relative_decrease < 1e-5)) {
+            result.converged = true;
+            break;
+        }
+    }
+
+    result.final_cost = computeCost(problem, options, result.state);
+    result.residual_rms_mps = residualRms(problem, result.state);
+    return result;
+}
+
+bool calculateObservationModel(const libgnss::ObservationData& epoch,
+                               const libgnss::Observation& observation,
+                               const libgnss::NavigationData& nav,
+                               const libgnss::Vector3d& receiver_position,
+                               const Options& options,
+                               libgnss::Vector3d& satellite_position,
+                               libgnss::Vector3d& satellite_velocity,
+                               double& satellite_clock_bias,
+                               double& satellite_clock_drift,
+                               const libgnss::Ephemeris*& eph,
+                               libgnss::NavigationData::SatelliteGeometry& geometry,
+                               libgnss::Vector3d& ex,
+                               double& range_m) {
+    if (!isPrimaryPdSignal(observation.signal) ||
+        !observation.valid ||
+        !observation.has_pseudorange ||
+        observation.pseudorange <= 0.0 ||
+        observation.snr < options.min_snr_dbhz) {
+        return false;
+    }
+
+    libgnss::GNSSTime transmit_time =
+        epoch.time - observation.pseudorange / libgnss::constants::SPEED_OF_LIGHT;
+    if (!nav.calculateSatelliteState(observation.satellite,
+                                     transmit_time,
+                                     satellite_position,
+                                     satellite_velocity,
+                                     satellite_clock_bias,
+                                     satellite_clock_drift)) {
+        return false;
+    }
+
+    transmit_time = transmit_time - satellite_clock_bias;
+    if (!nav.calculateSatelliteState(observation.satellite,
+                                     transmit_time,
+                                     satellite_position,
+                                     satellite_velocity,
+                                     satellite_clock_bias,
+                                     satellite_clock_drift)) {
+        return false;
+    }
+
+    eph = nav.getEphemeris(observation.satellite, transmit_time);
+    if (!eph || !isHealthyForPositioning(observation, *eph)) {
+        return false;
+    }
+
+    const libgnss::Vector3d delta = satellite_position - receiver_position;
+    range_m = delta.norm();
+    if (range_m <= 0.0) {
+        return false;
+    }
+    ex = delta / range_m;
+    geometry = nav.calculateGeometry(receiver_position, satellite_position);
+    return geometry.elevation >= options.min_elevation_deg * kDegreesToRadians;
+}
+
+bool preparePseudorangeFactor(const libgnss::ObservationData& epoch,
+                              std::size_t epoch_index,
+                              const libgnss::Observation& observation,
+                              const libgnss::NavigationData& nav,
+                              const libgnss::Vector3d& receiver_position,
+                              const Options& options,
+                              PseudorangeFactor& factor) {
+    libgnss::Vector3d satellite_position;
+    libgnss::Vector3d satellite_velocity;
+    double satellite_clock_bias = 0.0;
+    double satellite_clock_drift = 0.0;
+    const libgnss::Ephemeris* eph = nullptr;
+    libgnss::NavigationData::SatelliteGeometry geometry;
+    libgnss::Vector3d ex = libgnss::Vector3d::Zero();
+    double geometric_range = 0.0;
+    if (!calculateObservationModel(epoch,
+                                   observation,
+                                   nav,
+                                   receiver_position,
+                                   options,
+                                   satellite_position,
+                                   satellite_velocity,
+                                   satellite_clock_bias,
+                                   satellite_clock_drift,
+                                   eph,
+                                   geometry,
+                                   ex,
+                                   geometric_range)) {
+        return false;
+    }
+
+    double receiver_lat = 0.0;
+    double receiver_lon = 0.0;
+    double receiver_height = 0.0;
+    libgnss::ecef2geodetic(receiver_position,
+                           receiver_lat,
+                           receiver_lon,
+                           receiver_height);
+    double ionosphere_delay = 0.0;
+    if (nav.ionosphere_model.valid) {
+        ionosphere_delay = libgnss::models::ionoDelayKlobuchar(
+            receiver_lat,
+            receiver_lon,
+            geometry.azimuth,
+            geometry.elevation,
+            epoch.time.tow,
+            nav.ionosphere_model.alpha,
+            nav.ionosphere_model.beta);
+        const double frequency_hz =
+            libgnss::signalFrequencyHz(observation.signal, eph);
+        if (frequency_hz > 0.0) {
+            const double scale = libgnss::constants::GPS_L1_FREQ / frequency_hz;
+            ionosphere_delay *= scale * scale;
+        }
+    }
+    const double troposphere_delay =
+        libgnss::models::tropDelaySaastamoinen(receiver_position,
+                                               geometry.elevation);
+    const double satellite_clock_m =
+        satellite_clock_bias * libgnss::constants::SPEED_OF_LIGHT;
+    const double group_delay_m = groupDelayCorrectionMeters(observation, *eph);
+    const double modeled_range =
+        geometric_range + sagnacRangeCorrection(satellite_position, receiver_position);
+    const double corrected_pseudorange =
+        observation.pseudorange +
+        satellite_clock_m -
+        ionosphere_delay -
+        troposphere_delay -
+        group_delay_m;
+    const double residual = corrected_pseudorange - modeled_range;
+    const double sin_el = std::sin(geometry.elevation);
+    if (sin_el <= 0.0) {
+        return false;
+    }
+
+    factor.epoch_index = epoch_index;
+    factor.time = epoch.time;
+    factor.satellite = observation.satellite;
+    factor.signal = observation.signal;
+    factor.clock_group = clockGroup(observation.satellite.system);
+    factor.snr_dbhz = observation.snr;
+    factor.elevation_rad = geometry.elevation;
+    factor.sigma_m = options.pseudorange_sigma_zenith_m / std::sqrt(sin_el);
+    factor.residual_m = residual;
+    factor.corrected_pseudorange_m = corrected_pseudorange;
+    factor.modeled_range_m = modeled_range;
+    factor.ionosphere_delay_m = ionosphere_delay;
+    factor.troposphere_delay_m = troposphere_delay;
+    factor.satellite_clock_m = satellite_clock_m;
+    factor.group_delay_m = group_delay_m;
+    factor.los = -ex;
+    return std::isfinite(factor.residual_m) &&
+           std::isfinite(factor.sigma_m) &&
+           factor.sigma_m > 0.0;
+}
+
+bool prepareDopplerFactor(const libgnss::ObservationData& epoch,
+                          std::size_t epoch_index,
+                          std::size_t previous_epoch_index,
+                          const libgnss::Observation& observation,
+                          const libgnss::NavigationData& nav,
+                          const libgnss::Vector3d& receiver_position,
+                          const libgnss::Vector3d& receiver_velocity,
+                          double sigma_elevation_rad,
+                          double dt_s,
+                          const Options& options,
+                          DopplerFactor& factor) {
+    if (!isPrimaryPdSignal(observation.signal) ||
+        !observation.valid ||
+        !observation.has_pseudorange ||
+        !observation.has_doppler ||
+        observation.pseudorange <= 0.0) {
+        return false;
+    }
+
+    libgnss::Vector3d satellite_position;
+    libgnss::Vector3d satellite_velocity;
+    double satellite_clock_bias = 0.0;
+    double satellite_clock_drift = 0.0;
+    const libgnss::Ephemeris* eph = nullptr;
+    libgnss::NavigationData::SatelliteGeometry geometry;
+    libgnss::Vector3d ex = libgnss::Vector3d::Zero();
+    double range = 0.0;
+    libgnss::GNSSTime transmit_time =
+        epoch.time - observation.pseudorange / libgnss::constants::SPEED_OF_LIGHT;
+    if (!nav.calculateSatelliteState(observation.satellite,
+                                     transmit_time,
+                                     satellite_position,
+                                     satellite_velocity,
+                                     satellite_clock_bias,
+                                     satellite_clock_drift)) {
+        return false;
+    }
+    transmit_time = transmit_time - satellite_clock_bias;
+    if (!nav.calculateSatelliteState(observation.satellite,
+                                     transmit_time,
+                                     satellite_position,
+                                     satellite_velocity,
+                                     satellite_clock_bias,
+                                     satellite_clock_drift)) {
+        return false;
+    }
+    eph = nav.getEphemeris(observation.satellite, transmit_time);
+    if (!eph || !isHealthyForPositioning(observation, *eph)) {
+        return false;
+    }
+
+    const libgnss::Vector3d delta = satellite_position - receiver_position;
+    range = delta.norm();
+    if (range <= 0.0 || dt_s <= 0.0) {
+        return false;
+    }
+    ex = delta / range;
+    geometry = nav.calculateGeometry(receiver_position, satellite_position);
+
+    double wavelength = libgnss::signalWavelengthMeters(observation.signal, eph);
+    if (wavelength <= 0.0) {
+        wavelength = libgnss::signalWavelengthMeters(observation);
+    }
+    if (wavelength <= 0.0) {
+        return false;
+    }
+
+    const double sagnac_rate =
+        libgnss::constants::OMEGA_E / libgnss::constants::SPEED_OF_LIGHT *
+        (satellite_velocity(1) * receiver_position(0) -
+         satellite_velocity(0) * receiver_position(1));
+    const double modeled_range_rate =
+        (satellite_velocity - receiver_velocity).dot(ex) + sagnac_rate;
+    const double satellite_clock_drift_mps =
+        satellite_clock_drift * libgnss::constants::SPEED_OF_LIGHT;
+    const double measured_range_rate = -observation.doppler * wavelength;
+    const double residual =
+        measured_range_rate - (modeled_range_rate - satellite_clock_drift_mps);
+    const double sin_el = std::sin(sigma_elevation_rad);
+    if (sin_el <= 0.0) {
+        return false;
+    }
+
+    factor.epoch_index = epoch_index;
+    factor.previous_epoch_index = previous_epoch_index;
+    factor.time = epoch.time;
+    factor.midpoint_time = epoch.time;
+    factor.satellite = observation.satellite;
+    factor.signal = observation.signal;
+    factor.snr_dbhz = observation.snr;
+    factor.elevation_rad = sigma_elevation_rad;
+    factor.midpoint_elevation_rad = geometry.elevation;
+    factor.dt_s = dt_s;
+    factor.sigma_mps = options.doppler_sigma_zenith_mps / std::sqrt(sin_el);
+    factor.residual_mps = residual;
+    factor.measured_range_rate_mps = measured_range_rate;
+    factor.modeled_range_rate_mps = modeled_range_rate;
+    factor.satellite_clock_drift_mps = satellite_clock_drift_mps;
+    factor.wavelength_m = wavelength;
+    factor.los = -ex;
+    return std::isfinite(factor.residual_mps) &&
+           std::isfinite(factor.sigma_mps) &&
+           factor.sigma_mps > 0.0;
+}
+
+using ObservationKey = std::tuple<libgnss::SatelliteId, libgnss::SignalType>;
+
+libgnss::Observation interpolateObservation(const libgnss::Observation& lower,
+                                            const libgnss::Observation& upper,
+                                            double alpha) {
+    libgnss::Observation interpolated = lower;
+    interpolated.valid = lower.valid && upper.valid;
+    interpolated.has_pseudorange =
+        lower.has_pseudorange && upper.has_pseudorange;
+    interpolated.has_carrier_phase =
+        lower.has_carrier_phase && upper.has_carrier_phase;
+    interpolated.has_doppler = lower.has_doppler && upper.has_doppler;
+    if (interpolated.has_pseudorange) {
+        interpolated.pseudorange =
+            lower.pseudorange + alpha * (upper.pseudorange - lower.pseudorange);
+    }
+    if (interpolated.has_carrier_phase) {
+        interpolated.carrier_phase =
+            lower.carrier_phase +
+            alpha * (upper.carrier_phase - lower.carrier_phase);
+    }
+    if (interpolated.has_doppler) {
+        interpolated.doppler =
+            lower.doppler + alpha * (upper.doppler - lower.doppler);
+    }
+    interpolated.snr = std::min(lower.snr, upper.snr);
+    interpolated.signal_strength =
+        std::min(lower.signal_strength, upper.signal_strength);
+    interpolated.lli = lower.lli | upper.lli;
+    interpolated.loss_of_lock =
+        lower.loss_of_lock || upper.loss_of_lock ||
+        ((interpolated.lli & 0x01U) != 0);
+    interpolated.has_glonass_frequency_channel =
+        lower.has_glonass_frequency_channel &&
+        upper.has_glonass_frequency_channel &&
+        lower.glonass_frequency_channel == upper.glonass_frequency_channel;
+    if (interpolated.has_glonass_frequency_channel) {
+        interpolated.glonass_frequency_channel = lower.glonass_frequency_channel;
+    }
+    return interpolated;
+}
+
+bool observationElevationRad(const libgnss::ObservationData& epoch,
+                             const libgnss::Observation& observation,
+                             const libgnss::NavigationData& nav,
+                             const libgnss::Vector3d& receiver_position,
+                             double& elevation_rad) {
+    if (!isPrimaryPdSignal(observation.signal) ||
+        !observation.valid ||
+        !observation.has_pseudorange ||
+        observation.pseudorange <= 0.0) {
+        return false;
+    }
+
+    libgnss::Vector3d satellite_position;
+    libgnss::Vector3d satellite_velocity;
+    double satellite_clock_bias = 0.0;
+    double satellite_clock_drift = 0.0;
+    libgnss::GNSSTime transmit_time =
+        epoch.time - observation.pseudorange / libgnss::constants::SPEED_OF_LIGHT;
+    if (!nav.calculateSatelliteState(observation.satellite,
+                                     transmit_time,
+                                     satellite_position,
+                                     satellite_velocity,
+                                     satellite_clock_bias,
+                                     satellite_clock_drift)) {
+        return false;
+    }
+    transmit_time = transmit_time - satellite_clock_bias;
+    if (!nav.calculateSatelliteState(observation.satellite,
+                                     transmit_time,
+                                     satellite_position,
+                                     satellite_velocity,
+                                     satellite_clock_bias,
+                                     satellite_clock_drift)) {
+        return false;
+    }
+    const libgnss::Ephemeris* eph =
+        nav.getEphemeris(observation.satellite, transmit_time);
+    if (!eph || !isHealthyForPositioning(observation, *eph)) {
+        return false;
+    }
+    elevation_rad =
+        nav.calculateGeometry(receiver_position, satellite_position).elevation;
+    return std::isfinite(elevation_rad);
+}
+
+Problem buildProblem(const Options& options) {
+    libgnss::io::RINEXReader obs_reader;
+    if (!obs_reader.open(options.obs_path)) {
+        throw std::runtime_error("failed to open observation file: " + options.obs_path);
+    }
+    libgnss::io::RINEXReader::RINEXHeader obs_header;
+    if (!obs_reader.readHeader(obs_header)) {
+        throw std::runtime_error("failed to read observation header: " + options.obs_path);
+    }
+
+    libgnss::io::RINEXReader nav_reader;
+    if (!nav_reader.open(options.nav_path)) {
+        throw std::runtime_error("failed to open navigation file: " + options.nav_path);
+    }
+    libgnss::NavigationData nav_data;
+    if (!nav_reader.readNavigationData(nav_data)) {
+        throw std::runtime_error("failed to read navigation data: " + options.nav_path);
+    }
+
+    const std::vector<SeedPosition> seed_positions =
+        readSeedPositions(options.seed_pos_path);
+    std::size_t seed_cursor = 0;
+
+    Problem problem;
+    std::set<libgnss::SatelliteId> unique_satellites;
+    const double fixed_interval_s =
+        obs_header.interval > 0.0 ? obs_header.interval : 1.0;
+    const double gap_tolerance_s = std::max(0.01, 0.5 * fixed_interval_s);
+    std::map<libgnss::SatelliteId, double> previous_gps_pseudorange_by_satellite;
+    bool have_previous_gps_pseudorange = false;
+
+    auto append_epoch = [&](libgnss::ObservationData epoch,
+                            bool build_factors) -> bool {
+        if (options.max_epochs > 0 &&
+            static_cast<int>(problem.epochs.size()) >= options.max_epochs) {
+            return false;
+        }
+
+        libgnss::Vector3d seed_position = libgnss::Vector3d::Zero();
+        bool interpolated = false;
+        if (findSeedPosition(seed_positions,
+                             epoch.time,
+                             options.seed_match_tolerance_s,
+                             options.seed_interpolation_max_gap_s,
+                             seed_cursor,
+                             seed_position,
+                             interpolated)) {
+            epoch.receiver_position = seed_position;
+            ++problem.seed_matched_epochs;
+            if (interpolated) {
+                ++problem.seed_interpolated_epochs;
+            }
+        } else if (obs_header.approximate_position.norm() > 1e6) {
+            seed_position = obs_header.approximate_position;
+            epoch.receiver_position = seed_position;
+        } else {
+            return true;
+        }
+
+        const std::size_t epoch_index = problem.epochs.size();
+        std::map<libgnss::SatelliteId, double> gps_pseudorange_by_satellite;
+        if (build_factors) {
+            for (const auto& observation : epoch.observations) {
+                unique_satellites.insert(observation.satellite);
+                PseudorangeFactor pseudorange_factor;
+                if (preparePseudorangeFactor(epoch,
+                                             epoch_index,
+                                             observation,
+                                             nav_data,
+                                             seed_position,
+                                             options,
+                                             pseudorange_factor)) {
+                    problem.pseudorange_factors.push_back(pseudorange_factor);
+                    if (observation.satellite.system == libgnss::GNSSSystem::GPS) {
+                        gps_pseudorange_by_satellite[observation.satellite] =
+                            observation.pseudorange;
+                    }
+                }
+            }
+        }
+
+        bool clock_jump = false;
+        if (have_previous_gps_pseudorange && !gps_pseudorange_by_satellite.empty()) {
+            double sum_delta = 0.0;
+            std::size_t count = 0;
+            for (const auto& [satellite, pseudorange] : gps_pseudorange_by_satellite) {
+                const auto previous_it =
+                    previous_gps_pseudorange_by_satellite.find(satellite);
+                if (previous_it == previous_gps_pseudorange_by_satellite.end()) {
+                    continue;
+                }
+                sum_delta += pseudorange - previous_it->second;
+                ++count;
+            }
+            if (count > 0U) {
+                clock_jump = sum_delta / static_cast<double>(count) > 1e5;
+            }
+        }
+        problem.clock_jumps.push_back(clock_jump);
+        previous_gps_pseudorange_by_satellite = gps_pseudorange_by_satellite;
+        have_previous_gps_pseudorange = !gps_pseudorange_by_satellite.empty();
+
+        problem.seed_positions.push_back(seed_position);
+        problem.epochs.push_back(epoch);
+        return true;
+    };
+
+    libgnss::ObservationData epoch;
+    int raw_epoch_index = 0;
+    bool have_last_output_time = false;
+    libgnss::GNSSTime last_output_time;
+    while (obs_reader.readObservationEpoch(epoch)) {
+        if (raw_epoch_index++ < options.skip_epochs) {
+            continue;
+        }
+
+        if (have_last_output_time) {
+            libgnss::GNSSTime expected_time =
+                last_output_time + fixed_interval_s;
+            while (epoch.time - expected_time > gap_tolerance_s) {
+                libgnss::ObservationData empty_epoch(expected_time);
+                if (!append_epoch(empty_epoch, false)) {
+                    break;
+                }
+                last_output_time = expected_time;
+                expected_time = last_output_time + fixed_interval_s;
+                if (options.max_epochs > 0 &&
+                    static_cast<int>(problem.epochs.size()) >=
+                        options.max_epochs) {
+                    break;
+                }
+            }
+            if (options.max_epochs > 0 &&
+                static_cast<int>(problem.epochs.size()) >= options.max_epochs) {
+                break;
+            }
+        }
+
+        if (!append_epoch(epoch, true)) {
+            break;
+        }
+        last_output_time = epoch.time;
+        have_last_output_time = true;
+    }
+    problem.nsat = unique_satellites.size();
+
+    for (std::size_t i = 1; i < problem.epochs.size(); ++i) {
+        if (problem.clock_jumps[i]) {
+            continue;
+        }
+        const libgnss::ObservationData& previous_epoch = problem.epochs[i - 1U];
+        const libgnss::ObservationData& current_epoch = problem.epochs[i];
+        const double dt_s = current_epoch.time - previous_epoch.time;
+        if (dt_s <= 0.0) {
+            continue;
+        }
+
+        std::map<ObservationKey, const libgnss::Observation*> current_observations;
+        for (const auto& observation : current_epoch.observations) {
+            current_observations[{observation.satellite, observation.signal}] =
+                &observation;
+        }
+
+        libgnss::ObservationData midpoint_epoch(previous_epoch.time + 0.5 * dt_s);
+        const libgnss::Vector3d midpoint_position =
+            0.5 * (problem.seed_positions[i - 1U] + problem.seed_positions[i]);
+        const libgnss::Vector3d initial_velocity =
+            (problem.seed_positions[i] - problem.seed_positions[i - 1U]) / dt_s;
+        midpoint_epoch.receiver_position = midpoint_position;
+
+        for (const auto& previous_observation : previous_epoch.observations) {
+            const ObservationKey key{previous_observation.satellite,
+                                     previous_observation.signal};
+            const auto current_it = current_observations.find(key);
+            if (current_it == current_observations.end()) {
+                continue;
+            }
+            const libgnss::Observation& current_observation = *current_it->second;
+            double sigma_elevation_rad = 0.0;
+            if (!observationElevationRad(current_epoch,
+                                         current_observation,
+                                         nav_data,
+                                         problem.seed_positions[i],
+                                         sigma_elevation_rad)) {
+                continue;
+            }
+
+            libgnss::Observation interpolated_observation =
+                interpolateObservation(previous_observation,
+                                       current_observation,
+                                       0.5);
+            midpoint_epoch.observations.clear();
+            midpoint_epoch.addObservation(interpolated_observation);
+
+            DopplerFactor factor;
+            if (prepareDopplerFactor(midpoint_epoch,
+                                     i,
+                                     i - 1U,
+                                     interpolated_observation,
+                                     nav_data,
+                                     midpoint_position,
+                                     initial_velocity,
+                                     sigma_elevation_rad,
+                                     dt_s,
+                                     options,
+                                     factor)) {
+                problem.factors.push_back(factor);
+                unique_satellites.insert(factor.satellite);
+            }
+        }
+    }
+
+    problem.nsat = unique_satellites.size();
+    return problem;
+}
+
+bool writePerEpochCsv(const std::string& path,
+                      const Problem& problem,
+                      const SolveResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    output << "epoch,gps_week,gps_tow,spp_x_m,spp_y_m,spp_z_m,"
+              "fgo_x_m,fgo_y_m,fgo_z_m,"
+              "fgo_c_gps_m,fgo_c_glo_m,fgo_c_gal_m,fgo_c_qzs_m,"
+              "fgo_c_bds_m,clock_jump\n";
+    output << std::fixed << std::setprecision(15);
+    for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
+        const auto& epoch = problem.epochs[i];
+        const auto& seed = problem.seed_positions[i];
+        output << (i + 1U) << ','
+               << epoch.time.week << ','
+               << epoch.time.tow << ','
+               << seed(0) << ','
+               << seed(1) << ','
+               << seed(2) << ','
+               << seed(0) + result.state(positionColumn(i, 0)) << ','
+               << seed(1) + result.state(positionColumn(i, 1)) << ','
+               << seed(2) + result.state(positionColumn(i, 2)) << ','
+               << result.state(clockColumn(i, 0)) << ','
+               << result.state(clockColumn(i, 1)) << ','
+               << result.state(clockColumn(i, 2)) << ','
+               << result.state(clockColumn(i, 3)) << ','
+               << result.state(clockColumn(i, 4)) << ','
+               << (problem.clock_jumps[i] ? 1 : 0) << '\n';
+    }
+    return true;
+}
+
+bool writeFactorDebugCsv(const std::string& path,
+                         const Problem& problem,
+                         const SolveResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    output << "factor_type,epoch_index,gps_week,gps_tow,satellite,signal,"
+              "previous_epoch_index,midpoint_gps_week,midpoint_gps_tow,"
+              "clock_group,snr_dbhz,elevation_deg,sigma_p_m,sigma_d_mps,"
+              "res_pc_m,res_d_mps,measured_range_rate_mps,"
+              "modeled_range_rate_mps,satellite_clock_drift_mps,"
+              "dt_s,final_residual_m,los_x,los_y,los_z\n";
+    output << std::fixed << std::setprecision(15);
+    for (const PseudorangeFactor& factor : problem.pseudorange_factors) {
+        const double final_residual =
+            pseudorangePrediction(result.state, factor) - factor.residual_m;
+        output << "P,"
+               << factor.epoch_index << ','
+               << factor.time.week << ','
+               << factor.time.tow << ','
+               << factor.satellite.toString() << ','
+               << signalName(factor.signal) << ','
+               << "NaN,NaN,NaN,"
+               << factor.clock_group << ','
+               << factor.snr_dbhz << ','
+               << factor.elevation_rad * kRadiansToDegrees << ','
+               << factor.sigma_m << ",NaN,"
+               << factor.residual_m << ",NaN,NaN,NaN,NaN,NaN,"
+               << final_residual << ','
+               << factor.los(0) << ','
+               << factor.los(1) << ','
+               << factor.los(2) << '\n';
+    }
+    for (const DopplerFactor& factor : problem.factors) {
+        const double final_residual =
+            dopplerPrediction(result.state, factor) - factor.residual_mps;
+        output << "D,"
+               << factor.epoch_index << ','
+               << factor.time.week << ','
+               << factor.time.tow << ','
+               << factor.satellite.toString() << ','
+               << signalName(factor.signal) << ','
+               << factor.previous_epoch_index << ','
+               << factor.midpoint_time.week << ','
+               << factor.midpoint_time.tow << ','
+               << clockGroup(factor.satellite.system) << ','
+               << factor.snr_dbhz << ','
+               << factor.elevation_rad * kRadiansToDegrees << ','
+               << "NaN,"
+               << factor.sigma_mps << ','
+               << "NaN,"
+               << factor.residual_mps << ','
+               << factor.measured_range_rate_mps << ','
+               << factor.modeled_range_rate_mps << ','
+               << factor.satellite_clock_drift_mps << ','
+               << factor.dt_s << ','
+               << final_residual << ','
+               << factor.los(0) << ','
+               << factor.los(1) << ','
+               << factor.los(2) << '\n';
+    }
+    return true;
+}
+
+std::size_t graphFactorCount(const Problem& problem) {
+    if (problem.epochs.empty()) {
+        return problem.pseudorange_factors.size() + problem.factors.size();
+    }
+    return problem.pseudorange_factors.size() +
+           problem.factors.size() +
+           2U * problem.epochs.size() +
+           (problem.epochs.size() - 1U);
+}
+
+bool writeGraphCsv(const std::string& path,
+                   const Problem& problem,
+                   const SolveResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    output << "n,nsat,graph_factors,graph_values,initial_cost,final_cost,"
+              "optimizer_error,iterations,valid_position_epochs,"
+              "valid_clock_epochs\n";
+    output << std::fixed << std::setprecision(15)
+           << problem.epochs.size() << ','
+           << problem.nsat << ','
+           << graphFactorCount(problem) << ','
+           << 2U * problem.epochs.size() << ','
+           << result.initial_cost << ','
+           << result.final_cost << ','
+           << result.final_cost << ','
+           << result.iterations << ','
+           << problem.epochs.size() << ','
+           << problem.epochs.size() << '\n';
+    return true;
+}
+
+std::string jsonBool(bool value) {
+    return value ? "true" : "false";
+}
+
+bool writeSummaryJson(const std::string& path,
+                      const Options& options,
+                      const Problem& problem,
+                      const SolveResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    const std::size_t epoch_count = problem.epochs.size();
+    output << std::fixed << std::setprecision(15)
+           << "{\n"
+           << "  \"preset\": \"taroz-pos-pd\",\n"
+           << "  \"backend\": \"eigen\",\n"
+           << "  \"debug_problem_only\": " << jsonBool(options.debug_problem_only) << ",\n"
+           << "  \"optimized_epochs\": " << epoch_count << ",\n"
+           << "  \"valid_position_epochs\": " << epoch_count << ",\n"
+           << "  \"valid_clock_epochs\": " << epoch_count << ",\n"
+           << "  \"seed_matched_epochs\": " << problem.seed_matched_epochs << ",\n"
+           << "  \"seed_interpolated_epochs\": " << problem.seed_interpolated_epochs << ",\n"
+           << "  \"nsat\": " << problem.nsat << ",\n"
+           << "  \"pseudorange_factors\": " << problem.pseudorange_factors.size() << ",\n"
+           << "  \"doppler_factors\": " << problem.factors.size() << ",\n"
+           << "  \"position_prior_factors\": " << epoch_count << ",\n"
+           << "  \"clock_prior_factors\": " << epoch_count << ",\n"
+           << "  \"clock_motion_factors\": "
+           << (epoch_count > 0 ? epoch_count - 1U : 0U) << ",\n"
+           << "  \"graph_factors\": " << graphFactorCount(problem) << ",\n"
+           << "  \"graph_values\": " << 2U * epoch_count << ",\n"
+           << "  \"min_snr_dbhz\": " << options.min_snr_dbhz << ",\n"
+           << "  \"min_elevation_deg\": " << options.min_elevation_deg << ",\n"
+           << "  \"pseudorange_sigma_zenith_m\": "
+           << options.pseudorange_sigma_zenith_m << ",\n"
+           << "  \"doppler_sigma_zenith_mps\": "
+           << options.doppler_sigma_zenith_mps << ",\n"
+           << "  \"position_prior_sigma_m\": "
+           << options.position_prior_sigma_m << ",\n"
+           << "  \"clock_prior_sigma_m\": "
+           << options.clock_prior_sigma_m << ",\n"
+           << "  \"clock_motion_sigma_m\": "
+           << options.clock_motion_sigma_m << ",\n"
+           << "  \"clock_jump_sigma_m\": " << options.clock_jump_sigma_m << ",\n"
+           << "  \"huber_threshold_sigma\": "
+           << options.huber_threshold_sigma << ",\n"
+           << "  \"iterations\": " << result.iterations << ",\n"
+           << "  \"converged\": " << jsonBool(result.converged) << ",\n"
+           << "  \"initial_cost\": " << result.initial_cost << ",\n"
+           << "  \"final_cost\": " << result.final_cost << ",\n"
+           << "  \"residual_rms_mps\": " << result.residual_rms_mps << "\n"
+           << "}\n";
+    return true;
+}
+
+void printSummary(const Problem& problem, const SolveResult& result) {
+    std::cout << "Taroz position PD batch complete\n"
+              << "  epochs: " << problem.epochs.size() << "\n"
+              << "  satellites: " << problem.nsat << "\n"
+              << "  pseudorange_factors: "
+              << problem.pseudorange_factors.size() << "\n"
+              << "  doppler_factors: " << problem.factors.size() << "\n"
+              << "  graph_factors: " << graphFactorCount(problem) << "\n"
+              << "  iterations: " << result.iterations << "\n"
+              << "  converged: " << (result.converged ? "true" : "false") << "\n"
+              << std::fixed << std::setprecision(6)
+              << "  initial_cost: " << result.initial_cost << "\n"
+              << "  final_cost: " << result.final_cost << "\n"
+              << "  residual_rms_mps: " << result.residual_rms_mps << "\n";
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+    try {
+        const Options options = parseArguments(argc, argv);
+        const Problem problem = buildProblem(options);
+        const SolveResult result = solveProblem(problem, options);
+
+        if (!writePerEpochCsv(options.out_csv_path, problem, result)) {
+            std::cerr << "Error: failed to write state CSV: "
+                      << options.out_csv_path << "\n";
+            return 1;
+        }
+        if (!writeFactorDebugCsv(options.factor_debug_csv_path, problem, result)) {
+            std::cerr << "Error: failed to write factor debug CSV: "
+                      << options.factor_debug_csv_path << "\n";
+            return 1;
+        }
+        if (!writeGraphCsv(options.graph_csv_path, problem, result)) {
+            std::cerr << "Error: failed to write graph CSV: "
+                      << options.graph_csv_path << "\n";
+            return 1;
+        }
+        if (!writeSummaryJson(options.summary_json_path, options, problem, result)) {
+            std::cerr << "Error: failed to write summary JSON: "
+                      << options.summary_json_path << "\n";
+            return 1;
+        }
+        if (!options.quiet) {
+            printSummary(problem, result);
+        }
+        return 0;
+    } catch (const std::invalid_argument&) {
+        return 2;
+    } catch (const std::exception& ex) {
+        std::cerr << "Error: " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/apps/gnss_pos_pdc.cpp
+++ b/apps/gnss_pos_pdc.cpp
@@ -1,0 +1,2046 @@
+#include <libgnss++/core/constants.hpp>
+#include <libgnss++/core/coordinates.hpp>
+#include <libgnss++/core/navigation.hpp>
+#include <libgnss++/core/observation.hpp>
+#include <libgnss++/core/signals.hpp>
+#include <libgnss++/io/rinex.hpp>
+#include <libgnss++/models/ionosphere.hpp>
+#include <libgnss++/models/troposphere.hpp>
+
+#include <Eigen/Sparse>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace {
+
+constexpr double kPi = 3.141592653589793238462643383279502884;
+constexpr double kDegreesToRadians = kPi / 180.0;
+constexpr double kRadiansToDegrees = 180.0 / kPi;
+constexpr std::size_t kClockGroups = 5;
+constexpr std::size_t kStateStride = 8;
+
+struct Options {
+    std::string obs_path;
+    std::string nav_path;
+    std::string seed_pos_path;
+    std::string out_csv_path;
+    std::string factor_debug_csv_path;
+    std::string graph_csv_path;
+    std::string summary_json_path;
+    int skip_epochs = 0;
+    int max_epochs = 0;
+    int max_iterations = 1000;
+    double seed_match_tolerance_s = 0.51;
+    double seed_interpolation_max_gap_s = 60.0;
+    double min_snr_dbhz = 35.0;
+    double min_elevation_deg = 15.0;
+    double pseudorange_sigma_zenith_m = 3.0;
+    double doppler_sigma_zenith_mps = 0.2;
+    double tdcp_sigma_zenith_m = 0.05;
+    double position_prior_sigma_m = 1000.0;
+    double clock_prior_sigma_m = 1e6;
+    double clock_motion_sigma_m = 100.0;
+    double clock_jump_sigma_m = 1e6;
+    double inter_system_clock_motion_sigma_m = 1e-6;
+    double huber_threshold_sigma = 1.234;
+    bool debug_problem_only = false;
+    bool quiet = false;
+};
+
+struct SeedPosition {
+    libgnss::GNSSTime time;
+    libgnss::Vector3d position_ecef = libgnss::Vector3d::Zero();
+};
+
+struct DopplerFactor {
+    std::size_t epoch_index = 0;
+    std::size_t previous_epoch_index = 0;
+    libgnss::GNSSTime time;
+    libgnss::GNSSTime midpoint_time;
+    libgnss::SatelliteId satellite;
+    libgnss::SignalType signal = libgnss::SignalType::GPS_L1CA;
+    double snr_dbhz = 0.0;
+    double elevation_rad = 0.0;
+    double midpoint_elevation_rad = 0.0;
+    double dt_s = 1.0;
+    double sigma_mps = 1.0;
+    double residual_mps = 0.0;
+    double measured_range_rate_mps = 0.0;
+    double modeled_range_rate_mps = 0.0;
+    double satellite_clock_drift_mps = 0.0;
+    double wavelength_m = 0.0;
+    libgnss::Vector3d los = libgnss::Vector3d::Zero();
+};
+
+struct PseudorangeFactor {
+    std::size_t epoch_index = 0;
+    libgnss::GNSSTime time;
+    libgnss::SatelliteId satellite;
+    libgnss::SignalType signal = libgnss::SignalType::GPS_L1CA;
+    std::size_t clock_group = 0;
+    double snr_dbhz = 0.0;
+    double elevation_rad = 0.0;
+    double sigma_m = 1.0;
+    double residual_m = 0.0;
+    double corrected_pseudorange_m = 0.0;
+    double modeled_range_m = 0.0;
+    double ionosphere_delay_m = 0.0;
+    double troposphere_delay_m = 0.0;
+    double satellite_clock_m = 0.0;
+    double group_delay_m = 0.0;
+    libgnss::Vector3d los = libgnss::Vector3d::Zero();
+};
+
+using ObservationKey = std::tuple<libgnss::SatelliteId, libgnss::SignalType>;
+
+struct CarrierResidual {
+    std::size_t epoch_index = 0;
+    libgnss::GNSSTime time;
+    libgnss::SatelliteId satellite;
+    libgnss::SignalType signal = libgnss::SignalType::GPS_L1CA;
+    double snr_dbhz = 0.0;
+    double elevation_rad = 0.0;
+    double residual_m = 0.0;
+    double corrected_carrier_m = 0.0;
+    double modeled_range_m = 0.0;
+    double raw_carrier_cycles = 0.0;
+    double wavelength_m = 0.0;
+    double ionosphere_delay_m = 0.0;
+    double troposphere_delay_m = 0.0;
+    double satellite_clock_m = 0.0;
+    std::uint8_t lli = 0;
+    bool loss_of_lock = false;
+    libgnss::Vector3d los = libgnss::Vector3d::Zero();
+};
+
+struct TdcpFactor {
+    std::size_t epoch_index = 0;
+    std::size_t previous_epoch_index = 0;
+    libgnss::GNSSTime time;
+    libgnss::SatelliteId satellite;
+    libgnss::SignalType signal = libgnss::SignalType::GPS_L1CA;
+    double snr_dbhz = 0.0;
+    double elevation_rad = 0.0;
+    double previous_elevation_rad = 0.0;
+    double sigma_m = 1.0;
+    double residual_m = 0.0;
+    double previous_carrier_residual_m = 0.0;
+    double current_carrier_residual_m = 0.0;
+    double previous_raw_carrier_cycles = 0.0;
+    double current_raw_carrier_cycles = 0.0;
+    double wavelength_m = 0.0;
+    libgnss::Vector3d los = libgnss::Vector3d::Zero();
+};
+
+struct Problem {
+    std::vector<libgnss::ObservationData> epochs;
+    std::vector<libgnss::Vector3d> seed_positions;
+    std::vector<PseudorangeFactor> pseudorange_factors;
+    std::vector<DopplerFactor> factors;
+    std::vector<TdcpFactor> tdcp_factors;
+    std::vector<bool> clock_jumps;
+    std::size_t nsat = 0;
+    std::size_t seed_matched_epochs = 0;
+    std::size_t seed_interpolated_epochs = 0;
+};
+
+struct SolveResult {
+    Eigen::VectorXd state;
+    double initial_cost = 0.0;
+    double final_cost = 0.0;
+    double residual_rms_mps = 0.0;
+    int iterations = 0;
+    bool converged = false;
+};
+
+[[noreturn]] void usageError(const std::string& message, const char* argv0) {
+    std::cerr << "Error: " << message << "\n\n"
+              << "Usage: " << argv0 << " --obs rover.obs --nav base.nav "
+              << "--seed-pos rover_1Hz_spp.pos [options]\n\n"
+              << "Options:\n"
+              << "  --out-csv PATH                 Write per-epoch position/clock CSV.\n"
+              << "  --factor-debug-csv PATH        Write per-factor debug CSV.\n"
+              << "  --graph-csv PATH               Write taroz-like graph detail CSV.\n"
+              << "  --summary-json PATH            Write JSON summary.\n"
+              << "  --max-epochs N                 Limit processed epochs; 0 means all.\n"
+              << "  --skip-epochs N                Skip leading observation epochs.\n"
+              << "  --max-iterations N             IRLS iteration limit.\n"
+              << "  --tdcp-sigma-zenith M          TDCP zenith sigma in meters.\n"
+              << "  --debug-problem-only           Build factors and skip optimization.\n"
+              << "  --quiet                        Suppress human-readable summary.\n";
+    throw std::invalid_argument(message);
+}
+
+int parseIntArg(const std::string& value, const std::string& name, const char* argv0) {
+    try {
+        std::size_t consumed = 0;
+        const int parsed = std::stoi(value, &consumed);
+        if (consumed == value.size()) {
+            return parsed;
+        }
+    } catch (const std::exception&) {
+    }
+    usageError("invalid integer for " + name + ": " + value, argv0);
+}
+
+double parseDoubleArg(const std::string& value, const std::string& name, const char* argv0) {
+    try {
+        std::size_t consumed = 0;
+        const double parsed = std::stod(value, &consumed);
+        if (consumed == value.size() && std::isfinite(parsed)) {
+            return parsed;
+        }
+    } catch (const std::exception&) {
+    }
+    usageError("invalid number for " + name + ": " + value, argv0);
+}
+
+Options parseArguments(int argc, char* argv[]) {
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        auto require_value = [&](const std::string& name) -> std::string {
+            if (i + 1 >= argc) {
+                usageError("missing value for " + name, argv[0]);
+            }
+            return argv[++i];
+        };
+
+        if (arg == "--obs") {
+            options.obs_path = require_value(arg);
+        } else if (arg == "--nav") {
+            options.nav_path = require_value(arg);
+        } else if (arg == "--seed-pos") {
+            options.seed_pos_path = require_value(arg);
+        } else if (arg == "--out-csv") {
+            options.out_csv_path = require_value(arg);
+        } else if (arg == "--factor-debug-csv") {
+            options.factor_debug_csv_path = require_value(arg);
+        } else if (arg == "--graph-csv") {
+            options.graph_csv_path = require_value(arg);
+        } else if (arg == "--summary-json") {
+            options.summary_json_path = require_value(arg);
+        } else if (arg == "--skip-epochs") {
+            options.skip_epochs = parseIntArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--max-epochs") {
+            options.max_epochs = parseIntArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--max-iterations") {
+            options.max_iterations = parseIntArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--seed-match-tolerance") {
+            options.seed_match_tolerance_s = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--seed-interpolation-max-gap") {
+            options.seed_interpolation_max_gap_s = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--min-snr") {
+            options.min_snr_dbhz = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--min-elevation") {
+            options.min_elevation_deg = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--pseudorange-sigma-zenith") {
+            options.pseudorange_sigma_zenith_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--doppler-sigma-zenith") {
+            options.doppler_sigma_zenith_mps = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--tdcp-sigma-zenith") {
+            options.tdcp_sigma_zenith_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--position-prior-sigma") {
+            options.position_prior_sigma_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--clock-prior-sigma") {
+            options.clock_prior_sigma_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--clock-motion-sigma") {
+            options.clock_motion_sigma_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--clock-jump-sigma") {
+            options.clock_jump_sigma_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--isb-motion-sigma") {
+            options.inter_system_clock_motion_sigma_m =
+                parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--huber-threshold") {
+            options.huber_threshold_sigma = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--debug-problem-only") {
+            options.debug_problem_only = true;
+        } else if (arg == "--quiet") {
+            options.quiet = true;
+        } else if (arg == "--help" || arg == "-h") {
+            usageError("help requested", argv[0]);
+        } else {
+            usageError("unknown argument: " + arg, argv[0]);
+        }
+    }
+
+    if (options.obs_path.empty()) {
+        usageError("--obs is required", argv[0]);
+    }
+    if (options.nav_path.empty()) {
+        usageError("--nav is required", argv[0]);
+    }
+    if (options.seed_pos_path.empty()) {
+        usageError("--seed-pos is required", argv[0]);
+    }
+    if (options.skip_epochs < 0 || options.max_epochs < 0 ||
+        options.max_iterations < 0) {
+        usageError("epoch and iteration limits must be non-negative", argv[0]);
+    }
+    if (options.seed_match_tolerance_s < 0.0 ||
+        options.seed_interpolation_max_gap_s < 0.0 ||
+        options.pseudorange_sigma_zenith_m <= 0.0 ||
+        options.doppler_sigma_zenith_mps <= 0.0 ||
+        options.tdcp_sigma_zenith_m <= 0.0 ||
+        options.position_prior_sigma_m <= 0.0 ||
+        options.clock_prior_sigma_m <= 0.0 ||
+        options.clock_motion_sigma_m <= 0.0 ||
+        options.clock_jump_sigma_m <= 0.0 ||
+        options.inter_system_clock_motion_sigma_m <= 0.0 ||
+        options.huber_threshold_sigma <= 0.0) {
+        usageError("sigma, threshold, and tolerance values must be positive", argv[0]);
+    }
+    return options;
+}
+
+bool isPrimaryPdSignal(libgnss::SignalType signal) {
+    switch (signal) {
+        case libgnss::SignalType::GPS_L1CA:
+        case libgnss::SignalType::GLO_L1CA:
+        case libgnss::SignalType::GAL_E1:
+        case libgnss::SignalType::BDS_B1I:
+        case libgnss::SignalType::BDS_B1C:
+        case libgnss::SignalType::QZS_L1CA:
+            return true;
+        default:
+            return false;
+    }
+}
+
+std::string signalName(libgnss::SignalType signal) {
+    switch (signal) {
+        case libgnss::SignalType::GPS_L1CA: return "GPS_L1CA";
+        case libgnss::SignalType::GLO_L1CA: return "GLO_L1CA";
+        case libgnss::SignalType::GAL_E1: return "GAL_E1";
+        case libgnss::SignalType::BDS_B1I: return "BDS_B1I";
+        case libgnss::SignalType::BDS_B1C: return "BDS_B1C";
+        case libgnss::SignalType::QZS_L1CA: return "QZS_L1CA";
+        default: return "UNKNOWN";
+    }
+}
+
+bool isHealthyForPositioning(const libgnss::Observation& observation,
+                             const libgnss::Ephemeris& eph) {
+    int sv_health = static_cast<int>(eph.health);
+    if (observation.satellite.system == libgnss::GNSSSystem::QZSS) {
+        sv_health &= 0xFE;
+    }
+    return sv_health == 0;
+}
+
+std::size_t clockGroup(libgnss::GNSSSystem system) {
+    switch (system) {
+        case libgnss::GNSSSystem::GPS:
+            return 0U;
+        case libgnss::GNSSSystem::GLONASS:
+            return 1U;
+        case libgnss::GNSSSystem::Galileo:
+            return 2U;
+        case libgnss::GNSSSystem::QZSS:
+            return 3U;
+        case libgnss::GNSSSystem::BeiDou:
+            return 4U;
+        default:
+            return 0U;
+    }
+}
+
+double groupDelayCorrectionMeters(const libgnss::Observation& observation,
+                                  const libgnss::Ephemeris& eph) {
+    switch (observation.satellite.system) {
+        case libgnss::GNSSSystem::GPS:
+        case libgnss::GNSSSystem::QZSS:
+        case libgnss::GNSSSystem::Galileo:
+            return eph.tgd * libgnss::constants::SPEED_OF_LIGHT;
+        case libgnss::GNSSSystem::BeiDou:
+            switch (observation.signal) {
+                case libgnss::SignalType::BDS_B1I:
+                case libgnss::SignalType::BDS_B1C:
+                    return eph.tgd * libgnss::constants::SPEED_OF_LIGHT;
+                case libgnss::SignalType::BDS_B2I:
+                case libgnss::SignalType::BDS_B2A:
+                    return eph.tgd_secondary * libgnss::constants::SPEED_OF_LIGHT;
+                default:
+                    return 0.0;
+            }
+        default:
+            return 0.0;
+    }
+}
+
+double sagnacRangeCorrection(const libgnss::Vector3d& satellite_position,
+                             const libgnss::Vector3d& receiver_position) {
+    return libgnss::constants::OMEGA_E / libgnss::constants::SPEED_OF_LIGHT *
+           (satellite_position(0) * receiver_position(1) -
+            satellite_position(1) * receiver_position(0));
+}
+
+bool parseSeparatedIntegers(std::string value,
+                            char separator,
+                            int& first,
+                            int& second,
+                            int& third) {
+    std::replace(value.begin(), value.end(), separator, ' ');
+    std::istringstream input(value);
+    return static_cast<bool>(input >> first >> second >> third);
+}
+
+bool parseRtklibTime(std::string value,
+                     int& hour,
+                     int& minute,
+                     double& second) {
+    std::replace(value.begin(), value.end(), ':', ' ');
+    std::istringstream input(value);
+    return static_cast<bool>(input >> hour >> minute >> second);
+}
+
+bool isLeapYear(int year) {
+    return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+}
+
+libgnss::GNSSTime gpstCalendarToTime(int year,
+                                     int month,
+                                     int day,
+                                     int hour,
+                                     int minute,
+                                     double second) {
+    int days_since_gps_epoch = 0;
+    for (int current_year = 1980; current_year < year; ++current_year) {
+        days_since_gps_epoch += isLeapYear(current_year) ? 366 : 365;
+    }
+
+    int days_in_month[] = {
+        31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    if (isLeapYear(year)) {
+        days_in_month[1] = 29;
+    }
+    for (int current_month = 1; current_month < month; ++current_month) {
+        days_since_gps_epoch += days_in_month[current_month - 1];
+    }
+    days_since_gps_epoch += day;
+    days_since_gps_epoch -= 6;
+
+    const int gps_week = days_since_gps_epoch / 7;
+    const int day_of_week = days_since_gps_epoch % 7;
+    const double tow = static_cast<double>(day_of_week) * 86400.0 +
+                       static_cast<double>(hour) * 3600.0 +
+                       static_cast<double>(minute) * 60.0 + second;
+    return libgnss::GNSSTime(gps_week, tow);
+}
+
+bool parseRtklibSeedPositionLine(const std::string& line, SeedPosition& seed) {
+    std::istringstream input(line);
+    std::string date_token;
+    std::string time_token;
+    if (!(input >> date_token >> time_token)) {
+        return false;
+    }
+
+    int year = 0;
+    int month = 0;
+    int day = 0;
+    int hour = 0;
+    int minute = 0;
+    double second = 0.0;
+    if (!parseSeparatedIntegers(date_token, '/', year, month, day) ||
+        !parseRtklibTime(time_token, hour, minute, second)) {
+        return false;
+    }
+
+    double latitude_deg = 0.0;
+    double longitude_deg = 0.0;
+    double height_m = 0.0;
+    if (!(input >> latitude_deg >> longitude_deg >> height_m)) {
+        return false;
+    }
+    if (!std::isfinite(latitude_deg) || !std::isfinite(longitude_deg) ||
+        !std::isfinite(height_m)) {
+        return false;
+    }
+
+    seed.time = gpstCalendarToTime(year, month, day, hour, minute, second);
+    seed.position_ecef = libgnss::geodetic2ecef(latitude_deg * kDegreesToRadians,
+                                                longitude_deg * kDegreesToRadians,
+                                                height_m);
+    return seed.position_ecef.norm() > 1e6;
+}
+
+bool parseSeedPositionLine(const std::string& line, SeedPosition& seed) {
+    std::istringstream input(line);
+    std::string first_token;
+    if (!(input >> first_token)) {
+        return false;
+    }
+    if (first_token[0] == '%' || first_token[0] == '#') {
+        return false;
+    }
+    if (first_token.find('/') != std::string::npos) {
+        return parseRtklibSeedPositionLine(line, seed);
+    }
+
+    int week = 0;
+    try {
+        std::size_t consumed = 0;
+        week = std::stoi(first_token, &consumed);
+        if (consumed != first_token.size()) {
+            return false;
+        }
+    } catch (const std::exception&) {
+        return false;
+    }
+
+    double tow = 0.0;
+    double x = 0.0;
+    double y = 0.0;
+    double z = 0.0;
+    if (!(input >> tow >> x >> y >> z)) {
+        return false;
+    }
+    if (!std::isfinite(tow) || !std::isfinite(x) ||
+        !std::isfinite(y) || !std::isfinite(z)) {
+        return false;
+    }
+
+    seed.time = libgnss::GNSSTime(week, tow);
+    seed.position_ecef = libgnss::Vector3d(x, y, z);
+    return seed.position_ecef.norm() > 1e6;
+}
+
+std::vector<SeedPosition> readSeedPositions(const std::string& path) {
+    std::ifstream input(path);
+    if (!input.is_open()) {
+        throw std::runtime_error("failed to open seed POS file: " + path);
+    }
+
+    std::vector<SeedPosition> seeds;
+    std::string line;
+    while (std::getline(input, line)) {
+        SeedPosition seed;
+        if (parseSeedPositionLine(line, seed)) {
+            seeds.push_back(seed);
+        }
+    }
+    if (seeds.empty()) {
+        throw std::runtime_error(
+            "seed POS file has no readable LibGNSS++ or RTKLIB POS rows: " + path);
+    }
+
+    std::sort(seeds.begin(),
+              seeds.end(),
+              [](const SeedPosition& lhs, const SeedPosition& rhs) {
+                  return lhs.time < rhs.time;
+              });
+    return seeds;
+}
+
+bool findSeedPosition(const std::vector<SeedPosition>& seeds,
+                      const libgnss::GNSSTime& time,
+                      double tolerance_s,
+                      double interpolation_max_gap_s,
+                      std::size_t& cursor,
+                      libgnss::Vector3d& position_ecef,
+                      bool& interpolated) {
+    interpolated = false;
+    while (cursor < seeds.size() && seeds[cursor].time - time < -tolerance_s) {
+        ++cursor;
+    }
+
+    std::size_t best_index = seeds.size();
+    double best_abs_dt = tolerance_s;
+    if (cursor < seeds.size()) {
+        const double abs_dt = std::abs(seeds[cursor].time - time);
+        if (abs_dt <= best_abs_dt) {
+            best_index = cursor;
+            best_abs_dt = abs_dt;
+        }
+    }
+    if (cursor > 0) {
+        const std::size_t previous_index = cursor - 1;
+        const double abs_dt = std::abs(seeds[previous_index].time - time);
+        if (abs_dt <= best_abs_dt) {
+            best_index = previous_index;
+        }
+    }
+    if (best_index == seeds.size()) {
+        if (interpolation_max_gap_s <= 0.0 || cursor == 0 ||
+            cursor >= seeds.size()) {
+            return false;
+        }
+        const SeedPosition& lower = seeds[cursor - 1];
+        const SeedPosition& upper = seeds[cursor];
+        const double gap_s = upper.time - lower.time;
+        const double lower_dt_s = time - lower.time;
+        if (gap_s <= 0.0 || gap_s > interpolation_max_gap_s ||
+            lower_dt_s < 0.0 || lower_dt_s > gap_s) {
+            return false;
+        }
+        const double alpha = lower_dt_s / gap_s;
+        position_ecef =
+            lower.position_ecef +
+            alpha * (upper.position_ecef - lower.position_ecef);
+        interpolated = true;
+        return position_ecef.norm() > 1e6;
+    }
+
+    position_ecef = seeds[best_index].position_ecef;
+    return true;
+}
+
+void writeCsvDouble(std::ostream& output, double value) {
+    if (std::isfinite(value)) {
+        output << value;
+    } else {
+        output << "NaN";
+    }
+}
+
+double robustHuberLoss(double whitened_error, double threshold) {
+    const double abs_error = std::abs(whitened_error);
+    if (abs_error <= threshold) {
+        return 0.5 * whitened_error * whitened_error;
+    }
+    return threshold * (abs_error - 0.5 * threshold);
+}
+
+double robustHuberWeight(double whitened_error, double threshold) {
+    const double abs_error = std::abs(whitened_error);
+    if (abs_error <= threshold || abs_error <= 0.0) {
+        return 1.0;
+    }
+    return threshold / abs_error;
+}
+
+int positionColumn(std::size_t epoch_index, int component) {
+    return static_cast<int>(kStateStride * epoch_index +
+                            static_cast<std::size_t>(component));
+}
+
+int clockColumn(std::size_t epoch_index, std::size_t group) {
+    return static_cast<int>(kStateStride * epoch_index + 3U + group);
+}
+
+double pseudorangePrediction(const Eigen::VectorXd& state,
+                             const PseudorangeFactor& factor) {
+    const std::size_t i = factor.epoch_index;
+    double prediction =
+        factor.los(0) * state(positionColumn(i, 0)) +
+        factor.los(1) * state(positionColumn(i, 1)) +
+        factor.los(2) * state(positionColumn(i, 2)) +
+        state(clockColumn(i, 0));
+    if (factor.clock_group != 0U) {
+        prediction += state(clockColumn(i, factor.clock_group));
+    }
+    return prediction;
+}
+
+double dopplerPrediction(const Eigen::VectorXd& state, const DopplerFactor& factor) {
+    const std::size_t i = factor.epoch_index;
+    const std::size_t previous = factor.previous_epoch_index;
+    return factor.los(0) *
+               (state(positionColumn(i, 0)) -
+                state(positionColumn(previous, 0))) / factor.dt_s +
+           factor.los(1) *
+               (state(positionColumn(i, 1)) -
+                state(positionColumn(previous, 1))) / factor.dt_s +
+           factor.los(2) *
+               (state(positionColumn(i, 2)) -
+                state(positionColumn(previous, 2))) / factor.dt_s +
+           (state(clockColumn(i, 0)) -
+            state(clockColumn(previous, 0))) / factor.dt_s;
+}
+
+double tdcpPrediction(const Eigen::VectorXd& state, const TdcpFactor& factor) {
+    const std::size_t i = factor.epoch_index;
+    const std::size_t previous = factor.previous_epoch_index;
+    return factor.los(0) *
+               (state(positionColumn(i, 0)) -
+                state(positionColumn(previous, 0))) +
+           factor.los(1) *
+               (state(positionColumn(i, 1)) -
+                state(positionColumn(previous, 1))) +
+           factor.los(2) *
+               (state(positionColumn(i, 2)) -
+                state(positionColumn(previous, 2))) +
+           state(clockColumn(i, 0)) -
+           state(clockColumn(previous, 0));
+}
+
+double computeCost(const Problem& problem,
+                   const Options& options,
+                   const Eigen::VectorXd& state) {
+    double cost = 0.0;
+    for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
+        for (int component = 0; component < 3; ++component) {
+            const double e =
+                state(positionColumn(i, component)) /
+                options.position_prior_sigma_m;
+            cost += 0.5 * e * e;
+        }
+        for (std::size_t group = 0; group < kClockGroups; ++group) {
+            const double e =
+                state(clockColumn(i, group)) / options.clock_prior_sigma_m;
+            cost += 0.5 * e * e;
+        }
+        if (i > 0) {
+            for (std::size_t group = 0; group < kClockGroups; ++group) {
+                const double sigma =
+                    group == 0U
+                        ? (problem.clock_jumps[i]
+                               ? options.clock_jump_sigma_m
+                               : options.clock_motion_sigma_m)
+                        : options.inter_system_clock_motion_sigma_m;
+                const double prediction =
+                    state(clockColumn(i, group)) -
+                    state(clockColumn(i - 1U, group));
+                const double e = prediction / sigma;
+                cost += 0.5 * e * e;
+            }
+        }
+    }
+
+    for (const PseudorangeFactor& factor : problem.pseudorange_factors) {
+        const double error =
+            (pseudorangePrediction(state, factor) - factor.residual_m) /
+            factor.sigma_m;
+        cost += robustHuberLoss(error, options.huber_threshold_sigma);
+    }
+
+    for (const DopplerFactor& factor : problem.factors) {
+        const double error =
+            (dopplerPrediction(state, factor) - factor.residual_mps) /
+            factor.sigma_mps;
+        cost += robustHuberLoss(error, options.huber_threshold_sigma);
+    }
+    for (const TdcpFactor& factor : problem.tdcp_factors) {
+        const double error =
+            (tdcpPrediction(state, factor) - factor.residual_m) /
+            factor.sigma_m;
+        cost += robustHuberLoss(error, options.huber_threshold_sigma);
+    }
+    return cost;
+}
+
+struct NormalEquation {
+    Eigen::SparseMatrix<double> hessian;
+    Eigen::VectorXd rhs;
+};
+
+void addWeightedRow(std::vector<Eigen::Triplet<double>>& triplets,
+                    Eigen::VectorXd& rhs,
+                    const std::vector<int>& columns,
+                    const std::vector<double>& coefficients,
+                    double residual,
+                    double sigma,
+                    double robust_weight) {
+    const double inv_variance = robust_weight / (sigma * sigma);
+    for (std::size_t a = 0; a < columns.size(); ++a) {
+        const double weighted_a = inv_variance * coefficients[a];
+        rhs(columns[a]) += weighted_a * residual;
+        for (std::size_t b = 0; b < columns.size(); ++b) {
+            triplets.emplace_back(columns[a],
+                                  columns[b],
+                                  weighted_a * coefficients[b]);
+        }
+    }
+}
+
+NormalEquation buildNormalEquation(const Problem& problem,
+                                   const Options& options,
+                                   const Eigen::VectorXd& state) {
+    const int state_size = static_cast<int>(kStateStride * problem.epochs.size());
+    std::vector<Eigen::Triplet<double>> triplets;
+    triplets.reserve((problem.pseudorange_factors.size() +
+                      problem.factors.size() +
+                      problem.tdcp_factors.size()) * 16U +
+                     problem.epochs.size() * 48U);
+    Eigen::VectorXd rhs = Eigen::VectorXd::Zero(state_size);
+
+    for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
+        for (int component = 0; component < 3; ++component) {
+            const int col = positionColumn(i, component);
+            addWeightedRow(triplets,
+                           rhs,
+                           {col},
+                           {1.0},
+                           -state(col),
+                           options.position_prior_sigma_m,
+                           1.0);
+        }
+        for (std::size_t group = 0; group < kClockGroups; ++group) {
+            const int col = clockColumn(i, group);
+            addWeightedRow(triplets,
+                           rhs,
+                           {col},
+                           {1.0},
+                           -state(col),
+                           options.clock_prior_sigma_m,
+                           1.0);
+        }
+
+        if (i > 0) {
+            for (std::size_t group = 0; group < kClockGroups; ++group) {
+                const int previous = clockColumn(i - 1U, group);
+                const int current = clockColumn(i, group);
+                const double sigma =
+                    group == 0U
+                        ? (problem.clock_jumps[i]
+                               ? options.clock_jump_sigma_m
+                               : options.clock_motion_sigma_m)
+                        : options.inter_system_clock_motion_sigma_m;
+                const double prediction = state(current) - state(previous);
+                addWeightedRow(triplets,
+                               rhs,
+                               {previous, current},
+                               {-1.0, 1.0},
+                               -prediction,
+                               sigma,
+                               1.0);
+            }
+        }
+    }
+
+    for (const PseudorangeFactor& factor : problem.pseudorange_factors) {
+        const std::size_t i = factor.epoch_index;
+        const double prediction = pseudorangePrediction(state, factor);
+        const double residual = factor.residual_m - prediction;
+        const double whitened_error = -residual / factor.sigma_m;
+        const double robust_weight =
+            robustHuberWeight(whitened_error, options.huber_threshold_sigma);
+        std::vector<int> columns{
+            positionColumn(i, 0),
+            positionColumn(i, 1),
+            positionColumn(i, 2),
+            clockColumn(i, 0),
+        };
+        std::vector<double> coeffs{
+            factor.los(0),
+            factor.los(1),
+            factor.los(2),
+            1.0,
+        };
+        if (factor.clock_group != 0U) {
+            columns.push_back(clockColumn(i, factor.clock_group));
+            coeffs.push_back(1.0);
+        }
+        addWeightedRow(triplets,
+                       rhs,
+                       columns,
+                       coeffs,
+                       residual,
+                       factor.sigma_m,
+                       robust_weight);
+    }
+
+    for (const DopplerFactor& factor : problem.factors) {
+        const std::size_t i = factor.epoch_index;
+        const std::size_t previous = factor.previous_epoch_index;
+        const double prediction = dopplerPrediction(state, factor);
+        const double residual = factor.residual_mps - prediction;
+        const double whitened_error = -residual / factor.sigma_mps;
+        const double robust_weight =
+            robustHuberWeight(whitened_error, options.huber_threshold_sigma);
+        addWeightedRow(triplets,
+                       rhs,
+                       {positionColumn(previous, 0),
+                        positionColumn(i, 0),
+                        positionColumn(previous, 1),
+                        positionColumn(i, 1),
+                        positionColumn(previous, 2),
+                        positionColumn(i, 2),
+                        clockColumn(previous, 0),
+                        clockColumn(i, 0)},
+                       {-factor.los(0) / factor.dt_s,
+                        factor.los(0) / factor.dt_s,
+                        -factor.los(1) / factor.dt_s,
+                        factor.los(1) / factor.dt_s,
+                        -factor.los(2) / factor.dt_s,
+                        factor.los(2) / factor.dt_s,
+                        -1.0 / factor.dt_s,
+                        1.0 / factor.dt_s},
+                       residual,
+                       factor.sigma_mps,
+                       robust_weight);
+    }
+
+    for (const TdcpFactor& factor : problem.tdcp_factors) {
+        const std::size_t i = factor.epoch_index;
+        const std::size_t previous = factor.previous_epoch_index;
+        const double prediction = tdcpPrediction(state, factor);
+        const double residual = factor.residual_m - prediction;
+        const double whitened_error = -residual / factor.sigma_m;
+        const double robust_weight =
+            robustHuberWeight(whitened_error, options.huber_threshold_sigma);
+        addWeightedRow(triplets,
+                       rhs,
+                       {positionColumn(previous, 0),
+                        positionColumn(i, 0),
+                        positionColumn(previous, 1),
+                        positionColumn(i, 1),
+                        positionColumn(previous, 2),
+                        positionColumn(i, 2),
+                        clockColumn(previous, 0),
+                        clockColumn(i, 0)},
+                       {-factor.los(0),
+                        factor.los(0),
+                        -factor.los(1),
+                        factor.los(1),
+                        -factor.los(2),
+                        factor.los(2),
+                        -1.0,
+                        1.0},
+                       residual,
+                       factor.sigma_m,
+                       robust_weight);
+    }
+
+    NormalEquation normal;
+    normal.hessian.resize(state_size, state_size);
+    normal.hessian.setFromTriplets(triplets.begin(), triplets.end());
+    normal.rhs = std::move(rhs);
+    return normal;
+}
+
+double residualRms(const Problem& problem, const Eigen::VectorXd& state) {
+    const std::size_t count =
+        problem.pseudorange_factors.size() +
+        problem.factors.size() +
+        problem.tdcp_factors.size();
+    if (count == 0U) {
+        return 0.0;
+    }
+    double sum_sq = 0.0;
+    for (const PseudorangeFactor& factor : problem.pseudorange_factors) {
+        const double residual =
+            pseudorangePrediction(state, factor) - factor.residual_m;
+        sum_sq += residual * residual;
+    }
+    for (const DopplerFactor& factor : problem.factors) {
+        const double residual =
+            dopplerPrediction(state, factor) - factor.residual_mps;
+        sum_sq += residual * residual;
+    }
+    for (const TdcpFactor& factor : problem.tdcp_factors) {
+        const double residual =
+            tdcpPrediction(state, factor) - factor.residual_m;
+        sum_sq += residual * residual;
+    }
+    return std::sqrt(sum_sq / static_cast<double>(count));
+}
+
+SolveResult solveProblem(const Problem& problem, const Options& options) {
+    SolveResult result;
+    result.state =
+        Eigen::VectorXd::Zero(static_cast<int>(kStateStride * problem.epochs.size()));
+    result.initial_cost = computeCost(problem, options, result.state);
+
+    if (options.debug_problem_only || options.max_iterations == 0 ||
+        problem.epochs.empty()) {
+        result.final_cost = result.initial_cost;
+        result.residual_rms_mps = residualRms(problem, result.state);
+        return result;
+    }
+
+    double previous_cost = result.initial_cost;
+    double damping = 1e-3;
+    for (int iteration = 1; iteration <= options.max_iterations; ++iteration) {
+        NormalEquation normal = buildNormalEquation(problem, options, result.state);
+        bool accepted = false;
+        double cost = previous_cost;
+        Eigen::VectorXd candidate_state = result.state;
+        Eigen::VectorXd accepted_delta =
+            Eigen::VectorXd::Zero(result.state.size());
+        const Eigen::VectorXd diagonal =
+            normal.hessian.diagonal().cwiseAbs().cwiseMax(1.0);
+        for (int damping_attempt = 0; damping_attempt < 18; ++damping_attempt) {
+            Eigen::SparseMatrix<double> damped_hessian = normal.hessian;
+            for (int col = 0; col < damped_hessian.cols(); ++col) {
+                damped_hessian.coeffRef(col, col) += damping * diagonal(col);
+            }
+            damped_hessian.makeCompressed();
+
+            Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> solver;
+            solver.compute(damped_hessian);
+            if (solver.info() != Eigen::Success) {
+                damping *= 10.0;
+                continue;
+            }
+            const Eigen::VectorXd delta = solver.solve(normal.rhs);
+            if (solver.info() != Eigen::Success || !delta.allFinite()) {
+                damping *= 10.0;
+                continue;
+            }
+
+            double step_scale = 1.0;
+            for (int line_search_attempt = 0; line_search_attempt < 12;
+                 ++line_search_attempt) {
+                candidate_state = result.state + step_scale * delta;
+                cost = computeCost(problem, options, candidate_state);
+                if (std::isfinite(cost) && cost <= previous_cost) {
+                    accepted_delta = step_scale * delta;
+                    accepted = true;
+                    break;
+                }
+                step_scale *= 0.5;
+            }
+            if (accepted) {
+                damping = std::max(1e-12, damping * 0.3);
+                break;
+            }
+            damping *= 10.0;
+        }
+        if (!accepted) {
+            break;
+        }
+
+        result.state = std::move(candidate_state);
+        result.iterations = iteration;
+
+        const double absolute_decrease = previous_cost - cost;
+        const double relative_decrease =
+            absolute_decrease / std::max(1.0, std::abs(previous_cost));
+        previous_cost = cost;
+
+        if (accepted_delta.norm() < 1e-10 ||
+            (iteration > 1 && absolute_decrease >= 0.0 &&
+             relative_decrease < 1e-5)) {
+            result.converged = true;
+            break;
+        }
+    }
+
+    result.final_cost = computeCost(problem, options, result.state);
+    result.residual_rms_mps = residualRms(problem, result.state);
+    return result;
+}
+
+bool calculateObservationModel(const libgnss::ObservationData& epoch,
+                               const libgnss::Observation& observation,
+                               const libgnss::NavigationData& nav,
+                               const libgnss::Vector3d& receiver_position,
+                               const Options& options,
+                               libgnss::Vector3d& satellite_position,
+                               libgnss::Vector3d& satellite_velocity,
+                               double& satellite_clock_bias,
+                               double& satellite_clock_drift,
+                               const libgnss::Ephemeris*& eph,
+                               libgnss::NavigationData::SatelliteGeometry& geometry,
+                               libgnss::Vector3d& ex,
+                               double& range_m) {
+    if (!isPrimaryPdSignal(observation.signal) ||
+        !observation.valid ||
+        !observation.has_pseudorange ||
+        observation.pseudorange <= 0.0 ||
+        observation.snr < options.min_snr_dbhz) {
+        return false;
+    }
+
+    libgnss::GNSSTime transmit_time =
+        epoch.time - observation.pseudorange / libgnss::constants::SPEED_OF_LIGHT;
+    if (!nav.calculateSatelliteState(observation.satellite,
+                                     transmit_time,
+                                     satellite_position,
+                                     satellite_velocity,
+                                     satellite_clock_bias,
+                                     satellite_clock_drift)) {
+        return false;
+    }
+
+    transmit_time = transmit_time - satellite_clock_bias;
+    if (!nav.calculateSatelliteState(observation.satellite,
+                                     transmit_time,
+                                     satellite_position,
+                                     satellite_velocity,
+                                     satellite_clock_bias,
+                                     satellite_clock_drift)) {
+        return false;
+    }
+
+    eph = nav.getEphemeris(observation.satellite, transmit_time);
+    if (!eph || !isHealthyForPositioning(observation, *eph)) {
+        return false;
+    }
+
+    const libgnss::Vector3d delta = satellite_position - receiver_position;
+    range_m = delta.norm();
+    if (range_m <= 0.0) {
+        return false;
+    }
+    ex = delta / range_m;
+    geometry = nav.calculateGeometry(receiver_position, satellite_position);
+    return geometry.elevation >= options.min_elevation_deg * kDegreesToRadians;
+}
+
+bool preparePseudorangeFactor(const libgnss::ObservationData& epoch,
+                              std::size_t epoch_index,
+                              const libgnss::Observation& observation,
+                              const libgnss::NavigationData& nav,
+                              const libgnss::Vector3d& receiver_position,
+                              const Options& options,
+                              PseudorangeFactor& factor) {
+    libgnss::Vector3d satellite_position;
+    libgnss::Vector3d satellite_velocity;
+    double satellite_clock_bias = 0.0;
+    double satellite_clock_drift = 0.0;
+    const libgnss::Ephemeris* eph = nullptr;
+    libgnss::NavigationData::SatelliteGeometry geometry;
+    libgnss::Vector3d ex = libgnss::Vector3d::Zero();
+    double geometric_range = 0.0;
+    if (!calculateObservationModel(epoch,
+                                   observation,
+                                   nav,
+                                   receiver_position,
+                                   options,
+                                   satellite_position,
+                                   satellite_velocity,
+                                   satellite_clock_bias,
+                                   satellite_clock_drift,
+                                   eph,
+                                   geometry,
+                                   ex,
+                                   geometric_range)) {
+        return false;
+    }
+
+    double receiver_lat = 0.0;
+    double receiver_lon = 0.0;
+    double receiver_height = 0.0;
+    libgnss::ecef2geodetic(receiver_position,
+                           receiver_lat,
+                           receiver_lon,
+                           receiver_height);
+    double ionosphere_delay = 0.0;
+    if (nav.ionosphere_model.valid) {
+        ionosphere_delay = libgnss::models::ionoDelayKlobuchar(
+            receiver_lat,
+            receiver_lon,
+            geometry.azimuth,
+            geometry.elevation,
+            epoch.time.tow,
+            nav.ionosphere_model.alpha,
+            nav.ionosphere_model.beta);
+        const double frequency_hz =
+            libgnss::signalFrequencyHz(observation.signal, eph);
+        if (frequency_hz > 0.0) {
+            const double scale = libgnss::constants::GPS_L1_FREQ / frequency_hz;
+            ionosphere_delay *= scale * scale;
+        }
+    }
+    const double troposphere_delay =
+        libgnss::models::tropDelaySaastamoinen(receiver_position,
+                                               geometry.elevation);
+    const double satellite_clock_m =
+        satellite_clock_bias * libgnss::constants::SPEED_OF_LIGHT;
+    const double group_delay_m = groupDelayCorrectionMeters(observation, *eph);
+    const double modeled_range =
+        geometric_range + sagnacRangeCorrection(satellite_position, receiver_position);
+    const double corrected_pseudorange =
+        observation.pseudorange +
+        satellite_clock_m -
+        ionosphere_delay -
+        troposphere_delay -
+        group_delay_m;
+    const double residual = corrected_pseudorange - modeled_range;
+    const double sin_el = std::sin(geometry.elevation);
+    if (sin_el <= 0.0) {
+        return false;
+    }
+
+    factor.epoch_index = epoch_index;
+    factor.time = epoch.time;
+    factor.satellite = observation.satellite;
+    factor.signal = observation.signal;
+    factor.clock_group = clockGroup(observation.satellite.system);
+    factor.snr_dbhz = observation.snr;
+    factor.elevation_rad = geometry.elevation;
+    factor.sigma_m = options.pseudorange_sigma_zenith_m / std::sqrt(sin_el);
+    factor.residual_m = residual;
+    factor.corrected_pseudorange_m = corrected_pseudorange;
+    factor.modeled_range_m = modeled_range;
+    factor.ionosphere_delay_m = ionosphere_delay;
+    factor.troposphere_delay_m = troposphere_delay;
+    factor.satellite_clock_m = satellite_clock_m;
+    factor.group_delay_m = group_delay_m;
+    factor.los = -ex;
+    return std::isfinite(factor.residual_m) &&
+           std::isfinite(factor.sigma_m) &&
+           factor.sigma_m > 0.0;
+}
+
+bool prepareCarrierResidual(const libgnss::ObservationData& epoch,
+                            std::size_t epoch_index,
+                            const libgnss::Observation& observation,
+                            const libgnss::NavigationData& nav,
+                            const libgnss::Vector3d& receiver_position,
+                            const Options& options,
+                            CarrierResidual& residual_out) {
+    if (!observation.has_carrier_phase ||
+        observation.carrier_phase == 0.0 ||
+        observation.loss_of_lock ||
+        ((observation.lli & 0x01U) != 0U)) {
+        return false;
+    }
+
+    libgnss::Vector3d satellite_position;
+    libgnss::Vector3d satellite_velocity;
+    double satellite_clock_bias = 0.0;
+    double satellite_clock_drift = 0.0;
+    const libgnss::Ephemeris* eph = nullptr;
+    libgnss::NavigationData::SatelliteGeometry geometry;
+    libgnss::Vector3d ex = libgnss::Vector3d::Zero();
+    double geometric_range = 0.0;
+    if (!calculateObservationModel(epoch,
+                                   observation,
+                                   nav,
+                                   receiver_position,
+                                   options,
+                                   satellite_position,
+                                   satellite_velocity,
+                                   satellite_clock_bias,
+                                   satellite_clock_drift,
+                                   eph,
+                                   geometry,
+                                   ex,
+                                   geometric_range)) {
+        return false;
+    }
+
+    double wavelength = libgnss::signalWavelengthMeters(observation.signal, eph);
+    if (wavelength <= 0.0) {
+        wavelength = libgnss::signalWavelengthMeters(observation);
+    }
+    if (wavelength <= 0.0) {
+        return false;
+    }
+
+    double receiver_lat = 0.0;
+    double receiver_lon = 0.0;
+    double receiver_height = 0.0;
+    libgnss::ecef2geodetic(receiver_position,
+                           receiver_lat,
+                           receiver_lon,
+                           receiver_height);
+    double ionosphere_delay = 0.0;
+    if (nav.ionosphere_model.valid) {
+        ionosphere_delay = libgnss::models::ionoDelayKlobuchar(
+            receiver_lat,
+            receiver_lon,
+            geometry.azimuth,
+            geometry.elevation,
+            epoch.time.tow,
+            nav.ionosphere_model.alpha,
+            nav.ionosphere_model.beta);
+        const double frequency_hz =
+            libgnss::signalFrequencyHz(observation.signal, eph);
+        if (frequency_hz > 0.0) {
+            const double scale = libgnss::constants::GPS_L1_FREQ / frequency_hz;
+            ionosphere_delay *= scale * scale;
+        }
+    }
+    const double troposphere_delay =
+        libgnss::models::tropDelaySaastamoinen(receiver_position,
+                                               geometry.elevation);
+    const double satellite_clock_m =
+        satellite_clock_bias * libgnss::constants::SPEED_OF_LIGHT;
+    const double modeled_range =
+        geometric_range + sagnacRangeCorrection(satellite_position, receiver_position);
+    const double corrected_carrier =
+        observation.carrier_phase * wavelength +
+        satellite_clock_m -
+        troposphere_delay +
+        ionosphere_delay;
+    const double residual = corrected_carrier - modeled_range;
+
+    residual_out.epoch_index = epoch_index;
+    residual_out.time = epoch.time;
+    residual_out.satellite = observation.satellite;
+    residual_out.signal = observation.signal;
+    residual_out.snr_dbhz = observation.snr;
+    residual_out.elevation_rad = geometry.elevation;
+    residual_out.residual_m = residual;
+    residual_out.corrected_carrier_m = corrected_carrier;
+    residual_out.modeled_range_m = modeled_range;
+    residual_out.raw_carrier_cycles = observation.carrier_phase;
+    residual_out.wavelength_m = wavelength;
+    residual_out.ionosphere_delay_m = ionosphere_delay;
+    residual_out.troposphere_delay_m = troposphere_delay;
+    residual_out.satellite_clock_m = satellite_clock_m;
+    residual_out.lli = observation.lli;
+    residual_out.loss_of_lock = observation.loss_of_lock;
+    residual_out.los = -ex;
+    return std::isfinite(residual_out.residual_m) &&
+           std::isfinite(residual_out.wavelength_m) &&
+           residual_out.wavelength_m > 0.0;
+}
+
+bool prepareDopplerFactor(const libgnss::ObservationData& epoch,
+                          std::size_t epoch_index,
+                          std::size_t previous_epoch_index,
+                          const libgnss::Observation& observation,
+                          const libgnss::NavigationData& nav,
+                          const libgnss::Vector3d& receiver_position,
+                          const libgnss::Vector3d& receiver_velocity,
+                          double sigma_elevation_rad,
+                          double dt_s,
+                          const Options& options,
+                          DopplerFactor& factor) {
+    if (!isPrimaryPdSignal(observation.signal) ||
+        !observation.valid ||
+        !observation.has_pseudorange ||
+        !observation.has_doppler ||
+        observation.pseudorange <= 0.0) {
+        return false;
+    }
+
+    libgnss::Vector3d satellite_position;
+    libgnss::Vector3d satellite_velocity;
+    double satellite_clock_bias = 0.0;
+    double satellite_clock_drift = 0.0;
+    const libgnss::Ephemeris* eph = nullptr;
+    libgnss::NavigationData::SatelliteGeometry geometry;
+    libgnss::Vector3d ex = libgnss::Vector3d::Zero();
+    double range = 0.0;
+    libgnss::GNSSTime transmit_time =
+        epoch.time - observation.pseudorange / libgnss::constants::SPEED_OF_LIGHT;
+    if (!nav.calculateSatelliteState(observation.satellite,
+                                     transmit_time,
+                                     satellite_position,
+                                     satellite_velocity,
+                                     satellite_clock_bias,
+                                     satellite_clock_drift)) {
+        return false;
+    }
+    transmit_time = transmit_time - satellite_clock_bias;
+    if (!nav.calculateSatelliteState(observation.satellite,
+                                     transmit_time,
+                                     satellite_position,
+                                     satellite_velocity,
+                                     satellite_clock_bias,
+                                     satellite_clock_drift)) {
+        return false;
+    }
+    eph = nav.getEphemeris(observation.satellite, transmit_time);
+    if (!eph || !isHealthyForPositioning(observation, *eph)) {
+        return false;
+    }
+
+    const libgnss::Vector3d delta = satellite_position - receiver_position;
+    range = delta.norm();
+    if (range <= 0.0 || dt_s <= 0.0) {
+        return false;
+    }
+    ex = delta / range;
+    geometry = nav.calculateGeometry(receiver_position, satellite_position);
+
+    double wavelength = libgnss::signalWavelengthMeters(observation.signal, eph);
+    if (wavelength <= 0.0) {
+        wavelength = libgnss::signalWavelengthMeters(observation);
+    }
+    if (wavelength <= 0.0) {
+        return false;
+    }
+
+    const double sagnac_rate =
+        libgnss::constants::OMEGA_E / libgnss::constants::SPEED_OF_LIGHT *
+        (satellite_velocity(1) * receiver_position(0) -
+         satellite_velocity(0) * receiver_position(1));
+    const double modeled_range_rate =
+        (satellite_velocity - receiver_velocity).dot(ex) + sagnac_rate;
+    const double satellite_clock_drift_mps =
+        satellite_clock_drift * libgnss::constants::SPEED_OF_LIGHT;
+    const double measured_range_rate = -observation.doppler * wavelength;
+    const double residual =
+        measured_range_rate - (modeled_range_rate - satellite_clock_drift_mps);
+    const double sin_el = std::sin(sigma_elevation_rad);
+    if (sin_el <= 0.0) {
+        return false;
+    }
+
+    factor.epoch_index = epoch_index;
+    factor.previous_epoch_index = previous_epoch_index;
+    factor.time = epoch.time;
+    factor.midpoint_time = epoch.time;
+    factor.satellite = observation.satellite;
+    factor.signal = observation.signal;
+    factor.snr_dbhz = observation.snr;
+    factor.elevation_rad = sigma_elevation_rad;
+    factor.midpoint_elevation_rad = geometry.elevation;
+    factor.dt_s = dt_s;
+    factor.sigma_mps = options.doppler_sigma_zenith_mps / std::sqrt(sin_el);
+    factor.residual_mps = residual;
+    factor.measured_range_rate_mps = measured_range_rate;
+    factor.modeled_range_rate_mps = modeled_range_rate;
+    factor.satellite_clock_drift_mps = satellite_clock_drift_mps;
+    factor.wavelength_m = wavelength;
+    factor.los = -ex;
+    return std::isfinite(factor.residual_mps) &&
+           std::isfinite(factor.sigma_mps) &&
+           factor.sigma_mps > 0.0;
+}
+
+libgnss::Observation interpolateObservation(const libgnss::Observation& lower,
+                                            const libgnss::Observation& upper,
+                                            double alpha) {
+    libgnss::Observation interpolated = lower;
+    interpolated.valid = lower.valid && upper.valid;
+    interpolated.has_pseudorange =
+        lower.has_pseudorange && upper.has_pseudorange;
+    interpolated.has_carrier_phase =
+        lower.has_carrier_phase && upper.has_carrier_phase;
+    interpolated.has_doppler = lower.has_doppler && upper.has_doppler;
+    if (interpolated.has_pseudorange) {
+        interpolated.pseudorange =
+            lower.pseudorange + alpha * (upper.pseudorange - lower.pseudorange);
+    }
+    if (interpolated.has_carrier_phase) {
+        interpolated.carrier_phase =
+            lower.carrier_phase +
+            alpha * (upper.carrier_phase - lower.carrier_phase);
+    }
+    if (interpolated.has_doppler) {
+        interpolated.doppler =
+            lower.doppler + alpha * (upper.doppler - lower.doppler);
+    }
+    interpolated.snr = std::min(lower.snr, upper.snr);
+    interpolated.signal_strength =
+        std::min(lower.signal_strength, upper.signal_strength);
+    interpolated.lli = lower.lli | upper.lli;
+    interpolated.loss_of_lock =
+        lower.loss_of_lock || upper.loss_of_lock ||
+        ((interpolated.lli & 0x01U) != 0);
+    interpolated.has_glonass_frequency_channel =
+        lower.has_glonass_frequency_channel &&
+        upper.has_glonass_frequency_channel &&
+        lower.glonass_frequency_channel == upper.glonass_frequency_channel;
+    if (interpolated.has_glonass_frequency_channel) {
+        interpolated.glonass_frequency_channel = lower.glonass_frequency_channel;
+    }
+    return interpolated;
+}
+
+bool observationElevationRad(const libgnss::ObservationData& epoch,
+                             const libgnss::Observation& observation,
+                             const libgnss::NavigationData& nav,
+                             const libgnss::Vector3d& receiver_position,
+                             double& elevation_rad) {
+    if (!isPrimaryPdSignal(observation.signal) ||
+        !observation.valid ||
+        !observation.has_pseudorange ||
+        observation.pseudorange <= 0.0) {
+        return false;
+    }
+
+    libgnss::Vector3d satellite_position;
+    libgnss::Vector3d satellite_velocity;
+    double satellite_clock_bias = 0.0;
+    double satellite_clock_drift = 0.0;
+    libgnss::GNSSTime transmit_time =
+        epoch.time - observation.pseudorange / libgnss::constants::SPEED_OF_LIGHT;
+    if (!nav.calculateSatelliteState(observation.satellite,
+                                     transmit_time,
+                                     satellite_position,
+                                     satellite_velocity,
+                                     satellite_clock_bias,
+                                     satellite_clock_drift)) {
+        return false;
+    }
+    transmit_time = transmit_time - satellite_clock_bias;
+    if (!nav.calculateSatelliteState(observation.satellite,
+                                     transmit_time,
+                                     satellite_position,
+                                     satellite_velocity,
+                                     satellite_clock_bias,
+                                     satellite_clock_drift)) {
+        return false;
+    }
+    const libgnss::Ephemeris* eph =
+        nav.getEphemeris(observation.satellite, transmit_time);
+    if (!eph || !isHealthyForPositioning(observation, *eph)) {
+        return false;
+    }
+    elevation_rad =
+        nav.calculateGeometry(receiver_position, satellite_position).elevation;
+    return std::isfinite(elevation_rad);
+}
+
+Problem buildProblem(const Options& options) {
+    libgnss::io::RINEXReader obs_reader;
+    if (!obs_reader.open(options.obs_path)) {
+        throw std::runtime_error("failed to open observation file: " + options.obs_path);
+    }
+    libgnss::io::RINEXReader::RINEXHeader obs_header;
+    if (!obs_reader.readHeader(obs_header)) {
+        throw std::runtime_error("failed to read observation header: " + options.obs_path);
+    }
+
+    libgnss::io::RINEXReader nav_reader;
+    if (!nav_reader.open(options.nav_path)) {
+        throw std::runtime_error("failed to open navigation file: " + options.nav_path);
+    }
+    libgnss::NavigationData nav_data;
+    if (!nav_reader.readNavigationData(nav_data)) {
+        throw std::runtime_error("failed to read navigation data: " + options.nav_path);
+    }
+
+    const std::vector<SeedPosition> seed_positions =
+        readSeedPositions(options.seed_pos_path);
+    std::size_t seed_cursor = 0;
+
+    Problem problem;
+    std::set<libgnss::SatelliteId> unique_satellites;
+    const double fixed_interval_s =
+        obs_header.interval > 0.0 ? obs_header.interval : 1.0;
+    const double gap_tolerance_s = std::max(0.01, 0.5 * fixed_interval_s);
+    std::map<libgnss::SatelliteId, double> previous_gps_pseudorange_by_satellite;
+    bool have_previous_gps_pseudorange = false;
+    std::vector<std::map<ObservationKey, CarrierResidual>> carrier_residuals_by_epoch;
+
+    auto append_epoch = [&](libgnss::ObservationData epoch,
+                            bool build_factors) -> bool {
+        if (options.max_epochs > 0 &&
+            static_cast<int>(problem.epochs.size()) >= options.max_epochs) {
+            return false;
+        }
+
+        libgnss::Vector3d seed_position = libgnss::Vector3d::Zero();
+        bool interpolated = false;
+        if (findSeedPosition(seed_positions,
+                             epoch.time,
+                             options.seed_match_tolerance_s,
+                             options.seed_interpolation_max_gap_s,
+                             seed_cursor,
+                             seed_position,
+                             interpolated)) {
+            epoch.receiver_position = seed_position;
+            ++problem.seed_matched_epochs;
+            if (interpolated) {
+                ++problem.seed_interpolated_epochs;
+            }
+        } else if (obs_header.approximate_position.norm() > 1e6) {
+            seed_position = obs_header.approximate_position;
+            epoch.receiver_position = seed_position;
+        } else {
+            return true;
+        }
+
+        const std::size_t epoch_index = problem.epochs.size();
+        std::map<libgnss::SatelliteId, double> gps_pseudorange_by_satellite;
+        std::map<ObservationKey, CarrierResidual> carrier_residuals;
+        if (build_factors) {
+            for (const auto& observation : epoch.observations) {
+                unique_satellites.insert(observation.satellite);
+                PseudorangeFactor pseudorange_factor;
+                if (preparePseudorangeFactor(epoch,
+                                             epoch_index,
+                                             observation,
+                                             nav_data,
+                                             seed_position,
+                                             options,
+                                             pseudorange_factor)) {
+                    problem.pseudorange_factors.push_back(pseudorange_factor);
+                    if (observation.satellite.system == libgnss::GNSSSystem::GPS) {
+                        gps_pseudorange_by_satellite[observation.satellite] =
+                            observation.pseudorange;
+                    }
+                }
+                CarrierResidual carrier_residual;
+                if (prepareCarrierResidual(epoch,
+                                           epoch_index,
+                                           observation,
+                                           nav_data,
+                                           seed_position,
+                                           options,
+                                           carrier_residual)) {
+                    carrier_residuals[{observation.satellite, observation.signal}] =
+                        carrier_residual;
+                }
+            }
+        }
+
+        bool clock_jump = false;
+        if (have_previous_gps_pseudorange && !gps_pseudorange_by_satellite.empty()) {
+            double sum_delta = 0.0;
+            std::size_t count = 0;
+            for (const auto& [satellite, pseudorange] : gps_pseudorange_by_satellite) {
+                const auto previous_it =
+                    previous_gps_pseudorange_by_satellite.find(satellite);
+                if (previous_it == previous_gps_pseudorange_by_satellite.end()) {
+                    continue;
+                }
+                sum_delta += pseudorange - previous_it->second;
+                ++count;
+            }
+            if (count > 0U) {
+                clock_jump = sum_delta / static_cast<double>(count) > 1e5;
+            }
+        }
+        problem.clock_jumps.push_back(clock_jump);
+        previous_gps_pseudorange_by_satellite = gps_pseudorange_by_satellite;
+        have_previous_gps_pseudorange = !gps_pseudorange_by_satellite.empty();
+
+        problem.seed_positions.push_back(seed_position);
+        problem.epochs.push_back(epoch);
+        carrier_residuals_by_epoch.push_back(std::move(carrier_residuals));
+        return true;
+    };
+
+    libgnss::ObservationData epoch;
+    int raw_epoch_index = 0;
+    bool have_last_output_time = false;
+    libgnss::GNSSTime last_output_time;
+    while (obs_reader.readObservationEpoch(epoch)) {
+        if (raw_epoch_index++ < options.skip_epochs) {
+            continue;
+        }
+
+        if (have_last_output_time) {
+            libgnss::GNSSTime expected_time =
+                last_output_time + fixed_interval_s;
+            while (epoch.time - expected_time > gap_tolerance_s) {
+                libgnss::ObservationData empty_epoch(expected_time);
+                if (!append_epoch(empty_epoch, false)) {
+                    break;
+                }
+                last_output_time = expected_time;
+                expected_time = last_output_time + fixed_interval_s;
+                if (options.max_epochs > 0 &&
+                    static_cast<int>(problem.epochs.size()) >=
+                        options.max_epochs) {
+                    break;
+                }
+            }
+            if (options.max_epochs > 0 &&
+                static_cast<int>(problem.epochs.size()) >= options.max_epochs) {
+                break;
+            }
+        }
+
+        if (!append_epoch(epoch, true)) {
+            break;
+        }
+        last_output_time = epoch.time;
+        have_last_output_time = true;
+    }
+    problem.nsat = unique_satellites.size();
+
+    for (std::size_t i = 1; i < problem.epochs.size(); ++i) {
+        if (problem.clock_jumps[i]) {
+            continue;
+        }
+        const libgnss::ObservationData& previous_epoch = problem.epochs[i - 1U];
+        const libgnss::ObservationData& current_epoch = problem.epochs[i];
+        const double dt_s = current_epoch.time - previous_epoch.time;
+        if (dt_s <= 0.0) {
+            continue;
+        }
+
+        std::map<ObservationKey, const libgnss::Observation*> current_observations;
+        for (const auto& observation : current_epoch.observations) {
+            current_observations[{observation.satellite, observation.signal}] =
+                &observation;
+        }
+
+        libgnss::ObservationData midpoint_epoch(previous_epoch.time + 0.5 * dt_s);
+        const libgnss::Vector3d midpoint_position =
+            0.5 * (problem.seed_positions[i - 1U] + problem.seed_positions[i]);
+        const libgnss::Vector3d initial_velocity =
+            (problem.seed_positions[i] - problem.seed_positions[i - 1U]) / dt_s;
+        midpoint_epoch.receiver_position = midpoint_position;
+
+        for (const auto& previous_observation : previous_epoch.observations) {
+            const ObservationKey key{previous_observation.satellite,
+                                     previous_observation.signal};
+            const auto current_it = current_observations.find(key);
+            if (current_it == current_observations.end()) {
+                continue;
+            }
+            const libgnss::Observation& current_observation = *current_it->second;
+            double sigma_elevation_rad = 0.0;
+            if (!observationElevationRad(current_epoch,
+                                         current_observation,
+                                         nav_data,
+                                         problem.seed_positions[i],
+                                         sigma_elevation_rad)) {
+                continue;
+            }
+
+            libgnss::Observation interpolated_observation =
+                interpolateObservation(previous_observation,
+                                       current_observation,
+                                       0.5);
+            midpoint_epoch.observations.clear();
+            midpoint_epoch.addObservation(interpolated_observation);
+
+            DopplerFactor factor;
+            if (prepareDopplerFactor(midpoint_epoch,
+                                     i,
+                                     i - 1U,
+                                     interpolated_observation,
+                                     nav_data,
+                                     midpoint_position,
+                                     initial_velocity,
+                                     sigma_elevation_rad,
+                                     dt_s,
+                                     options,
+                                     factor)) {
+                problem.factors.push_back(factor);
+                unique_satellites.insert(factor.satellite);
+            }
+        }
+
+        const auto& previous_carriers = carrier_residuals_by_epoch[i - 1U];
+        const auto& current_carriers = carrier_residuals_by_epoch[i];
+        for (const auto& [key, current] : current_carriers) {
+            const auto previous_it = previous_carriers.find(key);
+            if (previous_it == previous_carriers.end()) {
+                continue;
+            }
+            const CarrierResidual& previous = previous_it->second;
+            const double sin_el = std::sin(current.elevation_rad);
+            if (sin_el <= 0.0) {
+                continue;
+            }
+
+            TdcpFactor factor;
+            factor.epoch_index = i;
+            factor.previous_epoch_index = i - 1U;
+            factor.time = current.time;
+            factor.satellite = current.satellite;
+            factor.signal = current.signal;
+            factor.snr_dbhz = current.snr_dbhz;
+            factor.elevation_rad = current.elevation_rad;
+            factor.previous_elevation_rad = previous.elevation_rad;
+            factor.sigma_m = options.tdcp_sigma_zenith_m / std::sqrt(sin_el);
+            factor.residual_m = current.residual_m - previous.residual_m;
+            factor.previous_carrier_residual_m = previous.residual_m;
+            factor.current_carrier_residual_m = current.residual_m;
+            factor.previous_raw_carrier_cycles = previous.raw_carrier_cycles;
+            factor.current_raw_carrier_cycles = current.raw_carrier_cycles;
+            factor.wavelength_m = current.wavelength_m;
+            factor.los = previous.los;
+            if (std::isfinite(factor.residual_m) &&
+                std::isfinite(factor.sigma_m) &&
+                factor.sigma_m > 0.0) {
+                problem.tdcp_factors.push_back(factor);
+                unique_satellites.insert(factor.satellite);
+            }
+        }
+    }
+
+    problem.nsat = unique_satellites.size();
+    return problem;
+}
+
+bool writePerEpochCsv(const std::string& path,
+                      const Problem& problem,
+                      const SolveResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    output << "epoch,gps_week,gps_tow,spp_x_m,spp_y_m,spp_z_m,"
+              "fgo_x_m,fgo_y_m,fgo_z_m,"
+              "fgo_c_gps_m,fgo_c_glo_m,fgo_c_gal_m,fgo_c_qzs_m,"
+              "fgo_c_bds_m,clock_jump\n";
+    output << std::fixed << std::setprecision(15);
+    for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
+        const auto& epoch = problem.epochs[i];
+        const auto& seed = problem.seed_positions[i];
+        output << (i + 1U) << ','
+               << epoch.time.week << ','
+               << epoch.time.tow << ','
+               << seed(0) << ','
+               << seed(1) << ','
+               << seed(2) << ','
+               << seed(0) + result.state(positionColumn(i, 0)) << ','
+               << seed(1) + result.state(positionColumn(i, 1)) << ','
+               << seed(2) + result.state(positionColumn(i, 2)) << ','
+               << result.state(clockColumn(i, 0)) << ','
+               << result.state(clockColumn(i, 1)) << ','
+               << result.state(clockColumn(i, 2)) << ','
+               << result.state(clockColumn(i, 3)) << ','
+               << result.state(clockColumn(i, 4)) << ','
+               << (problem.clock_jumps[i] ? 1 : 0) << '\n';
+    }
+    return true;
+}
+
+bool writeFactorDebugCsv(const std::string& path,
+                         const Problem& problem,
+                         const SolveResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    output << "factor_type,epoch_index,gps_week,gps_tow,satellite,signal,"
+              "previous_epoch_index,midpoint_gps_week,midpoint_gps_tow,"
+              "clock_group,snr_dbhz,elevation_deg,sigma_p_m,sigma_d_mps,"
+              "sigma_c_m,res_pc_m,res_d_mps,res_tdcp_m,measured_range_rate_mps,"
+              "modeled_range_rate_mps,satellite_clock_drift_mps,"
+              "dt_s,previous_carrier_residual_m,current_carrier_residual_m,"
+              "previous_raw_carrier_cycles,current_raw_carrier_cycles,"
+              "wavelength_m,final_residual_m,los_x,los_y,los_z\n";
+    output << std::fixed << std::setprecision(15);
+    for (const PseudorangeFactor& factor : problem.pseudorange_factors) {
+        const double final_residual =
+            pseudorangePrediction(result.state, factor) - factor.residual_m;
+        output << "P,"
+               << factor.epoch_index << ','
+               << factor.time.week << ','
+               << factor.time.tow << ','
+               << factor.satellite.toString() << ','
+               << signalName(factor.signal) << ','
+               << "NaN,NaN,NaN,"
+               << factor.clock_group << ','
+               << factor.snr_dbhz << ','
+               << factor.elevation_rad * kRadiansToDegrees << ','
+               << factor.sigma_m << ",NaN,"
+               << "NaN,"
+               << factor.residual_m << ",NaN,NaN,NaN,NaN,NaN,NaN,"
+               << "NaN,NaN,NaN,NaN,NaN,"
+               << final_residual << ','
+               << factor.los(0) << ','
+               << factor.los(1) << ','
+               << factor.los(2) << '\n';
+    }
+    for (const DopplerFactor& factor : problem.factors) {
+        const double final_residual =
+            dopplerPrediction(result.state, factor) - factor.residual_mps;
+        output << "D,"
+               << factor.epoch_index << ','
+               << factor.time.week << ','
+               << factor.time.tow << ','
+               << factor.satellite.toString() << ','
+               << signalName(factor.signal) << ','
+               << factor.previous_epoch_index << ','
+               << factor.midpoint_time.week << ','
+               << factor.midpoint_time.tow << ','
+               << clockGroup(factor.satellite.system) << ','
+               << factor.snr_dbhz << ','
+               << factor.elevation_rad * kRadiansToDegrees << ','
+               << "NaN,"
+               << factor.sigma_mps << ','
+               << "NaN,"
+               << "NaN,"
+               << factor.residual_mps << ','
+               << "NaN,"
+               << factor.measured_range_rate_mps << ','
+               << factor.modeled_range_rate_mps << ','
+               << factor.satellite_clock_drift_mps << ','
+               << factor.dt_s << ','
+               << "NaN,NaN,NaN,NaN,"
+               << factor.wavelength_m << ','
+               << final_residual << ','
+               << factor.los(0) << ','
+               << factor.los(1) << ','
+               << factor.los(2) << '\n';
+    }
+    for (const TdcpFactor& factor : problem.tdcp_factors) {
+        const double final_residual =
+            tdcpPrediction(result.state, factor) - factor.residual_m;
+        output << "C,"
+               << factor.epoch_index << ','
+               << factor.time.week << ','
+               << factor.time.tow << ','
+               << factor.satellite.toString() << ','
+               << signalName(factor.signal) << ','
+               << factor.previous_epoch_index << ','
+               << "NaN,NaN,"
+               << 0 << ','
+               << factor.snr_dbhz << ','
+               << factor.elevation_rad * kRadiansToDegrees << ','
+               << "NaN,NaN,"
+               << factor.sigma_m << ','
+               << "NaN,NaN,"
+               << factor.residual_m << ','
+               << "NaN,NaN,NaN,NaN,"
+               << factor.previous_carrier_residual_m << ','
+               << factor.current_carrier_residual_m << ','
+               << factor.previous_raw_carrier_cycles << ','
+               << factor.current_raw_carrier_cycles << ','
+               << factor.wavelength_m << ','
+               << final_residual << ','
+               << factor.los(0) << ','
+               << factor.los(1) << ','
+               << factor.los(2) << '\n';
+    }
+    return true;
+}
+
+std::size_t graphFactorCount(const Problem& problem) {
+    if (problem.epochs.empty()) {
+        return problem.pseudorange_factors.size() +
+               problem.factors.size() +
+               problem.tdcp_factors.size();
+    }
+    return problem.pseudorange_factors.size() +
+           problem.factors.size() +
+           problem.tdcp_factors.size() +
+           2U * problem.epochs.size() +
+           (problem.epochs.size() - 1U);
+}
+
+bool writeGraphCsv(const std::string& path,
+                   const Problem& problem,
+                   const SolveResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    output << "n,nsat,graph_factors,graph_values,initial_cost,final_cost,"
+              "optimizer_error,iterations,valid_position_epochs,"
+              "valid_clock_epochs\n";
+    output << std::fixed << std::setprecision(15)
+           << problem.epochs.size() << ','
+           << problem.nsat << ','
+           << graphFactorCount(problem) << ','
+           << 2U * problem.epochs.size() << ','
+           << result.initial_cost << ','
+           << result.final_cost << ','
+           << result.final_cost << ','
+           << result.iterations << ','
+           << problem.epochs.size() << ','
+           << problem.epochs.size() << '\n';
+    return true;
+}
+
+std::string jsonBool(bool value) {
+    return value ? "true" : "false";
+}
+
+bool writeSummaryJson(const std::string& path,
+                      const Options& options,
+                      const Problem& problem,
+                      const SolveResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    const std::size_t epoch_count = problem.epochs.size();
+    output << std::fixed << std::setprecision(15)
+           << "{\n"
+           << "  \"preset\": \"taroz-pos-pdc\",\n"
+           << "  \"backend\": \"eigen\",\n"
+           << "  \"debug_problem_only\": " << jsonBool(options.debug_problem_only) << ",\n"
+           << "  \"optimized_epochs\": " << epoch_count << ",\n"
+           << "  \"valid_position_epochs\": " << epoch_count << ",\n"
+           << "  \"valid_clock_epochs\": " << epoch_count << ",\n"
+           << "  \"seed_matched_epochs\": " << problem.seed_matched_epochs << ",\n"
+           << "  \"seed_interpolated_epochs\": " << problem.seed_interpolated_epochs << ",\n"
+           << "  \"nsat\": " << problem.nsat << ",\n"
+           << "  \"pseudorange_factors\": " << problem.pseudorange_factors.size() << ",\n"
+           << "  \"doppler_factors\": " << problem.factors.size() << ",\n"
+           << "  \"tdcp_factors\": " << problem.tdcp_factors.size() << ",\n"
+           << "  \"position_prior_factors\": " << epoch_count << ",\n"
+           << "  \"clock_prior_factors\": " << epoch_count << ",\n"
+           << "  \"clock_motion_factors\": "
+           << (epoch_count > 0 ? epoch_count - 1U : 0U) << ",\n"
+           << "  \"graph_factors\": " << graphFactorCount(problem) << ",\n"
+           << "  \"graph_values\": " << 2U * epoch_count << ",\n"
+           << "  \"min_snr_dbhz\": " << options.min_snr_dbhz << ",\n"
+           << "  \"min_elevation_deg\": " << options.min_elevation_deg << ",\n"
+           << "  \"pseudorange_sigma_zenith_m\": "
+           << options.pseudorange_sigma_zenith_m << ",\n"
+           << "  \"doppler_sigma_zenith_mps\": "
+           << options.doppler_sigma_zenith_mps << ",\n"
+           << "  \"tdcp_sigma_zenith_m\": "
+           << options.tdcp_sigma_zenith_m << ",\n"
+           << "  \"position_prior_sigma_m\": "
+           << options.position_prior_sigma_m << ",\n"
+           << "  \"clock_prior_sigma_m\": "
+           << options.clock_prior_sigma_m << ",\n"
+           << "  \"clock_motion_sigma_m\": "
+           << options.clock_motion_sigma_m << ",\n"
+           << "  \"clock_jump_sigma_m\": " << options.clock_jump_sigma_m << ",\n"
+           << "  \"huber_threshold_sigma\": "
+           << options.huber_threshold_sigma << ",\n"
+           << "  \"iterations\": " << result.iterations << ",\n"
+           << "  \"converged\": " << jsonBool(result.converged) << ",\n"
+           << "  \"initial_cost\": " << result.initial_cost << ",\n"
+           << "  \"final_cost\": " << result.final_cost << ",\n"
+           << "  \"residual_rms_mps\": " << result.residual_rms_mps << "\n"
+           << "}\n";
+    return true;
+}
+
+void printSummary(const Problem& problem, const SolveResult& result) {
+    std::cout << "Taroz position PDC batch complete\n"
+              << "  epochs: " << problem.epochs.size() << "\n"
+              << "  satellites: " << problem.nsat << "\n"
+              << "  pseudorange_factors: "
+              << problem.pseudorange_factors.size() << "\n"
+              << "  doppler_factors: " << problem.factors.size() << "\n"
+              << "  tdcp_factors: " << problem.tdcp_factors.size() << "\n"
+              << "  graph_factors: " << graphFactorCount(problem) << "\n"
+              << "  iterations: " << result.iterations << "\n"
+              << "  converged: " << (result.converged ? "true" : "false") << "\n"
+              << std::fixed << std::setprecision(6)
+              << "  initial_cost: " << result.initial_cost << "\n"
+              << "  final_cost: " << result.final_cost << "\n"
+              << "  residual_rms_mps: " << result.residual_rms_mps << "\n";
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+    try {
+        const Options options = parseArguments(argc, argv);
+        const Problem problem = buildProblem(options);
+        const SolveResult result = solveProblem(problem, options);
+
+        if (!writePerEpochCsv(options.out_csv_path, problem, result)) {
+            std::cerr << "Error: failed to write state CSV: "
+                      << options.out_csv_path << "\n";
+            return 1;
+        }
+        if (!writeFactorDebugCsv(options.factor_debug_csv_path, problem, result)) {
+            std::cerr << "Error: failed to write factor debug CSV: "
+                      << options.factor_debug_csv_path << "\n";
+            return 1;
+        }
+        if (!writeGraphCsv(options.graph_csv_path, problem, result)) {
+            std::cerr << "Error: failed to write graph CSV: "
+                      << options.graph_csv_path << "\n";
+            return 1;
+        }
+        if (!writeSummaryJson(options.summary_json_path, options, problem, result)) {
+            std::cerr << "Error: failed to write summary JSON: "
+                      << options.summary_json_path << "\n";
+            return 1;
+        }
+        if (!options.quiet) {
+            printSummary(problem, result);
+        }
+        return 0;
+    } catch (const std::invalid_argument&) {
+        return 2;
+    } catch (const std::exception& ex) {
+        std::cerr << "Error: " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/apps/gnss_pos_vel_pd.cpp
+++ b/apps/gnss_pos_vel_pd.cpp
@@ -1,0 +1,1638 @@
+#include <libgnss++/core/constants.hpp>
+#include <libgnss++/core/coordinates.hpp>
+#include <libgnss++/core/navigation.hpp>
+#include <libgnss++/core/observation.hpp>
+#include <libgnss++/core/signals.hpp>
+#include <libgnss++/io/rinex.hpp>
+#include <libgnss++/models/ionosphere.hpp>
+#include <libgnss++/models/troposphere.hpp>
+
+#include <Eigen/Sparse>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace {
+
+constexpr double kPi = 3.141592653589793238462643383279502884;
+constexpr double kDegreesToRadians = kPi / 180.0;
+constexpr double kRadiansToDegrees = 180.0 / kPi;
+constexpr std::size_t kClockGroups = 5;
+constexpr std::size_t kStateStride = 12;
+
+struct Options {
+    std::string obs_path;
+    std::string nav_path;
+    std::string seed_pos_path;
+    std::string out_csv_path;
+    std::string factor_debug_csv_path;
+    std::string graph_csv_path;
+    std::string summary_json_path;
+    int skip_epochs = 0;
+    int max_epochs = 0;
+    int max_iterations = 1000;
+    double seed_match_tolerance_s = 0.51;
+    double seed_interpolation_max_gap_s = 60.0;
+    double min_snr_dbhz = 35.0;
+    double min_elevation_deg = 15.0;
+    double pseudorange_sigma_zenith_m = 3.0;
+    double doppler_sigma_zenith_mps = 0.2;
+    double position_prior_sigma_m = 1000.0;
+    double clock_prior_sigma_m = 1e6;
+    double velocity_prior_sigma_mps = 1000.0;
+    double clock_drift_prior_sigma_mps = 1000.0;
+    double motion_sigma_m = 0.1;
+    double clock_motion_sigma_m = 0.1;
+    double clock_jump_sigma_m = 1e6;
+    double inter_system_clock_motion_sigma_m = 1e-6;
+    double clock_drift_between_sigma_mps = 0.1;
+    double huber_threshold_sigma = 1.234;
+    bool debug_problem_only = false;
+    bool quiet = false;
+};
+
+struct SeedPosition {
+    libgnss::GNSSTime time;
+    libgnss::Vector3d position_ecef = libgnss::Vector3d::Zero();
+};
+
+struct DopplerFactor {
+    std::size_t epoch_index = 0;
+    libgnss::GNSSTime time;
+    libgnss::SatelliteId satellite;
+    libgnss::SignalType signal = libgnss::SignalType::GPS_L1CA;
+    double snr_dbhz = 0.0;
+    double elevation_rad = 0.0;
+    double sigma_mps = 1.0;
+    double residual_mps = 0.0;
+    double measured_range_rate_mps = 0.0;
+    double modeled_range_rate_mps = 0.0;
+    double satellite_clock_drift_mps = 0.0;
+    double wavelength_m = 0.0;
+    libgnss::Vector3d los = libgnss::Vector3d::Zero();
+};
+
+struct PseudorangeFactor {
+    std::size_t epoch_index = 0;
+    libgnss::GNSSTime time;
+    libgnss::SatelliteId satellite;
+    libgnss::SignalType signal = libgnss::SignalType::GPS_L1CA;
+    std::size_t clock_group = 0;
+    double snr_dbhz = 0.0;
+    double elevation_rad = 0.0;
+    double sigma_m = 1.0;
+    double residual_m = 0.0;
+    double corrected_pseudorange_m = 0.0;
+    double modeled_range_m = 0.0;
+    double ionosphere_delay_m = 0.0;
+    double troposphere_delay_m = 0.0;
+    double satellite_clock_m = 0.0;
+    double group_delay_m = 0.0;
+    libgnss::Vector3d los = libgnss::Vector3d::Zero();
+};
+
+struct Problem {
+    std::vector<libgnss::ObservationData> epochs;
+    std::vector<libgnss::Vector3d> seed_positions;
+    std::vector<PseudorangeFactor> pseudorange_factors;
+    std::vector<DopplerFactor> factors;
+    std::vector<bool> clock_jumps;
+    std::size_t nsat = 0;
+    std::size_t seed_matched_epochs = 0;
+    std::size_t seed_interpolated_epochs = 0;
+};
+
+struct SolveResult {
+    Eigen::VectorXd state;
+    double initial_cost = 0.0;
+    double final_cost = 0.0;
+    double residual_rms_mps = 0.0;
+    int iterations = 0;
+    bool converged = false;
+};
+
+[[noreturn]] void usageError(const std::string& message, const char* argv0) {
+    std::cerr << "Error: " << message << "\n\n"
+              << "Usage: " << argv0 << " --obs rover.obs --nav base.nav "
+              << "--seed-pos rover_1Hz_spp.pos [options]\n\n"
+              << "Options:\n"
+              << "  --out-csv PATH                 Write per-epoch position/velocity CSV.\n"
+              << "  --factor-debug-csv PATH        Write per-factor debug CSV.\n"
+              << "  --graph-csv PATH               Write taroz-like graph detail CSV.\n"
+              << "  --summary-json PATH            Write JSON summary.\n"
+              << "  --max-epochs N                 Limit processed epochs; 0 means all.\n"
+              << "  --skip-epochs N                Skip leading observation epochs.\n"
+              << "  --max-iterations N             IRLS iteration limit.\n"
+              << "  --debug-problem-only           Build factors and skip optimization.\n"
+              << "  --quiet                        Suppress human-readable summary.\n";
+    throw std::invalid_argument(message);
+}
+
+int parseIntArg(const std::string& value, const std::string& name, const char* argv0) {
+    try {
+        std::size_t consumed = 0;
+        const int parsed = std::stoi(value, &consumed);
+        if (consumed == value.size()) {
+            return parsed;
+        }
+    } catch (const std::exception&) {
+    }
+    usageError("invalid integer for " + name + ": " + value, argv0);
+}
+
+double parseDoubleArg(const std::string& value, const std::string& name, const char* argv0) {
+    try {
+        std::size_t consumed = 0;
+        const double parsed = std::stod(value, &consumed);
+        if (consumed == value.size() && std::isfinite(parsed)) {
+            return parsed;
+        }
+    } catch (const std::exception&) {
+    }
+    usageError("invalid number for " + name + ": " + value, argv0);
+}
+
+Options parseArguments(int argc, char* argv[]) {
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        auto require_value = [&](const std::string& name) -> std::string {
+            if (i + 1 >= argc) {
+                usageError("missing value for " + name, argv[0]);
+            }
+            return argv[++i];
+        };
+
+        if (arg == "--obs") {
+            options.obs_path = require_value(arg);
+        } else if (arg == "--nav") {
+            options.nav_path = require_value(arg);
+        } else if (arg == "--seed-pos") {
+            options.seed_pos_path = require_value(arg);
+        } else if (arg == "--out-csv") {
+            options.out_csv_path = require_value(arg);
+        } else if (arg == "--factor-debug-csv") {
+            options.factor_debug_csv_path = require_value(arg);
+        } else if (arg == "--graph-csv") {
+            options.graph_csv_path = require_value(arg);
+        } else if (arg == "--summary-json") {
+            options.summary_json_path = require_value(arg);
+        } else if (arg == "--skip-epochs") {
+            options.skip_epochs = parseIntArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--max-epochs") {
+            options.max_epochs = parseIntArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--max-iterations") {
+            options.max_iterations = parseIntArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--seed-match-tolerance") {
+            options.seed_match_tolerance_s = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--seed-interpolation-max-gap") {
+            options.seed_interpolation_max_gap_s = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--min-snr") {
+            options.min_snr_dbhz = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--min-elevation") {
+            options.min_elevation_deg = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--pseudorange-sigma-zenith") {
+            options.pseudorange_sigma_zenith_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--doppler-sigma-zenith") {
+            options.doppler_sigma_zenith_mps = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--position-prior-sigma") {
+            options.position_prior_sigma_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--clock-prior-sigma") {
+            options.clock_prior_sigma_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--velocity-prior-sigma") {
+            options.velocity_prior_sigma_mps = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--clock-drift-prior-sigma") {
+            options.clock_drift_prior_sigma_mps = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--motion-sigma") {
+            options.motion_sigma_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--clock-motion-sigma") {
+            options.clock_motion_sigma_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--clock-jump-sigma") {
+            options.clock_jump_sigma_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--isb-motion-sigma") {
+            options.inter_system_clock_motion_sigma_m =
+                parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--clock-drift-between-sigma") {
+            options.clock_drift_between_sigma_mps = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--huber-threshold") {
+            options.huber_threshold_sigma = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--debug-problem-only") {
+            options.debug_problem_only = true;
+        } else if (arg == "--quiet") {
+            options.quiet = true;
+        } else if (arg == "--help" || arg == "-h") {
+            usageError("help requested", argv[0]);
+        } else {
+            usageError("unknown argument: " + arg, argv[0]);
+        }
+    }
+
+    if (options.obs_path.empty()) {
+        usageError("--obs is required", argv[0]);
+    }
+    if (options.nav_path.empty()) {
+        usageError("--nav is required", argv[0]);
+    }
+    if (options.seed_pos_path.empty()) {
+        usageError("--seed-pos is required", argv[0]);
+    }
+    if (options.skip_epochs < 0 || options.max_epochs < 0 ||
+        options.max_iterations < 0) {
+        usageError("epoch and iteration limits must be non-negative", argv[0]);
+    }
+    if (options.seed_match_tolerance_s < 0.0 ||
+        options.seed_interpolation_max_gap_s < 0.0 ||
+        options.pseudorange_sigma_zenith_m <= 0.0 ||
+        options.doppler_sigma_zenith_mps <= 0.0 ||
+        options.position_prior_sigma_m <= 0.0 ||
+        options.clock_prior_sigma_m <= 0.0 ||
+        options.velocity_prior_sigma_mps <= 0.0 ||
+        options.clock_drift_prior_sigma_mps <= 0.0 ||
+        options.motion_sigma_m <= 0.0 ||
+        options.clock_motion_sigma_m <= 0.0 ||
+        options.clock_jump_sigma_m <= 0.0 ||
+        options.inter_system_clock_motion_sigma_m <= 0.0 ||
+        options.clock_drift_between_sigma_mps <= 0.0 ||
+        options.huber_threshold_sigma <= 0.0) {
+        usageError("sigma, threshold, and tolerance values must be positive", argv[0]);
+    }
+    return options;
+}
+
+bool isPrimaryPdSignal(libgnss::SignalType signal) {
+    switch (signal) {
+        case libgnss::SignalType::GPS_L1CA:
+        case libgnss::SignalType::GLO_L1CA:
+        case libgnss::SignalType::GAL_E1:
+        case libgnss::SignalType::BDS_B1I:
+        case libgnss::SignalType::BDS_B1C:
+        case libgnss::SignalType::QZS_L1CA:
+            return true;
+        default:
+            return false;
+    }
+}
+
+std::string signalName(libgnss::SignalType signal) {
+    switch (signal) {
+        case libgnss::SignalType::GPS_L1CA: return "GPS_L1CA";
+        case libgnss::SignalType::GLO_L1CA: return "GLO_L1CA";
+        case libgnss::SignalType::GAL_E1: return "GAL_E1";
+        case libgnss::SignalType::BDS_B1I: return "BDS_B1I";
+        case libgnss::SignalType::BDS_B1C: return "BDS_B1C";
+        case libgnss::SignalType::QZS_L1CA: return "QZS_L1CA";
+        default: return "UNKNOWN";
+    }
+}
+
+bool isHealthyForPositioning(const libgnss::Observation& observation,
+                             const libgnss::Ephemeris& eph) {
+    int sv_health = static_cast<int>(eph.health);
+    if (observation.satellite.system == libgnss::GNSSSystem::QZSS) {
+        sv_health &= 0xFE;
+    }
+    return sv_health == 0;
+}
+
+std::size_t clockGroup(libgnss::GNSSSystem system) {
+    switch (system) {
+        case libgnss::GNSSSystem::GPS:
+            return 0U;
+        case libgnss::GNSSSystem::GLONASS:
+            return 1U;
+        case libgnss::GNSSSystem::Galileo:
+            return 2U;
+        case libgnss::GNSSSystem::QZSS:
+            return 3U;
+        case libgnss::GNSSSystem::BeiDou:
+            return 4U;
+        default:
+            return 0U;
+    }
+}
+
+double groupDelayCorrectionMeters(const libgnss::Observation& observation,
+                                  const libgnss::Ephemeris& eph) {
+    switch (observation.satellite.system) {
+        case libgnss::GNSSSystem::GPS:
+        case libgnss::GNSSSystem::QZSS:
+        case libgnss::GNSSSystem::Galileo:
+            return eph.tgd * libgnss::constants::SPEED_OF_LIGHT;
+        case libgnss::GNSSSystem::BeiDou:
+            switch (observation.signal) {
+                case libgnss::SignalType::BDS_B1I:
+                case libgnss::SignalType::BDS_B1C:
+                    return eph.tgd * libgnss::constants::SPEED_OF_LIGHT;
+                case libgnss::SignalType::BDS_B2I:
+                case libgnss::SignalType::BDS_B2A:
+                    return eph.tgd_secondary * libgnss::constants::SPEED_OF_LIGHT;
+                default:
+                    return 0.0;
+            }
+        default:
+            return 0.0;
+    }
+}
+
+double sagnacRangeCorrection(const libgnss::Vector3d& satellite_position,
+                             const libgnss::Vector3d& receiver_position) {
+    return libgnss::constants::OMEGA_E / libgnss::constants::SPEED_OF_LIGHT *
+           (satellite_position(0) * receiver_position(1) -
+            satellite_position(1) * receiver_position(0));
+}
+
+bool parseSeparatedIntegers(std::string value,
+                            char separator,
+                            int& first,
+                            int& second,
+                            int& third) {
+    std::replace(value.begin(), value.end(), separator, ' ');
+    std::istringstream input(value);
+    return static_cast<bool>(input >> first >> second >> third);
+}
+
+bool parseRtklibTime(std::string value,
+                     int& hour,
+                     int& minute,
+                     double& second) {
+    std::replace(value.begin(), value.end(), ':', ' ');
+    std::istringstream input(value);
+    return static_cast<bool>(input >> hour >> minute >> second);
+}
+
+bool isLeapYear(int year) {
+    return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+}
+
+libgnss::GNSSTime gpstCalendarToTime(int year,
+                                     int month,
+                                     int day,
+                                     int hour,
+                                     int minute,
+                                     double second) {
+    int days_since_gps_epoch = 0;
+    for (int current_year = 1980; current_year < year; ++current_year) {
+        days_since_gps_epoch += isLeapYear(current_year) ? 366 : 365;
+    }
+
+    int days_in_month[] = {
+        31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    if (isLeapYear(year)) {
+        days_in_month[1] = 29;
+    }
+    for (int current_month = 1; current_month < month; ++current_month) {
+        days_since_gps_epoch += days_in_month[current_month - 1];
+    }
+    days_since_gps_epoch += day;
+    days_since_gps_epoch -= 6;
+
+    const int gps_week = days_since_gps_epoch / 7;
+    const int day_of_week = days_since_gps_epoch % 7;
+    const double tow = static_cast<double>(day_of_week) * 86400.0 +
+                       static_cast<double>(hour) * 3600.0 +
+                       static_cast<double>(minute) * 60.0 + second;
+    return libgnss::GNSSTime(gps_week, tow);
+}
+
+bool parseRtklibSeedPositionLine(const std::string& line, SeedPosition& seed) {
+    std::istringstream input(line);
+    std::string date_token;
+    std::string time_token;
+    if (!(input >> date_token >> time_token)) {
+        return false;
+    }
+
+    int year = 0;
+    int month = 0;
+    int day = 0;
+    int hour = 0;
+    int minute = 0;
+    double second = 0.0;
+    if (!parseSeparatedIntegers(date_token, '/', year, month, day) ||
+        !parseRtklibTime(time_token, hour, minute, second)) {
+        return false;
+    }
+
+    double latitude_deg = 0.0;
+    double longitude_deg = 0.0;
+    double height_m = 0.0;
+    if (!(input >> latitude_deg >> longitude_deg >> height_m)) {
+        return false;
+    }
+    if (!std::isfinite(latitude_deg) || !std::isfinite(longitude_deg) ||
+        !std::isfinite(height_m)) {
+        return false;
+    }
+
+    seed.time = gpstCalendarToTime(year, month, day, hour, minute, second);
+    seed.position_ecef = libgnss::geodetic2ecef(latitude_deg * kDegreesToRadians,
+                                                longitude_deg * kDegreesToRadians,
+                                                height_m);
+    return seed.position_ecef.norm() > 1e6;
+}
+
+bool parseSeedPositionLine(const std::string& line, SeedPosition& seed) {
+    std::istringstream input(line);
+    std::string first_token;
+    if (!(input >> first_token)) {
+        return false;
+    }
+    if (first_token[0] == '%' || first_token[0] == '#') {
+        return false;
+    }
+    if (first_token.find('/') != std::string::npos) {
+        return parseRtklibSeedPositionLine(line, seed);
+    }
+
+    int week = 0;
+    try {
+        std::size_t consumed = 0;
+        week = std::stoi(first_token, &consumed);
+        if (consumed != first_token.size()) {
+            return false;
+        }
+    } catch (const std::exception&) {
+        return false;
+    }
+
+    double tow = 0.0;
+    double x = 0.0;
+    double y = 0.0;
+    double z = 0.0;
+    if (!(input >> tow >> x >> y >> z)) {
+        return false;
+    }
+    if (!std::isfinite(tow) || !std::isfinite(x) ||
+        !std::isfinite(y) || !std::isfinite(z)) {
+        return false;
+    }
+
+    seed.time = libgnss::GNSSTime(week, tow);
+    seed.position_ecef = libgnss::Vector3d(x, y, z);
+    return seed.position_ecef.norm() > 1e6;
+}
+
+std::vector<SeedPosition> readSeedPositions(const std::string& path) {
+    std::ifstream input(path);
+    if (!input.is_open()) {
+        throw std::runtime_error("failed to open seed POS file: " + path);
+    }
+
+    std::vector<SeedPosition> seeds;
+    std::string line;
+    while (std::getline(input, line)) {
+        SeedPosition seed;
+        if (parseSeedPositionLine(line, seed)) {
+            seeds.push_back(seed);
+        }
+    }
+    if (seeds.empty()) {
+        throw std::runtime_error(
+            "seed POS file has no readable LibGNSS++ or RTKLIB POS rows: " + path);
+    }
+
+    std::sort(seeds.begin(),
+              seeds.end(),
+              [](const SeedPosition& lhs, const SeedPosition& rhs) {
+                  return lhs.time < rhs.time;
+              });
+    return seeds;
+}
+
+bool findSeedPosition(const std::vector<SeedPosition>& seeds,
+                      const libgnss::GNSSTime& time,
+                      double tolerance_s,
+                      double interpolation_max_gap_s,
+                      std::size_t& cursor,
+                      libgnss::Vector3d& position_ecef,
+                      bool& interpolated) {
+    interpolated = false;
+    while (cursor < seeds.size() && seeds[cursor].time - time < -tolerance_s) {
+        ++cursor;
+    }
+
+    std::size_t best_index = seeds.size();
+    double best_abs_dt = tolerance_s;
+    if (cursor < seeds.size()) {
+        const double abs_dt = std::abs(seeds[cursor].time - time);
+        if (abs_dt <= best_abs_dt) {
+            best_index = cursor;
+            best_abs_dt = abs_dt;
+        }
+    }
+    if (cursor > 0) {
+        const std::size_t previous_index = cursor - 1;
+        const double abs_dt = std::abs(seeds[previous_index].time - time);
+        if (abs_dt <= best_abs_dt) {
+            best_index = previous_index;
+        }
+    }
+    if (best_index == seeds.size()) {
+        if (interpolation_max_gap_s <= 0.0 || cursor == 0 ||
+            cursor >= seeds.size()) {
+            return false;
+        }
+        const SeedPosition& lower = seeds[cursor - 1];
+        const SeedPosition& upper = seeds[cursor];
+        const double gap_s = upper.time - lower.time;
+        const double lower_dt_s = time - lower.time;
+        if (gap_s <= 0.0 || gap_s > interpolation_max_gap_s ||
+            lower_dt_s < 0.0 || lower_dt_s > gap_s) {
+            return false;
+        }
+        const double alpha = lower_dt_s / gap_s;
+        position_ecef =
+            lower.position_ecef +
+            alpha * (upper.position_ecef - lower.position_ecef);
+        interpolated = true;
+        return position_ecef.norm() > 1e6;
+    }
+
+    position_ecef = seeds[best_index].position_ecef;
+    return true;
+}
+
+void writeCsvDouble(std::ostream& output, double value) {
+    if (std::isfinite(value)) {
+        output << value;
+    } else {
+        output << "NaN";
+    }
+}
+
+double robustHuberLoss(double whitened_error, double threshold) {
+    const double abs_error = std::abs(whitened_error);
+    if (abs_error <= threshold) {
+        return 0.5 * whitened_error * whitened_error;
+    }
+    return threshold * (abs_error - 0.5 * threshold);
+}
+
+double robustHuberWeight(double whitened_error, double threshold) {
+    const double abs_error = std::abs(whitened_error);
+    if (abs_error <= threshold || abs_error <= 0.0) {
+        return 1.0;
+    }
+    return threshold / abs_error;
+}
+
+int positionColumn(std::size_t epoch_index, int component) {
+    return static_cast<int>(kStateStride * epoch_index +
+                            static_cast<std::size_t>(component));
+}
+
+int clockColumn(std::size_t epoch_index, std::size_t group) {
+    return static_cast<int>(kStateStride * epoch_index + 3U + group);
+}
+
+int velocityColumn(std::size_t epoch_index, int component) {
+    return static_cast<int>(kStateStride * epoch_index + 8U +
+                            static_cast<std::size_t>(component));
+}
+
+int driftColumn(std::size_t epoch_index) {
+    return static_cast<int>(kStateStride * epoch_index + 11U);
+}
+
+double pseudorangePrediction(const Eigen::VectorXd& state,
+                             const PseudorangeFactor& factor) {
+    const std::size_t i = factor.epoch_index;
+    double prediction =
+        factor.los(0) * state(positionColumn(i, 0)) +
+        factor.los(1) * state(positionColumn(i, 1)) +
+        factor.los(2) * state(positionColumn(i, 2)) +
+        state(clockColumn(i, 0));
+    if (factor.clock_group != 0U) {
+        prediction += state(clockColumn(i, factor.clock_group));
+    }
+    return prediction;
+}
+
+double dopplerPrediction(const Eigen::VectorXd& state, const DopplerFactor& factor) {
+    const std::size_t i = factor.epoch_index;
+    return factor.los(0) * state(velocityColumn(i, 0)) +
+           factor.los(1) * state(velocityColumn(i, 1)) +
+           factor.los(2) * state(velocityColumn(i, 2)) +
+           state(driftColumn(i));
+}
+
+double computeCost(const Problem& problem,
+                   const Options& options,
+                   const Eigen::VectorXd& state) {
+    double cost = 0.0;
+    for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
+        for (int component = 0; component < 3; ++component) {
+            const double e =
+                state(positionColumn(i, component)) /
+                options.position_prior_sigma_m;
+            cost += 0.5 * e * e;
+        }
+        for (std::size_t group = 0; group < kClockGroups; ++group) {
+            const double e =
+                state(clockColumn(i, group)) / options.clock_prior_sigma_m;
+            cost += 0.5 * e * e;
+        }
+        for (int component = 0; component < 3; ++component) {
+            const double e =
+                state(velocityColumn(i, component)) /
+                options.velocity_prior_sigma_mps;
+            cost += 0.5 * e * e;
+        }
+        const double d_prior =
+            state(driftColumn(i)) / options.clock_drift_prior_sigma_mps;
+        cost += 0.5 * d_prior * d_prior;
+        if (i > 0) {
+            for (std::size_t group = 0; group < kClockGroups; ++group) {
+                const double sigma =
+                    group == 0U
+                        ? (problem.clock_jumps[i]
+                               ? options.clock_jump_sigma_m
+                               : options.clock_motion_sigma_m)
+                        : options.inter_system_clock_motion_sigma_m;
+                double prediction =
+                    state(clockColumn(i, group)) -
+                    state(clockColumn(i - 1U, group));
+                if (group == 0U) {
+                    prediction -= 0.5 *
+                                  (state(driftColumn(i - 1U)) +
+                                   state(driftColumn(i)));
+                }
+                const double e = prediction / sigma;
+                cost += 0.5 * e * e;
+            }
+
+            for (int component = 0; component < 3; ++component) {
+                const double seed_delta =
+                    problem.seed_positions[i](component) -
+                    problem.seed_positions[i - 1U](component);
+                const double prediction =
+                    seed_delta +
+                    state(positionColumn(i, component)) -
+                    state(positionColumn(i - 1U, component)) -
+                    0.5 * (state(velocityColumn(i - 1U, component)) +
+                           state(velocityColumn(i, component)));
+                const double e = prediction / options.motion_sigma_m;
+                cost += 0.5 * e * e;
+            }
+
+            const double between =
+                (state(driftColumn(i)) - state(driftColumn(i - 1U))) /
+                options.clock_drift_between_sigma_mps;
+            cost += 0.5 * between * between;
+        }
+    }
+
+    for (const PseudorangeFactor& factor : problem.pseudorange_factors) {
+        const double error =
+            (pseudorangePrediction(state, factor) - factor.residual_m) /
+            factor.sigma_m;
+        cost += robustHuberLoss(error, options.huber_threshold_sigma);
+    }
+
+    for (const DopplerFactor& factor : problem.factors) {
+        const double error =
+            (dopplerPrediction(state, factor) - factor.residual_mps) /
+            factor.sigma_mps;
+        cost += robustHuberLoss(error, options.huber_threshold_sigma);
+    }
+    return cost;
+}
+
+struct NormalEquation {
+    Eigen::SparseMatrix<double> hessian;
+    Eigen::VectorXd rhs;
+};
+
+void addWeightedRow(std::vector<Eigen::Triplet<double>>& triplets,
+                    Eigen::VectorXd& rhs,
+                    const std::vector<int>& columns,
+                    const std::vector<double>& coefficients,
+                    double residual,
+                    double sigma,
+                    double robust_weight) {
+    const double inv_variance = robust_weight / (sigma * sigma);
+    for (std::size_t a = 0; a < columns.size(); ++a) {
+        const double weighted_a = inv_variance * coefficients[a];
+        rhs(columns[a]) += weighted_a * residual;
+        for (std::size_t b = 0; b < columns.size(); ++b) {
+            triplets.emplace_back(columns[a],
+                                  columns[b],
+                                  weighted_a * coefficients[b]);
+        }
+    }
+}
+
+NormalEquation buildNormalEquation(const Problem& problem,
+                                   const Options& options,
+                                   const Eigen::VectorXd& state) {
+    const int state_size = static_cast<int>(kStateStride * problem.epochs.size());
+    std::vector<Eigen::Triplet<double>> triplets;
+    triplets.reserve((problem.pseudorange_factors.size() + problem.factors.size()) * 16U +
+                     problem.epochs.size() * 80U);
+    Eigen::VectorXd rhs = Eigen::VectorXd::Zero(state_size);
+
+    for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
+        for (int component = 0; component < 3; ++component) {
+            const int col = positionColumn(i, component);
+            addWeightedRow(triplets,
+                           rhs,
+                           {col},
+                           {1.0},
+                           -state(col),
+                           options.position_prior_sigma_m,
+                           1.0);
+        }
+        for (std::size_t group = 0; group < kClockGroups; ++group) {
+            const int col = clockColumn(i, group);
+            addWeightedRow(triplets,
+                           rhs,
+                           {col},
+                           {1.0},
+                           -state(col),
+                           options.clock_prior_sigma_m,
+                           1.0);
+        }
+        for (int component = 0; component < 3; ++component) {
+            const int col = velocityColumn(i, component);
+            addWeightedRow(triplets,
+                           rhs,
+                           {col},
+                           {1.0},
+                           -state(col),
+                           options.velocity_prior_sigma_mps,
+                           1.0);
+        }
+
+        const int d_col = driftColumn(i);
+        addWeightedRow(triplets,
+                       rhs,
+                       {d_col},
+                       {1.0},
+                       -state(d_col),
+                       options.clock_drift_prior_sigma_mps,
+                       1.0);
+
+        if (i > 0) {
+            for (std::size_t group = 0; group < kClockGroups; ++group) {
+                const int previous = clockColumn(i - 1U, group);
+                const int current = clockColumn(i, group);
+                const double sigma =
+                    group == 0U
+                        ? (problem.clock_jumps[i]
+                               ? options.clock_jump_sigma_m
+                               : options.clock_motion_sigma_m)
+                        : options.inter_system_clock_motion_sigma_m;
+                std::vector<int> columns{previous, current};
+                std::vector<double> coeffs{-1.0, 1.0};
+                double prediction = state(current) - state(previous);
+                if (group == 0U) {
+                    const int previous_drift = driftColumn(i - 1U);
+                    const int current_drift = driftColumn(i);
+                    columns.push_back(previous_drift);
+                    columns.push_back(current_drift);
+                    coeffs.push_back(-0.5);
+                    coeffs.push_back(-0.5);
+                    prediction -= 0.5 *
+                                  (state(previous_drift) + state(current_drift));
+                }
+                addWeightedRow(triplets,
+                               rhs,
+                               columns,
+                               coeffs,
+                               -prediction,
+                               sigma,
+                               1.0);
+            }
+
+            for (int component = 0; component < 3; ++component) {
+                const int previous_position = positionColumn(i - 1U, component);
+                const int current_position = positionColumn(i, component);
+                const int previous_velocity = velocityColumn(i - 1U, component);
+                const int current_velocity = velocityColumn(i, component);
+                const double seed_delta =
+                    problem.seed_positions[i](component) -
+                    problem.seed_positions[i - 1U](component);
+                const double prediction =
+                    seed_delta +
+                    state(current_position) -
+                    state(previous_position) -
+                    0.5 * (state(previous_velocity) + state(current_velocity));
+                addWeightedRow(triplets,
+                               rhs,
+                               {previous_position,
+                                current_position,
+                                previous_velocity,
+                                current_velocity},
+                               {-1.0, 1.0, -0.5, -0.5},
+                               -prediction,
+                               options.motion_sigma_m,
+                               1.0);
+            }
+
+            const int previous = driftColumn(i - 1U);
+            const int current = driftColumn(i);
+            const double prediction = state(current) - state(previous);
+            addWeightedRow(triplets,
+                           rhs,
+                           {previous, current},
+                           {-1.0, 1.0},
+                           -prediction,
+                           options.clock_drift_between_sigma_mps,
+                           1.0);
+        }
+    }
+
+    for (const PseudorangeFactor& factor : problem.pseudorange_factors) {
+        const std::size_t i = factor.epoch_index;
+        const double prediction = pseudorangePrediction(state, factor);
+        const double residual = factor.residual_m - prediction;
+        const double whitened_error = -residual / factor.sigma_m;
+        const double robust_weight =
+            robustHuberWeight(whitened_error, options.huber_threshold_sigma);
+        std::vector<int> columns{
+            positionColumn(i, 0),
+            positionColumn(i, 1),
+            positionColumn(i, 2),
+            clockColumn(i, 0),
+        };
+        std::vector<double> coeffs{
+            factor.los(0),
+            factor.los(1),
+            factor.los(2),
+            1.0,
+        };
+        if (factor.clock_group != 0U) {
+            columns.push_back(clockColumn(i, factor.clock_group));
+            coeffs.push_back(1.0);
+        }
+        addWeightedRow(triplets,
+                       rhs,
+                       columns,
+                       coeffs,
+                       residual,
+                       factor.sigma_m,
+                       robust_weight);
+    }
+
+    for (const DopplerFactor& factor : problem.factors) {
+        const std::size_t i = factor.epoch_index;
+        const double prediction = dopplerPrediction(state, factor);
+        const double residual = factor.residual_mps - prediction;
+        const double whitened_error = -residual / factor.sigma_mps;
+        const double robust_weight =
+            robustHuberWeight(whitened_error, options.huber_threshold_sigma);
+        addWeightedRow(triplets,
+                       rhs,
+                       {velocityColumn(i, 0),
+                        velocityColumn(i, 1),
+                        velocityColumn(i, 2),
+                        driftColumn(i)},
+                       {factor.los(0), factor.los(1), factor.los(2), 1.0},
+                       residual,
+                       factor.sigma_mps,
+                       robust_weight);
+    }
+
+    NormalEquation normal;
+    normal.hessian.resize(state_size, state_size);
+    normal.hessian.setFromTriplets(triplets.begin(), triplets.end());
+    normal.rhs = std::move(rhs);
+    return normal;
+}
+
+double residualRms(const Problem& problem, const Eigen::VectorXd& state) {
+    const std::size_t count =
+        problem.pseudorange_factors.size() + problem.factors.size();
+    if (count == 0U) {
+        return 0.0;
+    }
+    double sum_sq = 0.0;
+    for (const PseudorangeFactor& factor : problem.pseudorange_factors) {
+        const double residual =
+            pseudorangePrediction(state, factor) - factor.residual_m;
+        sum_sq += residual * residual;
+    }
+    for (const DopplerFactor& factor : problem.factors) {
+        const double residual =
+            dopplerPrediction(state, factor) - factor.residual_mps;
+        sum_sq += residual * residual;
+    }
+    return std::sqrt(sum_sq / static_cast<double>(count));
+}
+
+SolveResult solveProblem(const Problem& problem, const Options& options) {
+    SolveResult result;
+    result.state =
+        Eigen::VectorXd::Zero(static_cast<int>(kStateStride * problem.epochs.size()));
+    result.initial_cost = computeCost(problem, options, result.state);
+
+    if (options.debug_problem_only || options.max_iterations == 0 ||
+        problem.epochs.empty()) {
+        result.final_cost = result.initial_cost;
+        result.residual_rms_mps = residualRms(problem, result.state);
+        return result;
+    }
+
+    double previous_cost = result.initial_cost;
+    for (int iteration = 1; iteration <= options.max_iterations; ++iteration) {
+        NormalEquation normal = buildNormalEquation(problem, options, result.state);
+        Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> solver;
+        solver.compute(normal.hessian);
+        if (solver.info() != Eigen::Success) {
+            throw std::runtime_error("failed to factor Doppler normal equation");
+        }
+        const Eigen::VectorXd delta = solver.solve(normal.rhs);
+        if (solver.info() != Eigen::Success || !delta.allFinite()) {
+            throw std::runtime_error("failed to solve Doppler normal equation");
+        }
+
+        result.state += delta;
+        result.iterations = iteration;
+
+        const double cost = computeCost(problem, options, result.state);
+        const double absolute_decrease = previous_cost - cost;
+        const double relative_decrease =
+            absolute_decrease / std::max(1.0, std::abs(previous_cost));
+        previous_cost = cost;
+
+        if (delta.norm() < 1e-10 ||
+            (iteration > 1 && absolute_decrease >= 0.0 &&
+             relative_decrease < 1e-5)) {
+            result.converged = true;
+            break;
+        }
+    }
+
+    result.final_cost = computeCost(problem, options, result.state);
+    result.residual_rms_mps = residualRms(problem, result.state);
+    return result;
+}
+
+bool calculateObservationModel(const libgnss::ObservationData& epoch,
+                               const libgnss::Observation& observation,
+                               const libgnss::NavigationData& nav,
+                               const libgnss::Vector3d& receiver_position,
+                               const Options& options,
+                               libgnss::Vector3d& satellite_position,
+                               libgnss::Vector3d& satellite_velocity,
+                               double& satellite_clock_bias,
+                               double& satellite_clock_drift,
+                               const libgnss::Ephemeris*& eph,
+                               libgnss::NavigationData::SatelliteGeometry& geometry,
+                               libgnss::Vector3d& ex,
+                               double& range_m) {
+    if (!isPrimaryPdSignal(observation.signal) ||
+        !observation.valid ||
+        !observation.has_pseudorange ||
+        observation.pseudorange <= 0.0 ||
+        observation.snr < options.min_snr_dbhz) {
+        return false;
+    }
+
+    libgnss::GNSSTime transmit_time =
+        epoch.time - observation.pseudorange / libgnss::constants::SPEED_OF_LIGHT;
+    if (!nav.calculateSatelliteState(observation.satellite,
+                                     transmit_time,
+                                     satellite_position,
+                                     satellite_velocity,
+                                     satellite_clock_bias,
+                                     satellite_clock_drift)) {
+        return false;
+    }
+
+    transmit_time = transmit_time - satellite_clock_bias;
+    if (!nav.calculateSatelliteState(observation.satellite,
+                                     transmit_time,
+                                     satellite_position,
+                                     satellite_velocity,
+                                     satellite_clock_bias,
+                                     satellite_clock_drift)) {
+        return false;
+    }
+
+    eph = nav.getEphemeris(observation.satellite, transmit_time);
+    if (!eph || !isHealthyForPositioning(observation, *eph)) {
+        return false;
+    }
+
+    const libgnss::Vector3d delta = satellite_position - receiver_position;
+    range_m = delta.norm();
+    if (range_m <= 0.0) {
+        return false;
+    }
+    ex = delta / range_m;
+    geometry = nav.calculateGeometry(receiver_position, satellite_position);
+    return geometry.elevation >= options.min_elevation_deg * kDegreesToRadians;
+}
+
+bool preparePseudorangeFactor(const libgnss::ObservationData& epoch,
+                              std::size_t epoch_index,
+                              const libgnss::Observation& observation,
+                              const libgnss::NavigationData& nav,
+                              const libgnss::Vector3d& receiver_position,
+                              const Options& options,
+                              PseudorangeFactor& factor) {
+    libgnss::Vector3d satellite_position;
+    libgnss::Vector3d satellite_velocity;
+    double satellite_clock_bias = 0.0;
+    double satellite_clock_drift = 0.0;
+    const libgnss::Ephemeris* eph = nullptr;
+    libgnss::NavigationData::SatelliteGeometry geometry;
+    libgnss::Vector3d ex = libgnss::Vector3d::Zero();
+    double geometric_range = 0.0;
+    if (!calculateObservationModel(epoch,
+                                   observation,
+                                   nav,
+                                   receiver_position,
+                                   options,
+                                   satellite_position,
+                                   satellite_velocity,
+                                   satellite_clock_bias,
+                                   satellite_clock_drift,
+                                   eph,
+                                   geometry,
+                                   ex,
+                                   geometric_range)) {
+        return false;
+    }
+
+    double receiver_lat = 0.0;
+    double receiver_lon = 0.0;
+    double receiver_height = 0.0;
+    libgnss::ecef2geodetic(receiver_position,
+                           receiver_lat,
+                           receiver_lon,
+                           receiver_height);
+    double ionosphere_delay = 0.0;
+    if (nav.ionosphere_model.valid) {
+        ionosphere_delay = libgnss::models::ionoDelayKlobuchar(
+            receiver_lat,
+            receiver_lon,
+            geometry.azimuth,
+            geometry.elevation,
+            epoch.time.tow,
+            nav.ionosphere_model.alpha,
+            nav.ionosphere_model.beta);
+        const double frequency_hz =
+            libgnss::signalFrequencyHz(observation.signal, eph);
+        if (frequency_hz > 0.0) {
+            const double scale = libgnss::constants::GPS_L1_FREQ / frequency_hz;
+            ionosphere_delay *= scale * scale;
+        }
+    }
+    const double troposphere_delay =
+        libgnss::models::tropDelaySaastamoinen(receiver_position,
+                                               geometry.elevation);
+    const double satellite_clock_m =
+        satellite_clock_bias * libgnss::constants::SPEED_OF_LIGHT;
+    const double group_delay_m = groupDelayCorrectionMeters(observation, *eph);
+    const double modeled_range =
+        geometric_range + sagnacRangeCorrection(satellite_position, receiver_position);
+    const double corrected_pseudorange =
+        observation.pseudorange +
+        satellite_clock_m -
+        ionosphere_delay -
+        troposphere_delay -
+        group_delay_m;
+    const double residual = corrected_pseudorange - modeled_range;
+    const double sin_el = std::sin(geometry.elevation);
+    if (sin_el <= 0.0) {
+        return false;
+    }
+
+    factor.epoch_index = epoch_index;
+    factor.time = epoch.time;
+    factor.satellite = observation.satellite;
+    factor.signal = observation.signal;
+    factor.clock_group = clockGroup(observation.satellite.system);
+    factor.snr_dbhz = observation.snr;
+    factor.elevation_rad = geometry.elevation;
+    factor.sigma_m = options.pseudorange_sigma_zenith_m / std::sqrt(sin_el);
+    factor.residual_m = residual;
+    factor.corrected_pseudorange_m = corrected_pseudorange;
+    factor.modeled_range_m = modeled_range;
+    factor.ionosphere_delay_m = ionosphere_delay;
+    factor.troposphere_delay_m = troposphere_delay;
+    factor.satellite_clock_m = satellite_clock_m;
+    factor.group_delay_m = group_delay_m;
+    factor.los = -ex;
+    return std::isfinite(factor.residual_m) &&
+           std::isfinite(factor.sigma_m) &&
+           factor.sigma_m > 0.0;
+}
+
+bool prepareDopplerFactor(const libgnss::ObservationData& epoch,
+                          std::size_t epoch_index,
+                          const libgnss::Observation& observation,
+                          const libgnss::NavigationData& nav,
+                          const libgnss::Vector3d& receiver_position,
+                          const Options& options,
+                          DopplerFactor& factor) {
+    if (!observation.has_doppler) {
+        return false;
+    }
+
+    libgnss::Vector3d satellite_position;
+    libgnss::Vector3d satellite_velocity;
+    double satellite_clock_bias = 0.0;
+    double satellite_clock_drift = 0.0;
+    const libgnss::Ephemeris* eph = nullptr;
+    libgnss::NavigationData::SatelliteGeometry geometry;
+    libgnss::Vector3d ex = libgnss::Vector3d::Zero();
+    double range = 0.0;
+    if (!calculateObservationModel(epoch,
+                                   observation,
+                                   nav,
+                                   receiver_position,
+                                   options,
+                                   satellite_position,
+                                   satellite_velocity,
+                                   satellite_clock_bias,
+                                   satellite_clock_drift,
+                                   eph,
+                                   geometry,
+                                   ex,
+                                   range)) {
+        return false;
+    }
+
+    double wavelength = libgnss::signalWavelengthMeters(observation.signal, eph);
+    if (wavelength <= 0.0) {
+        wavelength = libgnss::signalWavelengthMeters(observation);
+    }
+    if (wavelength <= 0.0) {
+        return false;
+    }
+
+    const double sagnac_rate =
+        libgnss::constants::OMEGA_E / libgnss::constants::SPEED_OF_LIGHT *
+        (satellite_velocity(1) * receiver_position(0) -
+         satellite_velocity(0) * receiver_position(1));
+    const double modeled_range_rate = satellite_velocity.dot(ex) + sagnac_rate;
+    const double satellite_clock_drift_mps =
+        satellite_clock_drift * libgnss::constants::SPEED_OF_LIGHT;
+    const double measured_range_rate = -observation.doppler * wavelength;
+    const double residual =
+        measured_range_rate - (modeled_range_rate - satellite_clock_drift_mps);
+    const double sin_el = std::sin(geometry.elevation);
+    if (sin_el <= 0.0) {
+        return false;
+    }
+
+    factor.epoch_index = epoch_index;
+    factor.time = epoch.time;
+    factor.satellite = observation.satellite;
+    factor.signal = observation.signal;
+    factor.snr_dbhz = observation.snr;
+    factor.elevation_rad = geometry.elevation;
+    factor.sigma_mps = options.doppler_sigma_zenith_mps / std::sqrt(sin_el);
+    factor.residual_mps = residual;
+    factor.measured_range_rate_mps = measured_range_rate;
+    factor.modeled_range_rate_mps = modeled_range_rate;
+    factor.satellite_clock_drift_mps = satellite_clock_drift_mps;
+    factor.wavelength_m = wavelength;
+    factor.los = -ex;
+    return std::isfinite(factor.residual_mps) &&
+           std::isfinite(factor.sigma_mps) &&
+           factor.sigma_mps > 0.0;
+}
+
+Problem buildProblem(const Options& options) {
+    libgnss::io::RINEXReader obs_reader;
+    if (!obs_reader.open(options.obs_path)) {
+        throw std::runtime_error("failed to open observation file: " + options.obs_path);
+    }
+    libgnss::io::RINEXReader::RINEXHeader obs_header;
+    if (!obs_reader.readHeader(obs_header)) {
+        throw std::runtime_error("failed to read observation header: " + options.obs_path);
+    }
+
+    libgnss::io::RINEXReader nav_reader;
+    if (!nav_reader.open(options.nav_path)) {
+        throw std::runtime_error("failed to open navigation file: " + options.nav_path);
+    }
+    libgnss::NavigationData nav_data;
+    if (!nav_reader.readNavigationData(nav_data)) {
+        throw std::runtime_error("failed to read navigation data: " + options.nav_path);
+    }
+
+    const std::vector<SeedPosition> seed_positions =
+        readSeedPositions(options.seed_pos_path);
+    std::size_t seed_cursor = 0;
+
+    Problem problem;
+    std::set<libgnss::SatelliteId> unique_satellites;
+    const double fixed_interval_s =
+        obs_header.interval > 0.0 ? obs_header.interval : 1.0;
+    const double gap_tolerance_s = std::max(0.01, 0.5 * fixed_interval_s);
+    std::map<libgnss::SatelliteId, double> previous_gps_pseudorange_by_satellite;
+    bool have_previous_gps_pseudorange = false;
+
+    auto append_epoch = [&](libgnss::ObservationData epoch,
+                            bool build_factors) -> bool {
+        if (options.max_epochs > 0 &&
+            static_cast<int>(problem.epochs.size()) >= options.max_epochs) {
+            return false;
+        }
+
+        libgnss::Vector3d seed_position = libgnss::Vector3d::Zero();
+        bool interpolated = false;
+        if (findSeedPosition(seed_positions,
+                             epoch.time,
+                             options.seed_match_tolerance_s,
+                             options.seed_interpolation_max_gap_s,
+                             seed_cursor,
+                             seed_position,
+                             interpolated)) {
+            epoch.receiver_position = seed_position;
+            ++problem.seed_matched_epochs;
+            if (interpolated) {
+                ++problem.seed_interpolated_epochs;
+            }
+        } else if (obs_header.approximate_position.norm() > 1e6) {
+            seed_position = obs_header.approximate_position;
+            epoch.receiver_position = seed_position;
+        } else {
+            return true;
+        }
+
+        const std::size_t epoch_index = problem.epochs.size();
+        std::map<libgnss::SatelliteId, double> gps_pseudorange_by_satellite;
+        if (build_factors) {
+            for (const auto& observation : epoch.observations) {
+                unique_satellites.insert(observation.satellite);
+                PseudorangeFactor pseudorange_factor;
+                if (preparePseudorangeFactor(epoch,
+                                             epoch_index,
+                                             observation,
+                                             nav_data,
+                                             seed_position,
+                                             options,
+                                             pseudorange_factor)) {
+                    problem.pseudorange_factors.push_back(pseudorange_factor);
+                    if (observation.satellite.system == libgnss::GNSSSystem::GPS) {
+                        gps_pseudorange_by_satellite[observation.satellite] =
+                            observation.pseudorange;
+                    }
+                }
+
+                DopplerFactor factor;
+                if (prepareDopplerFactor(epoch,
+                                         epoch_index,
+                                         observation,
+                                         nav_data,
+                                         seed_position,
+                                         options,
+                                         factor)) {
+                    problem.factors.push_back(factor);
+                }
+            }
+        }
+
+        bool clock_jump = false;
+        if (have_previous_gps_pseudorange && !gps_pseudorange_by_satellite.empty()) {
+            double sum_delta = 0.0;
+            std::size_t count = 0;
+            for (const auto& [satellite, pseudorange] : gps_pseudorange_by_satellite) {
+                const auto previous_it =
+                    previous_gps_pseudorange_by_satellite.find(satellite);
+                if (previous_it == previous_gps_pseudorange_by_satellite.end()) {
+                    continue;
+                }
+                sum_delta += pseudorange - previous_it->second;
+                ++count;
+            }
+            if (count > 0U) {
+                clock_jump = sum_delta / static_cast<double>(count) > 1e5;
+            }
+        }
+        problem.clock_jumps.push_back(clock_jump);
+        previous_gps_pseudorange_by_satellite = gps_pseudorange_by_satellite;
+        have_previous_gps_pseudorange = !gps_pseudorange_by_satellite.empty();
+
+        problem.seed_positions.push_back(seed_position);
+        problem.epochs.push_back(epoch);
+        return true;
+    };
+
+    libgnss::ObservationData epoch;
+    int raw_epoch_index = 0;
+    bool have_last_output_time = false;
+    libgnss::GNSSTime last_output_time;
+    while (obs_reader.readObservationEpoch(epoch)) {
+        if (raw_epoch_index++ < options.skip_epochs) {
+            continue;
+        }
+
+        if (have_last_output_time) {
+            libgnss::GNSSTime expected_time =
+                last_output_time + fixed_interval_s;
+            while (epoch.time - expected_time > gap_tolerance_s) {
+                libgnss::ObservationData empty_epoch(expected_time);
+                if (!append_epoch(empty_epoch, false)) {
+                    break;
+                }
+                last_output_time = expected_time;
+                expected_time = last_output_time + fixed_interval_s;
+                if (options.max_epochs > 0 &&
+                    static_cast<int>(problem.epochs.size()) >=
+                        options.max_epochs) {
+                    break;
+                }
+            }
+            if (options.max_epochs > 0 &&
+                static_cast<int>(problem.epochs.size()) >= options.max_epochs) {
+                break;
+            }
+        }
+
+        if (!append_epoch(epoch, true)) {
+            break;
+        }
+        last_output_time = epoch.time;
+        have_last_output_time = true;
+    }
+    problem.nsat = unique_satellites.size();
+    return problem;
+}
+
+bool writePerEpochCsv(const std::string& path,
+                      const Problem& problem,
+                      const SolveResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    output << "epoch,gps_week,gps_tow,spp_x_m,spp_y_m,spp_z_m,"
+              "fgo_x_m,fgo_y_m,fgo_z_m,"
+              "fgo_vx_mps,fgo_vy_mps,fgo_vz_mps,"
+              "fgo_c_gps_m,fgo_c_glo_m,fgo_c_gal_m,fgo_c_qzs_m,"
+              "fgo_c_bds_m,fgo_clock_drift_mps,clock_jump\n";
+    output << std::fixed << std::setprecision(15);
+    for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
+        const auto& epoch = problem.epochs[i];
+        const auto& seed = problem.seed_positions[i];
+        output << (i + 1U) << ','
+               << epoch.time.week << ','
+               << epoch.time.tow << ','
+               << seed(0) << ','
+               << seed(1) << ','
+               << seed(2) << ','
+               << seed(0) + result.state(positionColumn(i, 0)) << ','
+               << seed(1) + result.state(positionColumn(i, 1)) << ','
+               << seed(2) + result.state(positionColumn(i, 2)) << ','
+               << result.state(velocityColumn(i, 0)) << ','
+               << result.state(velocityColumn(i, 1)) << ','
+               << result.state(velocityColumn(i, 2)) << ','
+               << result.state(clockColumn(i, 0)) << ','
+               << result.state(clockColumn(i, 1)) << ','
+               << result.state(clockColumn(i, 2)) << ','
+               << result.state(clockColumn(i, 3)) << ','
+               << result.state(clockColumn(i, 4)) << ','
+               << result.state(driftColumn(i)) << ','
+               << (problem.clock_jumps[i] ? 1 : 0) << '\n';
+    }
+    return true;
+}
+
+bool writeFactorDebugCsv(const std::string& path,
+                         const Problem& problem,
+                         const SolveResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    output << "factor_type,epoch_index,gps_week,gps_tow,satellite,signal,"
+              "clock_group,snr_dbhz,elevation_deg,sigma_p_m,sigma_d_mps,"
+              "res_pc_m,res_d_mps,measured_range_rate_mps,"
+              "modeled_range_rate_mps,satellite_clock_drift_mps,"
+              "final_residual_m,los_x,los_y,los_z\n";
+    output << std::fixed << std::setprecision(15);
+    for (const PseudorangeFactor& factor : problem.pseudorange_factors) {
+        const double final_residual =
+            pseudorangePrediction(result.state, factor) - factor.residual_m;
+        output << "P,"
+               << factor.epoch_index << ','
+               << factor.time.week << ','
+               << factor.time.tow << ','
+               << factor.satellite.toString() << ','
+               << signalName(factor.signal) << ','
+               << factor.clock_group << ','
+               << factor.snr_dbhz << ','
+               << factor.elevation_rad * kRadiansToDegrees << ','
+               << factor.sigma_m << ",NaN,"
+               << factor.residual_m << ",NaN,NaN,NaN,NaN,"
+               << final_residual << ','
+               << factor.los(0) << ','
+               << factor.los(1) << ','
+               << factor.los(2) << '\n';
+    }
+    for (const DopplerFactor& factor : problem.factors) {
+        const double final_residual =
+            dopplerPrediction(result.state, factor) - factor.residual_mps;
+        output << "D,"
+               << factor.epoch_index << ','
+               << factor.time.week << ','
+               << factor.time.tow << ','
+               << factor.satellite.toString() << ','
+               << signalName(factor.signal) << ','
+               << clockGroup(factor.satellite.system) << ','
+               << factor.snr_dbhz << ','
+               << factor.elevation_rad * kRadiansToDegrees << ','
+               << "NaN,"
+               << factor.sigma_mps << ','
+               << "NaN,"
+               << factor.residual_mps << ','
+               << factor.measured_range_rate_mps << ','
+               << factor.modeled_range_rate_mps << ','
+               << factor.satellite_clock_drift_mps << ','
+               << final_residual << ','
+               << factor.los(0) << ','
+               << factor.los(1) << ','
+               << factor.los(2) << '\n';
+    }
+    return true;
+}
+
+std::size_t graphFactorCount(const Problem& problem) {
+    if (problem.epochs.empty()) {
+        return problem.pseudorange_factors.size() + problem.factors.size();
+    }
+    return problem.pseudorange_factors.size() +
+           problem.factors.size() +
+           4U * problem.epochs.size() +
+           3U * (problem.epochs.size() - 1U);
+}
+
+bool writeGraphCsv(const std::string& path,
+                   const Problem& problem,
+                   const SolveResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    output << "n,nsat,graph_factors,graph_values,initial_cost,final_cost,"
+              "optimizer_error,iterations,valid_position_epochs,"
+              "valid_velocity_epochs\n";
+    output << std::fixed << std::setprecision(15)
+           << problem.epochs.size() << ','
+           << problem.nsat << ','
+           << graphFactorCount(problem) << ','
+           << 4U * problem.epochs.size() << ','
+           << result.initial_cost << ','
+           << result.final_cost << ','
+           << result.final_cost << ','
+           << result.iterations << ','
+           << problem.epochs.size() << ','
+           << problem.epochs.size() << '\n';
+    return true;
+}
+
+std::string jsonBool(bool value) {
+    return value ? "true" : "false";
+}
+
+bool writeSummaryJson(const std::string& path,
+                      const Options& options,
+                      const Problem& problem,
+                      const SolveResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    const std::size_t epoch_count = problem.epochs.size();
+    output << std::fixed << std::setprecision(15)
+           << "{\n"
+           << "  \"preset\": \"taroz-pd\",\n"
+           << "  \"backend\": \"eigen\",\n"
+           << "  \"debug_problem_only\": " << jsonBool(options.debug_problem_only) << ",\n"
+           << "  \"optimized_epochs\": " << epoch_count << ",\n"
+           << "  \"valid_position_epochs\": " << epoch_count << ",\n"
+           << "  \"valid_velocity_epochs\": " << epoch_count << ",\n"
+           << "  \"seed_matched_epochs\": " << problem.seed_matched_epochs << ",\n"
+           << "  \"seed_interpolated_epochs\": " << problem.seed_interpolated_epochs << ",\n"
+           << "  \"nsat\": " << problem.nsat << ",\n"
+           << "  \"pseudorange_factors\": " << problem.pseudorange_factors.size() << ",\n"
+           << "  \"doppler_factors\": " << problem.factors.size() << ",\n"
+           << "  \"position_prior_factors\": " << epoch_count << ",\n"
+           << "  \"clock_prior_factors\": " << epoch_count << ",\n"
+           << "  \"velocity_prior_factors\": " << epoch_count << ",\n"
+           << "  \"clock_drift_prior_factors\": " << epoch_count << ",\n"
+           << "  \"motion_factors\": "
+           << (epoch_count > 0 ? epoch_count - 1U : 0U) << ",\n"
+           << "  \"clock_motion_factors\": "
+           << (epoch_count > 0 ? epoch_count - 1U : 0U) << ",\n"
+           << "  \"clock_drift_between_factors\": "
+           << (epoch_count > 0 ? epoch_count - 1U : 0U) << ",\n"
+           << "  \"graph_factors\": " << graphFactorCount(problem) << ",\n"
+           << "  \"graph_values\": " << 4U * epoch_count << ",\n"
+           << "  \"min_snr_dbhz\": " << options.min_snr_dbhz << ",\n"
+           << "  \"min_elevation_deg\": " << options.min_elevation_deg << ",\n"
+           << "  \"pseudorange_sigma_zenith_m\": "
+           << options.pseudorange_sigma_zenith_m << ",\n"
+           << "  \"doppler_sigma_zenith_mps\": "
+           << options.doppler_sigma_zenith_mps << ",\n"
+           << "  \"position_prior_sigma_m\": "
+           << options.position_prior_sigma_m << ",\n"
+           << "  \"clock_prior_sigma_m\": "
+           << options.clock_prior_sigma_m << ",\n"
+           << "  \"velocity_prior_sigma_mps\": "
+           << options.velocity_prior_sigma_mps << ",\n"
+           << "  \"clock_drift_prior_sigma_mps\": "
+           << options.clock_drift_prior_sigma_mps << ",\n"
+           << "  \"motion_sigma_m\": " << options.motion_sigma_m << ",\n"
+           << "  \"clock_motion_sigma_m\": "
+           << options.clock_motion_sigma_m << ",\n"
+           << "  \"clock_jump_sigma_m\": " << options.clock_jump_sigma_m << ",\n"
+           << "  \"clock_drift_between_sigma_mps\": "
+           << options.clock_drift_between_sigma_mps << ",\n"
+           << "  \"huber_threshold_sigma\": "
+           << options.huber_threshold_sigma << ",\n"
+           << "  \"iterations\": " << result.iterations << ",\n"
+           << "  \"converged\": " << jsonBool(result.converged) << ",\n"
+           << "  \"initial_cost\": " << result.initial_cost << ",\n"
+           << "  \"final_cost\": " << result.final_cost << ",\n"
+           << "  \"residual_rms_mps\": " << result.residual_rms_mps << "\n"
+           << "}\n";
+    return true;
+}
+
+void printSummary(const Problem& problem, const SolveResult& result) {
+    std::cout << "Taroz PD position/velocity batch complete\n"
+              << "  epochs: " << problem.epochs.size() << "\n"
+              << "  satellites: " << problem.nsat << "\n"
+              << "  pseudorange_factors: "
+              << problem.pseudorange_factors.size() << "\n"
+              << "  doppler_factors: " << problem.factors.size() << "\n"
+              << "  graph_factors: " << graphFactorCount(problem) << "\n"
+              << "  iterations: " << result.iterations << "\n"
+              << "  converged: " << (result.converged ? "true" : "false") << "\n"
+              << std::fixed << std::setprecision(6)
+              << "  initial_cost: " << result.initial_cost << "\n"
+              << "  final_cost: " << result.final_cost << "\n"
+              << "  residual_rms_mps: " << result.residual_rms_mps << "\n";
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+    try {
+        const Options options = parseArguments(argc, argv);
+        const Problem problem = buildProblem(options);
+        const SolveResult result = solveProblem(problem, options);
+
+        if (!writePerEpochCsv(options.out_csv_path, problem, result)) {
+            std::cerr << "Error: failed to write velocity CSV: "
+                      << options.out_csv_path << "\n";
+            return 1;
+        }
+        if (!writeFactorDebugCsv(options.factor_debug_csv_path, problem, result)) {
+            std::cerr << "Error: failed to write factor debug CSV: "
+                      << options.factor_debug_csv_path << "\n";
+            return 1;
+        }
+        if (!writeGraphCsv(options.graph_csv_path, problem, result)) {
+            std::cerr << "Error: failed to write graph CSV: "
+                      << options.graph_csv_path << "\n";
+            return 1;
+        }
+        if (!writeSummaryJson(options.summary_json_path, options, problem, result)) {
+            std::cerr << "Error: failed to write summary JSON: "
+                      << options.summary_json_path << "\n";
+            return 1;
+        }
+        if (!options.quiet) {
+            printSummary(problem, result);
+        }
+        return 0;
+    } catch (const std::invalid_argument&) {
+        return 2;
+    } catch (const std::exception& ex) {
+        std::cerr << "Error: " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/apps/gnss_pos_vel_pdc.cpp
+++ b/apps/gnss_pos_vel_pdc.cpp
@@ -1,0 +1,1998 @@
+#include <libgnss++/core/constants.hpp>
+#include <libgnss++/core/coordinates.hpp>
+#include <libgnss++/core/navigation.hpp>
+#include <libgnss++/core/observation.hpp>
+#include <libgnss++/core/signals.hpp>
+#include <libgnss++/io/rinex.hpp>
+#include <libgnss++/models/ionosphere.hpp>
+#include <libgnss++/models/troposphere.hpp>
+
+#include <Eigen/Sparse>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace {
+
+constexpr double kPi = 3.141592653589793238462643383279502884;
+constexpr double kDegreesToRadians = kPi / 180.0;
+constexpr double kRadiansToDegrees = 180.0 / kPi;
+constexpr std::size_t kClockGroups = 5;
+constexpr std::size_t kStateStride = 12;
+
+struct Options {
+    std::string obs_path;
+    std::string nav_path;
+    std::string seed_pos_path;
+    std::string out_csv_path;
+    std::string factor_debug_csv_path;
+    std::string graph_csv_path;
+    std::string summary_json_path;
+    int skip_epochs = 0;
+    int max_epochs = 0;
+    int max_iterations = 1000;
+    double seed_match_tolerance_s = 0.51;
+    double seed_interpolation_max_gap_s = 60.0;
+    double min_snr_dbhz = 35.0;
+    double min_elevation_deg = 15.0;
+    double pseudorange_sigma_zenith_m = 3.0;
+    double doppler_sigma_zenith_mps = 0.2;
+    double tdcp_sigma_zenith_m = 0.05;
+    double position_prior_sigma_m = 1000.0;
+    double clock_prior_sigma_m = 1e6;
+    double velocity_prior_sigma_mps = 1000.0;
+    double clock_drift_prior_sigma_mps = 1000.0;
+    double motion_sigma_m = 0.1;
+    double clock_motion_sigma_m = 0.1;
+    double clock_jump_sigma_m = 1e6;
+    double inter_system_clock_motion_sigma_m = 1e-6;
+    double clock_drift_between_sigma_mps = 0.1;
+    double huber_threshold_sigma = 1.234;
+    bool debug_problem_only = false;
+    bool quiet = false;
+};
+
+struct SeedPosition {
+    libgnss::GNSSTime time;
+    libgnss::Vector3d position_ecef = libgnss::Vector3d::Zero();
+};
+
+struct DopplerFactor {
+    std::size_t epoch_index = 0;
+    libgnss::GNSSTime time;
+    libgnss::SatelliteId satellite;
+    libgnss::SignalType signal = libgnss::SignalType::GPS_L1CA;
+    double snr_dbhz = 0.0;
+    double elevation_rad = 0.0;
+    double sigma_mps = 1.0;
+    double residual_mps = 0.0;
+    double measured_range_rate_mps = 0.0;
+    double modeled_range_rate_mps = 0.0;
+    double satellite_clock_drift_mps = 0.0;
+    double wavelength_m = 0.0;
+    libgnss::Vector3d los = libgnss::Vector3d::Zero();
+};
+
+struct PseudorangeFactor {
+    std::size_t epoch_index = 0;
+    libgnss::GNSSTime time;
+    libgnss::SatelliteId satellite;
+    libgnss::SignalType signal = libgnss::SignalType::GPS_L1CA;
+    std::size_t clock_group = 0;
+    double snr_dbhz = 0.0;
+    double elevation_rad = 0.0;
+    double sigma_m = 1.0;
+    double residual_m = 0.0;
+    double corrected_pseudorange_m = 0.0;
+    double modeled_range_m = 0.0;
+    double ionosphere_delay_m = 0.0;
+    double troposphere_delay_m = 0.0;
+    double satellite_clock_m = 0.0;
+    double group_delay_m = 0.0;
+    libgnss::Vector3d los = libgnss::Vector3d::Zero();
+};
+
+using ObservationKey = std::tuple<libgnss::SatelliteId, libgnss::SignalType>;
+
+struct CarrierResidual {
+    std::size_t epoch_index = 0;
+    libgnss::GNSSTime time;
+    libgnss::SatelliteId satellite;
+    libgnss::SignalType signal = libgnss::SignalType::GPS_L1CA;
+    double snr_dbhz = 0.0;
+    double elevation_rad = 0.0;
+    double residual_m = 0.0;
+    double corrected_carrier_m = 0.0;
+    double modeled_range_m = 0.0;
+    double raw_carrier_cycles = 0.0;
+    double wavelength_m = 0.0;
+    double ionosphere_delay_m = 0.0;
+    double troposphere_delay_m = 0.0;
+    double satellite_clock_m = 0.0;
+    std::uint8_t lli = 0;
+    bool loss_of_lock = false;
+    libgnss::Vector3d los = libgnss::Vector3d::Zero();
+};
+
+struct TdcpFactor {
+    std::size_t epoch_index = 0;
+    std::size_t previous_epoch_index = 0;
+    libgnss::GNSSTime time;
+    libgnss::SatelliteId satellite;
+    libgnss::SignalType signal = libgnss::SignalType::GPS_L1CA;
+    double snr_dbhz = 0.0;
+    double elevation_rad = 0.0;
+    double previous_elevation_rad = 0.0;
+    double sigma_m = 1.0;
+    double residual_m = 0.0;
+    double previous_carrier_residual_m = 0.0;
+    double current_carrier_residual_m = 0.0;
+    double previous_raw_carrier_cycles = 0.0;
+    double current_raw_carrier_cycles = 0.0;
+    double wavelength_m = 0.0;
+    libgnss::Vector3d los = libgnss::Vector3d::Zero();
+};
+
+struct Problem {
+    std::vector<libgnss::ObservationData> epochs;
+    std::vector<libgnss::Vector3d> seed_positions;
+    std::vector<PseudorangeFactor> pseudorange_factors;
+    std::vector<DopplerFactor> factors;
+    std::vector<TdcpFactor> tdcp_factors;
+    std::vector<bool> clock_jumps;
+    std::size_t nsat = 0;
+    std::size_t seed_matched_epochs = 0;
+    std::size_t seed_interpolated_epochs = 0;
+};
+
+struct SolveResult {
+    Eigen::VectorXd state;
+    double initial_cost = 0.0;
+    double final_cost = 0.0;
+    double residual_rms_mps = 0.0;
+    int iterations = 0;
+    bool converged = false;
+};
+
+[[noreturn]] void usageError(const std::string& message, const char* argv0) {
+    std::cerr << "Error: " << message << "\n\n"
+              << "Usage: " << argv0 << " --obs rover.obs --nav base.nav "
+              << "--seed-pos rover_1Hz_spp.pos [options]\n\n"
+              << "Options:\n"
+              << "  --out-csv PATH                 Write per-epoch position/velocity CSV.\n"
+              << "  --factor-debug-csv PATH        Write per-factor debug CSV.\n"
+              << "  --graph-csv PATH               Write taroz-like graph detail CSV.\n"
+              << "  --summary-json PATH            Write JSON summary.\n"
+              << "  --max-epochs N                 Limit processed epochs; 0 means all.\n"
+              << "  --skip-epochs N                Skip leading observation epochs.\n"
+              << "  --max-iterations N             IRLS iteration limit.\n"
+              << "  --tdcp-sigma-zenith M          TDCP zenith sigma in meters.\n"
+              << "  --debug-problem-only           Build factors and skip optimization.\n"
+              << "  --quiet                        Suppress human-readable summary.\n";
+    throw std::invalid_argument(message);
+}
+
+int parseIntArg(const std::string& value, const std::string& name, const char* argv0) {
+    try {
+        std::size_t consumed = 0;
+        const int parsed = std::stoi(value, &consumed);
+        if (consumed == value.size()) {
+            return parsed;
+        }
+    } catch (const std::exception&) {
+    }
+    usageError("invalid integer for " + name + ": " + value, argv0);
+}
+
+double parseDoubleArg(const std::string& value, const std::string& name, const char* argv0) {
+    try {
+        std::size_t consumed = 0;
+        const double parsed = std::stod(value, &consumed);
+        if (consumed == value.size() && std::isfinite(parsed)) {
+            return parsed;
+        }
+    } catch (const std::exception&) {
+    }
+    usageError("invalid number for " + name + ": " + value, argv0);
+}
+
+Options parseArguments(int argc, char* argv[]) {
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        auto require_value = [&](const std::string& name) -> std::string {
+            if (i + 1 >= argc) {
+                usageError("missing value for " + name, argv[0]);
+            }
+            return argv[++i];
+        };
+
+        if (arg == "--obs") {
+            options.obs_path = require_value(arg);
+        } else if (arg == "--nav") {
+            options.nav_path = require_value(arg);
+        } else if (arg == "--seed-pos") {
+            options.seed_pos_path = require_value(arg);
+        } else if (arg == "--out-csv") {
+            options.out_csv_path = require_value(arg);
+        } else if (arg == "--factor-debug-csv") {
+            options.factor_debug_csv_path = require_value(arg);
+        } else if (arg == "--graph-csv") {
+            options.graph_csv_path = require_value(arg);
+        } else if (arg == "--summary-json") {
+            options.summary_json_path = require_value(arg);
+        } else if (arg == "--skip-epochs") {
+            options.skip_epochs = parseIntArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--max-epochs") {
+            options.max_epochs = parseIntArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--max-iterations") {
+            options.max_iterations = parseIntArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--seed-match-tolerance") {
+            options.seed_match_tolerance_s = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--seed-interpolation-max-gap") {
+            options.seed_interpolation_max_gap_s = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--min-snr") {
+            options.min_snr_dbhz = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--min-elevation") {
+            options.min_elevation_deg = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--pseudorange-sigma-zenith") {
+            options.pseudorange_sigma_zenith_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--doppler-sigma-zenith") {
+            options.doppler_sigma_zenith_mps = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--tdcp-sigma-zenith") {
+            options.tdcp_sigma_zenith_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--position-prior-sigma") {
+            options.position_prior_sigma_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--clock-prior-sigma") {
+            options.clock_prior_sigma_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--velocity-prior-sigma") {
+            options.velocity_prior_sigma_mps = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--clock-drift-prior-sigma") {
+            options.clock_drift_prior_sigma_mps = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--motion-sigma") {
+            options.motion_sigma_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--clock-motion-sigma") {
+            options.clock_motion_sigma_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--clock-jump-sigma") {
+            options.clock_jump_sigma_m = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--isb-motion-sigma") {
+            options.inter_system_clock_motion_sigma_m =
+                parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--clock-drift-between-sigma") {
+            options.clock_drift_between_sigma_mps = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--huber-threshold") {
+            options.huber_threshold_sigma = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--debug-problem-only") {
+            options.debug_problem_only = true;
+        } else if (arg == "--quiet") {
+            options.quiet = true;
+        } else if (arg == "--help" || arg == "-h") {
+            usageError("help requested", argv[0]);
+        } else {
+            usageError("unknown argument: " + arg, argv[0]);
+        }
+    }
+
+    if (options.obs_path.empty()) {
+        usageError("--obs is required", argv[0]);
+    }
+    if (options.nav_path.empty()) {
+        usageError("--nav is required", argv[0]);
+    }
+    if (options.seed_pos_path.empty()) {
+        usageError("--seed-pos is required", argv[0]);
+    }
+    if (options.skip_epochs < 0 || options.max_epochs < 0 ||
+        options.max_iterations < 0) {
+        usageError("epoch and iteration limits must be non-negative", argv[0]);
+    }
+    if (options.seed_match_tolerance_s < 0.0 ||
+        options.seed_interpolation_max_gap_s < 0.0 ||
+        options.pseudorange_sigma_zenith_m <= 0.0 ||
+        options.doppler_sigma_zenith_mps <= 0.0 ||
+        options.tdcp_sigma_zenith_m <= 0.0 ||
+        options.position_prior_sigma_m <= 0.0 ||
+        options.clock_prior_sigma_m <= 0.0 ||
+        options.velocity_prior_sigma_mps <= 0.0 ||
+        options.clock_drift_prior_sigma_mps <= 0.0 ||
+        options.motion_sigma_m <= 0.0 ||
+        options.clock_motion_sigma_m <= 0.0 ||
+        options.clock_jump_sigma_m <= 0.0 ||
+        options.inter_system_clock_motion_sigma_m <= 0.0 ||
+        options.clock_drift_between_sigma_mps <= 0.0 ||
+        options.huber_threshold_sigma <= 0.0) {
+        usageError("sigma, threshold, and tolerance values must be positive", argv[0]);
+    }
+    return options;
+}
+
+bool isPrimaryPdSignal(libgnss::SignalType signal) {
+    switch (signal) {
+        case libgnss::SignalType::GPS_L1CA:
+        case libgnss::SignalType::GLO_L1CA:
+        case libgnss::SignalType::GAL_E1:
+        case libgnss::SignalType::BDS_B1I:
+        case libgnss::SignalType::BDS_B1C:
+        case libgnss::SignalType::QZS_L1CA:
+            return true;
+        default:
+            return false;
+    }
+}
+
+std::string signalName(libgnss::SignalType signal) {
+    switch (signal) {
+        case libgnss::SignalType::GPS_L1CA: return "GPS_L1CA";
+        case libgnss::SignalType::GLO_L1CA: return "GLO_L1CA";
+        case libgnss::SignalType::GAL_E1: return "GAL_E1";
+        case libgnss::SignalType::BDS_B1I: return "BDS_B1I";
+        case libgnss::SignalType::BDS_B1C: return "BDS_B1C";
+        case libgnss::SignalType::QZS_L1CA: return "QZS_L1CA";
+        default: return "UNKNOWN";
+    }
+}
+
+bool isHealthyForPositioning(const libgnss::Observation& observation,
+                             const libgnss::Ephemeris& eph) {
+    int sv_health = static_cast<int>(eph.health);
+    if (observation.satellite.system == libgnss::GNSSSystem::QZSS) {
+        sv_health &= 0xFE;
+    }
+    return sv_health == 0;
+}
+
+std::size_t clockGroup(libgnss::GNSSSystem system) {
+    switch (system) {
+        case libgnss::GNSSSystem::GPS:
+            return 0U;
+        case libgnss::GNSSSystem::GLONASS:
+            return 1U;
+        case libgnss::GNSSSystem::Galileo:
+            return 2U;
+        case libgnss::GNSSSystem::QZSS:
+            return 3U;
+        case libgnss::GNSSSystem::BeiDou:
+            return 4U;
+        default:
+            return 0U;
+    }
+}
+
+double groupDelayCorrectionMeters(const libgnss::Observation& observation,
+                                  const libgnss::Ephemeris& eph) {
+    switch (observation.satellite.system) {
+        case libgnss::GNSSSystem::GPS:
+        case libgnss::GNSSSystem::QZSS:
+        case libgnss::GNSSSystem::Galileo:
+            return eph.tgd * libgnss::constants::SPEED_OF_LIGHT;
+        case libgnss::GNSSSystem::BeiDou:
+            switch (observation.signal) {
+                case libgnss::SignalType::BDS_B1I:
+                case libgnss::SignalType::BDS_B1C:
+                    return eph.tgd * libgnss::constants::SPEED_OF_LIGHT;
+                case libgnss::SignalType::BDS_B2I:
+                case libgnss::SignalType::BDS_B2A:
+                    return eph.tgd_secondary * libgnss::constants::SPEED_OF_LIGHT;
+                default:
+                    return 0.0;
+            }
+        default:
+            return 0.0;
+    }
+}
+
+double sagnacRangeCorrection(const libgnss::Vector3d& satellite_position,
+                             const libgnss::Vector3d& receiver_position) {
+    return libgnss::constants::OMEGA_E / libgnss::constants::SPEED_OF_LIGHT *
+           (satellite_position(0) * receiver_position(1) -
+            satellite_position(1) * receiver_position(0));
+}
+
+bool parseSeparatedIntegers(std::string value,
+                            char separator,
+                            int& first,
+                            int& second,
+                            int& third) {
+    std::replace(value.begin(), value.end(), separator, ' ');
+    std::istringstream input(value);
+    return static_cast<bool>(input >> first >> second >> third);
+}
+
+bool parseRtklibTime(std::string value,
+                     int& hour,
+                     int& minute,
+                     double& second) {
+    std::replace(value.begin(), value.end(), ':', ' ');
+    std::istringstream input(value);
+    return static_cast<bool>(input >> hour >> minute >> second);
+}
+
+bool isLeapYear(int year) {
+    return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+}
+
+libgnss::GNSSTime gpstCalendarToTime(int year,
+                                     int month,
+                                     int day,
+                                     int hour,
+                                     int minute,
+                                     double second) {
+    int days_since_gps_epoch = 0;
+    for (int current_year = 1980; current_year < year; ++current_year) {
+        days_since_gps_epoch += isLeapYear(current_year) ? 366 : 365;
+    }
+
+    int days_in_month[] = {
+        31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    if (isLeapYear(year)) {
+        days_in_month[1] = 29;
+    }
+    for (int current_month = 1; current_month < month; ++current_month) {
+        days_since_gps_epoch += days_in_month[current_month - 1];
+    }
+    days_since_gps_epoch += day;
+    days_since_gps_epoch -= 6;
+
+    const int gps_week = days_since_gps_epoch / 7;
+    const int day_of_week = days_since_gps_epoch % 7;
+    const double tow = static_cast<double>(day_of_week) * 86400.0 +
+                       static_cast<double>(hour) * 3600.0 +
+                       static_cast<double>(minute) * 60.0 + second;
+    return libgnss::GNSSTime(gps_week, tow);
+}
+
+bool parseRtklibSeedPositionLine(const std::string& line, SeedPosition& seed) {
+    std::istringstream input(line);
+    std::string date_token;
+    std::string time_token;
+    if (!(input >> date_token >> time_token)) {
+        return false;
+    }
+
+    int year = 0;
+    int month = 0;
+    int day = 0;
+    int hour = 0;
+    int minute = 0;
+    double second = 0.0;
+    if (!parseSeparatedIntegers(date_token, '/', year, month, day) ||
+        !parseRtklibTime(time_token, hour, minute, second)) {
+        return false;
+    }
+
+    double latitude_deg = 0.0;
+    double longitude_deg = 0.0;
+    double height_m = 0.0;
+    if (!(input >> latitude_deg >> longitude_deg >> height_m)) {
+        return false;
+    }
+    if (!std::isfinite(latitude_deg) || !std::isfinite(longitude_deg) ||
+        !std::isfinite(height_m)) {
+        return false;
+    }
+
+    seed.time = gpstCalendarToTime(year, month, day, hour, minute, second);
+    seed.position_ecef = libgnss::geodetic2ecef(latitude_deg * kDegreesToRadians,
+                                                longitude_deg * kDegreesToRadians,
+                                                height_m);
+    return seed.position_ecef.norm() > 1e6;
+}
+
+bool parseSeedPositionLine(const std::string& line, SeedPosition& seed) {
+    std::istringstream input(line);
+    std::string first_token;
+    if (!(input >> first_token)) {
+        return false;
+    }
+    if (first_token[0] == '%' || first_token[0] == '#') {
+        return false;
+    }
+    if (first_token.find('/') != std::string::npos) {
+        return parseRtklibSeedPositionLine(line, seed);
+    }
+
+    int week = 0;
+    try {
+        std::size_t consumed = 0;
+        week = std::stoi(first_token, &consumed);
+        if (consumed != first_token.size()) {
+            return false;
+        }
+    } catch (const std::exception&) {
+        return false;
+    }
+
+    double tow = 0.0;
+    double x = 0.0;
+    double y = 0.0;
+    double z = 0.0;
+    if (!(input >> tow >> x >> y >> z)) {
+        return false;
+    }
+    if (!std::isfinite(tow) || !std::isfinite(x) ||
+        !std::isfinite(y) || !std::isfinite(z)) {
+        return false;
+    }
+
+    seed.time = libgnss::GNSSTime(week, tow);
+    seed.position_ecef = libgnss::Vector3d(x, y, z);
+    return seed.position_ecef.norm() > 1e6;
+}
+
+std::vector<SeedPosition> readSeedPositions(const std::string& path) {
+    std::ifstream input(path);
+    if (!input.is_open()) {
+        throw std::runtime_error("failed to open seed POS file: " + path);
+    }
+
+    std::vector<SeedPosition> seeds;
+    std::string line;
+    while (std::getline(input, line)) {
+        SeedPosition seed;
+        if (parseSeedPositionLine(line, seed)) {
+            seeds.push_back(seed);
+        }
+    }
+    if (seeds.empty()) {
+        throw std::runtime_error(
+            "seed POS file has no readable LibGNSS++ or RTKLIB POS rows: " + path);
+    }
+
+    std::sort(seeds.begin(),
+              seeds.end(),
+              [](const SeedPosition& lhs, const SeedPosition& rhs) {
+                  return lhs.time < rhs.time;
+              });
+    return seeds;
+}
+
+bool findSeedPosition(const std::vector<SeedPosition>& seeds,
+                      const libgnss::GNSSTime& time,
+                      double tolerance_s,
+                      double interpolation_max_gap_s,
+                      std::size_t& cursor,
+                      libgnss::Vector3d& position_ecef,
+                      bool& interpolated) {
+    interpolated = false;
+    while (cursor < seeds.size() && seeds[cursor].time - time < -tolerance_s) {
+        ++cursor;
+    }
+
+    std::size_t best_index = seeds.size();
+    double best_abs_dt = tolerance_s;
+    if (cursor < seeds.size()) {
+        const double abs_dt = std::abs(seeds[cursor].time - time);
+        if (abs_dt <= best_abs_dt) {
+            best_index = cursor;
+            best_abs_dt = abs_dt;
+        }
+    }
+    if (cursor > 0) {
+        const std::size_t previous_index = cursor - 1;
+        const double abs_dt = std::abs(seeds[previous_index].time - time);
+        if (abs_dt <= best_abs_dt) {
+            best_index = previous_index;
+        }
+    }
+    if (best_index == seeds.size()) {
+        if (interpolation_max_gap_s <= 0.0 || cursor == 0 ||
+            cursor >= seeds.size()) {
+            return false;
+        }
+        const SeedPosition& lower = seeds[cursor - 1];
+        const SeedPosition& upper = seeds[cursor];
+        const double gap_s = upper.time - lower.time;
+        const double lower_dt_s = time - lower.time;
+        if (gap_s <= 0.0 || gap_s > interpolation_max_gap_s ||
+            lower_dt_s < 0.0 || lower_dt_s > gap_s) {
+            return false;
+        }
+        const double alpha = lower_dt_s / gap_s;
+        position_ecef =
+            lower.position_ecef +
+            alpha * (upper.position_ecef - lower.position_ecef);
+        interpolated = true;
+        return position_ecef.norm() > 1e6;
+    }
+
+    position_ecef = seeds[best_index].position_ecef;
+    return true;
+}
+
+void writeCsvDouble(std::ostream& output, double value) {
+    if (std::isfinite(value)) {
+        output << value;
+    } else {
+        output << "NaN";
+    }
+}
+
+double robustHuberLoss(double whitened_error, double threshold) {
+    const double abs_error = std::abs(whitened_error);
+    if (abs_error <= threshold) {
+        return 0.5 * whitened_error * whitened_error;
+    }
+    return threshold * (abs_error - 0.5 * threshold);
+}
+
+double robustHuberWeight(double whitened_error, double threshold) {
+    const double abs_error = std::abs(whitened_error);
+    if (abs_error <= threshold || abs_error <= 0.0) {
+        return 1.0;
+    }
+    return threshold / abs_error;
+}
+
+int positionColumn(std::size_t epoch_index, int component) {
+    return static_cast<int>(kStateStride * epoch_index +
+                            static_cast<std::size_t>(component));
+}
+
+int clockColumn(std::size_t epoch_index, std::size_t group) {
+    return static_cast<int>(kStateStride * epoch_index + 3U + group);
+}
+
+int velocityColumn(std::size_t epoch_index, int component) {
+    return static_cast<int>(kStateStride * epoch_index + 8U +
+                            static_cast<std::size_t>(component));
+}
+
+int driftColumn(std::size_t epoch_index) {
+    return static_cast<int>(kStateStride * epoch_index + 11U);
+}
+
+double pseudorangePrediction(const Eigen::VectorXd& state,
+                             const PseudorangeFactor& factor) {
+    const std::size_t i = factor.epoch_index;
+    double prediction =
+        factor.los(0) * state(positionColumn(i, 0)) +
+        factor.los(1) * state(positionColumn(i, 1)) +
+        factor.los(2) * state(positionColumn(i, 2)) +
+        state(clockColumn(i, 0));
+    if (factor.clock_group != 0U) {
+        prediction += state(clockColumn(i, factor.clock_group));
+    }
+    return prediction;
+}
+
+double dopplerPrediction(const Eigen::VectorXd& state, const DopplerFactor& factor) {
+    const std::size_t i = factor.epoch_index;
+    return factor.los(0) * state(velocityColumn(i, 0)) +
+           factor.los(1) * state(velocityColumn(i, 1)) +
+           factor.los(2) * state(velocityColumn(i, 2)) +
+           state(driftColumn(i));
+}
+
+double tdcpPrediction(const Eigen::VectorXd& state, const TdcpFactor& factor) {
+    const std::size_t i = factor.epoch_index;
+    const std::size_t previous = factor.previous_epoch_index;
+    return factor.los(0) *
+               (state(positionColumn(i, 0)) -
+                state(positionColumn(previous, 0))) +
+           factor.los(1) *
+               (state(positionColumn(i, 1)) -
+                state(positionColumn(previous, 1))) +
+           factor.los(2) *
+               (state(positionColumn(i, 2)) -
+                state(positionColumn(previous, 2))) +
+           state(clockColumn(i, 0)) -
+           state(clockColumn(previous, 0));
+}
+
+double computeCost(const Problem& problem,
+                   const Options& options,
+                   const Eigen::VectorXd& state) {
+    double cost = 0.0;
+    for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
+        for (int component = 0; component < 3; ++component) {
+            const double e =
+                state(positionColumn(i, component)) /
+                options.position_prior_sigma_m;
+            cost += 0.5 * e * e;
+        }
+        for (std::size_t group = 0; group < kClockGroups; ++group) {
+            const double e =
+                state(clockColumn(i, group)) / options.clock_prior_sigma_m;
+            cost += 0.5 * e * e;
+        }
+        for (int component = 0; component < 3; ++component) {
+            const double e =
+                state(velocityColumn(i, component)) /
+                options.velocity_prior_sigma_mps;
+            cost += 0.5 * e * e;
+        }
+        const double d_prior =
+            state(driftColumn(i)) / options.clock_drift_prior_sigma_mps;
+        cost += 0.5 * d_prior * d_prior;
+        if (i > 0) {
+            for (std::size_t group = 0; group < kClockGroups; ++group) {
+                const double sigma =
+                    group == 0U
+                        ? (problem.clock_jumps[i]
+                               ? options.clock_jump_sigma_m
+                               : options.clock_motion_sigma_m)
+                        : options.inter_system_clock_motion_sigma_m;
+                double prediction =
+                    state(clockColumn(i, group)) -
+                    state(clockColumn(i - 1U, group));
+                if (group == 0U) {
+                    prediction -= 0.5 *
+                                  (state(driftColumn(i - 1U)) +
+                                   state(driftColumn(i)));
+                }
+                const double e = prediction / sigma;
+                cost += 0.5 * e * e;
+            }
+
+            for (int component = 0; component < 3; ++component) {
+                const double seed_delta =
+                    problem.seed_positions[i](component) -
+                    problem.seed_positions[i - 1U](component);
+                const double prediction =
+                    seed_delta +
+                    state(positionColumn(i, component)) -
+                    state(positionColumn(i - 1U, component)) -
+                    0.5 * (state(velocityColumn(i - 1U, component)) +
+                           state(velocityColumn(i, component)));
+                const double e = prediction / options.motion_sigma_m;
+                cost += 0.5 * e * e;
+            }
+
+            const double between =
+                (state(driftColumn(i)) - state(driftColumn(i - 1U))) /
+                options.clock_drift_between_sigma_mps;
+            cost += 0.5 * between * between;
+        }
+    }
+
+    for (const PseudorangeFactor& factor : problem.pseudorange_factors) {
+        const double error =
+            (pseudorangePrediction(state, factor) - factor.residual_m) /
+            factor.sigma_m;
+        cost += robustHuberLoss(error, options.huber_threshold_sigma);
+    }
+
+    for (const DopplerFactor& factor : problem.factors) {
+        const double error =
+            (dopplerPrediction(state, factor) - factor.residual_mps) /
+            factor.sigma_mps;
+        cost += robustHuberLoss(error, options.huber_threshold_sigma);
+    }
+    for (const TdcpFactor& factor : problem.tdcp_factors) {
+        const double error =
+            (tdcpPrediction(state, factor) - factor.residual_m) /
+            factor.sigma_m;
+        cost += robustHuberLoss(error, options.huber_threshold_sigma);
+    }
+    return cost;
+}
+
+struct NormalEquation {
+    Eigen::SparseMatrix<double> hessian;
+    Eigen::VectorXd rhs;
+};
+
+void addWeightedRow(std::vector<Eigen::Triplet<double>>& triplets,
+                    Eigen::VectorXd& rhs,
+                    const std::vector<int>& columns,
+                    const std::vector<double>& coefficients,
+                    double residual,
+                    double sigma,
+                    double robust_weight) {
+    const double inv_variance = robust_weight / (sigma * sigma);
+    for (std::size_t a = 0; a < columns.size(); ++a) {
+        const double weighted_a = inv_variance * coefficients[a];
+        rhs(columns[a]) += weighted_a * residual;
+        for (std::size_t b = 0; b < columns.size(); ++b) {
+            triplets.emplace_back(columns[a],
+                                  columns[b],
+                                  weighted_a * coefficients[b]);
+        }
+    }
+}
+
+NormalEquation buildNormalEquation(const Problem& problem,
+                                   const Options& options,
+                                   const Eigen::VectorXd& state) {
+    const int state_size = static_cast<int>(kStateStride * problem.epochs.size());
+    std::vector<Eigen::Triplet<double>> triplets;
+    triplets.reserve((problem.pseudorange_factors.size() +
+                      problem.factors.size() +
+                      problem.tdcp_factors.size()) * 16U +
+                     problem.epochs.size() * 80U);
+    Eigen::VectorXd rhs = Eigen::VectorXd::Zero(state_size);
+
+    for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
+        for (int component = 0; component < 3; ++component) {
+            const int col = positionColumn(i, component);
+            addWeightedRow(triplets,
+                           rhs,
+                           {col},
+                           {1.0},
+                           -state(col),
+                           options.position_prior_sigma_m,
+                           1.0);
+        }
+        for (std::size_t group = 0; group < kClockGroups; ++group) {
+            const int col = clockColumn(i, group);
+            addWeightedRow(triplets,
+                           rhs,
+                           {col},
+                           {1.0},
+                           -state(col),
+                           options.clock_prior_sigma_m,
+                           1.0);
+        }
+        for (int component = 0; component < 3; ++component) {
+            const int col = velocityColumn(i, component);
+            addWeightedRow(triplets,
+                           rhs,
+                           {col},
+                           {1.0},
+                           -state(col),
+                           options.velocity_prior_sigma_mps,
+                           1.0);
+        }
+
+        const int d_col = driftColumn(i);
+        addWeightedRow(triplets,
+                       rhs,
+                       {d_col},
+                       {1.0},
+                       -state(d_col),
+                       options.clock_drift_prior_sigma_mps,
+                       1.0);
+
+        if (i > 0) {
+            for (std::size_t group = 0; group < kClockGroups; ++group) {
+                const int previous = clockColumn(i - 1U, group);
+                const int current = clockColumn(i, group);
+                const double sigma =
+                    group == 0U
+                        ? (problem.clock_jumps[i]
+                               ? options.clock_jump_sigma_m
+                               : options.clock_motion_sigma_m)
+                        : options.inter_system_clock_motion_sigma_m;
+                std::vector<int> columns{previous, current};
+                std::vector<double> coeffs{-1.0, 1.0};
+                double prediction = state(current) - state(previous);
+                if (group == 0U) {
+                    const int previous_drift = driftColumn(i - 1U);
+                    const int current_drift = driftColumn(i);
+                    columns.push_back(previous_drift);
+                    columns.push_back(current_drift);
+                    coeffs.push_back(-0.5);
+                    coeffs.push_back(-0.5);
+                    prediction -= 0.5 *
+                                  (state(previous_drift) + state(current_drift));
+                }
+                addWeightedRow(triplets,
+                               rhs,
+                               columns,
+                               coeffs,
+                               -prediction,
+                               sigma,
+                               1.0);
+            }
+
+            for (int component = 0; component < 3; ++component) {
+                const int previous_position = positionColumn(i - 1U, component);
+                const int current_position = positionColumn(i, component);
+                const int previous_velocity = velocityColumn(i - 1U, component);
+                const int current_velocity = velocityColumn(i, component);
+                const double seed_delta =
+                    problem.seed_positions[i](component) -
+                    problem.seed_positions[i - 1U](component);
+                const double prediction =
+                    seed_delta +
+                    state(current_position) -
+                    state(previous_position) -
+                    0.5 * (state(previous_velocity) + state(current_velocity));
+                addWeightedRow(triplets,
+                               rhs,
+                               {previous_position,
+                                current_position,
+                                previous_velocity,
+                                current_velocity},
+                               {-1.0, 1.0, -0.5, -0.5},
+                               -prediction,
+                               options.motion_sigma_m,
+                               1.0);
+            }
+
+            const int previous = driftColumn(i - 1U);
+            const int current = driftColumn(i);
+            const double prediction = state(current) - state(previous);
+            addWeightedRow(triplets,
+                           rhs,
+                           {previous, current},
+                           {-1.0, 1.0},
+                           -prediction,
+                           options.clock_drift_between_sigma_mps,
+                           1.0);
+        }
+    }
+
+    for (const PseudorangeFactor& factor : problem.pseudorange_factors) {
+        const std::size_t i = factor.epoch_index;
+        const double prediction = pseudorangePrediction(state, factor);
+        const double residual = factor.residual_m - prediction;
+        const double whitened_error = -residual / factor.sigma_m;
+        const double robust_weight =
+            robustHuberWeight(whitened_error, options.huber_threshold_sigma);
+        std::vector<int> columns{
+            positionColumn(i, 0),
+            positionColumn(i, 1),
+            positionColumn(i, 2),
+            clockColumn(i, 0),
+        };
+        std::vector<double> coeffs{
+            factor.los(0),
+            factor.los(1),
+            factor.los(2),
+            1.0,
+        };
+        if (factor.clock_group != 0U) {
+            columns.push_back(clockColumn(i, factor.clock_group));
+            coeffs.push_back(1.0);
+        }
+        addWeightedRow(triplets,
+                       rhs,
+                       columns,
+                       coeffs,
+                       residual,
+                       factor.sigma_m,
+                       robust_weight);
+    }
+
+    for (const DopplerFactor& factor : problem.factors) {
+        const std::size_t i = factor.epoch_index;
+        const double prediction = dopplerPrediction(state, factor);
+        const double residual = factor.residual_mps - prediction;
+        const double whitened_error = -residual / factor.sigma_mps;
+        const double robust_weight =
+            robustHuberWeight(whitened_error, options.huber_threshold_sigma);
+        addWeightedRow(triplets,
+                       rhs,
+                       {velocityColumn(i, 0),
+                        velocityColumn(i, 1),
+                        velocityColumn(i, 2),
+                        driftColumn(i)},
+                       {factor.los(0), factor.los(1), factor.los(2), 1.0},
+                       residual,
+                       factor.sigma_mps,
+                       robust_weight);
+    }
+
+    for (const TdcpFactor& factor : problem.tdcp_factors) {
+        const std::size_t i = factor.epoch_index;
+        const std::size_t previous = factor.previous_epoch_index;
+        const double prediction = tdcpPrediction(state, factor);
+        const double residual = factor.residual_m - prediction;
+        const double whitened_error = -residual / factor.sigma_m;
+        const double robust_weight =
+            robustHuberWeight(whitened_error, options.huber_threshold_sigma);
+        addWeightedRow(triplets,
+                       rhs,
+                       {positionColumn(previous, 0),
+                        positionColumn(i, 0),
+                        positionColumn(previous, 1),
+                        positionColumn(i, 1),
+                        positionColumn(previous, 2),
+                        positionColumn(i, 2),
+                        clockColumn(previous, 0),
+                        clockColumn(i, 0)},
+                       {-factor.los(0),
+                        factor.los(0),
+                        -factor.los(1),
+                        factor.los(1),
+                        -factor.los(2),
+                        factor.los(2),
+                        -1.0,
+                        1.0},
+                       residual,
+                       factor.sigma_m,
+                       robust_weight);
+    }
+
+    NormalEquation normal;
+    normal.hessian.resize(state_size, state_size);
+    normal.hessian.setFromTriplets(triplets.begin(), triplets.end());
+    normal.rhs = std::move(rhs);
+    return normal;
+}
+
+double residualRms(const Problem& problem, const Eigen::VectorXd& state) {
+    const std::size_t count =
+        problem.pseudorange_factors.size() +
+        problem.factors.size() +
+        problem.tdcp_factors.size();
+    if (count == 0U) {
+        return 0.0;
+    }
+    double sum_sq = 0.0;
+    for (const PseudorangeFactor& factor : problem.pseudorange_factors) {
+        const double residual =
+            pseudorangePrediction(state, factor) - factor.residual_m;
+        sum_sq += residual * residual;
+    }
+    for (const DopplerFactor& factor : problem.factors) {
+        const double residual =
+            dopplerPrediction(state, factor) - factor.residual_mps;
+        sum_sq += residual * residual;
+    }
+    for (const TdcpFactor& factor : problem.tdcp_factors) {
+        const double residual =
+            tdcpPrediction(state, factor) - factor.residual_m;
+        sum_sq += residual * residual;
+    }
+    return std::sqrt(sum_sq / static_cast<double>(count));
+}
+
+SolveResult solveProblem(const Problem& problem, const Options& options) {
+    SolveResult result;
+    result.state =
+        Eigen::VectorXd::Zero(static_cast<int>(kStateStride * problem.epochs.size()));
+    result.initial_cost = computeCost(problem, options, result.state);
+
+    if (options.debug_problem_only || options.max_iterations == 0 ||
+        problem.epochs.empty()) {
+        result.final_cost = result.initial_cost;
+        result.residual_rms_mps = residualRms(problem, result.state);
+        return result;
+    }
+
+    double previous_cost = result.initial_cost;
+    double damping = 1e-3;
+    for (int iteration = 1; iteration <= options.max_iterations; ++iteration) {
+        NormalEquation normal = buildNormalEquation(problem, options, result.state);
+        bool accepted = false;
+        double cost = previous_cost;
+        Eigen::VectorXd candidate_state = result.state;
+        Eigen::VectorXd accepted_delta =
+            Eigen::VectorXd::Zero(result.state.size());
+        const Eigen::VectorXd diagonal =
+            normal.hessian.diagonal().cwiseAbs().cwiseMax(1.0);
+        for (int damping_attempt = 0; damping_attempt < 18; ++damping_attempt) {
+            Eigen::SparseMatrix<double> damped_hessian = normal.hessian;
+            for (int col = 0; col < damped_hessian.cols(); ++col) {
+                damped_hessian.coeffRef(col, col) += damping * diagonal(col);
+            }
+            damped_hessian.makeCompressed();
+
+            Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> solver;
+            solver.compute(damped_hessian);
+            if (solver.info() != Eigen::Success) {
+                damping *= 10.0;
+                continue;
+            }
+            const Eigen::VectorXd delta = solver.solve(normal.rhs);
+            if (solver.info() != Eigen::Success || !delta.allFinite()) {
+                damping *= 10.0;
+                continue;
+            }
+
+            double step_scale = 1.0;
+            for (int line_search_attempt = 0; line_search_attempt < 12;
+                 ++line_search_attempt) {
+                candidate_state = result.state + step_scale * delta;
+                cost = computeCost(problem, options, candidate_state);
+                if (std::isfinite(cost) && cost <= previous_cost) {
+                    accepted_delta = step_scale * delta;
+                    accepted = true;
+                    break;
+                }
+                step_scale *= 0.5;
+            }
+            if (accepted) {
+                damping = std::max(1e-12, damping * 0.3);
+                break;
+            }
+            damping *= 10.0;
+        }
+        if (!accepted) {
+            break;
+        }
+
+        result.state = std::move(candidate_state);
+        result.iterations = iteration;
+
+        const double absolute_decrease = previous_cost - cost;
+        const double relative_decrease =
+            absolute_decrease / std::max(1.0, std::abs(previous_cost));
+        previous_cost = cost;
+
+        if (accepted_delta.norm() < 1e-10 ||
+            (iteration > 1 && absolute_decrease >= 0.0 &&
+             relative_decrease < 1e-5)) {
+            result.converged = true;
+            break;
+        }
+    }
+
+    result.final_cost = computeCost(problem, options, result.state);
+    result.residual_rms_mps = residualRms(problem, result.state);
+    return result;
+}
+
+bool calculateObservationModel(const libgnss::ObservationData& epoch,
+                               const libgnss::Observation& observation,
+                               const libgnss::NavigationData& nav,
+                               const libgnss::Vector3d& receiver_position,
+                               const Options& options,
+                               libgnss::Vector3d& satellite_position,
+                               libgnss::Vector3d& satellite_velocity,
+                               double& satellite_clock_bias,
+                               double& satellite_clock_drift,
+                               const libgnss::Ephemeris*& eph,
+                               libgnss::NavigationData::SatelliteGeometry& geometry,
+                               libgnss::Vector3d& ex,
+                               double& range_m) {
+    if (!isPrimaryPdSignal(observation.signal) ||
+        !observation.valid ||
+        !observation.has_pseudorange ||
+        observation.pseudorange <= 0.0 ||
+        observation.snr < options.min_snr_dbhz) {
+        return false;
+    }
+
+    libgnss::GNSSTime transmit_time =
+        epoch.time - observation.pseudorange / libgnss::constants::SPEED_OF_LIGHT;
+    if (!nav.calculateSatelliteState(observation.satellite,
+                                     transmit_time,
+                                     satellite_position,
+                                     satellite_velocity,
+                                     satellite_clock_bias,
+                                     satellite_clock_drift)) {
+        return false;
+    }
+
+    transmit_time = transmit_time - satellite_clock_bias;
+    if (!nav.calculateSatelliteState(observation.satellite,
+                                     transmit_time,
+                                     satellite_position,
+                                     satellite_velocity,
+                                     satellite_clock_bias,
+                                     satellite_clock_drift)) {
+        return false;
+    }
+
+    eph = nav.getEphemeris(observation.satellite, transmit_time);
+    if (!eph || !isHealthyForPositioning(observation, *eph)) {
+        return false;
+    }
+
+    const libgnss::Vector3d delta = satellite_position - receiver_position;
+    range_m = delta.norm();
+    if (range_m <= 0.0) {
+        return false;
+    }
+    ex = delta / range_m;
+    geometry = nav.calculateGeometry(receiver_position, satellite_position);
+    return geometry.elevation >= options.min_elevation_deg * kDegreesToRadians;
+}
+
+bool preparePseudorangeFactor(const libgnss::ObservationData& epoch,
+                              std::size_t epoch_index,
+                              const libgnss::Observation& observation,
+                              const libgnss::NavigationData& nav,
+                              const libgnss::Vector3d& receiver_position,
+                              const Options& options,
+                              PseudorangeFactor& factor) {
+    libgnss::Vector3d satellite_position;
+    libgnss::Vector3d satellite_velocity;
+    double satellite_clock_bias = 0.0;
+    double satellite_clock_drift = 0.0;
+    const libgnss::Ephemeris* eph = nullptr;
+    libgnss::NavigationData::SatelliteGeometry geometry;
+    libgnss::Vector3d ex = libgnss::Vector3d::Zero();
+    double geometric_range = 0.0;
+    if (!calculateObservationModel(epoch,
+                                   observation,
+                                   nav,
+                                   receiver_position,
+                                   options,
+                                   satellite_position,
+                                   satellite_velocity,
+                                   satellite_clock_bias,
+                                   satellite_clock_drift,
+                                   eph,
+                                   geometry,
+                                   ex,
+                                   geometric_range)) {
+        return false;
+    }
+
+    double receiver_lat = 0.0;
+    double receiver_lon = 0.0;
+    double receiver_height = 0.0;
+    libgnss::ecef2geodetic(receiver_position,
+                           receiver_lat,
+                           receiver_lon,
+                           receiver_height);
+    double ionosphere_delay = 0.0;
+    if (nav.ionosphere_model.valid) {
+        ionosphere_delay = libgnss::models::ionoDelayKlobuchar(
+            receiver_lat,
+            receiver_lon,
+            geometry.azimuth,
+            geometry.elevation,
+            epoch.time.tow,
+            nav.ionosphere_model.alpha,
+            nav.ionosphere_model.beta);
+        const double frequency_hz =
+            libgnss::signalFrequencyHz(observation.signal, eph);
+        if (frequency_hz > 0.0) {
+            const double scale = libgnss::constants::GPS_L1_FREQ / frequency_hz;
+            ionosphere_delay *= scale * scale;
+        }
+    }
+    const double troposphere_delay =
+        libgnss::models::tropDelaySaastamoinen(receiver_position,
+                                               geometry.elevation);
+    const double satellite_clock_m =
+        satellite_clock_bias * libgnss::constants::SPEED_OF_LIGHT;
+    const double group_delay_m = groupDelayCorrectionMeters(observation, *eph);
+    const double modeled_range =
+        geometric_range + sagnacRangeCorrection(satellite_position, receiver_position);
+    const double corrected_pseudorange =
+        observation.pseudorange +
+        satellite_clock_m -
+        ionosphere_delay -
+        troposphere_delay -
+        group_delay_m;
+    const double residual = corrected_pseudorange - modeled_range;
+    const double sin_el = std::sin(geometry.elevation);
+    if (sin_el <= 0.0) {
+        return false;
+    }
+
+    factor.epoch_index = epoch_index;
+    factor.time = epoch.time;
+    factor.satellite = observation.satellite;
+    factor.signal = observation.signal;
+    factor.clock_group = clockGroup(observation.satellite.system);
+    factor.snr_dbhz = observation.snr;
+    factor.elevation_rad = geometry.elevation;
+    factor.sigma_m = options.pseudorange_sigma_zenith_m / std::sqrt(sin_el);
+    factor.residual_m = residual;
+    factor.corrected_pseudorange_m = corrected_pseudorange;
+    factor.modeled_range_m = modeled_range;
+    factor.ionosphere_delay_m = ionosphere_delay;
+    factor.troposphere_delay_m = troposphere_delay;
+    factor.satellite_clock_m = satellite_clock_m;
+    factor.group_delay_m = group_delay_m;
+    factor.los = -ex;
+    return std::isfinite(factor.residual_m) &&
+           std::isfinite(factor.sigma_m) &&
+           factor.sigma_m > 0.0;
+}
+
+bool prepareCarrierResidual(const libgnss::ObservationData& epoch,
+                            std::size_t epoch_index,
+                            const libgnss::Observation& observation,
+                            const libgnss::NavigationData& nav,
+                            const libgnss::Vector3d& receiver_position,
+                            const Options& options,
+                            CarrierResidual& residual_out) {
+    if (!observation.has_carrier_phase ||
+        observation.carrier_phase == 0.0 ||
+        observation.loss_of_lock ||
+        ((observation.lli & 0x01U) != 0U)) {
+        return false;
+    }
+
+    libgnss::Vector3d satellite_position;
+    libgnss::Vector3d satellite_velocity;
+    double satellite_clock_bias = 0.0;
+    double satellite_clock_drift = 0.0;
+    const libgnss::Ephemeris* eph = nullptr;
+    libgnss::NavigationData::SatelliteGeometry geometry;
+    libgnss::Vector3d ex = libgnss::Vector3d::Zero();
+    double geometric_range = 0.0;
+    if (!calculateObservationModel(epoch,
+                                   observation,
+                                   nav,
+                                   receiver_position,
+                                   options,
+                                   satellite_position,
+                                   satellite_velocity,
+                                   satellite_clock_bias,
+                                   satellite_clock_drift,
+                                   eph,
+                                   geometry,
+                                   ex,
+                                   geometric_range)) {
+        return false;
+    }
+
+    double wavelength = libgnss::signalWavelengthMeters(observation.signal, eph);
+    if (wavelength <= 0.0) {
+        wavelength = libgnss::signalWavelengthMeters(observation);
+    }
+    if (wavelength <= 0.0) {
+        return false;
+    }
+
+    double receiver_lat = 0.0;
+    double receiver_lon = 0.0;
+    double receiver_height = 0.0;
+    libgnss::ecef2geodetic(receiver_position,
+                           receiver_lat,
+                           receiver_lon,
+                           receiver_height);
+    double ionosphere_delay = 0.0;
+    if (nav.ionosphere_model.valid) {
+        ionosphere_delay = libgnss::models::ionoDelayKlobuchar(
+            receiver_lat,
+            receiver_lon,
+            geometry.azimuth,
+            geometry.elevation,
+            epoch.time.tow,
+            nav.ionosphere_model.alpha,
+            nav.ionosphere_model.beta);
+        const double frequency_hz =
+            libgnss::signalFrequencyHz(observation.signal, eph);
+        if (frequency_hz > 0.0) {
+            const double scale = libgnss::constants::GPS_L1_FREQ / frequency_hz;
+            ionosphere_delay *= scale * scale;
+        }
+    }
+    const double troposphere_delay =
+        libgnss::models::tropDelaySaastamoinen(receiver_position,
+                                               geometry.elevation);
+    const double satellite_clock_m =
+        satellite_clock_bias * libgnss::constants::SPEED_OF_LIGHT;
+    const double modeled_range =
+        geometric_range + sagnacRangeCorrection(satellite_position, receiver_position);
+    const double corrected_carrier =
+        observation.carrier_phase * wavelength +
+        satellite_clock_m -
+        troposphere_delay +
+        ionosphere_delay;
+    const double residual = corrected_carrier - modeled_range;
+
+    residual_out.epoch_index = epoch_index;
+    residual_out.time = epoch.time;
+    residual_out.satellite = observation.satellite;
+    residual_out.signal = observation.signal;
+    residual_out.snr_dbhz = observation.snr;
+    residual_out.elevation_rad = geometry.elevation;
+    residual_out.residual_m = residual;
+    residual_out.corrected_carrier_m = corrected_carrier;
+    residual_out.modeled_range_m = modeled_range;
+    residual_out.raw_carrier_cycles = observation.carrier_phase;
+    residual_out.wavelength_m = wavelength;
+    residual_out.ionosphere_delay_m = ionosphere_delay;
+    residual_out.troposphere_delay_m = troposphere_delay;
+    residual_out.satellite_clock_m = satellite_clock_m;
+    residual_out.lli = observation.lli;
+    residual_out.loss_of_lock = observation.loss_of_lock;
+    residual_out.los = -ex;
+    return std::isfinite(residual_out.residual_m) &&
+           std::isfinite(residual_out.wavelength_m) &&
+           residual_out.wavelength_m > 0.0;
+}
+
+bool prepareDopplerFactor(const libgnss::ObservationData& epoch,
+                          std::size_t epoch_index,
+                          const libgnss::Observation& observation,
+                          const libgnss::NavigationData& nav,
+                          const libgnss::Vector3d& receiver_position,
+                          const Options& options,
+                          DopplerFactor& factor) {
+    if (!observation.has_doppler) {
+        return false;
+    }
+
+    libgnss::Vector3d satellite_position;
+    libgnss::Vector3d satellite_velocity;
+    double satellite_clock_bias = 0.0;
+    double satellite_clock_drift = 0.0;
+    const libgnss::Ephemeris* eph = nullptr;
+    libgnss::NavigationData::SatelliteGeometry geometry;
+    libgnss::Vector3d ex = libgnss::Vector3d::Zero();
+    double range = 0.0;
+    if (!calculateObservationModel(epoch,
+                                   observation,
+                                   nav,
+                                   receiver_position,
+                                   options,
+                                   satellite_position,
+                                   satellite_velocity,
+                                   satellite_clock_bias,
+                                   satellite_clock_drift,
+                                   eph,
+                                   geometry,
+                                   ex,
+                                   range)) {
+        return false;
+    }
+
+    double wavelength = libgnss::signalWavelengthMeters(observation.signal, eph);
+    if (wavelength <= 0.0) {
+        wavelength = libgnss::signalWavelengthMeters(observation);
+    }
+    if (wavelength <= 0.0) {
+        return false;
+    }
+
+    const double sagnac_rate =
+        libgnss::constants::OMEGA_E / libgnss::constants::SPEED_OF_LIGHT *
+        (satellite_velocity(1) * receiver_position(0) -
+         satellite_velocity(0) * receiver_position(1));
+    const double modeled_range_rate = satellite_velocity.dot(ex) + sagnac_rate;
+    const double satellite_clock_drift_mps =
+        satellite_clock_drift * libgnss::constants::SPEED_OF_LIGHT;
+    const double measured_range_rate = -observation.doppler * wavelength;
+    const double residual =
+        measured_range_rate - (modeled_range_rate - satellite_clock_drift_mps);
+    const double sin_el = std::sin(geometry.elevation);
+    if (sin_el <= 0.0) {
+        return false;
+    }
+
+    factor.epoch_index = epoch_index;
+    factor.time = epoch.time;
+    factor.satellite = observation.satellite;
+    factor.signal = observation.signal;
+    factor.snr_dbhz = observation.snr;
+    factor.elevation_rad = geometry.elevation;
+    factor.sigma_mps = options.doppler_sigma_zenith_mps / std::sqrt(sin_el);
+    factor.residual_mps = residual;
+    factor.measured_range_rate_mps = measured_range_rate;
+    factor.modeled_range_rate_mps = modeled_range_rate;
+    factor.satellite_clock_drift_mps = satellite_clock_drift_mps;
+    factor.wavelength_m = wavelength;
+    factor.los = -ex;
+    return std::isfinite(factor.residual_mps) &&
+           std::isfinite(factor.sigma_mps) &&
+           factor.sigma_mps > 0.0;
+}
+
+Problem buildProblem(const Options& options) {
+    libgnss::io::RINEXReader obs_reader;
+    if (!obs_reader.open(options.obs_path)) {
+        throw std::runtime_error("failed to open observation file: " + options.obs_path);
+    }
+    libgnss::io::RINEXReader::RINEXHeader obs_header;
+    if (!obs_reader.readHeader(obs_header)) {
+        throw std::runtime_error("failed to read observation header: " + options.obs_path);
+    }
+
+    libgnss::io::RINEXReader nav_reader;
+    if (!nav_reader.open(options.nav_path)) {
+        throw std::runtime_error("failed to open navigation file: " + options.nav_path);
+    }
+    libgnss::NavigationData nav_data;
+    if (!nav_reader.readNavigationData(nav_data)) {
+        throw std::runtime_error("failed to read navigation data: " + options.nav_path);
+    }
+
+    const std::vector<SeedPosition> seed_positions =
+        readSeedPositions(options.seed_pos_path);
+    std::size_t seed_cursor = 0;
+
+    Problem problem;
+    std::set<libgnss::SatelliteId> unique_satellites;
+    const double fixed_interval_s =
+        obs_header.interval > 0.0 ? obs_header.interval : 1.0;
+    const double gap_tolerance_s = std::max(0.01, 0.5 * fixed_interval_s);
+    std::map<libgnss::SatelliteId, double> previous_gps_pseudorange_by_satellite;
+    bool have_previous_gps_pseudorange = false;
+    std::vector<std::map<ObservationKey, CarrierResidual>> carrier_residuals_by_epoch;
+
+    auto append_epoch = [&](libgnss::ObservationData epoch,
+                            bool build_factors) -> bool {
+        if (options.max_epochs > 0 &&
+            static_cast<int>(problem.epochs.size()) >= options.max_epochs) {
+            return false;
+        }
+
+        libgnss::Vector3d seed_position = libgnss::Vector3d::Zero();
+        bool interpolated = false;
+        if (findSeedPosition(seed_positions,
+                             epoch.time,
+                             options.seed_match_tolerance_s,
+                             options.seed_interpolation_max_gap_s,
+                             seed_cursor,
+                             seed_position,
+                             interpolated)) {
+            epoch.receiver_position = seed_position;
+            ++problem.seed_matched_epochs;
+            if (interpolated) {
+                ++problem.seed_interpolated_epochs;
+            }
+        } else if (obs_header.approximate_position.norm() > 1e6) {
+            seed_position = obs_header.approximate_position;
+            epoch.receiver_position = seed_position;
+        } else {
+            return true;
+        }
+
+        const std::size_t epoch_index = problem.epochs.size();
+        std::map<libgnss::SatelliteId, double> gps_pseudorange_by_satellite;
+        std::map<ObservationKey, CarrierResidual> carrier_residuals;
+        if (build_factors) {
+            for (const auto& observation : epoch.observations) {
+                unique_satellites.insert(observation.satellite);
+                PseudorangeFactor pseudorange_factor;
+                if (preparePseudorangeFactor(epoch,
+                                             epoch_index,
+                                             observation,
+                                             nav_data,
+                                             seed_position,
+                                             options,
+                                             pseudorange_factor)) {
+                    problem.pseudorange_factors.push_back(pseudorange_factor);
+                    if (observation.satellite.system == libgnss::GNSSSystem::GPS) {
+                        gps_pseudorange_by_satellite[observation.satellite] =
+                            observation.pseudorange;
+                    }
+                }
+
+                DopplerFactor factor;
+                if (prepareDopplerFactor(epoch,
+                                         epoch_index,
+                                         observation,
+                                         nav_data,
+                                         seed_position,
+                                         options,
+                                         factor)) {
+                    problem.factors.push_back(factor);
+                }
+
+                CarrierResidual carrier_residual;
+                if (prepareCarrierResidual(epoch,
+                                           epoch_index,
+                                           observation,
+                                           nav_data,
+                                           seed_position,
+                                           options,
+                                           carrier_residual)) {
+                    carrier_residuals[{observation.satellite, observation.signal}] =
+                        carrier_residual;
+                }
+            }
+        }
+
+        bool clock_jump = false;
+        if (have_previous_gps_pseudorange && !gps_pseudorange_by_satellite.empty()) {
+            double sum_delta = 0.0;
+            std::size_t count = 0;
+            for (const auto& [satellite, pseudorange] : gps_pseudorange_by_satellite) {
+                const auto previous_it =
+                    previous_gps_pseudorange_by_satellite.find(satellite);
+                if (previous_it == previous_gps_pseudorange_by_satellite.end()) {
+                    continue;
+                }
+                sum_delta += pseudorange - previous_it->second;
+                ++count;
+            }
+            if (count > 0U) {
+                clock_jump = sum_delta / static_cast<double>(count) > 1e5;
+            }
+        }
+        problem.clock_jumps.push_back(clock_jump);
+        previous_gps_pseudorange_by_satellite = gps_pseudorange_by_satellite;
+        have_previous_gps_pseudorange = !gps_pseudorange_by_satellite.empty();
+
+        problem.seed_positions.push_back(seed_position);
+        problem.epochs.push_back(epoch);
+        carrier_residuals_by_epoch.push_back(std::move(carrier_residuals));
+        return true;
+    };
+
+    libgnss::ObservationData epoch;
+    int raw_epoch_index = 0;
+    bool have_last_output_time = false;
+    libgnss::GNSSTime last_output_time;
+    while (obs_reader.readObservationEpoch(epoch)) {
+        if (raw_epoch_index++ < options.skip_epochs) {
+            continue;
+        }
+
+        if (have_last_output_time) {
+            libgnss::GNSSTime expected_time =
+                last_output_time + fixed_interval_s;
+            while (epoch.time - expected_time > gap_tolerance_s) {
+                libgnss::ObservationData empty_epoch(expected_time);
+                if (!append_epoch(empty_epoch, false)) {
+                    break;
+                }
+                last_output_time = expected_time;
+                expected_time = last_output_time + fixed_interval_s;
+                if (options.max_epochs > 0 &&
+                    static_cast<int>(problem.epochs.size()) >=
+                        options.max_epochs) {
+                    break;
+                }
+            }
+            if (options.max_epochs > 0 &&
+                static_cast<int>(problem.epochs.size()) >= options.max_epochs) {
+                break;
+            }
+        }
+
+        if (!append_epoch(epoch, true)) {
+            break;
+        }
+        last_output_time = epoch.time;
+        have_last_output_time = true;
+    }
+    problem.nsat = unique_satellites.size();
+
+    for (std::size_t i = 1; i < problem.epochs.size(); ++i) {
+        if (problem.clock_jumps[i]) {
+            continue;
+        }
+        const auto& previous_carriers = carrier_residuals_by_epoch[i - 1U];
+        const auto& current_carriers = carrier_residuals_by_epoch[i];
+        for (const auto& [key, current] : current_carriers) {
+            const auto previous_it = previous_carriers.find(key);
+            if (previous_it == previous_carriers.end()) {
+                continue;
+            }
+            const CarrierResidual& previous = previous_it->second;
+            const double sin_el = std::sin(current.elevation_rad);
+            if (sin_el <= 0.0) {
+                continue;
+            }
+
+            TdcpFactor factor;
+            factor.epoch_index = i;
+            factor.previous_epoch_index = i - 1U;
+            factor.time = current.time;
+            factor.satellite = current.satellite;
+            factor.signal = current.signal;
+            factor.snr_dbhz = current.snr_dbhz;
+            factor.elevation_rad = current.elevation_rad;
+            factor.previous_elevation_rad = previous.elevation_rad;
+            factor.sigma_m = options.tdcp_sigma_zenith_m / std::sqrt(sin_el);
+            factor.residual_m = current.residual_m - previous.residual_m;
+            factor.previous_carrier_residual_m = previous.residual_m;
+            factor.current_carrier_residual_m = current.residual_m;
+            factor.previous_raw_carrier_cycles = previous.raw_carrier_cycles;
+            factor.current_raw_carrier_cycles = current.raw_carrier_cycles;
+            factor.wavelength_m = current.wavelength_m;
+            factor.los = previous.los;
+            if (std::isfinite(factor.residual_m) &&
+                std::isfinite(factor.sigma_m) &&
+                factor.sigma_m > 0.0) {
+                problem.tdcp_factors.push_back(factor);
+                unique_satellites.insert(factor.satellite);
+            }
+        }
+    }
+    problem.nsat = unique_satellites.size();
+    return problem;
+}
+
+bool writePerEpochCsv(const std::string& path,
+                      const Problem& problem,
+                      const SolveResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    output << "epoch,gps_week,gps_tow,spp_x_m,spp_y_m,spp_z_m,"
+              "fgo_x_m,fgo_y_m,fgo_z_m,"
+              "fgo_vx_mps,fgo_vy_mps,fgo_vz_mps,"
+              "fgo_c_gps_m,fgo_c_glo_m,fgo_c_gal_m,fgo_c_qzs_m,"
+              "fgo_c_bds_m,fgo_clock_drift_mps,clock_jump\n";
+    output << std::fixed << std::setprecision(15);
+    for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
+        const auto& epoch = problem.epochs[i];
+        const auto& seed = problem.seed_positions[i];
+        output << (i + 1U) << ','
+               << epoch.time.week << ','
+               << epoch.time.tow << ','
+               << seed(0) << ','
+               << seed(1) << ','
+               << seed(2) << ','
+               << seed(0) + result.state(positionColumn(i, 0)) << ','
+               << seed(1) + result.state(positionColumn(i, 1)) << ','
+               << seed(2) + result.state(positionColumn(i, 2)) << ','
+               << result.state(velocityColumn(i, 0)) << ','
+               << result.state(velocityColumn(i, 1)) << ','
+               << result.state(velocityColumn(i, 2)) << ','
+               << result.state(clockColumn(i, 0)) << ','
+               << result.state(clockColumn(i, 1)) << ','
+               << result.state(clockColumn(i, 2)) << ','
+               << result.state(clockColumn(i, 3)) << ','
+               << result.state(clockColumn(i, 4)) << ','
+               << result.state(driftColumn(i)) << ','
+               << (problem.clock_jumps[i] ? 1 : 0) << '\n';
+    }
+    return true;
+}
+
+bool writeFactorDebugCsv(const std::string& path,
+                         const Problem& problem,
+                         const SolveResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    output << "factor_type,epoch_index,gps_week,gps_tow,satellite,signal,"
+              "previous_epoch_index,clock_group,snr_dbhz,elevation_deg,"
+              "previous_elevation_deg,sigma_p_m,sigma_d_mps,sigma_c_m,"
+              "res_pc_m,res_d_mps,res_tdcp_m,measured_range_rate_mps,"
+              "modeled_range_rate_mps,satellite_clock_drift_mps,"
+              "previous_carrier_residual_m,current_carrier_residual_m,"
+              "previous_raw_carrier_cycles,current_raw_carrier_cycles,"
+              "wavelength_m,final_residual_m,los_x,los_y,los_z\n";
+    output << std::fixed << std::setprecision(15);
+    for (const PseudorangeFactor& factor : problem.pseudorange_factors) {
+        const double final_residual =
+            pseudorangePrediction(result.state, factor) - factor.residual_m;
+        output << "P,"
+               << factor.epoch_index << ','
+               << factor.time.week << ','
+               << factor.time.tow << ','
+               << factor.satellite.toString() << ','
+               << signalName(factor.signal) << ','
+               << "NaN,"
+               << factor.clock_group << ','
+               << factor.snr_dbhz << ','
+               << factor.elevation_rad * kRadiansToDegrees << ','
+               << "NaN,"
+               << factor.sigma_m << ",NaN,NaN,"
+               << factor.residual_m << ",NaN,NaN,NaN,NaN,NaN,"
+               << "NaN,NaN,NaN,NaN,NaN,"
+               << final_residual << ','
+               << factor.los(0) << ','
+               << factor.los(1) << ','
+               << factor.los(2) << '\n';
+    }
+    for (const DopplerFactor& factor : problem.factors) {
+        const double final_residual =
+            dopplerPrediction(result.state, factor) - factor.residual_mps;
+        output << "D,"
+               << factor.epoch_index << ','
+               << factor.time.week << ','
+               << factor.time.tow << ','
+               << factor.satellite.toString() << ','
+               << signalName(factor.signal) << ','
+               << "NaN,"
+               << clockGroup(factor.satellite.system) << ','
+               << factor.snr_dbhz << ','
+               << factor.elevation_rad * kRadiansToDegrees << ','
+               << "NaN,"
+               << "NaN,"
+               << factor.sigma_mps << ",NaN,"
+               << "NaN,"
+               << factor.residual_mps << ','
+               << "NaN,"
+               << factor.measured_range_rate_mps << ','
+               << factor.modeled_range_rate_mps << ','
+               << factor.satellite_clock_drift_mps << ','
+               << "NaN,NaN,NaN,NaN,"
+               << factor.wavelength_m << ','
+               << final_residual << ','
+               << factor.los(0) << ','
+               << factor.los(1) << ','
+               << factor.los(2) << '\n';
+    }
+    for (const TdcpFactor& factor : problem.tdcp_factors) {
+        const double final_residual =
+            tdcpPrediction(result.state, factor) - factor.residual_m;
+        output << "C,"
+               << factor.epoch_index << ','
+               << factor.time.week << ','
+               << factor.time.tow << ','
+               << factor.satellite.toString() << ','
+               << signalName(factor.signal) << ','
+               << factor.previous_epoch_index << ','
+               << 0 << ','
+               << factor.snr_dbhz << ','
+               << factor.elevation_rad * kRadiansToDegrees << ','
+               << factor.previous_elevation_rad * kRadiansToDegrees << ','
+               << "NaN,NaN,"
+               << factor.sigma_m << ','
+               << "NaN,NaN,"
+               << factor.residual_m << ','
+               << "NaN,NaN,NaN,"
+               << factor.previous_carrier_residual_m << ','
+               << factor.current_carrier_residual_m << ','
+               << factor.previous_raw_carrier_cycles << ','
+               << factor.current_raw_carrier_cycles << ','
+               << factor.wavelength_m << ','
+               << final_residual << ','
+               << factor.los(0) << ','
+               << factor.los(1) << ','
+               << factor.los(2) << '\n';
+    }
+    return true;
+}
+
+std::size_t graphFactorCount(const Problem& problem) {
+    if (problem.epochs.empty()) {
+        return problem.pseudorange_factors.size() +
+               problem.factors.size() +
+               problem.tdcp_factors.size();
+    }
+    return problem.pseudorange_factors.size() +
+           problem.factors.size() +
+           problem.tdcp_factors.size() +
+           4U * problem.epochs.size() +
+           3U * (problem.epochs.size() - 1U);
+}
+
+bool writeGraphCsv(const std::string& path,
+                   const Problem& problem,
+                   const SolveResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    output << "n,nsat,graph_factors,graph_values,initial_cost,final_cost,"
+              "optimizer_error,iterations,valid_position_epochs,"
+              "valid_velocity_epochs\n";
+    output << std::fixed << std::setprecision(15)
+           << problem.epochs.size() << ','
+           << problem.nsat << ','
+           << graphFactorCount(problem) << ','
+           << 4U * problem.epochs.size() << ','
+           << result.initial_cost << ','
+           << result.final_cost << ','
+           << result.final_cost << ','
+           << result.iterations << ','
+           << problem.epochs.size() << ','
+           << problem.epochs.size() << '\n';
+    return true;
+}
+
+std::string jsonBool(bool value) {
+    return value ? "true" : "false";
+}
+
+bool writeSummaryJson(const std::string& path,
+                      const Options& options,
+                      const Problem& problem,
+                      const SolveResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    const std::size_t epoch_count = problem.epochs.size();
+    output << std::fixed << std::setprecision(15)
+           << "{\n"
+           << "  \"preset\": \"taroz-pdc\",\n"
+           << "  \"backend\": \"eigen\",\n"
+           << "  \"debug_problem_only\": " << jsonBool(options.debug_problem_only) << ",\n"
+           << "  \"optimized_epochs\": " << epoch_count << ",\n"
+           << "  \"valid_position_epochs\": " << epoch_count << ",\n"
+           << "  \"valid_velocity_epochs\": " << epoch_count << ",\n"
+           << "  \"seed_matched_epochs\": " << problem.seed_matched_epochs << ",\n"
+           << "  \"seed_interpolated_epochs\": " << problem.seed_interpolated_epochs << ",\n"
+           << "  \"nsat\": " << problem.nsat << ",\n"
+           << "  \"pseudorange_factors\": " << problem.pseudorange_factors.size() << ",\n"
+           << "  \"doppler_factors\": " << problem.factors.size() << ",\n"
+           << "  \"tdcp_factors\": " << problem.tdcp_factors.size() << ",\n"
+           << "  \"position_prior_factors\": " << epoch_count << ",\n"
+           << "  \"clock_prior_factors\": " << epoch_count << ",\n"
+           << "  \"velocity_prior_factors\": " << epoch_count << ",\n"
+           << "  \"clock_drift_prior_factors\": " << epoch_count << ",\n"
+           << "  \"motion_factors\": "
+           << (epoch_count > 0 ? epoch_count - 1U : 0U) << ",\n"
+           << "  \"clock_motion_factors\": "
+           << (epoch_count > 0 ? epoch_count - 1U : 0U) << ",\n"
+           << "  \"clock_drift_between_factors\": "
+           << (epoch_count > 0 ? epoch_count - 1U : 0U) << ",\n"
+           << "  \"graph_factors\": " << graphFactorCount(problem) << ",\n"
+           << "  \"graph_values\": " << 4U * epoch_count << ",\n"
+           << "  \"min_snr_dbhz\": " << options.min_snr_dbhz << ",\n"
+           << "  \"min_elevation_deg\": " << options.min_elevation_deg << ",\n"
+           << "  \"pseudorange_sigma_zenith_m\": "
+           << options.pseudorange_sigma_zenith_m << ",\n"
+           << "  \"doppler_sigma_zenith_mps\": "
+           << options.doppler_sigma_zenith_mps << ",\n"
+           << "  \"tdcp_sigma_zenith_m\": "
+           << options.tdcp_sigma_zenith_m << ",\n"
+           << "  \"position_prior_sigma_m\": "
+           << options.position_prior_sigma_m << ",\n"
+           << "  \"clock_prior_sigma_m\": "
+           << options.clock_prior_sigma_m << ",\n"
+           << "  \"velocity_prior_sigma_mps\": "
+           << options.velocity_prior_sigma_mps << ",\n"
+           << "  \"clock_drift_prior_sigma_mps\": "
+           << options.clock_drift_prior_sigma_mps << ",\n"
+           << "  \"motion_sigma_m\": " << options.motion_sigma_m << ",\n"
+           << "  \"clock_motion_sigma_m\": "
+           << options.clock_motion_sigma_m << ",\n"
+           << "  \"clock_jump_sigma_m\": " << options.clock_jump_sigma_m << ",\n"
+           << "  \"clock_drift_between_sigma_mps\": "
+           << options.clock_drift_between_sigma_mps << ",\n"
+           << "  \"huber_threshold_sigma\": "
+           << options.huber_threshold_sigma << ",\n"
+           << "  \"iterations\": " << result.iterations << ",\n"
+           << "  \"converged\": " << jsonBool(result.converged) << ",\n"
+           << "  \"initial_cost\": " << result.initial_cost << ",\n"
+           << "  \"final_cost\": " << result.final_cost << ",\n"
+           << "  \"residual_rms_mps\": " << result.residual_rms_mps << "\n"
+           << "}\n";
+    return true;
+}
+
+void printSummary(const Problem& problem, const SolveResult& result) {
+    std::cout << "Taroz PDC position/velocity batch complete\n"
+              << "  epochs: " << problem.epochs.size() << "\n"
+              << "  satellites: " << problem.nsat << "\n"
+              << "  pseudorange_factors: "
+              << problem.pseudorange_factors.size() << "\n"
+              << "  doppler_factors: " << problem.factors.size() << "\n"
+              << "  tdcp_factors: " << problem.tdcp_factors.size() << "\n"
+              << "  graph_factors: " << graphFactorCount(problem) << "\n"
+              << "  iterations: " << result.iterations << "\n"
+              << "  converged: " << (result.converged ? "true" : "false") << "\n"
+              << std::fixed << std::setprecision(6)
+              << "  initial_cost: " << result.initial_cost << "\n"
+              << "  final_cost: " << result.final_cost << "\n"
+              << "  residual_rms_mps: " << result.residual_rms_mps << "\n";
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+    try {
+        const Options options = parseArguments(argc, argv);
+        const Problem problem = buildProblem(options);
+        const SolveResult result = solveProblem(problem, options);
+
+        if (!writePerEpochCsv(options.out_csv_path, problem, result)) {
+            std::cerr << "Error: failed to write velocity CSV: "
+                      << options.out_csv_path << "\n";
+            return 1;
+        }
+        if (!writeFactorDebugCsv(options.factor_debug_csv_path, problem, result)) {
+            std::cerr << "Error: failed to write factor debug CSV: "
+                      << options.factor_debug_csv_path << "\n";
+            return 1;
+        }
+        if (!writeGraphCsv(options.graph_csv_path, problem, result)) {
+            std::cerr << "Error: failed to write graph CSV: "
+                      << options.graph_csv_path << "\n";
+            return 1;
+        }
+        if (!writeSummaryJson(options.summary_json_path, options, problem, result)) {
+            std::cerr << "Error: failed to write summary JSON: "
+                      << options.summary_json_path << "\n";
+            return 1;
+        }
+        if (!options.quiet) {
+            printSummary(problem, result);
+        }
+        return 0;
+    } catch (const std::invalid_argument&) {
+        return 2;
+    } catch (const std::exception& ex) {
+        std::cerr << "Error: " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/apps/gnss_ppc_taroz_amb_pdc_smoke.py
+++ b/apps/gnss_ppc_taroz_amb_pdc_smoke.py
@@ -1,0 +1,653 @@
+#!/usr/bin/env python3
+"""Run taroz ambiguity PDC FGO checks on PPC-Dataset runs."""
+
+from __future__ import annotations
+
+import argparse
+import bisect
+import csv
+from dataclasses import dataclass
+import glob
+import json
+import math
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+APPS_DIR = Path(__file__).resolve().parent
+EXE_SUFFIX = ".exe" if os.name == "nt" else ""
+BUILD_CONFIGS = ("Release", "RelWithDebInfo", "Debug", "MinSizeRel")
+
+DEFAULT_DATASET_ROOT = Path(
+    os.environ.get("GNSSPP_PPC_DATASET_ROOT", str(ROOT_DIR / "data/PPC-Dataset"))
+)
+DEFAULT_OUT_DIR = ROOT_DIR / "output/dogfood/ppc_taroz_amb_pdc_smoke"
+REQUIRED_RUN_FILES = ("rover.obs", "base.obs", "base.nav", "reference.csv")
+
+
+@dataclass(frozen=True)
+class PpcRun:
+    site: str
+    name: str
+    path: Path
+
+    @property
+    def label(self) -> str:
+        return f"{self.site}_{self.name}"
+
+    @property
+    def spec(self) -> str:
+        return f"{self.site}/{self.name}"
+
+
+@dataclass(frozen=True)
+class PosRecord:
+    week: int
+    tow: float
+    x: float
+    y: float
+    z: float
+    status: int
+
+
+@dataclass(frozen=True)
+class ReferenceRecord:
+    week: int
+    tow: float
+    x: float
+    y: float
+    z: float
+
+
+def find_binary(target_name: str) -> Path | None:
+    filename = target_name + EXE_SUFFIX
+    build_roots = [
+        Path(path)
+        for path in sorted(glob.glob(str(ROOT_DIR / "build*")))
+        if Path(path).is_dir()
+    ]
+    default_build = ROOT_DIR / "build"
+    if default_build not in build_roots:
+        build_roots.insert(0, default_build)
+
+    candidates = [APPS_DIR / filename]
+    for build_root in build_roots:
+        candidates.append(build_root / "apps" / filename)
+        for config in BUILD_CONFIGS:
+            candidates.append(build_root / "apps" / config / filename)
+            candidates.append(build_root / config / "apps" / filename)
+            candidates.append(build_root / config / filename)
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+
+    recursive_hits: list[Path] = []
+    for build_root in build_roots:
+        recursive_hits.extend(
+            Path(path)
+            for path in glob.glob(str(build_root / "**" / filename), recursive=True)
+            if Path(path).is_file()
+        )
+    return sorted(recursive_hits)[0] if recursive_hits else None
+
+
+def resolve_dataset_root(root: Path) -> Path:
+    candidates = [root, root / "PPC-Dataset"]
+    for candidate in candidates:
+        if (candidate / "nagoya").is_dir() or (candidate / "tokyo").is_dir():
+            return candidate
+    return root
+
+
+def discover_runs(dataset_root: Path) -> list[PpcRun]:
+    root = resolve_dataset_root(dataset_root)
+    runs: list[PpcRun] = []
+    for site_dir in sorted(root.iterdir() if root.exists() else []):
+        if not site_dir.is_dir() or site_dir.name.startswith("."):
+            continue
+        for run_dir in sorted(site_dir.glob("run*")):
+            if not run_dir.is_dir():
+                continue
+            if all((run_dir / name).is_file() for name in REQUIRED_RUN_FILES):
+                runs.append(PpcRun(site_dir.name, run_dir.name, run_dir))
+    return runs
+
+
+def selected_runs(all_runs: list[PpcRun], specs: list[str]) -> list[PpcRun]:
+    if not specs:
+        return all_runs
+    wanted: list[str] = []
+    for raw_spec in specs:
+        wanted.extend(token.strip() for token in raw_spec.split(",") if token.strip())
+    by_spec = {run.spec: run for run in all_runs}
+    by_label = {run.label: run for run in all_runs}
+    selected: list[PpcRun] = []
+    missing: list[str] = []
+    for spec in wanted:
+        run = by_spec.get(spec) or by_label.get(spec)
+        if run is None:
+            missing.append(spec)
+        else:
+            selected.append(run)
+    if missing:
+        available = ", ".join(run.spec for run in all_runs)
+        raise SystemExit(
+            f"unknown PPC run(s): {', '.join(missing)}. Available runs: {available}"
+        )
+    return selected
+
+
+def output_paths(out_dir: Path, run: PpcRun) -> dict[str, Path]:
+    run_dir = out_dir / run.label
+    return {
+        "run_dir": run_dir,
+        "seed_pos": run_dir / "spp_seed.pos",
+        "pos": run_dir / "fgo.pos",
+        "summary": run_dir / "summary.json",
+        "epoch_debug": run_dir / "epoch_debug.csv",
+    }
+
+
+def build_spp_seed_command(
+    args: argparse.Namespace,
+    run: PpcRun,
+    paths: dict[str, Path],
+) -> list[str]:
+    spp_bin = Path(args.spp_bin) if args.spp_bin else find_binary("gnss_spp")
+    if spp_bin is None:
+        if args.dry_run:
+            spp_bin = Path("gnss_spp")
+        else:
+            raise SystemExit(
+                "gnss_spp binary not found. Build it first with "
+                "`cmake --build build --target gnss_spp`, or pass --spp-bin."
+            )
+
+    command = [
+        str(spp_bin),
+        "--obs",
+        str(run.path / "rover.obs"),
+        "--nav",
+        str(run.path / "base.nav"),
+        "--out",
+        str(paths["seed_pos"]),
+        "--quiet",
+    ]
+    if args.max_epochs > 0:
+        seed_epochs = args.skip_epochs + args.max_epochs
+        command.extend(["--max-epochs", str(seed_epochs)])
+    return command
+
+
+def build_fgo_command(
+    args: argparse.Namespace,
+    run: PpcRun,
+    paths: dict[str, Path],
+) -> list[str]:
+    fgo_bin = Path(args.fgo_bin) if args.fgo_bin else find_binary("gnss_fgo")
+    if fgo_bin is None:
+        if args.dry_run:
+            fgo_bin = Path("gnss_fgo")
+        else:
+            raise SystemExit(
+                "gnss_fgo binary not found. Build it first with "
+                "`cmake --build build --target gnss_fgo`, or pass --fgo-bin."
+            )
+
+    command = [
+        str(fgo_bin),
+        "--preset",
+        "taroz-amb-pdc",
+        "--obs",
+        str(run.path / "rover.obs"),
+        "--base",
+        str(run.path / "base.obs"),
+        "--nav",
+        str(run.path / "base.nav"),
+        "--out",
+        str(paths["pos"]),
+        "--summary-json",
+        str(paths["summary"]),
+        "--epoch-debug-csv",
+        str(paths["epoch_debug"]),
+        "--quiet",
+    ]
+    if args.skip_epochs > 0:
+        command.extend(["--skip-epochs", str(args.skip_epochs)])
+    if args.max_epochs > 0:
+        command.extend(["--max-epochs", str(args.max_epochs)])
+    if args.generate_spp_seed:
+        command.extend(["--seed-pos", str(paths["seed_pos"])])
+    command.extend(args.fgo_extra_arg)
+    return command
+
+
+def run_command(command: list[str]) -> tuple[int, float]:
+    import time
+
+    start = time.monotonic()
+    completed = subprocess.run(command, cwd=ROOT_DIR, check=False)
+    return completed.returncode, time.monotonic() - start
+
+
+def load_json(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def read_pos(path: Path) -> list[PosRecord]:
+    rows: list[PosRecord] = []
+    with path.open(encoding="ascii", errors="ignore") as handle:
+        for line_number, raw_line in enumerate(handle, start=1):
+            line = raw_line.strip()
+            if not line or line.startswith("%"):
+                continue
+            parts = line.split()
+            if len(parts) < 10:
+                raise ValueError(f"{path}:{line_number}: expected at least 10 POS columns")
+            rows.append(
+                PosRecord(
+                    week=int(float(parts[0])),
+                    tow=float(parts[1]),
+                    x=float(parts[2]),
+                    y=float(parts[3]),
+                    z=float(parts[4]),
+                    status=int(float(parts[8])),
+                )
+            )
+    return rows
+
+
+def _row_value(row: dict[str, str], column: str) -> str:
+    for key, value in row.items():
+        if key.strip() == column:
+            return value
+    raise KeyError(column)
+
+
+def read_reference(path: Path) -> dict[int, list[ReferenceRecord]]:
+    by_week: dict[int, list[ReferenceRecord]] = {}
+    with path.open(newline="", encoding="ascii", errors="ignore") as handle:
+        for row in csv.DictReader(handle):
+            week = int(float(_row_value(row, "GPS Week")))
+            record = ReferenceRecord(
+                week=week,
+                tow=float(_row_value(row, "GPS TOW (s)")),
+                x=float(_row_value(row, "ECEF X (m)")),
+                y=float(_row_value(row, "ECEF Y (m)")),
+                z=float(_row_value(row, "ECEF Z (m)")),
+            )
+            by_week.setdefault(week, []).append(record)
+    for records in by_week.values():
+        records.sort(key=lambda record: record.tow)
+    return by_week
+
+
+def percentile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    return ordered[int(fraction * (len(ordered) - 1))]
+
+
+def summarize_reference_errors(
+    pos_path: Path,
+    reference_csv: Path,
+    tolerance_s: float,
+) -> dict[str, Any]:
+    pos_records = read_pos(pos_path)
+    reference_by_week = read_reference(reference_csv)
+    reference_tows = {
+        week: [record.tow for record in records]
+        for week, records in reference_by_week.items()
+    }
+    valid_errors: list[float] = []
+    all_output_errors: list[float] = []
+    fixed_errors: list[float] = []
+    float_errors: list[float] = []
+    no_solution_errors: list[float] = []
+    status_counts: dict[str, int] = {}
+    for pos in pos_records:
+        status_counts[str(pos.status)] = status_counts.get(str(pos.status), 0) + 1
+        references = reference_by_week.get(pos.week)
+        tows = reference_tows.get(pos.week)
+        if not references or not tows:
+            continue
+        index = bisect.bisect_left(tows, pos.tow)
+        candidates = []
+        if index < len(references):
+            candidates.append(references[index])
+        if index > 0:
+            candidates.append(references[index - 1])
+        if not candidates:
+            continue
+        reference = min(candidates, key=lambda record: abs(record.tow - pos.tow))
+        if abs(reference.tow - pos.tow) > tolerance_s:
+            continue
+        dx = pos.x - reference.x
+        dy = pos.y - reference.y
+        dz = pos.z - reference.z
+        error = math.sqrt(dx * dx + dy * dy + dz * dz)
+        all_output_errors.append(error)
+        if pos.status == 4:
+            fixed_errors.append(error)
+            valid_errors.append(error)
+        elif pos.status == 3:
+            float_errors.append(error)
+            valid_errors.append(error)
+        else:
+            no_solution_errors.append(error)
+
+    def stats(values: list[float]) -> dict[str, float | int | None]:
+        if not values:
+            return {
+                "matched_epochs": 0,
+                "mean_3d_error_m": None,
+                "p95_3d_error_m": None,
+                "max_3d_error_m": None,
+            }
+        return {
+            "matched_epochs": len(values),
+            "mean_3d_error_m": sum(values) / len(values),
+            "p95_3d_error_m": percentile(values, 0.95),
+            "max_3d_error_m": max(values),
+        }
+
+    result = stats(valid_errors)
+    result["fixed"] = stats(fixed_errors)
+    result["float"] = stats(float_errors)
+    result["no_solution"] = stats(no_solution_errors)
+    result["all_output"] = stats(all_output_errors)
+    result["position_status_counts"] = status_counts
+    return rounded(result)
+
+
+def selected_native_summary(summary: dict[str, Any]) -> dict[str, Any]:
+    keys = [
+        "preset",
+        "backend",
+        "input_epochs",
+        "optimized_epochs",
+        "valid_solutions",
+        "fixed_solutions",
+        "float_solutions",
+        "fix_rate_percent",
+        "skip_epochs",
+        "seed_pos",
+        "seed_matched_epochs",
+        "seed_interpolated_epochs",
+        "use_spp_seed",
+        "single_difference_doppler_factors",
+        "single_difference_tdcp_factors",
+        "double_difference_pseudorange_factors",
+        "double_difference_carrier_factors",
+        "lambda_ambiguity_attempts",
+        "lambda_ambiguity_candidates",
+        "lambda_ambiguity_used_candidates",
+        "iterations",
+        "converged",
+        "final_cost",
+        "total_processing_time_ms",
+    ]
+    return {key: summary.get(key) for key in keys if key in summary}
+
+
+def validate_native_summary(args: argparse.Namespace, summary: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    if summary.get("preset") != "taroz-amb-pdc":
+        failures.append("preset is not taroz-amb-pdc")
+    if summary.get("backend") != "eigen":
+        failures.append("backend is not eigen")
+    if args.max_epochs > 0 and summary.get("optimized_epochs") != args.max_epochs:
+        failures.append(
+            f"optimized_epochs {summary.get('optimized_epochs')} != {args.max_epochs}"
+        )
+    if int(summary.get("valid_solutions", 0)) < args.require_valid_min:
+        failures.append(
+            f"valid_solutions {summary.get('valid_solutions')} < {args.require_valid_min}"
+        )
+    if int(summary.get("double_difference_carrier_factors", 0)) < args.require_dd_carrier_min:
+        failures.append(
+            "double_difference_carrier_factors "
+            f"{summary.get('double_difference_carrier_factors')} < "
+            f"{args.require_dd_carrier_min}"
+        )
+    if int(summary.get("lambda_ambiguity_attempts", 0)) < args.require_lambda_attempts_min:
+        failures.append(
+            f"lambda_ambiguity_attempts {summary.get('lambda_ambiguity_attempts')} < "
+            f"{args.require_lambda_attempts_min}"
+        )
+    fix_rate = float(summary.get("fix_rate_percent", 0.0))
+    if fix_rate < args.require_fix_rate_min:
+        failures.append(f"fix_rate_percent {fix_rate:.6f} < {args.require_fix_rate_min}")
+    if not args.allow_not_converged and summary.get("converged") is not True:
+        failures.append("optimization did not converge")
+    return failures
+
+
+def _check_metric_max(
+    failures: list[str],
+    label: str,
+    value: Any,
+    threshold: float,
+) -> None:
+    if threshold <= 0.0:
+        return
+    if value is None:
+        failures.append(f"{label} is unavailable")
+        return
+    numeric = float(value)
+    if numeric > threshold:
+        failures.append(f"{label} {numeric:.6f} > {threshold}")
+
+
+def validate_reference_summary(
+    args: argparse.Namespace,
+    summary: dict[str, Any],
+) -> list[str]:
+    failures: list[str] = []
+    _check_metric_max(
+        failures,
+        "valid p95_3d_error_m",
+        summary.get("p95_3d_error_m"),
+        args.require_valid_p95_3d_max,
+    )
+    _check_metric_max(
+        failures,
+        "valid max_3d_error_m",
+        summary.get("max_3d_error_m"),
+        args.require_valid_max_3d_max,
+    )
+    fixed = summary.get("fixed", {})
+    _check_metric_max(
+        failures,
+        "fixed p95_3d_error_m",
+        fixed.get("p95_3d_error_m"),
+        args.require_fixed_p95_3d_max,
+    )
+    return failures
+
+
+def rounded(value: Any) -> Any:
+    if isinstance(value, float):
+        return round(value, 9) if math.isfinite(value) else value
+    if isinstance(value, dict):
+        return {key: rounded(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [rounded(item) for item in value]
+    return value
+
+
+def write_summary(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(rounded(payload), indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Run taroz-amb-pdc FGO checks on PPC-Dataset runs."
+    )
+    parser.add_argument("--dataset-root", type=Path, default=DEFAULT_DATASET_ROOT)
+    parser.add_argument(
+        "--run",
+        action="append",
+        default=[],
+        help="Run spec such as nagoya/run1 or tokyo_run2. Repeat or comma-separate.",
+    )
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument(
+        "--summary-json",
+        type=Path,
+        default=None,
+        help="Aggregate summary path (default: <out-dir>/summary.json).",
+    )
+    parser.add_argument("--fgo-bin", type=Path, default=None)
+    parser.add_argument("--spp-bin", type=Path, default=None)
+    parser.add_argument("--generate-spp-seed", action="store_true")
+    parser.add_argument("--skip-epochs", type=int, default=0)
+    parser.add_argument("--max-epochs", type=int, default=20)
+    parser.add_argument("--reference-match-tolerance-s", type=float, default=0.05)
+    parser.add_argument("--require-valid-min", type=int, default=1)
+    parser.add_argument("--require-dd-carrier-min", type=int, default=1)
+    parser.add_argument("--require-lambda-attempts-min", type=int, default=1)
+    parser.add_argument("--require-fix-rate-min", type=float, default=0.0)
+    parser.add_argument("--require-valid-p95-3d-max", type=float, default=0.0)
+    parser.add_argument("--require-valid-max-3d-max", type=float, default=0.0)
+    parser.add_argument("--require-fixed-p95-3d-max", type=float, default=0.0)
+    parser.add_argument("--allow-not-converged", action="store_true")
+    parser.add_argument(
+        "--fgo-extra-arg",
+        action="append",
+        default=[],
+        help="Extra single argument passed to gnss_fgo. Repeat for multiple tokens.",
+    )
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    if args.max_epochs < 0:
+        raise SystemExit("--max-epochs must be non-negative")
+    if args.skip_epochs < 0:
+        raise SystemExit("--skip-epochs must be non-negative")
+    if args.reference_match_tolerance_s < 0:
+        raise SystemExit("--reference-match-tolerance-s must be non-negative")
+    if args.require_valid_p95_3d_max < 0:
+        raise SystemExit("--require-valid-p95-3d-max must be non-negative")
+    if args.require_valid_max_3d_max < 0:
+        raise SystemExit("--require-valid-max-3d-max must be non-negative")
+    if args.require_fixed_p95_3d_max < 0:
+        raise SystemExit("--require-fixed-p95-3d-max must be non-negative")
+
+    dataset_root = resolve_dataset_root(args.dataset_root)
+    runs = selected_runs(discover_runs(dataset_root), args.run)
+    if not runs:
+        raise SystemExit(f"no PPC runs found under {dataset_root}")
+
+    summary_path = args.summary_json or (args.out_dir / "summary.json")
+    payload: dict[str, Any] = {
+        "status": "planned",
+        "dataset_root": str(dataset_root),
+        "out_dir": str(args.out_dir),
+        "skip_epochs": args.skip_epochs,
+        "max_epochs": args.max_epochs,
+        "generate_spp_seed": args.generate_spp_seed,
+        "runs": {},
+    }
+
+    planned: dict[str, list[str]] = {}
+    planned_seed: dict[str, list[str]] = {}
+    for run in runs:
+        paths = output_paths(args.out_dir, run)
+        if args.generate_spp_seed:
+            planned_seed[run.spec] = build_spp_seed_command(args, run, paths)
+        planned[run.spec] = build_fgo_command(args, run, paths)
+    if planned_seed:
+        payload["planned_seed_commands"] = planned_seed
+    payload["planned_commands"] = planned
+
+    if args.dry_run:
+        payload["status"] = "dry-run"
+        write_summary(summary_path, payload)
+        print("Dry run. Planned PPC taroz ambiguity PDC smoke runs:")
+        for spec, command in planned_seed.items():
+            print(f"[{spec} seed] {' '.join(command)}")
+        for spec, command in planned.items():
+            print(f"[{spec}] {' '.join(command)}")
+        print(f"Summary: {summary_path}")
+        return 0
+
+    all_failures: list[str] = []
+    for run in runs:
+        paths = output_paths(args.out_dir, run)
+        paths["run_dir"].mkdir(parents=True, exist_ok=True)
+        run_payload: dict[str, Any] = {
+            "site": run.site,
+            "run": run.name,
+            "path": str(run.path),
+            "outputs": {
+                key: str(path)
+                for key, path in paths.items()
+                if key != "run_dir" and (key != "seed_pos" or args.generate_spp_seed)
+            },
+        }
+        if args.generate_spp_seed:
+            seed_command = planned_seed[run.spec]
+            seed_returncode, seed_wall_time_s = run_command(seed_command)
+            run_payload["seed_command"] = seed_command
+            run_payload["seed_returncode"] = seed_returncode
+            run_payload["seed_wall_time_s"] = seed_wall_time_s
+            if seed_returncode != 0:
+                failure = f"{run.spec}: gnss_spp returned {seed_returncode}"
+                run_payload["status"] = "failed"
+                run_payload["failures"] = [failure]
+                all_failures.append(failure)
+                payload["runs"][run.spec] = run_payload
+                continue
+
+        command = planned[run.spec]
+        returncode, wall_time_s = run_command(command)
+        run_payload["command"] = command
+        run_payload["returncode"] = returncode
+        run_payload["solver_wall_time_s"] = wall_time_s
+        if returncode != 0:
+            failure = f"{run.spec}: gnss_fgo returned {returncode}"
+            run_payload["status"] = "failed"
+            run_payload["failures"] = [failure]
+            all_failures.append(failure)
+            payload["runs"][run.spec] = run_payload
+            continue
+
+        native_summary = load_json(paths["summary"])
+        failures = validate_native_summary(args, native_summary)
+        run_payload["native_summary"] = selected_native_summary(native_summary)
+        reference_summary = summarize_reference_errors(
+            paths["pos"],
+            run.path / "reference.csv",
+            args.reference_match_tolerance_s,
+        )
+        failures.extend(validate_reference_summary(args, reference_summary))
+        run_payload["reference_summary"] = reference_summary
+        run_payload["failures"] = failures
+        run_payload["status"] = "ok" if not failures else "failed"
+        all_failures.extend(f"{run.spec}: {failure}" for failure in failures)
+        payload["runs"][run.spec] = run_payload
+
+    payload["failures"] = all_failures
+    payload["status"] = "ok" if not all_failures else "failed"
+    write_summary(summary_path, payload)
+    if all_failures:
+        for failure in all_failures:
+            print(f"Error: {failure}", file=sys.stderr)
+        return 1
+    print(f"PPC taroz ambiguity PDC smoke OK: {len(runs)} run(s)")
+    print(f"Summary: {summary_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/gnss_rcv.py
+++ b/apps/gnss_rcv.py
@@ -66,26 +66,38 @@ ALLOWED_KEYS = {
 
 def find_binary(target_name: str) -> str | None:
     filename = target_name + EXE_SUFFIX
-    candidates = [
-        APPS_DIR / filename,
-        ROOT_DIR / "build" / "apps" / filename,
+    build_roots = [
+        Path(path)
+        for path in sorted(glob.glob(str(ROOT_DIR / "build*")))
+        if Path(path).is_dir()
     ]
-    for config in BUILD_CONFIGS:
-        candidates.extend(
-            [
-                ROOT_DIR / "build" / "apps" / config / filename,
-                ROOT_DIR / "build" / config / "apps" / filename,
-                ROOT_DIR / "build" / config / filename,
-            ]
-        )
+    default_build = ROOT_DIR / "build"
+    if default_build not in build_roots:
+        build_roots.insert(0, default_build)
+
+    candidates = [APPS_DIR / filename]
+    for build_root in build_roots:
+        candidates.append(build_root / "apps" / filename)
+        for config in BUILD_CONFIGS:
+            candidates.extend(
+                [
+                    build_root / "apps" / config / filename,
+                    build_root / config / "apps" / filename,
+                    build_root / config / filename,
+                ]
+            )
     for candidate in candidates:
         if candidate.is_file():
             return str(candidate)
 
-    hits = sorted(
-        path for path in glob.glob(str(ROOT_DIR / "build" / "**" / filename), recursive=True)
-        if os.path.isfile(path)
-    )
+    hits: list[str] = []
+    for build_root in build_roots:
+        hits.extend(
+            path
+            for path in glob.glob(str(build_root / "**" / filename), recursive=True)
+            if os.path.isfile(path)
+        )
+    hits.sort()
     return hits[0] if hits else None
 
 

--- a/apps/gnss_taroz_p_dogfood.py
+++ b/apps/gnss_taroz_p_dogfood.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""Regenerate and verify taroz P FGO smoke artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import math
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+APPS_DIR = Path(__file__).resolve().parent
+EXE_SUFFIX = ".exe" if os.name == "nt" else ""
+BUILD_CONFIGS = ("Release", "RelWithDebInfo", "Debug", "MinSizeRel")
+
+DEFAULT_DATA_DIR = Path("/tmp/taroz_gtsam_gnss/examples/data")
+DEFAULT_OUT_DIR = ROOT_DIR / "output/dogfood/taroz_p_dogfood_current"
+DEFAULT_MATLAB_DIR = ROOT_DIR / "output/dogfood/taroz_matlab_p_debug"
+DEFAULT_PARITY_TEST = ROOT_DIR / "tests/test_taroz_p_internal_parity.py"
+DEFAULT_MAX_EPOCHS = 80
+DEFAULT_MAX_ITERATIONS = 40
+
+POS_NAME = "fgo_taroz_p.pos"
+SUMMARY_NAME = "fgo_taroz_p_summary.json"
+EPOCH_DEBUG_NAME = "fgo_taroz_p_epoch_debug.csv"
+FACTOR_DEBUG_NAME = "fgo_taroz_p_factor_debug.csv"
+
+
+def default_path(name: str) -> Path:
+    return DEFAULT_DATA_DIR / name
+
+
+def find_binary(target_name: str) -> Path | None:
+    filename = target_name + EXE_SUFFIX
+    build_roots = [
+        Path(path)
+        for path in sorted(glob.glob(str(ROOT_DIR / "build*")))
+        if Path(path).is_dir()
+    ]
+    default_build = ROOT_DIR / "build"
+    if default_build not in build_roots:
+        build_roots.insert(0, default_build)
+
+    candidates = [APPS_DIR / filename]
+    for build_root in build_roots:
+        candidates.append(build_root / "apps" / filename)
+        for config in BUILD_CONFIGS:
+            candidates.append(build_root / "apps" / config / filename)
+            candidates.append(build_root / config / "apps" / filename)
+            candidates.append(build_root / config / filename)
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+
+    recursive_hits: list[Path] = []
+    for build_root in build_roots:
+        recursive_hits.extend(
+            Path(path)
+            for path in glob.glob(str(build_root / "**" / filename), recursive=True)
+            if Path(path).is_file()
+        )
+    return sorted(recursive_hits)[0] if recursive_hits else None
+
+
+def output_paths(out_dir: Path) -> dict[str, Path]:
+    return {
+        "pos": out_dir / POS_NAME,
+        "summary": out_dir / SUMMARY_NAME,
+        "epoch_debug": out_dir / EPOCH_DEBUG_NAME,
+        "factor_debug": out_dir / FACTOR_DEBUG_NAME,
+    }
+
+
+def build_fgo_command(args: argparse.Namespace, paths: dict[str, Path]) -> list[str]:
+    fgo_bin = Path(args.fgo_bin) if args.fgo_bin else find_binary("gnss_fgo")
+    if fgo_bin is None:
+        if args.dry_run:
+            fgo_bin = Path("gnss_fgo")
+        else:
+            raise SystemExit(
+                "gnss_fgo binary not found. Build it first with "
+                "`cmake --build build --target gnss_fgo`, or pass --fgo-bin."
+            )
+
+    command = [
+        str(fgo_bin),
+        "--preset",
+        "taroz-p",
+        "--obs",
+        str(args.obs),
+        "--nav",
+        str(args.nav),
+        "--seed-pos",
+        str(args.seed_pos),
+        "--out",
+        str(paths["pos"]),
+        "--summary-json",
+        str(paths["summary"]),
+        "--epoch-debug-csv",
+        str(paths["epoch_debug"]),
+        "--factor-debug-csv",
+        str(paths["factor_debug"]),
+        "--quiet",
+    ]
+    if args.max_epochs > 0:
+        command.extend(["--max-epochs", str(args.max_epochs)])
+    if args.max_iterations > 0:
+        command.extend(["--max-iterations", str(args.max_iterations)])
+    if args.debug_problem_only:
+        command.append("--debug-problem-only")
+    command.extend(args.fgo_extra_arg)
+    return command
+
+
+def validate_inputs(args: argparse.Namespace) -> None:
+    missing = [
+        path
+        for path in (args.obs, args.nav, args.seed_pos)
+        if not Path(path).exists()
+    ]
+    if missing:
+        joined = ", ".join(str(path) for path in missing)
+        raise SystemExit(f"missing taroz P input file(s): {joined}")
+
+
+def run_command(command: list[str], *, env: dict[str, str] | None = None) -> int:
+    completed = subprocess.run(command, cwd=ROOT_DIR, env=env, check=False)
+    return completed.returncode
+
+
+def load_native_summary(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def selected_native_summary(summary: dict[str, Any]) -> dict[str, Any]:
+    keys = [
+        "preset",
+        "backend",
+        "use_spp_seed",
+        "optimized_epochs",
+        "valid_solutions",
+        "pseudorange_factors",
+        "tdcp_factors",
+        "carrier_phase_factors",
+        "double_difference_pseudorange_factors",
+        "double_difference_carrier_factors",
+        "motion_factors",
+        "iterations",
+        "converged",
+        "final_cost",
+        "residual_rms_m",
+        "debug_problem_only",
+        "graph_factors",
+        "graph_values",
+    ]
+    return {key: summary.get(key) for key in keys if key in summary}
+
+
+def _close(actual: Any, expected: float, tolerance: float = 1e-9) -> bool:
+    return isinstance(actual, (int, float)) and math.isclose(
+        float(actual),
+        expected,
+        rel_tol=tolerance,
+        abs_tol=tolerance,
+    )
+
+
+def _is_finite_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and math.isfinite(float(value))
+
+
+def verify_native_summary(
+    summary: dict[str, Any],
+    *,
+    expected_max_epochs: int,
+    expected_max_iterations: int,
+    debug_problem_only: bool = False,
+) -> list[str]:
+    failures: list[str] = []
+    if bool(summary.get("debug_problem_only", False)) != debug_problem_only:
+        failures.append("native summary debug_problem_only does not match request")
+    if summary.get("preset") != "taroz-p":
+        failures.append("native summary preset is not taroz-p")
+    if summary.get("backend") != "eigen":
+        failures.append("native summary backend is not eigen")
+    if summary.get("use_spp_seed") is not False:
+        failures.append("taroz-p must report use_spp_seed=false")
+    if summary.get("use_pseudorange_factors") is not True:
+        failures.append("taroz-p must enable raw pseudorange factors")
+    if not _close(summary.get("pseudorange_sigma_m"), 3.0):
+        failures.append("taroz-p pseudorange_sigma_m must be 3")
+    if not _close(summary.get("pseudorange_elevation_sigma_power"), 0.5):
+        failures.append("taroz-p elevation sigma power must be 0.5")
+    if not _close(summary.get("position_prior_sigma_m"), 1000.0):
+        failures.append("taroz-p position prior sigma must be 1000")
+    if not _close(summary.get("clock_prior_sigma_m"), 1e6):
+        failures.append("taroz-p clock prior sigma must be 1e6")
+    if not _close(summary.get("clock_motion_sigma_m"), 100.0):
+        failures.append("taroz-p clock motion sigma must be 100")
+    if summary.get("use_position_motion_factors") is not False:
+        failures.append("taroz-p must disable position motion factors")
+    if summary.get("use_clock_motion_factors") is not True:
+        failures.append("taroz-p must enable clock motion factors")
+
+    zero_factor_keys = [
+        "tdcp_factors",
+        "carrier_phase_factors",
+        "double_difference_pseudorange_factors",
+        "double_difference_carrier_factors",
+        "ambiguity_states",
+    ]
+    for key in zero_factor_keys:
+        if summary.get(key) != 0:
+            failures.append(f"taroz-p must keep {key}=0")
+
+    optimized_epochs = summary.get("optimized_epochs")
+    if not isinstance(optimized_epochs, int) or optimized_epochs <= 0:
+        failures.append("taroz-p optimized_epochs must be positive")
+    elif expected_max_epochs > 0 and optimized_epochs != expected_max_epochs:
+        failures.append(
+            f"taroz-p optimized_epochs must equal requested max epochs "
+            f"({expected_max_epochs})"
+        )
+
+    if not isinstance(summary.get("valid_solutions"), int) or summary["valid_solutions"] <= 0:
+        failures.append("taroz-p valid_solutions must be positive")
+    if not isinstance(summary.get("pseudorange_factors"), int) or summary["pseudorange_factors"] <= 0:
+        failures.append("taroz-p pseudorange_factors must be positive")
+    if isinstance(optimized_epochs, int) and optimized_epochs > 0:
+        expected_motion_factors = max(0, optimized_epochs - 1)
+        if summary.get("motion_factors") != expected_motion_factors:
+            failures.append(
+                f"taroz-p motion_factors must be {expected_motion_factors}"
+            )
+
+    iterations = summary.get("iterations")
+    if debug_problem_only:
+        if iterations != 0:
+            failures.append("taroz-p debug-only iterations must be 0")
+    elif not isinstance(iterations, int) or iterations <= 0:
+        failures.append("taroz-p iterations must be positive")
+    elif expected_max_iterations > 0 and iterations > expected_max_iterations:
+        failures.append("taroz-p iterations exceeded requested max iterations")
+    if not debug_problem_only and summary.get("converged") is not True:
+        failures.append("taroz-p smoke should converge")
+    if not _is_finite_number(summary.get("final_cost")):
+        failures.append("taroz-p final_cost must be finite")
+    if not _is_finite_number(summary.get("residual_rms_m")):
+        failures.append("taroz-p residual_rms_m must be finite")
+    return failures
+
+
+def write_run_summary(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def run_parity(args: argparse.Namespace, out_dir: Path) -> int:
+    env = os.environ.copy()
+    env["GNSSPP_TAROZ_P_CPP_DIR"] = str(out_dir)
+    env["GNSSPP_TAROZ_P_MATLAB_DIR"] = str(args.matlab_dir)
+    return run_command([sys.executable, str(args.parity_test)], env=env)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Regenerate taroz estimate_pos_P-equivalent C++ outputs and verify "
+            "the raw-pseudorange FGO configuration."
+        )
+    )
+    parser.add_argument("--obs", type=Path, default=default_path("rover_1Hz.obs"))
+    parser.add_argument("--nav", type=Path, default=default_path("base.nav"))
+    parser.add_argument(
+        "--seed-pos",
+        type=Path,
+        default=default_path("rover_1Hz_spp.pos"),
+        help="RTKLIB POS used as taroz x_ini seed.",
+    )
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument(
+        "--summary-json",
+        type=Path,
+        default=None,
+        help="Harness summary JSON path (default: <out-dir>/taroz_p_dogfood_summary.json).",
+    )
+    parser.add_argument("--fgo-bin", type=Path, default=None)
+    parser.add_argument(
+        "--max-epochs",
+        type=int,
+        default=DEFAULT_MAX_EPOCHS,
+        help="Epoch cap for the smoke run; 0 keeps the preset default.",
+    )
+    parser.add_argument(
+        "--max-iterations",
+        type=int,
+        default=DEFAULT_MAX_ITERATIONS,
+        help="Iteration cap for the smoke run; 0 keeps the preset default.",
+    )
+    parser.add_argument(
+        "--fgo-extra-arg",
+        action="append",
+        default=[],
+        help="Extra single argument passed to gnss_fgo. Repeat for multiple tokens.",
+    )
+    parser.add_argument("--matlab-dir", type=Path, default=DEFAULT_MATLAB_DIR)
+    parser.add_argument("--parity-test", type=Path, default=DEFAULT_PARITY_TEST)
+    parser.add_argument(
+        "--debug-problem-only",
+        action="store_true",
+        help="Build full factor/debug outputs without running FGO optimization.",
+    )
+    parser.add_argument("--skip-parity", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    if args.max_epochs < 0:
+        raise SystemExit("--max-epochs must be non-negative")
+    if args.max_iterations < 0:
+        raise SystemExit("--max-iterations must be non-negative")
+
+    out_dir = args.out_dir
+    paths = output_paths(out_dir)
+    harness_summary = args.summary_json or (out_dir / "taroz_p_dogfood_summary.json")
+    payload: dict[str, Any] = {
+        "status": "planned",
+        "inputs": {
+            "obs": str(args.obs),
+            "nav": str(args.nav),
+            "seed_pos": str(args.seed_pos),
+        },
+        "out_dir": str(out_dir),
+        "outputs": {name: str(path) for name, path in paths.items()},
+        "harness_summary_json": str(harness_summary),
+        "matlab_dir": str(args.matlab_dir),
+        "expected": {
+            "preset": "taroz-p",
+            "backend": "eigen",
+            "use_spp_seed": False,
+            "max_epochs": args.max_epochs,
+            "max_iterations": args.max_iterations,
+            "debug_problem_only": args.debug_problem_only,
+        },
+    }
+
+    command = build_fgo_command(args, paths)
+    payload["fgo_command"] = command
+
+    if args.dry_run:
+        payload["status"] = "dry-run"
+        write_run_summary(harness_summary, payload)
+        print("Dry run. Planned taroz P dogfood command:")
+        print(" ".join(command))
+        print(f"Harness summary: {harness_summary}")
+        return 0
+
+    validate_inputs(args)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    fgo_returncode = run_command(command)
+    payload["fgo_returncode"] = fgo_returncode
+    if fgo_returncode != 0:
+        payload["status"] = "failed"
+        write_run_summary(harness_summary, payload)
+        return fgo_returncode
+
+    native_summary = load_native_summary(paths["summary"])
+    payload["native_summary"] = selected_native_summary(native_summary)
+    native_failures = verify_native_summary(
+        native_summary,
+        expected_max_epochs=args.max_epochs,
+        expected_max_iterations=args.max_iterations,
+        debug_problem_only=args.debug_problem_only,
+    )
+    payload["native_summary_failures"] = native_failures
+    if native_failures:
+        payload["status"] = "failed"
+        write_run_summary(harness_summary, payload)
+        for failure in native_failures:
+            print(f"Error: {failure}", file=sys.stderr)
+        return 1
+
+    if args.skip_parity:
+        payload["parity"] = {"status": "skipped"}
+    else:
+        parity_returncode = run_parity(args, out_dir)
+        payload["parity"] = {
+            "status": "ok" if parity_returncode == 0 else "failed",
+            "returncode": parity_returncode,
+            "test": str(args.parity_test),
+            "matlab_dir": str(args.matlab_dir),
+        }
+        if parity_returncode != 0:
+            payload["status"] = "failed"
+            write_run_summary(harness_summary, payload)
+            return parity_returncode
+
+    payload["status"] = "ok"
+    write_run_summary(harness_summary, payload)
+    print(f"Taroz P dogfood OK: {out_dir}")
+    print(f"Harness summary: {harness_summary}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/gnss_taroz_pc_dogfood.py
+++ b/apps/gnss_taroz_pc_dogfood.py
@@ -1,0 +1,417 @@
+#!/usr/bin/env python3
+"""Regenerate and verify the taroz PC FGO dogfood artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import filecmp
+import glob
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+APPS_DIR = Path(__file__).resolve().parent
+EXE_SUFFIX = ".exe" if os.name == "nt" else ""
+BUILD_CONFIGS = ("Release", "RelWithDebInfo", "Debug", "MinSizeRel")
+
+DEFAULT_DATA_DIR = Path("/tmp/taroz_gtsam_gnss/examples/data")
+DEFAULT_OUT_DIR = ROOT_DIR / "output/dogfood/taroz_pc_dogfood_current"
+DEFAULT_BASELINE_CPP_DIR = (
+    ROOT_DIR / "output/dogfood/taroz_pc_full_gtsam_fixed_taroz_nocorr"
+)
+DEFAULT_BASELINE_LAMBDA_DIR = ROOT_DIR / "output/dogfood/taroz_pc_lambda_debug"
+DEFAULT_MATLAB_DIR = ROOT_DIR / "output/dogfood/taroz_matlab_pc_debug"
+DEFAULT_PARITY_TEST = ROOT_DIR / "tests/test_taroz_pc_internal_parity.py"
+
+POS_NAME = "fgo_taroz_pc_gtsam_fixed.pos"
+SUMMARY_NAME = "fgo_taroz_pc_gtsam_fixed_summary.json"
+EPOCH_DEBUG_NAME = "fgo_taroz_pc_gtsam_fixed_epoch_debug.csv"
+FACTOR_DEBUG_NAME = "fgo_taroz_pc_gtsam_fixed_factor_debug.csv"
+LAMBDA_DEBUG_NAME = "fgo_taroz_pc_gtsam_fixed_lambda_debug.csv"
+
+
+def default_path(name: str) -> Path:
+    return DEFAULT_DATA_DIR / name
+
+
+def find_binary(target_name: str) -> Path | None:
+    filename = target_name + EXE_SUFFIX
+    build_roots = [
+        Path(path)
+        for path in sorted(glob.glob(str(ROOT_DIR / "build*")))
+        if Path(path).is_dir()
+    ]
+    default_build = ROOT_DIR / "build"
+    if default_build not in build_roots:
+        build_roots.insert(0, default_build)
+
+    candidates = [APPS_DIR / filename]
+    for build_root in build_roots:
+        candidates.append(build_root / "apps" / filename)
+        for config in BUILD_CONFIGS:
+            candidates.append(build_root / "apps" / config / filename)
+            candidates.append(build_root / config / "apps" / filename)
+            candidates.append(build_root / config / filename)
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+
+    recursive_hits: list[Path] = []
+    for build_root in build_roots:
+        recursive_hits.extend(
+            Path(path)
+            for path in glob.glob(str(build_root / "**" / filename), recursive=True)
+            if Path(path).is_file()
+        )
+    return sorted(recursive_hits)[0] if recursive_hits else None
+
+
+def output_paths(out_dir: Path) -> dict[str, Path]:
+    return {
+        "pos": out_dir / POS_NAME,
+        "summary": out_dir / SUMMARY_NAME,
+        "epoch_debug": out_dir / EPOCH_DEBUG_NAME,
+        "factor_debug": out_dir / FACTOR_DEBUG_NAME,
+        "lambda_debug": out_dir / LAMBDA_DEBUG_NAME,
+    }
+
+
+def build_fgo_command(args: argparse.Namespace, paths: dict[str, Path]) -> list[str]:
+    fgo_bin = Path(args.fgo_bin) if args.fgo_bin else find_binary("gnss_fgo")
+    if fgo_bin is None:
+        if args.dry_run:
+            fgo_bin = Path("gnss_fgo")
+        else:
+            raise SystemExit(
+                "gnss_fgo binary not found. Build it first with "
+                "`cmake --build build --target gnss_fgo`, or pass --fgo-bin."
+            )
+
+    command = [
+        str(fgo_bin),
+        "--preset",
+        "taroz-pc",
+        "--backend",
+        "gtsam-pc",
+        "--fix-ambiguities",
+        "--obs",
+        str(args.obs),
+        "--base",
+        str(args.base),
+        "--nav",
+        str(args.nav),
+        "--seed-pos",
+        str(args.seed_pos),
+        "--out",
+        str(paths["pos"]),
+        "--summary-json",
+        str(paths["summary"]),
+        "--epoch-debug-csv",
+        str(paths["epoch_debug"]),
+        "--factor-debug-csv",
+        str(paths["factor_debug"]),
+        "--lambda-debug-csv",
+        str(paths["lambda_debug"]),
+        "--quiet",
+    ]
+    command.extend(args.fgo_extra_arg)
+    return command
+
+
+def validate_inputs(args: argparse.Namespace) -> None:
+    missing = [
+        path
+        for path in (args.obs, args.base, args.nav, args.seed_pos)
+        if not Path(path).exists()
+    ]
+    if missing:
+        joined = ", ".join(str(path) for path in missing)
+        raise SystemExit(f"missing taroz PC input file(s): {joined}")
+
+
+def run_command(command: list[str], *, env: dict[str, str] | None = None) -> int:
+    completed = subprocess.run(command, cwd=ROOT_DIR, env=env, check=False)
+    return completed.returncode
+
+
+def load_native_summary(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def selected_native_summary(summary: dict[str, Any]) -> dict[str, Any]:
+    keys = [
+        "preset",
+        "backend",
+        "use_spp_seed",
+        "optimized_epochs",
+        "valid_solutions",
+        "fixed_solutions",
+        "float_solutions",
+        "double_difference_pseudorange_factors",
+        "double_difference_carrier_factors",
+        "lambda_ambiguity_candidates",
+        "lambda_ambiguity_used_candidates",
+        "iterations",
+        "initial_cost",
+        "final_cost",
+    ]
+    return {key: summary.get(key) for key in keys if key in summary}
+
+
+def verify_native_summary(summary: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    if summary.get("preset") != "taroz-pc":
+        failures.append("native summary preset is not taroz-pc")
+    if summary.get("backend") != "gtsam-pc":
+        failures.append("native summary backend is not gtsam-pc")
+    if summary.get("use_spp_seed") is not False:
+        failures.append("taroz-pc must report use_spp_seed=false")
+    return failures
+
+
+def compare_file_pairs(
+    out_dir: Path,
+    baseline_cpp_dir: Path,
+    baseline_lambda_dir: Path,
+) -> dict[str, dict[str, Any]]:
+    current = output_paths(out_dir)
+    pairs = {
+        "pos": (baseline_cpp_dir / POS_NAME, current["pos"]),
+        "epoch_debug": (baseline_cpp_dir / EPOCH_DEBUG_NAME, current["epoch_debug"]),
+        "factor_debug": (baseline_cpp_dir / FACTOR_DEBUG_NAME, current["factor_debug"]),
+        "lambda_debug": (baseline_lambda_dir / LAMBDA_DEBUG_NAME, current["lambda_debug"]),
+    }
+    results: dict[str, dict[str, Any]] = {}
+    for name, (baseline, generated) in pairs.items():
+        result: dict[str, Any] = {
+            "baseline": str(baseline),
+            "generated": str(generated),
+        }
+        if not baseline.exists() or not generated.exists():
+            result["status"] = "missing"
+        elif baseline.resolve() == generated.resolve():
+            result["status"] = "same-file"
+        elif filecmp.cmp(baseline, generated, shallow=False):
+            result["status"] = "same"
+        else:
+            result["status"] = "different"
+        results[name] = result
+    return results
+
+
+def compare_summaries(
+    generated_summary: Path,
+    baseline_summary: Path,
+) -> dict[str, Any]:
+    ignored = {
+        "obs",
+        "base",
+        "nav",
+        "out",
+        "epoch_debug_csv",
+        "factor_debug_csv",
+        "lambda_debug_csv",
+        "processing_time_ms",
+        "max_iterations",
+    }
+    result: dict[str, Any] = {
+        "baseline": str(baseline_summary),
+        "generated": str(generated_summary),
+    }
+    if not baseline_summary.exists() or not generated_summary.exists():
+        result["status"] = "missing"
+        return result
+
+    baseline = load_native_summary(baseline_summary)
+    generated = load_native_summary(generated_summary)
+    keys = sorted(set(baseline) - ignored)
+    diffs = [
+        {
+            "key": key,
+            "baseline": baseline.get(key),
+            "generated": generated.get(key),
+        }
+        for key in keys
+        if baseline.get(key) != generated.get(key)
+    ]
+    result["status"] = "same" if not diffs else "different"
+    result["checked_keys"] = len(keys)
+    result["extra_generated_keys"] = sorted(set(generated) - set(baseline) - ignored)
+    result["diffs"] = diffs
+    return result
+
+
+def byte_comparison_failures(results: dict[str, dict[str, Any]]) -> list[str]:
+    failures: list[str] = []
+    for name, result in results.items():
+        status = result.get("status")
+        if status == "different":
+            failures.append(f"{name} differs from baseline")
+    return failures
+
+
+def run_parity(args: argparse.Namespace, out_dir: Path) -> int:
+    env = os.environ.copy()
+    env["GNSSPP_TAROZ_PC_CPP_DIR"] = str(out_dir)
+    env["GNSSPP_TAROZ_PC_CPP_LAMBDA_DIR"] = str(out_dir)
+    env["GNSSPP_TAROZ_PC_MATLAB_DIR"] = str(args.matlab_dir)
+    return run_command([sys.executable, str(args.parity_test)], env=env)
+
+
+def write_run_summary(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Regenerate taroz estimate_pos_ambiguity_PC-equivalent C++ outputs "
+            "and verify intermediate/final parity."
+        )
+    )
+    parser.add_argument("--obs", type=Path, default=default_path("rover_1Hz.obs"))
+    parser.add_argument("--base", type=Path, default=default_path("base.obs"))
+    parser.add_argument("--nav", type=Path, default=default_path("base.nav"))
+    parser.add_argument(
+        "--seed-pos",
+        type=Path,
+        default=default_path("rover_1Hz_spp.pos"),
+        help="RTKLIB POS used as taroz x_ini seed.",
+    )
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument(
+        "--summary-json",
+        type=Path,
+        default=None,
+        help="Harness summary JSON path (default: <out-dir>/taroz_pc_dogfood_summary.json).",
+    )
+    parser.add_argument("--fgo-bin", type=Path, default=None)
+    parser.add_argument(
+        "--fgo-extra-arg",
+        action="append",
+        default=[],
+        help="Extra single argument passed to gnss_fgo. Repeat for multiple tokens.",
+    )
+    parser.add_argument("--matlab-dir", type=Path, default=DEFAULT_MATLAB_DIR)
+    parser.add_argument("--parity-test", type=Path, default=DEFAULT_PARITY_TEST)
+    parser.add_argument("--skip-parity", action="store_true")
+    parser.add_argument("--baseline-cpp-dir", type=Path, default=DEFAULT_BASELINE_CPP_DIR)
+    parser.add_argument(
+        "--baseline-lambda-dir",
+        type=Path,
+        default=DEFAULT_BASELINE_LAMBDA_DIR,
+    )
+    parser.add_argument("--no-byte-compare", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    out_dir = args.out_dir
+    paths = output_paths(out_dir)
+    harness_summary = args.summary_json or (out_dir / "taroz_pc_dogfood_summary.json")
+    payload: dict[str, Any] = {
+        "status": "planned",
+        "inputs": {
+            "obs": str(args.obs),
+            "base": str(args.base),
+            "nav": str(args.nav),
+            "seed_pos": str(args.seed_pos),
+        },
+        "out_dir": str(out_dir),
+        "outputs": {name: str(path) for name, path in paths.items()},
+        "harness_summary_json": str(harness_summary),
+        "expected": {
+            "preset": "taroz-pc",
+            "backend": "gtsam-pc",
+            "use_spp_seed": False,
+        },
+    }
+
+    command = build_fgo_command(args, paths)
+    payload["fgo_command"] = command
+
+    if args.dry_run:
+        payload["status"] = "dry-run"
+        write_run_summary(harness_summary, payload)
+        print("Dry run. Planned taroz PC dogfood command:")
+        print(" ".join(command))
+        print(f"Harness summary: {harness_summary}")
+        return 0
+
+    validate_inputs(args)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    fgo_returncode = run_command(command)
+    payload["fgo_returncode"] = fgo_returncode
+    if fgo_returncode != 0:
+        payload["status"] = "failed"
+        write_run_summary(harness_summary, payload)
+        return fgo_returncode
+
+    native_summary = load_native_summary(paths["summary"])
+    payload["native_summary"] = selected_native_summary(native_summary)
+    native_failures = verify_native_summary(native_summary)
+    payload["native_summary_failures"] = native_failures
+    if native_failures:
+        payload["status"] = "failed"
+        write_run_summary(harness_summary, payload)
+        for failure in native_failures:
+            print(f"Error: {failure}", file=sys.stderr)
+        return 1
+
+    if args.no_byte_compare:
+        payload["byte_comparison"] = {"status": "skipped"}
+    else:
+        byte_comparison = compare_file_pairs(
+            out_dir,
+            args.baseline_cpp_dir,
+            args.baseline_lambda_dir,
+        )
+        byte_comparison["summary"] = compare_summaries(
+            paths["summary"],
+            args.baseline_cpp_dir / SUMMARY_NAME,
+        )
+        payload["byte_comparison"] = byte_comparison
+        byte_failures = byte_comparison_failures(byte_comparison)
+        payload["byte_comparison_failures"] = byte_failures
+        if byte_failures:
+            payload["status"] = "failed"
+            write_run_summary(harness_summary, payload)
+            for failure in byte_failures:
+                print(f"Error: {failure}", file=sys.stderr)
+            return 1
+
+    if args.skip_parity:
+        payload["parity"] = {"status": "skipped"}
+    else:
+        parity_returncode = run_parity(args, out_dir)
+        payload["parity"] = {
+            "status": "ok" if parity_returncode == 0 else "failed",
+            "returncode": parity_returncode,
+            "test": str(args.parity_test),
+            "matlab_dir": str(args.matlab_dir),
+        }
+        if parity_returncode != 0:
+            payload["status"] = "failed"
+            write_run_summary(harness_summary, payload)
+            return parity_returncode
+
+    payload["status"] = "ok"
+    write_run_summary(harness_summary, payload)
+    print(f"Taroz PC dogfood OK: {out_dir}")
+    print(f"Harness summary: {harness_summary}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/gnss_taroz_pd_dogfood.py
+++ b/apps/gnss_taroz_pd_dogfood.py
@@ -1,0 +1,399 @@
+#!/usr/bin/env python3
+"""Regenerate and verify taroz position/velocity PD dogfood artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import math
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+APPS_DIR = Path(__file__).resolve().parent
+EXE_SUFFIX = ".exe" if os.name == "nt" else ""
+BUILD_CONFIGS = ("Release", "RelWithDebInfo", "Debug", "MinSizeRel")
+
+DEFAULT_DATA_DIR = Path("/tmp/taroz_gtsam_gnss/examples/data")
+DEFAULT_OUT_DIR = ROOT_DIR / "output/dogfood/taroz_pd_dogfood_current"
+DEFAULT_MATLAB_DIR = ROOT_DIR / "output/dogfood/taroz_matlab_pd_debug"
+DEFAULT_PARITY_TEST = ROOT_DIR / "tests/test_taroz_pd_internal_parity.py"
+DEFAULT_MAX_EPOCHS = 80
+DEFAULT_MAX_ITERATIONS = 40
+
+EPOCH_STATE_NAME = "per_epoch_state.csv"
+FACTOR_DEBUG_NAME = "factor_debug.csv"
+GRAPH_DETAIL_NAME = "graph_detail.csv"
+SUMMARY_NAME = "summary.json"
+
+
+def default_path(name: str) -> Path:
+    return DEFAULT_DATA_DIR / name
+
+
+def find_binary(target_name: str) -> Path | None:
+    filename = target_name + EXE_SUFFIX
+    build_roots = [
+        Path(path)
+        for path in sorted(glob.glob(str(ROOT_DIR / "build*")))
+        if Path(path).is_dir()
+    ]
+    default_build = ROOT_DIR / "build"
+    if default_build not in build_roots:
+        build_roots.insert(0, default_build)
+
+    candidates = [APPS_DIR / filename]
+    for build_root in build_roots:
+        candidates.append(build_root / "apps" / filename)
+        for config in BUILD_CONFIGS:
+            candidates.append(build_root / "apps" / config / filename)
+            candidates.append(build_root / config / "apps" / filename)
+            candidates.append(build_root / config / filename)
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+
+    recursive_hits: list[Path] = []
+    for build_root in build_roots:
+        recursive_hits.extend(
+            Path(path)
+            for path in glob.glob(str(build_root / "**" / filename), recursive=True)
+            if Path(path).is_file()
+        )
+    return sorted(recursive_hits)[0] if recursive_hits else None
+
+
+def output_paths(out_dir: Path) -> dict[str, Path]:
+    return {
+        "epoch_state": out_dir / EPOCH_STATE_NAME,
+        "factor_debug": out_dir / FACTOR_DEBUG_NAME,
+        "graph_detail": out_dir / GRAPH_DETAIL_NAME,
+        "summary": out_dir / SUMMARY_NAME,
+    }
+
+
+def build_pd_command(args: argparse.Namespace, paths: dict[str, Path]) -> list[str]:
+    pd_bin = Path(args.pd_bin) if args.pd_bin else find_binary("gnss_pos_vel_pd")
+    if pd_bin is None:
+        if args.dry_run:
+            pd_bin = Path("gnss_pos_vel_pd")
+        else:
+            raise SystemExit(
+                "gnss_pos_vel_pd binary not found. Build it first with "
+                "`cmake --build build --target gnss_pos_vel_pd`, or pass --pd-bin."
+            )
+
+    command = [
+        str(pd_bin),
+        "--obs",
+        str(args.obs),
+        "--nav",
+        str(args.nav),
+        "--seed-pos",
+        str(args.seed_pos),
+        "--out-csv",
+        str(paths["epoch_state"]),
+        "--factor-debug-csv",
+        str(paths["factor_debug"]),
+        "--graph-csv",
+        str(paths["graph_detail"]),
+        "--summary-json",
+        str(paths["summary"]),
+        "--quiet",
+    ]
+    if args.max_epochs > 0:
+        command.extend(["--max-epochs", str(args.max_epochs)])
+    if args.max_iterations > 0:
+        command.extend(["--max-iterations", str(args.max_iterations)])
+    command.extend(args.pd_extra_arg)
+    return command
+
+
+def validate_inputs(args: argparse.Namespace) -> None:
+    missing = [
+        path
+        for path in (args.obs, args.nav, args.seed_pos)
+        if not Path(path).exists()
+    ]
+    if missing:
+        joined = ", ".join(str(path) for path in missing)
+        raise SystemExit(f"missing taroz PD input file(s): {joined}")
+
+
+def run_command(command: list[str], *, env: dict[str, str] | None = None) -> int:
+    completed = subprocess.run(command, cwd=ROOT_DIR, env=env, check=False)
+    return completed.returncode
+
+
+def load_native_summary(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def selected_native_summary(summary: dict[str, Any]) -> dict[str, Any]:
+    keys = [
+        "preset",
+        "backend",
+        "optimized_epochs",
+        "valid_position_epochs",
+        "valid_velocity_epochs",
+        "pseudorange_factors",
+        "doppler_factors",
+        "motion_factors",
+        "clock_motion_factors",
+        "clock_drift_between_factors",
+        "graph_factors",
+        "graph_values",
+        "iterations",
+        "converged",
+        "initial_cost",
+        "final_cost",
+        "residual_rms_mps",
+    ]
+    return {key: summary.get(key) for key in keys if key in summary}
+
+
+def _close(actual: Any, expected: float, tolerance: float = 1e-9) -> bool:
+    return isinstance(actual, (int, float)) and math.isclose(
+        float(actual),
+        expected,
+        rel_tol=tolerance,
+        abs_tol=tolerance,
+    )
+
+
+def _is_finite_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and math.isfinite(float(value))
+
+
+def verify_native_summary(
+    summary: dict[str, Any],
+    *,
+    expected_max_epochs: int,
+    expected_max_iterations: int,
+) -> list[str]:
+    failures: list[str] = []
+    if summary.get("preset") != "taroz-pd":
+        failures.append("native summary preset is not taroz-pd")
+    if summary.get("backend") != "eigen":
+        failures.append("native summary backend is not eigen")
+    if not _close(summary.get("pseudorange_sigma_zenith_m"), 3.0):
+        failures.append("taroz-pd pseudorange_sigma_zenith_m must be 3")
+    if not _close(summary.get("doppler_sigma_zenith_mps"), 0.2):
+        failures.append("taroz-pd doppler_sigma_zenith_mps must be 0.2")
+    if not _close(summary.get("position_prior_sigma_m"), 1000.0):
+        failures.append("taroz-pd position prior sigma must be 1000")
+    if not _close(summary.get("clock_prior_sigma_m"), 1e6):
+        failures.append("taroz-pd clock prior sigma must be 1e6")
+    if not _close(summary.get("velocity_prior_sigma_mps"), 1000.0):
+        failures.append("taroz-pd velocity prior sigma must be 1000")
+    if not _close(summary.get("clock_drift_prior_sigma_mps"), 1000.0):
+        failures.append("taroz-pd clock drift prior sigma must be 1000")
+    if not _close(summary.get("motion_sigma_m"), 0.1):
+        failures.append("taroz-pd position/velocity motion sigma must be 0.1")
+    if not _close(summary.get("clock_motion_sigma_m"), 0.1):
+        failures.append("taroz-pd clock motion sigma must be 0.1")
+    if not _close(summary.get("clock_drift_between_sigma_mps"), 0.1):
+        failures.append("taroz-pd clock drift between sigma must be 0.1")
+
+    optimized_epochs = summary.get("optimized_epochs")
+    if not isinstance(optimized_epochs, int) or optimized_epochs <= 0:
+        failures.append("taroz-pd optimized_epochs must be positive")
+    elif expected_max_epochs > 0 and optimized_epochs != expected_max_epochs:
+        failures.append(
+            f"taroz-pd optimized_epochs must equal requested max epochs "
+            f"({expected_max_epochs})"
+        )
+    if isinstance(optimized_epochs, int) and optimized_epochs > 0:
+        expected_between = max(0, optimized_epochs - 1)
+        if summary.get("valid_position_epochs") != optimized_epochs:
+            failures.append("taroz-pd valid_position_epochs must match optimized_epochs")
+        if summary.get("valid_velocity_epochs") != optimized_epochs:
+            failures.append("taroz-pd valid_velocity_epochs must match optimized_epochs")
+        if summary.get("motion_factors") != expected_between:
+            failures.append(f"taroz-pd motion_factors must be {expected_between}")
+        if summary.get("clock_motion_factors") != expected_between:
+            failures.append(f"taroz-pd clock_motion_factors must be {expected_between}")
+        if summary.get("clock_drift_between_factors") != expected_between:
+            failures.append(
+                f"taroz-pd clock_drift_between_factors must be {expected_between}"
+            )
+        if summary.get("graph_values") != 4 * optimized_epochs:
+            failures.append("taroz-pd graph_values must be 4 per epoch")
+
+    if not isinstance(summary.get("pseudorange_factors"), int) or summary["pseudorange_factors"] <= 0:
+        failures.append("taroz-pd pseudorange_factors must be positive")
+    if not isinstance(summary.get("doppler_factors"), int) or summary["doppler_factors"] <= 0:
+        failures.append("taroz-pd doppler_factors must be positive")
+
+    iterations = summary.get("iterations")
+    if not isinstance(iterations, int) or iterations <= 0:
+        failures.append("taroz-pd iterations must be positive")
+    elif expected_max_iterations > 0 and iterations > expected_max_iterations:
+        failures.append("taroz-pd iterations exceeded requested max iterations")
+    if summary.get("converged") is not True:
+        failures.append("taroz-pd smoke should converge")
+    if not _is_finite_number(summary.get("initial_cost")):
+        failures.append("taroz-pd initial_cost must be finite")
+    if not _is_finite_number(summary.get("final_cost")):
+        failures.append("taroz-pd final_cost must be finite")
+    if not _is_finite_number(summary.get("residual_rms_mps")):
+        failures.append("taroz-pd residual_rms_mps must be finite")
+    return failures
+
+
+def write_run_summary(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def run_parity(args: argparse.Namespace, out_dir: Path) -> int:
+    env = os.environ.copy()
+    env["GNSSPP_TAROZ_PD_CPP_DIR"] = str(out_dir)
+    env["GNSSPP_TAROZ_PD_MATLAB_DIR"] = str(args.matlab_dir)
+    return run_command([sys.executable, str(args.parity_test)], env=env)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Regenerate taroz estimate_pos_vel_PD-equivalent C++ outputs and "
+            "verify position/velocity PD parity."
+        )
+    )
+    parser.add_argument("--obs", type=Path, default=default_path("rover_1Hz.obs"))
+    parser.add_argument("--nav", type=Path, default=default_path("base.nav"))
+    parser.add_argument(
+        "--seed-pos",
+        type=Path,
+        default=default_path("rover_1Hz_spp.pos"),
+        help="RTKLIB POS used as taroz x_ini seed.",
+    )
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument(
+        "--summary-json",
+        type=Path,
+        default=None,
+        help="Harness summary JSON path (default: <out-dir>/taroz_pd_dogfood_summary.json).",
+    )
+    parser.add_argument("--pd-bin", type=Path, default=None)
+    parser.add_argument(
+        "--max-epochs",
+        type=int,
+        default=DEFAULT_MAX_EPOCHS,
+        help="Epoch cap for the smoke run; 0 keeps the native default.",
+    )
+    parser.add_argument(
+        "--max-iterations",
+        type=int,
+        default=DEFAULT_MAX_ITERATIONS,
+        help="Iteration cap for the smoke run; 0 keeps the native default.",
+    )
+    parser.add_argument(
+        "--pd-extra-arg",
+        action="append",
+        default=[],
+        help="Extra single argument passed to gnss_pos_vel_pd. Repeat for multiple tokens.",
+    )
+    parser.add_argument("--matlab-dir", type=Path, default=DEFAULT_MATLAB_DIR)
+    parser.add_argument("--parity-test", type=Path, default=DEFAULT_PARITY_TEST)
+    parser.add_argument("--skip-parity", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    if args.max_epochs < 0:
+        raise SystemExit("--max-epochs must be non-negative")
+    if args.max_iterations < 0:
+        raise SystemExit("--max-iterations must be non-negative")
+
+    out_dir = args.out_dir
+    paths = output_paths(out_dir)
+    harness_summary = args.summary_json or (out_dir / "taroz_pd_dogfood_summary.json")
+    payload: dict[str, Any] = {
+        "status": "planned",
+        "inputs": {
+            "obs": str(args.obs),
+            "nav": str(args.nav),
+            "seed_pos": str(args.seed_pos),
+        },
+        "out_dir": str(out_dir),
+        "outputs": {name: str(path) for name, path in paths.items()},
+        "harness_summary_json": str(harness_summary),
+        "matlab_dir": str(args.matlab_dir),
+        "expected": {
+            "preset": "taroz-pd",
+            "backend": "eigen",
+            "max_epochs": args.max_epochs,
+            "max_iterations": args.max_iterations,
+        },
+    }
+
+    command = build_pd_command(args, paths)
+    payload["pd_command"] = command
+
+    if args.dry_run:
+        payload["status"] = "dry-run"
+        write_run_summary(harness_summary, payload)
+        print("Dry run. Planned taroz PD dogfood command:")
+        print(" ".join(command))
+        print(f"Harness summary: {harness_summary}")
+        return 0
+
+    validate_inputs(args)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    pd_returncode = run_command(command)
+    payload["pd_returncode"] = pd_returncode
+    if pd_returncode != 0:
+        payload["status"] = "failed"
+        write_run_summary(harness_summary, payload)
+        return pd_returncode
+
+    native_summary = load_native_summary(paths["summary"])
+    payload["native_summary"] = selected_native_summary(native_summary)
+    native_failures = verify_native_summary(
+        native_summary,
+        expected_max_epochs=args.max_epochs,
+        expected_max_iterations=args.max_iterations,
+    )
+    payload["native_summary_failures"] = native_failures
+    if native_failures:
+        payload["status"] = "failed"
+        write_run_summary(harness_summary, payload)
+        for failure in native_failures:
+            print(f"Error: {failure}", file=sys.stderr)
+        return 1
+
+    if args.skip_parity:
+        payload["parity"] = {"status": "skipped"}
+    else:
+        parity_returncode = run_parity(args, out_dir)
+        payload["parity"] = {
+            "status": "ok" if parity_returncode == 0 else "failed",
+            "returncode": parity_returncode,
+            "test": str(args.parity_test),
+            "matlab_dir": str(args.matlab_dir),
+        }
+        if parity_returncode != 0:
+            payload["status"] = "failed"
+            write_run_summary(harness_summary, payload)
+            return parity_returncode
+
+    payload["status"] = "ok"
+    write_run_summary(harness_summary, payload)
+    print(f"Taroz PD dogfood OK: {out_dir}")
+    print(f"Harness summary: {harness_summary}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/gnss_taroz_pos_vel_amb_pdc_dogfood.py
+++ b/apps/gnss_taroz_pos_vel_amb_pdc_dogfood.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Regenerate and verify taroz position/velocity ambiguity PDC artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import glob
+import json
+import math
+import os
+from pathlib import Path
+import subprocess
+import sys
+from typing import Any
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+APPS_DIR = Path(__file__).resolve().parent
+EXE_SUFFIX = ".exe" if os.name == "nt" else ""
+BUILD_CONFIGS = ("Release", "RelWithDebInfo", "Debug", "MinSizeRel")
+
+DEFAULT_DATA_DIR = Path("/tmp/taroz_gtsam_gnss/examples/data")
+DEFAULT_OUT_DIR = ROOT_DIR / "output/dogfood/taroz_pos_vel_amb_pdc_current"
+DEFAULT_MATLAB_DIR = (
+    ROOT_DIR / "output/dogfood/taroz_matlab_pos_vel_amb_pdc_debug"
+)
+DEFAULT_PARITY_TEST = ROOT_DIR / "tests/test_taroz_pos_vel_amb_pdc_factor_parity.py"
+
+POS_NAME = "opt.pos"
+SUMMARY_NAME = "summary.json"
+EPOCH_DEBUG_NAME = "epoch_debug.csv"
+FACTOR_DEBUG_NAME = "factor_debug.csv"
+SD_FACTOR_DEBUG_NAME = "sd_factor_debug.csv"
+LAMBDA_DEBUG_NAME = "lambda_debug.csv"
+
+EXPECTED_FULL_COUNTS = {
+    "input_epochs": 1141,
+    "optimized_epochs": 1141,
+    "valid_solutions": 964,
+    "fixed_solutions": 721,
+    "float_solutions": 243,
+    "single_difference_doppler_factors": 18330,
+    "single_difference_tdcp_factors": 13509,
+    "double_difference_pseudorange_factors": 15013,
+    "double_difference_carrier_factors": 13826,
+    "ambiguity_states": 13826,
+    "lambda_ambiguity_candidates": 13362,
+    "lambda_ambiguity_used_candidates": 10737,
+    "lambda_ambiguity_attempts": 964,
+    "fixed_ambiguities": 10737,
+    "motion_factors": 1140,
+    "ambiguity_between_factors": 13398,
+    "graph_factors": 76357,
+    "graph_values": 21813,
+    "iterations": 24,
+}
+
+
+def default_path(name: str) -> Path:
+    return DEFAULT_DATA_DIR / name
+
+
+def find_binary(target_name: str) -> Path | None:
+    filename = target_name + EXE_SUFFIX
+    build_roots = [
+        Path(path)
+        for path in sorted(glob.glob(str(ROOT_DIR / "build*")))
+        if Path(path).is_dir()
+    ]
+    default_build = ROOT_DIR / "build"
+    if default_build not in build_roots:
+        build_roots.insert(0, default_build)
+
+    candidates = [APPS_DIR / filename]
+    for build_root in build_roots:
+        candidates.append(build_root / "apps" / filename)
+        for config in BUILD_CONFIGS:
+            candidates.append(build_root / "apps" / config / filename)
+            candidates.append(build_root / config / "apps" / filename)
+            candidates.append(build_root / config / filename)
+
+    for candidate in candidates:
+        if candidate.is_file():
+            return candidate
+
+    recursive_hits: list[Path] = []
+    for build_root in build_roots:
+        recursive_hits.extend(
+            Path(path)
+            for path in glob.glob(str(build_root / "**" / filename), recursive=True)
+            if Path(path).is_file()
+        )
+    return sorted(recursive_hits)[0] if recursive_hits else None
+
+
+def output_paths(out_dir: Path) -> dict[str, Path]:
+    return {
+        "pos": out_dir / POS_NAME,
+        "summary": out_dir / SUMMARY_NAME,
+        "epoch_debug": out_dir / EPOCH_DEBUG_NAME,
+        "factor_debug": out_dir / FACTOR_DEBUG_NAME,
+        "sd_factor_debug": out_dir / SD_FACTOR_DEBUG_NAME,
+        "lambda_debug": out_dir / LAMBDA_DEBUG_NAME,
+    }
+
+
+def build_fgo_command(args: argparse.Namespace, paths: dict[str, Path]) -> list[str]:
+    fgo_bin = Path(args.fgo_bin) if args.fgo_bin else find_binary("gnss_fgo")
+    if fgo_bin is None:
+        if args.dry_run:
+            fgo_bin = Path("gnss_fgo")
+        else:
+            raise SystemExit(
+                "gnss_fgo binary not found. Build it first with "
+                "`cmake --build build --target gnss_fgo`, or pass --fgo-bin."
+            )
+
+    command = [
+        str(fgo_bin),
+        "--preset",
+        "taroz-amb-pdc",
+        "--obs",
+        str(args.obs),
+        "--base",
+        str(args.base),
+        "--nav",
+        str(args.nav),
+        "--seed-pos",
+        str(args.seed_pos),
+        "--out",
+        str(paths["pos"]),
+        "--summary-json",
+        str(paths["summary"]),
+        "--epoch-debug-csv",
+        str(paths["epoch_debug"]),
+        "--factor-debug-csv",
+        str(paths["factor_debug"]),
+        "--sd-factor-debug-csv",
+        str(paths["sd_factor_debug"]),
+        "--lambda-debug-csv",
+        str(paths["lambda_debug"]),
+        "--quiet",
+    ]
+    command.extend(args.fgo_extra_arg)
+    return command
+
+
+def validate_inputs(args: argparse.Namespace) -> None:
+    missing = [
+        path
+        for path in (args.obs, args.base, args.nav, args.seed_pos)
+        if not Path(path).exists()
+    ]
+    if missing:
+        joined = ", ".join(str(path) for path in missing)
+        raise SystemExit(f"missing taroz ambiguity PDC input file(s): {joined}")
+
+
+def run_command(command: list[str], *, env: dict[str, str] | None = None) -> int:
+    completed = subprocess.run(command, cwd=ROOT_DIR, env=env, check=False)
+    return completed.returncode
+
+
+def load_native_summary(path: Path) -> dict[str, Any]:
+    with path.open(encoding="utf-8") as handle:
+        return json.load(handle)
+
+
+def selected_native_summary(summary: dict[str, Any]) -> dict[str, Any]:
+    keys = [
+        "preset",
+        "backend",
+        "optimized_epochs",
+        "valid_solutions",
+        "fixed_solutions",
+        "float_solutions",
+        "double_difference_pseudorange_factors",
+        "double_difference_carrier_factors",
+        "single_difference_doppler_factors",
+        "single_difference_tdcp_factors",
+        "ambiguity_states",
+        "lambda_ambiguity_candidates",
+        "lambda_ambiguity_used_candidates",
+        "lambda_ambiguity_attempts",
+        "fixed_ambiguities",
+        "iterations",
+        "converged",
+        "final_cost",
+        "epoch_lambda_processing_time_ms",
+        "epoch_lambda_covariance_solve_time_ms",
+        "total_processing_time_ms",
+    ]
+    return {key: summary.get(key) for key in keys if key in summary}
+
+
+def _close(actual: Any, expected: float, tolerance: float = 1e-9) -> bool:
+    return isinstance(actual, (int, float)) and math.isclose(
+        float(actual),
+        expected,
+        rel_tol=tolerance,
+        abs_tol=tolerance,
+    )
+
+
+def _is_finite_number(value: Any) -> bool:
+    return isinstance(value, (int, float)) and math.isfinite(float(value))
+
+
+def verify_native_summary(summary: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+    if summary.get("preset") != "taroz-amb-pdc":
+        failures.append("native summary preset is not taroz-amb-pdc")
+    if summary.get("backend") != "eigen":
+        failures.append("native summary backend is not eigen")
+    if summary.get("debug_problem_only") is not False:
+        failures.append("taroz-amb-pdc dogfood must run full optimization")
+    if summary.get("use_spp_seed") is not False:
+        failures.append("taroz-amb-pdc must report use_spp_seed=false")
+    if summary.get("use_pseudorange_factors") is not False:
+        failures.append("taroz-amb-pdc must disable raw pseudorange factors")
+    if summary.get("use_single_difference_doppler_factors") is not True:
+        failures.append("taroz-amb-pdc must enable SD Doppler factors")
+    if summary.get("use_single_difference_tdcp_factors") is not True:
+        failures.append("taroz-amb-pdc must enable SD TDCP factors")
+    if summary.get("use_velocity_states") is not True:
+        failures.append("taroz-amb-pdc must enable velocity states")
+    if summary.get("use_velocity_motion_factors") is not True:
+        failures.append("taroz-amb-pdc must enable velocity motion factors")
+    if summary.get("use_ambiguity_between_factors") is not True:
+        failures.append("taroz-amb-pdc must enable ambiguity between factors")
+    if summary.get("linearize_double_difference_factors_at_seed") is not True:
+        failures.append("taroz-amb-pdc must seed-linearize DD factors")
+    if summary.get("use_epoch_lambda_fixed_output") is not True:
+        failures.append("taroz-amb-pdc must enable epoch LAMBDA fixed output")
+    if summary.get("dd_ambiguity_per_epoch") is not True:
+        failures.append("taroz-amb-pdc must use per-epoch DD ambiguity states")
+    if summary.get("use_ambiguity_priors") is not False:
+        failures.append("taroz-amb-pdc must disable ambiguity priors")
+    if summary.get("reject_rover_carrier_lli") is not True:
+        failures.append("taroz-amb-pdc must reject rover carrier LLI")
+    if summary.get("insert_fixed_interval_gaps") is not True:
+        failures.append("taroz-amb-pdc must insert fixed interval gaps")
+    if summary.get("exclude_glonass_qzss_sbas") is not True:
+        failures.append("taroz-amb-pdc must exclude GLONASS/QZSS/SBAS")
+
+    numeric_expectations = {
+        "pseudorange_huber_threshold_sigma": 1.234,
+        "carrier_phase_huber_threshold_sigma": 1.234,
+        "tdcp_huber_threshold_sigma": 1.234,
+        "velocity_motion_sigma_m": 0.01,
+        "ambiguity_between_sigma_cycles": 0.001,
+        "min_snr_dbhz": 35.0,
+        "min_satellites_per_epoch": 0,
+        "min_output_dd_carrier_factors_per_epoch": 6,
+    }
+    for key, expected in numeric_expectations.items():
+        if not _close(summary.get(key), expected):
+            failures.append(f"taroz-amb-pdc {key} must be {expected}")
+
+    for key, expected in EXPECTED_FULL_COUNTS.items():
+        if summary.get(key) != expected:
+            failures.append(f"taroz-amb-pdc {key} must be {expected}")
+
+    if summary.get("lambda_ambiguity_fix_solved") is not True:
+        failures.append("taroz-amb-pdc LAMBDA must solve")
+    if summary.get("lambda_ambiguity_fix_used") is not True:
+        failures.append("taroz-amb-pdc LAMBDA fixed output must be used")
+    if summary.get("partial_lambda_ambiguity_fix_used") is not False:
+        failures.append("taroz-amb-pdc must not require partial LAMBDA retry")
+    if summary.get("fixed_solution") is not True:
+        failures.append("taroz-amb-pdc summary must report fixed_solution=true")
+    if summary.get("converged") is not True:
+        failures.append("taroz-amb-pdc optimization must converge")
+    if not _is_finite_number(summary.get("final_cost")):
+        failures.append("taroz-amb-pdc final_cost must be finite")
+    if not _is_finite_number(summary.get("total_processing_time_ms")):
+        failures.append("taroz-amb-pdc total_processing_time_ms must be finite")
+    return failures
+
+
+def write_run_summary(path: Path, payload: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def run_parity(args: argparse.Namespace, paths: dict[str, Path], out_dir: Path) -> int:
+    env = os.environ.copy()
+    env["GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_DIR"] = str(out_dir)
+    env["GNSSPP_TAROZ_POS_VEL_AMB_PDC_MATLAB_DIR"] = str(args.matlab_dir)
+    env["GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_OPT_POS"] = str(paths["pos"])
+    env["GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_OPT_EPOCH_DEBUG"] = str(
+        paths["epoch_debug"]
+    )
+    env["GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_OPT_LAMBDA_DEBUG"] = str(
+        paths["lambda_debug"]
+    )
+    return run_command([sys.executable, str(args.parity_test)], env=env)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Regenerate taroz estimate_pos_vel_ambiguity_PDC-equivalent C++ "
+            "outputs and verify raw factors, final output, and LAMBDA parity."
+        )
+    )
+    parser.add_argument("--obs", type=Path, default=default_path("rover_1Hz.obs"))
+    parser.add_argument("--base", type=Path, default=default_path("base.obs"))
+    parser.add_argument("--nav", type=Path, default=default_path("base.nav"))
+    parser.add_argument(
+        "--seed-pos",
+        type=Path,
+        default=default_path("rover_1Hz_spp.pos"),
+        help="RTKLIB POS used as taroz x_ini seed.",
+    )
+    parser.add_argument("--out-dir", type=Path, default=DEFAULT_OUT_DIR)
+    parser.add_argument(
+        "--summary-json",
+        type=Path,
+        default=None,
+        help=(
+            "Harness summary JSON path (default: "
+            "<out-dir>/taroz_pos_vel_amb_pdc_dogfood_summary.json)."
+        ),
+    )
+    parser.add_argument("--fgo-bin", type=Path, default=None)
+    parser.add_argument(
+        "--fgo-extra-arg",
+        action="append",
+        default=[],
+        help="Extra single argument passed to gnss_fgo. Repeat for multiple tokens.",
+    )
+    parser.add_argument("--matlab-dir", type=Path, default=DEFAULT_MATLAB_DIR)
+    parser.add_argument("--parity-test", type=Path, default=DEFAULT_PARITY_TEST)
+    parser.add_argument("--skip-parity", action="store_true")
+    parser.add_argument("--dry-run", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    out_dir = args.out_dir
+    paths = output_paths(out_dir)
+    harness_summary = args.summary_json or (
+        out_dir / "taroz_pos_vel_amb_pdc_dogfood_summary.json"
+    )
+    payload: dict[str, Any] = {
+        "status": "planned",
+        "inputs": {
+            "obs": str(args.obs),
+            "base": str(args.base),
+            "nav": str(args.nav),
+            "seed_pos": str(args.seed_pos),
+        },
+        "out_dir": str(out_dir),
+        "outputs": {name: str(path) for name, path in paths.items()},
+        "harness_summary_json": str(harness_summary),
+        "matlab_dir": str(args.matlab_dir),
+        "expected": {
+            "preset": "taroz-amb-pdc",
+            "backend": "eigen",
+            "counts": EXPECTED_FULL_COUNTS,
+        },
+    }
+
+    command = build_fgo_command(args, paths)
+    payload["fgo_command"] = command
+
+    if args.dry_run:
+        payload["status"] = "dry-run"
+        write_run_summary(harness_summary, payload)
+        print("Dry run. Planned taroz ambiguity PDC dogfood command:")
+        print(" ".join(command))
+        print(f"Harness summary: {harness_summary}")
+        return 0
+
+    validate_inputs(args)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    fgo_returncode = run_command(command)
+    payload["fgo_returncode"] = fgo_returncode
+    if fgo_returncode != 0:
+        payload["status"] = "failed"
+        write_run_summary(harness_summary, payload)
+        return fgo_returncode
+
+    native_summary = load_native_summary(paths["summary"])
+    payload["native_summary"] = selected_native_summary(native_summary)
+    native_failures = verify_native_summary(native_summary)
+    payload["native_summary_failures"] = native_failures
+    if native_failures:
+        payload["status"] = "failed"
+        write_run_summary(harness_summary, payload)
+        for failure in native_failures:
+            print(f"Error: {failure}", file=sys.stderr)
+        return 1
+
+    if args.skip_parity:
+        payload["parity"] = {"status": "skipped"}
+    else:
+        parity_returncode = run_parity(args, paths, out_dir)
+        payload["parity"] = {
+            "status": "ok" if parity_returncode == 0 else "failed",
+            "returncode": parity_returncode,
+            "test": str(args.parity_test),
+            "matlab_dir": str(args.matlab_dir),
+        }
+        if parity_returncode != 0:
+            payload["status"] = "failed"
+            write_run_summary(harness_summary, payload)
+            return parity_returncode
+
+    payload["status"] = "ok"
+    write_run_summary(harness_summary, payload)
+    print(f"Taroz ambiguity PDC dogfood OK: {out_dir}")
+    print(f"Harness summary: {harness_summary}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/gnss_toml_config.py
+++ b/apps/gnss_toml_config.py
@@ -6,8 +6,12 @@ from __future__ import annotations
 import argparse
 from pathlib import Path
 import sys
-import tomllib
 from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 compatibility.
+    import tomli as tomllib
 
 
 def _extract_config_path(argv: list[str]) -> Path | None:

--- a/apps/gnss_vel_d.cpp
+++ b/apps/gnss_vel_d.cpp
@@ -1,0 +1,1116 @@
+#include <libgnss++/core/constants.hpp>
+#include <libgnss++/core/coordinates.hpp>
+#include <libgnss++/core/navigation.hpp>
+#include <libgnss++/core/observation.hpp>
+#include <libgnss++/core/signals.hpp>
+#include <libgnss++/io/rinex.hpp>
+
+#include <Eigen/Sparse>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <map>
+#include <set>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace {
+
+constexpr double kPi = 3.141592653589793238462643383279502884;
+constexpr double kDegreesToRadians = kPi / 180.0;
+constexpr double kRadiansToDegrees = 180.0 / kPi;
+
+struct Options {
+    std::string obs_path;
+    std::string nav_path;
+    std::string seed_pos_path;
+    std::string out_csv_path;
+    std::string factor_debug_csv_path;
+    std::string graph_csv_path;
+    std::string summary_json_path;
+    int skip_epochs = 0;
+    int max_epochs = 0;
+    int max_iterations = 1000;
+    double seed_match_tolerance_s = 0.51;
+    double seed_interpolation_max_gap_s = 60.0;
+    double min_snr_dbhz = 35.0;
+    double min_elevation_deg = 15.0;
+    double doppler_sigma_zenith_mps = 0.2;
+    double velocity_prior_sigma_mps = 1000.0;
+    double clock_drift_prior_sigma_mps = 1000.0;
+    double clock_drift_between_sigma_mps = 0.1;
+    double huber_threshold_sigma = 1.234;
+    bool debug_problem_only = false;
+    bool quiet = false;
+};
+
+struct SeedPosition {
+    libgnss::GNSSTime time;
+    libgnss::Vector3d position_ecef = libgnss::Vector3d::Zero();
+};
+
+struct DopplerFactor {
+    std::size_t epoch_index = 0;
+    libgnss::GNSSTime time;
+    libgnss::SatelliteId satellite;
+    libgnss::SignalType signal = libgnss::SignalType::GPS_L1CA;
+    double snr_dbhz = 0.0;
+    double elevation_rad = 0.0;
+    double sigma_mps = 1.0;
+    double residual_mps = 0.0;
+    double measured_range_rate_mps = 0.0;
+    double modeled_range_rate_mps = 0.0;
+    double satellite_clock_drift_mps = 0.0;
+    double wavelength_m = 0.0;
+    libgnss::Vector3d los = libgnss::Vector3d::Zero();
+};
+
+struct Problem {
+    std::vector<libgnss::ObservationData> epochs;
+    std::vector<libgnss::Vector3d> seed_positions;
+    std::vector<DopplerFactor> factors;
+    std::size_t nsat = 0;
+    std::size_t seed_matched_epochs = 0;
+    std::size_t seed_interpolated_epochs = 0;
+};
+
+struct SolveResult {
+    Eigen::VectorXd state;
+    double initial_cost = 0.0;
+    double final_cost = 0.0;
+    double residual_rms_mps = 0.0;
+    int iterations = 0;
+    bool converged = false;
+};
+
+[[noreturn]] void usageError(const std::string& message, const char* argv0) {
+    std::cerr << "Error: " << message << "\n\n"
+              << "Usage: " << argv0 << " --obs rover.obs --nav base.nav "
+              << "--seed-pos rover_1Hz_spp.pos [options]\n\n"
+              << "Options:\n"
+              << "  --out-csv PATH                 Write per-epoch velocity CSV.\n"
+              << "  --factor-debug-csv PATH        Write per-Doppler-factor debug CSV.\n"
+              << "  --graph-csv PATH               Write taroz-like graph detail CSV.\n"
+              << "  --summary-json PATH            Write JSON summary.\n"
+              << "  --max-epochs N                 Limit processed epochs; 0 means all.\n"
+              << "  --skip-epochs N                Skip leading observation epochs.\n"
+              << "  --max-iterations N             IRLS iteration limit.\n"
+              << "  --debug-problem-only           Build factors and skip optimization.\n"
+              << "  --quiet                        Suppress human-readable summary.\n";
+    throw std::invalid_argument(message);
+}
+
+int parseIntArg(const std::string& value, const std::string& name, const char* argv0) {
+    try {
+        std::size_t consumed = 0;
+        const int parsed = std::stoi(value, &consumed);
+        if (consumed == value.size()) {
+            return parsed;
+        }
+    } catch (const std::exception&) {
+    }
+    usageError("invalid integer for " + name + ": " + value, argv0);
+}
+
+double parseDoubleArg(const std::string& value, const std::string& name, const char* argv0) {
+    try {
+        std::size_t consumed = 0;
+        const double parsed = std::stod(value, &consumed);
+        if (consumed == value.size() && std::isfinite(parsed)) {
+            return parsed;
+        }
+    } catch (const std::exception&) {
+    }
+    usageError("invalid number for " + name + ": " + value, argv0);
+}
+
+Options parseArguments(int argc, char* argv[]) {
+    Options options;
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        auto require_value = [&](const std::string& name) -> std::string {
+            if (i + 1 >= argc) {
+                usageError("missing value for " + name, argv[0]);
+            }
+            return argv[++i];
+        };
+
+        if (arg == "--obs") {
+            options.obs_path = require_value(arg);
+        } else if (arg == "--nav") {
+            options.nav_path = require_value(arg);
+        } else if (arg == "--seed-pos") {
+            options.seed_pos_path = require_value(arg);
+        } else if (arg == "--out-csv") {
+            options.out_csv_path = require_value(arg);
+        } else if (arg == "--factor-debug-csv") {
+            options.factor_debug_csv_path = require_value(arg);
+        } else if (arg == "--graph-csv") {
+            options.graph_csv_path = require_value(arg);
+        } else if (arg == "--summary-json") {
+            options.summary_json_path = require_value(arg);
+        } else if (arg == "--skip-epochs") {
+            options.skip_epochs = parseIntArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--max-epochs") {
+            options.max_epochs = parseIntArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--max-iterations") {
+            options.max_iterations = parseIntArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--seed-match-tolerance") {
+            options.seed_match_tolerance_s = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--seed-interpolation-max-gap") {
+            options.seed_interpolation_max_gap_s = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--min-snr") {
+            options.min_snr_dbhz = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--min-elevation") {
+            options.min_elevation_deg = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--doppler-sigma-zenith") {
+            options.doppler_sigma_zenith_mps = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--velocity-prior-sigma") {
+            options.velocity_prior_sigma_mps = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--clock-drift-prior-sigma") {
+            options.clock_drift_prior_sigma_mps = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--clock-drift-between-sigma") {
+            options.clock_drift_between_sigma_mps = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--huber-threshold") {
+            options.huber_threshold_sigma = parseDoubleArg(require_value(arg), arg, argv[0]);
+        } else if (arg == "--debug-problem-only") {
+            options.debug_problem_only = true;
+        } else if (arg == "--quiet") {
+            options.quiet = true;
+        } else if (arg == "--help" || arg == "-h") {
+            usageError("help requested", argv[0]);
+        } else {
+            usageError("unknown argument: " + arg, argv[0]);
+        }
+    }
+
+    if (options.obs_path.empty()) {
+        usageError("--obs is required", argv[0]);
+    }
+    if (options.nav_path.empty()) {
+        usageError("--nav is required", argv[0]);
+    }
+    if (options.seed_pos_path.empty()) {
+        usageError("--seed-pos is required", argv[0]);
+    }
+    if (options.skip_epochs < 0 || options.max_epochs < 0 ||
+        options.max_iterations < 0) {
+        usageError("epoch and iteration limits must be non-negative", argv[0]);
+    }
+    if (options.seed_match_tolerance_s < 0.0 ||
+        options.seed_interpolation_max_gap_s < 0.0 ||
+        options.doppler_sigma_zenith_mps <= 0.0 ||
+        options.velocity_prior_sigma_mps <= 0.0 ||
+        options.clock_drift_prior_sigma_mps <= 0.0 ||
+        options.clock_drift_between_sigma_mps <= 0.0 ||
+        options.huber_threshold_sigma <= 0.0) {
+        usageError("sigma, threshold, and tolerance values must be positive", argv[0]);
+    }
+    return options;
+}
+
+bool isPrimaryDopplerSignal(libgnss::SignalType signal) {
+    switch (signal) {
+        case libgnss::SignalType::GPS_L1CA:
+        case libgnss::SignalType::GLO_L1CA:
+        case libgnss::SignalType::GAL_E1:
+        case libgnss::SignalType::BDS_B1I:
+        case libgnss::SignalType::BDS_B1C:
+        case libgnss::SignalType::QZS_L1CA:
+            return true;
+        default:
+            return false;
+    }
+}
+
+std::string signalName(libgnss::SignalType signal) {
+    switch (signal) {
+        case libgnss::SignalType::GPS_L1CA: return "GPS_L1CA";
+        case libgnss::SignalType::GLO_L1CA: return "GLO_L1CA";
+        case libgnss::SignalType::GAL_E1: return "GAL_E1";
+        case libgnss::SignalType::BDS_B1I: return "BDS_B1I";
+        case libgnss::SignalType::BDS_B1C: return "BDS_B1C";
+        case libgnss::SignalType::QZS_L1CA: return "QZS_L1CA";
+        default: return "UNKNOWN";
+    }
+}
+
+bool isHealthyForPositioning(const libgnss::Observation& observation,
+                             const libgnss::Ephemeris& eph) {
+    int sv_health = static_cast<int>(eph.health);
+    if (observation.satellite.system == libgnss::GNSSSystem::QZSS) {
+        sv_health &= 0xFE;
+    }
+    return sv_health == 0;
+}
+
+bool parseSeparatedIntegers(std::string value,
+                            char separator,
+                            int& first,
+                            int& second,
+                            int& third) {
+    std::replace(value.begin(), value.end(), separator, ' ');
+    std::istringstream input(value);
+    return static_cast<bool>(input >> first >> second >> third);
+}
+
+bool parseRtklibTime(std::string value,
+                     int& hour,
+                     int& minute,
+                     double& second) {
+    std::replace(value.begin(), value.end(), ':', ' ');
+    std::istringstream input(value);
+    return static_cast<bool>(input >> hour >> minute >> second);
+}
+
+bool isLeapYear(int year) {
+    return (year % 4 == 0 && year % 100 != 0) || (year % 400 == 0);
+}
+
+libgnss::GNSSTime gpstCalendarToTime(int year,
+                                     int month,
+                                     int day,
+                                     int hour,
+                                     int minute,
+                                     double second) {
+    int days_since_gps_epoch = 0;
+    for (int current_year = 1980; current_year < year; ++current_year) {
+        days_since_gps_epoch += isLeapYear(current_year) ? 366 : 365;
+    }
+
+    int days_in_month[] = {
+        31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    if (isLeapYear(year)) {
+        days_in_month[1] = 29;
+    }
+    for (int current_month = 1; current_month < month; ++current_month) {
+        days_since_gps_epoch += days_in_month[current_month - 1];
+    }
+    days_since_gps_epoch += day;
+    days_since_gps_epoch -= 6;
+
+    const int gps_week = days_since_gps_epoch / 7;
+    const int day_of_week = days_since_gps_epoch % 7;
+    const double tow = static_cast<double>(day_of_week) * 86400.0 +
+                       static_cast<double>(hour) * 3600.0 +
+                       static_cast<double>(minute) * 60.0 + second;
+    return libgnss::GNSSTime(gps_week, tow);
+}
+
+bool parseRtklibSeedPositionLine(const std::string& line, SeedPosition& seed) {
+    std::istringstream input(line);
+    std::string date_token;
+    std::string time_token;
+    if (!(input >> date_token >> time_token)) {
+        return false;
+    }
+
+    int year = 0;
+    int month = 0;
+    int day = 0;
+    int hour = 0;
+    int minute = 0;
+    double second = 0.0;
+    if (!parseSeparatedIntegers(date_token, '/', year, month, day) ||
+        !parseRtklibTime(time_token, hour, minute, second)) {
+        return false;
+    }
+
+    double latitude_deg = 0.0;
+    double longitude_deg = 0.0;
+    double height_m = 0.0;
+    if (!(input >> latitude_deg >> longitude_deg >> height_m)) {
+        return false;
+    }
+    if (!std::isfinite(latitude_deg) || !std::isfinite(longitude_deg) ||
+        !std::isfinite(height_m)) {
+        return false;
+    }
+
+    seed.time = gpstCalendarToTime(year, month, day, hour, minute, second);
+    seed.position_ecef = libgnss::geodetic2ecef(latitude_deg * kDegreesToRadians,
+                                                longitude_deg * kDegreesToRadians,
+                                                height_m);
+    return seed.position_ecef.norm() > 1e6;
+}
+
+bool parseSeedPositionLine(const std::string& line, SeedPosition& seed) {
+    std::istringstream input(line);
+    std::string first_token;
+    if (!(input >> first_token)) {
+        return false;
+    }
+    if (first_token[0] == '%' || first_token[0] == '#') {
+        return false;
+    }
+    if (first_token.find('/') != std::string::npos) {
+        return parseRtklibSeedPositionLine(line, seed);
+    }
+
+    int week = 0;
+    try {
+        std::size_t consumed = 0;
+        week = std::stoi(first_token, &consumed);
+        if (consumed != first_token.size()) {
+            return false;
+        }
+    } catch (const std::exception&) {
+        return false;
+    }
+
+    double tow = 0.0;
+    double x = 0.0;
+    double y = 0.0;
+    double z = 0.0;
+    if (!(input >> tow >> x >> y >> z)) {
+        return false;
+    }
+    if (!std::isfinite(tow) || !std::isfinite(x) ||
+        !std::isfinite(y) || !std::isfinite(z)) {
+        return false;
+    }
+
+    seed.time = libgnss::GNSSTime(week, tow);
+    seed.position_ecef = libgnss::Vector3d(x, y, z);
+    return seed.position_ecef.norm() > 1e6;
+}
+
+std::vector<SeedPosition> readSeedPositions(const std::string& path) {
+    std::ifstream input(path);
+    if (!input.is_open()) {
+        throw std::runtime_error("failed to open seed POS file: " + path);
+    }
+
+    std::vector<SeedPosition> seeds;
+    std::string line;
+    while (std::getline(input, line)) {
+        SeedPosition seed;
+        if (parseSeedPositionLine(line, seed)) {
+            seeds.push_back(seed);
+        }
+    }
+    if (seeds.empty()) {
+        throw std::runtime_error(
+            "seed POS file has no readable LibGNSS++ or RTKLIB POS rows: " + path);
+    }
+
+    std::sort(seeds.begin(),
+              seeds.end(),
+              [](const SeedPosition& lhs, const SeedPosition& rhs) {
+                  return lhs.time < rhs.time;
+              });
+    return seeds;
+}
+
+bool findSeedPosition(const std::vector<SeedPosition>& seeds,
+                      const libgnss::GNSSTime& time,
+                      double tolerance_s,
+                      double interpolation_max_gap_s,
+                      std::size_t& cursor,
+                      libgnss::Vector3d& position_ecef,
+                      bool& interpolated) {
+    interpolated = false;
+    while (cursor < seeds.size() && seeds[cursor].time - time < -tolerance_s) {
+        ++cursor;
+    }
+
+    std::size_t best_index = seeds.size();
+    double best_abs_dt = tolerance_s;
+    if (cursor < seeds.size()) {
+        const double abs_dt = std::abs(seeds[cursor].time - time);
+        if (abs_dt <= best_abs_dt) {
+            best_index = cursor;
+            best_abs_dt = abs_dt;
+        }
+    }
+    if (cursor > 0) {
+        const std::size_t previous_index = cursor - 1;
+        const double abs_dt = std::abs(seeds[previous_index].time - time);
+        if (abs_dt <= best_abs_dt) {
+            best_index = previous_index;
+        }
+    }
+    if (best_index == seeds.size()) {
+        if (interpolation_max_gap_s <= 0.0 || cursor == 0 ||
+            cursor >= seeds.size()) {
+            return false;
+        }
+        const SeedPosition& lower = seeds[cursor - 1];
+        const SeedPosition& upper = seeds[cursor];
+        const double gap_s = upper.time - lower.time;
+        const double lower_dt_s = time - lower.time;
+        if (gap_s <= 0.0 || gap_s > interpolation_max_gap_s ||
+            lower_dt_s < 0.0 || lower_dt_s > gap_s) {
+            return false;
+        }
+        const double alpha = lower_dt_s / gap_s;
+        position_ecef =
+            lower.position_ecef +
+            alpha * (upper.position_ecef - lower.position_ecef);
+        interpolated = true;
+        return position_ecef.norm() > 1e6;
+    }
+
+    position_ecef = seeds[best_index].position_ecef;
+    return true;
+}
+
+void writeCsvDouble(std::ostream& output, double value) {
+    if (std::isfinite(value)) {
+        output << value;
+    } else {
+        output << "NaN";
+    }
+}
+
+double robustHuberLoss(double whitened_error, double threshold) {
+    const double abs_error = std::abs(whitened_error);
+    if (abs_error <= threshold) {
+        return 0.5 * whitened_error * whitened_error;
+    }
+    return threshold * (abs_error - 0.5 * threshold);
+}
+
+double robustHuberWeight(double whitened_error, double threshold) {
+    const double abs_error = std::abs(whitened_error);
+    if (abs_error <= threshold || abs_error <= 0.0) {
+        return 1.0;
+    }
+    return threshold / abs_error;
+}
+
+int velocityColumn(std::size_t epoch_index, int component) {
+    return static_cast<int>(4 * epoch_index + static_cast<std::size_t>(component));
+}
+
+int clockColumn(std::size_t epoch_index) {
+    return static_cast<int>(4 * epoch_index + 3U);
+}
+
+double factorPrediction(const Eigen::VectorXd& state, const DopplerFactor& factor) {
+    const std::size_t i = factor.epoch_index;
+    return factor.los(0) * state(velocityColumn(i, 0)) +
+           factor.los(1) * state(velocityColumn(i, 1)) +
+           factor.los(2) * state(velocityColumn(i, 2)) +
+           state(clockColumn(i));
+}
+
+double computeCost(const Problem& problem,
+                   const Options& options,
+                   const Eigen::VectorXd& state) {
+    double cost = 0.0;
+    for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
+        for (int component = 0; component < 3; ++component) {
+            const double e =
+                state(velocityColumn(i, component)) /
+                options.velocity_prior_sigma_mps;
+            cost += 0.5 * e * e;
+        }
+        const double d_prior =
+            state(clockColumn(i)) / options.clock_drift_prior_sigma_mps;
+        cost += 0.5 * d_prior * d_prior;
+        if (i > 0) {
+            const double between =
+                (state(clockColumn(i)) - state(clockColumn(i - 1))) /
+                options.clock_drift_between_sigma_mps;
+            cost += 0.5 * between * between;
+        }
+    }
+
+    for (const DopplerFactor& factor : problem.factors) {
+        const double error =
+            (factorPrediction(state, factor) - factor.residual_mps) /
+            factor.sigma_mps;
+        cost += robustHuberLoss(error, options.huber_threshold_sigma);
+    }
+    return cost;
+}
+
+struct NormalEquation {
+    Eigen::SparseMatrix<double> hessian;
+    Eigen::VectorXd rhs;
+};
+
+void addWeightedRow(std::vector<Eigen::Triplet<double>>& triplets,
+                    Eigen::VectorXd& rhs,
+                    const std::vector<int>& columns,
+                    const std::vector<double>& coefficients,
+                    double residual,
+                    double sigma,
+                    double robust_weight) {
+    const double inv_variance = robust_weight / (sigma * sigma);
+    for (std::size_t a = 0; a < columns.size(); ++a) {
+        const double weighted_a = inv_variance * coefficients[a];
+        rhs(columns[a]) += weighted_a * residual;
+        for (std::size_t b = 0; b < columns.size(); ++b) {
+            triplets.emplace_back(columns[a],
+                                  columns[b],
+                                  weighted_a * coefficients[b]);
+        }
+    }
+}
+
+NormalEquation buildNormalEquation(const Problem& problem,
+                                   const Options& options,
+                                   const Eigen::VectorXd& state) {
+    const int state_size = static_cast<int>(4 * problem.epochs.size());
+    std::vector<Eigen::Triplet<double>> triplets;
+    triplets.reserve(problem.factors.size() * 16U + problem.epochs.size() * 20U);
+    Eigen::VectorXd rhs = Eigen::VectorXd::Zero(state_size);
+
+    for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
+        for (int component = 0; component < 3; ++component) {
+            const int col = velocityColumn(i, component);
+            addWeightedRow(triplets,
+                           rhs,
+                           {col},
+                           {1.0},
+                           -state(col),
+                           options.velocity_prior_sigma_mps,
+                           1.0);
+        }
+
+        const int d_col = clockColumn(i);
+        addWeightedRow(triplets,
+                       rhs,
+                       {d_col},
+                       {1.0},
+                       -state(d_col),
+                       options.clock_drift_prior_sigma_mps,
+                       1.0);
+
+        if (i > 0) {
+            const int previous = clockColumn(i - 1);
+            const int current = clockColumn(i);
+            const double prediction = state(current) - state(previous);
+            addWeightedRow(triplets,
+                           rhs,
+                           {previous, current},
+                           {-1.0, 1.0},
+                           -prediction,
+                           options.clock_drift_between_sigma_mps,
+                           1.0);
+        }
+    }
+
+    for (const DopplerFactor& factor : problem.factors) {
+        const std::size_t i = factor.epoch_index;
+        const double prediction = factorPrediction(state, factor);
+        const double residual = factor.residual_mps - prediction;
+        const double whitened_error = -residual / factor.sigma_mps;
+        const double robust_weight =
+            robustHuberWeight(whitened_error, options.huber_threshold_sigma);
+        addWeightedRow(triplets,
+                       rhs,
+                       {velocityColumn(i, 0),
+                        velocityColumn(i, 1),
+                        velocityColumn(i, 2),
+                        clockColumn(i)},
+                       {factor.los(0), factor.los(1), factor.los(2), 1.0},
+                       residual,
+                       factor.sigma_mps,
+                       robust_weight);
+    }
+
+    NormalEquation normal;
+    normal.hessian.resize(state_size, state_size);
+    normal.hessian.setFromTriplets(triplets.begin(), triplets.end());
+    normal.rhs = std::move(rhs);
+    return normal;
+}
+
+double residualRms(const Problem& problem, const Eigen::VectorXd& state) {
+    if (problem.factors.empty()) {
+        return 0.0;
+    }
+    double sum_sq = 0.0;
+    for (const DopplerFactor& factor : problem.factors) {
+        const double residual = factorPrediction(state, factor) - factor.residual_mps;
+        sum_sq += residual * residual;
+    }
+    return std::sqrt(sum_sq / static_cast<double>(problem.factors.size()));
+}
+
+SolveResult solveProblem(const Problem& problem, const Options& options) {
+    SolveResult result;
+    result.state = Eigen::VectorXd::Zero(static_cast<int>(4 * problem.epochs.size()));
+    result.initial_cost = computeCost(problem, options, result.state);
+
+    if (options.debug_problem_only || options.max_iterations == 0 ||
+        problem.epochs.empty()) {
+        result.final_cost = result.initial_cost;
+        result.residual_rms_mps = residualRms(problem, result.state);
+        return result;
+    }
+
+    double previous_cost = result.initial_cost;
+    for (int iteration = 1; iteration <= options.max_iterations; ++iteration) {
+        NormalEquation normal = buildNormalEquation(problem, options, result.state);
+        Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> solver;
+        solver.compute(normal.hessian);
+        if (solver.info() != Eigen::Success) {
+            throw std::runtime_error("failed to factor Doppler normal equation");
+        }
+        const Eigen::VectorXd delta = solver.solve(normal.rhs);
+        if (solver.info() != Eigen::Success || !delta.allFinite()) {
+            throw std::runtime_error("failed to solve Doppler normal equation");
+        }
+
+        result.state += delta;
+        result.iterations = iteration;
+
+        const double cost = computeCost(problem, options, result.state);
+        const double absolute_decrease = previous_cost - cost;
+        const double relative_decrease =
+            absolute_decrease / std::max(1.0, std::abs(previous_cost));
+        previous_cost = cost;
+
+        if (delta.norm() < 1e-10 ||
+            (iteration > 1 && absolute_decrease >= 0.0 &&
+             relative_decrease < 1e-5)) {
+            result.converged = true;
+            break;
+        }
+    }
+
+    result.final_cost = computeCost(problem, options, result.state);
+    result.residual_rms_mps = residualRms(problem, result.state);
+    return result;
+}
+
+bool prepareDopplerFactor(const libgnss::ObservationData& epoch,
+                          std::size_t epoch_index,
+                          const libgnss::Observation& observation,
+                          const libgnss::NavigationData& nav,
+                          const libgnss::Vector3d& receiver_position,
+                          const Options& options,
+                          DopplerFactor& factor) {
+    if (!isPrimaryDopplerSignal(observation.signal) ||
+        !observation.valid ||
+        !observation.has_pseudorange ||
+        !observation.has_doppler ||
+        observation.pseudorange <= 0.0 ||
+        observation.snr < options.min_snr_dbhz) {
+        return false;
+    }
+
+    libgnss::Vector3d satellite_position;
+    libgnss::Vector3d satellite_velocity;
+    double satellite_clock_bias = 0.0;
+    double satellite_clock_drift = 0.0;
+
+    libgnss::GNSSTime transmit_time =
+        epoch.time - observation.pseudorange / libgnss::constants::SPEED_OF_LIGHT;
+    if (!nav.calculateSatelliteState(observation.satellite,
+                                     transmit_time,
+                                     satellite_position,
+                                     satellite_velocity,
+                                     satellite_clock_bias,
+                                     satellite_clock_drift)) {
+        return false;
+    }
+
+    transmit_time = transmit_time - satellite_clock_bias;
+    if (!nav.calculateSatelliteState(observation.satellite,
+                                     transmit_time,
+                                     satellite_position,
+                                     satellite_velocity,
+                                     satellite_clock_bias,
+                                     satellite_clock_drift)) {
+        return false;
+    }
+
+    const libgnss::Ephemeris* eph = nav.getEphemeris(observation.satellite, transmit_time);
+    if (!eph || !isHealthyForPositioning(observation, *eph)) {
+        return false;
+    }
+
+    const libgnss::Vector3d delta = satellite_position - receiver_position;
+    const double range = delta.norm();
+    if (range <= 0.0) {
+        return false;
+    }
+    const libgnss::Vector3d ex = delta / range;
+    const auto geometry = nav.calculateGeometry(receiver_position, satellite_position);
+    if (geometry.elevation < options.min_elevation_deg * kDegreesToRadians) {
+        return false;
+    }
+
+    double wavelength = libgnss::signalWavelengthMeters(observation.signal, eph);
+    if (wavelength <= 0.0) {
+        wavelength = libgnss::signalWavelengthMeters(observation);
+    }
+    if (wavelength <= 0.0) {
+        return false;
+    }
+
+    const double sagnac_rate =
+        libgnss::constants::OMEGA_E / libgnss::constants::SPEED_OF_LIGHT *
+        (satellite_velocity(1) * receiver_position(0) -
+         satellite_velocity(0) * receiver_position(1));
+    const double modeled_range_rate = satellite_velocity.dot(ex) + sagnac_rate;
+    const double satellite_clock_drift_mps =
+        satellite_clock_drift * libgnss::constants::SPEED_OF_LIGHT;
+    const double measured_range_rate = -observation.doppler * wavelength;
+    const double residual =
+        measured_range_rate - (modeled_range_rate - satellite_clock_drift_mps);
+    const double sin_el = std::sin(geometry.elevation);
+    if (sin_el <= 0.0) {
+        return false;
+    }
+
+    factor.epoch_index = epoch_index;
+    factor.time = epoch.time;
+    factor.satellite = observation.satellite;
+    factor.signal = observation.signal;
+    factor.snr_dbhz = observation.snr;
+    factor.elevation_rad = geometry.elevation;
+    factor.sigma_mps = options.doppler_sigma_zenith_mps / std::sqrt(sin_el);
+    factor.residual_mps = residual;
+    factor.measured_range_rate_mps = measured_range_rate;
+    factor.modeled_range_rate_mps = modeled_range_rate;
+    factor.satellite_clock_drift_mps = satellite_clock_drift_mps;
+    factor.wavelength_m = wavelength;
+    factor.los = -ex;
+    return std::isfinite(factor.residual_mps) &&
+           std::isfinite(factor.sigma_mps) &&
+           factor.sigma_mps > 0.0;
+}
+
+Problem buildProblem(const Options& options) {
+    libgnss::io::RINEXReader obs_reader;
+    if (!obs_reader.open(options.obs_path)) {
+        throw std::runtime_error("failed to open observation file: " + options.obs_path);
+    }
+    libgnss::io::RINEXReader::RINEXHeader obs_header;
+    if (!obs_reader.readHeader(obs_header)) {
+        throw std::runtime_error("failed to read observation header: " + options.obs_path);
+    }
+
+    libgnss::io::RINEXReader nav_reader;
+    if (!nav_reader.open(options.nav_path)) {
+        throw std::runtime_error("failed to open navigation file: " + options.nav_path);
+    }
+    libgnss::NavigationData nav_data;
+    if (!nav_reader.readNavigationData(nav_data)) {
+        throw std::runtime_error("failed to read navigation data: " + options.nav_path);
+    }
+
+    const std::vector<SeedPosition> seed_positions =
+        readSeedPositions(options.seed_pos_path);
+    std::size_t seed_cursor = 0;
+
+    Problem problem;
+    std::set<libgnss::SatelliteId> unique_satellites;
+    const double fixed_interval_s =
+        obs_header.interval > 0.0 ? obs_header.interval : 1.0;
+    const double gap_tolerance_s = std::max(0.01, 0.5 * fixed_interval_s);
+
+    auto append_epoch = [&](libgnss::ObservationData epoch,
+                            bool build_factors) -> bool {
+        if (options.max_epochs > 0 &&
+            static_cast<int>(problem.epochs.size()) >= options.max_epochs) {
+            return false;
+        }
+
+        libgnss::Vector3d seed_position = libgnss::Vector3d::Zero();
+        bool interpolated = false;
+        if (findSeedPosition(seed_positions,
+                             epoch.time,
+                             options.seed_match_tolerance_s,
+                             options.seed_interpolation_max_gap_s,
+                             seed_cursor,
+                             seed_position,
+                             interpolated)) {
+            epoch.receiver_position = seed_position;
+            ++problem.seed_matched_epochs;
+            if (interpolated) {
+                ++problem.seed_interpolated_epochs;
+            }
+        } else if (obs_header.approximate_position.norm() > 1e6) {
+            seed_position = obs_header.approximate_position;
+            epoch.receiver_position = seed_position;
+        } else {
+            return true;
+        }
+
+        const std::size_t epoch_index = problem.epochs.size();
+        if (build_factors) {
+            for (const auto& observation : epoch.observations) {
+                unique_satellites.insert(observation.satellite);
+                DopplerFactor factor;
+                if (prepareDopplerFactor(epoch,
+                                         epoch_index,
+                                         observation,
+                                         nav_data,
+                                         seed_position,
+                                         options,
+                                         factor)) {
+                    problem.factors.push_back(factor);
+                }
+            }
+        }
+
+        problem.seed_positions.push_back(seed_position);
+        problem.epochs.push_back(epoch);
+        return true;
+    };
+
+    libgnss::ObservationData epoch;
+    int raw_epoch_index = 0;
+    bool have_last_output_time = false;
+    libgnss::GNSSTime last_output_time;
+    while (obs_reader.readObservationEpoch(epoch)) {
+        if (raw_epoch_index++ < options.skip_epochs) {
+            continue;
+        }
+
+        if (have_last_output_time) {
+            libgnss::GNSSTime expected_time =
+                last_output_time + fixed_interval_s;
+            while (epoch.time - expected_time > gap_tolerance_s) {
+                libgnss::ObservationData empty_epoch(expected_time);
+                if (!append_epoch(empty_epoch, false)) {
+                    break;
+                }
+                last_output_time = expected_time;
+                expected_time = last_output_time + fixed_interval_s;
+                if (options.max_epochs > 0 &&
+                    static_cast<int>(problem.epochs.size()) >=
+                        options.max_epochs) {
+                    break;
+                }
+            }
+            if (options.max_epochs > 0 &&
+                static_cast<int>(problem.epochs.size()) >= options.max_epochs) {
+                break;
+            }
+        }
+
+        if (!append_epoch(epoch, true)) {
+            break;
+        }
+        last_output_time = epoch.time;
+        have_last_output_time = true;
+    }
+    problem.nsat = unique_satellites.size();
+    return problem;
+}
+
+bool writePerEpochCsv(const std::string& path,
+                      const Problem& problem,
+                      const SolveResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    output << "epoch,gps_week,gps_tow,spp_x_m,spp_y_m,spp_z_m,"
+              "fgo_vx_mps,fgo_vy_mps,fgo_vz_mps,fgo_clock_drift_mps\n";
+    output << std::fixed << std::setprecision(15);
+    for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
+        const auto& epoch = problem.epochs[i];
+        const auto& seed = problem.seed_positions[i];
+        output << (i + 1U) << ','
+               << epoch.time.week << ','
+               << epoch.time.tow << ','
+               << seed(0) << ','
+               << seed(1) << ','
+               << seed(2) << ','
+               << result.state(velocityColumn(i, 0)) << ','
+               << result.state(velocityColumn(i, 1)) << ','
+               << result.state(velocityColumn(i, 2)) << ','
+               << result.state(clockColumn(i)) << '\n';
+    }
+    return true;
+}
+
+bool writeFactorDebugCsv(const std::string& path,
+                         const Problem& problem,
+                         const SolveResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    output << "epoch_index,gps_week,gps_tow,satellite,signal,snr_dbhz,"
+              "elevation_deg,sigma_d_mps,res_d_mps,measured_range_rate_mps,"
+              "modeled_range_rate_mps,satellite_clock_drift_mps,"
+              "final_residual_mps,los_x,los_y,los_z\n";
+    output << std::fixed << std::setprecision(15);
+    for (const DopplerFactor& factor : problem.factors) {
+        const double final_residual =
+            factorPrediction(result.state, factor) - factor.residual_mps;
+        output << factor.epoch_index << ','
+               << factor.time.week << ','
+               << factor.time.tow << ','
+               << factor.satellite.toString() << ','
+               << signalName(factor.signal) << ','
+               << factor.snr_dbhz << ','
+               << factor.elevation_rad * kRadiansToDegrees << ','
+               << factor.sigma_mps << ','
+               << factor.residual_mps << ','
+               << factor.measured_range_rate_mps << ','
+               << factor.modeled_range_rate_mps << ','
+               << factor.satellite_clock_drift_mps << ','
+               << final_residual << ','
+               << factor.los(0) << ','
+               << factor.los(1) << ','
+               << factor.los(2) << '\n';
+    }
+    return true;
+}
+
+std::size_t graphFactorCount(const Problem& problem) {
+    if (problem.epochs.empty()) {
+        return problem.factors.size();
+    }
+    return problem.factors.size() +
+           2U * problem.epochs.size() +
+           (problem.epochs.size() - 1U);
+}
+
+bool writeGraphCsv(const std::string& path,
+                   const Problem& problem,
+                   const SolveResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    output << "n,nsat,graph_factors,graph_values,initial_cost,final_cost,"
+              "optimizer_error,iterations,valid_velocity_epochs\n";
+    output << std::fixed << std::setprecision(15)
+           << problem.epochs.size() << ','
+           << problem.nsat << ','
+           << graphFactorCount(problem) << ','
+           << 2U * problem.epochs.size() << ','
+           << result.initial_cost << ','
+           << result.final_cost << ','
+           << result.final_cost << ','
+           << result.iterations << ','
+           << problem.epochs.size() << '\n';
+    return true;
+}
+
+std::string jsonBool(bool value) {
+    return value ? "true" : "false";
+}
+
+bool writeSummaryJson(const std::string& path,
+                      const Options& options,
+                      const Problem& problem,
+                      const SolveResult& result) {
+    if (path.empty()) {
+        return true;
+    }
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+    const std::size_t epoch_count = problem.epochs.size();
+    output << std::fixed << std::setprecision(15)
+           << "{\n"
+           << "  \"preset\": \"taroz-d\",\n"
+           << "  \"backend\": \"eigen\",\n"
+           << "  \"debug_problem_only\": " << jsonBool(options.debug_problem_only) << ",\n"
+           << "  \"optimized_epochs\": " << epoch_count << ",\n"
+           << "  \"valid_velocity_epochs\": " << epoch_count << ",\n"
+           << "  \"seed_matched_epochs\": " << problem.seed_matched_epochs << ",\n"
+           << "  \"seed_interpolated_epochs\": " << problem.seed_interpolated_epochs << ",\n"
+           << "  \"nsat\": " << problem.nsat << ",\n"
+           << "  \"doppler_factors\": " << problem.factors.size() << ",\n"
+           << "  \"velocity_prior_factors\": " << epoch_count << ",\n"
+           << "  \"clock_drift_prior_factors\": " << epoch_count << ",\n"
+           << "  \"clock_drift_between_factors\": "
+           << (epoch_count > 0 ? epoch_count - 1U : 0U) << ",\n"
+           << "  \"graph_factors\": " << graphFactorCount(problem) << ",\n"
+           << "  \"graph_values\": " << 2U * epoch_count << ",\n"
+           << "  \"min_snr_dbhz\": " << options.min_snr_dbhz << ",\n"
+           << "  \"min_elevation_deg\": " << options.min_elevation_deg << ",\n"
+           << "  \"doppler_sigma_zenith_mps\": "
+           << options.doppler_sigma_zenith_mps << ",\n"
+           << "  \"velocity_prior_sigma_mps\": "
+           << options.velocity_prior_sigma_mps << ",\n"
+           << "  \"clock_drift_prior_sigma_mps\": "
+           << options.clock_drift_prior_sigma_mps << ",\n"
+           << "  \"clock_drift_between_sigma_mps\": "
+           << options.clock_drift_between_sigma_mps << ",\n"
+           << "  \"huber_threshold_sigma\": "
+           << options.huber_threshold_sigma << ",\n"
+           << "  \"iterations\": " << result.iterations << ",\n"
+           << "  \"converged\": " << jsonBool(result.converged) << ",\n"
+           << "  \"initial_cost\": " << result.initial_cost << ",\n"
+           << "  \"final_cost\": " << result.final_cost << ",\n"
+           << "  \"residual_rms_mps\": " << result.residual_rms_mps << "\n"
+           << "}\n";
+    return true;
+}
+
+void printSummary(const Problem& problem, const SolveResult& result) {
+    std::cout << "Taroz D velocity batch complete\n"
+              << "  epochs: " << problem.epochs.size() << "\n"
+              << "  satellites: " << problem.nsat << "\n"
+              << "  doppler_factors: " << problem.factors.size() << "\n"
+              << "  graph_factors: " << graphFactorCount(problem) << "\n"
+              << "  iterations: " << result.iterations << "\n"
+              << "  converged: " << (result.converged ? "true" : "false") << "\n"
+              << std::fixed << std::setprecision(6)
+              << "  initial_cost: " << result.initial_cost << "\n"
+              << "  final_cost: " << result.final_cost << "\n"
+              << "  residual_rms_mps: " << result.residual_rms_mps << "\n";
+}
+
+}  // namespace
+
+int main(int argc, char* argv[]) {
+    try {
+        const Options options = parseArguments(argc, argv);
+        const Problem problem = buildProblem(options);
+        const SolveResult result = solveProblem(problem, options);
+
+        if (!writePerEpochCsv(options.out_csv_path, problem, result)) {
+            std::cerr << "Error: failed to write velocity CSV: "
+                      << options.out_csv_path << "\n";
+            return 1;
+        }
+        if (!writeFactorDebugCsv(options.factor_debug_csv_path, problem, result)) {
+            std::cerr << "Error: failed to write factor debug CSV: "
+                      << options.factor_debug_csv_path << "\n";
+            return 1;
+        }
+        if (!writeGraphCsv(options.graph_csv_path, problem, result)) {
+            std::cerr << "Error: failed to write graph CSV: "
+                      << options.graph_csv_path << "\n";
+            return 1;
+        }
+        if (!writeSummaryJson(options.summary_json_path, options, problem, result)) {
+            std::cerr << "Error: failed to write summary JSON: "
+                      << options.summary_json_path << "\n";
+            return 1;
+        }
+        if (!options.quiet) {
+            printSummary(problem, result);
+        }
+        return 0;
+    } catch (const std::invalid_argument&) {
+        return 2;
+    } catch (const std::exception& ex) {
+        std::cerr << "Error: " << ex.what() << "\n";
+        return 1;
+    }
+}

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -584,6 +584,38 @@ python3 scripts/generate_ppc_tail_cleanup_scorecard.py \
   --output docs/ppc_tail_cleanup_scorecard.png
 ```
 
+### Taroz Ambiguity PDC FGO Dogfood
+
+The taroz ambiguity PDC FGO port uses a separate PPC harness so public-run
+behavior can be checked without changing the RTK sign-off flow:
+
+```bash
+python3 apps/gnss.py ppc-taroz-amb-pdc-smoke \
+  --dataset-root /datasets/PPC-Dataset \
+  --max-epochs 20
+
+python3 apps/gnss.py ppc-taroz-amb-pdc-smoke \
+  --dataset-root /datasets/PPC-Dataset \
+  --max-epochs 200 \
+  --generate-spp-seed \
+  --require-valid-p95-3d-max 2.0 \
+  --summary-json output/dogfood/ppc_taroz_amb_pdc_smoke_200/summary.json
+
+python3 apps/gnss.py ppc-taroz-amb-pdc-smoke \
+  --dataset-root /datasets/PPC-Dataset \
+  --run nagoya/run3 \
+  --skip-epochs 400 \
+  --max-epochs 200 \
+  --generate-spp-seed \
+  --require-valid-p95-3d-max 2.0 \
+  --summary-json output/dogfood/ppc_taroz_amb_pdc_nagoya_run3_shifted/summary.json
+```
+
+The 20-epoch form is intended as a lightweight smoke. The 200-epoch and shifted
+window forms are local dogfood checks for longer behavior, especially runs such
+as `nagoya/run3` where the first 20 epochs can remain FLOAT before later
+fixed-ambiguity epochs appear.
+
 ### Multi-candidate selector matrix (6-run)
 
 `scripts/run_ppc_multi_candidate_selector_matrix.py` drives

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -45,6 +45,16 @@ CI lanes are split as follows:
 
 Docs-only changes keep CI on the lightweight path: hygiene here, plus the separate Docs workflow.
 
+Keep taroz FGO validation split by cost:
+
+- Light unit coverage belongs in CTest, such as `python_ppc_taroz_amb_pdc_smoke_tests`
+  dry-run checks and focused C++ factor tests.
+- Heavy local checks include `python3 apps/gnss.py taroz-pos-vel-amb-pdc-dogfood`,
+  `python3 apps/gnss.py ppc-taroz-amb-pdc-smoke --max-epochs 200 --generate-spp-seed`,
+  and optional MATLAB/taroz parity tests when their external artifacts are present.
+- External PPC-Dataset runs are dataset-gated and should not be required for the
+  cross-platform CI lane unless a dedicated optional job provides the data.
+
 ## External code references
 
 When taking ideas from external repos:

--- a/experiments/ppp_ar/run_experiments.py
+++ b/experiments/ppp_ar/run_experiments.py
@@ -13,8 +13,12 @@ from pathlib import Path
 import subprocess
 import sys
 import time
-import tomllib
 from typing import Any
+
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11 compatibility.
+    import tomli as tomllib
 
 
 ROOT_DIR = Path(__file__).resolve().parents[2]

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -1,0 +1,418 @@
+#pragma once
+
+#include <libgnss++/core/navigation.hpp>
+#include <libgnss++/core/observation.hpp>
+#include <libgnss++/core/solution.hpp>
+#include <libgnss++/core/types.hpp>
+
+#include <cstddef>
+#include <map>
+#include <set>
+#include <vector>
+
+namespace libgnss {
+
+/**
+ * @brief Batch pseudorange factor-graph optimizer.
+ *
+ * This is the native Eigen backend for the GNSS FGO pipeline. It keeps the
+ * factor/problem representation explicit so a GTSAM backend can be added later
+ * without changing callers that prepare GNSS factors from RINEX/navigation data.
+ */
+class FGOProcessor {
+public:
+    struct FGOConfig {
+        int max_iterations = 8;
+        double convergence_threshold_m = 1e-4;
+        double relative_cost_convergence_threshold = 0.0;
+        double absolute_cost_convergence_threshold = 0.0;
+        double pseudorange_sigma_m = 3.0;
+        double pseudorange_elevation_sigma_power = 1.0;
+        double min_elevation_deg = 10.0;
+        double min_snr_dbhz = 0.0;
+        double double_difference_reference_min_snr_dbhz = -1.0;
+        double double_difference_base_min_snr_dbhz = -1.0;
+        int min_satellites_per_epoch = 4;
+        int min_output_double_difference_carrier_factors_per_epoch = 0;
+
+        bool use_spp_seed = true;
+        bool use_pseudorange_factors = true;
+        bool use_motion_factors = true;
+        bool use_position_motion_factors = true;
+        bool use_clock_motion_factors = true;
+        bool use_tdcp_factors = true;
+        bool use_carrier_phase_factors = false;
+        bool use_double_difference_factors = false;
+        bool use_single_difference_doppler_factors = false;
+        bool use_single_difference_tdcp_factors = false;
+        bool use_velocity_states = false;
+        bool use_velocity_motion_factors = false;
+        bool use_ambiguity_between_factors = false;
+        bool linearize_double_difference_factors_at_seed = false;
+        bool reset_double_difference_ambiguities_each_epoch = false;
+        bool use_inter_system_biases = true;
+        bool use_ambiguity_priors = true;
+        bool fix_ambiguities = false;
+        bool prefer_double_difference_ambiguity_fixing = true;
+        bool use_lambda_ambiguity_fix = true;
+        bool use_epoch_lambda_fixed_output = false;
+        bool use_partial_lambda_ambiguity_fix = true;
+        bool use_robust_loss = true;
+        double motion_sigma_m = 50.0;
+        double clock_motion_sigma_m = 300.0;
+        double velocity_prior_sigma_mps = 100.0;
+        double velocity_motion_sigma_m = 0.01;
+        double ambiguity_between_sigma_cycles = 0.001;
+        double position_prior_sigma_m = 0.0;
+        double clock_prior_sigma_m = 0.0;
+        double tdcp_sigma_m = 0.03;
+        double carrier_phase_sigma_m = 0.01;
+        double single_difference_doppler_sigma_mps = 0.2;
+        double single_difference_tdcp_sigma_m = 0.003;
+        double double_difference_pseudorange_sigma_m = 1.0;
+        double double_difference_carrier_sigma_m = 0.02;
+        double pseudorange_huber_threshold_sigma = 4.0;
+        double carrier_phase_huber_threshold_sigma = 4.0;
+        double tdcp_huber_threshold_sigma = 4.0;
+        double ambiguity_prior_sigma_m = 1000.0;
+        double fixed_ambiguity_sigma_m = 0.003;
+        double ambiguity_fix_max_fractional_cycles = 0.15;
+        double lambda_ratio_threshold = 3.0;
+        int min_fixed_ambiguities = 4;
+        int max_lambda_ambiguities = 12;
+        double max_tdcp_gap_s = 2.0;
+        double base_epoch_match_tolerance_s = 0.02;
+        double base_interpolation_max_gap_s = 1.2;
+        bool reject_tdcp_loss_of_lock = true;
+        bool reject_rover_carrier_loss_of_lock = false;
+        bool reject_tdcp_code_phase_jump = true;
+        double tdcp_code_phase_jump_threshold_m = 10.0;
+
+        bool use_ionosphere_model = true;
+        bool use_troposphere_model = true;
+        bool use_multi_constellation = true;
+        bool collect_lambda_debug = false;
+    };
+
+    struct EpochSeed {
+        GNSSTime time;
+        Vector3d position_ecef = Vector3d::Zero();
+        double receiver_clock_bias_m = 0.0;
+    };
+
+    struct ObservationModelDebug {
+        double raw_pseudorange_m = 0.0;
+        double raw_carrier_m = 0.0;
+        double satellite_clock_m = 0.0;
+        double ionosphere_delay_m = 0.0;
+        double troposphere_delay_m = 0.0;
+        double group_delay_m = 0.0;
+        double corrected_pseudorange_m = 0.0;
+        double corrected_carrier_m = 0.0;
+        double geometric_range_m = 0.0;
+        double elevation_rad = 0.0;
+        double azimuth_rad = 0.0;
+    };
+
+    struct PseudorangeFactor {
+        std::size_t epoch_index = 0;
+        SatelliteId satellite;
+        GNSSSystem clock_group = GNSSSystem::GPS;
+        Vector3d satellite_position_ecef = Vector3d::Zero();
+        double corrected_pseudorange_m = 0.0;
+        double sigma_m = 1.0;
+        double elevation_rad = 0.0;
+    };
+
+    struct TimeDifferencedCarrierFactor {
+        std::size_t previous_epoch_index = 0;
+        std::size_t current_epoch_index = 0;
+        SatelliteId satellite;
+        SignalType signal = SignalType::GPS_L1CA;
+        Vector3d previous_satellite_position_ecef = Vector3d::Zero();
+        Vector3d current_satellite_position_ecef = Vector3d::Zero();
+        double delta_carrier_m = 0.0;
+        double sigma_m = 0.03;
+        double dt_s = 0.0;
+    };
+
+    struct SingleDifferenceDopplerFactor {
+        std::size_t epoch_index = 0;
+        SatelliteId satellite;
+        SatelliteId reference_satellite;
+        SignalType signal = SignalType::GPS_L1CA;
+        Vector3d los = Vector3d::Zero();
+        double residual_mps = 0.0;
+        double sigma_mps = 0.2;
+        double elevation_rad = 0.0;
+    };
+
+    struct SingleDifferenceTdcpFactor {
+        std::size_t previous_epoch_index = 0;
+        std::size_t current_epoch_index = 0;
+        SatelliteId satellite;
+        SatelliteId reference_satellite;
+        SignalType signal = SignalType::GPS_L1CA;
+        Vector3d previous_los = Vector3d::Zero();
+        Vector3d los = Vector3d::Zero();
+        double delta_carrier_m = 0.0;
+        double sigma_m = 0.003;
+        double elevation_rad = 0.0;
+    };
+
+    struct AmbiguityState {
+        SatelliteId satellite;
+        SatelliteId reference_satellite;
+        SignalType signal = SignalType::GPS_L1CA;
+        std::size_t segment_index = 0;
+        double wavelength_m = 0.0;
+        double initial_ambiguity_m = 0.0;
+        bool is_double_difference = false;
+    };
+
+    struct CarrierPhaseFactor {
+        std::size_t epoch_index = 0;
+        std::size_t ambiguity_index = 0;
+        SatelliteId satellite;
+        GNSSSystem clock_group = GNSSSystem::GPS;
+        SignalType signal = SignalType::GPS_L1CA;
+        Vector3d satellite_position_ecef = Vector3d::Zero();
+        double corrected_pseudorange_m = 0.0;
+        double corrected_carrier_m = 0.0;
+        double wavelength_m = 0.0;
+        double sigma_m = 0.01;
+        double elevation_rad = 0.0;
+        bool has_carrier_phase = true;
+        bool loss_of_lock = false;
+        bool has_doppler_residual = false;
+        double doppler_residual_mps = 0.0;
+        double doppler_sigma_mps = 0.2;
+        Vector3d los = Vector3d::Zero();
+        ObservationModelDebug model_debug;
+    };
+
+    struct DoubleDifferencePseudorangeFactor {
+        std::size_t epoch_index = 0;
+        SatelliteId satellite;
+        SatelliteId reference_satellite;
+        SignalType signal = SignalType::GPS_L1CA;
+        Vector3d rover_satellite_position_ecef = Vector3d::Zero();
+        Vector3d rover_reference_position_ecef = Vector3d::Zero();
+        Vector3d base_satellite_position_ecef = Vector3d::Zero();
+        Vector3d base_reference_position_ecef = Vector3d::Zero();
+        Vector3d base_position_ecef = Vector3d::Zero();
+        double observed_dd_pseudorange_m = 0.0;
+        double sigma_m = 1.0;
+        double elevation_rad = 0.0;
+        ObservationModelDebug rover_satellite_model;
+        ObservationModelDebug rover_reference_model;
+        ObservationModelDebug base_satellite_model;
+        ObservationModelDebug base_reference_model;
+    };
+
+    struct DoubleDifferenceCarrierFactor {
+        std::size_t epoch_index = 0;
+        std::size_t ambiguity_index = 0;
+        std::size_t reference_ambiguity_index = 0;
+        bool use_ambiguity_difference = true;
+        SatelliteId satellite;
+        SatelliteId reference_satellite;
+        SignalType signal = SignalType::GPS_L1CA;
+        Vector3d rover_satellite_position_ecef = Vector3d::Zero();
+        Vector3d rover_reference_position_ecef = Vector3d::Zero();
+        Vector3d base_satellite_position_ecef = Vector3d::Zero();
+        Vector3d base_reference_position_ecef = Vector3d::Zero();
+        Vector3d base_position_ecef = Vector3d::Zero();
+        double observed_dd_carrier_m = 0.0;
+        double sigma_m = 0.02;
+        double elevation_rad = 0.0;
+        ObservationModelDebug rover_satellite_model;
+        ObservationModelDebug rover_reference_model;
+        ObservationModelDebug base_satellite_model;
+        ObservationModelDebug base_reference_model;
+    };
+
+    struct AmbiguityBetweenFactor {
+        std::size_t previous_epoch_index = 0;
+        std::size_t current_epoch_index = 0;
+        std::size_t previous_ambiguity_index = 0;
+        std::size_t current_ambiguity_index = 0;
+        SatelliteId satellite;
+        SignalType signal = SignalType::GPS_L1CA;
+        double sigma_m = 0.001;
+    };
+
+    struct FGOProblemDiagnostics {
+        std::size_t input_epochs = 0;
+        std::size_t seeded_epochs = 0;
+        std::size_t skipped_epochs_without_seed = 0;
+        std::size_t double_difference_matched_base_epochs = 0;
+        std::size_t double_difference_interpolated_base_epochs = 0;
+        std::size_t double_difference_candidate_pairs = 0;
+        std::size_t double_difference_rejected_no_base_epoch = 0;
+        std::size_t double_difference_rejected_no_reference = 0;
+        std::size_t tdcp_candidate_pairs = 0;
+        std::size_t tdcp_rejected_gap = 0;
+        std::size_t tdcp_rejected_missing_previous = 0;
+        std::size_t tdcp_rejected_loss_of_lock = 0;
+        std::size_t tdcp_rejected_code_phase_jump = 0;
+    };
+
+    struct FGOProblem {
+        std::vector<EpochSeed> epochs;
+        std::vector<bool> clock_jumps;
+        std::vector<PseudorangeFactor> pseudorange_factors;
+        std::vector<TimeDifferencedCarrierFactor> tdcp_factors;
+        std::vector<SingleDifferenceDopplerFactor> single_difference_doppler_factors;
+        std::vector<SingleDifferenceTdcpFactor> single_difference_tdcp_factors;
+        std::vector<AmbiguityState> ambiguity_states;
+        std::vector<CarrierPhaseFactor> carrier_observations;
+        std::vector<CarrierPhaseFactor> double_difference_pseudorange_observations;
+        std::vector<CarrierPhaseFactor> double_difference_reference_observations;
+        std::vector<CarrierPhaseFactor> carrier_phase_factors;
+        std::vector<DoubleDifferencePseudorangeFactor> double_difference_pseudorange_factors;
+        std::vector<DoubleDifferenceCarrierFactor> double_difference_carrier_factors;
+        std::vector<AmbiguityBetweenFactor> ambiguity_between_factors;
+        FGOProblemDiagnostics diagnostics;
+    };
+
+    struct FGODiagnostics {
+        int iterations = 0;
+        bool converged = false;
+        std::size_t epochs = 0;
+        std::size_t pseudorange_factors = 0;
+        std::size_t tdcp_factors = 0;
+        std::size_t single_difference_doppler_factors = 0;
+        std::size_t single_difference_tdcp_factors = 0;
+        std::size_t carrier_phase_factors = 0;
+        std::size_t double_difference_pseudorange_factors = 0;
+        std::size_t double_difference_carrier_factors = 0;
+        std::size_t ambiguity_states = 0;
+        std::size_t ambiguity_fix_candidates = 0;
+        std::size_t lambda_ambiguity_candidates = 0;
+        std::size_t lambda_ambiguity_used_candidates = 0;
+        std::size_t lambda_ambiguity_attempts = 0;
+        std::size_t fixed_ambiguities = 0;
+        std::size_t tdcp_candidate_pairs = 0;
+        std::size_t tdcp_rejected_gap = 0;
+        std::size_t tdcp_rejected_missing_previous = 0;
+        std::size_t tdcp_rejected_loss_of_lock = 0;
+        std::size_t tdcp_rejected_code_phase_jump = 0;
+        std::size_t double_difference_matched_base_epochs = 0;
+        std::size_t double_difference_interpolated_base_epochs = 0;
+        std::size_t double_difference_candidate_pairs = 0;
+        std::size_t double_difference_rejected_no_base_epoch = 0;
+        std::size_t double_difference_rejected_no_reference = 0;
+        std::size_t motion_factors = 0;
+        std::size_t ambiguity_between_factors = 0;
+        std::size_t robust_pseudorange_factors = 0;
+        std::size_t robust_carrier_phase_factors = 0;
+        std::size_t robust_double_difference_pseudorange_factors = 0;
+        std::size_t robust_double_difference_carrier_factors = 0;
+        std::size_t robust_tdcp_factors = 0;
+        std::size_t graph_factors = 0;
+        std::size_t graph_values = 0;
+        bool fixed_solution = false;
+        bool lambda_ambiguity_fix_solved = false;
+        bool lambda_ambiguity_fix_used = false;
+        bool partial_lambda_ambiguity_fix_used = false;
+        double initial_cost = 0.0;
+        double final_cost = 0.0;
+        double processing_time_ms = 0.0;
+        double epoch_lambda_processing_time_ms = 0.0;
+        double epoch_lambda_setup_time_ms = 0.0;
+        double epoch_lambda_factorization_time_ms = 0.0;
+        double epoch_lambda_covariance_solve_time_ms = 0.0;
+        double epoch_lambda_search_time_ms = 0.0;
+        double epoch_lambda_fixed_output_time_ms = 0.0;
+        double epoch_lambda_debug_record_time_ms = 0.0;
+        double postprocessing_time_ms = 0.0;
+        double total_processing_time_ms = 0.0;
+        double last_update_norm_m = 0.0;
+        double residual_rms_m = 0.0;
+        double tdcp_residual_rms_m = 0.0;
+        double single_difference_doppler_residual_rms_mps = 0.0;
+        double single_difference_tdcp_residual_rms_m = 0.0;
+        double carrier_phase_residual_rms_m = 0.0;
+        double double_difference_pseudorange_residual_rms_m = 0.0;
+        double double_difference_carrier_residual_rms_m = 0.0;
+        double fixed_ambiguity_residual_rms_cycles = 0.0;
+        double lambda_ambiguity_ratio = 0.0;
+    };
+
+    struct AmbiguityEstimate {
+        SatelliteId satellite;
+        SignalType signal = SignalType::GPS_L1CA;
+        std::size_t segment_index = 0;
+        double wavelength_m = 0.0;
+        double ambiguity_m = 0.0;
+        double ambiguity_cycles = 0.0;
+        int fixed_cycles = 0;
+        double fixed_ambiguity_m = 0.0;
+        double fix_residual_cycles = 0.0;
+        bool is_fixed = false;
+        bool fixed_by_lambda = false;
+    };
+
+    struct LambdaDebugEntry {
+        std::size_t epoch_index = 0;
+        GNSSTime time;
+        bool solved = false;
+        bool fixed_epoch = false;
+        double ratio = 0.0;
+        int candidate_count = 0;
+        int row = 0;
+        int col = 0;
+        int local_index = 0;
+        int other_local_index = 0;
+        SatelliteId satellite;
+        SatelliteId other_satellite;
+        double ambiguity_float = 0.0;
+        double fixed_ambiguity = 0.0;
+        double covariance = 0.0;
+        double position_covariance_x = 0.0;
+        double position_covariance_y = 0.0;
+        double position_covariance_z = 0.0;
+    };
+
+    struct FGOResult {
+        Solution solution;
+        FGODiagnostics diagnostics;
+        std::vector<AmbiguityEstimate> ambiguity_estimates;
+        std::vector<std::set<SatelliteId>> ambiguity_candidate_satellites_by_epoch;
+        std::vector<std::set<SatelliteId>> ambiguity_reference_satellites_by_epoch;
+        std::vector<std::map<SatelliteId, double>> ambiguity_estimate_cycles_by_epoch;
+        std::vector<Vector3d> epoch_velocities_ecef_mps;
+        std::vector<LambdaDebugEntry> lambda_debug_entries;
+    };
+
+    FGOProcessor() = default;
+    explicit FGOProcessor(const FGOConfig& config) : config_(config) {}
+
+    const FGOConfig& getConfig() const { return config_; }
+    void setConfig(const FGOConfig& config) { config_ = config; }
+
+    FGOProblem buildPseudorangeProblem(const std::vector<ObservationData>& epochs,
+                                       const NavigationData& nav) const;
+
+    FGOProblem buildDoubleDifferenceProblem(
+        const std::vector<ObservationData>& rover_epochs,
+        const std::vector<ObservationData>& base_epochs,
+        const NavigationData& nav,
+        const Vector3d& base_position_ecef) const;
+
+    FGOResult optimize(const std::vector<ObservationData>& epochs,
+                       const NavigationData& nav) const;
+
+    FGOResult optimize(const std::vector<ObservationData>& rover_epochs,
+                       const std::vector<ObservationData>& base_epochs,
+                       const NavigationData& nav,
+                       const Vector3d& base_position_ecef) const;
+
+    FGOResult optimizeProblem(const FGOProblem& problem) const;
+
+private:
+    FGOConfig config_;
+};
+
+}  // namespace libgnss

--- a/scripts/dump_taroz_d_debug.m
+++ b/scripts/dump_taroz_d_debug.m
@@ -1,0 +1,137 @@
+% Dump taroz estimate_vel_D internals for LibGNSS++ parity checks.
+%
+% Environment overrides:
+%   GNSSPP_TAROZ_ROOT          Root of taroz/PPC-Dataset checkout.
+%   GNSSPP_TAROZ_D_EXAMPLE_DIR Directory containing estimate_vel_D.m.
+%   GNSSPP_TAROZ_D_OUT_DIR     Output directory for CSV dumps.
+
+taroz_root = getenv("GNSSPP_TAROZ_ROOT");
+if strlength(taroz_root) == 0
+    taroz_root = "/tmp/taroz_gtsam_gnss";
+end
+
+example_dir = getenv("GNSSPP_TAROZ_D_EXAMPLE_DIR");
+if strlength(example_dir) == 0
+    example_dir = fullfile(taroz_root, "examples");
+end
+
+out_dir = getenv("GNSSPP_TAROZ_D_OUT_DIR");
+if strlength(out_dir) == 0
+    out_dir = fullfile(pwd, "output", "dogfood", "taroz_matlab_d_debug");
+end
+if ~isfolder(out_dir)
+    mkdir(out_dir);
+end
+
+set(0, "DefaultFigureVisible", "off");
+cd(example_dir);
+estimate_vel_D;
+close all force;
+
+out_dir = getenv("GNSSPP_TAROZ_D_OUT_DIR");
+if strlength(out_dir) == 0
+    out_dir = fullfile(pwd, "output", "dogfood", "taroz_matlab_d_debug");
+end
+if ~isfolder(out_dir)
+    mkdir(out_dir);
+end
+
+graph_factors = scalar_or_nan(@() graph.size);
+graph_values = scalar_or_nan(@() initials.size);
+initial_cost = scalar_or_nan(@() graph.error(initials));
+final_cost = scalar_or_nan(@() graph.error(results));
+optimizer_error = scalar_or_nan(@() optimizer.error);
+iterations = scalar_or_nan(@() optimizer.iterations);
+valid_velocity_epochs = nnz(all(isfinite(v_est), 2));
+
+graph_table = table(n, nsat, graph_factors, graph_values, initial_cost, ...
+                    final_cost, optimizer_error, iterations, ...
+                    valid_velocity_epochs);
+writetable(graph_table, fullfile(out_dir, "graph_detail.csv"));
+
+epoch = (1:n)';
+gps_week = obs.time.week(:);
+gps_tow = obs.time.tow(:);
+spp_x_m = x_ini(:,1);
+spp_y_m = x_ini(:,2);
+spp_z_m = x_ini(:,3);
+fgo_vx_mps = v_est(:,1);
+fgo_vy_mps = v_est(:,2);
+fgo_vz_mps = v_est(:,3);
+fgo_clock_drift_mps = d_est(:,1);
+
+epoch_table = table(epoch, gps_week, gps_tow, spp_x_m, spp_y_m, spp_z_m, ...
+                    fgo_vx_mps, fgo_vy_mps, fgo_vz_mps, ...
+                    fgo_clock_drift_mps);
+writetable(epoch_table, fullfile(out_dir, "per_epoch_vel.csv"));
+
+satstr = string(obs.satstr);
+rows = n * nsat;
+epoch_col = zeros(rows, 1);
+gps_week_col = zeros(rows, 1);
+gps_tow_col = zeros(rows, 1);
+satellite = strings(rows, 1);
+system = strings(rows, 1);
+snr_dbhz = nan(rows, 1);
+elevation_deg = nan(rows, 1);
+sigma_d_mps = nan(rows, 1);
+res_d_mps = nan(rows, 1);
+raw_d_hz = nan(rows, 1);
+wavelength_m = nan(rows, 1);
+measured_range_rate_mps = nan(rows, 1);
+modeled_range_rate_mps = nan(rows, 1);
+satellite_clock_drift_mps = nan(rows, 1);
+valid_doppler = false(rows, 1);
+los_x = nan(rows, 1);
+los_y = nan(rows, 1);
+los_z = nan(rows, 1);
+
+k = 0;
+for i = 1:n
+    for j = 1:nsat
+        k = k + 1;
+        epoch_col(k) = i;
+        gps_week_col(k) = obs.time.week(i);
+        gps_tow_col(k) = obs.time.tow(i);
+        satellite(k) = satstr(j);
+        system(k) = string(obs.sys(j));
+        snr_dbhz(k) = obs.L1.S(i,j);
+        elevation_deg(k) = sat.el(i,j);
+        sigma_d_mps(k) = sigmaD(i,j);
+        res_d_mps(k) = obs.L1.resD(i,j);
+        raw_d_hz(k) = obs.L1.D(i,j);
+        wavelength_m(k) = obs.L1.lam(j);
+        measured_range_rate_mps(k) = -obs.L1.D(i,j) * obs.L1.lam(j);
+        modeled_range_rate_mps(k) = sat.rate(i,j);
+        satellite_clock_drift_mps(k) = sat.ddts(i,j);
+        valid_doppler(k) = ~isnan(obs.L1.resD(i,j));
+        los_x(k) = -sat.ex(i,j);
+        los_y(k) = -sat.ey(i,j);
+        los_z(k) = -sat.ez(i,j);
+    end
+end
+
+sat_table = table(epoch_col, gps_week_col, gps_tow_col, satellite, system, ...
+                  snr_dbhz, elevation_deg, sigma_d_mps, res_d_mps, ...
+                  raw_d_hz, wavelength_m, measured_range_rate_mps, ...
+                  modeled_range_rate_mps, satellite_clock_drift_mps, ...
+                  valid_doppler, los_x, los_y, los_z, ...
+                  'VariableNames', {'epoch','gps_week','gps_tow', ...
+                                    'satellite','system','snr_dbhz', ...
+                                    'elevation_deg','sigma_d_mps','res_d_mps', ...
+                                    'raw_d_hz','wavelength_m', ...
+                                    'measured_range_rate_mps', ...
+                                    'modeled_range_rate_mps', ...
+                                    'satellite_clock_drift_mps', ...
+                                    'valid_doppler','los_x','los_y','los_z'});
+writetable(sat_table, fullfile(out_dir, "per_sat_detail.csv"));
+
+fprintf("Wrote taroz D debug CSVs to %s\n", out_dir);
+
+function value = scalar_or_nan(callback)
+    try
+        value = callback();
+    catch
+        value = NaN;
+    end
+end

--- a/scripts/dump_taroz_p_debug.m
+++ b/scripts/dump_taroz_p_debug.m
@@ -1,0 +1,125 @@
+% Dump taroz estimate_pos_P internals for LibGNSS++ parity checks.
+%
+% Environment overrides:
+%   GNSSPP_TAROZ_ROOT          Root of taroz/PPC-Dataset checkout.
+%   GNSSPP_TAROZ_P_EXAMPLE_DIR Directory containing estimate_pos_P.m.
+%   GNSSPP_TAROZ_P_OUT_DIR     Output directory for CSV dumps.
+
+taroz_root = getenv("GNSSPP_TAROZ_ROOT");
+if strlength(taroz_root) == 0
+    taroz_root = "/tmp/taroz_gtsam_gnss";
+end
+
+example_dir = getenv("GNSSPP_TAROZ_P_EXAMPLE_DIR");
+if strlength(example_dir) == 0
+    example_dir = fullfile(taroz_root, "examples");
+end
+
+out_dir = getenv("GNSSPP_TAROZ_P_OUT_DIR");
+if strlength(out_dir) == 0
+    out_dir = fullfile(pwd, "output", "dogfood", "taroz_matlab_p_debug");
+end
+if ~isfolder(out_dir)
+    mkdir(out_dir);
+end
+
+set(0, "DefaultFigureVisible", "off");
+cd(example_dir);
+estimate_pos_P;
+close all force;
+
+out_dir = getenv("GNSSPP_TAROZ_P_OUT_DIR");
+if strlength(out_dir) == 0
+    out_dir = fullfile(pwd, "output", "dogfood", "taroz_matlab_p_debug");
+end
+if ~isfolder(out_dir)
+    mkdir(out_dir);
+end
+
+graph_factors = scalar_or_nan(@() graph.size);
+graph_values = scalar_or_nan(@() initials.size);
+initial_cost = scalar_or_nan(@() graph.error(initials));
+final_cost = scalar_or_nan(@() graph.error(results));
+optimizer_error = scalar_or_nan(@() optimizer.error);
+iterations = scalar_or_nan(@() optimizer.iterations);
+valid_solution_epochs = nnz(all(isfinite(x_est), 2));
+
+graph_table = table(n, nsat, graph_factors, graph_values, initial_cost, ...
+                    final_cost, optimizer_error, iterations, ...
+                    valid_solution_epochs);
+writetable(graph_table, fullfile(out_dir, "graph_detail.csv"));
+
+epoch = (1:n)';
+gps_week = obs.time.week(:);
+gps_tow = obs.time.tow(:);
+spp_x_m = x_ini(:,1);
+spp_y_m = x_ini(:,2);
+spp_z_m = x_ini(:,3);
+fgo_x_m = x_est(:,1);
+fgo_y_m = x_est(:,2);
+fgo_z_m = x_est(:,3);
+fgo_c_gps_m = c_est(:,1);
+fgo_c_glo_m = c_est(:,2);
+fgo_c_gal_m = c_est(:,3);
+fgo_c_qzs_m = c_est(:,4);
+fgo_c_bds_m = c_est(:,5);
+
+epoch_table = table(epoch, gps_week, gps_tow, spp_x_m, spp_y_m, spp_z_m, ...
+                    fgo_x_m, fgo_y_m, fgo_z_m, fgo_c_gps_m, ...
+                    fgo_c_glo_m, fgo_c_gal_m, fgo_c_qzs_m, fgo_c_bds_m);
+writetable(epoch_table, fullfile(out_dir, "per_epoch_est.csv"));
+
+satstr = string(obs.satstr);
+rows = n * nsat;
+epoch_col = zeros(rows, 1);
+gps_week_col = zeros(rows, 1);
+gps_tow_col = zeros(rows, 1);
+satellite = strings(rows, 1);
+system = strings(rows, 1);
+snr_dbhz = nan(rows, 1);
+elevation_deg = nan(rows, 1);
+sigma_p_m = nan(rows, 1);
+res_pc_m = nan(rows, 1);
+valid_pseudorange = false(rows, 1);
+los_x = nan(rows, 1);
+los_y = nan(rows, 1);
+los_z = nan(rows, 1);
+
+k = 0;
+for i = 1:n
+    for j = 1:nsat
+        k = k + 1;
+        epoch_col(k) = i;
+        gps_week_col(k) = obs.time.week(i);
+        gps_tow_col(k) = obs.time.tow(i);
+        satellite(k) = satstr(j);
+        system(k) = string(obs.sys(j));
+        snr_dbhz(k) = obs.L1.S(i,j);
+        elevation_deg(k) = sat.el(i,j);
+        sigma_p_m(k) = sigmaP(i,j);
+        res_pc_m(k) = obs.L1.resPc(i,j);
+        valid_pseudorange(k) = ~isnan(obs.L1.resPc(i,j));
+        los_x(k) = -sat.ex(i,j);
+        los_y(k) = -sat.ey(i,j);
+        los_z(k) = -sat.ez(i,j);
+    end
+end
+
+sat_table = table(epoch_col, gps_week_col, gps_tow_col, satellite, system, ...
+                  snr_dbhz, elevation_deg, sigma_p_m, res_pc_m, ...
+                  valid_pseudorange, los_x, los_y, los_z, ...
+                  'VariableNames', {'epoch','gps_week','gps_tow', ...
+                                    'satellite','system','snr_dbhz', ...
+                                    'elevation_deg','sigma_p_m','res_pc_m', ...
+                                    'valid_pseudorange','los_x','los_y','los_z'});
+writetable(sat_table, fullfile(out_dir, "per_sat_detail.csv"));
+
+fprintf("Wrote taroz P debug CSVs to %s\n", out_dir);
+
+function value = scalar_or_nan(callback)
+    try
+        value = callback();
+    catch
+        value = NaN;
+    end
+end

--- a/scripts/dump_taroz_pd_debug.m
+++ b/scripts/dump_taroz_pd_debug.m
@@ -1,0 +1,158 @@
+% Dump taroz estimate_pos_vel_PD internals for LibGNSS++ parity checks.
+%
+% Environment overrides:
+%   GNSSPP_TAROZ_ROOT           Root of taroz/PPC-Dataset checkout.
+%   GNSSPP_TAROZ_PD_EXAMPLE_DIR Directory containing estimate_pos_vel_PD.m.
+%   GNSSPP_TAROZ_PD_OUT_DIR     Output directory for CSV dumps.
+
+taroz_root = getenv("GNSSPP_TAROZ_ROOT");
+if strlength(taroz_root) == 0
+    taroz_root = "/tmp/taroz_gtsam_gnss";
+end
+
+example_dir = getenv("GNSSPP_TAROZ_PD_EXAMPLE_DIR");
+if strlength(example_dir) == 0
+    example_dir = fullfile(taroz_root, "examples");
+end
+
+out_dir = getenv("GNSSPP_TAROZ_PD_OUT_DIR");
+if strlength(out_dir) == 0
+    out_dir = fullfile(pwd, "output", "dogfood", "taroz_matlab_pd_debug");
+end
+if ~isfolder(out_dir)
+    mkdir(out_dir);
+end
+
+set(0, "DefaultFigureVisible", "off");
+cd(example_dir);
+estimate_pos_vel_PD;
+close all force;
+
+out_dir = getenv("GNSSPP_TAROZ_PD_OUT_DIR");
+if strlength(out_dir) == 0
+    out_dir = fullfile(pwd, "output", "dogfood", "taroz_matlab_pd_debug");
+end
+if ~isfolder(out_dir)
+    mkdir(out_dir);
+end
+
+graph_factors = scalar_or_nan(@() graph.size);
+graph_values = scalar_or_nan(@() initials.size);
+initial_cost = scalar_or_nan(@() graph.error(initials));
+final_cost = scalar_or_nan(@() graph.error(results));
+optimizer_error = scalar_or_nan(@() optimizer.error);
+iterations = scalar_or_nan(@() optimizer.iterations);
+valid_position_epochs = nnz(all(isfinite(x_est), 2));
+valid_velocity_epochs = nnz(all(isfinite(v_est), 2));
+
+graph_table = table(n, nsat, graph_factors, graph_values, initial_cost, ...
+                    final_cost, optimizer_error, iterations, ...
+                    valid_position_epochs, valid_velocity_epochs);
+writetable(graph_table, fullfile(out_dir, "graph_detail.csv"));
+
+epoch = (1:n)';
+gps_week = obs.time.week(:);
+gps_tow = obs.time.tow(:);
+spp_x_m = x_ini(:,1);
+spp_y_m = x_ini(:,2);
+spp_z_m = x_ini(:,3);
+fgo_x_m = x_est(:,1);
+fgo_y_m = x_est(:,2);
+fgo_z_m = x_est(:,3);
+fgo_vx_mps = v_est(:,1);
+fgo_vy_mps = v_est(:,2);
+fgo_vz_mps = v_est(:,3);
+fgo_c_gps_m = c_est(:,1);
+fgo_c_glo_m = c_est(:,2);
+fgo_c_gal_m = c_est(:,3);
+fgo_c_qzs_m = c_est(:,4);
+fgo_c_bds_m = c_est(:,5);
+fgo_clock_drift_mps = d_est(:,1);
+clock_jump = clockjump(:);
+
+epoch_table = table(epoch, gps_week, gps_tow, spp_x_m, spp_y_m, spp_z_m, ...
+                    fgo_x_m, fgo_y_m, fgo_z_m, ...
+                    fgo_vx_mps, fgo_vy_mps, fgo_vz_mps, ...
+                    fgo_c_gps_m, fgo_c_glo_m, fgo_c_gal_m, ...
+                    fgo_c_qzs_m, fgo_c_bds_m, fgo_clock_drift_mps, ...
+                    clock_jump);
+writetable(epoch_table, fullfile(out_dir, "per_epoch_state.csv"));
+
+satstr = string(obs.satstr);
+rows = n * nsat;
+epoch_col = zeros(rows, 1);
+gps_week_col = zeros(rows, 1);
+gps_tow_col = zeros(rows, 1);
+satellite = strings(rows, 1);
+system = strings(rows, 1);
+snr_dbhz = nan(rows, 1);
+elevation_deg = nan(rows, 1);
+sigma_p_m = nan(rows, 1);
+sigma_d_mps = nan(rows, 1);
+res_pc_m = nan(rows, 1);
+res_d_mps = nan(rows, 1);
+raw_d_hz = nan(rows, 1);
+wavelength_m = nan(rows, 1);
+measured_range_rate_mps = nan(rows, 1);
+modeled_range_rate_mps = nan(rows, 1);
+satellite_clock_drift_mps = nan(rows, 1);
+valid_pseudorange = false(rows, 1);
+valid_doppler = false(rows, 1);
+los_x = nan(rows, 1);
+los_y = nan(rows, 1);
+los_z = nan(rows, 1);
+
+k = 0;
+for i = 1:n
+    for j = 1:nsat
+        k = k + 1;
+        epoch_col(k) = i;
+        gps_week_col(k) = obs.time.week(i);
+        gps_tow_col(k) = obs.time.tow(i);
+        satellite(k) = satstr(j);
+        system(k) = string(obs.sys(j));
+        snr_dbhz(k) = obs.L1.S(i,j);
+        elevation_deg(k) = sat.el(i,j);
+        sigma_p_m(k) = sigmaP(i,j);
+        sigma_d_mps(k) = sigmaD(i,j);
+        res_pc_m(k) = obs.L1.resPc(i,j);
+        res_d_mps(k) = obs.L1.resD(i,j);
+        raw_d_hz(k) = obs.L1.D(i,j);
+        wavelength_m(k) = obs.L1.lam(j);
+        measured_range_rate_mps(k) = -obs.L1.D(i,j) * obs.L1.lam(j);
+        modeled_range_rate_mps(k) = sat.rate(i,j);
+        satellite_clock_drift_mps(k) = sat.ddts(i,j);
+        valid_pseudorange(k) = ~isnan(obs.L1.resPc(i,j));
+        valid_doppler(k) = ~isnan(obs.L1.resD(i,j));
+        los_x(k) = -sat.ex(i,j);
+        los_y(k) = -sat.ey(i,j);
+        los_z(k) = -sat.ez(i,j);
+    end
+end
+
+sat_table = table(epoch_col, gps_week_col, gps_tow_col, satellite, system, ...
+                  snr_dbhz, elevation_deg, sigma_p_m, sigma_d_mps, ...
+                  res_pc_m, res_d_mps, raw_d_hz, wavelength_m, ...
+                  measured_range_rate_mps, modeled_range_rate_mps, ...
+                  satellite_clock_drift_mps, valid_pseudorange, valid_doppler, ...
+                  los_x, los_y, los_z, ...
+                  'VariableNames', {'epoch','gps_week','gps_tow', ...
+                                    'satellite','system','snr_dbhz', ...
+                                    'elevation_deg','sigma_p_m','sigma_d_mps', ...
+                                    'res_pc_m','res_d_mps','raw_d_hz', ...
+                                    'wavelength_m','measured_range_rate_mps', ...
+                                    'modeled_range_rate_mps', ...
+                                    'satellite_clock_drift_mps', ...
+                                    'valid_pseudorange','valid_doppler', ...
+                                    'los_x','los_y','los_z'});
+writetable(sat_table, fullfile(out_dir, "per_sat_detail.csv"));
+
+fprintf("Wrote taroz PD debug CSVs to %s\n", out_dir);
+
+function value = scalar_or_nan(callback)
+    try
+        value = callback();
+    catch
+        value = NaN;
+    end
+end

--- a/scripts/dump_taroz_pos_pd_debug.m
+++ b/scripts/dump_taroz_pos_pd_debug.m
@@ -1,0 +1,199 @@
+% Dump taroz estimate_pos_PD internals for LibGNSS++ parity checks.
+%
+% Environment overrides:
+%   GNSSPP_TAROZ_ROOT               Root of taroz/PPC-Dataset checkout.
+%   GNSSPP_TAROZ_POS_PD_EXAMPLE_DIR Directory containing estimate_pos_PD.m.
+%   GNSSPP_TAROZ_POS_PD_OUT_DIR     Output directory for CSV dumps.
+
+taroz_root = getenv("GNSSPP_TAROZ_ROOT");
+if strlength(taroz_root) == 0
+    taroz_root = "/tmp/taroz_gtsam_gnss";
+end
+
+example_dir = getenv("GNSSPP_TAROZ_POS_PD_EXAMPLE_DIR");
+if strlength(example_dir) == 0
+    example_dir = fullfile(taroz_root, "examples");
+end
+
+out_dir = getenv("GNSSPP_TAROZ_POS_PD_OUT_DIR");
+if strlength(out_dir) == 0
+    out_dir = fullfile(pwd, "output", "dogfood", "taroz_matlab_pos_pd_debug");
+end
+if ~isfolder(out_dir)
+    mkdir(out_dir);
+end
+
+set(0, "DefaultFigureVisible", "off");
+cd(example_dir);
+estimate_pos_PD;
+close all force;
+
+out_dir = getenv("GNSSPP_TAROZ_POS_PD_OUT_DIR");
+if strlength(out_dir) == 0
+    out_dir = fullfile(pwd, "output", "dogfood", "taroz_matlab_pos_pd_debug");
+end
+if ~isfolder(out_dir)
+    mkdir(out_dir);
+end
+
+graph_factors = scalar_or_nan(@() graph.size);
+graph_values = scalar_or_nan(@() initials.size);
+initial_cost = scalar_or_nan(@() graph.error(initials));
+final_cost = scalar_or_nan(@() graph.error(results));
+optimizer_error = scalar_or_nan(@() optimizer.error);
+iterations = scalar_or_nan(@() optimizer.iterations);
+valid_position_epochs = nnz(all(isfinite(x_est), 2));
+valid_clock_epochs = nnz(all(isfinite(c_est), 2));
+
+graph_table = table(n, nsat, graph_factors, graph_values, initial_cost, ...
+                    final_cost, optimizer_error, iterations, ...
+                    valid_position_epochs, valid_clock_epochs);
+writetable(graph_table, fullfile(out_dir, "graph_detail.csv"));
+
+epoch = (1:n)';
+gps_week = obs.time.week(:);
+gps_tow = obs.time.tow(:);
+spp_x_m = x_ini(:,1);
+spp_y_m = x_ini(:,2);
+spp_z_m = x_ini(:,3);
+fgo_x_m = x_est(:,1);
+fgo_y_m = x_est(:,2);
+fgo_z_m = x_est(:,3);
+fgo_c_gps_m = c_est(:,1);
+fgo_c_glo_m = c_est(:,2);
+fgo_c_gal_m = c_est(:,3);
+fgo_c_qzs_m = c_est(:,4);
+fgo_c_bds_m = c_est(:,5);
+clock_jump = clockjump(:);
+
+epoch_table = table(epoch, gps_week, gps_tow, spp_x_m, spp_y_m, spp_z_m, ...
+                    fgo_x_m, fgo_y_m, fgo_z_m, ...
+                    fgo_c_gps_m, fgo_c_glo_m, fgo_c_gal_m, ...
+                    fgo_c_qzs_m, fgo_c_bds_m, clock_jump);
+writetable(epoch_table, fullfile(out_dir, "per_epoch_state.csv"));
+
+satstr = string(obs.satstr);
+rows = n * nsat;
+epoch_col = zeros(rows, 1);
+gps_week_col = zeros(rows, 1);
+gps_tow_col = zeros(rows, 1);
+satellite = strings(rows, 1);
+system = strings(rows, 1);
+snr_dbhz = nan(rows, 1);
+elevation_deg = nan(rows, 1);
+sigma_p_m = nan(rows, 1);
+res_pc_m = nan(rows, 1);
+valid_pseudorange = false(rows, 1);
+los_x = nan(rows, 1);
+los_y = nan(rows, 1);
+los_z = nan(rows, 1);
+
+k = 0;
+for i = 1:n
+    for j = 1:nsat
+        k = k + 1;
+        epoch_col(k) = i;
+        gps_week_col(k) = obs.time.week(i);
+        gps_tow_col(k) = obs.time.tow(i);
+        satellite(k) = satstr(j);
+        system(k) = string(obs.sys(j));
+        snr_dbhz(k) = obs.L1.S(i,j);
+        elevation_deg(k) = sat.el(i,j);
+        sigma_p_m(k) = sigmaP(i,j);
+        res_pc_m(k) = obs.L1.resPc(i,j);
+        valid_pseudorange(k) = ~isnan(obs.L1.resPc(i,j));
+        los_x(k) = -sat.ex(i,j);
+        los_y(k) = -sat.ey(i,j);
+        los_z(k) = -sat.ez(i,j);
+    end
+end
+
+p_table = table(epoch_col, gps_week_col, gps_tow_col, satellite, system, ...
+                snr_dbhz, elevation_deg, sigma_p_m, res_pc_m, ...
+                valid_pseudorange, los_x, los_y, los_z, ...
+                'VariableNames', {'epoch','gps_week','gps_tow', ...
+                                  'satellite','system','snr_dbhz', ...
+                                  'elevation_deg','sigma_p_m','res_pc_m', ...
+                                  'valid_pseudorange','los_x','los_y','los_z'});
+writetable(p_table, fullfile(out_dir, "per_sat_detail.csv"));
+
+d_rows = (n - 1) * nsat;
+epoch_col = zeros(d_rows, 1);
+previous_epoch = zeros(d_rows, 1);
+gps_week_col = zeros(d_rows, 1);
+gps_tow_col = zeros(d_rows, 1);
+midpoint_gps_week = zeros(d_rows, 1);
+midpoint_gps_tow = zeros(d_rows, 1);
+satellite = strings(d_rows, 1);
+system = strings(d_rows, 1);
+snr_dbhz = nan(d_rows, 1);
+elevation_deg = nan(d_rows, 1);
+midpoint_elevation_deg = nan(d_rows, 1);
+sigma_d_mps = nan(d_rows, 1);
+res_d_mps = nan(d_rows, 1);
+raw_d_hz = nan(d_rows, 1);
+wavelength_m = nan(d_rows, 1);
+measured_range_rate_mps = nan(d_rows, 1);
+modeled_range_rate_mps = nan(d_rows, 1);
+satellite_clock_drift_mps = nan(d_rows, 1);
+valid_doppler = false(d_rows, 1);
+los_x = nan(d_rows, 1);
+los_y = nan(d_rows, 1);
+los_z = nan(d_rows, 1);
+
+k = 0;
+for i = 2:n
+    for j = 1:nsat
+        k = k + 1;
+        epoch_col(k) = i;
+        previous_epoch(k) = i - 1;
+        gps_week_col(k) = obs.time.week(i);
+        gps_tow_col(k) = obs.time.tow(i);
+        midpoint_gps_week(k) = obsi.time.week(i-1);
+        midpoint_gps_tow(k) = obsi.time.tow(i-1);
+        satellite(k) = satstr(j);
+        system(k) = string(obs.sys(j));
+        snr_dbhz(k) = obsi.L1.S(i-1,j);
+        elevation_deg(k) = sat.el(i,j);
+        midpoint_elevation_deg(k) = sati.el(i-1,j);
+        sigma_d_mps(k) = sigmaD(i,j);
+        res_d_mps(k) = obsi.L1.resD(i-1,j);
+        raw_d_hz(k) = obsi.L1.D(i-1,j);
+        wavelength_m(k) = obsi.L1.lam(j);
+        measured_range_rate_mps(k) = -obsi.L1.D(i-1,j) * obsi.L1.lam(j);
+        modeled_range_rate_mps(k) = sati.rate(i-1,j);
+        satellite_clock_drift_mps(k) = sati.ddts(i-1,j);
+        valid_doppler(k) = ~isnan(obsi.L1.resD(i-1,j)) && ~clockjump(i);
+        los_x(k) = -sati.ex(i-1,j);
+        los_y(k) = -sati.ey(i-1,j);
+        los_z(k) = -sati.ez(i-1,j);
+    end
+end
+
+d_table = table(epoch_col, previous_epoch, gps_week_col, gps_tow_col, ...
+                midpoint_gps_week, midpoint_gps_tow, satellite, system, ...
+                snr_dbhz, elevation_deg, midpoint_elevation_deg, ...
+                sigma_d_mps, res_d_mps, raw_d_hz, wavelength_m, ...
+                measured_range_rate_mps, modeled_range_rate_mps, ...
+                satellite_clock_drift_mps, valid_doppler, ...
+                los_x, los_y, los_z, ...
+                'VariableNames', {'epoch','previous_epoch','gps_week','gps_tow', ...
+                                  'midpoint_gps_week','midpoint_gps_tow', ...
+                                  'satellite','system','snr_dbhz', ...
+                                  'elevation_deg','midpoint_elevation_deg', ...
+                                  'sigma_d_mps','res_d_mps','raw_d_hz', ...
+                                  'wavelength_m','measured_range_rate_mps', ...
+                                  'modeled_range_rate_mps', ...
+                                  'satellite_clock_drift_mps', ...
+                                  'valid_doppler','los_x','los_y','los_z'});
+writetable(d_table, fullfile(out_dir, "per_doppler_detail.csv"));
+
+fprintf("Wrote taroz position PD debug CSVs to %s\n", out_dir);
+
+function value = scalar_or_nan(callback)
+    try
+        value = callback();
+    catch
+        value = NaN;
+    end
+end

--- a/scripts/dump_taroz_pos_pdc_debug.m
+++ b/scripts/dump_taroz_pos_pdc_debug.m
@@ -1,0 +1,264 @@
+% Dump taroz estimate_pos_PDC internals for LibGNSS++ parity checks.
+%
+% Environment overrides:
+%   GNSSPP_TAROZ_ROOT               Root of taroz/PPC-Dataset checkout.
+%   GNSSPP_TAROZ_POS_PDC_EXAMPLE_DIR Directory containing estimate_pos_PDC.m.
+%   GNSSPP_TAROZ_POS_PDC_OUT_DIR     Output directory for CSV dumps.
+
+taroz_root = getenv("GNSSPP_TAROZ_ROOT");
+if strlength(taroz_root) == 0
+    taroz_root = "/tmp/taroz_gtsam_gnss";
+end
+
+example_dir = getenv("GNSSPP_TAROZ_POS_PDC_EXAMPLE_DIR");
+if strlength(example_dir) == 0
+    example_dir = fullfile(taroz_root, "examples");
+end
+
+out_dir = getenv("GNSSPP_TAROZ_POS_PDC_OUT_DIR");
+if strlength(out_dir) == 0
+    out_dir = fullfile(pwd, "output", "dogfood", "taroz_matlab_pos_pdc_debug");
+end
+if ~isfolder(out_dir)
+    mkdir(out_dir);
+end
+
+set(0, "DefaultFigureVisible", "off");
+cd(example_dir);
+estimate_pos_PDC;
+close all force;
+
+out_dir = getenv("GNSSPP_TAROZ_POS_PDC_OUT_DIR");
+if strlength(out_dir) == 0
+    out_dir = fullfile(pwd, "output", "dogfood", "taroz_matlab_pos_pdc_debug");
+end
+if ~isfolder(out_dir)
+    mkdir(out_dir);
+end
+
+graph_factors = scalar_or_nan(@() graph.size);
+graph_values = scalar_or_nan(@() initials.size);
+initial_cost = scalar_or_nan(@() graph.error(initials));
+final_cost = scalar_or_nan(@() graph.error(results));
+optimizer_error = scalar_or_nan(@() optimizer.error);
+iterations = scalar_or_nan(@() optimizer.iterations);
+valid_position_epochs = nnz(all(isfinite(x_est), 2));
+valid_clock_epochs = nnz(all(isfinite(c_est), 2));
+
+graph_table = table(n, nsat, graph_factors, graph_values, initial_cost, ...
+                    final_cost, optimizer_error, iterations, ...
+                    valid_position_epochs, valid_clock_epochs);
+writetable(graph_table, fullfile(out_dir, "graph_detail.csv"));
+
+epoch = (1:n)';
+gps_week = obs.time.week(:);
+gps_tow = obs.time.tow(:);
+spp_x_m = x_ini(:,1);
+spp_y_m = x_ini(:,2);
+spp_z_m = x_ini(:,3);
+fgo_x_m = x_est(:,1);
+fgo_y_m = x_est(:,2);
+fgo_z_m = x_est(:,3);
+fgo_c_gps_m = c_est(:,1);
+fgo_c_glo_m = c_est(:,2);
+fgo_c_gal_m = c_est(:,3);
+fgo_c_qzs_m = c_est(:,4);
+fgo_c_bds_m = c_est(:,5);
+clock_jump = clockjump(:);
+
+epoch_table = table(epoch, gps_week, gps_tow, spp_x_m, spp_y_m, spp_z_m, ...
+                    fgo_x_m, fgo_y_m, fgo_z_m, ...
+                    fgo_c_gps_m, fgo_c_glo_m, fgo_c_gal_m, ...
+                    fgo_c_qzs_m, fgo_c_bds_m, clock_jump);
+writetable(epoch_table, fullfile(out_dir, "per_epoch_state.csv"));
+
+satstr = string(obs.satstr);
+rows = n * nsat;
+epoch_col = zeros(rows, 1);
+gps_week_col = zeros(rows, 1);
+gps_tow_col = zeros(rows, 1);
+satellite = strings(rows, 1);
+system = strings(rows, 1);
+snr_dbhz = nan(rows, 1);
+elevation_deg = nan(rows, 1);
+sigma_p_m = nan(rows, 1);
+res_pc_m = nan(rows, 1);
+valid_pseudorange = false(rows, 1);
+los_x = nan(rows, 1);
+los_y = nan(rows, 1);
+los_z = nan(rows, 1);
+
+k = 0;
+for i = 1:n
+    for j = 1:nsat
+        k = k + 1;
+        epoch_col(k) = i;
+        gps_week_col(k) = obs.time.week(i);
+        gps_tow_col(k) = obs.time.tow(i);
+        satellite(k) = satstr(j);
+        system(k) = string(obs.sys(j));
+        snr_dbhz(k) = obs.L1.S(i,j);
+        elevation_deg(k) = sat.el(i,j);
+        sigma_p_m(k) = sigmaP(i,j);
+        res_pc_m(k) = obs.L1.resPc(i,j);
+        valid_pseudorange(k) = ~isnan(obs.L1.resPc(i,j));
+        los_x(k) = -sat.ex(i,j);
+        los_y(k) = -sat.ey(i,j);
+        los_z(k) = -sat.ez(i,j);
+    end
+end
+
+p_table = table(epoch_col, gps_week_col, gps_tow_col, satellite, system, ...
+                snr_dbhz, elevation_deg, sigma_p_m, res_pc_m, ...
+                valid_pseudorange, los_x, los_y, los_z, ...
+                'VariableNames', {'epoch','gps_week','gps_tow', ...
+                                  'satellite','system','snr_dbhz', ...
+                                  'elevation_deg','sigma_p_m','res_pc_m', ...
+                                  'valid_pseudorange','los_x','los_y','los_z'});
+writetable(p_table, fullfile(out_dir, "per_sat_detail.csv"));
+
+d_rows = (n - 1) * nsat;
+epoch_col = zeros(d_rows, 1);
+previous_epoch = zeros(d_rows, 1);
+gps_week_col = zeros(d_rows, 1);
+gps_tow_col = zeros(d_rows, 1);
+midpoint_gps_week = zeros(d_rows, 1);
+midpoint_gps_tow = zeros(d_rows, 1);
+satellite = strings(d_rows, 1);
+system = strings(d_rows, 1);
+snr_dbhz = nan(d_rows, 1);
+elevation_deg = nan(d_rows, 1);
+midpoint_elevation_deg = nan(d_rows, 1);
+sigma_d_mps = nan(d_rows, 1);
+res_d_mps = nan(d_rows, 1);
+raw_d_hz = nan(d_rows, 1);
+wavelength_m = nan(d_rows, 1);
+measured_range_rate_mps = nan(d_rows, 1);
+modeled_range_rate_mps = nan(d_rows, 1);
+satellite_clock_drift_mps = nan(d_rows, 1);
+valid_doppler = false(d_rows, 1);
+los_x = nan(d_rows, 1);
+los_y = nan(d_rows, 1);
+los_z = nan(d_rows, 1);
+
+k = 0;
+for i = 2:n
+    for j = 1:nsat
+        k = k + 1;
+        epoch_col(k) = i;
+        previous_epoch(k) = i - 1;
+        gps_week_col(k) = obs.time.week(i);
+        gps_tow_col(k) = obs.time.tow(i);
+        midpoint_gps_week(k) = obsi.time.week(i-1);
+        midpoint_gps_tow(k) = obsi.time.tow(i-1);
+        satellite(k) = satstr(j);
+        system(k) = string(obs.sys(j));
+        snr_dbhz(k) = obsi.L1.S(i-1,j);
+        elevation_deg(k) = sat.el(i,j);
+        midpoint_elevation_deg(k) = sati.el(i-1,j);
+        sigma_d_mps(k) = sigmaD(i,j);
+        res_d_mps(k) = obsi.L1.resD(i-1,j);
+        raw_d_hz(k) = obsi.L1.D(i-1,j);
+        wavelength_m(k) = obsi.L1.lam(j);
+        measured_range_rate_mps(k) = -obsi.L1.D(i-1,j) * obsi.L1.lam(j);
+        modeled_range_rate_mps(k) = sati.rate(i-1,j);
+        satellite_clock_drift_mps(k) = sati.ddts(i-1,j);
+        valid_doppler(k) = ~isnan(obsi.L1.resD(i-1,j)) && ~clockjump(i);
+        los_x(k) = -sati.ex(i-1,j);
+        los_y(k) = -sati.ey(i-1,j);
+        los_z(k) = -sati.ez(i-1,j);
+    end
+end
+
+d_table = table(epoch_col, previous_epoch, gps_week_col, gps_tow_col, ...
+                midpoint_gps_week, midpoint_gps_tow, satellite, system, ...
+                snr_dbhz, elevation_deg, midpoint_elevation_deg, ...
+                sigma_d_mps, res_d_mps, raw_d_hz, wavelength_m, ...
+                measured_range_rate_mps, modeled_range_rate_mps, ...
+                satellite_clock_drift_mps, valid_doppler, ...
+                los_x, los_y, los_z, ...
+                'VariableNames', {'epoch','previous_epoch','gps_week','gps_tow', ...
+                                  'midpoint_gps_week','midpoint_gps_tow', ...
+                                  'satellite','system','snr_dbhz', ...
+                                  'elevation_deg','midpoint_elevation_deg', ...
+                                  'sigma_d_mps','res_d_mps','raw_d_hz', ...
+                                  'wavelength_m','measured_range_rate_mps', ...
+                                  'modeled_range_rate_mps', ...
+                                  'satellite_clock_drift_mps', ...
+                                  'valid_doppler','los_x','los_y','los_z'});
+writetable(d_table, fullfile(out_dir, "per_doppler_detail.csv"));
+
+c_rows = (n - 1) * nsat;
+epoch_col = zeros(c_rows, 1);
+previous_epoch = zeros(c_rows, 1);
+gps_week_col = zeros(c_rows, 1);
+gps_tow_col = zeros(c_rows, 1);
+satellite = strings(c_rows, 1);
+system = strings(c_rows, 1);
+snr_dbhz = nan(c_rows, 1);
+elevation_deg = nan(c_rows, 1);
+previous_elevation_deg = nan(c_rows, 1);
+sigma_c_m = nan(c_rows, 1);
+res_l_previous_m = nan(c_rows, 1);
+res_l_current_m = nan(c_rows, 1);
+tdcp_m = nan(c_rows, 1);
+raw_l_previous_cycles = nan(c_rows, 1);
+raw_l_current_cycles = nan(c_rows, 1);
+wavelength_m = nan(c_rows, 1);
+valid_tdcp = false(c_rows, 1);
+los_x = nan(c_rows, 1);
+los_y = nan(c_rows, 1);
+los_z = nan(c_rows, 1);
+
+k = 0;
+for i = 2:n
+    for j = 1:nsat
+        k = k + 1;
+        epoch_col(k) = i;
+        previous_epoch(k) = i - 1;
+        gps_week_col(k) = obs.time.week(i);
+        gps_tow_col(k) = obs.time.tow(i);
+        satellite(k) = satstr(j);
+        system(k) = string(obs.sys(j));
+        snr_dbhz(k) = obs.L1.S(i,j);
+        elevation_deg(k) = sat.el(i,j);
+        previous_elevation_deg(k) = sat.el(i-1,j);
+        sigma_c_m(k) = sigmaC(i,j);
+        res_l_previous_m(k) = obs.L1.resL(i-1,j);
+        res_l_current_m(k) = obs.L1.resL(i,j);
+        tdcp_m(k) = obs.L1.resL(i,j) - obs.L1.resL(i-1,j);
+        raw_l_previous_cycles(k) = obs.L1.L(i-1,j);
+        raw_l_current_cycles(k) = obs.L1.L(i,j);
+        wavelength_m(k) = obs.L1.lam(j);
+        valid_tdcp(k) = ~isnan(tdcp_m(k)) && ~clockjump(i);
+        los_x(k) = -sat.ex(i-1,j);
+        los_y(k) = -sat.ey(i-1,j);
+        los_z(k) = -sat.ez(i-1,j);
+    end
+end
+
+c_table = table(epoch_col, previous_epoch, gps_week_col, gps_tow_col, ...
+                satellite, system, snr_dbhz, elevation_deg, ...
+                previous_elevation_deg, sigma_c_m, ...
+                res_l_previous_m, res_l_current_m, tdcp_m, ...
+                raw_l_previous_cycles, raw_l_current_cycles, wavelength_m, ...
+                valid_tdcp, los_x, los_y, los_z, ...
+                'VariableNames', {'epoch','previous_epoch','gps_week','gps_tow', ...
+                                  'satellite','system','snr_dbhz', ...
+                                  'elevation_deg','previous_elevation_deg', ...
+                                  'sigma_c_m','res_l_previous_m', ...
+                                  'res_l_current_m','tdcp_m', ...
+                                  'raw_l_previous_cycles', ...
+                                  'raw_l_current_cycles','wavelength_m', ...
+                                  'valid_tdcp','los_x','los_y','los_z'});
+writetable(c_table, fullfile(out_dir, "per_tdcp_detail.csv"));
+
+fprintf("Wrote taroz position PDC debug CSVs to %s\n", out_dir);
+
+function value = scalar_or_nan(callback)
+    try
+        value = callback();
+    catch
+        value = NaN;
+    end
+end

--- a/scripts/dump_taroz_pos_vel_ambiguity_pdc_debug.m
+++ b/scripts/dump_taroz_pos_vel_ambiguity_pdc_debug.m
@@ -1,0 +1,328 @@
+% Dump taroz estimate_pos_vel_ambiguity_PDC internals for LibGNSS++ parity checks.
+%
+% Environment overrides:
+%   GNSSPP_TAROZ_ROOT                         Root of taroz/PPC-Dataset checkout.
+%   GNSSPP_TAROZ_POS_VEL_AMB_PDC_EXAMPLE_DIR Directory containing estimate_pos_vel_ambiguity_PDC.m.
+%   GNSSPP_TAROZ_POS_VEL_AMB_PDC_OUT_DIR     Output directory for CSV dumps.
+
+taroz_root = getenv("GNSSPP_TAROZ_ROOT");
+if strlength(taroz_root) == 0
+    taroz_root = "/tmp/taroz_gtsam_gnss";
+end
+
+example_dir = getenv("GNSSPP_TAROZ_POS_VEL_AMB_PDC_EXAMPLE_DIR");
+if strlength(example_dir) == 0
+    example_dir = fullfile(taroz_root, "examples");
+end
+
+out_dir = getenv("GNSSPP_TAROZ_POS_VEL_AMB_PDC_OUT_DIR");
+if strlength(out_dir) == 0
+    out_dir = fullfile(pwd, "output", "dogfood", "taroz_matlab_pos_vel_amb_pdc_debug");
+end
+if ~isfolder(out_dir)
+    mkdir(out_dir);
+end
+
+set(0, "DefaultFigureVisible", "off");
+cd(example_dir);
+estimate_pos_vel_ambiguity_PDC;
+close all force;
+
+out_dir = getenv("GNSSPP_TAROZ_POS_VEL_AMB_PDC_OUT_DIR");
+if strlength(out_dir) == 0
+    out_dir = fullfile(pwd, "output", "dogfood", "taroz_matlab_pos_vel_amb_pdc_debug");
+end
+if ~isfolder(out_dir)
+    mkdir(out_dir);
+end
+
+v_est = nan(n, 3);
+for i = 1:n
+    v_est(i,:) = results.atVector(sym('v',i))';
+end
+
+graph_factors = scalar_or_nan(@() graph.size);
+graph_values = scalar_or_nan(@() initials.size);
+initial_cost = scalar_or_nan(@() graph.error(initials));
+final_cost = scalar_or_nan(@() graph.error(results));
+optimizer_error = scalar_or_nan(@() optimizer.error);
+iterations = scalar_or_nan(@() optimizer.iterations);
+valid_position_epochs = nnz(all(isfinite(x_est), 2));
+valid_velocity_epochs = nnz(all(isfinite(v_est), 2));
+valid_ambiguity_states = nnz(b_est ~= 0 & isfinite(b_est));
+fixed_epochs = nnz(idxfix);
+
+graph_table = table(n, nsat, graph_factors, graph_values, initial_cost, ...
+                    final_cost, optimizer_error, iterations, ...
+                    valid_position_epochs, valid_velocity_epochs, ...
+                    valid_ambiguity_states, fixed_epochs);
+writetable(graph_table, fullfile(out_dir, "graph_detail.csv"));
+
+epoch = (1:n)';
+gps_week = obs.time.week(:);
+gps_tow = obs.time.tow(:);
+spp_x_m = x_ini(:,1);
+spp_y_m = x_ini(:,2);
+spp_z_m = x_ini(:,3);
+float_x_m = x_est(:,1);
+float_y_m = x_est(:,2);
+float_z_m = x_est(:,3);
+fixed_x_m = xa_est(:,1);
+fixed_y_m = xa_est(:,2);
+fixed_z_m = xa_est(:,3);
+fgo_vx_mps = v_est(:,1);
+fgo_vy_mps = v_est(:,2);
+fgo_vz_mps = v_est(:,3);
+ratio_col = ratio(:);
+idxfix_col = idxfix(:);
+candidate_count = zeros(n, 1);
+fixed_ambiguity_count = zeros(n, 1);
+for i = 1:n
+    candidate_count(i) = nnz(b_est(i,:) ~= 0 & isfinite(b_est(i,:)));
+    fixed_ambiguity_count(i) = nnz(isfinite(ba_est(i,:)));
+end
+
+epoch_table = table(epoch, gps_week, gps_tow, spp_x_m, spp_y_m, spp_z_m, ...
+                    float_x_m, float_y_m, float_z_m, ...
+                    fixed_x_m, fixed_y_m, fixed_z_m, ...
+                    fgo_vx_mps, fgo_vy_mps, fgo_vz_mps, ...
+                    ratio_col, idxfix_col, candidate_count, fixed_ambiguity_count, ...
+                    'VariableNames', {'epoch','gps_week','gps_tow', ...
+                                      'spp_x_m','spp_y_m','spp_z_m', ...
+                                      'float_x_m','float_y_m','float_z_m', ...
+                                      'fixed_x_m','fixed_y_m','fixed_z_m', ...
+                                      'fgo_vx_mps','fgo_vy_mps','fgo_vz_mps', ...
+                                      'ratio','idxfix','candidate_count', ...
+                                      'fixed_ambiguity_count'});
+writetable(epoch_table, fullfile(out_dir, "per_epoch_state.csv"));
+
+satstr = string(obs.satstr);
+rows = n * nsat;
+epoch_col = zeros(rows, 1);
+gps_week_col = zeros(rows, 1);
+gps_tow_col = zeros(rows, 1);
+satellite = strings(rows, 1);
+reference = strings(rows, 1);
+system = strings(rows, 1);
+snr_dbhz = nan(rows, 1);
+elevation_deg = nan(rows, 1);
+reference_elevation_deg = nan(rows, 1);
+sigma_pdd_m = nan(rows, 1);
+sigma_ldd_m = nan(rows, 1);
+sigma_dsd_mps = nan(rows, 1);
+res_pdd = nan(rows, 1);
+res_ldd = nan(rows, 1);
+res_dsd_mps = nan(rows, 1);
+res_lsd_m = nan(rows, 1);
+tdcp_sd_m = nan(rows, 1);
+raw_p_rover_m = nan(rows, 1);
+raw_l_rover_cycles = nan(rows, 1);
+raw_d_rover_hz = nan(rows, 1);
+wavelength_m = nan(rows, 1);
+ambiguity_initial = nan(rows, 1);
+ambiguity_estimate = nan(rows, 1);
+ambiguity_fixed = nan(rows, 1);
+valid_pseudorange_dd = false(rows, 1);
+valid_carrier_dd = false(rows, 1);
+valid_doppler_sd = false(rows, 1);
+valid_tdcp_sd = false(rows, 1);
+los_x = nan(rows, 1);
+los_y = nan(rows, 1);
+los_z = nan(rows, 1);
+
+k = 0;
+for i = 1:n
+    for j = 1:nsat
+        ref_idx = reference_index_for_observation(refsatidx, i, j);
+        k = k + 1;
+        epoch_col(k) = i;
+        gps_week_col(k) = obs.time.week(i);
+        gps_tow_col(k) = obs.time.tow(i);
+        satellite(k) = satstr(j);
+        if isfinite(ref_idx) && ref_idx >= 1 && ref_idx <= nsat
+            reference(k) = satstr(ref_idx);
+            reference_elevation_deg(k) = sat.el(i,ref_idx);
+        end
+        system(k) = string(obs.sys(j));
+        snr_dbhz(k) = obs.L1.S(i,j);
+        elevation_deg(k) = sat.el(i,j);
+        sigma_pdd_m(k) = sigmaP(i,j);
+        sigma_ldd_m(k) = sigmaL(i,j);
+        sigma_dsd_mps(k) = sigmaD(i,j);
+        res_pdd(k) = obs.L1.resPdd(i,j);
+        res_ldd(k) = obs.L1.resLdd(i,j);
+        res_dsd_mps(k) = resDsd(i,j);
+        res_lsd_m(k) = resLsd(i,j);
+        raw_p_rover_m(k) = obs.L1.P(i,j);
+        raw_l_rover_cycles(k) = obs.L1.L(i,j);
+        raw_d_rover_hz(k) = obs.L1.D(i,j);
+        wavelength_m(k) = obs.L1.lam(j);
+        ambiguity_initial(k) = b_ini(i,j);
+        ambiguity_estimate(k) = b_est(i,j);
+        ambiguity_fixed(k) = ba_est(i,j);
+        valid_pseudorange_dd(k) = ~isnan(obs.L1.resPdd(i,j));
+        valid_carrier_dd(k) = ~isnan(obs.L1.resLdd(i,j));
+        valid_doppler_sd(k) = ~isnan(resDsd(i,j));
+        los_x(k) = -exdd(i,j);
+        los_y(k) = -eydd(i,j);
+        los_z(k) = -ezdd(i,j);
+        if i > 1
+            tdcp_sd_m(k) = resLsd(i,j) - resLsd(i-1,j);
+            valid_tdcp_sd(k) = ~isnan(tdcp_sd_m(k)) && tdcp_sd_m(k) ~= 0;
+        end
+    end
+end
+
+sat_table = table(epoch_col, gps_week_col, gps_tow_col, satellite, reference, ...
+                  system, snr_dbhz, elevation_deg, reference_elevation_deg, ...
+                  sigma_pdd_m, sigma_ldd_m, sigma_dsd_mps, ...
+                  res_pdd, res_ldd, res_dsd_mps, res_lsd_m, tdcp_sd_m, ...
+                  raw_p_rover_m, raw_l_rover_cycles, raw_d_rover_hz, ...
+                  wavelength_m, ambiguity_initial, ambiguity_estimate, ...
+                  ambiguity_fixed, valid_pseudorange_dd, valid_carrier_dd, ...
+                  valid_doppler_sd, valid_tdcp_sd, los_x, los_y, los_z, ...
+                  'VariableNames', {'epoch','gps_week','gps_tow', ...
+                                    'satellite','reference','system', ...
+                                    'snr_dbhz','elevation_deg', ...
+                                    'reference_elevation_deg', ...
+                                    'sigma_pdd_m','sigma_ldd_m', ...
+                                    'sigma_dsd_mps','res_pdd','res_ldd', ...
+                                    'res_dsd_mps','res_lsd_m','tdcp_sd_m', ...
+                                    'raw_p_rover_m','raw_l_rover_cycles', ...
+                                    'raw_d_rover_hz','wavelength_m', ...
+                                    'ambiguity_initial','ambiguity_estimate', ...
+                                    'ambiguity_fixed','valid_pseudorange_dd', ...
+                                    'valid_carrier_dd','valid_doppler_sd', ...
+                                    'valid_tdcp_sd','los_x','los_y','los_z'});
+writetable(sat_table, fullfile(out_dir, "per_sat_detail.csv"));
+
+lambda_rows = 0;
+for i = 1:n
+    valid_idx = find(b_est(i,:) ~= 0 & isfinite(b_est(i,:)));
+    candidate_n = length(valid_idx);
+    if candidate_n > minobs_th
+        lambda_rows = lambda_rows + candidate_n * candidate_n;
+    end
+end
+
+lambda_epoch = zeros(lambda_rows, 1);
+lambda_gps_week = zeros(lambda_rows, 1);
+lambda_gps_tow = zeros(lambda_rows, 1);
+solved = false(lambda_rows, 1);
+fixed_epoch = false(lambda_rows, 1);
+ratio_dump = nan(lambda_rows, 1);
+candidate_count_dump = zeros(lambda_rows, 1);
+row_dump = zeros(lambda_rows, 1);
+col_dump = zeros(lambda_rows, 1);
+local_index = zeros(lambda_rows, 1);
+other_local_index = zeros(lambda_rows, 1);
+satellite_dump = strings(lambda_rows, 1);
+other_satellite = strings(lambda_rows, 1);
+ambiguity_float = nan(lambda_rows, 1);
+fixed_ambiguity = nan(lambda_rows, 1);
+covariance = nan(lambda_rows, 1);
+position_covariance_x = nan(lambda_rows, 1);
+position_covariance_y = nan(lambda_rows, 1);
+position_covariance_z = nan(lambda_rows, 1);
+
+k = 0;
+for i = 1:n
+    valid_idx = find(b_est(i,:) ~= 0 & isfinite(b_est(i,:)));
+    candidate_n = length(valid_idx);
+    if candidate_n <= minobs_th
+        continue;
+    end
+    Qfafa = covxb_est(valid_idx, valid_idx, i);
+    Qxfa = covxb_est(end-2:end, valid_idx, i);
+    lambda_solved = false;
+    lambda_fixed = false;
+    lambda_ratio = NaN;
+    a = nan(2, candidate_n);
+    try
+        [a,s] = rtklib.lambda(2, b_est(i,valid_idx), Qfafa);
+        lambda_solved = true;
+        lambda_ratio = s(2) / s(1);
+        lambda_fixed = lambda_ratio > ratio_th;
+    catch
+        lambda_solved = false;
+    end
+    for r = 1:candidate_n
+        for c = 1:candidate_n
+            k = k + 1;
+            sat_idx = valid_idx(r);
+            other_sat_idx = valid_idx(c);
+            lambda_epoch(k) = i;
+            lambda_gps_week(k) = obs.time.week(i);
+            lambda_gps_tow(k) = obs.time.tow(i);
+            solved(k) = lambda_solved;
+            fixed_epoch(k) = lambda_fixed;
+            ratio_dump(k) = lambda_ratio;
+            candidate_count_dump(k) = candidate_n;
+            row_dump(k) = r - 1;
+            col_dump(k) = c - 1;
+            local_index(k) = sat_idx - 1;
+            other_local_index(k) = other_sat_idx - 1;
+            satellite_dump(k) = satstr(sat_idx);
+            other_satellite(k) = satstr(other_sat_idx);
+            ambiguity_float(k) = b_est(i,sat_idx);
+            if lambda_solved
+                fixed_ambiguity(k) = a(1,r);
+            end
+            covariance(k) = Qfafa(r,c);
+            position_covariance_x(k) = Qxfa(1,r);
+            position_covariance_y(k) = Qxfa(2,r);
+            position_covariance_z(k) = Qxfa(3,r);
+        end
+    end
+end
+
+lambda_table = table(lambda_epoch, lambda_gps_week, lambda_gps_tow, ...
+                     solved, fixed_epoch, ratio_dump, candidate_count_dump, ...
+                     row_dump, col_dump, local_index, other_local_index, ...
+                     satellite_dump, other_satellite, ambiguity_float, ...
+                     fixed_ambiguity, covariance, position_covariance_x, ...
+                     position_covariance_y, position_covariance_z, ...
+                     'VariableNames', {'epoch','gps_week','gps_tow', ...
+                                       'solved','fixed_epoch','ratio', ...
+                                       'candidate_count','row','col', ...
+                                       'local_index','other_local_index', ...
+                                       'satellite','other_satellite', ...
+                                       'ambiguity_float','fixed_ambiguity', ...
+                                       'covariance','position_covariance_x', ...
+                                       'position_covariance_y', ...
+                                       'position_covariance_z'});
+writetable(lambda_table, fullfile(out_dir, "per_lambda_detail.csv"));
+
+fprintf("Wrote taroz position/velocity ambiguity PDC debug CSVs to %s\n", out_dir);
+
+function value = scalar_or_nan(callback)
+    try
+        value = callback();
+    catch
+        value = NaN;
+    end
+end
+
+function ref_idx = reference_index_for_observation(refsatidx, epoch_index, satellite_index)
+    if isscalar(refsatidx)
+        ref_idx = refsatidx;
+    elseif isvector(refsatidx)
+        if numel(refsatidx) >= satellite_index
+            ref_values = refsatidx(:);
+            ref_idx = ref_values(satellite_index);
+        elseif numel(refsatidx) >= epoch_index
+            ref_values = refsatidx(:);
+            ref_idx = ref_values(epoch_index);
+        else
+            ref_idx = NaN;
+        end
+    elseif size(refsatidx, 1) >= epoch_index && size(refsatidx, 2) >= satellite_index
+        ref_idx = refsatidx(epoch_index, satellite_index);
+    elseif size(refsatidx, 1) >= epoch_index
+        ref_idx = refsatidx(epoch_index, 1);
+    elseif size(refsatidx, 2) >= satellite_index
+        ref_idx = refsatidx(1, satellite_index);
+    else
+        ref_idx = NaN;
+    end
+end

--- a/scripts/dump_taroz_pos_vel_pdc_debug.m
+++ b/scripts/dump_taroz_pos_vel_pdc_debug.m
@@ -1,0 +1,223 @@
+% Dump taroz estimate_pos_vel_PDC internals for LibGNSS++ parity checks.
+%
+% Environment overrides:
+%   GNSSPP_TAROZ_ROOT           Root of taroz/PPC-Dataset checkout.
+%   GNSSPP_TAROZ_POS_VEL_PDC_EXAMPLE_DIR Directory containing estimate_pos_vel_PDC.m.
+%   GNSSPP_TAROZ_POS_VEL_PDC_OUT_DIR     Output directory for CSV dumps.
+
+taroz_root = getenv("GNSSPP_TAROZ_ROOT");
+if strlength(taroz_root) == 0
+    taroz_root = "/tmp/taroz_gtsam_gnss";
+end
+
+example_dir = getenv("GNSSPP_TAROZ_POS_VEL_PDC_EXAMPLE_DIR");
+if strlength(example_dir) == 0
+    example_dir = fullfile(taroz_root, "examples");
+end
+
+out_dir = getenv("GNSSPP_TAROZ_POS_VEL_PDC_OUT_DIR");
+if strlength(out_dir) == 0
+    out_dir = fullfile(pwd, "output", "dogfood", "taroz_matlab_pos_vel_pdc_debug");
+end
+if ~isfolder(out_dir)
+    mkdir(out_dir);
+end
+
+set(0, "DefaultFigureVisible", "off");
+cd(example_dir);
+estimate_pos_vel_PDC;
+close all force;
+
+out_dir = getenv("GNSSPP_TAROZ_POS_VEL_PDC_OUT_DIR");
+if strlength(out_dir) == 0
+    out_dir = fullfile(pwd, "output", "dogfood", "taroz_matlab_pos_vel_pdc_debug");
+end
+if ~isfolder(out_dir)
+    mkdir(out_dir);
+end
+
+graph_factors = scalar_or_nan(@() graph.size);
+graph_values = scalar_or_nan(@() initials.size);
+initial_cost = scalar_or_nan(@() graph.error(initials));
+final_cost = scalar_or_nan(@() graph.error(results));
+optimizer_error = scalar_or_nan(@() optimizer.error);
+iterations = scalar_or_nan(@() optimizer.iterations);
+valid_position_epochs = nnz(all(isfinite(x_est), 2));
+valid_velocity_epochs = nnz(all(isfinite(v_est), 2));
+
+graph_table = table(n, nsat, graph_factors, graph_values, initial_cost, ...
+                    final_cost, optimizer_error, iterations, ...
+                    valid_position_epochs, valid_velocity_epochs);
+writetable(graph_table, fullfile(out_dir, "graph_detail.csv"));
+
+epoch = (1:n)';
+gps_week = obs.time.week(:);
+gps_tow = obs.time.tow(:);
+spp_x_m = x_ini(:,1);
+spp_y_m = x_ini(:,2);
+spp_z_m = x_ini(:,3);
+fgo_x_m = x_est(:,1);
+fgo_y_m = x_est(:,2);
+fgo_z_m = x_est(:,3);
+fgo_vx_mps = v_est(:,1);
+fgo_vy_mps = v_est(:,2);
+fgo_vz_mps = v_est(:,3);
+fgo_c_gps_m = c_est(:,1);
+fgo_c_glo_m = c_est(:,2);
+fgo_c_gal_m = c_est(:,3);
+fgo_c_qzs_m = c_est(:,4);
+fgo_c_bds_m = c_est(:,5);
+fgo_clock_drift_mps = d_est(:,1);
+clock_jump = clockjump(:);
+
+epoch_table = table(epoch, gps_week, gps_tow, spp_x_m, spp_y_m, spp_z_m, ...
+                    fgo_x_m, fgo_y_m, fgo_z_m, ...
+                    fgo_vx_mps, fgo_vy_mps, fgo_vz_mps, ...
+                    fgo_c_gps_m, fgo_c_glo_m, fgo_c_gal_m, ...
+                    fgo_c_qzs_m, fgo_c_bds_m, fgo_clock_drift_mps, ...
+                    clock_jump);
+writetable(epoch_table, fullfile(out_dir, "per_epoch_state.csv"));
+
+satstr = string(obs.satstr);
+rows = n * nsat;
+epoch_col = zeros(rows, 1);
+gps_week_col = zeros(rows, 1);
+gps_tow_col = zeros(rows, 1);
+satellite = strings(rows, 1);
+system = strings(rows, 1);
+snr_dbhz = nan(rows, 1);
+elevation_deg = nan(rows, 1);
+sigma_p_m = nan(rows, 1);
+sigma_d_mps = nan(rows, 1);
+res_pc_m = nan(rows, 1);
+res_d_mps = nan(rows, 1);
+raw_d_hz = nan(rows, 1);
+wavelength_m = nan(rows, 1);
+measured_range_rate_mps = nan(rows, 1);
+modeled_range_rate_mps = nan(rows, 1);
+satellite_clock_drift_mps = nan(rows, 1);
+valid_pseudorange = false(rows, 1);
+valid_doppler = false(rows, 1);
+los_x = nan(rows, 1);
+los_y = nan(rows, 1);
+los_z = nan(rows, 1);
+
+k = 0;
+for i = 1:n
+    for j = 1:nsat
+        k = k + 1;
+        epoch_col(k) = i;
+        gps_week_col(k) = obs.time.week(i);
+        gps_tow_col(k) = obs.time.tow(i);
+        satellite(k) = satstr(j);
+        system(k) = string(obs.sys(j));
+        snr_dbhz(k) = obs.L1.S(i,j);
+        elevation_deg(k) = sat.el(i,j);
+        sigma_p_m(k) = sigmaP(i,j);
+        sigma_d_mps(k) = sigmaD(i,j);
+        res_pc_m(k) = obs.L1.resPc(i,j);
+        res_d_mps(k) = obs.L1.resD(i,j);
+        raw_d_hz(k) = obs.L1.D(i,j);
+        wavelength_m(k) = obs.L1.lam(j);
+        measured_range_rate_mps(k) = -obs.L1.D(i,j) * obs.L1.lam(j);
+        modeled_range_rate_mps(k) = sat.rate(i,j);
+        satellite_clock_drift_mps(k) = sat.ddts(i,j);
+        valid_pseudorange(k) = ~isnan(obs.L1.resPc(i,j));
+        valid_doppler(k) = ~isnan(obs.L1.resD(i,j));
+        los_x(k) = -sat.ex(i,j);
+        los_y(k) = -sat.ey(i,j);
+        los_z(k) = -sat.ez(i,j);
+    end
+end
+
+sat_table = table(epoch_col, gps_week_col, gps_tow_col, satellite, system, ...
+                  snr_dbhz, elevation_deg, sigma_p_m, sigma_d_mps, ...
+                  res_pc_m, res_d_mps, raw_d_hz, wavelength_m, ...
+                  measured_range_rate_mps, modeled_range_rate_mps, ...
+                  satellite_clock_drift_mps, valid_pseudorange, valid_doppler, ...
+                  los_x, los_y, los_z, ...
+                  'VariableNames', {'epoch','gps_week','gps_tow', ...
+                                    'satellite','system','snr_dbhz', ...
+                                    'elevation_deg','sigma_p_m','sigma_d_mps', ...
+                                    'res_pc_m','res_d_mps','raw_d_hz', ...
+                                    'wavelength_m','measured_range_rate_mps', ...
+                                    'modeled_range_rate_mps', ...
+                                    'satellite_clock_drift_mps', ...
+                                    'valid_pseudorange','valid_doppler', ...
+                                    'los_x','los_y','los_z'});
+writetable(sat_table, fullfile(out_dir, "per_sat_detail.csv"));
+
+c_rows = (n - 1) * nsat;
+epoch_col = zeros(c_rows, 1);
+previous_epoch = zeros(c_rows, 1);
+gps_week_col = zeros(c_rows, 1);
+gps_tow_col = zeros(c_rows, 1);
+satellite = strings(c_rows, 1);
+system = strings(c_rows, 1);
+snr_dbhz = nan(c_rows, 1);
+elevation_deg = nan(c_rows, 1);
+previous_elevation_deg = nan(c_rows, 1);
+sigma_c_m = nan(c_rows, 1);
+res_l_previous_m = nan(c_rows, 1);
+res_l_current_m = nan(c_rows, 1);
+tdcp_m = nan(c_rows, 1);
+raw_l_previous_cycles = nan(c_rows, 1);
+raw_l_current_cycles = nan(c_rows, 1);
+wavelength_m = nan(c_rows, 1);
+valid_tdcp = false(c_rows, 1);
+los_x = nan(c_rows, 1);
+los_y = nan(c_rows, 1);
+los_z = nan(c_rows, 1);
+
+k = 0;
+for i = 2:n
+    for j = 1:nsat
+        k = k + 1;
+        epoch_col(k) = i;
+        previous_epoch(k) = i - 1;
+        gps_week_col(k) = obs.time.week(i);
+        gps_tow_col(k) = obs.time.tow(i);
+        satellite(k) = satstr(j);
+        system(k) = string(obs.sys(j));
+        snr_dbhz(k) = obs.L1.S(i,j);
+        elevation_deg(k) = sat.el(i,j);
+        previous_elevation_deg(k) = sat.el(i-1,j);
+        sigma_c_m(k) = sigmaC(i,j);
+        res_l_previous_m(k) = obs.L1.resL(i-1,j);
+        res_l_current_m(k) = obs.L1.resL(i,j);
+        tdcp_m(k) = obs.L1.resL(i,j) - obs.L1.resL(i-1,j);
+        raw_l_previous_cycles(k) = obs.L1.L(i-1,j);
+        raw_l_current_cycles(k) = obs.L1.L(i,j);
+        wavelength_m(k) = obs.L1.lam(j);
+        valid_tdcp(k) = ~isnan(tdcp_m(k)) && ~clockjump(i);
+        los_x(k) = -sat.ex(i-1,j);
+        los_y(k) = -sat.ey(i-1,j);
+        los_z(k) = -sat.ez(i-1,j);
+    end
+end
+
+c_table = table(epoch_col, previous_epoch, gps_week_col, gps_tow_col, ...
+                satellite, system, snr_dbhz, elevation_deg, ...
+                previous_elevation_deg, sigma_c_m, ...
+                res_l_previous_m, res_l_current_m, tdcp_m, ...
+                raw_l_previous_cycles, raw_l_current_cycles, wavelength_m, ...
+                valid_tdcp, los_x, los_y, los_z, ...
+                'VariableNames', {'epoch','previous_epoch','gps_week','gps_tow', ...
+                                  'satellite','system','snr_dbhz', ...
+                                  'elevation_deg','previous_elevation_deg', ...
+                                  'sigma_c_m','res_l_previous_m', ...
+                                  'res_l_current_m','tdcp_m', ...
+                                  'raw_l_previous_cycles', ...
+                                  'raw_l_current_cycles','wavelength_m', ...
+                                  'valid_tdcp','los_x','los_y','los_z'});
+writetable(c_table, fullfile(out_dir, "per_tdcp_detail.csv"));
+
+fprintf("Wrote taroz position/velocity PDC debug CSVs to %s\n", out_dir);
+
+function value = scalar_or_nan(callback)
+    try
+        value = callback();
+    catch
+        value = NaN;
+    end
+end

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -1,0 +1,3966 @@
+#include <libgnss++/algorithms/fgo.hpp>
+
+#include <libgnss++/algorithms/lambda.hpp>
+#include <libgnss++/algorithms/spp.hpp>
+#include <libgnss++/core/constants.hpp>
+#include <libgnss++/core/coordinates.hpp>
+#include <libgnss++/core/signals.hpp>
+#include <libgnss++/models/ionosphere.hpp>
+#include <libgnss++/models/troposphere.hpp>
+
+#include <Eigen/Dense>
+#include <Eigen/Sparse>
+#ifdef GNSSPP_HAS_CHOLMOD
+#include <Eigen/CholmodSupport>
+#endif
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <limits>
+#include <map>
+#include <numeric>
+#include <set>
+#include <tuple>
+
+namespace libgnss {
+namespace {
+
+bool isPrimaryFgoSignal(SignalType signal, bool use_multi_constellation) {
+    if (!use_multi_constellation) {
+        return signal == SignalType::GPS_L1CA;
+    }
+
+    switch (signal) {
+        case SignalType::GPS_L1CA:
+        case SignalType::GLO_L1CA:
+        case SignalType::GAL_E1:
+        case SignalType::BDS_B1I:
+        case SignalType::BDS_B1C:
+        case SignalType::QZS_L1CA:
+            return true;
+        default:
+            return false;
+    }
+}
+
+GNSSSystem clockBiasGroup(GNSSSystem system) {
+    switch (system) {
+        case GNSSSystem::GPS:
+        case GNSSSystem::QZSS:
+            return GNSSSystem::GPS;
+        case GNSSSystem::Galileo:
+        case GNSSSystem::BeiDou:
+        case GNSSSystem::GLONASS:
+        case GNSSSystem::NavIC:
+            return system;
+        default:
+            return GNSSSystem::UNKNOWN;
+    }
+}
+
+bool usesSeparateClockBias(GNSSSystem group) {
+    return group != GNSSSystem::UNKNOWN && group != GNSSSystem::GPS;
+}
+
+double groupDelayCorrectionMeters(const Observation& observation, const Ephemeris& eph) {
+    switch (observation.satellite.system) {
+        case GNSSSystem::GPS:
+        case GNSSSystem::QZSS:
+        case GNSSSystem::Galileo:
+            return eph.tgd * constants::SPEED_OF_LIGHT;
+        case GNSSSystem::BeiDou:
+            switch (observation.signal) {
+                case SignalType::BDS_B1I:
+                case SignalType::BDS_B1C:
+                    return eph.tgd * constants::SPEED_OF_LIGHT;
+                case SignalType::BDS_B2I:
+                case SignalType::BDS_B2A:
+                    return eph.tgd_secondary * constants::SPEED_OF_LIGHT;
+                default:
+                    return 0.0;
+            }
+        default:
+            return 0.0;
+    }
+}
+
+bool isHealthyForPositioning(const Observation& observation, const Ephemeris& eph) {
+    int sv_health = static_cast<int>(eph.health);
+    if (observation.satellite.system == GNSSSystem::QZSS) {
+        sv_health &= 0xFE;
+    }
+    return sv_health == 0;
+}
+
+Vector3d earthRotationCorrected(const Vector3d& satellite_position,
+                                const Vector3d& receiver_position) {
+    const double signal_travel_time =
+        (satellite_position - receiver_position).norm() / constants::SPEED_OF_LIGHT;
+    const double angle = constants::OMEGA_E * signal_travel_time;
+
+    Eigen::Matrix3d earth_rotation;
+    earth_rotation << std::cos(angle),  std::sin(angle), 0.0,
+                     -std::sin(angle),  std::cos(angle), 0.0,
+                      0.0,              0.0,             1.0;
+    return earth_rotation * satellite_position;
+}
+
+PositionSolution makeInvalidSolution(const GNSSTime& time) {
+    PositionSolution solution;
+    solution.time = time;
+    solution.status = SolutionStatus::NONE;
+    return solution;
+}
+
+Eigen::MatrixXd pseudoInverse(const Eigen::MatrixXd& matrix, double tolerance = 1e-12) {
+    if (matrix.size() == 0) {
+        return Eigen::MatrixXd();
+    }
+
+    Eigen::JacobiSVD<Eigen::MatrixXd> svd(
+        matrix,
+        Eigen::ComputeThinU | Eigen::ComputeThinV);
+    const auto& singular_values = svd.singularValues();
+    Eigen::VectorXd inverse_values = Eigen::VectorXd::Zero(singular_values.size());
+    const double threshold =
+        tolerance * std::max(matrix.rows(), matrix.cols()) *
+        (singular_values.size() > 0 ? singular_values.array().abs().maxCoeff() : 0.0);
+
+    for (int i = 0; i < singular_values.size(); ++i) {
+        if (singular_values(i) > threshold) {
+            inverse_values(i) = 1.0 / singular_values(i);
+        }
+    }
+
+    return svd.matrixV() * inverse_values.asDiagonal() * svd.matrixU().transpose();
+}
+
+struct DoubleDifferencePrediction {
+    bool valid = false;
+    double geometry_m = 0.0;
+    Vector3d position_jacobian = Vector3d::Zero();
+};
+
+DoubleDifferencePrediction doubleDifferencePredictionAt(
+    const Vector3d& position,
+    const Vector3d& base_position,
+    const Vector3d& rover_satellite_position,
+    const Vector3d& rover_reference_position,
+    const Vector3d& base_satellite_position,
+    const Vector3d& base_reference_position) {
+    DoubleDifferencePrediction prediction;
+    const Vector3d rover_satellite_delta = rover_satellite_position - position;
+    const Vector3d rover_reference_delta = rover_reference_position - position;
+    const double rover_satellite_range = rover_satellite_delta.norm();
+    const double rover_reference_range = rover_reference_delta.norm();
+    const double base_satellite_range =
+        (base_satellite_position - base_position).norm();
+    const double base_reference_range =
+        (base_reference_position - base_position).norm();
+    if (rover_satellite_range <= 0.0 || rover_reference_range <= 0.0 ||
+        base_satellite_range <= 0.0 || base_reference_range <= 0.0) {
+        return prediction;
+    }
+
+    const Vector3d rover_satellite_los =
+        rover_satellite_delta / rover_satellite_range;
+    const Vector3d rover_reference_los =
+        rover_reference_delta / rover_reference_range;
+    prediction.valid = true;
+    prediction.geometry_m =
+        (rover_satellite_range - base_satellite_range) -
+        (rover_reference_range - base_reference_range);
+    prediction.position_jacobian = -rover_satellite_los + rover_reference_los;
+    return prediction;
+}
+
+struct PreparedCarrierObservation {
+    SatelliteId satellite;
+    SignalType signal = SignalType::GPS_L1CA;
+    Vector3d satellite_position_ecef = Vector3d::Zero();
+    double corrected_pseudorange_m = 0.0;
+    double corrected_carrier_m = 0.0;
+    double wavelength_m = 0.0;
+    double sigma_m = 0.01;
+    double elevation_rad = 0.0;
+    bool loss_of_lock = false;
+    bool has_carrier_phase = true;
+    bool has_doppler_residual = false;
+    double doppler_residual_mps = 0.0;
+    double doppler_sigma_mps = 0.2;
+    Vector3d los = Vector3d::Zero();
+    FGOProcessor::ObservationModelDebug model_debug;
+};
+
+struct ActiveCarrierSegment {
+    std::size_t ambiguity_index = 0;
+    std::size_t last_epoch_index = 0;
+};
+
+struct FixedAmbiguityConstraint {
+    std::size_t ambiguity_index = 0;
+    double fixed_ambiguity_m = 0.0;
+    int fixed_cycles = 0;
+    double residual_cycles = 0.0;
+    bool fixed_by_lambda = false;
+};
+
+using CarrierKey = std::pair<SatelliteId, SignalType>;
+
+struct DoubleDifferenceAmbiguityKey {
+    SatelliteId satellite;
+    SatelliteId reference_satellite;
+    SignalType signal = SignalType::GPS_L1CA;
+    std::size_t satellite_ambiguity_index = 0;
+    std::size_t reference_ambiguity_index = 0;
+
+    bool operator<(const DoubleDifferenceAmbiguityKey& other) const {
+        return std::tie(satellite,
+                        reference_satellite,
+                        signal,
+                        satellite_ambiguity_index,
+                        reference_ambiguity_index) <
+               std::tie(other.satellite,
+                        other.reference_satellite,
+                        other.signal,
+                        other.satellite_ambiguity_index,
+                        other.reference_ambiguity_index);
+    }
+};
+
+struct DoubleDifferenceSegmentKey {
+    SatelliteId satellite;
+    SatelliteId reference_satellite;
+    SignalType signal = SignalType::GPS_L1CA;
+
+    bool operator<(const DoubleDifferenceSegmentKey& other) const {
+        return std::tie(satellite, reference_satellite, signal) <
+               std::tie(other.satellite, other.reference_satellite, other.signal);
+    }
+};
+
+struct SingleDifferenceReferenceKey {
+    std::size_t epoch_index = 0;
+    GNSSSystem system = GNSSSystem::UNKNOWN;
+    SignalType signal = SignalType::GPS_L1CA;
+
+    bool operator<(const SingleDifferenceReferenceKey& other) const {
+        return std::tie(epoch_index, system, signal) <
+               std::tie(other.epoch_index, other.system, other.signal);
+    }
+};
+
+struct SingleDifferenceDefaultReferenceKey {
+    GNSSSystem system = GNSSSystem::UNKNOWN;
+    SignalType signal = SignalType::GPS_L1CA;
+
+    bool operator<(const SingleDifferenceDefaultReferenceKey& other) const {
+        return std::tie(system, signal) <
+               std::tie(other.system, other.signal);
+    }
+};
+
+struct SingleDifferenceCarrierResidual {
+    std::size_t epoch_index = 0;
+    double residual_m = 0.0;
+    Vector3d los = Vector3d::Zero();
+};
+
+std::map<CarrierKey, PreparedCarrierObservation> prepareCarrierObservationsForReceiver(
+    const ObservationData& epoch,
+    const NavigationData& nav,
+    const Vector3d& receiver_position,
+    const FGOProcessor::FGOConfig& config,
+    double min_snr_dbhz,
+    bool require_carrier_phase = true,
+    bool apply_elevation_mask = true) {
+    std::map<CarrierKey, PreparedCarrierObservation> carriers;
+    if (receiver_position.norm() <= 1e6) {
+        return carriers;
+    }
+
+    double receiver_lat = 0.0;
+    double receiver_lon = 0.0;
+    double receiver_height = 0.0;
+    ecef2geodetic(receiver_position, receiver_lat, receiver_lon, receiver_height);
+
+    const double min_elevation_rad = config.min_elevation_deg * M_PI / 180.0;
+    for (const auto& observation : epoch.observations) {
+        if (!isPrimaryFgoSignal(observation.signal, config.use_multi_constellation)) {
+            continue;
+        }
+        const bool has_carrier_phase =
+            observation.has_carrier_phase && observation.carrier_phase != 0.0;
+        if (!observation.valid || !observation.has_pseudorange ||
+            observation.pseudorange <= 0.0 || observation.snr < min_snr_dbhz ||
+            (require_carrier_phase && !has_carrier_phase)) {
+            continue;
+        }
+
+        Vector3d satellite_position;
+        Vector3d satellite_velocity;
+        double satellite_clock_bias = 0.0;
+        double satellite_clock_drift = 0.0;
+
+        GNSSTime transmit_time =
+            epoch.time - observation.pseudorange / constants::SPEED_OF_LIGHT;
+        if (!nav.calculateSatelliteState(observation.satellite,
+                                         transmit_time,
+                                         satellite_position,
+                                         satellite_velocity,
+                                         satellite_clock_bias,
+                                         satellite_clock_drift)) {
+            continue;
+        }
+
+        transmit_time = transmit_time - satellite_clock_bias;
+        if (!nav.calculateSatelliteState(observation.satellite,
+                                         transmit_time,
+                                         satellite_position,
+                                         satellite_velocity,
+                                         satellite_clock_bias,
+                                         satellite_clock_drift)) {
+            continue;
+        }
+
+        const Ephemeris* eph = nav.getEphemeris(observation.satellite, transmit_time);
+        if (!eph || !isHealthyForPositioning(observation, *eph)) {
+            continue;
+        }
+
+        const Vector3d corrected_satellite_position =
+            earthRotationCorrected(satellite_position, receiver_position);
+        const auto geometry =
+            nav.calculateGeometry(receiver_position, corrected_satellite_position);
+        if (apply_elevation_mask && geometry.elevation < min_elevation_rad) {
+            continue;
+        }
+
+        double ionosphere_delay = 0.0;
+        if (config.use_ionosphere_model && nav.ionosphere_model.valid) {
+            ionosphere_delay = models::ionoDelayKlobuchar(
+                receiver_lat,
+                receiver_lon,
+                geometry.azimuth,
+                geometry.elevation,
+                epoch.time.tow,
+                nav.ionosphere_model.alpha,
+                nav.ionosphere_model.beta);
+
+            const double frequency_hz = signalFrequencyHz(observation.signal, eph);
+            if (frequency_hz > 0.0) {
+                const double scale = constants::GPS_L1_FREQ / frequency_hz;
+                ionosphere_delay *= scale * scale;
+            }
+        }
+
+        double troposphere_delay = 0.0;
+        if (config.use_troposphere_model) {
+            troposphere_delay =
+                models::tropDelaySaastamoinen(receiver_position, geometry.elevation);
+        }
+
+        double wavelength = signalWavelengthMeters(observation);
+        if (wavelength <= 0.0) {
+            wavelength = signalWavelengthMeters(observation.signal, eph);
+        }
+        const bool usable_carrier = has_carrier_phase && wavelength > 0.0;
+        if (require_carrier_phase && !usable_carrier) {
+            continue;
+        }
+
+        const double satellite_clock_m =
+            satellite_clock_bias * constants::SPEED_OF_LIGHT;
+        const double group_delay_m = groupDelayCorrectionMeters(observation, *eph);
+        const double corrected_pseudorange =
+            observation.pseudorange +
+            satellite_clock_m -
+            ionosphere_delay -
+            troposphere_delay -
+            group_delay_m;
+        const double corrected_carrier =
+            usable_carrier
+                ? observation.carrier_phase * wavelength +
+                      satellite_clock_m -
+                      troposphere_delay +
+                      ionosphere_delay
+                : 0.0;
+
+        FGOProcessor::ObservationModelDebug model_debug;
+        model_debug.raw_pseudorange_m = observation.pseudorange;
+        model_debug.raw_carrier_m =
+            usable_carrier ? observation.carrier_phase * wavelength : 0.0;
+        model_debug.satellite_clock_m = satellite_clock_m;
+        model_debug.ionosphere_delay_m = ionosphere_delay;
+        model_debug.troposphere_delay_m = troposphere_delay;
+        model_debug.group_delay_m = group_delay_m;
+        model_debug.corrected_pseudorange_m = corrected_pseudorange;
+        model_debug.corrected_carrier_m = corrected_carrier;
+        const Vector3d corrected_delta =
+            corrected_satellite_position - receiver_position;
+        const double corrected_range = corrected_delta.norm();
+        if (corrected_range <= 0.0) {
+            continue;
+        }
+        model_debug.geometric_range_m = corrected_range;
+        model_debug.elevation_rad = geometry.elevation;
+        model_debug.azimuth_rad = geometry.azimuth;
+
+        const double sin_el = std::max(0.1, std::sin(geometry.elevation));
+        PreparedCarrierObservation carrier;
+        carrier.satellite = observation.satellite;
+        carrier.signal = observation.signal;
+        carrier.satellite_position_ecef = corrected_satellite_position;
+        carrier.corrected_pseudorange_m = corrected_pseudorange;
+        carrier.corrected_carrier_m = corrected_carrier;
+        carrier.wavelength_m = wavelength;
+        carrier.sigma_m = std::max(1e-4, config.carrier_phase_sigma_m / sin_el);
+        carrier.elevation_rad = geometry.elevation;
+        carrier.loss_of_lock =
+            observation.loss_of_lock || ((observation.lli & 0x01U) != 0);
+        carrier.has_carrier_phase = usable_carrier;
+        carrier.los = -corrected_delta / corrected_range;
+        carrier.doppler_sigma_mps =
+            std::max(1e-4, config.single_difference_doppler_sigma_mps /
+                               std::sqrt(sin_el));
+        if (observation.has_doppler && wavelength > 0.0) {
+            const Vector3d doppler_delta = satellite_position - receiver_position;
+            const double doppler_range = doppler_delta.norm();
+            if (doppler_range > 0.0) {
+                const Vector3d ex = doppler_delta / doppler_range;
+                const double sagnac_rate =
+                    constants::OMEGA_E / constants::SPEED_OF_LIGHT *
+                    (satellite_velocity(1) * receiver_position(0) -
+                     satellite_velocity(0) * receiver_position(1));
+                const double modeled_range_rate =
+                    satellite_velocity.dot(ex) + sagnac_rate;
+                const double satellite_clock_drift_mps =
+                    satellite_clock_drift * constants::SPEED_OF_LIGHT;
+                const double measured_range_rate =
+                    -observation.doppler * wavelength;
+                carrier.doppler_residual_mps =
+                    measured_range_rate -
+                    (modeled_range_rate - satellite_clock_drift_mps);
+                carrier.has_doppler_residual =
+                    std::isfinite(carrier.doppler_residual_mps);
+            }
+        }
+        carrier.model_debug = model_debug;
+        carriers[{observation.satellite, observation.signal}] = carrier;
+    }
+
+    return carriers;
+}
+
+Observation interpolateObservation(const Observation& lower,
+                                   const Observation& upper,
+                                   double alpha) {
+    Observation interpolated = lower;
+    interpolated.valid = lower.valid && upper.valid;
+    interpolated.has_pseudorange =
+        lower.has_pseudorange && upper.has_pseudorange;
+    interpolated.has_carrier_phase =
+        lower.has_carrier_phase && upper.has_carrier_phase;
+    interpolated.has_doppler = lower.has_doppler && upper.has_doppler;
+    if (interpolated.has_pseudorange) {
+        interpolated.pseudorange =
+            lower.pseudorange + alpha * (upper.pseudorange - lower.pseudorange);
+    }
+    if (interpolated.has_carrier_phase) {
+        interpolated.carrier_phase =
+            lower.carrier_phase +
+            alpha * (upper.carrier_phase - lower.carrier_phase);
+    }
+    if (interpolated.has_doppler) {
+        interpolated.doppler =
+            lower.doppler + alpha * (upper.doppler - lower.doppler);
+    }
+    interpolated.snr = std::min(lower.snr, upper.snr);
+    interpolated.signal_strength =
+        std::min(lower.signal_strength, upper.signal_strength);
+    interpolated.lli = lower.lli | upper.lli;
+    interpolated.loss_of_lock =
+        lower.loss_of_lock || upper.loss_of_lock ||
+        ((interpolated.lli & 0x01U) != 0);
+    interpolated.has_glonass_frequency_channel =
+        lower.has_glonass_frequency_channel &&
+        upper.has_glonass_frequency_channel &&
+        lower.glonass_frequency_channel == upper.glonass_frequency_channel;
+    return interpolated;
+}
+
+bool findMatchedBaseEpoch(const std::vector<ObservationData>& base_epochs,
+                          const GNSSTime& rover_time,
+                          std::size_t& cursor,
+                          double exact_tolerance_s,
+                          double interpolation_max_gap_s,
+                          ObservationData& matched_epoch,
+                          bool& interpolated) {
+    if (base_epochs.empty()) {
+        return false;
+    }
+
+    while (cursor + 1 < base_epochs.size() &&
+           base_epochs[cursor + 1].time <= rover_time) {
+        ++cursor;
+    }
+
+    const ObservationData* exact_match = nullptr;
+    double best_abs_dt = std::numeric_limits<double>::infinity();
+    auto consider_exact = [&](std::size_t index) {
+        if (index >= base_epochs.size()) {
+            return;
+        }
+        const double dt = std::abs(base_epochs[index].time - rover_time);
+        if (dt <= exact_tolerance_s && dt < best_abs_dt) {
+            best_abs_dt = dt;
+            exact_match = &base_epochs[index];
+        }
+    };
+    consider_exact(cursor);
+    consider_exact(cursor + 1);
+    if (cursor > 0) {
+        consider_exact(cursor - 1);
+    }
+
+    if (exact_match != nullptr) {
+        matched_epoch = *exact_match;
+        interpolated = false;
+        return true;
+    }
+
+    if (interpolation_max_gap_s <= 0.0) {
+        return false;
+    }
+
+    std::size_t lower_index = cursor;
+    if (base_epochs[lower_index].time > rover_time) {
+        if (lower_index == 0) {
+            return false;
+        }
+        --lower_index;
+    }
+    const std::size_t upper_index = lower_index + 1;
+    if (upper_index >= base_epochs.size()) {
+        return false;
+    }
+
+    const ObservationData& lower_epoch = base_epochs[lower_index];
+    const ObservationData& upper_epoch = base_epochs[upper_index];
+    const double total_dt = upper_epoch.time - lower_epoch.time;
+    const double lower_dt = rover_time - lower_epoch.time;
+    if (total_dt <= 0.0 || total_dt > interpolation_max_gap_s ||
+        lower_dt < 0.0 || lower_dt > total_dt) {
+        return false;
+    }
+
+    const double alpha = lower_dt / total_dt;
+    std::map<CarrierKey, const Observation*> upper_observations;
+    for (const auto& observation : upper_epoch.observations) {
+        upper_observations[{observation.satellite, observation.signal}] =
+            &observation;
+    }
+
+    ObservationData candidate(rover_time);
+    candidate.receiver_position = lower_epoch.receiver_position;
+    if (candidate.receiver_position.norm() <= 1e6) {
+        candidate.receiver_position = upper_epoch.receiver_position;
+    }
+    candidate.receiver_clock_bias =
+        lower_epoch.receiver_clock_bias +
+        alpha * (upper_epoch.receiver_clock_bias -
+                 lower_epoch.receiver_clock_bias);
+
+    for (const auto& lower_observation : lower_epoch.observations) {
+        const CarrierKey key{lower_observation.satellite, lower_observation.signal};
+        const auto upper_it = upper_observations.find(key);
+        if (upper_it == upper_observations.end()) {
+            continue;
+        }
+        const Observation& upper_observation = *upper_it->second;
+        if (!lower_observation.valid || !upper_observation.valid ||
+            !lower_observation.has_pseudorange ||
+            !upper_observation.has_pseudorange ||
+            !lower_observation.has_carrier_phase ||
+            !upper_observation.has_carrier_phase) {
+            continue;
+        }
+        candidate.addObservation(
+            interpolateObservation(lower_observation, upper_observation, alpha));
+    }
+
+    if (candidate.observations.empty()) {
+        return false;
+    }
+
+    matched_epoch = std::move(candidate);
+    interpolated = true;
+    return true;
+}
+
+}  // namespace
+
+FGOProcessor::FGOProblem FGOProcessor::buildPseudorangeProblem(
+    const std::vector<ObservationData>& input_epochs,
+    const NavigationData& nav) const {
+    FGOProblem problem;
+    problem.diagnostics.input_epochs = input_epochs.size();
+    if (input_epochs.empty()) {
+        return problem;
+    }
+
+    ProcessorConfig spp_processor_config;
+    spp_processor_config.mode = PositioningMode::SPP;
+    spp_processor_config.elevation_mask = config_.min_elevation_deg;
+    spp_processor_config.snr_mask = config_.min_snr_dbhz;
+    spp_processor_config.use_ionosphere_model = config_.use_ionosphere_model;
+    spp_processor_config.use_troposphere_model = config_.use_troposphere_model;
+
+    SPPProcessor::SPPConfig spp_config;
+    spp_config.apply_atmospheric_corrections =
+        config_.use_ionosphere_model || config_.use_troposphere_model;
+    spp_config.use_multi_constellation = config_.use_multi_constellation;
+
+    SPPProcessor spp_processor(spp_config);
+    spp_processor.initialize(spp_processor_config);
+
+    const double min_elevation_rad = config_.min_elevation_deg * M_PI / 180.0;
+    const double dd_reference_min_snr_dbhz =
+        config_.double_difference_reference_min_snr_dbhz >= 0.0
+            ? config_.double_difference_reference_min_snr_dbhz
+            : config_.min_snr_dbhz;
+    std::vector<std::map<std::pair<SatelliteId, SignalType>, PreparedCarrierObservation>>
+        carrier_by_problem_epoch;
+    std::vector<std::map<std::pair<SatelliteId, SignalType>, PreparedCarrierObservation>>
+        dd_pseudorange_by_problem_epoch;
+    std::vector<std::map<std::pair<SatelliteId, SignalType>, PreparedCarrierObservation>>
+        dd_reference_carrier_by_problem_epoch;
+    std::map<SatelliteId, double> previous_gps_pseudorange_by_satellite;
+
+    for (const auto& epoch : input_epochs) {
+        EpochSeed seed;
+        seed.time = epoch.time;
+
+        PositionSolution spp_solution = makeInvalidSolution(epoch.time);
+        if (config_.use_spp_seed) {
+            spp_solution = spp_processor.processEpoch(epoch, nav);
+        }
+
+        if (spp_solution.isValid()) {
+            seed.position_ecef = spp_solution.position_ecef;
+            seed.receiver_clock_bias_m = spp_solution.receiver_clock_bias;
+        } else if (epoch.receiver_position.norm() > 1e6) {
+            seed.position_ecef = epoch.receiver_position;
+            seed.receiver_clock_bias_m = epoch.receiver_clock_bias * constants::SPEED_OF_LIGHT;
+        } else {
+            ++problem.diagnostics.skipped_epochs_without_seed;
+            continue;
+        }
+
+        std::vector<PseudorangeFactor> epoch_factors;
+        epoch_factors.reserve(epoch.observations.size());
+        std::map<std::pair<SatelliteId, SignalType>, PreparedCarrierObservation> epoch_carriers;
+        std::map<std::pair<SatelliteId, SignalType>, PreparedCarrierObservation>
+            epoch_dd_pseudorange_observations;
+        std::map<std::pair<SatelliteId, SignalType>, PreparedCarrierObservation>
+            epoch_dd_reference_carriers;
+        std::map<SatelliteId, double> gps_pseudorange_by_satellite;
+
+        double receiver_lat = 0.0;
+        double receiver_lon = 0.0;
+        double receiver_height = 0.0;
+        ecef2geodetic(seed.position_ecef, receiver_lat, receiver_lon, receiver_height);
+
+        for (const auto& observation : epoch.observations) {
+            if (!isPrimaryFgoSignal(observation.signal, config_.use_multi_constellation)) {
+                continue;
+            }
+            if (!observation.valid || !observation.has_pseudorange ||
+                observation.pseudorange <= 0.0) {
+                continue;
+            }
+            const bool passes_snr_mask = observation.snr >= config_.min_snr_dbhz;
+            const bool passes_dd_reference_snr_mask =
+                dd_reference_min_snr_dbhz <= 0.0 ||
+                observation.snr >= dd_reference_min_snr_dbhz;
+
+            Vector3d satellite_position;
+            Vector3d satellite_velocity;
+            double satellite_clock_bias = 0.0;
+            double satellite_clock_drift = 0.0;
+
+            GNSSTime transmit_time =
+                epoch.time - observation.pseudorange / constants::SPEED_OF_LIGHT;
+            if (!nav.calculateSatelliteState(observation.satellite,
+                                             transmit_time,
+                                             satellite_position,
+                                             satellite_velocity,
+                                             satellite_clock_bias,
+                                             satellite_clock_drift)) {
+                continue;
+            }
+
+            transmit_time = transmit_time - satellite_clock_bias;
+            if (!nav.calculateSatelliteState(observation.satellite,
+                                             transmit_time,
+                                             satellite_position,
+                                             satellite_velocity,
+                                             satellite_clock_bias,
+                                             satellite_clock_drift)) {
+                continue;
+            }
+
+            const Ephemeris* eph = nav.getEphemeris(observation.satellite, transmit_time);
+            if (!eph || !isHealthyForPositioning(observation, *eph)) {
+                continue;
+            }
+
+            const Vector3d corrected_satellite_position =
+                earthRotationCorrected(satellite_position, seed.position_ecef);
+            const auto geometry =
+                nav.calculateGeometry(seed.position_ecef, corrected_satellite_position);
+            const bool passes_elevation_mask =
+                geometry.elevation >= min_elevation_rad;
+
+            double ionosphere_delay = 0.0;
+            if (config_.use_ionosphere_model && nav.ionosphere_model.valid) {
+                ionosphere_delay = models::ionoDelayKlobuchar(
+                    receiver_lat,
+                    receiver_lon,
+                    geometry.azimuth,
+                    geometry.elevation,
+                    epoch.time.tow,
+                    nav.ionosphere_model.alpha,
+                    nav.ionosphere_model.beta);
+
+                const double frequency_hz = signalFrequencyHz(observation.signal, eph);
+                if (frequency_hz > 0.0) {
+                    const double scale = constants::GPS_L1_FREQ / frequency_hz;
+                    ionosphere_delay *= scale * scale;
+                }
+            }
+
+            double troposphere_delay = 0.0;
+            if (config_.use_troposphere_model) {
+                troposphere_delay =
+                    models::tropDelaySaastamoinen(seed.position_ecef, geometry.elevation);
+            }
+
+            const double satellite_clock_m =
+                satellite_clock_bias * constants::SPEED_OF_LIGHT;
+            const double group_delay_m =
+                groupDelayCorrectionMeters(observation, *eph);
+            const double corrected_pseudorange =
+                observation.pseudorange +
+                satellite_clock_m -
+                ionosphere_delay -
+                troposphere_delay -
+                group_delay_m;
+
+            const double sin_el = std::max(0.1, std::sin(geometry.elevation));
+            const double pseudorange_elevation_scale = std::pow(
+                sin_el,
+                std::max(0.0, config_.pseudorange_elevation_sigma_power));
+            if (passes_snr_mask && passes_elevation_mask) {
+                PseudorangeFactor factor;
+                factor.satellite = observation.satellite;
+                factor.clock_group = clockBiasGroup(observation.satellite.system);
+                factor.satellite_position_ecef = corrected_satellite_position;
+                factor.corrected_pseudorange_m = corrected_pseudorange;
+                factor.sigma_m =
+                    std::max(1e-3,
+                             config_.pseudorange_sigma_m /
+                                 std::max(1e-6, pseudorange_elevation_scale));
+                factor.elevation_rad = geometry.elevation;
+                epoch_factors.push_back(factor);
+                if (observation.satellite.system == GNSSSystem::GPS) {
+                    gps_pseudorange_by_satellite[observation.satellite] =
+                        observation.pseudorange;
+                }
+            }
+
+            const bool carrier_loss_of_lock =
+                observation.loss_of_lock || ((observation.lli & 0x01U) != 0);
+            double wavelength = signalWavelengthMeters(observation);
+            const bool has_carrier_phase =
+                observation.has_carrier_phase && observation.carrier_phase != 0.0;
+            if (wavelength <= 0.0) {
+                wavelength = signalWavelengthMeters(observation.signal, eph);
+            }
+            const bool usable_carrier = has_carrier_phase && wavelength > 0.0;
+            const double corrected_carrier =
+                usable_carrier
+                    ? observation.carrier_phase * wavelength +
+                          satellite_clock_m -
+                          troposphere_delay +
+                          ionosphere_delay
+                    : 0.0;
+
+            FGOProcessor::ObservationModelDebug model_debug;
+            model_debug.raw_pseudorange_m = observation.pseudorange;
+            model_debug.raw_carrier_m =
+                usable_carrier ? observation.carrier_phase * wavelength : 0.0;
+            model_debug.satellite_clock_m = satellite_clock_m;
+            model_debug.ionosphere_delay_m = ionosphere_delay;
+            model_debug.troposphere_delay_m = troposphere_delay;
+            model_debug.group_delay_m = group_delay_m;
+            model_debug.corrected_pseudorange_m = corrected_pseudorange;
+            model_debug.corrected_carrier_m = corrected_carrier;
+            const Vector3d corrected_delta =
+                corrected_satellite_position - seed.position_ecef;
+            const double corrected_range = corrected_delta.norm();
+            if (corrected_range <= 0.0) {
+                continue;
+            }
+            model_debug.geometric_range_m = corrected_range;
+            model_debug.elevation_rad = geometry.elevation;
+            model_debug.azimuth_rad = geometry.azimuth;
+
+            PreparedCarrierObservation carrier;
+            carrier.satellite = observation.satellite;
+            carrier.signal = observation.signal;
+            carrier.satellite_position_ecef = corrected_satellite_position;
+            carrier.corrected_pseudorange_m = corrected_pseudorange;
+            carrier.corrected_carrier_m = corrected_carrier;
+            carrier.wavelength_m = wavelength;
+            carrier.sigma_m =
+                std::max(1e-4, config_.carrier_phase_sigma_m / sin_el);
+            carrier.elevation_rad = geometry.elevation;
+            carrier.loss_of_lock = carrier_loss_of_lock;
+            carrier.has_carrier_phase = usable_carrier;
+            carrier.los = -corrected_delta / corrected_range;
+            carrier.doppler_sigma_mps =
+                std::max(1e-4,
+                         config_.single_difference_doppler_sigma_mps /
+                             std::sqrt(sin_el));
+            if (observation.has_doppler && wavelength > 0.0) {
+                const Vector3d doppler_delta =
+                    satellite_position - seed.position_ecef;
+                const double doppler_range = doppler_delta.norm();
+                if (doppler_range > 0.0) {
+                    const Vector3d ex = doppler_delta / doppler_range;
+                    const double sagnac_rate =
+                        constants::OMEGA_E / constants::SPEED_OF_LIGHT *
+                        (satellite_velocity(1) * seed.position_ecef(0) -
+                         satellite_velocity(0) * seed.position_ecef(1));
+                    const double modeled_range_rate =
+                        satellite_velocity.dot(ex) + sagnac_rate;
+                    const double satellite_clock_drift_mps =
+                        satellite_clock_drift * constants::SPEED_OF_LIGHT;
+                    const double measured_range_rate =
+                        -observation.doppler * wavelength;
+                    carrier.doppler_residual_mps =
+                        measured_range_rate -
+                        (modeled_range_rate - satellite_clock_drift_mps);
+                    carrier.has_doppler_residual =
+                        std::isfinite(carrier.doppler_residual_mps);
+                }
+            }
+            carrier.model_debug = model_debug;
+            if (passes_dd_reference_snr_mask) {
+                epoch_dd_reference_carriers[
+                    {observation.satellite, observation.signal}] = carrier;
+            }
+            if (passes_snr_mask && passes_elevation_mask) {
+                epoch_dd_pseudorange_observations[
+                    {observation.satellite, observation.signal}] = carrier;
+            }
+            if (usable_carrier && passes_snr_mask && passes_elevation_mask) {
+                if (!(config_.reject_rover_carrier_loss_of_lock &&
+                      carrier_loss_of_lock)) {
+                    epoch_carriers[{observation.satellite, observation.signal}] =
+                        carrier;
+                }
+            }
+        }
+
+        const std::size_t usable_epoch_measurements =
+            config_.use_pseudorange_factors ? epoch_factors.size()
+                                            : epoch_carriers.size();
+        if (static_cast<int>(usable_epoch_measurements) <
+            config_.min_satellites_per_epoch) {
+            continue;
+        }
+
+        const std::size_t epoch_index = problem.epochs.size();
+        problem.epochs.push_back(seed);
+        bool clock_jump = false;
+        double gps_pseudorange_delta_sum = 0.0;
+        std::size_t gps_pseudorange_delta_count = 0;
+        for (const auto& [satellite, pseudorange] : gps_pseudorange_by_satellite) {
+            const auto previous_it =
+                previous_gps_pseudorange_by_satellite.find(satellite);
+            if (previous_it == previous_gps_pseudorange_by_satellite.end()) {
+                continue;
+            }
+            gps_pseudorange_delta_sum += pseudorange - previous_it->second;
+            ++gps_pseudorange_delta_count;
+        }
+        if (gps_pseudorange_delta_count > 0) {
+            const double mean_delta =
+                gps_pseudorange_delta_sum /
+                static_cast<double>(gps_pseudorange_delta_count);
+            clock_jump = mean_delta > 1e5;
+        }
+        problem.clock_jumps.push_back(clock_jump);
+        previous_gps_pseudorange_by_satellite =
+            std::move(gps_pseudorange_by_satellite);
+        problem.diagnostics.seeded_epochs = problem.epochs.size();
+        carrier_by_problem_epoch.push_back(std::move(epoch_carriers));
+        dd_pseudorange_by_problem_epoch.push_back(
+            std::move(epoch_dd_pseudorange_observations));
+        dd_reference_carrier_by_problem_epoch.push_back(
+            std::move(epoch_dd_reference_carriers));
+        if (config_.use_pseudorange_factors) {
+            for (auto& factor : epoch_factors) {
+                factor.epoch_index = epoch_index;
+                problem.pseudorange_factors.push_back(factor);
+            }
+        }
+    }
+
+    if ((config_.use_carrier_phase_factors || config_.use_double_difference_factors) &&
+        !carrier_by_problem_epoch.empty()) {
+        using CarrierKey = std::pair<SatelliteId, SignalType>;
+        std::map<CarrierKey, ActiveCarrierSegment> active_segments;
+        std::map<CarrierKey, std::size_t> next_segment_indices;
+        const double max_gap = std::max(0.0, config_.max_tdcp_gap_s);
+
+        for (std::size_t epoch_index = 0; epoch_index < problem.epochs.size(); ++epoch_index) {
+            const auto& current_carriers = carrier_by_problem_epoch[epoch_index];
+            for (const auto& [key, carrier] : current_carriers) {
+                auto active_it = active_segments.find(key);
+                bool start_new_segment = active_it == active_segments.end();
+                if (active_it != active_segments.end()) {
+                    const double dt = problem.epochs[epoch_index].time -
+                                      problem.epochs[active_it->second.last_epoch_index].time;
+                    if (dt <= 0.0 || (max_gap > 0.0 && dt > max_gap) ||
+                        carrier.loss_of_lock) {
+                        start_new_segment = true;
+                    }
+                }
+
+                if (start_new_segment) {
+                    const std::size_t segment_index = next_segment_indices[key]++;
+                    std::size_t carrier_segment_index = segment_index;
+                    if (config_.use_carrier_phase_factors) {
+                        AmbiguityState ambiguity;
+                        ambiguity.satellite = carrier.satellite;
+                        ambiguity.signal = carrier.signal;
+                        ambiguity.segment_index = segment_index;
+                        ambiguity.wavelength_m = carrier.wavelength_m;
+                        ambiguity.initial_ambiguity_m =
+                            carrier.corrected_carrier_m -
+                            carrier.corrected_pseudorange_m;
+                        carrier_segment_index = problem.ambiguity_states.size();
+                        problem.ambiguity_states.push_back(ambiguity);
+                    }
+                    active_it = active_segments
+                                    .insert_or_assign(
+                                        key,
+                                        ActiveCarrierSegment{carrier_segment_index,
+                                                             epoch_index})
+                                    .first;
+                } else {
+                    active_it->second.last_epoch_index = epoch_index;
+                }
+
+                CarrierPhaseFactor carrier_observation;
+                carrier_observation.epoch_index = epoch_index;
+                carrier_observation.ambiguity_index = active_it->second.ambiguity_index;
+                carrier_observation.satellite = carrier.satellite;
+                carrier_observation.clock_group =
+                    clockBiasGroup(carrier.satellite.system);
+                carrier_observation.signal = carrier.signal;
+                carrier_observation.satellite_position_ecef =
+                    carrier.satellite_position_ecef;
+                carrier_observation.corrected_pseudorange_m =
+                    carrier.corrected_pseudorange_m;
+                carrier_observation.corrected_carrier_m =
+                    carrier.corrected_carrier_m;
+                carrier_observation.wavelength_m = carrier.wavelength_m;
+                carrier_observation.sigma_m = carrier.sigma_m;
+                carrier_observation.elevation_rad = carrier.elevation_rad;
+                carrier_observation.has_carrier_phase = carrier.has_carrier_phase;
+                carrier_observation.loss_of_lock = carrier.loss_of_lock;
+                carrier_observation.has_doppler_residual =
+                    carrier.has_doppler_residual;
+                carrier_observation.doppler_residual_mps =
+                    carrier.doppler_residual_mps;
+                carrier_observation.doppler_sigma_mps =
+                    carrier.doppler_sigma_mps;
+                carrier_observation.los = carrier.los;
+                carrier_observation.model_debug = carrier.model_debug;
+                problem.carrier_observations.push_back(carrier_observation);
+                if (config_.use_carrier_phase_factors) {
+                    problem.carrier_phase_factors.push_back(carrier_observation);
+                }
+            }
+        }
+    }
+
+    if (config_.use_double_difference_factors) {
+        for (std::size_t epoch_index = 0;
+             epoch_index < dd_pseudorange_by_problem_epoch.size();
+             ++epoch_index) {
+            for (const auto& [key, carrier] :
+                 dd_pseudorange_by_problem_epoch[epoch_index]) {
+                CarrierPhaseFactor pseudorange_observation;
+                pseudorange_observation.epoch_index = epoch_index;
+                pseudorange_observation.satellite = carrier.satellite;
+                pseudorange_observation.clock_group =
+                    clockBiasGroup(carrier.satellite.system);
+                pseudorange_observation.signal = carrier.signal;
+                pseudorange_observation.satellite_position_ecef =
+                    carrier.satellite_position_ecef;
+                pseudorange_observation.corrected_pseudorange_m =
+                    carrier.corrected_pseudorange_m;
+                pseudorange_observation.corrected_carrier_m =
+                    carrier.corrected_carrier_m;
+                pseudorange_observation.wavelength_m = carrier.wavelength_m;
+                pseudorange_observation.sigma_m = carrier.sigma_m;
+                pseudorange_observation.elevation_rad = carrier.elevation_rad;
+                pseudorange_observation.has_carrier_phase =
+                    carrier.has_carrier_phase;
+                pseudorange_observation.loss_of_lock = carrier.loss_of_lock;
+                pseudorange_observation.has_doppler_residual =
+                    carrier.has_doppler_residual;
+                pseudorange_observation.doppler_residual_mps =
+                    carrier.doppler_residual_mps;
+                pseudorange_observation.doppler_sigma_mps =
+                    carrier.doppler_sigma_mps;
+                pseudorange_observation.los = carrier.los;
+                pseudorange_observation.model_debug = carrier.model_debug;
+                problem.double_difference_pseudorange_observations.push_back(
+                    pseudorange_observation);
+            }
+        }
+    }
+
+    if (config_.use_tdcp_factors && problem.epochs.size() >= 2) {
+        const double sigma = std::max(1e-4, config_.tdcp_sigma_m);
+        const double max_gap = std::max(0.0, config_.max_tdcp_gap_s);
+        for (std::size_t epoch_index = 1; epoch_index < problem.epochs.size(); ++epoch_index) {
+            const double dt = problem.epochs[epoch_index].time -
+                              problem.epochs[epoch_index - 1].time;
+            if (dt <= 0.0 || (max_gap > 0.0 && dt > max_gap)) {
+                problem.diagnostics.tdcp_rejected_gap +=
+                    carrier_by_problem_epoch[epoch_index].size();
+                continue;
+            }
+
+            const auto& previous_carriers = carrier_by_problem_epoch[epoch_index - 1];
+            const auto& current_carriers = carrier_by_problem_epoch[epoch_index];
+            for (const auto& [key, current] : current_carriers) {
+                const auto previous_it = previous_carriers.find(key);
+                if (previous_it == previous_carriers.end()) {
+                    ++problem.diagnostics.tdcp_rejected_missing_previous;
+                    continue;
+                }
+                const auto& previous = previous_it->second;
+                ++problem.diagnostics.tdcp_candidate_pairs;
+                if (config_.reject_tdcp_loss_of_lock &&
+                    (previous.loss_of_lock || current.loss_of_lock)) {
+                    ++problem.diagnostics.tdcp_rejected_loss_of_lock;
+                    continue;
+                }
+
+                const double delta_carrier_m =
+                    current.corrected_carrier_m - previous.corrected_carrier_m;
+                const double delta_code_m =
+                    current.corrected_pseudorange_m - previous.corrected_pseudorange_m;
+                const double code_phase_jump_m = std::abs(delta_carrier_m - delta_code_m);
+                if (config_.reject_tdcp_code_phase_jump &&
+                    config_.tdcp_code_phase_jump_threshold_m > 0.0 &&
+                    code_phase_jump_m > config_.tdcp_code_phase_jump_threshold_m) {
+                    ++problem.diagnostics.tdcp_rejected_code_phase_jump;
+                    continue;
+                }
+
+                TimeDifferencedCarrierFactor factor;
+                factor.previous_epoch_index = epoch_index - 1;
+                factor.current_epoch_index = epoch_index;
+                factor.satellite = current.satellite;
+                factor.signal = current.signal;
+                factor.previous_satellite_position_ecef = previous.satellite_position_ecef;
+                factor.current_satellite_position_ecef = current.satellite_position_ecef;
+                factor.delta_carrier_m = delta_carrier_m;
+                factor.sigma_m = sigma;
+                factor.dt_s = dt;
+                problem.tdcp_factors.push_back(factor);
+            }
+        }
+    }
+
+    if (config_.use_double_difference_factors) {
+        for (std::size_t epoch_index = 0;
+             epoch_index < dd_reference_carrier_by_problem_epoch.size();
+             ++epoch_index) {
+            for (const auto& [key, carrier] :
+                 dd_reference_carrier_by_problem_epoch[epoch_index]) {
+                CarrierPhaseFactor reference_observation;
+                reference_observation.epoch_index = epoch_index;
+                reference_observation.satellite = carrier.satellite;
+                reference_observation.clock_group =
+                    clockBiasGroup(carrier.satellite.system);
+                reference_observation.signal = carrier.signal;
+                reference_observation.satellite_position_ecef =
+                    carrier.satellite_position_ecef;
+                reference_observation.corrected_pseudorange_m =
+                    carrier.corrected_pseudorange_m;
+                reference_observation.corrected_carrier_m =
+                    carrier.corrected_carrier_m;
+                reference_observation.wavelength_m = carrier.wavelength_m;
+                reference_observation.sigma_m = carrier.sigma_m;
+                reference_observation.elevation_rad = carrier.elevation_rad;
+                reference_observation.has_carrier_phase = carrier.has_carrier_phase;
+                reference_observation.loss_of_lock = carrier.loss_of_lock;
+                reference_observation.has_doppler_residual =
+                    carrier.has_doppler_residual;
+                reference_observation.doppler_residual_mps =
+                    carrier.doppler_residual_mps;
+                reference_observation.doppler_sigma_mps =
+                    carrier.doppler_sigma_mps;
+                reference_observation.los = carrier.los;
+                reference_observation.model_debug = carrier.model_debug;
+                problem.double_difference_reference_observations.push_back(
+                    reference_observation);
+            }
+        }
+    }
+
+    return problem;
+}
+
+FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
+    const std::vector<ObservationData>& rover_epochs,
+    const std::vector<ObservationData>& base_epochs,
+    const NavigationData& nav,
+    const Vector3d& base_position_ecef) const {
+    FGOProblem problem = buildPseudorangeProblem(rover_epochs, nav);
+    if (!config_.use_double_difference_factors ||
+        problem.carrier_observations.empty() ||
+        base_epochs.empty() ||
+        base_position_ecef.norm() <= 1e6) {
+        return problem;
+    }
+
+    std::map<std::size_t, std::vector<const CarrierPhaseFactor*>>
+        rover_carriers_by_epoch;
+    for (const auto& factor : problem.carrier_observations) {
+        if (factor.epoch_index < problem.epochs.size()) {
+            rover_carriers_by_epoch[factor.epoch_index].push_back(&factor);
+        }
+    }
+    std::map<std::size_t, std::vector<const CarrierPhaseFactor*>>
+        rover_pseudoranges_by_epoch;
+    for (const auto& factor :
+         problem.double_difference_pseudorange_observations) {
+        if (factor.epoch_index < problem.epochs.size()) {
+            rover_pseudoranges_by_epoch[factor.epoch_index].push_back(&factor);
+        }
+    }
+    std::map<std::size_t, std::vector<const CarrierPhaseFactor*>>
+        rover_reference_carriers_by_epoch;
+    for (const auto& factor : problem.double_difference_reference_observations) {
+        if (factor.epoch_index < problem.epochs.size()) {
+            rover_reference_carriers_by_epoch[factor.epoch_index].push_back(&factor);
+        }
+    }
+
+    std::size_t base_cursor = 0;
+    const double match_tolerance = std::max(0.0, config_.base_epoch_match_tolerance_s);
+    const double pseudorange_sigma =
+        std::max(1e-3, config_.double_difference_pseudorange_sigma_m);
+    const double carrier_sigma =
+        std::max(1e-4, config_.double_difference_carrier_sigma_m);
+    const double max_segment_gap = std::max(0.0, config_.max_tdcp_gap_s);
+    std::map<DoubleDifferenceAmbiguityKey, ActiveCarrierSegment>
+        active_dd_segments;
+    std::map<DoubleDifferenceSegmentKey, std::size_t> next_dd_segment_indices;
+    using DdFactorKey =
+        std::tuple<std::size_t, SatelliteId, SatelliteId, SignalType>;
+    std::map<SingleDifferenceReferenceKey, SatelliteId> sd_reference_by_group;
+    std::map<SingleDifferenceDefaultReferenceKey, std::map<SatelliteId, std::size_t>>
+        sd_default_reference_counts;
+
+    for (std::size_t epoch_index = 0; epoch_index < problem.epochs.size(); ++epoch_index) {
+        const auto rover_it = rover_carriers_by_epoch.find(epoch_index);
+        const auto rover_pseudorange_it =
+            rover_pseudoranges_by_epoch.find(epoch_index);
+        const auto rover_reference_it =
+            rover_reference_carriers_by_epoch.find(epoch_index);
+        if ((rover_it == rover_carriers_by_epoch.end() ||
+             rover_it->second.empty()) &&
+            (rover_pseudorange_it == rover_pseudoranges_by_epoch.end() ||
+             rover_pseudorange_it->second.empty())) {
+            continue;
+        }
+
+        ObservationData matched_base_epoch;
+        bool interpolated_base_epoch = false;
+        const bool has_base_epoch =
+            findMatchedBaseEpoch(base_epochs,
+                                 problem.epochs[epoch_index].time,
+                                 base_cursor,
+                                 match_tolerance,
+                                 config_.base_interpolation_max_gap_s,
+                                 matched_base_epoch,
+                                 interpolated_base_epoch);
+        if (!has_base_epoch) {
+            problem.diagnostics.double_difference_rejected_no_base_epoch +=
+                rover_it == rover_carriers_by_epoch.end()
+                    ? 0
+                    : rover_it->second.size();
+            continue;
+        }
+        ++problem.diagnostics.double_difference_matched_base_epochs;
+        if (interpolated_base_epoch) {
+            ++problem.diagnostics.double_difference_interpolated_base_epochs;
+        }
+
+        std::map<std::pair<GNSSSystem, SignalType>, std::vector<const CarrierPhaseFactor*>>
+            grouped_rover_pseudoranges;
+        std::map<std::pair<GNSSSystem, SignalType>, std::vector<const CarrierPhaseFactor*>>
+            grouped_rover_carriers;
+        std::map<CarrierKey, const CarrierPhaseFactor*> rover_references_by_key;
+        if (rover_reference_it != rover_reference_carriers_by_epoch.end()) {
+            for (const auto* reference_factor : rover_reference_it->second) {
+                rover_references_by_key[{reference_factor->satellite,
+                                          reference_factor->signal}] =
+                    reference_factor;
+            }
+        }
+        std::map<std::pair<GNSSSystem, SignalType>,
+                 std::vector<const PreparedCarrierObservation*>>
+            grouped_reference_observations;
+        const double base_min_snr_dbhz =
+            config_.double_difference_base_min_snr_dbhz >= 0.0
+                ? config_.double_difference_base_min_snr_dbhz
+                : config_.min_snr_dbhz;
+        const double reference_min_snr_dbhz =
+            config_.double_difference_reference_min_snr_dbhz >= 0.0
+                ? config_.double_difference_reference_min_snr_dbhz
+                : config_.min_snr_dbhz;
+        const auto base_carriers =
+            prepareCarrierObservationsForReceiver(
+                matched_base_epoch,
+                nav,
+                base_position_ecef,
+                config_,
+                base_min_snr_dbhz,
+                true,
+                false);
+        const auto base_pseudorange_observations =
+            prepareCarrierObservationsForReceiver(
+                matched_base_epoch,
+                nav,
+                base_position_ecef,
+                config_,
+                base_min_snr_dbhz,
+                false,
+                false);
+        const auto base_reference_observations =
+            prepareCarrierObservationsForReceiver(
+                matched_base_epoch,
+                nav,
+                base_position_ecef,
+                config_,
+                reference_min_snr_dbhz,
+                false,
+                false);
+        if (rover_pseudorange_it != rover_pseudoranges_by_epoch.end()) {
+            for (const auto* rover_factor : rover_pseudorange_it->second) {
+                const CarrierKey key{rover_factor->satellite,
+                                     rover_factor->signal};
+                if (base_pseudorange_observations.find(key) ==
+                    base_pseudorange_observations.end()) {
+                    continue;
+                }
+                grouped_rover_pseudoranges[{rover_factor->satellite.system,
+                                            rover_factor->signal}]
+                    .push_back(rover_factor);
+            }
+        }
+        if (rover_it != rover_carriers_by_epoch.end()) {
+            for (const auto* rover_factor : rover_it->second) {
+                const CarrierKey key{rover_factor->satellite,
+                                     rover_factor->signal};
+                if (base_carriers.find(key) == base_carriers.end()) {
+                    continue;
+                }
+                grouped_rover_carriers[{rover_factor->satellite.system,
+                                        rover_factor->signal}]
+                    .push_back(rover_factor);
+            }
+        }
+        for (const auto& [key, reference_observation] :
+             base_reference_observations) {
+            grouped_reference_observations[{reference_observation.satellite.system,
+                                            reference_observation.signal}]
+                .push_back(&reference_observation);
+        }
+
+        const auto select_reference =
+            [&](const std::pair<GNSSSystem, SignalType>& group_key,
+                std::size_t rejected_count,
+                const CarrierPhaseFactor*& reference,
+                const PreparedCarrierObservation*& base_reference) {
+                if (group_key.first == GNSSSystem::GLONASS) {
+                    problem.diagnostics.double_difference_rejected_no_reference +=
+                        rejected_count;
+                    return false;
+                }
+
+                const auto reference_group_it =
+                    grouped_reference_observations.find(group_key);
+                if (reference_group_it == grouped_reference_observations.end() ||
+                    reference_group_it->second.empty()) {
+                    problem.diagnostics.double_difference_rejected_no_reference +=
+                        rejected_count;
+                    return false;
+                }
+
+                const PreparedCarrierObservation* base_reference_selection =
+                    *std::max_element(
+                        reference_group_it->second.begin(),
+                        reference_group_it->second.end(),
+                        [](const PreparedCarrierObservation* lhs,
+                           const PreparedCarrierObservation* rhs) {
+                            return lhs->elevation_rad < rhs->elevation_rad;
+                        });
+                const CarrierKey reference_key{
+                    base_reference_selection->satellite,
+                    base_reference_selection->signal};
+                const auto rover_reference_by_key_it =
+                    rover_references_by_key.find(reference_key);
+                if (rover_reference_by_key_it == rover_references_by_key.end()) {
+                    problem.diagnostics.double_difference_rejected_no_reference +=
+                        rejected_count;
+                    return false;
+                }
+                reference = rover_reference_by_key_it->second;
+                base_reference = base_reference_selection;
+                return true;
+            };
+
+        std::map<DdFactorKey, DoubleDifferencePseudorangeFactor>
+            pseudorange_factors_by_key;
+        for (const auto& [group_key, group] : grouped_rover_pseudoranges) {
+            if (group_key.first == GNSSSystem::GLONASS) {
+                problem.diagnostics.double_difference_rejected_no_reference +=
+                    group.size();
+                continue;
+            }
+
+            const CarrierPhaseFactor* reference = nullptr;
+            const PreparedCarrierObservation* base_reference_ptr = nullptr;
+            if (!select_reference(group_key,
+                                  group.size(),
+                                  reference,
+                                  base_reference_ptr)) {
+                continue;
+            }
+            const auto& base_reference = *base_reference_ptr;
+            for (const auto* satellite : group) {
+                if (satellite->satellite == reference->satellite &&
+                    satellite->signal == reference->signal) {
+                    continue;
+                }
+                const CarrierKey satellite_key{satellite->satellite, satellite->signal};
+                const auto base_satellite_it =
+                    base_pseudorange_observations.find(satellite_key);
+                if (base_satellite_it == base_pseudorange_observations.end()) {
+                    continue;
+                }
+
+                const auto& base_satellite = base_satellite_it->second;
+                const double satellite_sin_el =
+                    std::max(0.1, std::sin(satellite->elevation_rad));
+                const double satellite_sqrt_sin_el =
+                    std::sqrt(satellite_sin_el);
+
+                DoubleDifferencePseudorangeFactor pseudorange_factor;
+                pseudorange_factor.epoch_index = epoch_index;
+                pseudorange_factor.satellite = satellite->satellite;
+                pseudorange_factor.reference_satellite = reference->satellite;
+                pseudorange_factor.signal = satellite->signal;
+                pseudorange_factor.rover_satellite_position_ecef =
+                    satellite->satellite_position_ecef;
+                pseudorange_factor.rover_reference_position_ecef =
+                    reference->satellite_position_ecef;
+                pseudorange_factor.base_satellite_position_ecef =
+                    base_satellite.satellite_position_ecef;
+                pseudorange_factor.base_reference_position_ecef =
+                    base_reference.satellite_position_ecef;
+                pseudorange_factor.base_position_ecef = base_position_ecef;
+                pseudorange_factor.observed_dd_pseudorange_m =
+                    (satellite->corrected_pseudorange_m -
+                     base_satellite.corrected_pseudorange_m) -
+                    (reference->corrected_pseudorange_m -
+                     base_reference.corrected_pseudorange_m);
+                pseudorange_factor.sigma_m =
+                    pseudorange_sigma / satellite_sqrt_sin_el;
+                pseudorange_factor.elevation_rad = satellite->elevation_rad;
+                pseudorange_factor.rover_satellite_model =
+                    satellite->model_debug;
+                pseudorange_factor.rover_reference_model =
+                    reference->model_debug;
+                pseudorange_factor.base_satellite_model =
+                    base_satellite.model_debug;
+                pseudorange_factor.base_reference_model =
+                    base_reference.model_debug;
+                problem.double_difference_pseudorange_factors.push_back(
+                    pseudorange_factor);
+                pseudorange_factors_by_key[DdFactorKey{
+                    epoch_index,
+                    satellite->satellite,
+                    reference->satellite,
+                    satellite->signal,
+                }] = pseudorange_factor;
+            }
+        }
+
+        for (const auto& [group_key, group] : grouped_rover_carriers) {
+            const CarrierPhaseFactor* reference = nullptr;
+            const PreparedCarrierObservation* base_reference_ptr = nullptr;
+            if (!select_reference(group_key,
+                                  group.size(),
+                                  reference,
+                                  base_reference_ptr)) {
+                continue;
+            }
+            const auto& base_reference = *base_reference_ptr;
+
+            for (const auto* satellite : group) {
+                if (satellite->satellite == reference->satellite &&
+                    satellite->signal == reference->signal) {
+                    continue;
+                }
+                const CarrierKey satellite_key{satellite->satellite, satellite->signal};
+                const auto base_satellite_it = base_carriers.find(satellite_key);
+                if (base_satellite_it == base_carriers.end()) {
+                    continue;
+                }
+                const auto pseudorange_factor_it =
+                    pseudorange_factors_by_key.find(DdFactorKey{
+                        epoch_index,
+                        satellite->satellite,
+                        reference->satellite,
+                        satellite->signal,
+                    });
+                if (pseudorange_factor_it == pseudorange_factors_by_key.end()) {
+                    continue;
+                }
+                ++problem.diagnostics.double_difference_candidate_pairs;
+
+                const auto& base_satellite = base_satellite_it->second;
+                const auto& pseudorange_factor = pseudorange_factor_it->second;
+                const double satellite_sin_el =
+                    std::max(0.1, std::sin(satellite->elevation_rad));
+                const double satellite_sqrt_sin_el =
+                    std::sqrt(satellite_sin_el);
+
+                if (!reference->has_carrier_phase ||
+                    !base_reference.has_carrier_phase) {
+                    continue;
+                }
+
+                DoubleDifferenceCarrierFactor factor;
+                factor.epoch_index = epoch_index;
+                factor.use_ambiguity_difference = false;
+                factor.satellite = satellite->satellite;
+                factor.reference_satellite = reference->satellite;
+                factor.signal = satellite->signal;
+                factor.rover_satellite_position_ecef =
+                    satellite->satellite_position_ecef;
+                factor.rover_reference_position_ecef =
+                    reference->satellite_position_ecef;
+                factor.base_satellite_position_ecef =
+                    base_satellite.satellite_position_ecef;
+                factor.base_reference_position_ecef =
+                    base_reference.satellite_position_ecef;
+                factor.base_position_ecef = base_position_ecef;
+                factor.observed_dd_carrier_m =
+                    (satellite->corrected_carrier_m -
+                     base_satellite.corrected_carrier_m) -
+                    (reference->corrected_carrier_m -
+                     base_reference.corrected_carrier_m);
+                factor.sigma_m = carrier_sigma / satellite_sqrt_sin_el;
+                factor.elevation_rad = satellite->elevation_rad;
+                factor.rover_satellite_model = satellite->model_debug;
+                factor.rover_reference_model = reference->model_debug;
+                factor.base_satellite_model = base_satellite.model_debug;
+                factor.base_reference_model = base_reference.model_debug;
+
+                const Vector3d seed_position =
+                    problem.epochs[epoch_index].position_ecef;
+                const double rover_satellite_range =
+                    (factor.rover_satellite_position_ecef - seed_position).norm();
+                const double rover_reference_range =
+                    (factor.rover_reference_position_ecef - seed_position).norm();
+                const double base_satellite_range =
+                    (factor.base_satellite_position_ecef - base_position_ecef).norm();
+                const double base_reference_range =
+                    (factor.base_reference_position_ecef - base_position_ecef).norm();
+
+                const DoubleDifferenceAmbiguityKey ambiguity_key{
+                    satellite->satellite,
+                    reference->satellite,
+                    satellite->signal,
+                    satellite->ambiguity_index,
+                    0,
+                };
+                auto active_it = active_dd_segments.find(ambiguity_key);
+                bool start_new_segment =
+                    config_.reset_double_difference_ambiguities_each_epoch ||
+                    active_it == active_dd_segments.end();
+                if (!start_new_segment) {
+                    const double dt = problem.epochs[epoch_index].time -
+                                      problem.epochs[active_it->second.last_epoch_index].time;
+                    if (dt <= 0.0 ||
+                        (max_segment_gap > 0.0 && dt > max_segment_gap)) {
+                        start_new_segment = true;
+                    }
+                }
+
+                if (start_new_segment) {
+                    AmbiguityState ambiguity;
+                    ambiguity.satellite = satellite->satellite;
+                    ambiguity.reference_satellite = reference->satellite;
+                    ambiguity.signal = satellite->signal;
+                    ambiguity.is_double_difference = true;
+                    ambiguity.segment_index =
+                        next_dd_segment_indices[DoubleDifferenceSegmentKey{
+                            satellite->satellite,
+                            reference->satellite,
+                            satellite->signal,
+                        }]++;
+                    ambiguity.wavelength_m = satellite->wavelength_m;
+                    const double dd_geometry_at_seed =
+                        (rover_satellite_range - base_satellite_range) -
+                        (rover_reference_range - base_reference_range);
+                    const double carrier_residual_at_seed =
+                        factor.observed_dd_carrier_m - dd_geometry_at_seed;
+                    const double pseudorange_residual_at_seed =
+                        pseudorange_factor.observed_dd_pseudorange_m -
+                        dd_geometry_at_seed;
+                    ambiguity.initial_ambiguity_m =
+                        carrier_residual_at_seed -
+                        pseudorange_residual_at_seed;
+                    active_it =
+                        active_dd_segments
+                            .insert_or_assign(
+                                ambiguity_key,
+                                ActiveCarrierSegment{problem.ambiguity_states.size(),
+                                                     epoch_index})
+                            .first;
+                    problem.ambiguity_states.push_back(ambiguity);
+                } else {
+                    active_it->second.last_epoch_index = epoch_index;
+                }
+
+                factor.ambiguity_index = active_it->second.ambiguity_index;
+                problem.double_difference_carrier_factors.push_back(factor);
+            }
+        }
+    }
+
+    for (const auto& factor : problem.double_difference_pseudorange_factors) {
+        sd_reference_by_group[SingleDifferenceReferenceKey{
+            factor.epoch_index,
+            factor.satellite.system,
+            factor.signal,
+        }] = factor.reference_satellite;
+        ++sd_default_reference_counts[SingleDifferenceDefaultReferenceKey{
+            factor.satellite.system,
+            factor.signal,
+        }][factor.reference_satellite];
+    }
+    for (const auto& factor : problem.double_difference_carrier_factors) {
+        sd_reference_by_group[SingleDifferenceReferenceKey{
+            factor.epoch_index,
+            factor.satellite.system,
+            factor.signal,
+        }] = factor.reference_satellite;
+        ++sd_default_reference_counts[SingleDifferenceDefaultReferenceKey{
+            factor.satellite.system,
+            factor.signal,
+        }][factor.reference_satellite];
+    }
+
+    if (config_.use_ambiguity_between_factors) {
+        using AmbiguityTrackKey = std::pair<SatelliteId, SignalType>;
+        std::map<AmbiguityTrackKey, const DoubleDifferenceCarrierFactor*>
+            previous_by_track;
+        for (const auto& factor : problem.double_difference_carrier_factors) {
+            if (factor.ambiguity_index >= problem.ambiguity_states.size()) {
+                continue;
+            }
+            const AmbiguityTrackKey track_key{factor.satellite, factor.signal};
+            const auto previous_it = previous_by_track.find(track_key);
+            if (previous_it != previous_by_track.end()) {
+                const auto* previous = previous_it->second;
+                const double dt =
+                    problem.epochs[factor.epoch_index].time -
+                    problem.epochs[previous->epoch_index].time;
+                if (factor.epoch_index == previous->epoch_index + 1 &&
+                    dt > 0.0 &&
+                    (config_.max_tdcp_gap_s <= 0.0 ||
+                     dt <= config_.max_tdcp_gap_s) &&
+                    previous->ambiguity_index != factor.ambiguity_index) {
+                    const auto& ambiguity =
+                        problem.ambiguity_states[factor.ambiguity_index];
+                    if (ambiguity.wavelength_m > 0.0) {
+                        AmbiguityBetweenFactor between;
+                        between.previous_epoch_index = previous->epoch_index;
+                        between.current_epoch_index = factor.epoch_index;
+                        between.previous_ambiguity_index =
+                            previous->ambiguity_index;
+                        between.current_ambiguity_index = factor.ambiguity_index;
+                        between.satellite = factor.satellite;
+                        between.signal = factor.signal;
+                        between.sigma_m =
+                            std::max(1e-9,
+                                     config_.ambiguity_between_sigma_cycles *
+                                         ambiguity.wavelength_m);
+                        problem.ambiguity_between_factors.push_back(between);
+                    }
+                }
+            }
+            previous_by_track[track_key] = &factor;
+        }
+    }
+
+    std::map<SingleDifferenceDefaultReferenceKey, SatelliteId>
+        sd_default_reference_by_group;
+    for (const auto& [group_key, counts] : sd_default_reference_counts) {
+        const auto best_it =
+            std::max_element(counts.begin(),
+                             counts.end(),
+                             [](const auto& lhs, const auto& rhs) {
+                                 return lhs.second < rhs.second;
+                             });
+        if (best_it != counts.end()) {
+            sd_default_reference_by_group[group_key] = best_it->first;
+        }
+    }
+
+    if (config_.use_single_difference_doppler_factors ||
+        config_.use_single_difference_tdcp_factors) {
+        std::map<CarrierKey, SingleDifferenceCarrierResidual>
+            previous_sd_carrier_residuals;
+        for (std::size_t epoch_index = 0; epoch_index < problem.epochs.size();
+             ++epoch_index) {
+            std::map<CarrierKey, const CarrierPhaseFactor*> rover_by_key;
+            std::vector<const CarrierPhaseFactor*> rover_factor_rows;
+            const auto rover_pseudorange_it =
+                rover_pseudoranges_by_epoch.find(epoch_index);
+            if (rover_pseudorange_it != rover_pseudoranges_by_epoch.end()) {
+                for (const auto* rover : rover_pseudorange_it->second) {
+                    rover_by_key[{rover->satellite, rover->signal}] = rover;
+                    rover_factor_rows.push_back(rover);
+                }
+            }
+
+            std::map<CarrierKey, SingleDifferenceCarrierResidual>
+                current_sd_carrier_residuals;
+            for (const auto* rover : rover_factor_rows) {
+                const CarrierKey carrier_key{rover->satellite, rover->signal};
+                const auto reference_it =
+                    sd_reference_by_group.find(SingleDifferenceReferenceKey{
+                        epoch_index,
+                        rover->satellite.system,
+                        rover->signal,
+                    });
+                SatelliteId reference_satellite;
+                if (reference_it != sd_reference_by_group.end()) {
+                    reference_satellite = reference_it->second;
+                } else {
+                    const auto default_reference_it =
+                        sd_default_reference_by_group.find(
+                            SingleDifferenceDefaultReferenceKey{
+                                rover->satellite.system,
+                                rover->signal,
+                            });
+                    if (default_reference_it ==
+                            sd_default_reference_by_group.end() ||
+                        !(rover->satellite == default_reference_it->second)) {
+                        continue;
+                    }
+                    reference_satellite = default_reference_it->second;
+                }
+
+                const auto reference_model_it =
+                    rover_by_key.find({reference_satellite, rover->signal});
+                if (reference_model_it == rover_by_key.end()) {
+                    continue;
+                }
+                const auto* reference = reference_model_it->second;
+                const Vector3d sd_los = rover->los - reference->los;
+
+                if (config_.use_single_difference_doppler_factors &&
+                    rover->has_doppler_residual &&
+                    reference->has_doppler_residual) {
+                    SingleDifferenceDopplerFactor factor;
+                    factor.epoch_index = epoch_index;
+                    factor.satellite = rover->satellite;
+                    factor.reference_satellite = reference_satellite;
+                    factor.signal = rover->signal;
+                    factor.los = sd_los;
+                    factor.residual_mps =
+                        rover->doppler_residual_mps -
+                        reference->doppler_residual_mps;
+                    factor.sigma_mps = rover->doppler_sigma_mps;
+                    factor.elevation_rad = rover->elevation_rad;
+                    if (std::isfinite(factor.residual_mps) &&
+                        std::isfinite(factor.sigma_mps) &&
+                        factor.sigma_mps > 0.0) {
+                        problem.single_difference_doppler_factors.push_back(factor);
+                    }
+                }
+
+                if (rover->has_carrier_phase &&
+                    reference->has_carrier_phase &&
+                    !rover->loss_of_lock &&
+                    !reference->loss_of_lock) {
+                    const double rover_carrier_residual =
+                        rover->corrected_carrier_m -
+                        rover->model_debug.geometric_range_m;
+                    const double reference_carrier_residual =
+                        reference->corrected_carrier_m -
+                        reference->model_debug.geometric_range_m;
+                    const double sd_carrier_residual =
+                        rover_carrier_residual - reference_carrier_residual;
+                    current_sd_carrier_residuals[carrier_key] =
+                        SingleDifferenceCarrierResidual{
+                            epoch_index,
+                            sd_carrier_residual,
+                            sd_los,
+                        };
+
+                    const auto previous_it =
+                        previous_sd_carrier_residuals.find(carrier_key);
+                    if (config_.use_single_difference_tdcp_factors &&
+                        previous_it != previous_sd_carrier_residuals.end()) {
+                        const double tdcp =
+                            sd_carrier_residual - previous_it->second.residual_m;
+                        if (std::isfinite(tdcp) && tdcp != 0.0) {
+                            SingleDifferenceTdcpFactor factor;
+                            factor.previous_epoch_index =
+                                previous_it->second.epoch_index;
+                            factor.current_epoch_index = epoch_index;
+                            factor.satellite = rover->satellite;
+                            factor.reference_satellite = reference_satellite;
+                            factor.signal = rover->signal;
+                            factor.previous_los = sd_los;
+                            factor.los = sd_los;
+                            factor.delta_carrier_m = tdcp;
+                            const double sin_el =
+                                std::max(0.1, std::sin(rover->elevation_rad));
+                            factor.sigma_m =
+                                std::max(1e-4,
+                                         config_.single_difference_tdcp_sigma_m /
+                                             std::sqrt(sin_el));
+                            factor.elevation_rad = rover->elevation_rad;
+                            problem.single_difference_tdcp_factors.push_back(factor);
+                        }
+                    }
+                }
+            }
+            previous_sd_carrier_residuals =
+                std::move(current_sd_carrier_residuals);
+        }
+    }
+
+    return problem;
+}
+
+FGOProcessor::FGOResult FGOProcessor::optimize(
+    const std::vector<ObservationData>& epochs,
+    const NavigationData& nav) const {
+    return optimizeProblem(buildPseudorangeProblem(epochs, nav));
+}
+
+FGOProcessor::FGOResult FGOProcessor::optimize(
+    const std::vector<ObservationData>& rover_epochs,
+    const std::vector<ObservationData>& base_epochs,
+    const NavigationData& nav,
+    const Vector3d& base_position_ecef) const {
+    return optimizeProblem(
+        buildDoubleDifferenceProblem(rover_epochs, base_epochs, nav, base_position_ecef));
+}
+
+FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem) const {
+    const auto optimize_problem_start =
+        std::chrono::high_resolution_clock::now();
+    FGOResult result;
+    result.diagnostics.epochs = problem.epochs.size();
+    result.diagnostics.pseudorange_factors = problem.pseudorange_factors.size();
+    result.diagnostics.tdcp_factors = problem.tdcp_factors.size();
+    result.diagnostics.single_difference_doppler_factors =
+        problem.single_difference_doppler_factors.size();
+    result.diagnostics.single_difference_tdcp_factors =
+        problem.single_difference_tdcp_factors.size();
+    result.diagnostics.carrier_phase_factors = problem.carrier_phase_factors.size();
+    result.diagnostics.double_difference_pseudorange_factors =
+        problem.double_difference_pseudorange_factors.size();
+    result.diagnostics.double_difference_carrier_factors =
+        problem.double_difference_carrier_factors.size();
+    result.diagnostics.ambiguity_between_factors =
+        problem.ambiguity_between_factors.size();
+    result.diagnostics.ambiguity_states = problem.ambiguity_states.size();
+    result.diagnostics.tdcp_candidate_pairs = problem.diagnostics.tdcp_candidate_pairs;
+    result.diagnostics.tdcp_rejected_gap = problem.diagnostics.tdcp_rejected_gap;
+    result.diagnostics.tdcp_rejected_missing_previous =
+        problem.diagnostics.tdcp_rejected_missing_previous;
+    result.diagnostics.tdcp_rejected_loss_of_lock =
+        problem.diagnostics.tdcp_rejected_loss_of_lock;
+    result.diagnostics.tdcp_rejected_code_phase_jump =
+        problem.diagnostics.tdcp_rejected_code_phase_jump;
+    result.diagnostics.double_difference_matched_base_epochs =
+        problem.diagnostics.double_difference_matched_base_epochs;
+    result.diagnostics.double_difference_interpolated_base_epochs =
+        problem.diagnostics.double_difference_interpolated_base_epochs;
+    result.diagnostics.double_difference_candidate_pairs =
+        problem.diagnostics.double_difference_candidate_pairs;
+    result.diagnostics.double_difference_rejected_no_base_epoch =
+        problem.diagnostics.double_difference_rejected_no_base_epoch;
+    result.diagnostics.double_difference_rejected_no_reference =
+        problem.diagnostics.double_difference_rejected_no_reference;
+
+    if (problem.epochs.empty() ||
+        (problem.pseudorange_factors.empty() &&
+         problem.carrier_phase_factors.empty() &&
+         problem.double_difference_pseudorange_factors.empty() &&
+         problem.double_difference_carrier_factors.empty() &&
+         problem.tdcp_factors.empty() &&
+         problem.single_difference_doppler_factors.empty() &&
+         problem.single_difference_tdcp_factors.empty())) {
+        return result;
+    }
+
+    const int num_epochs = static_cast<int>(problem.epochs.size());
+    std::vector<GNSSSystem> bias_groups;
+    std::map<GNSSSystem, int> bias_group_columns;
+    if (config_.use_inter_system_biases) {
+        std::map<GNSSSystem, bool> present_bias_groups;
+        for (const auto& factor : problem.pseudorange_factors) {
+            if (usesSeparateClockBias(factor.clock_group)) {
+                present_bias_groups[factor.clock_group] = true;
+            }
+        }
+        for (const auto& factor : problem.carrier_phase_factors) {
+            if (usesSeparateClockBias(factor.clock_group)) {
+                present_bias_groups[factor.clock_group] = true;
+            }
+        }
+        for (const auto& [group, present] : present_bias_groups) {
+            if (!present) {
+                continue;
+            }
+            bias_group_columns[group] = static_cast<int>(bias_groups.size());
+            bias_groups.push_back(group);
+        }
+    }
+    const int epoch_state_size = 4;
+    const int position_clock_state_size = epoch_state_size * num_epochs;
+    const bool use_velocity_states = config_.use_velocity_states;
+    const int velocity_state_size = use_velocity_states ? 3 * num_epochs : 0;
+    const int velocity_state_offset = position_clock_state_size;
+    const int bias_state_offset = velocity_state_offset + velocity_state_size;
+    const int base_state_size =
+        bias_state_offset + static_cast<int>(bias_groups.size());
+    const int ambiguity_count = static_cast<int>(problem.ambiguity_states.size());
+    const int state_size = base_state_size + ambiguity_count;
+    constexpr int kSparseNormalStateThreshold = 300;
+    const bool use_sparse_normal = state_size > kSparseNormalStateThreshold;
+    Eigen::VectorXd initial_state = Eigen::VectorXd::Zero(state_size);
+    for (int i = 0; i < num_epochs; ++i) {
+        const int epoch_col = epoch_state_size * i;
+        initial_state.segment<3>(epoch_col) = problem.epochs[i].position_ecef;
+        initial_state(epoch_col + 3) = problem.epochs[i].receiver_clock_bias_m;
+    }
+    if (use_velocity_states) {
+        for (int i = 0; i < num_epochs; ++i) {
+            initial_state.segment<3>(velocity_state_offset + 3 * i).setZero();
+        }
+    }
+    for (int i = 0; i < ambiguity_count; ++i) {
+        initial_state(base_state_size + i) =
+            problem.ambiguity_states[i].initial_ambiguity_m;
+    }
+
+    auto epoch_state_col = [&](std::size_t epoch_index) -> int {
+        return epoch_state_size * static_cast<int>(epoch_index);
+    };
+
+    auto velocity_state_col = [&](std::size_t epoch_index) -> int {
+        if (!use_velocity_states) {
+            return -1;
+        }
+        return velocity_state_offset + 3 * static_cast<int>(epoch_index);
+    };
+
+    auto system_bias_col = [&](int /*epoch_col*/, GNSSSystem group) -> int {
+        const auto bias_it = bias_group_columns.find(group);
+        if (bias_it == bias_group_columns.end()) {
+            return -1;
+        }
+        return bias_state_offset + bias_it->second;
+    };
+
+    auto motion_rows_per_pair = [&]() -> std::size_t {
+        const bool use_velocity_motion =
+            config_.use_velocity_motion_factors && use_velocity_states;
+        if (!config_.use_motion_factors && !use_velocity_motion) {
+            return 0;
+        }
+        std::size_t rows_per_pair = 0;
+        if (config_.use_motion_factors &&
+            config_.use_position_motion_factors) {
+            rows_per_pair += 3;
+        }
+        if (config_.use_motion_factors && config_.use_clock_motion_factors) {
+            rows_per_pair += 1;
+        }
+        if (use_velocity_motion) {
+            rows_per_pair += 3;
+        }
+        return rows_per_pair;
+    };
+
+    auto motion_factor_count = [&]() -> std::size_t {
+        const bool use_velocity_motion =
+            config_.use_velocity_motion_factors && use_velocity_states;
+        if ((!config_.use_motion_factors && !use_velocity_motion) ||
+            num_epochs < 2) {
+            return 0;
+        }
+        return static_cast<std::size_t>(num_epochs - 1) * motion_rows_per_pair();
+    };
+
+    auto ambiguity_prior_count = [&]() -> std::size_t {
+        if (!config_.use_ambiguity_priors || config_.ambiguity_prior_sigma_m <= 0.0) {
+            return 0;
+        }
+        return problem.ambiguity_states.size();
+    };
+
+    auto velocity_prior_count = [&]() -> std::size_t {
+        if (!use_velocity_states || config_.velocity_prior_sigma_mps <= 0.0) {
+            return 0;
+        }
+        return static_cast<std::size_t>(num_epochs) * 3U;
+    };
+
+    struct OptimizationOutput {
+        Eigen::VectorXd state;
+        Eigen::MatrixXd normal_matrix;
+        Eigen::SparseMatrix<double> sparse_normal_matrix;
+        int iterations = 0;
+        bool converged = false;
+        double final_cost = 0.0;
+        double processing_ms = 0.0;
+        double last_dx_norm = std::numeric_limits<double>::infinity();
+        std::size_t robust_pseudorange_factors = 0;
+        std::size_t robust_carrier_phase_factors = 0;
+        std::size_t robust_double_difference_pseudorange_factors = 0;
+        std::size_t robust_double_difference_carrier_factors = 0;
+        std::size_t robust_tdcp_factors = 0;
+    };
+
+    auto robust_scale = [&](double normalized_residual,
+                            double threshold_sigma) -> double {
+        if (!config_.use_robust_loss || threshold_sigma <= 0.0) {
+            return 1.0;
+        }
+        const double abs_residual = std::abs(normalized_residual);
+        if (!std::isfinite(abs_residual) || abs_residual <= threshold_sigma) {
+            return 1.0;
+        }
+        return std::sqrt(threshold_sigma / abs_residual);
+    };
+
+    auto run_optimizer =
+        [&](const Eigen::VectorXd& start_state,
+            const std::vector<FixedAmbiguityConstraint>& fixed_constraints)
+            -> OptimizationOutput {
+        OptimizationOutput output;
+        output.state = start_state;
+
+        const auto start_time = std::chrono::high_resolution_clock::now();
+        double previous_cost = std::numeric_limits<double>::infinity();
+        for (int iter = 0; iter < config_.max_iterations; ++iter) {
+            const int pr_rows = static_cast<int>(problem.pseudorange_factors.size());
+            const int carrier_phase_rows =
+                static_cast<int>(problem.carrier_phase_factors.size());
+            const int double_difference_pseudorange_rows =
+                static_cast<int>(problem.double_difference_pseudorange_factors.size());
+            const int double_difference_carrier_rows =
+                static_cast<int>(problem.double_difference_carrier_factors.size());
+            const int ambiguity_between_rows =
+                static_cast<int>(problem.ambiguity_between_factors.size());
+            const int tdcp_rows = static_cast<int>(problem.tdcp_factors.size());
+            const int single_difference_doppler_rows =
+                static_cast<int>(problem.single_difference_doppler_factors.size());
+            const int single_difference_tdcp_rows =
+                static_cast<int>(problem.single_difference_tdcp_factors.size());
+            const int motion_rows = static_cast<int>(motion_factor_count());
+            const int ambiguity_prior_rows = static_cast<int>(ambiguity_prior_count());
+            const int velocity_prior_rows = static_cast<int>(velocity_prior_count());
+            const int fixed_ambiguity_rows = static_cast<int>(fixed_constraints.size());
+            const int estimated_rows =
+                pr_rows + carrier_phase_rows + double_difference_pseudorange_rows +
+                double_difference_carrier_rows + ambiguity_between_rows + tdcp_rows +
+                single_difference_doppler_rows + single_difference_tdcp_rows +
+                motion_rows + ambiguity_prior_rows + velocity_prior_rows +
+                fixed_ambiguity_rows;
+            (void)estimated_rows;
+            Eigen::MatrixXd normal_matrix;
+            std::vector<Eigen::Triplet<double>> normal_triplets;
+            if (use_sparse_normal) {
+                normal_triplets.reserve(
+                    static_cast<std::size_t>(std::max(1, estimated_rows)) * 25U);
+            } else {
+                normal_matrix = Eigen::MatrixXd::Zero(state_size, state_size);
+            }
+            Eigen::VectorXd normal_rhs = Eigen::VectorXd::Zero(state_size);
+            double weighted_residual_square_sum = 0.0;
+            std::size_t robust_pseudorange_count = 0;
+            std::size_t robust_carrier_phase_count = 0;
+            std::size_t robust_double_difference_pseudorange_count = 0;
+            std::size_t robust_double_difference_carrier_count = 0;
+            std::size_t robust_tdcp_count = 0;
+
+            int row = 0;
+            auto add_weighted_row =
+                [&](const std::vector<std::pair<int, double>>& jacobian,
+                    double weighted_residual) {
+                    if (jacobian.empty()) {
+                        return;
+                    }
+                    weighted_residual_square_sum +=
+                        weighted_residual * weighted_residual;
+                    for (const auto& lhs : jacobian) {
+                        if (lhs.first < 0 || lhs.first >= state_size) {
+                            continue;
+                        }
+                        normal_rhs(lhs.first) += lhs.second * weighted_residual;
+                        for (const auto& rhs : jacobian) {
+                            if (rhs.first < 0 || rhs.first >= state_size) {
+                                continue;
+                            }
+                            const double normal_entry = lhs.second * rhs.second;
+                            if (use_sparse_normal) {
+                                normal_triplets.emplace_back(
+                                    lhs.first, rhs.first, normal_entry);
+                            } else {
+                                normal_matrix(lhs.first, rhs.first) +=
+                                    normal_entry;
+                            }
+                        }
+                    }
+                    ++row;
+                };
+            if (config_.position_prior_sigma_m > 0.0) {
+                const double position_prior_weight =
+                    1.0 / std::max(1e-3, config_.position_prior_sigma_m);
+                for (int i = 0; i < num_epochs; ++i) {
+                    const int epoch_col = epoch_state_col(static_cast<std::size_t>(i));
+                    for (int axis = 0; axis < 3; ++axis) {
+                        const double weighted_residual =
+                            (problem.epochs[i].position_ecef(axis) -
+                             output.state(epoch_col + axis)) *
+                            position_prior_weight;
+                        add_weighted_row(
+                            {{epoch_col + axis, position_prior_weight}},
+                            weighted_residual);
+                    }
+                }
+            }
+
+            if (config_.clock_prior_sigma_m > 0.0) {
+                const double clock_prior_weight =
+                    1.0 / std::max(1e-3, config_.clock_prior_sigma_m);
+                for (int i = 0; i < num_epochs; ++i) {
+                    const int epoch_col = epoch_state_col(static_cast<std::size_t>(i));
+                    const double weighted_residual =
+                        (problem.epochs[i].receiver_clock_bias_m -
+                         output.state(epoch_col + 3)) *
+                        clock_prior_weight;
+                    add_weighted_row(
+                        {{epoch_col + 3, clock_prior_weight}},
+                        weighted_residual);
+                }
+                for (const auto& [group, offset] : bias_group_columns) {
+                    (void)group;
+                    const int bias_col = bias_state_offset + offset;
+                    const double weighted_residual =
+                        -output.state(bias_col) * clock_prior_weight;
+                    add_weighted_row({{bias_col, clock_prior_weight}},
+                                     weighted_residual);
+                }
+            }
+
+            if (use_velocity_states && config_.velocity_prior_sigma_mps > 0.0) {
+                const double velocity_prior_weight =
+                    1.0 / std::max(1e-6, config_.velocity_prior_sigma_mps);
+                for (int i = 0; i < num_epochs; ++i) {
+                    const int velocity_col =
+                        velocity_state_col(static_cast<std::size_t>(i));
+                    for (int axis = 0; axis < 3; ++axis) {
+                        const double weighted_residual =
+                            -output.state(velocity_col + axis) *
+                            velocity_prior_weight;
+                        add_weighted_row(
+                            {{velocity_col + axis, velocity_prior_weight}},
+                            weighted_residual);
+                    }
+                }
+            }
+
+            for (const auto& factor : problem.pseudorange_factors) {
+                if (factor.epoch_index >= problem.epochs.size()) {
+                    continue;
+                }
+
+                const int epoch_col = epoch_state_col(factor.epoch_index);
+                const Vector3d position = output.state.segment<3>(epoch_col);
+                const double clock_bias_m = output.state(epoch_col + 3);
+                const int bias_col = system_bias_col(epoch_col, factor.clock_group);
+                const Vector3d delta = factor.satellite_position_ecef - position;
+                const double range = delta.norm();
+                if (range <= 0.0) {
+                    continue;
+                }
+
+                const Vector3d los = delta / range;
+                double predicted = range + clock_bias_m;
+                if (bias_col >= 0) {
+                    predicted += output.state(bias_col);
+                }
+                const double sigma = std::max(1e-3, factor.sigma_m);
+                const double raw_residual =
+                    factor.corrected_pseudorange_m - predicted;
+                const double scale =
+                    robust_scale(raw_residual / sigma,
+                                 config_.pseudorange_huber_threshold_sigma);
+                if (scale < 1.0) {
+                    ++robust_pseudorange_count;
+                }
+                const double weight = scale / sigma;
+
+                std::vector<std::pair<int, double>> jacobian;
+                jacobian.reserve(5);
+                jacobian.emplace_back(epoch_col + 0, -los(0) * weight);
+                jacobian.emplace_back(epoch_col + 1, -los(1) * weight);
+                jacobian.emplace_back(epoch_col + 2, -los(2) * weight);
+                jacobian.emplace_back(epoch_col + 3, 1.0 * weight);
+                if (bias_col >= 0) {
+                    jacobian.emplace_back(bias_col, 1.0 * weight);
+                }
+                add_weighted_row(jacobian, raw_residual * weight);
+            }
+
+            for (const auto& factor : problem.carrier_phase_factors) {
+                if (factor.epoch_index >= problem.epochs.size() ||
+                    factor.ambiguity_index >= problem.ambiguity_states.size()) {
+                    continue;
+                }
+
+                const int epoch_col = epoch_state_col(factor.epoch_index);
+                const int ambiguity_col =
+                    base_state_size + static_cast<int>(factor.ambiguity_index);
+                const Vector3d position = output.state.segment<3>(epoch_col);
+                const double clock_bias_m = output.state(epoch_col + 3);
+                const int bias_col = system_bias_col(epoch_col, factor.clock_group);
+                const double ambiguity_m = output.state(ambiguity_col);
+                const Vector3d delta = factor.satellite_position_ecef - position;
+                const double range = delta.norm();
+                if (range <= 0.0) {
+                    continue;
+                }
+
+                const Vector3d los = delta / range;
+                double predicted = range + clock_bias_m + ambiguity_m;
+                if (bias_col >= 0) {
+                    predicted += output.state(bias_col);
+                }
+                const double sigma = std::max(1e-4, factor.sigma_m);
+                const double raw_residual =
+                    factor.corrected_carrier_m - predicted;
+                const double scale =
+                    robust_scale(raw_residual / sigma,
+                                 config_.carrier_phase_huber_threshold_sigma);
+                if (scale < 1.0) {
+                    ++robust_carrier_phase_count;
+                }
+                const double weight = scale / sigma;
+
+                std::vector<std::pair<int, double>> jacobian;
+                jacobian.reserve(6);
+                jacobian.emplace_back(epoch_col + 0, -los(0) * weight);
+                jacobian.emplace_back(epoch_col + 1, -los(1) * weight);
+                jacobian.emplace_back(epoch_col + 2, -los(2) * weight);
+                jacobian.emplace_back(epoch_col + 3, 1.0 * weight);
+                if (bias_col >= 0) {
+                    jacobian.emplace_back(bias_col, 1.0 * weight);
+                }
+                jacobian.emplace_back(ambiguity_col, 1.0 * weight);
+                add_weighted_row(jacobian, raw_residual * weight);
+            }
+
+            for (const auto& factor : problem.double_difference_pseudorange_factors) {
+                if (factor.epoch_index >= problem.epochs.size()) {
+                    continue;
+                }
+
+                const int epoch_col = epoch_state_col(factor.epoch_index);
+                const Vector3d position = output.state.segment<3>(epoch_col);
+                const Vector3d seed_position =
+                    problem.epochs[factor.epoch_index].position_ecef;
+                const Vector3d linearization_position =
+                    config_.linearize_double_difference_factors_at_seed
+                        ? seed_position
+                        : position;
+                const DoubleDifferencePrediction dd_prediction =
+                    doubleDifferencePredictionAt(
+                        linearization_position,
+                        factor.base_position_ecef,
+                        factor.rover_satellite_position_ecef,
+                        factor.rover_reference_position_ecef,
+                        factor.base_satellite_position_ecef,
+                        factor.base_reference_position_ecef);
+                if (!dd_prediction.valid) {
+                    continue;
+                }
+
+                double predicted = dd_prediction.geometry_m;
+                if (config_.linearize_double_difference_factors_at_seed) {
+                    predicted +=
+                        dd_prediction.position_jacobian.dot(position - seed_position);
+                }
+                const double sigma = std::max(1e-3, factor.sigma_m);
+                const double raw_residual =
+                    factor.observed_dd_pseudorange_m - predicted;
+                const double scale =
+                    robust_scale(raw_residual / sigma,
+                                 config_.pseudorange_huber_threshold_sigma);
+                if (scale < 1.0) {
+                    ++robust_double_difference_pseudorange_count;
+                }
+                const double weight = scale / sigma;
+
+                std::vector<std::pair<int, double>> jacobian;
+                jacobian.reserve(3);
+                jacobian.emplace_back(epoch_col + 0,
+                                      dd_prediction.position_jacobian(0) * weight);
+                jacobian.emplace_back(epoch_col + 1,
+                                      dd_prediction.position_jacobian(1) * weight);
+                jacobian.emplace_back(epoch_col + 2,
+                                      dd_prediction.position_jacobian(2) * weight);
+                add_weighted_row(jacobian, raw_residual * weight);
+            }
+
+            for (const auto& factor : problem.double_difference_carrier_factors) {
+                if (factor.epoch_index >= problem.epochs.size() ||
+                    factor.ambiguity_index >= problem.ambiguity_states.size() ||
+                    (factor.use_ambiguity_difference &&
+                     factor.reference_ambiguity_index >=
+                         problem.ambiguity_states.size())) {
+                    continue;
+                }
+
+                const int epoch_col = epoch_state_col(factor.epoch_index);
+                const int ambiguity_col =
+                    base_state_size + static_cast<int>(factor.ambiguity_index);
+                const int reference_ambiguity_col =
+                    factor.use_ambiguity_difference
+                        ? base_state_size +
+                              static_cast<int>(factor.reference_ambiguity_index)
+                        : -1;
+                const Vector3d position = output.state.segment<3>(epoch_col);
+                const Vector3d seed_position =
+                    problem.epochs[factor.epoch_index].position_ecef;
+                const Vector3d linearization_position =
+                    config_.linearize_double_difference_factors_at_seed
+                        ? seed_position
+                        : position;
+                const DoubleDifferencePrediction dd_prediction =
+                    doubleDifferencePredictionAt(
+                        linearization_position,
+                        factor.base_position_ecef,
+                        factor.rover_satellite_position_ecef,
+                        factor.rover_reference_position_ecef,
+                        factor.base_satellite_position_ecef,
+                        factor.base_reference_position_ecef);
+                if (!dd_prediction.valid) {
+                    continue;
+                }
+
+                const double ambiguity_m = output.state(ambiguity_col);
+                double predicted = dd_prediction.geometry_m + ambiguity_m;
+                if (config_.linearize_double_difference_factors_at_seed) {
+                    predicted +=
+                        dd_prediction.position_jacobian.dot(position - seed_position);
+                }
+                if (factor.use_ambiguity_difference) {
+                    predicted -= output.state(reference_ambiguity_col);
+                }
+                const double sigma = std::max(1e-4, factor.sigma_m);
+                const double raw_residual =
+                    factor.observed_dd_carrier_m - predicted;
+                const double scale =
+                    robust_scale(raw_residual / sigma,
+                                 config_.carrier_phase_huber_threshold_sigma);
+                if (scale < 1.0) {
+                    ++robust_double_difference_carrier_count;
+                }
+                const double weight = scale / sigma;
+
+                std::vector<std::pair<int, double>> jacobian;
+                jacobian.reserve(5);
+                jacobian.emplace_back(epoch_col + 0,
+                                      dd_prediction.position_jacobian(0) * weight);
+                jacobian.emplace_back(epoch_col + 1,
+                                      dd_prediction.position_jacobian(1) * weight);
+                jacobian.emplace_back(epoch_col + 2,
+                                      dd_prediction.position_jacobian(2) * weight);
+                jacobian.emplace_back(ambiguity_col, 1.0 * weight);
+                if (factor.use_ambiguity_difference) {
+                    jacobian.emplace_back(reference_ambiguity_col, -1.0 * weight);
+                }
+                add_weighted_row(jacobian, raw_residual * weight);
+            }
+
+            for (const auto& factor : problem.ambiguity_between_factors) {
+                if (factor.previous_ambiguity_index >=
+                        problem.ambiguity_states.size() ||
+                    factor.current_ambiguity_index >=
+                        problem.ambiguity_states.size()) {
+                    continue;
+                }
+
+                const int previous_col =
+                    base_state_size +
+                    static_cast<int>(factor.previous_ambiguity_index);
+                const int current_col =
+                    base_state_size +
+                    static_cast<int>(factor.current_ambiguity_index);
+                const double sigma = std::max(1e-9, factor.sigma_m);
+                const double weight = 1.0 / sigma;
+                const double predicted =
+                    output.state(current_col) - output.state(previous_col);
+                add_weighted_row({{previous_col, -weight},
+                                  {current_col, weight}},
+                                 -predicted * weight);
+            }
+
+            for (const auto& factor : problem.tdcp_factors) {
+                if (factor.previous_epoch_index >= problem.epochs.size() ||
+                    factor.current_epoch_index >= problem.epochs.size()) {
+                    continue;
+                }
+
+                const int previous_col =
+                    epoch_state_col(factor.previous_epoch_index);
+                const int current_col = epoch_state_col(factor.current_epoch_index);
+                const int previous_bias_col =
+                    system_bias_col(previous_col,
+                                    clockBiasGroup(factor.satellite.system));
+                const int current_bias_col =
+                    system_bias_col(current_col,
+                                    clockBiasGroup(factor.satellite.system));
+                const Vector3d previous_position = output.state.segment<3>(previous_col);
+                const Vector3d current_position = output.state.segment<3>(current_col);
+                const Vector3d previous_delta =
+                    factor.previous_satellite_position_ecef - previous_position;
+                const Vector3d current_delta =
+                    factor.current_satellite_position_ecef - current_position;
+                const double previous_range = previous_delta.norm();
+                const double current_range = current_delta.norm();
+                if (previous_range <= 0.0 || current_range <= 0.0) {
+                    continue;
+                }
+
+                const Vector3d previous_los = previous_delta / previous_range;
+                const Vector3d current_los = current_delta / current_range;
+                double predicted =
+                    current_range + output.state(current_col + 3) -
+                    previous_range - output.state(previous_col + 3);
+                if (previous_bias_col >= 0 && current_bias_col >= 0 &&
+                    previous_bias_col != current_bias_col) {
+                    predicted += output.state(current_bias_col) -
+                                 output.state(previous_bias_col);
+                }
+                const double sigma = std::max(1e-4, factor.sigma_m);
+                const double raw_residual = factor.delta_carrier_m - predicted;
+                const double scale =
+                    robust_scale(raw_residual / sigma,
+                                 config_.tdcp_huber_threshold_sigma);
+                if (scale < 1.0) {
+                    ++robust_tdcp_count;
+                }
+                const double weight = scale / sigma;
+
+                std::vector<std::pair<int, double>> jacobian;
+                jacobian.reserve(10);
+                jacobian.emplace_back(previous_col + 0, previous_los(0) * weight);
+                jacobian.emplace_back(previous_col + 1, previous_los(1) * weight);
+                jacobian.emplace_back(previous_col + 2, previous_los(2) * weight);
+                jacobian.emplace_back(previous_col + 3, -1.0 * weight);
+                if (previous_bias_col >= 0 &&
+                    previous_bias_col != current_bias_col) {
+                    jacobian.emplace_back(previous_bias_col, -1.0 * weight);
+                }
+                jacobian.emplace_back(current_col + 0, -current_los(0) * weight);
+                jacobian.emplace_back(current_col + 1, -current_los(1) * weight);
+                jacobian.emplace_back(current_col + 2, -current_los(2) * weight);
+                jacobian.emplace_back(current_col + 3, 1.0 * weight);
+                if (current_bias_col >= 0 &&
+                    previous_bias_col != current_bias_col) {
+                    jacobian.emplace_back(current_bias_col, 1.0 * weight);
+                }
+                add_weighted_row(jacobian, raw_residual * weight);
+            }
+
+            for (const auto& factor : problem.single_difference_doppler_factors) {
+                if (factor.epoch_index >= problem.epochs.size()) {
+                    continue;
+                }
+
+                int velocity_col = velocity_state_col(factor.epoch_index);
+                Vector3d velocity = Vector3d::Zero();
+                if (velocity_col >= 0) {
+                    velocity = output.state.segment<3>(velocity_col);
+                } else {
+                    if (factor.epoch_index == 0) {
+                        continue;
+                    }
+                    const std::size_t previous_epoch_index =
+                        factor.epoch_index - 1;
+                    const double dt =
+                        problem.epochs[factor.epoch_index].time -
+                        problem.epochs[previous_epoch_index].time;
+                    if (dt <= 0.0 ||
+                        (config_.max_tdcp_gap_s > 0.0 &&
+                         dt > config_.max_tdcp_gap_s)) {
+                        continue;
+                    }
+
+                    const int previous_col = epoch_state_col(previous_epoch_index);
+                    const int current_col = epoch_state_col(factor.epoch_index);
+                    velocity =
+                        (output.state.segment<3>(current_col) -
+                         output.state.segment<3>(previous_col)) /
+                        dt;
+                    velocity_col = current_col;
+                }
+                const double predicted = factor.los.dot(velocity);
+                const double sigma = std::max(1e-4, factor.sigma_mps);
+                const double raw_residual = factor.residual_mps - predicted;
+                const double scale =
+                    robust_scale(raw_residual / sigma,
+                                 config_.tdcp_huber_threshold_sigma);
+                const double weight = scale / sigma;
+
+                std::vector<std::pair<int, double>> jacobian;
+                if (use_velocity_states) {
+                    jacobian.reserve(3);
+                    for (int axis = 0; axis < 3; ++axis) {
+                        jacobian.emplace_back(velocity_col + axis,
+                                              factor.los(axis) * weight);
+                    }
+                } else {
+                    if (factor.epoch_index == 0) {
+                        continue;
+                    }
+                    const std::size_t previous_epoch_index =
+                        factor.epoch_index - 1;
+                    const double dt =
+                        problem.epochs[factor.epoch_index].time -
+                        problem.epochs[previous_epoch_index].time;
+                    const int previous_col = epoch_state_col(previous_epoch_index);
+                    const int current_col = epoch_state_col(factor.epoch_index);
+                    jacobian.reserve(6);
+                    for (int axis = 0; axis < 3; ++axis) {
+                        jacobian.emplace_back(previous_col + axis,
+                                              -factor.los(axis) / dt * weight);
+                        jacobian.emplace_back(current_col + axis,
+                                              factor.los(axis) / dt * weight);
+                    }
+                }
+                add_weighted_row(jacobian, raw_residual * weight);
+            }
+
+            for (const auto& factor : problem.single_difference_tdcp_factors) {
+                if (factor.previous_epoch_index >= problem.epochs.size() ||
+                    factor.current_epoch_index >= problem.epochs.size()) {
+                    continue;
+                }
+
+                const int previous_col =
+                    epoch_state_col(factor.previous_epoch_index);
+                const int current_col = epoch_state_col(factor.current_epoch_index);
+                const Vector3d previous_delta =
+                    output.state.segment<3>(previous_col) -
+                    problem.epochs[factor.previous_epoch_index].position_ecef;
+                const Vector3d current_delta =
+                    output.state.segment<3>(current_col) -
+                    problem.epochs[factor.current_epoch_index].position_ecef;
+                const double predicted =
+                    factor.los.dot(current_delta) -
+                    factor.previous_los.dot(previous_delta);
+                const double sigma = std::max(1e-4, factor.sigma_m);
+                const double raw_residual = factor.delta_carrier_m - predicted;
+                const double scale =
+                    robust_scale(raw_residual / sigma,
+                                 config_.tdcp_huber_threshold_sigma);
+                const double weight = scale / sigma;
+
+                std::vector<std::pair<int, double>> jacobian;
+                jacobian.reserve(6);
+                for (int axis = 0; axis < 3; ++axis) {
+                    jacobian.emplace_back(previous_col + axis,
+                                          -factor.previous_los(axis) * weight);
+                    jacobian.emplace_back(current_col + axis,
+                                          factor.los(axis) * weight);
+                }
+                add_weighted_row(jacobian, raw_residual * weight);
+            }
+
+            const bool use_velocity_motion =
+                config_.use_velocity_motion_factors && use_velocity_states;
+            if ((config_.use_motion_factors || use_velocity_motion) &&
+                num_epochs >= 2) {
+                const double motion_sigma = std::max(1e-3, config_.motion_sigma_m);
+                const double clock_motion_sigma =
+                    std::max(1e-3, config_.clock_motion_sigma_m);
+                const double velocity_motion_sigma =
+                    std::max(1e-6, config_.velocity_motion_sigma_m);
+                for (int i = 1; i < num_epochs; ++i) {
+                    const int prev_col =
+                        epoch_state_col(static_cast<std::size_t>(i - 1));
+                    const int curr_col =
+                        epoch_state_col(static_cast<std::size_t>(i));
+                    const double dt = std::max(
+                        1.0,
+                        std::abs(problem.epochs[i].time - problem.epochs[i - 1].time));
+                    const double pos_weight = 1.0 / (motion_sigma * dt);
+                    const bool clock_jump =
+                        static_cast<std::size_t>(i) < problem.clock_jumps.size() &&
+                        problem.clock_jumps[static_cast<std::size_t>(i)];
+                    const double epoch_clock_motion_sigma =
+                        clock_jump ? 1e6 : clock_motion_sigma;
+                    const double clock_weight =
+                        1.0 / (epoch_clock_motion_sigma * dt);
+
+                    if (config_.use_motion_factors &&
+                        config_.use_position_motion_factors) {
+                        for (int axis = 0; axis < 3; ++axis) {
+                            const double weighted_residual =
+                                -(output.state(curr_col + axis) -
+                                  output.state(prev_col + axis)) *
+                                pos_weight;
+                            add_weighted_row(
+                                {{prev_col + axis, -pos_weight},
+                                 {curr_col + axis, pos_weight}},
+                                weighted_residual);
+                        }
+                    }
+
+                    if (config_.use_motion_factors &&
+                        config_.use_clock_motion_factors) {
+                        const double weighted_clock_residual =
+                            -(output.state(curr_col + 3) -
+                              output.state(prev_col + 3)) *
+                            clock_weight;
+                        add_weighted_row(
+                            {{prev_col + 3, -clock_weight},
+                             {curr_col + 3, clock_weight}},
+                            weighted_clock_residual);
+
+                        for (int bias_offset = 4; bias_offset < epoch_state_size;
+                             ++bias_offset) {
+                            const double weighted_bias_residual =
+                                -(output.state(curr_col + bias_offset) -
+                                  output.state(prev_col + bias_offset)) *
+                                clock_weight;
+                            add_weighted_row(
+                                {{prev_col + bias_offset, -clock_weight},
+                                 {curr_col + bias_offset, clock_weight}},
+                                weighted_bias_residual);
+                        }
+                    }
+
+                    if (use_velocity_motion) {
+                        const int prev_velocity_col =
+                            velocity_state_col(static_cast<std::size_t>(i - 1));
+                        const int curr_velocity_col =
+                            velocity_state_col(static_cast<std::size_t>(i));
+                        const double weight = 1.0 / velocity_motion_sigma;
+                        for (int axis = 0; axis < 3; ++axis) {
+                            const double predicted =
+                                output.state(curr_col + axis) -
+                                output.state(prev_col + axis) -
+                                0.5 * dt *
+                                    (output.state(prev_velocity_col + axis) +
+                                     output.state(curr_velocity_col + axis));
+                            add_weighted_row(
+                                {{prev_col + axis, -weight},
+                                 {curr_col + axis, weight},
+                                 {prev_velocity_col + axis, -0.5 * dt * weight},
+                                 {curr_velocity_col + axis, -0.5 * dt * weight}},
+                                -predicted * weight);
+                        }
+                    }
+                }
+            }
+
+            if (config_.use_ambiguity_priors && config_.ambiguity_prior_sigma_m > 0.0) {
+                const double ambiguity_prior_sigma =
+                    std::max(1e-3, config_.ambiguity_prior_sigma_m);
+                const double ambiguity_prior_weight = 1.0 / ambiguity_prior_sigma;
+                for (int i = 0; i < ambiguity_count; ++i) {
+                    const int ambiguity_col = base_state_size + i;
+                    const double weighted_residual =
+                        (problem.ambiguity_states[i].initial_ambiguity_m -
+                         output.state(ambiguity_col)) *
+                        ambiguity_prior_weight;
+                    add_weighted_row(
+                        {{ambiguity_col, ambiguity_prior_weight}},
+                        weighted_residual);
+                }
+            }
+
+            if (!fixed_constraints.empty()) {
+                const double fixed_sigma =
+                    std::max(1e-5, config_.fixed_ambiguity_sigma_m);
+                const double fixed_weight = 1.0 / fixed_sigma;
+                for (const auto& fixed : fixed_constraints) {
+                    if (fixed.ambiguity_index >= problem.ambiguity_states.size()) {
+                        continue;
+                    }
+                    const int ambiguity_col =
+                        base_state_size + static_cast<int>(fixed.ambiguity_index);
+                    const double weighted_residual =
+                        (fixed.fixed_ambiguity_m - output.state(ambiguity_col)) *
+                        fixed_weight;
+                    add_weighted_row({{ambiguity_col, fixed_weight}},
+                                     weighted_residual);
+                }
+            }
+
+            if (row == 0) {
+                return output;
+            }
+
+            Eigen::VectorXd dx;
+            bool solved = false;
+            Eigen::SparseMatrix<double> current_sparse_normal;
+            auto store_current_linearization = [&]() {
+                output.final_cost = weighted_residual_square_sum;
+                if (!use_sparse_normal) {
+                    output.normal_matrix = normal_matrix;
+                }
+                output.robust_pseudorange_factors = robust_pseudorange_count;
+                output.robust_carrier_phase_factors = robust_carrier_phase_count;
+                output.robust_double_difference_pseudorange_factors =
+                    robust_double_difference_pseudorange_count;
+                output.robust_double_difference_carrier_factors =
+                    robust_double_difference_carrier_count;
+                output.robust_tdcp_factors = robust_tdcp_count;
+            };
+            auto cost_converged = [&]() {
+                if (iter == 0 || !std::isfinite(previous_cost) ||
+                    !std::isfinite(weighted_residual_square_sum)) {
+                    return false;
+                }
+                const double absolute_decrease =
+                    previous_cost - weighted_residual_square_sum;
+                if (absolute_decrease < 0.0) {
+                    return false;
+                }
+                const double relative_decrease =
+                    previous_cost > 0.0
+                        ? absolute_decrease / previous_cost
+                        : absolute_decrease;
+                return (config_.absolute_cost_convergence_threshold > 0.0 &&
+                        absolute_decrease <
+                            config_.absolute_cost_convergence_threshold) ||
+                       (config_.relative_cost_convergence_threshold > 0.0 &&
+                        relative_decrease <
+                            config_.relative_cost_convergence_threshold);
+            };
+            if (use_sparse_normal) {
+                Eigen::SparseMatrix<double> sparse_normal(state_size, state_size);
+                sparse_normal.setFromTriplets(
+                    normal_triplets.begin(), normal_triplets.end());
+                sparse_normal.makeCompressed();
+                if (cost_converged()) {
+                    store_current_linearization();
+                    if (config_.collect_lambda_debug ||
+                        config_.use_epoch_lambda_fixed_output) {
+                        output.sparse_normal_matrix = std::move(sparse_normal);
+                    }
+                    output.iterations = iter;
+                    output.converged = true;
+                    break;
+                }
+
+                double max_diagonal = 0.0;
+                for (int i = 0; i < state_size; ++i) {
+                    max_diagonal =
+                        std::max(max_diagonal, std::abs(sparse_normal.coeff(i, i)));
+                }
+                double damping = std::max(1e-12, max_diagonal * 1e-12);
+                for (int attempt = 0; attempt < 6; ++attempt) {
+                    Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> ldlt;
+                    ldlt.setShift(damping);
+                    ldlt.compute(sparse_normal);
+                    if (ldlt.info() == Eigen::Success) {
+                        dx = ldlt.solve(normal_rhs);
+                        if (ldlt.info() == Eigen::Success && dx.allFinite()) {
+                            solved = true;
+                            break;
+                        }
+                    }
+                    damping *= 10.0;
+                }
+                if (config_.collect_lambda_debug ||
+                    config_.use_epoch_lambda_fixed_output) {
+                    current_sparse_normal = std::move(sparse_normal);
+                }
+            } else {
+                if (cost_converged()) {
+                    store_current_linearization();
+                    output.iterations = iter;
+                    output.converged = true;
+                    break;
+                }
+                const double max_diagonal =
+                    normal_matrix.diagonal().cwiseAbs().maxCoeff();
+                double damping = std::max(1e-12, max_diagonal * 1e-12);
+                for (int attempt = 0; attempt < 6; ++attempt) {
+                    Eigen::MatrixXd damped_normal = normal_matrix;
+                    damped_normal.diagonal().array() += damping;
+                    Eigen::LDLT<Eigen::MatrixXd> ldlt(damped_normal);
+                    if (ldlt.info() == Eigen::Success) {
+                        dx = ldlt.solve(normal_rhs);
+                        if (dx.allFinite()) {
+                            solved = true;
+                            break;
+                        }
+                    }
+                    damping *= 10.0;
+                }
+            }
+
+            if (!solved) {
+                break;
+            }
+
+            output.state += dx;
+            output.last_dx_norm = dx.norm();
+            output.iterations = iter + 1;
+            store_current_linearization();
+            if (use_sparse_normal &&
+                (config_.collect_lambda_debug ||
+                 config_.use_epoch_lambda_fixed_output)) {
+                output.sparse_normal_matrix = std::move(current_sparse_normal);
+            }
+            previous_cost = weighted_residual_square_sum;
+
+            if (output.last_dx_norm < config_.convergence_threshold_m) {
+                output.converged = true;
+                break;
+            }
+        }
+
+        const auto end_time = std::chrono::high_resolution_clock::now();
+        output.processing_ms =
+            std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(
+                end_time - start_time)
+                .count();
+        return output;
+    };
+
+    OptimizationOutput optimization = run_optimizer(initial_state, {});
+    int total_iterations = optimization.iterations;
+    double total_processing_ms = optimization.processing_ms;
+    std::vector<FixedAmbiguityConstraint> fixed_constraints;
+    const bool has_ambiguity_measurements =
+        !problem.carrier_phase_factors.empty() ||
+        !problem.double_difference_carrier_factors.empty();
+    if (config_.fix_ambiguities &&
+        ambiguity_count > 0 &&
+        has_ambiguity_measurements) {
+        const double max_fractional =
+            std::max(0.0, config_.ambiguity_fix_max_fractional_cycles);
+        double fixed_residual_square_sum = 0.0;
+        const bool has_double_difference_ambiguities =
+            std::any_of(problem.ambiguity_states.begin(),
+                        problem.ambiguity_states.end(),
+                        [](const AmbiguityState& ambiguity) {
+                            return ambiguity.is_double_difference;
+                        });
+        auto is_fix_candidate = [&](const AmbiguityState& ambiguity) -> bool {
+            if (config_.prefer_double_difference_ambiguity_fixing &&
+                has_double_difference_ambiguities) {
+                return ambiguity.is_double_difference;
+            }
+            return true;
+        };
+
+        auto build_nearest_integer_constraints = [&]() {
+            fixed_constraints.clear();
+            fixed_residual_square_sum = 0.0;
+            for (int i = 0; i < ambiguity_count; ++i) {
+                const auto& ambiguity = problem.ambiguity_states[i];
+                if (ambiguity.wavelength_m <= 0.0 || !is_fix_candidate(ambiguity)) {
+                    continue;
+                }
+
+                const double ambiguity_m = optimization.state(base_state_size + i);
+                const double ambiguity_cycles = ambiguity_m / ambiguity.wavelength_m;
+                if (!std::isfinite(ambiguity_cycles)) {
+                    continue;
+                }
+
+                ++result.diagnostics.ambiguity_fix_candidates;
+                const double fixed_cycles_d = std::round(ambiguity_cycles);
+                const double residual_cycles = ambiguity_cycles - fixed_cycles_d;
+                if (std::abs(residual_cycles) > max_fractional) {
+                    continue;
+                }
+
+                FixedAmbiguityConstraint fixed;
+                fixed.ambiguity_index = static_cast<std::size_t>(i);
+                fixed.fixed_cycles = static_cast<int>(fixed_cycles_d);
+                fixed.fixed_ambiguity_m = fixed_cycles_d * ambiguity.wavelength_m;
+                fixed.residual_cycles = residual_cycles;
+                fixed_constraints.push_back(fixed);
+                fixed_residual_square_sum += residual_cycles * residual_cycles;
+            }
+        };
+
+        auto build_lambda_constraints = [&]() -> bool {
+            if (!config_.use_lambda_ambiguity_fix ||
+                optimization.normal_matrix.rows() != state_size) {
+                return false;
+            }
+
+            const Eigen::MatrixXd float_covariance =
+                pseudoInverse(optimization.normal_matrix);
+            if (float_covariance.rows() != state_size) {
+                return false;
+            }
+
+            struct LambdaCandidate {
+                int ambiguity_index = 0;
+                double variance_cycles = 0.0;
+                double fractional_cycles = 0.0;
+            };
+
+            std::vector<LambdaCandidate> candidates;
+            candidates.reserve(problem.ambiguity_states.size());
+            for (int i = 0; i < ambiguity_count; ++i) {
+                const auto& ambiguity = problem.ambiguity_states[i];
+                if (ambiguity.wavelength_m <= 0.0 || !is_fix_candidate(ambiguity)) {
+                    continue;
+                }
+
+                const int col = base_state_size + i;
+                const double variance_m2 = float_covariance(col, col);
+                const double variance_cycles =
+                    variance_m2 / (ambiguity.wavelength_m * ambiguity.wavelength_m);
+                const double ambiguity_cycles =
+                    optimization.state(col) / ambiguity.wavelength_m;
+                if (!std::isfinite(variance_cycles) || variance_cycles <= 0.0 ||
+                    !std::isfinite(ambiguity_cycles)) {
+                    continue;
+                }
+
+                const double nearest_cycles = std::round(ambiguity_cycles);
+                LambdaCandidate candidate;
+                candidate.ambiguity_index = i;
+                candidate.variance_cycles = variance_cycles;
+                candidate.fractional_cycles = std::abs(ambiguity_cycles - nearest_cycles);
+                candidates.push_back(candidate);
+            }
+
+            std::stable_sort(candidates.begin(),
+                             candidates.end(),
+                             [](const LambdaCandidate& lhs,
+                                const LambdaCandidate& rhs) {
+                                 if (lhs.fractional_cycles == rhs.fractional_cycles) {
+                                     return lhs.variance_cycles < rhs.variance_cycles;
+                                 }
+                                 return lhs.fractional_cycles < rhs.fractional_cycles;
+                             });
+
+            const int max_lambda_ambiguities =
+                std::max(0, config_.max_lambda_ambiguities);
+            if (max_lambda_ambiguities > 0 &&
+                static_cast<int>(candidates.size()) > max_lambda_ambiguities) {
+                candidates.resize(static_cast<std::size_t>(max_lambda_ambiguities));
+            }
+
+            result.diagnostics.lambda_ambiguity_candidates = candidates.size();
+            result.diagnostics.ambiguity_fix_candidates = candidates.size();
+            const int min_fixed_ambiguities = std::max(1, config_.min_fixed_ambiguities);
+            if (static_cast<int>(candidates.size()) < min_fixed_ambiguities) {
+                return false;
+            }
+
+            auto solve_candidate_subset = [&](std::size_t subset_size) -> bool {
+                const int n = static_cast<int>(subset_size);
+                Eigen::VectorXd float_ambiguities = Eigen::VectorXd::Zero(n);
+                Eigen::MatrixXd ambiguity_covariance = Eigen::MatrixXd::Zero(n, n);
+                for (int row = 0; row < n; ++row) {
+                    const int ambiguity_row = candidates[row].ambiguity_index;
+                    const auto& row_state = problem.ambiguity_states[ambiguity_row];
+                    const int row_col = base_state_size + ambiguity_row;
+                    float_ambiguities(row) =
+                        optimization.state(row_col) / row_state.wavelength_m;
+                    for (int col = 0; col < n; ++col) {
+                        const int ambiguity_col = candidates[col].ambiguity_index;
+                        const auto& col_state = problem.ambiguity_states[ambiguity_col];
+                        const int state_col = base_state_size + ambiguity_col;
+                        ambiguity_covariance(row, col) =
+                            float_covariance(row_col, state_col) /
+                            (row_state.wavelength_m * col_state.wavelength_m);
+                    }
+                }
+
+                ambiguity_covariance =
+                    0.5 * (ambiguity_covariance + ambiguity_covariance.transpose());
+                for (int i = 0; i < n; ++i) {
+                    const double diagonal = std::abs(ambiguity_covariance(i, i));
+                    ambiguity_covariance(i, i) += std::max(1e-12, diagonal * 1e-9);
+                }
+
+                Eigen::VectorXd fixed_ambiguities;
+                double lambda_ratio = 0.0;
+                ++result.diagnostics.lambda_ambiguity_attempts;
+                const bool lambda_solved =
+                    lambdaSearch(float_ambiguities,
+                                 ambiguity_covariance,
+                                 fixed_ambiguities,
+                                 lambda_ratio);
+                if (lambda_solved) {
+                    result.diagnostics.lambda_ambiguity_fix_solved = true;
+                }
+                if (lambda_solved && std::isfinite(lambda_ratio)) {
+                    result.diagnostics.lambda_ambiguity_ratio =
+                        std::max(result.diagnostics.lambda_ambiguity_ratio,
+                                 lambda_ratio);
+                }
+                if (!lambda_solved || !std::isfinite(lambda_ratio) ||
+                    (config_.lambda_ratio_threshold > 0.0 &&
+                     lambda_ratio < config_.lambda_ratio_threshold)) {
+                    return false;
+                }
+
+                std::vector<FixedAmbiguityConstraint> lambda_constraints;
+                lambda_constraints.reserve(subset_size);
+                double lambda_residual_square_sum = 0.0;
+                for (int i = 0; i < n; ++i) {
+                    const int ambiguity_index = candidates[i].ambiguity_index;
+                    const auto& ambiguity = problem.ambiguity_states[ambiguity_index];
+                    const double fixed_cycles_d = std::round(fixed_ambiguities(i));
+                    const double residual_cycles = float_ambiguities(i) - fixed_cycles_d;
+
+                    FixedAmbiguityConstraint fixed;
+                    fixed.ambiguity_index = static_cast<std::size_t>(ambiguity_index);
+                    fixed.fixed_cycles = static_cast<int>(fixed_cycles_d);
+                    fixed.fixed_ambiguity_m = fixed_cycles_d * ambiguity.wavelength_m;
+                    fixed.residual_cycles = residual_cycles;
+                    fixed.fixed_by_lambda = true;
+                    lambda_constraints.push_back(fixed);
+                    lambda_residual_square_sum += residual_cycles * residual_cycles;
+                }
+
+                if (static_cast<int>(lambda_constraints.size()) <
+                    min_fixed_ambiguities) {
+                    return false;
+                }
+
+                fixed_constraints = std::move(lambda_constraints);
+                fixed_residual_square_sum = lambda_residual_square_sum;
+                result.diagnostics.lambda_ambiguity_fix_used = true;
+                result.diagnostics.partial_lambda_ambiguity_fix_used =
+                    subset_size < candidates.size();
+                result.diagnostics.lambda_ambiguity_used_candidates = subset_size;
+                result.diagnostics.lambda_ambiguity_ratio = lambda_ratio;
+                return true;
+            };
+
+            const std::size_t min_subset_size =
+                static_cast<std::size_t>(min_fixed_ambiguities);
+            for (std::size_t subset_size = candidates.size();
+                 subset_size >= min_subset_size;
+                 --subset_size) {
+                if (solve_candidate_subset(subset_size)) {
+                    return true;
+                }
+                if (!config_.use_partial_lambda_ambiguity_fix ||
+                    subset_size == min_subset_size) {
+                    break;
+                }
+            }
+
+            return false;
+        };
+
+        const bool can_attempt_lambda =
+            config_.use_lambda_ambiguity_fix &&
+            optimization.normal_matrix.rows() == state_size;
+        const bool lambda_constraints_built =
+            can_attempt_lambda && build_lambda_constraints();
+        if (!lambda_constraints_built &&
+            (!config_.use_lambda_ambiguity_fix || !can_attempt_lambda)) {
+            build_nearest_integer_constraints();
+        }
+
+        if (static_cast<int>(fixed_constraints.size()) >=
+            std::max(1, config_.min_fixed_ambiguities)) {
+            OptimizationOutput fixed_optimization =
+                run_optimizer(optimization.state, fixed_constraints);
+            total_iterations += fixed_optimization.iterations;
+            total_processing_ms += fixed_optimization.processing_ms;
+            optimization = std::move(fixed_optimization);
+            result.diagnostics.fixed_solution = true;
+            result.diagnostics.fixed_ambiguities = fixed_constraints.size();
+            result.diagnostics.fixed_ambiguity_residual_rms_cycles =
+                std::sqrt(fixed_residual_square_sum /
+                          static_cast<double>(fixed_constraints.size()));
+        } else {
+            fixed_constraints.clear();
+        }
+    }
+
+    const Eigen::VectorXd& state = optimization.state;
+    result.diagnostics.iterations = total_iterations;
+    result.diagnostics.final_cost = optimization.final_cost;
+    result.diagnostics.converged = optimization.converged;
+    if (!result.diagnostics.converged &&
+        std::isfinite(optimization.last_dx_norm) &&
+        optimization.last_dx_norm < config_.convergence_threshold_m) {
+        result.diagnostics.converged = true;
+    }
+    const double processing_ms = total_processing_ms;
+    result.diagnostics.processing_time_ms = processing_ms;
+    result.diagnostics.last_update_norm_m =
+        std::isfinite(optimization.last_dx_norm) ? optimization.last_dx_norm : 0.0;
+
+    Eigen::MatrixXd covariance;
+    if (optimization.normal_matrix.rows() == state_size) {
+        covariance = pseudoInverse(optimization.normal_matrix);
+    }
+
+    std::vector<Vector3d> epoch_output_positions(
+        static_cast<std::size_t>(num_epochs),
+        Vector3d::Zero());
+    std::vector<bool> epoch_lambda_fixed_output(
+        static_cast<std::size_t>(num_epochs),
+        false);
+    std::vector<double> epoch_lambda_ratios(
+        static_cast<std::size_t>(num_epochs),
+        0.0);
+    std::vector<int> epoch_fixed_ambiguity_counts(
+        static_cast<std::size_t>(num_epochs),
+        0);
+    for (int i = 0; i < num_epochs; ++i) {
+        epoch_output_positions[static_cast<std::size_t>(i)] =
+            state.segment<3>(epoch_state_col(static_cast<std::size_t>(i)));
+    }
+    std::size_t epoch_lambda_fixed_solution_count = 0;
+    std::size_t epoch_lambda_fixed_ambiguity_total = 0;
+
+    const bool compute_epoch_lambda =
+        (config_.collect_lambda_debug ||
+         config_.use_epoch_lambda_fixed_output) &&
+        ambiguity_count > 0;
+    const auto epoch_lambda_start =
+        std::chrono::high_resolution_clock::now();
+    if (compute_epoch_lambda) {
+        const auto elapsed_ms = [](const auto& start, const auto& end) {
+            return std::chrono::duration_cast<
+                       std::chrono::duration<double, std::milli>>(end - start)
+                .count();
+        };
+        const auto setup_start = std::chrono::high_resolution_clock::now();
+        std::map<std::size_t, std::set<std::size_t>> ambiguity_indices_by_epoch;
+        for (const auto& factor : problem.double_difference_carrier_factors) {
+            if (factor.epoch_index < problem.epochs.size() &&
+                factor.ambiguity_index < problem.ambiguity_states.size()) {
+                ambiguity_indices_by_epoch[factor.epoch_index].insert(
+                    factor.ambiguity_index);
+            }
+        }
+
+        const int min_lambda_debug_candidates =
+            std::max(6, std::max(1, config_.min_fixed_ambiguities + 1));
+        struct EpochLambdaWork {
+            std::size_t epoch_index = 0;
+            std::vector<std::size_t> candidate_indices;
+            std::vector<int> state_columns;
+            int epoch_col = 0;
+            int candidate_count = 0;
+        };
+        std::vector<EpochLambdaWork> epoch_lambda_work;
+        epoch_lambda_work.reserve(ambiguity_indices_by_epoch.size());
+        for (const auto& [epoch_index, ambiguity_set] :
+             ambiguity_indices_by_epoch) {
+            if (static_cast<int>(ambiguity_set.size()) <
+                min_lambda_debug_candidates) {
+                continue;
+            }
+
+            EpochLambdaWork work;
+            work.epoch_index = epoch_index;
+            work.candidate_indices.assign(ambiguity_set.begin(),
+                                          ambiguity_set.end());
+            std::sort(
+                work.candidate_indices.begin(),
+                work.candidate_indices.end(),
+                [&](std::size_t lhs, std::size_t rhs) {
+                    const auto& lhs_ambiguity = problem.ambiguity_states[lhs];
+                    const auto& rhs_ambiguity = problem.ambiguity_states[rhs];
+                    return std::tie(lhs_ambiguity.satellite,
+                                    lhs_ambiguity.reference_satellite,
+                                    lhs_ambiguity.signal,
+                                    lhs) <
+                           std::tie(rhs_ambiguity.satellite,
+                                    rhs_ambiguity.reference_satellite,
+                                    rhs_ambiguity.signal,
+                                    rhs);
+                });
+
+            work.candidate_count =
+                static_cast<int>(work.candidate_indices.size());
+            work.state_columns.reserve(
+                static_cast<std::size_t>(work.candidate_count));
+            for (const std::size_t ambiguity_index : work.candidate_indices) {
+                work.state_columns.push_back(
+                    base_state_size + static_cast<int>(ambiguity_index));
+            }
+            work.epoch_col = epoch_state_col(epoch_index);
+            epoch_lambda_work.push_back(std::move(work));
+        }
+
+        if (config_.collect_lambda_debug) {
+            std::size_t lambda_debug_capacity = 0;
+            for (const auto& work : epoch_lambda_work) {
+                lambda_debug_capacity +=
+                    static_cast<std::size_t>(work.candidate_count) *
+                    static_cast<std::size_t>(work.candidate_count);
+            }
+            result.lambda_debug_entries.reserve(lambda_debug_capacity);
+        }
+        result.diagnostics.epoch_lambda_setup_time_ms += elapsed_ms(
+            setup_start, std::chrono::high_resolution_clock::now());
+
+#ifdef GNSSPP_HAS_CHOLMOD
+        Eigen::CholmodSupernodalLLT<Eigen::SparseMatrix<double>>
+            sparse_covariance_ldlt;
+#else
+        Eigen::SimplicialLLT<Eigen::SparseMatrix<double>> sparse_covariance_ldlt;
+#endif
+        bool has_sparse_covariance_solver = false;
+        if (!epoch_lambda_work.empty() &&
+            covariance.rows() != state_size &&
+            optimization.sparse_normal_matrix.rows() == state_size) {
+            const auto factorization_start =
+                std::chrono::high_resolution_clock::now();
+            double max_diagonal = 0.0;
+            for (int i = 0; i < state_size; ++i) {
+                max_diagonal =
+                    std::max(max_diagonal,
+                             std::abs(optimization.sparse_normal_matrix.coeff(i, i)));
+            }
+            const double damping = std::max(1e-12, max_diagonal * 1e-12);
+            sparse_covariance_ldlt.setShift(damping);
+            sparse_covariance_ldlt.compute(optimization.sparse_normal_matrix);
+            has_sparse_covariance_solver =
+                sparse_covariance_ldlt.info() == Eigen::Success;
+            result.diagnostics.epoch_lambda_factorization_time_ms +=
+                elapsed_ms(factorization_start,
+                           std::chrono::high_resolution_clock::now());
+        }
+
+        auto process_epoch_lambda_work =
+            [&](const EpochLambdaWork& work, const auto& covarianceValue) {
+                const std::size_t epoch_index = work.epoch_index;
+                const auto& candidate_indices = work.candidate_indices;
+                const int candidate_count = work.candidate_count;
+                const int epoch_col = work.epoch_col;
+                Eigen::VectorXd ambiguity_float =
+                    Eigen::VectorXd::Zero(candidate_count);
+                Eigen::MatrixXd ambiguity_covariance =
+                    Eigen::MatrixXd::Zero(candidate_count, candidate_count);
+                bool valid_covariance = true;
+                for (int row = 0; row < candidate_count; ++row) {
+                    const auto& row_ambiguity =
+                        problem.ambiguity_states[candidate_indices[row]];
+                    if (row_ambiguity.wavelength_m <= 0.0) {
+                        valid_covariance = false;
+                        break;
+                    }
+                    const int row_col =
+                        work.state_columns[static_cast<std::size_t>(row)];
+                    ambiguity_float(row) =
+                        state(row_col) / row_ambiguity.wavelength_m;
+                    for (int col = 0; col < candidate_count; ++col) {
+                        const auto& col_ambiguity =
+                            problem.ambiguity_states[candidate_indices[col]];
+                        if (col_ambiguity.wavelength_m <= 0.0) {
+                            valid_covariance = false;
+                            break;
+                        }
+                        ambiguity_covariance(row, col) =
+                            covarianceValue(row_col, col) /
+                            (row_ambiguity.wavelength_m *
+                             col_ambiguity.wavelength_m);
+                    }
+                    if (!valid_covariance) {
+                        break;
+                    }
+                }
+                if (!valid_covariance || !ambiguity_float.allFinite() ||
+                    !ambiguity_covariance.allFinite()) {
+                    return;
+                }
+
+                ambiguity_covariance =
+                    0.5 * (ambiguity_covariance +
+                           ambiguity_covariance.transpose());
+                for (int i = 0; i < candidate_count; ++i) {
+                    const double diagonal = std::abs(ambiguity_covariance(i, i));
+                    ambiguity_covariance(i, i) +=
+                        std::max(1e-12, diagonal * 1e-9);
+                }
+
+                Eigen::VectorXd fixed_ambiguities;
+                double lambda_ratio = 0.0;
+                const auto lambda_search_start =
+                    std::chrono::high_resolution_clock::now();
+                const bool lambda_solved =
+                    lambdaSearch(ambiguity_float,
+                                 ambiguity_covariance,
+                                 fixed_ambiguities,
+                                 lambda_ratio);
+                result.diagnostics.epoch_lambda_search_time_ms += elapsed_ms(
+                    lambda_search_start,
+                    std::chrono::high_resolution_clock::now());
+                const bool fixed_epoch =
+                    lambda_solved && std::isfinite(lambda_ratio) &&
+                    (config_.lambda_ratio_threshold <= 0.0 ||
+                     lambda_ratio > config_.lambda_ratio_threshold);
+
+                result.diagnostics.lambda_ambiguity_candidates +=
+                    static_cast<std::size_t>(candidate_count);
+                ++result.diagnostics.lambda_ambiguity_attempts;
+
+                if (lambda_solved) {
+                    result.diagnostics.lambda_ambiguity_fix_solved = true;
+                    result.diagnostics.lambda_ambiguity_ratio =
+                        std::max(result.diagnostics.lambda_ambiguity_ratio,
+                                 lambda_ratio);
+                    epoch_lambda_ratios[epoch_index] = lambda_ratio;
+                }
+
+                if (config_.use_epoch_lambda_fixed_output && fixed_epoch &&
+                    fixed_ambiguities.size() == candidate_count) {
+                    const auto fixed_output_start =
+                        std::chrono::high_resolution_clock::now();
+                    Eigen::MatrixXd position_ambiguity_covariance =
+                        Eigen::MatrixXd::Zero(3, candidate_count);
+                    for (int row = 0; row < candidate_count; ++row) {
+                        const auto& row_ambiguity =
+                            problem.ambiguity_states[candidate_indices[row]];
+                        if (row_ambiguity.wavelength_m <= 0.0) {
+                            valid_covariance = false;
+                            break;
+                        }
+                        position_ambiguity_covariance(0, row) =
+                            covarianceValue(epoch_col, row) /
+                            row_ambiguity.wavelength_m;
+                        position_ambiguity_covariance(1, row) =
+                            covarianceValue(epoch_col + 1, row) /
+                            row_ambiguity.wavelength_m;
+                        position_ambiguity_covariance(2, row) =
+                            covarianceValue(epoch_col + 2, row) /
+                            row_ambiguity.wavelength_m;
+                    }
+                    if (valid_covariance &&
+                        position_ambiguity_covariance.allFinite()) {
+                        Eigen::LDLT<Eigen::MatrixXd> ambiguity_ldlt(
+                            ambiguity_covariance);
+                        if (ambiguity_ldlt.info() == Eigen::Success) {
+                            const Eigen::VectorXd ambiguity_delta =
+                                ambiguity_float - fixed_ambiguities;
+                            const Eigen::VectorXd correction =
+                                ambiguity_ldlt.solve(ambiguity_delta);
+                            if (ambiguity_ldlt.info() == Eigen::Success &&
+                                correction.allFinite()) {
+                                const Vector3d position_delta =
+                                    position_ambiguity_covariance * correction;
+                                if (position_delta.allFinite()) {
+                                    epoch_output_positions[epoch_index] =
+                                        state.segment<3>(epoch_col) -
+                                        position_delta;
+                                    epoch_lambda_fixed_output[epoch_index] = true;
+                                    epoch_fixed_ambiguity_counts[epoch_index] =
+                                        candidate_count;
+                                    ++epoch_lambda_fixed_solution_count;
+                                    epoch_lambda_fixed_ambiguity_total +=
+                                        static_cast<std::size_t>(candidate_count);
+                                    result.diagnostics
+                                        .lambda_ambiguity_used_candidates +=
+                                        static_cast<std::size_t>(candidate_count);
+                                    result.diagnostics
+                                        .lambda_ambiguity_fix_used = true;
+                                }
+                            }
+                        }
+                    }
+                    result.diagnostics.epoch_lambda_fixed_output_time_ms +=
+                        elapsed_ms(fixed_output_start,
+                                   std::chrono::high_resolution_clock::now());
+                }
+
+                if (config_.collect_lambda_debug) {
+                    const auto debug_record_start =
+                        std::chrono::high_resolution_clock::now();
+                    for (int row = 0; row < candidate_count; ++row) {
+                        const std::size_t row_ambiguity_index =
+                            candidate_indices[row];
+                        const auto& row_ambiguity =
+                            problem.ambiguity_states[row_ambiguity_index];
+                        for (int col = 0; col < candidate_count; ++col) {
+                            const auto& col_ambiguity =
+                                problem.ambiguity_states[candidate_indices[col]];
+                            LambdaDebugEntry entry;
+                            entry.epoch_index = epoch_index;
+                            entry.time = problem.epochs[epoch_index].time;
+                            entry.solved = lambda_solved;
+                            entry.fixed_epoch = fixed_epoch;
+                            entry.ratio = lambda_solved ? lambda_ratio : 0.0;
+                            entry.candidate_count = candidate_count;
+                            entry.row = row;
+                            entry.col = col;
+                            entry.local_index = row;
+                            entry.other_local_index = col;
+                            entry.satellite = row_ambiguity.satellite;
+                            entry.other_satellite = col_ambiguity.satellite;
+                            entry.ambiguity_float = ambiguity_float(row);
+                            entry.fixed_ambiguity =
+                                lambda_solved && fixed_ambiguities.size() > row
+                                    ? fixed_ambiguities(row)
+                                    : std::numeric_limits<double>::quiet_NaN();
+                            entry.covariance = ambiguity_covariance(row, col);
+                            entry.position_covariance_x =
+                                covarianceValue(epoch_col, row) /
+                                row_ambiguity.wavelength_m;
+                            entry.position_covariance_y =
+                                covarianceValue(epoch_col + 1, row) /
+                                row_ambiguity.wavelength_m;
+                            entry.position_covariance_z =
+                                covarianceValue(epoch_col + 2, row) /
+                                row_ambiguity.wavelength_m;
+                            result.lambda_debug_entries.push_back(entry);
+                        }
+                    }
+                    result.diagnostics.epoch_lambda_debug_record_time_ms +=
+                        elapsed_ms(debug_record_start,
+                                   std::chrono::high_resolution_clock::now());
+                }
+            };
+
+        if (covariance.rows() == state_size) {
+            for (const auto& work : epoch_lambda_work) {
+                process_epoch_lambda_work(
+                    work,
+                    [&](int row, int column_index) -> double {
+                        return covariance(
+                            row,
+                            work.state_columns[static_cast<std::size_t>(
+                                column_index)]);
+                    });
+            }
+        } else if (has_sparse_covariance_solver) {
+            constexpr int kMaxSparseCovarianceBatchColumns = 64;
+            for (std::size_t begin = 0; begin < epoch_lambda_work.size();) {
+                std::size_t end = begin;
+                int batch_column_count = 0;
+                while (end < epoch_lambda_work.size()) {
+                    const int next_count =
+                        epoch_lambda_work[end].candidate_count;
+                    if (batch_column_count > 0 &&
+                        batch_column_count + next_count >
+                            kMaxSparseCovarianceBatchColumns) {
+                        break;
+                    }
+                    batch_column_count += next_count;
+                    ++end;
+                }
+
+                Eigen::MatrixXd rhs =
+                    Eigen::MatrixXd::Zero(state_size, batch_column_count);
+                int column_offset = 0;
+                for (std::size_t work_index = begin; work_index < end;
+                     ++work_index) {
+                    const auto& work = epoch_lambda_work[work_index];
+                    for (int col = 0; col < work.candidate_count; ++col) {
+                        rhs(work.state_columns[static_cast<std::size_t>(col)],
+                            column_offset + col) = 1.0;
+                    }
+                    column_offset += work.candidate_count;
+                }
+
+                const auto covariance_solve_start =
+                    std::chrono::high_resolution_clock::now();
+                const Eigen::MatrixXd batch_covariance_columns =
+                    sparse_covariance_ldlt.solve(rhs);
+                result.diagnostics.epoch_lambda_covariance_solve_time_ms +=
+                    elapsed_ms(covariance_solve_start,
+                               std::chrono::high_resolution_clock::now());
+                if (sparse_covariance_ldlt.info() != Eigen::Success ||
+                    batch_covariance_columns.cols() != batch_column_count) {
+                    begin = end;
+                    continue;
+                }
+
+                column_offset = 0;
+                for (std::size_t work_index = begin; work_index < end;
+                     ++work_index) {
+                    const auto& work = epoch_lambda_work[work_index];
+                    const int work_column_offset = column_offset;
+                    process_epoch_lambda_work(
+                        work,
+                        [&](int row, int column_index) -> double {
+                            return batch_covariance_columns(
+                                row, work_column_offset + column_index);
+                        });
+                    column_offset += work.candidate_count;
+                }
+
+                begin = end;
+            }
+        }
+    }
+    if (compute_epoch_lambda) {
+        const auto epoch_lambda_end =
+            std::chrono::high_resolution_clock::now();
+        result.diagnostics.epoch_lambda_processing_time_ms =
+            std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(
+                epoch_lambda_end - epoch_lambda_start)
+                .count();
+    }
+
+    const bool has_epoch_lambda_fixed_outputs =
+        epoch_lambda_fixed_solution_count > 0;
+    if (has_epoch_lambda_fixed_outputs) {
+        result.diagnostics.fixed_solution = true;
+        result.diagnostics.fixed_ambiguities =
+            epoch_lambda_fixed_ambiguity_total;
+    }
+
+    const std::size_t rows_per_motion_pair = motion_rows_per_pair();
+    result.diagnostics.motion_factors =
+        rows_per_motion_pair > 0
+            ? motion_factor_count() / rows_per_motion_pair
+            : 0;
+    const std::size_t position_prior_factors =
+        config_.position_prior_sigma_m > 0.0
+            ? static_cast<std::size_t>(num_epochs)
+            : 0;
+    const std::size_t clock_prior_factors =
+        config_.clock_prior_sigma_m > 0.0
+            ? static_cast<std::size_t>(num_epochs)
+            : 0;
+    const std::size_t velocity_prior_factors =
+        use_velocity_states && config_.velocity_prior_sigma_mps > 0.0
+            ? static_cast<std::size_t>(num_epochs)
+            : 0;
+    const std::size_t ambiguity_prior_factors =
+        config_.use_ambiguity_priors && config_.ambiguity_prior_sigma_m > 0.0
+            ? problem.ambiguity_states.size()
+            : 0;
+    result.diagnostics.graph_factors =
+        result.diagnostics.pseudorange_factors +
+        result.diagnostics.tdcp_factors +
+        result.diagnostics.single_difference_doppler_factors +
+        result.diagnostics.single_difference_tdcp_factors +
+        result.diagnostics.carrier_phase_factors +
+        result.diagnostics.double_difference_pseudorange_factors +
+        result.diagnostics.double_difference_carrier_factors +
+        result.diagnostics.ambiguity_between_factors +
+        result.diagnostics.motion_factors +
+        position_prior_factors +
+        clock_prior_factors +
+        velocity_prior_factors +
+        ambiguity_prior_factors +
+        fixed_constraints.size();
+    result.diagnostics.graph_values =
+        static_cast<std::size_t>(state_size);
+    result.diagnostics.robust_pseudorange_factors =
+        optimization.robust_pseudorange_factors;
+    result.diagnostics.robust_carrier_phase_factors =
+        optimization.robust_carrier_phase_factors;
+    result.diagnostics.robust_double_difference_pseudorange_factors =
+        optimization.robust_double_difference_pseudorange_factors;
+    result.diagnostics.robust_double_difference_carrier_factors =
+        optimization.robust_double_difference_carrier_factors;
+    result.diagnostics.robust_tdcp_factors = optimization.robust_tdcp_factors;
+    result.ambiguity_estimates.reserve(problem.ambiguity_states.size());
+    for (std::size_t i = 0; i < problem.ambiguity_states.size(); ++i) {
+        const auto& ambiguity = problem.ambiguity_states[i];
+        AmbiguityEstimate estimate;
+        estimate.satellite = ambiguity.satellite;
+        estimate.signal = ambiguity.signal;
+        estimate.segment_index = ambiguity.segment_index;
+        estimate.wavelength_m = ambiguity.wavelength_m;
+        estimate.ambiguity_m = state(base_state_size + static_cast<int>(i));
+        if (ambiguity.wavelength_m > 0.0) {
+            estimate.ambiguity_cycles = estimate.ambiguity_m / ambiguity.wavelength_m;
+        }
+        const auto fixed_it =
+            std::find_if(fixed_constraints.begin(),
+                         fixed_constraints.end(),
+                         [i](const FixedAmbiguityConstraint& fixed) {
+                             return fixed.ambiguity_index == i;
+                         });
+        if (fixed_it != fixed_constraints.end()) {
+            estimate.is_fixed = true;
+            estimate.fixed_cycles = fixed_it->fixed_cycles;
+            estimate.fixed_ambiguity_m = fixed_it->fixed_ambiguity_m;
+            estimate.fix_residual_cycles = fixed_it->residual_cycles;
+            estimate.fixed_by_lambda = fixed_it->fixed_by_lambda;
+        }
+        result.ambiguity_estimates.push_back(estimate);
+    }
+
+    std::map<std::size_t, std::vector<const PseudorangeFactor*>> factors_by_epoch;
+    for (const auto& factor : problem.pseudorange_factors) {
+        factors_by_epoch[factor.epoch_index].push_back(&factor);
+    }
+    std::map<std::size_t, std::set<SatelliteId>> dd_satellites_by_epoch;
+    for (const auto& factor : problem.double_difference_pseudorange_factors) {
+        dd_satellites_by_epoch[factor.epoch_index].insert(factor.satellite);
+        dd_satellites_by_epoch[factor.epoch_index].insert(
+            factor.reference_satellite);
+    }
+    for (const auto& factor : problem.double_difference_carrier_factors) {
+        dd_satellites_by_epoch[factor.epoch_index].insert(factor.satellite);
+        dd_satellites_by_epoch[factor.epoch_index].insert(
+            factor.reference_satellite);
+    }
+    std::map<std::size_t, std::size_t> dd_carrier_factors_by_epoch;
+    for (const auto& factor : problem.double_difference_carrier_factors) {
+        ++dd_carrier_factors_by_epoch[factor.epoch_index];
+    }
+
+    double residual_square_sum = 0.0;
+    std::size_t residual_count = 0;
+    double carrier_phase_residual_square_sum = 0.0;
+    std::size_t carrier_phase_residual_count = 0;
+    double double_difference_pseudorange_residual_square_sum = 0.0;
+    std::size_t double_difference_pseudorange_residual_count = 0;
+    double double_difference_carrier_residual_square_sum = 0.0;
+    std::size_t double_difference_carrier_residual_count = 0;
+    double tdcp_residual_square_sum = 0.0;
+    std::size_t tdcp_residual_count = 0;
+    double single_difference_doppler_residual_square_sum = 0.0;
+    std::size_t single_difference_doppler_residual_count = 0;
+    double single_difference_tdcp_residual_square_sum = 0.0;
+    std::size_t single_difference_tdcp_residual_count = 0;
+    const bool has_float_ambiguity_solution =
+        ambiguity_count > 0 && has_ambiguity_measurements;
+    const SolutionStatus fgo_solution_status =
+        result.diagnostics.fixed_solution && !has_epoch_lambda_fixed_outputs
+            ? SolutionStatus::FIXED
+            : (has_float_ambiguity_solution ? SolutionStatus::FLOAT
+                                            : SolutionStatus::SPP);
+
+    if (use_velocity_states) {
+        result.epoch_velocities_ecef_mps.resize(static_cast<std::size_t>(num_epochs));
+    }
+
+    for (int i = 0; i < num_epochs; ++i) {
+        const int epoch_col = epoch_state_col(static_cast<std::size_t>(i));
+        PositionSolution solution;
+        solution.time = problem.epochs[i].time;
+        solution.status = fgo_solution_status;
+        const std::size_t epoch_index = static_cast<std::size_t>(i);
+        if (has_epoch_lambda_fixed_outputs && has_float_ambiguity_solution) {
+            solution.status = epoch_lambda_fixed_output[epoch_index]
+                                  ? SolutionStatus::FIXED
+                                  : SolutionStatus::FLOAT;
+        }
+        solution.position_ecef = epoch_output_positions[epoch_index];
+        solution.receiver_clock_bias =
+            state(epoch_col + 3) / constants::SPEED_OF_LIGHT;
+        solution.num_frequencies = 1;
+        if (has_epoch_lambda_fixed_outputs && has_float_ambiguity_solution) {
+            solution.ratio = epoch_lambda_ratios[epoch_index] > 0.0
+                                 ? epoch_lambda_ratios[epoch_index]
+                                 : 0.0;
+        } else {
+            solution.ratio =
+                epoch_lambda_ratios[epoch_index] > 0.0
+                    ? epoch_lambda_ratios[epoch_index]
+                    : result.diagnostics.lambda_ambiguity_ratio;
+        }
+        solution.num_fixed_ambiguities =
+            has_epoch_lambda_fixed_outputs
+                ? (epoch_lambda_fixed_output[epoch_index]
+                       ? epoch_fixed_ambiguity_counts[epoch_index]
+                       : 0)
+                : static_cast<int>(result.diagnostics.fixed_ambiguities);
+        solution.iterations = result.diagnostics.iterations;
+        solution.processing_time_ms = processing_ms / static_cast<double>(num_epochs);
+        solution.position_covariance = Matrix3d::Identity() * 9999.0;
+
+        double lat = 0.0;
+        double lon = 0.0;
+        double height = 0.0;
+        ecef2geodetic(solution.position_ecef, lat, lon, height);
+        solution.position_geodetic = GeodeticCoord(lat, lon, height);
+
+        const auto epoch_factor_it = factors_by_epoch.find(static_cast<std::size_t>(i));
+        bool has_epoch_pseudorange_solution = false;
+        if (epoch_factor_it != factors_by_epoch.end()) {
+            has_epoch_pseudorange_solution = true;
+            const auto& epoch_factors = epoch_factor_it->second;
+            solution.num_satellites = static_cast<int>(epoch_factors.size());
+            solution.satellites_used.reserve(epoch_factors.size());
+            solution.satellite_elevations.reserve(epoch_factors.size());
+            solution.satellite_residuals.reserve(epoch_factors.size());
+
+            Eigen::MatrixXd geometry = Eigen::MatrixXd::Zero(epoch_factors.size(), 4);
+            for (int j = 0; j < static_cast<int>(epoch_factors.size()); ++j) {
+                const auto& factor = *epoch_factors[j];
+                const Vector3d delta = factor.satellite_position_ecef - solution.position_ecef;
+                const double range = delta.norm();
+                const Vector3d los = delta / range;
+                const int bias_col = system_bias_col(epoch_col, factor.clock_group);
+                double predicted_pseudorange = range + state(epoch_col + 3);
+                if (bias_col >= 0) {
+                    predicted_pseudorange += state(bias_col);
+                }
+                const double pseudorange_residual =
+                    factor.corrected_pseudorange_m - predicted_pseudorange;
+
+                solution.satellites_used.push_back(factor.satellite);
+                solution.satellite_elevations.push_back(factor.elevation_rad);
+                solution.satellite_residuals.push_back(pseudorange_residual);
+                residual_square_sum += pseudorange_residual * pseudorange_residual;
+                ++residual_count;
+
+                geometry(j, 0) = -los(0);
+                geometry(j, 1) = -los(1);
+                geometry(j, 2) = -los(2);
+                geometry(j, 3) = 1.0;
+            }
+
+            solution.residual_rms = std::sqrt(std::accumulate(
+                solution.satellite_residuals.begin(),
+                solution.satellite_residuals.end(),
+                0.0,
+                [](double acc, double residual) {
+                    return acc + residual * residual;
+                }) / static_cast<double>(solution.satellite_residuals.size()));
+
+            if (geometry.rows() >= 4) {
+                const Eigen::MatrixXd q = pseudoInverse(geometry.transpose() * geometry);
+                solution.gdop = std::sqrt(std::max(0.0, q.trace()));
+                solution.pdop = std::sqrt(std::max(0.0, q(0, 0) + q(1, 1) + q(2, 2)));
+                solution.hdop = std::sqrt(std::max(0.0, q(0, 0) + q(1, 1)));
+                solution.vdop = std::sqrt(std::max(0.0, q(2, 2)));
+            }
+        } else {
+            const auto dd_satellite_it =
+                dd_satellites_by_epoch.find(static_cast<std::size_t>(i));
+            if (dd_satellite_it != dd_satellites_by_epoch.end()) {
+                solution.num_satellites =
+                    static_cast<int>(dd_satellite_it->second.size());
+                solution.satellites_used.assign(dd_satellite_it->second.begin(),
+                                                dd_satellite_it->second.end());
+            }
+        }
+
+        if (!has_epoch_pseudorange_solution &&
+            config_.min_output_double_difference_carrier_factors_per_epoch > 0) {
+            const auto dd_carrier_count_it =
+                dd_carrier_factors_by_epoch.find(static_cast<std::size_t>(i));
+            const std::size_t dd_carrier_count =
+                dd_carrier_count_it == dd_carrier_factors_by_epoch.end()
+                    ? 0
+                    : dd_carrier_count_it->second;
+            if (dd_carrier_count <
+                static_cast<std::size_t>(
+                    config_
+                        .min_output_double_difference_carrier_factors_per_epoch)) {
+                solution.status = SolutionStatus::NONE;
+            }
+        }
+
+        if (covariance.rows() == state_size) {
+            solution.position_covariance =
+                covariance.block<3, 3>(epoch_col, epoch_col) *
+                (config_.pseudorange_sigma_m * config_.pseudorange_sigma_m);
+        }
+
+        result.solution.addSolution(solution);
+
+        if (use_velocity_states) {
+            const int velocity_col = velocity_state_col(static_cast<std::size_t>(i));
+            result.epoch_velocities_ecef_mps[static_cast<std::size_t>(i)] =
+                state.segment<3>(velocity_col);
+        }
+    }
+
+    for (const auto& factor : problem.carrier_phase_factors) {
+        if (factor.epoch_index >= problem.epochs.size() ||
+            factor.ambiguity_index >= problem.ambiguity_states.size()) {
+            continue;
+        }
+
+        const int epoch_col = epoch_state_col(factor.epoch_index);
+        const int ambiguity_col = base_state_size + static_cast<int>(factor.ambiguity_index);
+        const Vector3d position = state.segment<3>(epoch_col);
+        const double range = (factor.satellite_position_ecef - position).norm();
+        const int bias_col = system_bias_col(epoch_col, factor.clock_group);
+        double predicted = range + state(epoch_col + 3) + state(ambiguity_col);
+        if (bias_col >= 0) {
+            predicted += state(bias_col);
+        }
+        const double carrier_phase_residual = factor.corrected_carrier_m - predicted;
+        carrier_phase_residual_square_sum +=
+            carrier_phase_residual * carrier_phase_residual;
+        ++carrier_phase_residual_count;
+    }
+
+    for (const auto& factor : problem.double_difference_pseudorange_factors) {
+        if (factor.epoch_index >= problem.epochs.size()) {
+            continue;
+        }
+
+        const int epoch_col = epoch_state_col(factor.epoch_index);
+        const Vector3d position = state.segment<3>(epoch_col);
+        const Vector3d seed_position =
+            problem.epochs[factor.epoch_index].position_ecef;
+        const Vector3d linearization_position =
+            config_.linearize_double_difference_factors_at_seed
+                ? seed_position
+                : position;
+        const DoubleDifferencePrediction dd_prediction =
+            doubleDifferencePredictionAt(linearization_position,
+                                         factor.base_position_ecef,
+                                         factor.rover_satellite_position_ecef,
+                                         factor.rover_reference_position_ecef,
+                                         factor.base_satellite_position_ecef,
+                                         factor.base_reference_position_ecef);
+        if (!dd_prediction.valid) {
+            continue;
+        }
+        double predicted = dd_prediction.geometry_m;
+        if (config_.linearize_double_difference_factors_at_seed) {
+            predicted +=
+                dd_prediction.position_jacobian.dot(position - seed_position);
+        }
+        const double residual =
+            factor.observed_dd_pseudorange_m - predicted;
+        double_difference_pseudorange_residual_square_sum += residual * residual;
+        ++double_difference_pseudorange_residual_count;
+    }
+
+    for (const auto& factor : problem.double_difference_carrier_factors) {
+        if (factor.epoch_index >= problem.epochs.size() ||
+            factor.ambiguity_index >= problem.ambiguity_states.size() ||
+            (factor.use_ambiguity_difference &&
+             factor.reference_ambiguity_index >= problem.ambiguity_states.size())) {
+            continue;
+        }
+
+        const int epoch_col = epoch_state_col(factor.epoch_index);
+        const int ambiguity_col = base_state_size + static_cast<int>(factor.ambiguity_index);
+        const int reference_ambiguity_col =
+            factor.use_ambiguity_difference
+                ? base_state_size +
+                      static_cast<int>(factor.reference_ambiguity_index)
+                : -1;
+        const Vector3d position = state.segment<3>(epoch_col);
+        const Vector3d seed_position =
+            problem.epochs[factor.epoch_index].position_ecef;
+        const Vector3d linearization_position =
+            config_.linearize_double_difference_factors_at_seed
+                ? seed_position
+                : position;
+        const DoubleDifferencePrediction dd_prediction =
+            doubleDifferencePredictionAt(linearization_position,
+                                         factor.base_position_ecef,
+                                         factor.rover_satellite_position_ecef,
+                                         factor.rover_reference_position_ecef,
+                                         factor.base_satellite_position_ecef,
+                                         factor.base_reference_position_ecef);
+        if (!dd_prediction.valid) {
+            continue;
+        }
+        double predicted = dd_prediction.geometry_m + state(ambiguity_col);
+        if (config_.linearize_double_difference_factors_at_seed) {
+            predicted +=
+                dd_prediction.position_jacobian.dot(position - seed_position);
+        }
+        if (factor.use_ambiguity_difference) {
+            predicted -= state(reference_ambiguity_col);
+        }
+        const double residual =
+            factor.observed_dd_carrier_m - predicted;
+        double_difference_carrier_residual_square_sum += residual * residual;
+        ++double_difference_carrier_residual_count;
+    }
+
+    for (const auto& factor : problem.tdcp_factors) {
+        if (factor.previous_epoch_index >= problem.epochs.size() ||
+            factor.current_epoch_index >= problem.epochs.size()) {
+            continue;
+        }
+
+        const int previous_col = epoch_state_col(factor.previous_epoch_index);
+        const int current_col = epoch_state_col(factor.current_epoch_index);
+        const int previous_bias_col =
+            system_bias_col(previous_col, clockBiasGroup(factor.satellite.system));
+        const int current_bias_col =
+            system_bias_col(current_col, clockBiasGroup(factor.satellite.system));
+        const Vector3d previous_position = state.segment<3>(previous_col);
+        const Vector3d current_position = state.segment<3>(current_col);
+        const double previous_range =
+            (factor.previous_satellite_position_ecef - previous_position).norm();
+        const double current_range =
+            (factor.current_satellite_position_ecef - current_position).norm();
+        double predicted =
+            current_range + state(current_col + 3) -
+            previous_range - state(previous_col + 3);
+        if (previous_bias_col >= 0 && current_bias_col >= 0 &&
+            previous_bias_col != current_bias_col) {
+            predicted += state(current_bias_col) - state(previous_bias_col);
+        }
+        const double tdcp_residual = factor.delta_carrier_m - predicted;
+        tdcp_residual_square_sum += tdcp_residual * tdcp_residual;
+        ++tdcp_residual_count;
+    }
+
+    for (const auto& factor : problem.single_difference_doppler_factors) {
+        if (factor.epoch_index >= problem.epochs.size()) {
+            continue;
+        }
+
+        Vector3d velocity = Vector3d::Zero();
+        const int velocity_col = velocity_state_col(factor.epoch_index);
+        if (velocity_col >= 0) {
+            velocity = state.segment<3>(velocity_col);
+        } else {
+            if (factor.epoch_index == 0) {
+                continue;
+            }
+            const std::size_t previous_epoch_index = factor.epoch_index - 1;
+            const double dt =
+                problem.epochs[factor.epoch_index].time -
+                problem.epochs[previous_epoch_index].time;
+            if (dt <= 0.0 ||
+                (config_.max_tdcp_gap_s > 0.0 && dt > config_.max_tdcp_gap_s)) {
+                continue;
+            }
+
+            const int previous_col = epoch_state_col(previous_epoch_index);
+            const int current_col = epoch_state_col(factor.epoch_index);
+            velocity =
+                (state.segment<3>(current_col) -
+                 state.segment<3>(previous_col)) /
+                dt;
+        }
+        const double residual = factor.residual_mps - factor.los.dot(velocity);
+        single_difference_doppler_residual_square_sum += residual * residual;
+        ++single_difference_doppler_residual_count;
+    }
+
+    for (const auto& factor : problem.single_difference_tdcp_factors) {
+        if (factor.previous_epoch_index >= problem.epochs.size() ||
+            factor.current_epoch_index >= problem.epochs.size()) {
+            continue;
+        }
+
+        const int previous_col = epoch_state_col(factor.previous_epoch_index);
+        const int current_col = epoch_state_col(factor.current_epoch_index);
+        const Vector3d previous_delta =
+            state.segment<3>(previous_col) -
+            problem.epochs[factor.previous_epoch_index].position_ecef;
+        const Vector3d current_delta =
+            state.segment<3>(current_col) -
+            problem.epochs[factor.current_epoch_index].position_ecef;
+        const double predicted =
+            factor.los.dot(current_delta) -
+            factor.previous_los.dot(previous_delta);
+        const double residual = factor.delta_carrier_m - predicted;
+        single_difference_tdcp_residual_square_sum += residual * residual;
+        ++single_difference_tdcp_residual_count;
+    }
+
+    if (residual_count > 0) {
+        result.diagnostics.residual_rms_m =
+            std::sqrt(residual_square_sum / static_cast<double>(residual_count));
+    }
+    if (carrier_phase_residual_count > 0) {
+        result.diagnostics.carrier_phase_residual_rms_m =
+            std::sqrt(carrier_phase_residual_square_sum /
+                      static_cast<double>(carrier_phase_residual_count));
+    }
+    if (double_difference_pseudorange_residual_count > 0) {
+        result.diagnostics.double_difference_pseudorange_residual_rms_m =
+            std::sqrt(double_difference_pseudorange_residual_square_sum /
+                      static_cast<double>(
+                          double_difference_pseudorange_residual_count));
+    }
+    if (double_difference_carrier_residual_count > 0) {
+        result.diagnostics.double_difference_carrier_residual_rms_m =
+            std::sqrt(double_difference_carrier_residual_square_sum /
+                      static_cast<double>(double_difference_carrier_residual_count));
+    }
+    if (tdcp_residual_count > 0) {
+        result.diagnostics.tdcp_residual_rms_m =
+            std::sqrt(tdcp_residual_square_sum / static_cast<double>(tdcp_residual_count));
+    }
+    if (single_difference_doppler_residual_count > 0) {
+        result.diagnostics.single_difference_doppler_residual_rms_mps =
+            std::sqrt(single_difference_doppler_residual_square_sum /
+                      static_cast<double>(
+                          single_difference_doppler_residual_count));
+    }
+    if (single_difference_tdcp_residual_count > 0) {
+        result.diagnostics.single_difference_tdcp_residual_rms_m =
+            std::sqrt(single_difference_tdcp_residual_square_sum /
+                      static_cast<double>(
+                          single_difference_tdcp_residual_count));
+    }
+
+    const auto optimize_problem_end =
+        std::chrono::high_resolution_clock::now();
+    result.diagnostics.total_processing_time_ms =
+        std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(
+            optimize_problem_end - optimize_problem_start)
+            .count();
+    result.diagnostics.postprocessing_time_ms =
+        std::max(0.0,
+                 result.diagnostics.total_processing_time_ms -
+                     result.diagnostics.processing_time_ms);
+
+    return result;
+}
+
+}  // namespace libgnss

--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -318,6 +318,10 @@ double solveKepler(double mean_anomaly, double eccentricity) {
     return E;
 }
 
+bool isBeiDouGeoPrn(uint8_t prn) {
+    return prn <= 5 || (prn >= 59 && prn <= 63);
+}
+
 bool computeBroadcastState(const Ephemeris& eph,
                            const GNSSTime& time,
                            Vector3d& pos,
@@ -354,18 +358,18 @@ bool computeBroadcastState(const Ephemeris& eph,
     const double r = a * (1.0 - eph.e * cos_e) + dr;
     const double inclination = eph.i0 + eph.idot * tk + di;
     const double toe_seconds = eph.toes != 0.0 ? eph.toes : eph.toe.tow;
-    const double omega = eph.omega0 + (eph.omega_dot - earth_rotation) * tk
-        - earth_rotation * toe_seconds;
 
     const double x_orb = r * std::cos(u);
     const double y_orb = r * std::sin(u);
 
-    const double cos_omega = std::cos(omega);
-    const double sin_omega = std::sin(omega);
     const double cos_i = std::cos(inclination);
     const double sin_i = std::sin(inclination);
 
-    if (is_beidou && eph.satellite.prn <= 5) {
+    if (is_beidou && isBeiDouGeoPrn(eph.satellite.prn)) {
+        const double omega_geo =
+            eph.omega0 + eph.omega_dot * tk - earth_rotation * toe_seconds;
+        const double cos_omega = std::cos(omega_geo);
+        const double sin_omega = std::sin(omega_geo);
         const double xg = x_orb * cos_omega - y_orb * cos_i * sin_omega;
         const double yg = x_orb * sin_omega + y_orb * cos_i * cos_omega;
         const double zg = y_orb * sin_i;
@@ -377,6 +381,10 @@ bool computeBroadcastState(const Ephemeris& eph,
                  zg * cos_rot * kBeiDouGeoSin5Deg;
         pos(2) = -yg * kBeiDouGeoSin5Deg + zg * kBeiDouGeoCos5Deg;
     } else {
+        const double omega = eph.omega0 + (eph.omega_dot - earth_rotation) * tk
+            - earth_rotation * toe_seconds;
+        const double cos_omega = std::cos(omega);
+        const double sin_omega = std::sin(omega);
         pos(0) = x_orb * cos_omega - y_orb * cos_i * sin_omega;
         pos(1) = x_orb * sin_omega + y_orb * cos_i * cos_omega;
         pos(2) = y_orb * sin_i;

--- a/src/core/solution.cpp
+++ b/src/core/solution.cpp
@@ -3,8 +3,105 @@
 #include <sstream>
 #include <iomanip>
 #include <cmath>
+#include <utility>
 
 namespace libgnss {
+namespace {
+
+constexpr std::size_t kMandatorySolutionColumns = 11;
+
+std::vector<std::string> parseSolutionColumnsHeader(const std::string& line) {
+    const std::string columns_marker = "% Columns:";
+    std::string column_text;
+
+    if (line.rfind(columns_marker, 0) == 0) {
+        column_text = line.substr(columns_marker.size());
+    } else if (!line.empty() && line[0] == '%') {
+        column_text = line.substr(1);
+        std::istringstream probe(column_text);
+        std::string first_column;
+        probe >> first_column;
+        if (first_column != "GPS_Week") {
+            return {};
+        }
+    } else {
+        return {};
+    }
+
+    std::istringstream column_stream(column_text);
+    std::vector<std::string> columns;
+    std::string column;
+    while (column_stream >> column) {
+        columns.push_back(column);
+    }
+    return columns;
+}
+
+int optionalColumnToInt(double value) {
+    return static_cast<int>(std::lround(value));
+}
+
+void applyOptionalSolutionColumns(PositionSolution& sol,
+                                  const std::vector<std::string>& columns,
+                                  const std::vector<double>& values) {
+    if (values.empty()) {
+        return;
+    }
+
+    if (columns.empty()) {
+        sol.ratio = values[0];
+        if (values.size() > 1) {
+            sol.num_fixed_ambiguities = optionalColumnToInt(values[1]);
+        }
+        if (values.size() > 2) {
+            sol.iterations = optionalColumnToInt(values[2]);
+        }
+        return;
+    }
+
+    for (std::size_t offset = 0; offset < values.size(); ++offset) {
+        const std::size_t column_index = kMandatorySolutionColumns + offset;
+        if (column_index >= columns.size()) {
+            continue;
+        }
+
+        const std::string& name = columns[column_index];
+        const double value = values[offset];
+        if (name == "Ratio") {
+            sol.ratio = value;
+        } else if (name == "FixedAmbiguities") {
+            sol.num_fixed_ambiguities = optionalColumnToInt(value);
+        } else if (name == "Iterations" || name == "RTKIter" || name == "RtkIter") {
+            sol.iterations = optionalColumnToInt(value);
+        } else if (name == "Baseline(m)") {
+            sol.baseline_length = value;
+        } else if (name == "RTKObs" || name == "RtkObs") {
+            sol.rtk_update_observations = optionalColumnToInt(value);
+        } else if (name == "RTKPhaseObs" || name == "RtkPhaseObs") {
+            sol.rtk_update_phase_observations = optionalColumnToInt(value);
+        } else if (name == "RTKCodeObs" || name == "RtkCodeObs") {
+            sol.rtk_update_code_observations = optionalColumnToInt(value);
+        } else if (name == "RTKOutliers" || name == "RtkOutliers") {
+            sol.rtk_update_suppressed_outliers = optionalColumnToInt(value);
+        } else if (name == "RTKPrefitRMS(m)") {
+            sol.rtk_update_prefit_residual_rms_m = value;
+        } else if (name == "RTKPrefitMax(m)") {
+            sol.rtk_update_prefit_residual_max_m = value;
+        } else if (name == "RTKPostSuppressRMS(m)") {
+            sol.rtk_update_post_suppression_residual_rms_m = value;
+        } else if (name == "RTKPostSuppressMax(m)") {
+            sol.rtk_update_post_suppression_residual_max_m = value;
+        } else if (name == "RTKUpdateNIS") {
+            sol.rtk_update_normalized_innovation_squared = value;
+        } else if (name == "RTKUpdateNISPerObs") {
+            sol.rtk_update_normalized_innovation_squared_per_observation = value;
+        } else if (name == "RTKUpdateNISRejected") {
+            sol.rtk_update_rejected_by_innovation_gate = optionalColumnToInt(value);
+        }
+    }
+}
+
+} // namespace
 
 double PositionSolution::getHorizontalAccuracy() const {
     // 95% confidence (2-sigma)
@@ -124,7 +221,7 @@ bool Solution::writeToFile(const std::string& filename, const std::string& forma
     // Write header
     file << "% LibGNSS++ Position Solution\n";
     file << "% Format: " << format << "\n";
-    file << "% Columns: GPS_Week GPS_TOW X(m) Y(m) Z(m) Lat(deg) Lon(deg) Height(m) Status Satellites PDOP\n";
+    file << "% Columns: GPS_Week GPS_TOW X(m) Y(m) Z(m) Lat(deg) Lon(deg) Height(m) Status Satellites PDOP Ratio FixedAmbiguities Iterations\n";
     
     for (const auto& sol : solutions) {
         file << std::fixed << std::setprecision(6);
@@ -135,7 +232,10 @@ bool Solution::writeToFile(const std::string& filename, const std::string& forma
         file << sol.position_geodetic.height << " ";
         file << static_cast<int>(sol.status) << " ";
         file << sol.num_satellites << " ";
-        file << sol.pdop << "\n";
+        file << sol.pdop << " ";
+        file << sol.ratio << " ";
+        file << sol.num_fixed_ambiguities << " ";
+        file << sol.iterations << "\n";
     }
     
     return true;
@@ -196,8 +296,17 @@ bool Solution::loadFromFile(const std::string& filename) {
     solutions.clear();
 
     std::string line;
+    std::vector<std::string> columns;
     while (std::getline(file, line)) {
-        if (line.empty() || line[0] == '%') {
+        if (line.empty()) {
+            continue;
+        }
+
+        if (line[0] == '%') {
+            std::vector<std::string> parsed_columns = parseSolutionColumnsHeader(line);
+            if (!parsed_columns.empty()) {
+                columns = std::move(parsed_columns);
+            }
             continue;
         }
 
@@ -213,6 +322,13 @@ bool Solution::loadFromFile(const std::string& filename) {
                   >> status >> sol.num_satellites >> sol.pdop)) {
             continue;
         }
+
+        std::vector<double> optional_values;
+        double optional_value = 0.0;
+        while (iss >> optional_value) {
+            optional_values.push_back(optional_value);
+        }
+        applyOptionalSolutionColumns(sol, columns, optional_values);
 
         sol.position_geodetic.latitude = lat_deg * M_PI / 180.0;
         sol.position_geodetic.longitude = lon_deg * M_PI / 180.0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -160,6 +160,10 @@ if(GTest_FOUND)
         python_bindings_tests
         PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/python"
     )
+    set_tests_properties(
+        python_packaging_tests
+        PROPERTIES ENVIRONMENT "GNSSPP_BINARY_DIR=${CMAKE_BINARY_DIR}"
+    )
     if(TARGET gnss_solution_node)
         add_test(
             NAME python_ros2_node_tests

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,6 +19,7 @@ if(GTest_FOUND)
         test_rtk_update.cpp
         test_rtk_selection.cpp
         test_rtk_validation.cpp
+        test_fgo.cpp
         test_signal_policy.cpp
         test_types.cpp
         test_observation.cpp
@@ -58,6 +59,7 @@ if(GTest_FOUND)
     )
     add_dependencies(run_tests
         gnss_convert
+        gnss_fgo
         gnss_live
         gnss_ppp
         gnss_replay
@@ -65,6 +67,7 @@ if(GTest_FOUND)
         gnss_solve
         gnss_stream
         gnss_ubx_info
+        gnss_vel_d
     )
 
     # Add test to CTest
@@ -80,6 +83,58 @@ if(GTest_FOUND)
     add_test(
         NAME python_madoca_solution_diff_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_madoca_solution_diff.py
+    )
+    add_test(
+        NAME python_mode_compare_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_mode_compare.py
+    )
+    add_test(
+        NAME python_ppc_taroz_amb_pdc_smoke_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_ppc_taroz_amb_pdc_smoke.py
+    )
+    add_test(
+        NAME python_taroz_pc_internal_parity_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_taroz_pc_internal_parity.py
+    )
+    add_test(
+        NAME python_taroz_pc_dogfood_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_taroz_pc_dogfood.py
+    )
+    add_test(
+        NAME python_taroz_p_dogfood_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_taroz_p_dogfood.py
+    )
+    add_test(
+        NAME python_taroz_p_internal_parity_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_taroz_p_internal_parity.py
+    )
+    add_test(
+        NAME python_taroz_d_internal_parity_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_taroz_d_internal_parity.py
+    )
+    add_test(
+        NAME python_taroz_pos_pd_internal_parity_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_taroz_pos_pd_internal_parity.py
+    )
+    add_test(
+        NAME python_taroz_pos_pdc_internal_parity_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_taroz_pos_pdc_internal_parity.py
+    )
+    add_test(
+        NAME python_taroz_pos_vel_pdc_internal_parity_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_taroz_pos_vel_pdc_internal_parity.py
+    )
+    add_test(
+        NAME python_taroz_pos_vel_amb_pdc_factor_parity_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_taroz_pos_vel_amb_pdc_factor_parity.py
+    )
+    add_test(
+        NAME python_taroz_pos_vel_amb_pdc_dogfood_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_taroz_pos_vel_amb_pdc_dogfood.py
+    )
+    add_test(
+        NAME python_taroz_pd_internal_parity_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_taroz_pd_internal_parity.py
     )
     add_test(
         NAME python_packaging_tests

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -2843,8 +2843,16 @@ class CLIToolsTest(unittest.TestCase):
         "test_clas_ppp_cli_accepts_direct_qzss_l6_with_stec_inventory",
         "test_clas_ppp_cli_accepts_direct_qzss_l6_gridded_corrections",
         "test_clas_ppp_cli_accepts_direct_qzss_l6_code_phase_bias",
+        "test_clas_ppp_cli_accepts_direct_qzss_l6_code_bias_composition_policy",
+        "test_clas_ppp_cli_accepts_direct_qzss_l6_code_bias_bank_policy",
+        "test_clas_ppp_cli_accepts_direct_qzss_l6_bias_row_materialization",
+        "test_clas_ppp_cli_accepts_direct_qzss_l6_row_construction_policy",
         "test_clas_ppp_cli_reports_applied_atmospheric_corrections_for_direct_qzss_l6",
         "test_clas_ppp_cli_uses_nearest_clas_grid_residuals_for_direct_qzss_l6",
+        "test_ppp_products_signoff_cli_runs_static_profile_with_local_templates",
+        "test_ppp_products_signoff_cli_runs_ppc_profile_with_existing_solution",
+        "test_ppp_products_signoff_cli_reads_ppc_config_toml",
+        "test_ppp_products_signoff_cli_runs_ppc_profile_with_malib_bin",
     }
     SHORT_BASELINE_DATA_TESTS = {
         "test_solve_short_baseline_cli_reaches_fixed_solution",
@@ -2856,8 +2864,10 @@ class CLIToolsTest(unittest.TestCase):
         "test_rtk_kinematic_signoff_cli_writes_summary_and_passes_thresholds",
         "test_ppp_kinematic_signoff_cli_writes_summary_and_passes_thresholds",
         "test_ppp_kinematic_signoff_cli_can_fetch_precise_products",
+        "test_ppp_products_signoff_cli_runs_kinematic_profile_with_malib_bin",
         "test_replay_solves_bundled_rinex_sequence",
         "test_replay_supports_moving_base_mode",
+        "test_solve_accepts_low_cost_preset_and_hold_knobs",
     }
     STATIC_DATA_TESTS |= {
         "test_ppp_static_signoff_cli_can_fetch_precise_products",

--- a/tests/test_fgo.cpp
+++ b/tests/test_fgo.cpp
@@ -1,0 +1,963 @@
+#include <gtest/gtest.h>
+#include <libgnss++/algorithms/fgo.hpp>
+#include <libgnss++/core/constants.hpp>
+
+#include <array>
+#include <cmath>
+#include <map>
+#include <vector>
+
+using namespace libgnss;
+
+namespace {
+
+std::vector<Vector3d> makeSatelliteGeometry() {
+    return {
+        Vector3d(15600000.0, 7540000.0, 20140000.0),
+        Vector3d(-18760000.0, 2750000.0, 18610000.0),
+        Vector3d(17610000.0, -14630000.0, 13480000.0),
+        Vector3d(19170000.0, 610000.0, -18390000.0),
+        Vector3d(-13480000.0, -15600000.0, 17760000.0),
+        Vector3d(21700000.0, 13000000.0, 9000000.0),
+    };
+}
+
+double trueAmbiguityMeters(std::size_t satellite_index) {
+    return constants::GPS_L1_WAVELENGTH *
+           static_cast<double>(100 + static_cast<int>(satellite_index));
+}
+
+int trueAmbiguityCycles(std::size_t satellite_index) {
+    return 100 + static_cast<int>(satellite_index);
+}
+
+template <typename Factor>
+double doubleDifferenceGeometry(const Vector3d& position,
+                                const Factor& factor) {
+    const double rover_satellite_range =
+        (factor.rover_satellite_position_ecef - position).norm();
+    const double rover_reference_range =
+        (factor.rover_reference_position_ecef - position).norm();
+    const double base_satellite_range =
+        (factor.base_satellite_position_ecef -
+         factor.base_position_ecef)
+            .norm();
+    const double base_reference_range =
+        (factor.base_reference_position_ecef -
+         factor.base_position_ecef)
+            .norm();
+    return (rover_satellite_range - base_satellite_range) -
+           (rover_reference_range - base_reference_range);
+}
+
+template <typename Factor>
+Vector3d doubleDifferencePositionJacobian(const Vector3d& position,
+                                          const Factor& factor) {
+    const Vector3d rover_satellite_delta =
+        factor.rover_satellite_position_ecef - position;
+    const Vector3d rover_reference_delta =
+        factor.rover_reference_position_ecef - position;
+    const Vector3d rover_satellite_los =
+        rover_satellite_delta / rover_satellite_delta.norm();
+    const Vector3d rover_reference_los =
+        rover_reference_delta / rover_reference_delta.norm();
+    return -rover_satellite_los + rover_reference_los;
+}
+
+FGOProcessor::FGOProblem makeSyntheticProblem(bool include_tdcp = false,
+                                              bool include_carrier_phase = false) {
+    const std::array<Vector3d, 2> true_positions = {
+        Vector3d(1113194.0, -4841695.0, 3985350.0),
+        Vector3d(1113196.5, -4841694.0, 3985349.4),
+    };
+    const std::array<double, 2> true_clock_bias_m = {42.0, 43.5};
+
+    FGOProcessor::FGOProblem problem;
+    const auto satellites = makeSatelliteGeometry();
+    std::vector<std::size_t> ambiguity_indices(satellites.size(), 0);
+
+    if (include_carrier_phase) {
+        for (std::size_t sat = 0; sat < satellites.size(); ++sat) {
+            FGOProcessor::AmbiguityState ambiguity;
+            ambiguity.satellite =
+                SatelliteId(GNSSSystem::GPS, static_cast<uint8_t>(sat + 1));
+            ambiguity.signal = SignalType::GPS_L1CA;
+            ambiguity.segment_index = 0;
+            ambiguity.wavelength_m = constants::SPEED_OF_LIGHT / constants::GPS_L1_FREQ;
+            ambiguity.initial_ambiguity_m = trueAmbiguityMeters(sat) - 4.0;
+            ambiguity_indices[sat] = problem.ambiguity_states.size();
+            problem.ambiguity_states.push_back(ambiguity);
+        }
+    }
+
+    for (std::size_t epoch = 0; epoch < true_positions.size(); ++epoch) {
+        FGOProcessor::EpochSeed seed;
+        seed.time = GNSSTime(2300, 100000.0 + static_cast<double>(epoch));
+        seed.position_ecef = true_positions[epoch] + Vector3d(35.0, -18.0, 12.0);
+        seed.receiver_clock_bias_m = true_clock_bias_m[epoch] - 25.0;
+        problem.epochs.push_back(seed);
+
+        for (std::size_t sat = 0; sat < satellites.size(); ++sat) {
+            FGOProcessor::PseudorangeFactor factor;
+            factor.epoch_index = epoch;
+            factor.satellite = SatelliteId(GNSSSystem::GPS, static_cast<uint8_t>(sat + 1));
+            factor.satellite_position_ecef = satellites[sat];
+            factor.corrected_pseudorange_m =
+                (satellites[sat] - true_positions[epoch]).norm() +
+                true_clock_bias_m[epoch];
+            factor.sigma_m = 1.0;
+            factor.elevation_rad = 0.7;
+            problem.pseudorange_factors.push_back(factor);
+
+            if (include_carrier_phase) {
+                FGOProcessor::CarrierPhaseFactor carrier_factor;
+                carrier_factor.epoch_index = epoch;
+                carrier_factor.ambiguity_index = ambiguity_indices[sat];
+                carrier_factor.satellite = factor.satellite;
+                carrier_factor.signal = SignalType::GPS_L1CA;
+                carrier_factor.satellite_position_ecef = satellites[sat];
+                carrier_factor.corrected_carrier_m =
+                    (satellites[sat] - true_positions[epoch]).norm() +
+                    true_clock_bias_m[epoch] +
+                    trueAmbiguityMeters(sat);
+                carrier_factor.sigma_m = 0.01;
+                carrier_factor.elevation_rad = 0.7;
+                problem.carrier_phase_factors.push_back(carrier_factor);
+            }
+        }
+    }
+
+    if (include_tdcp) {
+        for (std::size_t sat = 0; sat < satellites.size(); ++sat) {
+            FGOProcessor::TimeDifferencedCarrierFactor factor;
+            factor.previous_epoch_index = 0;
+            factor.current_epoch_index = 1;
+            factor.satellite = SatelliteId(GNSSSystem::GPS, static_cast<uint8_t>(sat + 1));
+            factor.signal = SignalType::GPS_L1CA;
+            factor.previous_satellite_position_ecef = satellites[sat];
+            factor.current_satellite_position_ecef = satellites[sat];
+            factor.delta_carrier_m =
+                ((satellites[sat] - true_positions[1]).norm() + true_clock_bias_m[1]) -
+                ((satellites[sat] - true_positions[0]).norm() + true_clock_bias_m[0]);
+            factor.sigma_m = 0.02;
+            factor.dt_s = 1.0;
+            problem.tdcp_factors.push_back(factor);
+        }
+        problem.diagnostics.tdcp_candidate_pairs = satellites.size();
+    }
+
+    problem.diagnostics.input_epochs = true_positions.size();
+    problem.diagnostics.seeded_epochs = true_positions.size();
+    return problem;
+}
+
+FGOProcessor::FGOProblem makeSyntheticDoubleDifferenceProblem(
+    bool include_pseudorange_dd = false) {
+    FGOProcessor::FGOProblem problem = makeSyntheticProblem(false, true);
+    const auto satellites = makeSatelliteGeometry();
+    const std::array<Vector3d, 2> true_positions = {
+        Vector3d(1113194.0, -4841695.0, 3985350.0),
+        Vector3d(1113196.5, -4841694.0, 3985349.4),
+    };
+    const Vector3d base_position =
+        true_positions[0] + Vector3d(-320.0, 180.0, 45.0);
+
+    for (std::size_t epoch = 0; epoch < true_positions.size(); ++epoch) {
+        for (std::size_t sat = 1; sat < satellites.size(); ++sat) {
+            if (include_pseudorange_dd) {
+                FGOProcessor::DoubleDifferencePseudorangeFactor code_factor;
+                code_factor.epoch_index = epoch;
+                code_factor.satellite =
+                    SatelliteId(GNSSSystem::GPS, static_cast<uint8_t>(sat + 1));
+                code_factor.reference_satellite = SatelliteId(GNSSSystem::GPS, 1);
+                code_factor.signal = SignalType::GPS_L1CA;
+                code_factor.rover_satellite_position_ecef = satellites[sat];
+                code_factor.rover_reference_position_ecef = satellites[0];
+                code_factor.base_satellite_position_ecef = satellites[sat];
+                code_factor.base_reference_position_ecef = satellites[0];
+                code_factor.base_position_ecef = base_position;
+                code_factor.observed_dd_pseudorange_m =
+                    ((satellites[sat] - true_positions[epoch]).norm() -
+                     (satellites[sat] - base_position).norm()) -
+                    ((satellites[0] - true_positions[epoch]).norm() -
+                     (satellites[0] - base_position).norm());
+                code_factor.sigma_m = 0.5;
+                code_factor.elevation_rad = 0.7;
+                problem.double_difference_pseudorange_factors.push_back(
+                    code_factor);
+            }
+
+            FGOProcessor::DoubleDifferenceCarrierFactor factor;
+            factor.epoch_index = epoch;
+            factor.ambiguity_index = sat;
+            factor.reference_ambiguity_index = 0;
+            factor.satellite = SatelliteId(GNSSSystem::GPS, static_cast<uint8_t>(sat + 1));
+            factor.reference_satellite = SatelliteId(GNSSSystem::GPS, 1);
+            factor.signal = SignalType::GPS_L1CA;
+            factor.rover_satellite_position_ecef = satellites[sat];
+            factor.rover_reference_position_ecef = satellites[0];
+            factor.base_satellite_position_ecef = satellites[sat];
+            factor.base_reference_position_ecef = satellites[0];
+            factor.base_position_ecef = base_position;
+            factor.observed_dd_carrier_m =
+                ((satellites[sat] - true_positions[epoch]).norm() -
+                 (satellites[sat] - base_position).norm()) -
+                ((satellites[0] - true_positions[epoch]).norm() -
+                 (satellites[0] - base_position).norm()) +
+                trueAmbiguityMeters(sat) - trueAmbiguityMeters(0);
+            factor.sigma_m = 0.01;
+            factor.elevation_rad = 0.7;
+            problem.double_difference_carrier_factors.push_back(factor);
+        }
+    }
+
+    problem.carrier_phase_factors.clear();
+    problem.diagnostics.double_difference_matched_base_epochs = true_positions.size();
+    problem.diagnostics.double_difference_candidate_pairs =
+        problem.double_difference_carrier_factors.size();
+    return problem;
+}
+
+FGOProcessor::FGOProblem makeSyntheticSingleDifferenceProblem() {
+    FGOProcessor::FGOProblem problem = makeSyntheticProblem();
+    const auto satellites = makeSatelliteGeometry();
+    const std::array<Vector3d, 2> true_positions = {
+        Vector3d(1113194.0, -4841695.0, 3985350.0),
+        Vector3d(1113196.5, -4841694.0, 3985349.4),
+    };
+    const double dt = problem.epochs[1].time - problem.epochs[0].time;
+    const Vector3d true_velocity =
+        (true_positions[1] - true_positions[0]) / dt;
+
+    auto sd_los = [&](std::size_t epoch, std::size_t sat) -> Vector3d {
+        const Vector3d sat_delta =
+            satellites[sat] - problem.epochs[epoch].position_ecef;
+        const Vector3d ref_delta =
+            satellites[0] - problem.epochs[epoch].position_ecef;
+        return -sat_delta / sat_delta.norm() + ref_delta / ref_delta.norm();
+    };
+
+    for (std::size_t sat = 1; sat < satellites.size(); ++sat) {
+        const Vector3d previous_los = sd_los(0, sat);
+        const Vector3d current_los = sd_los(1, sat);
+
+        FGOProcessor::SingleDifferenceDopplerFactor doppler_factor;
+        doppler_factor.epoch_index = 1;
+        doppler_factor.satellite =
+            SatelliteId(GNSSSystem::GPS, static_cast<uint8_t>(sat + 1));
+        doppler_factor.reference_satellite = SatelliteId(GNSSSystem::GPS, 1);
+        doppler_factor.signal = SignalType::GPS_L1CA;
+        doppler_factor.los = current_los;
+        doppler_factor.residual_mps = current_los.dot(true_velocity);
+        doppler_factor.sigma_mps = 0.2;
+        doppler_factor.elevation_rad = 0.7;
+        problem.single_difference_doppler_factors.push_back(doppler_factor);
+
+        FGOProcessor::SingleDifferenceTdcpFactor tdcp_factor;
+        tdcp_factor.previous_epoch_index = 0;
+        tdcp_factor.current_epoch_index = 1;
+        tdcp_factor.satellite = doppler_factor.satellite;
+        tdcp_factor.reference_satellite = doppler_factor.reference_satellite;
+        tdcp_factor.signal = SignalType::GPS_L1CA;
+        tdcp_factor.previous_los = previous_los;
+        tdcp_factor.los = current_los;
+        tdcp_factor.delta_carrier_m =
+            current_los.dot(true_positions[1] -
+                            problem.epochs[1].position_ecef) -
+            previous_los.dot(true_positions[0] -
+                             problem.epochs[0].position_ecef);
+        tdcp_factor.sigma_m = 0.003;
+        tdcp_factor.elevation_rad = 0.7;
+        problem.single_difference_tdcp_factors.push_back(tdcp_factor);
+    }
+
+    return problem;
+}
+
+Ephemeris makeSyntheticGpsEphemeris(uint8_t prn) {
+    Ephemeris eph;
+    eph.satellite = SatelliteId(GNSSSystem::GPS, prn);
+    eph.valid = true;
+    eph.week = 2300;
+    eph.toe = GNSSTime(eph.week, 100000.0);
+    eph.toc = eph.toe;
+    eph.tof = eph.toe;
+    eph.toes = eph.toe.tow;
+    eph.sqrt_a = std::sqrt(26560000.0);
+    eph.e = 0.004 + 0.0002 * static_cast<double>(prn);
+    eph.i0 = 0.94 + 0.01 * static_cast<double>(prn % 3);
+    eph.omega0 = 0.35 * static_cast<double>(prn);
+    eph.omega = 0.17 * static_cast<double>(prn);
+    eph.m0 = 0.61 * static_cast<double>(prn);
+    eph.delta_n = 1e-9 * static_cast<double>(prn);
+    eph.omega_dot = -8.0e-9;
+    eph.health = 0;
+    return eph;
+}
+
+NavigationData makeSyntheticGpsNavigation(std::size_t satellite_count) {
+    NavigationData nav;
+    for (std::size_t sat = 1; sat <= satellite_count; ++sat) {
+        nav.addEphemeris(
+            makeSyntheticGpsEphemeris(static_cast<uint8_t>(sat)));
+    }
+    return nav;
+}
+
+bool makeSyntheticGpsL1Observation(const NavigationData& nav,
+                                   const SatelliteId& satellite,
+                                   const GNSSTime& time,
+                                   const Vector3d& receiver_position,
+                                   double carrier_bias_m,
+                                   Observation& observation) {
+    double pseudorange = 22'000'000.0;
+    Vector3d satellite_position = Vector3d::Zero();
+    Vector3d satellite_velocity = Vector3d::Zero();
+    double satellite_clock_bias = 0.0;
+    double satellite_clock_drift = 0.0;
+    for (int iteration = 0; iteration < 3; ++iteration) {
+        const GNSSTime transmit_time =
+            time - pseudorange / constants::SPEED_OF_LIGHT;
+        if (!nav.calculateSatelliteState(satellite,
+                                         transmit_time,
+                                         satellite_position,
+                                         satellite_velocity,
+                                         satellite_clock_bias,
+                                         satellite_clock_drift)) {
+            return false;
+        }
+        pseudorange =
+            (satellite_position - receiver_position).norm() -
+            satellite_clock_bias * constants::SPEED_OF_LIGHT;
+    }
+
+    observation = Observation(satellite, SignalType::GPS_L1CA);
+    observation.pseudorange = pseudorange;
+    observation.carrier_phase =
+        (pseudorange + carrier_bias_m) / constants::GPS_L1_WAVELENGTH;
+    observation.snr = 45.0;
+    observation.has_pseudorange = true;
+    observation.has_carrier_phase = true;
+    observation.valid = true;
+    return true;
+}
+
+std::vector<ObservationData> makeSyntheticDoubleDifferenceObservationEpochs(
+    const NavigationData& nav,
+    const std::array<Vector3d, 2>& receiver_positions,
+    double carrier_epoch_slope_m) {
+    std::vector<ObservationData> epochs;
+    for (std::size_t epoch_index = 0; epoch_index < receiver_positions.size();
+         ++epoch_index) {
+        ObservationData epoch(GNSSTime(2300, 100100.0 + epoch_index));
+        epoch.receiver_position = receiver_positions[epoch_index];
+        for (uint8_t prn = 1; prn <= 4; ++prn) {
+            Observation observation;
+            const double carrier_bias_m =
+                10.0 * static_cast<double>(prn) +
+                carrier_epoch_slope_m * static_cast<double>(epoch_index) *
+                    static_cast<double>(prn);
+            if (makeSyntheticGpsL1Observation(
+                    nav,
+                    SatelliteId(GNSSSystem::GPS, prn),
+                    epoch.time,
+                    receiver_positions[epoch_index],
+                    carrier_bias_m,
+                    observation)) {
+                epoch.addObservation(observation);
+            }
+        }
+        epochs.push_back(epoch);
+    }
+    return epochs;
+}
+
+FGOProcessor::FGOProblem makeSyntheticInterSystemBiasProblem() {
+    const std::array<Vector3d, 2> true_positions = {
+        Vector3d(1113194.0, -4841695.0, 3985350.0),
+        Vector3d(1113196.5, -4841694.0, 3985349.4),
+    };
+    const std::array<double, 2> true_clock_bias_m = {42.0, 43.5};
+    constexpr double galileo_bias_m = 87.0;
+
+    FGOProcessor::FGOProblem problem;
+    const auto satellites = makeSatelliteGeometry();
+    for (std::size_t epoch = 0; epoch < true_positions.size(); ++epoch) {
+        FGOProcessor::EpochSeed seed;
+        seed.time = GNSSTime(2300, 100000.0 + static_cast<double>(epoch));
+        seed.position_ecef =
+            true_positions[epoch] + Vector3d(35.0, -18.0, 12.0);
+        seed.receiver_clock_bias_m = true_clock_bias_m[epoch] - 25.0;
+        problem.epochs.push_back(seed);
+
+        for (std::size_t sat = 0; sat < satellites.size(); ++sat) {
+            const bool is_galileo = sat >= satellites.size() / 2;
+            FGOProcessor::PseudorangeFactor factor;
+            factor.epoch_index = epoch;
+            factor.satellite =
+                SatelliteId(is_galileo ? GNSSSystem::Galileo : GNSSSystem::GPS,
+                            static_cast<uint8_t>(sat + 1));
+            factor.clock_group =
+                is_galileo ? GNSSSystem::Galileo : GNSSSystem::GPS;
+            factor.satellite_position_ecef = satellites[sat];
+            factor.corrected_pseudorange_m =
+                (satellites[sat] - true_positions[epoch]).norm() +
+                true_clock_bias_m[epoch] +
+                (is_galileo ? galileo_bias_m : 0.0);
+            factor.sigma_m = 1.0;
+            factor.elevation_rad = 0.7;
+            problem.pseudorange_factors.push_back(factor);
+        }
+    }
+
+    problem.diagnostics.input_epochs = true_positions.size();
+    problem.diagnostics.seeded_epochs = true_positions.size();
+    return problem;
+}
+
+}  // namespace
+
+TEST(FGOTest, EmptyProblemProducesNoSolutions) {
+    FGOProcessor processor;
+    const auto result = processor.optimizeProblem(FGOProcessor::FGOProblem{});
+
+    EXPECT_TRUE(result.solution.isEmpty());
+    EXPECT_EQ(result.diagnostics.epochs, 0u);
+    EXPECT_EQ(result.diagnostics.pseudorange_factors, 0u);
+}
+
+TEST(FGOTest, BatchPseudorangeFactorsRecoverSyntheticTrajectory) {
+    FGOProcessor::FGOConfig config;
+    config.max_iterations = 10;
+    config.convergence_threshold_m = 1e-8;
+    config.use_motion_factors = false;
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(makeSyntheticProblem());
+
+    ASSERT_EQ(result.solution.size(), 2u);
+    EXPECT_TRUE(result.diagnostics.converged);
+    EXPECT_EQ(result.diagnostics.pseudorange_factors, 12u);
+    EXPECT_LT(result.diagnostics.residual_rms_m, 1e-5);
+
+    const Vector3d expected_first(1113194.0, -4841695.0, 3985350.0);
+    const Vector3d expected_second(1113196.5, -4841694.0, 3985349.4);
+
+    ASSERT_TRUE(result.solution.solutions[0].isValid());
+    ASSERT_TRUE(result.solution.solutions[1].isValid());
+    EXPECT_EQ(result.solution.solutions[0].status, SolutionStatus::SPP);
+    EXPECT_EQ(result.solution.solutions[1].status, SolutionStatus::SPP);
+    const auto stats = result.solution.calculateStatistics();
+    EXPECT_EQ(stats.float_solutions, 0u);
+    EXPECT_EQ(stats.fixed_solutions, 0u);
+    EXPECT_LT((result.solution.solutions[0].position_ecef - expected_first).norm(), 1e-3);
+    EXPECT_LT((result.solution.solutions[1].position_ecef - expected_second).norm(), 1e-3);
+    EXPECT_NEAR(result.solution.solutions[0].receiver_clock_bias,
+                42.0 / constants::SPEED_OF_LIGHT,
+                1e-12);
+    EXPECT_NEAR(result.solution.solutions[1].receiver_clock_bias,
+                43.5 / constants::SPEED_OF_LIGHT,
+                1e-12);
+}
+
+TEST(FGOTest, InterSystemBiasFactorsRecoverMixedConstellationTrajectory) {
+    FGOProcessor::FGOConfig config;
+    config.max_iterations = 10;
+    config.use_motion_factors = false;
+    config.use_tdcp_factors = false;
+    config.use_inter_system_biases = true;
+    FGOProcessor processor(config);
+
+    const auto result =
+        processor.optimizeProblem(makeSyntheticInterSystemBiasProblem());
+
+    ASSERT_EQ(result.solution.solutions.size(), 2u);
+    EXPECT_TRUE(result.diagnostics.converged);
+    EXPECT_LT(result.diagnostics.residual_rms_m, 1e-5);
+    const std::array<Vector3d, 2> true_positions = {
+        Vector3d(1113194.0, -4841695.0, 3985350.0),
+        Vector3d(1113196.5, -4841694.0, 3985349.4),
+    };
+    for (std::size_t i = 0; i < result.solution.solutions.size(); ++i) {
+        EXPECT_LT((result.solution.solutions[i].position_ecef -
+                   true_positions[i])
+                      .norm(),
+                  0.05);
+    }
+}
+
+TEST(FGOTest, TimeDifferencedCarrierFactorsRecoverSyntheticTrajectory) {
+    FGOProcessor::FGOConfig config;
+    config.max_iterations = 10;
+    config.convergence_threshold_m = 1e-8;
+    config.use_motion_factors = false;
+    config.tdcp_sigma_m = 0.02;
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(makeSyntheticProblem(true));
+
+    ASSERT_EQ(result.solution.size(), 2u);
+    EXPECT_TRUE(result.diagnostics.converged);
+    EXPECT_EQ(result.solution.solutions[0].status, SolutionStatus::SPP);
+    EXPECT_EQ(result.solution.solutions[1].status, SolutionStatus::SPP);
+    const auto stats = result.solution.calculateStatistics();
+    EXPECT_EQ(stats.float_solutions, 0u);
+    EXPECT_EQ(stats.fixed_solutions, 0u);
+    EXPECT_EQ(result.diagnostics.pseudorange_factors, 12u);
+    EXPECT_EQ(result.diagnostics.tdcp_factors, 6u);
+    EXPECT_EQ(result.diagnostics.tdcp_candidate_pairs, 6u);
+    EXPECT_LT(result.diagnostics.residual_rms_m, 1e-5);
+    EXPECT_LT(result.diagnostics.tdcp_residual_rms_m, 1e-5);
+
+    const Vector3d expected_second(1113196.5, -4841694.0, 3985349.4);
+    EXPECT_LT((result.solution.solutions[1].position_ecef - expected_second).norm(), 1e-3);
+}
+
+TEST(FGOTest, SingleDifferenceDopplerAndTdcpFactorsConstrainMotion) {
+    FGOProcessor::FGOConfig config;
+    config.max_iterations = 10;
+    config.convergence_threshold_m = 1e-8;
+    config.use_motion_factors = false;
+    config.use_robust_loss = false;
+
+    FGOProcessor processor(config);
+    const auto result =
+        processor.optimizeProblem(makeSyntheticSingleDifferenceProblem());
+
+    ASSERT_EQ(result.solution.size(), 2u);
+    EXPECT_TRUE(result.diagnostics.converged);
+    EXPECT_EQ(result.diagnostics.single_difference_doppler_factors, 5u);
+    EXPECT_EQ(result.diagnostics.single_difference_tdcp_factors, 5u);
+    EXPECT_LT(result.diagnostics.single_difference_doppler_residual_rms_mps,
+              1e-5);
+    EXPECT_LT(result.diagnostics.single_difference_tdcp_residual_rms_m,
+              1e-5);
+}
+
+TEST(FGOTest, BuiltSingleDifferenceTdcpFactorsUseCurrentEpochLos) {
+    const NavigationData nav = makeSyntheticGpsNavigation(4);
+    const std::array<Vector3d, 2> rover_positions = {
+        Vector3d(1113194.0, -4841695.0, 3985350.0),
+        Vector3d(1113214.0, -4841680.0, 3985342.0),
+    };
+    const std::array<Vector3d, 2> base_positions = {
+        rover_positions[0] + Vector3d(-320.0, 180.0, 45.0),
+        rover_positions[1] + Vector3d(-320.0, 180.0, 45.0),
+    };
+    const auto rover_epochs =
+        makeSyntheticDoubleDifferenceObservationEpochs(nav, rover_positions, 0.04);
+    const auto base_epochs =
+        makeSyntheticDoubleDifferenceObservationEpochs(nav, base_positions, 0.02);
+
+    FGOProcessor::FGOConfig config;
+    config.use_spp_seed = false;
+    config.use_pseudorange_factors = false;
+    config.use_motion_factors = false;
+    config.use_tdcp_factors = false;
+    config.use_double_difference_factors = true;
+    config.use_single_difference_tdcp_factors = true;
+    config.use_ionosphere_model = false;
+    config.use_troposphere_model = false;
+    config.reject_tdcp_code_phase_jump = false;
+    config.min_elevation_deg = -90.0;
+    config.min_satellites_per_epoch = 2;
+
+    FGOProcessor processor(config);
+    const auto problem = processor.buildDoubleDifferenceProblem(
+        rover_epochs, base_epochs, nav, base_positions[0]);
+
+    ASSERT_FALSE(problem.single_difference_tdcp_factors.empty());
+
+    using ObservationKey = std::tuple<std::size_t, SatelliteId, SignalType>;
+    std::map<ObservationKey, const FGOProcessor::CarrierPhaseFactor*>
+        rover_observations;
+    for (const auto& observation :
+         problem.double_difference_pseudorange_observations) {
+        rover_observations[{observation.epoch_index,
+                            observation.satellite,
+                            observation.signal}] = &observation;
+    }
+
+    double max_previous_current_los_delta = 0.0;
+    for (const auto& factor : problem.single_difference_tdcp_factors) {
+        const auto current_satellite_it =
+            rover_observations.find({factor.current_epoch_index,
+                                     factor.satellite,
+                                     factor.signal});
+        const auto current_reference_it =
+            rover_observations.find({factor.current_epoch_index,
+                                     factor.reference_satellite,
+                                     factor.signal});
+        const auto previous_satellite_it =
+            rover_observations.find({factor.previous_epoch_index,
+                                     factor.satellite,
+                                     factor.signal});
+        const auto previous_reference_it =
+            rover_observations.find({factor.previous_epoch_index,
+                                     factor.reference_satellite,
+                                     factor.signal});
+        ASSERT_NE(current_satellite_it, rover_observations.end());
+        ASSERT_NE(current_reference_it, rover_observations.end());
+        ASSERT_NE(previous_satellite_it, rover_observations.end());
+        ASSERT_NE(previous_reference_it, rover_observations.end());
+
+        const Vector3d current_sd_los =
+            current_satellite_it->second->los - current_reference_it->second->los;
+        const Vector3d previous_sd_los =
+            previous_satellite_it->second->los - previous_reference_it->second->los;
+
+        EXPECT_LT((factor.los - current_sd_los).norm(), 1e-12);
+        EXPECT_LT((factor.previous_los - current_sd_los).norm(), 1e-12);
+        max_previous_current_los_delta =
+            std::max(max_previous_current_los_delta,
+                     (previous_sd_los - current_sd_los).norm());
+    }
+
+    EXPECT_GT(max_previous_current_los_delta, 1e-8);
+}
+
+TEST(FGOTest, RobustLossDownweightsPseudorangeOutlier) {
+    FGOProcessor::FGOProblem problem = makeSyntheticProblem();
+    for (auto& factor : problem.pseudorange_factors) {
+        if (factor.epoch_index == 0 && factor.satellite.prn == 6) {
+            factor.corrected_pseudorange_m += 5000.0;
+        }
+    }
+
+    FGOProcessor::FGOConfig base_config;
+    base_config.max_iterations = 20;
+    base_config.convergence_threshold_m = 1e-8;
+    base_config.use_motion_factors = false;
+    base_config.pseudorange_huber_threshold_sigma = 2.0;
+
+    FGOProcessor::FGOConfig plain_config = base_config;
+    plain_config.use_robust_loss = false;
+    FGOProcessor plain_processor(plain_config);
+    const auto plain_result = plain_processor.optimizeProblem(problem);
+
+    FGOProcessor robust_processor(base_config);
+    const auto robust_result = robust_processor.optimizeProblem(problem);
+
+    ASSERT_EQ(plain_result.solution.size(), 2u);
+    ASSERT_EQ(robust_result.solution.size(), 2u);
+    const Vector3d expected_first(1113194.0, -4841695.0, 3985350.0);
+    const double plain_error =
+        (plain_result.solution.solutions[0].position_ecef - expected_first).norm();
+    const double robust_error =
+        (robust_result.solution.solutions[0].position_ecef - expected_first).norm();
+
+    EXPECT_GT(plain_error, 100.0);
+    EXPECT_LT(robust_error, plain_error * 0.25);
+    EXPECT_GT(robust_result.diagnostics.robust_pseudorange_factors, 0u);
+    EXPECT_EQ(robust_result.diagnostics.robust_carrier_phase_factors, 0u);
+    EXPECT_EQ(robust_result.diagnostics.robust_tdcp_factors, 0u);
+}
+
+TEST(FGOTest, CarrierPhaseAmbiguityStatesRecoverSyntheticTrajectory) {
+    FGOProcessor::FGOConfig config;
+    config.max_iterations = 12;
+    config.convergence_threshold_m = 1e-8;
+    config.use_motion_factors = false;
+    config.carrier_phase_sigma_m = 0.01;
+    config.ambiguity_prior_sigma_m = 1000.0;
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(makeSyntheticProblem(false, true));
+
+    ASSERT_EQ(result.solution.size(), 2u);
+    EXPECT_TRUE(result.diagnostics.converged);
+    EXPECT_EQ(result.solution.solutions[0].status, SolutionStatus::FLOAT);
+    EXPECT_EQ(result.solution.solutions[1].status, SolutionStatus::FLOAT);
+    const auto stats = result.solution.calculateStatistics();
+    EXPECT_EQ(stats.float_solutions, 2u);
+    EXPECT_EQ(stats.fixed_solutions, 0u);
+    EXPECT_EQ(result.diagnostics.pseudorange_factors, 12u);
+    EXPECT_EQ(result.diagnostics.carrier_phase_factors, 12u);
+    EXPECT_EQ(result.diagnostics.ambiguity_states, 6u);
+    EXPECT_EQ(result.ambiguity_estimates.size(), 6u);
+    EXPECT_LT(result.diagnostics.residual_rms_m, 1e-5);
+    EXPECT_LT(result.diagnostics.carrier_phase_residual_rms_m, 1e-5);
+
+    const Vector3d expected_second(1113196.5, -4841694.0, 3985349.4);
+    EXPECT_LT((result.solution.solutions[1].position_ecef - expected_second).norm(), 1e-3);
+
+    for (std::size_t sat = 0; sat < result.ambiguity_estimates.size(); ++sat) {
+        EXPECT_NEAR(result.ambiguity_estimates[sat].ambiguity_m,
+                    trueAmbiguityMeters(sat),
+                    1e-3);
+    }
+}
+
+TEST(FGOTest, DoubleDifferenceCarrierFactorsConstrainAmbiguityDifferences) {
+    FGOProcessor::FGOConfig config;
+    config.max_iterations = 12;
+    config.convergence_threshold_m = 1e-8;
+    config.use_motion_factors = false;
+    config.carrier_phase_sigma_m = 0.01;
+    config.double_difference_carrier_sigma_m = 0.01;
+    config.ambiguity_prior_sigma_m = 1000.0;
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(makeSyntheticDoubleDifferenceProblem());
+
+    ASSERT_EQ(result.solution.size(), 2u);
+    EXPECT_TRUE(result.diagnostics.converged);
+    EXPECT_EQ(result.diagnostics.carrier_phase_factors, 0u);
+    EXPECT_EQ(result.diagnostics.double_difference_pseudorange_factors, 0u);
+    EXPECT_EQ(result.diagnostics.double_difference_carrier_factors, 10u);
+    EXPECT_EQ(result.diagnostics.double_difference_matched_base_epochs, 2u);
+    EXPECT_EQ(result.diagnostics.double_difference_candidate_pairs, 10u);
+    EXPECT_LT(result.diagnostics.double_difference_carrier_residual_rms_m, 1e-5);
+    EXPECT_EQ(result.diagnostics.robust_double_difference_carrier_factors, 0u);
+
+    ASSERT_EQ(result.ambiguity_estimates.size(), 6u);
+    for (std::size_t sat = 1; sat < result.ambiguity_estimates.size(); ++sat) {
+        const double dd_ambiguity =
+            result.ambiguity_estimates[sat].ambiguity_m -
+            result.ambiguity_estimates[0].ambiguity_m;
+        EXPECT_NEAR(dd_ambiguity,
+                    trueAmbiguityMeters(sat) - trueAmbiguityMeters(0),
+                    1e-3);
+    }
+}
+
+TEST(FGOTest, DoubleDifferencePseudorangeFactorsRecoverSyntheticGeometry) {
+    FGOProcessor::FGOConfig config;
+    config.max_iterations = 12;
+    config.convergence_threshold_m = 1e-8;
+    config.use_motion_factors = false;
+    config.double_difference_pseudorange_sigma_m = 0.5;
+    config.double_difference_carrier_sigma_m = 0.01;
+    config.ambiguity_prior_sigma_m = 1000.0;
+
+    FGOProcessor processor(config);
+    const auto result =
+        processor.optimizeProblem(makeSyntheticDoubleDifferenceProblem(true));
+
+    ASSERT_EQ(result.solution.size(), 2u);
+    EXPECT_TRUE(result.diagnostics.converged);
+    EXPECT_EQ(result.diagnostics.carrier_phase_factors, 0u);
+    EXPECT_EQ(result.diagnostics.double_difference_pseudorange_factors, 10u);
+    EXPECT_EQ(result.diagnostics.double_difference_carrier_factors, 10u);
+    EXPECT_LT(result.diagnostics.double_difference_pseudorange_residual_rms_m,
+              1e-5);
+    EXPECT_LT(result.diagnostics.double_difference_carrier_residual_rms_m,
+              1e-5);
+    EXPECT_EQ(result.diagnostics.robust_double_difference_pseudorange_factors,
+              0u);
+}
+
+TEST(FGOTest, DoubleDifferenceOutputGateRequiresEnoughCarrierCandidates) {
+    FGOProcessor::FGOProblem problem = makeSyntheticDoubleDifferenceProblem();
+    problem.pseudorange_factors.clear();
+
+    FGOProcessor::FGOConfig config;
+    config.max_iterations = 1;
+    config.use_motion_factors = false;
+    config.min_output_double_difference_carrier_factors_per_epoch = 6;
+
+    FGOProcessor gated_processor(config);
+    const auto gated_result = gated_processor.optimizeProblem(problem);
+
+    ASSERT_EQ(gated_result.solution.size(), 2u);
+    EXPECT_EQ(gated_result.diagnostics.double_difference_carrier_factors, 10u);
+    EXPECT_EQ(gated_result.solution.solutions[0].num_satellites, 6);
+    EXPECT_EQ(gated_result.solution.solutions[0].status, SolutionStatus::NONE);
+    EXPECT_EQ(gated_result.solution.solutions[1].status, SolutionStatus::NONE);
+
+    config.min_output_double_difference_carrier_factors_per_epoch = 5;
+    FGOProcessor accepted_processor(config);
+    const auto accepted_result = accepted_processor.optimizeProblem(problem);
+
+    ASSERT_EQ(accepted_result.solution.size(), 2u);
+    EXPECT_EQ(accepted_result.solution.solutions[0].status,
+              SolutionStatus::FLOAT);
+    EXPECT_EQ(accepted_result.solution.solutions[1].status,
+              SolutionStatus::FLOAT);
+}
+
+TEST(FGOTest, DoubleDifferenceInternalsMatchTarozLinearizedFactors) {
+    const auto problem = makeSyntheticDoubleDifferenceProblem(true);
+    ASSERT_FALSE(problem.double_difference_pseudorange_factors.empty());
+    ASSERT_FALSE(problem.double_difference_carrier_factors.empty());
+
+    const auto& code_factor =
+        problem.double_difference_pseudorange_factors.front();
+    const auto& carrier_factor =
+        problem.double_difference_carrier_factors.front();
+    ASSERT_EQ(code_factor.epoch_index, carrier_factor.epoch_index);
+    ASSERT_EQ(code_factor.satellite, carrier_factor.satellite);
+    ASSERT_EQ(code_factor.reference_satellite,
+              carrier_factor.reference_satellite);
+
+    const Vector3d seed_position =
+        problem.epochs[code_factor.epoch_index].position_ecef;
+    const double geometry_at_seed =
+        doubleDifferenceGeometry(seed_position, code_factor);
+    const double code_residual_at_seed =
+        code_factor.observed_dd_pseudorange_m - geometry_at_seed;
+    const double carrier_residual_at_seed =
+        carrier_factor.observed_dd_carrier_m - geometry_at_seed;
+    const double taroz_ambiguity_seed_m =
+        carrier_residual_at_seed - code_residual_at_seed;
+
+    EXPECT_NEAR(taroz_ambiguity_seed_m,
+                trueAmbiguityMeters(1) - trueAmbiguityMeters(0),
+                1e-6);
+
+    const Vector3d dx(0.001, -0.002, 0.0015);
+    const Vector3d taroz_los =
+        doubleDifferencePositionJacobian(seed_position, code_factor);
+    const Vector3d moved_position = seed_position + dx;
+    const double linearized_geometry =
+        geometry_at_seed + taroz_los.dot(dx);
+    const double moved_geometry =
+        doubleDifferenceGeometry(moved_position, code_factor);
+    EXPECT_NEAR(linearized_geometry, moved_geometry, 1e-9);
+
+    const double taroz_code_error =
+        taroz_los.dot(dx) - code_residual_at_seed;
+    const double nonlinear_code_error =
+        -(code_factor.observed_dd_pseudorange_m - moved_geometry);
+    EXPECT_NEAR(taroz_code_error, nonlinear_code_error, 1e-9);
+
+    const double taroz_bias_cycles =
+        taroz_ambiguity_seed_m / constants::GPS_L1_WAVELENGTH;
+    const double taroz_carrier_error =
+        taroz_los.dot(dx) -
+        (carrier_residual_at_seed -
+         constants::GPS_L1_WAVELENGTH * taroz_bias_cycles);
+    const double nonlinear_carrier_error =
+        -(carrier_factor.observed_dd_carrier_m -
+          (doubleDifferenceGeometry(moved_position, carrier_factor) +
+           taroz_ambiguity_seed_m));
+    EXPECT_NEAR(taroz_carrier_error, nonlinear_carrier_error, 1e-9);
+}
+
+TEST(FGOTest, FixedAmbiguityPassSnapsIntegerCarrierPhaseStates) {
+    FGOProcessor::FGOConfig config;
+    config.max_iterations = 12;
+    config.convergence_threshold_m = 1e-8;
+    config.use_motion_factors = false;
+    config.fix_ambiguities = true;
+    config.use_lambda_ambiguity_fix = true;
+    config.carrier_phase_sigma_m = 0.01;
+    config.ambiguity_prior_sigma_m = 1000.0;
+    config.fixed_ambiguity_sigma_m = 1e-4;
+    config.ambiguity_fix_max_fractional_cycles = 0.2;
+    config.lambda_ratio_threshold = 1.5;
+    config.min_fixed_ambiguities = 4;
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(makeSyntheticProblem(false, true));
+
+    ASSERT_EQ(result.solution.size(), 2u);
+    EXPECT_TRUE(result.diagnostics.converged);
+    EXPECT_TRUE(result.diagnostics.fixed_solution);
+    EXPECT_EQ(result.solution.solutions[0].status, SolutionStatus::FIXED);
+    EXPECT_EQ(result.solution.solutions[1].status, SolutionStatus::FIXED);
+    EXPECT_TRUE(result.solution.solutions[0].isFixed());
+    EXPECT_EQ(result.solution.solutions[0].num_fixed_ambiguities, 6);
+    EXPECT_GT(result.solution.solutions[0].ratio, config.lambda_ratio_threshold);
+    const auto stats = result.solution.calculateStatistics();
+    EXPECT_EQ(stats.float_solutions, 0u);
+    EXPECT_EQ(stats.fixed_solutions, 2u);
+    EXPECT_DOUBLE_EQ(stats.fix_rate, 1.0);
+    EXPECT_TRUE(result.diagnostics.lambda_ambiguity_fix_solved);
+    EXPECT_TRUE(result.diagnostics.lambda_ambiguity_fix_used);
+    EXPECT_GT(result.diagnostics.lambda_ambiguity_ratio, config.lambda_ratio_threshold);
+    EXPECT_EQ(result.diagnostics.ambiguity_fix_candidates, 6u);
+    EXPECT_EQ(result.diagnostics.lambda_ambiguity_candidates, 6u);
+    EXPECT_EQ(result.diagnostics.lambda_ambiguity_used_candidates, 6u);
+    EXPECT_EQ(result.diagnostics.lambda_ambiguity_attempts, 1u);
+    EXPECT_FALSE(result.diagnostics.partial_lambda_ambiguity_fix_used);
+    EXPECT_EQ(result.diagnostics.fixed_ambiguities, 6u);
+    EXPECT_LT(result.diagnostics.fixed_ambiguity_residual_rms_cycles, 1e-4);
+    ASSERT_EQ(result.ambiguity_estimates.size(), 6u);
+
+    for (std::size_t sat = 0; sat < result.ambiguity_estimates.size(); ++sat) {
+        const auto& estimate = result.ambiguity_estimates[sat];
+        EXPECT_TRUE(estimate.is_fixed);
+        EXPECT_TRUE(estimate.fixed_by_lambda);
+        EXPECT_EQ(estimate.fixed_cycles, trueAmbiguityCycles(sat));
+        EXPECT_NEAR(estimate.ambiguity_cycles,
+                    static_cast<double>(trueAmbiguityCycles(sat)),
+                    1e-4);
+        EXPECT_NEAR(estimate.fixed_ambiguity_m,
+                    trueAmbiguityMeters(sat),
+                    1e-10);
+    }
+}
+
+TEST(FGOTest, LambdaAcceptsRatioQualifiedCandidatesWithoutFractionalGate) {
+    FGOProcessor::FGOProblem problem = makeSyntheticProblem(false, true);
+    const SatelliteId degraded_satellite(GNSSSystem::GPS, 6);
+    for (auto& factor : problem.carrier_phase_factors) {
+        if (factor.satellite == degraded_satellite) {
+            factor.corrected_carrier_m +=
+                0.45 * constants::GPS_L1_WAVELENGTH;
+            factor.sigma_m = 0.5;
+        }
+    }
+
+    FGOProcessor::FGOConfig config;
+    config.max_iterations = 12;
+    config.convergence_threshold_m = 1e-8;
+    config.use_motion_factors = false;
+    config.fix_ambiguities = true;
+    config.use_lambda_ambiguity_fix = true;
+    config.use_partial_lambda_ambiguity_fix = true;
+    config.carrier_phase_sigma_m = 0.01;
+    config.ambiguity_prior_sigma_m = 1000.0;
+    config.fixed_ambiguity_sigma_m = 1e-4;
+    config.ambiguity_fix_max_fractional_cycles = 0.2;
+    config.lambda_ratio_threshold = 0.0;
+    config.min_fixed_ambiguities = 4;
+    config.max_lambda_ambiguities = 6;
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(problem);
+
+    ASSERT_EQ(result.solution.size(), 2u);
+    EXPECT_TRUE(result.diagnostics.converged);
+    EXPECT_TRUE(result.diagnostics.fixed_solution);
+    EXPECT_TRUE(result.diagnostics.lambda_ambiguity_fix_solved);
+    EXPECT_TRUE(result.diagnostics.lambda_ambiguity_fix_used);
+    EXPECT_FALSE(result.diagnostics.partial_lambda_ambiguity_fix_used);
+    EXPECT_EQ(result.solution.solutions[0].status, SolutionStatus::FIXED);
+    EXPECT_EQ(result.solution.solutions[0].num_fixed_ambiguities, 6);
+    EXPECT_EQ(result.diagnostics.lambda_ambiguity_candidates, 6u);
+    EXPECT_EQ(result.diagnostics.lambda_ambiguity_used_candidates, 6u);
+    EXPECT_EQ(result.diagnostics.lambda_ambiguity_attempts, 1u);
+    EXPECT_EQ(result.diagnostics.fixed_ambiguities, 6u);
+    ASSERT_EQ(result.ambiguity_estimates.size(), 6u);
+
+    for (const auto& estimate : result.ambiguity_estimates) {
+        EXPECT_TRUE(estimate.is_fixed);
+        EXPECT_TRUE(estimate.fixed_by_lambda);
+    }
+}
+
+TEST(FGOTest, PropagatesTdcpQualityDiagnostics) {
+    auto problem = makeSyntheticProblem();
+    problem.diagnostics.tdcp_candidate_pairs = 9;
+    problem.diagnostics.tdcp_rejected_gap = 2;
+    problem.diagnostics.tdcp_rejected_missing_previous = 3;
+    problem.diagnostics.tdcp_rejected_loss_of_lock = 4;
+    problem.diagnostics.tdcp_rejected_code_phase_jump = 5;
+
+    FGOProcessor::FGOConfig config;
+    config.max_iterations = 10;
+    config.convergence_threshold_m = 1e-8;
+    config.use_motion_factors = false;
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(problem);
+
+    ASSERT_FALSE(result.solution.isEmpty());
+    EXPECT_EQ(result.diagnostics.tdcp_candidate_pairs, 9u);
+    EXPECT_EQ(result.diagnostics.tdcp_rejected_gap, 2u);
+    EXPECT_EQ(result.diagnostics.tdcp_rejected_missing_previous, 3u);
+    EXPECT_EQ(result.diagnostics.tdcp_rejected_loss_of_lock, 4u);
+    EXPECT_EQ(result.diagnostics.tdcp_rejected_code_phase_jump, 5u);
+}

--- a/tests/test_mode_compare.py
+++ b/tests/test_mode_compare.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""Tests for the SPP/FGO/RTK mode comparison runner."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import subprocess
+import sys
+import tempfile
+import unittest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+APPS_DIR = ROOT_DIR / "apps"
+sys.path.insert(0, str(APPS_DIR))
+
+import gnss_mode_compare  # noqa: E402
+
+
+class ModeCompareTest(unittest.TestCase):
+    def write_pos(self, path: Path, rows: list[tuple[float, float, int, int, float]]) -> None:
+        lines = [
+            "% LibGNSS++ Position Solution\n",
+            "% Columns: GPS_Week GPS_TOW X(m) Y(m) Z(m) Lat(deg) Lon(deg) Height(m) Status Satellites PDOP Ratio\n",
+        ]
+        for tow, x, status, satellites, ratio in rows:
+            lines.append(
+                f"2200 {tow:.3f} {x:.4f} 2.0000 3.0000 "
+                f"35.000000000 139.000000000 10.0000 {status} {satellites} 1.20 {ratio:.1f}\n"
+            )
+        path.write_text("".join(lines), encoding="ascii")
+
+    def write_reference_csv(self, path: Path) -> None:
+        path.write_text(
+            "\n".join(
+                [
+                    "GPS TOW (s),GPS Week,Latitude (deg),Longitude (deg),Ellipsoid Height (m),ECEF X (m),ECEF Y (m),ECEF Z (m),Roll (deg),Pitch (deg),Heading (deg),East Velocity (m/s),North Velocity (m/s),Up Velocity (m/s)",
+                    "10.000, 2200, 0.0, 0.0, 0.0, 1.0, 2.0, 3.0, 0, 0, 0, 0, 0, 0",
+                    "11.000, 2200, 0.0, 0.0, 0.0, 2.0, 2.3, 3.4, 0, 0, 0, 0, 0, 0",
+                    "",
+                ]
+            ),
+            encoding="ascii",
+        )
+
+    def test_summarizes_pos_records_and_pairwise_deltas(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_mode_compare_pos_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            spp_path = temp_root / "spp.pos"
+            fgo_path = temp_root / "fgo.pos"
+            self.write_pos(
+                spp_path,
+                [
+                    (10.000, 1.0, 1, 7, 0.0),
+                    (11.000, 2.0, 1, 8, 0.0),
+                ],
+            )
+            self.write_pos(
+                fgo_path,
+                [
+                    (10.004, 1.5, 3, 9, 2.5),
+                    (11.004, 3.0, 4, 10, 4.0),
+                ],
+            )
+
+            spp_records = gnss_mode_compare.read_pos_records(spp_path)
+            fgo_records = gnss_mode_compare.read_pos_records(fgo_path)
+            spp_summary = gnss_mode_compare.summarize_records(spp_records)
+            pair_summary = gnss_mode_compare.summarize_pairwise(
+                "spp",
+                spp_records,
+                "fgo",
+                fgo_records,
+                tolerance_s=0.01,
+            )
+
+            self.assertEqual(spp_summary["epochs"], 2)
+            self.assertEqual(spp_summary["spp_epochs"], 2)
+            self.assertEqual(spp_summary["status_counts"], {"SPP": 2})
+            self.assertEqual(pair_summary["common_epochs"], 2)
+            self.assertAlmostEqual(float(pair_summary["mean_3d_delta_m"]), 0.75)
+            self.assertAlmostEqual(float(pair_summary["max_3d_delta_m"]), 1.0)
+
+    def test_run_plan_reports_solver_wall_time(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_mode_compare_wall_time_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            plan = gnss_mode_compare.ModePlan(
+                name="noop",
+                pos_path=temp_root / "noop.pos",
+                summary_path=None,
+                command=[sys.executable, "-c", "print('ok')"],
+            )
+
+            completed, solver_wall_time_s = gnss_mode_compare.run_plan(plan, keep_going=False)
+
+            self.assertEqual(completed.returncode, 0)
+            self.assertGreater(solver_wall_time_s, 0.0)
+
+    def test_dry_run_writes_planned_auto_mode_summary(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_mode_compare_dry_run_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            obs_path = temp_root / "rover.obs"
+            nav_path = temp_root / "nav.rnx"
+            base_path = temp_root / "base.obs"
+            for path in (obs_path, nav_path, base_path):
+                path.write_text("", encoding="ascii")
+            summary_path = temp_root / "summary.json"
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(APPS_DIR / "gnss_mode_compare.py"),
+                    "--obs",
+                    str(obs_path),
+                    "--nav",
+                    str(nav_path),
+                    "--base",
+                    str(base_path),
+                    "--out-dir",
+                    str(temp_root / "out"),
+                    "--summary-json",
+                    str(summary_path),
+                    "--fgo-preset",
+                    "taroz-pc",
+                    "--fgo-skip-epochs",
+                    "7",
+                    "--max-epochs",
+                    "5",
+                    "--dry-run",
+                ],
+                cwd=ROOT_DIR,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            payload = json.loads(summary_path.read_text(encoding="utf-8"))
+            self.assertEqual(set(payload["modes"]), {"spp", "fgo", "rtk"})
+            self.assertEqual(payload["modes"]["spp"]["status"], "planned")
+            self.assertEqual(payload["fgo_skip_epochs"], 7)
+            self.assertIsNone(payload["modes"]["spp"]["solver_wall_time_s"])
+            self.assertIn("fgo", payload["modes"]["fgo"]["command"])
+            self.assertIn("--summary-json", payload["modes"]["fgo"]["command"])
+            self.assertIn("--preset", payload["modes"]["fgo"]["command"])
+            self.assertIn("taroz-pc", payload["modes"]["fgo"]["command"])
+            self.assertIn("--backend", payload["modes"]["fgo"]["command"])
+            self.assertIn("gtsam-pc", payload["modes"]["fgo"]["command"])
+            self.assertIn("--skip-epochs", payload["modes"]["fgo"]["command"])
+            self.assertIn("7", payload["modes"]["fgo"]["command"])
+            self.assertIn("--base", payload["modes"]["fgo"]["command"])
+            self.assertIn(str(base_path), payload["modes"]["fgo"]["command"])
+            self.assertIn("solve", payload["modes"]["rtk"]["command"])
+            self.assertIn("--no-kml", payload["modes"]["rtk"]["command"])
+
+    def test_existing_pos_inputs_do_not_require_rinex_inputs(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_mode_compare_external_pos_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            spp_path = temp_root / "existing_spp.pos"
+            fgo_path = temp_root / "existing_fgo.pos"
+            fgo_summary_path = temp_root / "existing_fgo_summary.json"
+            summary_path = temp_root / "summary.json"
+            self.write_pos(
+                spp_path,
+                [
+                    (10.000, 1.0, 1, 7, 0.0),
+                    (11.000, 2.0, 1, 8, 0.0),
+                ],
+            )
+            self.write_pos(
+                fgo_path,
+                [
+                    (10.000, 1.2, 3, 9, 2.5),
+                    (11.000, 2.4, 4, 10, 4.0),
+                ],
+            )
+            fgo_summary_path.write_text(
+                json.dumps({"fixed_solutions": 1, "float_solutions": 1}) + "\n",
+                encoding="utf-8",
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(APPS_DIR / "gnss_mode_compare.py"),
+                    "--modes",
+                    "spp,fgo",
+                    "--spp-pos",
+                    str(spp_path),
+                    "--fgo-pos",
+                    str(fgo_path),
+                    "--fgo-summary-json",
+                    str(fgo_summary_path),
+                    "--summary-json",
+                    str(summary_path),
+                    "--require-mode-epochs-min",
+                    "spp=2",
+                    "--require-mode-fix-rate-min",
+                    "fgo=50",
+                    "--require-pair-common-min",
+                    "spp:fgo=2",
+                    "--require-pair-p95-3d-max",
+                    "spp:fgo=0.4",
+                ],
+                cwd=ROOT_DIR,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            payload = json.loads(summary_path.read_text(encoding="utf-8"))
+            self.assertIsNone(payload["obs"])
+            self.assertIsNone(payload["nav"])
+            self.assertEqual(payload["modes"]["spp"]["status"], "external")
+            self.assertEqual(payload["modes"]["fgo"]["status"], "external")
+            self.assertEqual(payload["modes"]["fgo"]["native_summary"]["fixed_solutions"], 1)
+            self.assertEqual(payload["modes"]["fgo"]["summary"]["fixed_epochs"], 1)
+            self.assertEqual(payload["pairwise"][0]["common_epochs"], 2)
+            self.assertTrue(payload["requirements"]["passed"])
+            self.assertEqual(payload["requirements"]["failures"], [])
+
+    def test_reference_csv_adds_per_mode_reference_metrics(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_mode_compare_reference_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            spp_path = temp_root / "existing_spp.pos"
+            fgo_path = temp_root / "existing_fgo.pos"
+            reference_path = temp_root / "reference.csv"
+            summary_path = temp_root / "summary.json"
+            self.write_pos(
+                spp_path,
+                [
+                    (10.000, 1.0, 1, 7, 0.0),
+                    (11.000, 2.0, 1, 8, 0.0),
+                ],
+            )
+            self.write_pos(
+                fgo_path,
+                [
+                    (10.000, 1.0, 3, 9, 2.5),
+                    (11.000, 2.0, 4, 10, 4.0),
+                ],
+            )
+            self.write_reference_csv(reference_path)
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(APPS_DIR / "gnss_mode_compare.py"),
+                    "--modes",
+                    "spp,fgo",
+                    "--spp-pos",
+                    str(spp_path),
+                    "--fgo-pos",
+                    str(fgo_path),
+                    "--reference-csv",
+                    str(reference_path),
+                    "--summary-json",
+                    str(summary_path),
+                ],
+                cwd=ROOT_DIR,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            self.assertIn("ref_mean_h", result.stdout)
+            self.assertIn("ref_3d50_matched=100.00%", result.stdout)
+            self.assertIn("ref_3d50_ref=100.00%", result.stdout)
+            payload = json.loads(summary_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["reference_csv"], str(reference_path))
+            self.assertEqual(payload["reference_match_tolerance_s"], 0.25)
+            spp_reference = payload["modes"]["spp"]["reference_summary"]
+            fgo_reference = payload["modes"]["fgo"]["reference_summary"]
+            self.assertEqual(spp_reference["matched_epochs"], 2)
+            self.assertAlmostEqual(float(spp_reference["mean_h_m"]), 0.25)
+            self.assertAlmostEqual(float(spp_reference["p95_h_m"]), 0.475)
+            self.assertEqual(spp_reference["ppc_score_3d_50cm_matched_pct"], 100.0)
+            self.assertEqual(fgo_reference["matched_epochs"], 2)
+
+    def test_requirement_failures_return_nonzero_and_stay_in_summary(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_mode_compare_requirements_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            spp_path = temp_root / "spp.pos"
+            fgo_path = temp_root / "fgo.pos"
+            summary_path = temp_root / "summary.json"
+            self.write_pos(
+                spp_path,
+                [
+                    (10.000, 1.0, 1, 7, 0.0),
+                    (11.000, 2.0, 1, 8, 0.0),
+                ],
+            )
+            self.write_pos(
+                fgo_path,
+                [
+                    (10.000, 1.2, 3, 9, 2.5),
+                    (11.000, 2.4, 4, 10, 4.0),
+                ],
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(APPS_DIR / "gnss_mode_compare.py"),
+                    "--modes",
+                    "spp,fgo",
+                    "--spp-pos",
+                    str(spp_path),
+                    "--fgo-pos",
+                    str(fgo_path),
+                    "--summary-json",
+                    str(summary_path),
+                    "--require-mode-fix-rate-min",
+                    "fgo=75",
+                    "--require-pair-p95-3d-max",
+                    "spp:fgo=0.1",
+                ],
+                cwd=ROOT_DIR,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("Requirement checks failed", result.stderr)
+            payload = json.loads(summary_path.read_text(encoding="utf-8"))
+            self.assertFalse(payload["requirements"]["passed"])
+            self.assertEqual(len(payload["requirements"]["failures"]), 2)
+            self.assertIn("fgo=75", payload["requirements"]["failures"][0])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -12,7 +12,7 @@ from pathlib import Path
 
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
-BUILD_DIR = ROOT_DIR / "build"
+BUILD_DIR = Path(os.environ.get("GNSSPP_BINARY_DIR", ROOT_DIR / "build"))
 
 
 def repo_data_exists(*relative_paths: str) -> bool:

--- a/tests/test_ppc_taroz_amb_pdc_smoke.py
+++ b/tests/test_ppc_taroz_amb_pdc_smoke.py
@@ -1,0 +1,174 @@
+#!/usr/bin/env python3
+"""Tests for the PPC taroz ambiguity PDC smoke harness."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+APPS_DIR = ROOT_DIR / "apps"
+sys.path.insert(0, str(APPS_DIR))
+
+import gnss_ppc_taroz_amb_pdc_smoke  # noqa: E402
+
+
+class PpcTarozAmbPdcSmokeTest(unittest.TestCase):
+    def make_run(self, root: Path, spec: str) -> Path:
+        site, run_name = spec.split("/")
+        run_dir = root / site / run_name
+        run_dir.mkdir(parents=True)
+        for name in ("rover.obs", "base.obs", "base.nav", "reference.csv"):
+            (run_dir / name).write_text("", encoding="ascii")
+        return run_dir
+
+    def test_discovers_nested_dataset_root(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ppc_discover_test_") as temp_dir:
+            outer_root = Path(temp_dir)
+            dataset_root = outer_root / "PPC-Dataset"
+            self.make_run(dataset_root, "nagoya/run1")
+            self.make_run(dataset_root, "tokyo/run2")
+
+            runs = gnss_ppc_taroz_amb_pdc_smoke.discover_runs(outer_root)
+
+            self.assertEqual([run.spec for run in runs], ["nagoya/run1", "tokyo/run2"])
+
+    def test_dry_run_writes_planned_commands(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ppc_smoke_dry_run_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            dataset_root = temp_root / "PPC-Dataset"
+            self.make_run(dataset_root, "nagoya/run1")
+            summary_json = temp_root / "summary.json"
+
+            result = gnss_ppc_taroz_amb_pdc_smoke.main(
+                [
+                    "--dataset-root",
+                    str(temp_root),
+                    "--run",
+                    "nagoya/run1",
+                    "--summary-json",
+                    str(summary_json),
+                    "--fgo-bin",
+                    str(temp_root / "gnss_fgo"),
+                    "--spp-bin",
+                    str(temp_root / "gnss_spp"),
+                    "--skip-epochs",
+                    "7",
+                    "--generate-spp-seed",
+                    "--dry-run",
+                ]
+            )
+
+            self.assertEqual(result, 0)
+            payload = json.loads(summary_json.read_text(encoding="utf-8"))
+            command = payload["planned_commands"]["nagoya/run1"]
+            seed_command = payload["planned_seed_commands"]["nagoya/run1"]
+            self.assertEqual(payload["status"], "dry-run")
+            self.assertEqual(payload["skip_epochs"], 7)
+            self.assertTrue(payload["generate_spp_seed"])
+            self.assertIn("--max-epochs", seed_command)
+            self.assertIn("27", seed_command)
+            self.assertIn("--skip-epochs", command)
+            self.assertIn("7", command)
+            self.assertIn("--seed-pos", command)
+            self.assertIn("--preset", command)
+            self.assertIn("taroz-amb-pdc", command)
+            self.assertIn("--max-epochs", command)
+            self.assertIn("20", command)
+
+    def test_native_summary_validation_flags_low_candidate_run(self) -> None:
+        class Args:
+            max_epochs = 20
+            require_valid_min = 1
+            require_dd_carrier_min = 1
+            require_lambda_attempts_min = 1
+            require_fix_rate_min = 0.0
+            allow_not_converged = False
+
+        failures = gnss_ppc_taroz_amb_pdc_smoke.validate_native_summary(
+            Args(),
+            {
+                "preset": "taroz-amb-pdc",
+                "backend": "eigen",
+                "optimized_epochs": 20,
+                "valid_solutions": 0,
+                "double_difference_carrier_factors": 0,
+                "lambda_ambiguity_attempts": 0,
+                "fix_rate_percent": 0.0,
+                "converged": True,
+            },
+        )
+
+        self.assertEqual(
+            failures,
+            [
+                "valid_solutions 0 < 1",
+                "double_difference_carrier_factors 0 < 1",
+                "lambda_ambiguity_attempts 0 < 1",
+            ],
+        )
+
+    def test_reference_summary_keeps_no_solution_out_of_valid_error(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ppc_reference_summary_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            pos_path = temp_root / "solution.pos"
+            reference_csv = temp_root / "reference.csv"
+            pos_path.write_text(
+                "\n".join(
+                    [
+                        "% synthetic solution",
+                        "2325 10.000000 1.0 0.0 0.0 0 0 0 3 8",
+                        "2325 10.200000 1000.0 0.0 0.0 0 0 0 0 0",
+                    ]
+                )
+                + "\n",
+                encoding="ascii",
+            )
+            reference_csv.write_text(
+                "GPS Week,GPS TOW (s),ECEF X (m),ECEF Y (m),ECEF Z (m)\n"
+                "2325,10.000000,0.0,0.0,0.0\n"
+                "2325,10.200000,0.0,0.0,0.0\n",
+                encoding="ascii",
+            )
+
+            summary = gnss_ppc_taroz_amb_pdc_smoke.summarize_reference_errors(
+                pos_path,
+                reference_csv,
+                0.05,
+            )
+
+            self.assertEqual(summary["matched_epochs"], 1)
+            self.assertEqual(summary["p95_3d_error_m"], 1.0)
+            self.assertEqual(summary["no_solution"]["matched_epochs"], 1)
+            self.assertEqual(summary["all_output"]["max_3d_error_m"], 1000.0)
+
+    def test_reference_summary_validation_flags_large_valid_p95(self) -> None:
+        class Args:
+            require_valid_p95_3d_max = 2.0
+            require_valid_max_3d_max = 0.0
+            require_fixed_p95_3d_max = 0.5
+
+        failures = gnss_ppc_taroz_amb_pdc_smoke.validate_reference_summary(
+            Args(),
+            {
+                "p95_3d_error_m": 3.25,
+                "max_3d_error_m": 10.0,
+                "fixed": {"p95_3d_error_m": 0.75},
+            },
+        )
+
+        self.assertEqual(
+            failures,
+            [
+                "valid p95_3d_error_m 3.250000 > 2.0",
+                "fixed p95_3d_error_m 0.750000 > 0.5",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_spp.cpp
+++ b/tests/test_spp.cpp
@@ -21,7 +21,118 @@ bool sourcePathExists(const std::string& relative_path) {
     return std::filesystem::exists(sourcePath(relative_path));
 }
 
+double solveKeplerForTest(double mean_anomaly, double eccentricity) {
+    double eccentric_anomaly = mean_anomaly;
+    for (int i = 0; i < 30; ++i) {
+        const double previous = eccentric_anomaly;
+        eccentric_anomaly -=
+            (eccentric_anomaly - eccentricity * std::sin(eccentric_anomaly) -
+             mean_anomaly) /
+            (1.0 - eccentricity * std::cos(eccentric_anomaly));
+        if (std::abs(eccentric_anomaly - previous) < 1e-14) {
+            break;
+        }
+    }
+    return eccentric_anomaly;
+}
+
+Vector3d expectedBeiDouGeoPosition(const Ephemeris& eph,
+                                   const GNSSTime& time,
+                                   bool use_geo_omega) {
+    constexpr double kBeiDouEarthMu = 3.986004418e14;
+    constexpr double kBeiDouEarthRotationRate = 7.292115e-5;
+    constexpr double kSinMinus5Deg = -0.0871557427476582;
+    constexpr double kCosMinus5Deg = 0.9961946980917456;
+
+    const double semi_major_axis = eph.sqrt_a * eph.sqrt_a;
+    const double tk = time - eph.toe;
+    const double n0 = std::sqrt(kBeiDouEarthMu /
+                                (semi_major_axis * semi_major_axis *
+                                 semi_major_axis));
+    const double mean_anomaly = eph.m0 + (n0 + eph.delta_n) * tk;
+    const double eccentric_anomaly = solveKeplerForTest(mean_anomaly, eph.e);
+    const double sin_e = std::sin(eccentric_anomaly);
+    const double cos_e = std::cos(eccentric_anomaly);
+    const double true_anomaly =
+        std::atan2(std::sqrt(1.0 - eph.e * eph.e) * sin_e, cos_e - eph.e);
+    const double phi = true_anomaly + eph.omega;
+    const double two_phi = 2.0 * phi;
+    const double u = phi + eph.cus * std::sin(two_phi) +
+                     eph.cuc * std::cos(two_phi);
+    const double r = semi_major_axis * (1.0 - eph.e * cos_e) +
+                     eph.crs * std::sin(two_phi) +
+                     eph.crc * std::cos(two_phi);
+    const double inclination =
+        eph.i0 + eph.idot * tk +
+        eph.cis * std::sin(two_phi) + eph.cic * std::cos(two_phi);
+    const double toe_seconds = eph.toes != 0.0 ? eph.toes : eph.toe.tow;
+    const double omega =
+        use_geo_omega
+            ? eph.omega0 + eph.omega_dot * tk -
+                  kBeiDouEarthRotationRate * toe_seconds
+            : eph.omega0 + (eph.omega_dot - kBeiDouEarthRotationRate) * tk -
+                  kBeiDouEarthRotationRate * toe_seconds;
+
+    const double x_orb = r * std::cos(u);
+    const double y_orb = r * std::sin(u);
+    const double xg = x_orb * std::cos(omega) -
+                      y_orb * std::cos(inclination) * std::sin(omega);
+    const double yg = x_orb * std::sin(omega) +
+                      y_orb * std::cos(inclination) * std::cos(omega);
+    const double zg = y_orb * std::sin(inclination);
+    const double sin_rot = std::sin(kBeiDouEarthRotationRate * tk);
+    const double cos_rot = std::cos(kBeiDouEarthRotationRate * tk);
+
+    Vector3d position;
+    position(0) = xg * cos_rot + yg * sin_rot * kCosMinus5Deg +
+                  zg * sin_rot * kSinMinus5Deg;
+    position(1) = -xg * sin_rot + yg * cos_rot * kCosMinus5Deg +
+                  zg * cos_rot * kSinMinus5Deg;
+    position(2) = -yg * kSinMinus5Deg + zg * kCosMinus5Deg;
+    return position;
+}
+
 }  // namespace
+
+TEST(NavigationTest, BeiDouGeoBroadcastStateUsesGeoRotationFrame) {
+    Ephemeris eph;
+    eph.satellite = SatelliteId(GNSSSystem::BeiDou, 1);
+    eph.valid = true;
+    eph.week = 2323;
+    eph.toe = GNSSTime(2323, 553800.0);
+    eph.toc = eph.toe;
+    eph.toes = 553800.0;
+    eph.sqrt_a = std::sqrt(42164000.0);
+    eph.e = 0.0012;
+    eph.i0 = 0.08;
+    eph.omega0 = 1.25;
+    eph.omega = 0.61;
+    eph.m0 = 0.42;
+    eph.delta_n = 1.0e-9;
+    eph.idot = -2.0e-10;
+    eph.omega_dot = -2.6e-9;
+    eph.cuc = 1.0e-6;
+    eph.cus = -2.0e-6;
+    eph.crc = 120.0;
+    eph.crs = -30.0;
+    eph.cic = 2.0e-7;
+    eph.cis = -3.0e-7;
+
+    const GNSSTime eval_time = eph.toe + 120.0;
+    Vector3d position;
+    Vector3d velocity;
+    double clock_bias = 0.0;
+    double clock_drift = 0.0;
+    ASSERT_TRUE(eph.calculateSatelliteState(
+        eval_time, position, velocity, clock_bias, clock_drift));
+
+    const Vector3d expected =
+        expectedBeiDouGeoPosition(eph, eval_time, true);
+    const Vector3d non_geo_omega =
+        expectedBeiDouGeoPosition(eph, eval_time, false);
+    EXPECT_LT((position - expected).norm(), 1e-3);
+    EXPECT_GT((position - non_geo_omega).norm(), 100000.0);
+}
 
 class SPPTest : public ::testing::Test {
 protected:

--- a/tests/test_taroz_d_internal_parity.py
+++ b/tests/test_taroz_d_internal_parity.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Optional parity checks against taroz MATLAB Doppler velocity dumps."""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+import os
+from pathlib import Path
+import statistics
+import unittest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def configured_path(env_name: str, default_relative_path: str) -> Path:
+    configured = os.environ.get(env_name)
+    if configured:
+        path = Path(configured)
+        return path if path.is_absolute() else ROOT_DIR / path
+    return ROOT_DIR / default_relative_path
+
+
+CPP_DIR = configured_path(
+    "GNSSPP_TAROZ_D_CPP_DIR",
+    "output/dogfood/taroz_d_dogfood_current",
+)
+MATLAB_DIR = configured_path(
+    "GNSSPP_TAROZ_D_MATLAB_DIR",
+    "output/dogfood/taroz_matlab_d_debug",
+)
+
+
+def read_json(path: Path) -> dict[str, object]:
+    with path.open() as handle:
+        return json.load(handle)
+
+
+def read_csv_by_tow(path: Path) -> dict[int, dict[str, str]]:
+    with path.open(newline="") as handle:
+        return {
+            round(float(row["gps_tow"])): row
+            for row in csv.DictReader(handle)
+        }
+
+
+def read_cpp_factor_rows(path: Path) -> dict[tuple[int, str], dict[str, str]]:
+    with path.open(newline="") as handle:
+        return {
+            (round(float(row["gps_tow"])), row["satellite"]): row
+            for row in csv.DictReader(handle)
+        }
+
+
+def read_taroz_factor_rows(path: Path) -> dict[tuple[int, str], dict[str, str]]:
+    rows: dict[tuple[int, str], dict[str, str]] = {}
+    with path.open(newline="") as handle:
+        for row in csv.DictReader(handle):
+            if row.get("valid_doppler", "").lower() not in {"1", "true"}:
+                continue
+            rows[(round(float(row["gps_tow"])), row["satellite"])] = row
+    return rows
+
+
+def max_abs_diff(
+    keys: list[tuple[int, str]],
+    left: dict[tuple[int, str], dict[str, str]],
+    right: dict[tuple[int, str], dict[str, str]],
+    left_column: str,
+    right_column: str,
+) -> float:
+    return max(
+        abs(float(left[key][left_column]) - float(right[key][right_column]))
+        for key in keys
+    )
+
+
+def mean_abs_diff(
+    keys: list[tuple[int, str]],
+    left: dict[tuple[int, str], dict[str, str]],
+    right: dict[tuple[int, str], dict[str, str]],
+    left_column: str,
+    right_column: str,
+) -> float:
+    return statistics.mean(
+        abs(float(left[key][left_column]) - float(right[key][right_column]))
+        for key in keys
+    )
+
+
+class TarozDInternalParityTest(unittest.TestCase):
+    def require_dogfood_files(self, *paths: Path) -> None:
+        missing = [str(path.relative_to(ROOT_DIR)) for path in paths if not path.exists()]
+        if missing:
+            self.skipTest("missing optional taroz D dogfood files: " + ", ".join(missing))
+
+    def test_graph_and_factor_counts_match_taroz_d_dump(self) -> None:
+        cpp_summary_path = CPP_DIR / "summary.json"
+        cpp_graph_path = CPP_DIR / "graph_detail.csv"
+        taroz_graph_path = MATLAB_DIR / "graph_detail.csv"
+        taroz_sat_path = MATLAB_DIR / "per_sat_detail.csv"
+        self.require_dogfood_files(
+            cpp_summary_path,
+            cpp_graph_path,
+            taroz_graph_path,
+            taroz_sat_path,
+        )
+
+        cpp = read_json(cpp_summary_path)
+        with cpp_graph_path.open(newline="") as handle:
+            cpp_graph = next(csv.DictReader(handle))
+        with taroz_graph_path.open(newline="") as handle:
+            taroz_graph = next(csv.DictReader(handle))
+        taroz_factors = read_taroz_factor_rows(taroz_sat_path)
+
+        self.assertEqual(cpp["preset"], "taroz-d")
+        self.assertEqual(cpp["backend"], "eigen")
+        self.assertEqual(cpp["optimized_epochs"], int(float(taroz_graph["n"])))
+        self.assertEqual(cpp["doppler_factors"], len(taroz_factors))
+        self.assertEqual(int(float(cpp_graph["graph_factors"])), int(float(taroz_graph["graph_factors"])))
+        self.assertEqual(int(float(cpp_graph["graph_values"])), int(float(taroz_graph["graph_values"])))
+        self.assertLessEqual(
+            abs(float(cpp_graph["initial_cost"]) - float(taroz_graph["initial_cost"])) /
+            max(1.0, abs(float(taroz_graph["initial_cost"]))),
+            1e-4,
+        )
+        self.assertLessEqual(
+            abs(float(cpp_graph["final_cost"]) - float(taroz_graph["final_cost"])) /
+            max(1.0, abs(float(taroz_graph["final_cost"]))),
+            1e-3,
+        )
+
+    def test_raw_doppler_factors_match_taroz_d_dump(self) -> None:
+        cpp_factor_path = CPP_DIR / "factor_debug.csv"
+        taroz_sat_path = MATLAB_DIR / "per_sat_detail.csv"
+        self.require_dogfood_files(cpp_factor_path, taroz_sat_path)
+
+        cpp_factors = read_cpp_factor_rows(cpp_factor_path)
+        taroz_factors = read_taroz_factor_rows(taroz_sat_path)
+
+        self.assertEqual(set(cpp_factors), set(taroz_factors))
+        keys = sorted(cpp_factors)
+        self.assertEqual(len(keys), 24092)
+        self.assertLessEqual(max_abs_diff(keys, cpp_factors, taroz_factors, "elevation_deg", "elevation_deg"), 1e-4)
+        self.assertLessEqual(max_abs_diff(keys, cpp_factors, taroz_factors, "sigma_d_mps", "sigma_d_mps"), 1e-6)
+        self.assertLessEqual(mean_abs_diff(keys, cpp_factors, taroz_factors, "res_d_mps", "res_d_mps"), 1e-3)
+        self.assertLessEqual(max_abs_diff(keys, cpp_factors, taroz_factors, "res_d_mps", "res_d_mps"), 0.02)
+        for axis in ("x", "y", "z"):
+            self.assertLessEqual(
+                max_abs_diff(keys, cpp_factors, taroz_factors, f"los_{axis}", f"los_{axis}"),
+                1e-6,
+            )
+
+    def test_final_velocity_matches_taroz_d_dump(self) -> None:
+        cpp_epoch_path = CPP_DIR / "per_epoch_vel.csv"
+        taroz_epoch_path = MATLAB_DIR / "per_epoch_vel.csv"
+        self.require_dogfood_files(cpp_epoch_path, taroz_epoch_path)
+
+        cpp_epochs = read_csv_by_tow(cpp_epoch_path)
+        taroz_epochs = read_csv_by_tow(taroz_epoch_path)
+        common_tows = sorted(set(cpp_epochs) & set(taroz_epochs))
+        self.assertEqual(len(common_tows), 1141)
+
+        velocity_diffs: list[float] = []
+        clock_diffs: list[float] = []
+        for tow in common_tows:
+            cpp = cpp_epochs[tow]
+            taroz = taroz_epochs[tow]
+            cpp_velocity = (
+                float(cpp["fgo_vx_mps"]),
+                float(cpp["fgo_vy_mps"]),
+                float(cpp["fgo_vz_mps"]),
+            )
+            taroz_velocity = (
+                float(taroz["fgo_vx_mps"]),
+                float(taroz["fgo_vy_mps"]),
+                float(taroz["fgo_vz_mps"]),
+            )
+            velocity_diffs.append(math.dist(cpp_velocity, taroz_velocity))
+            clock_diffs.append(
+                abs(float(cpp["fgo_clock_drift_mps"]) - float(taroz["fgo_clock_drift_mps"]))
+            )
+
+        self.assertLessEqual(statistics.mean(velocity_diffs), 0.01)
+        self.assertLessEqual(max(velocity_diffs), 0.05)
+        self.assertLessEqual(statistics.mean(clock_diffs), 0.01)
+        self.assertLessEqual(max(clock_diffs), 0.05)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_taroz_p_dogfood.py
+++ b/tests/test_taroz_p_dogfood.py
@@ -1,0 +1,241 @@
+#!/usr/bin/env python3
+"""Tests for the taroz P dogfood harness."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+APPS_DIR = ROOT_DIR / "apps"
+sys.path.insert(0, str(APPS_DIR))
+
+import gnss_taroz_p_dogfood  # noqa: E402
+
+
+class TarozPDogfoodTest(unittest.TestCase):
+    def touch_inputs(self, root: Path) -> tuple[Path, Path, Path]:
+        obs = root / "rover.obs"
+        nav = root / "base.nav"
+        seed_pos = root / "seed.pos"
+        for path in (obs, nav, seed_pos):
+            path.write_text("", encoding="ascii")
+        return obs, nav, seed_pos
+
+    def test_dry_run_writes_bounded_smoke_plan(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_taroz_p_dogfood_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            obs, nav, seed_pos = self.touch_inputs(temp_root)
+            summary_json = temp_root / "summary.json"
+            out_dir = temp_root / "out"
+
+            result = gnss_taroz_p_dogfood.main(
+                [
+                    "--obs",
+                    str(obs),
+                    "--nav",
+                    str(nav),
+                    "--seed-pos",
+                    str(seed_pos),
+                    "--out-dir",
+                    str(out_dir),
+                    "--summary-json",
+                    str(summary_json),
+                    "--fgo-bin",
+                    str(temp_root / "gnss_fgo"),
+                    "--dry-run",
+                ]
+            )
+
+            self.assertEqual(result, 0)
+            payload = json.loads(summary_json.read_text(encoding="utf-8"))
+            command = payload["fgo_command"]
+            self.assertEqual(payload["status"], "dry-run")
+            self.assertIn("--preset", command)
+            self.assertIn("taroz-p", command)
+            self.assertIn("--max-epochs", command)
+            self.assertIn(str(gnss_taroz_p_dogfood.DEFAULT_MAX_EPOCHS), command)
+            self.assertIn("--max-iterations", command)
+            self.assertIn(str(gnss_taroz_p_dogfood.DEFAULT_MAX_ITERATIONS), command)
+            self.assertIn("--factor-debug-csv", command)
+            self.assertIn("fgo_taroz_p_factor_debug.csv", " ".join(command))
+            self.assertFalse(payload["expected"]["use_spp_seed"])
+            self.assertFalse(payload["expected"]["debug_problem_only"])
+
+    def test_dry_run_can_keep_preset_runtime_limits(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_taroz_p_dogfood_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            obs, nav, seed_pos = self.touch_inputs(temp_root)
+            summary_json = temp_root / "summary.json"
+
+            result = gnss_taroz_p_dogfood.main(
+                [
+                    "--obs",
+                    str(obs),
+                    "--nav",
+                    str(nav),
+                    "--seed-pos",
+                    str(seed_pos),
+                    "--summary-json",
+                    str(summary_json),
+                    "--fgo-bin",
+                    str(temp_root / "gnss_fgo"),
+                    "--max-epochs",
+                    "0",
+                    "--max-iterations",
+                    "0",
+                    "--dry-run",
+                ]
+            )
+
+            self.assertEqual(result, 0)
+            command = json.loads(summary_json.read_text(encoding="utf-8"))["fgo_command"]
+            self.assertNotIn("--max-epochs", command)
+            self.assertNotIn("--max-iterations", command)
+
+    def test_dry_run_can_request_debug_problem_only(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_taroz_p_dogfood_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            obs, nav, seed_pos = self.touch_inputs(temp_root)
+            summary_json = temp_root / "summary.json"
+
+            result = gnss_taroz_p_dogfood.main(
+                [
+                    "--obs",
+                    str(obs),
+                    "--nav",
+                    str(nav),
+                    "--seed-pos",
+                    str(seed_pos),
+                    "--summary-json",
+                    str(summary_json),
+                    "--fgo-bin",
+                    str(temp_root / "gnss_fgo"),
+                    "--debug-problem-only",
+                    "--dry-run",
+                ]
+            )
+
+            self.assertEqual(result, 0)
+            payload = json.loads(summary_json.read_text(encoding="utf-8"))
+            command = payload["fgo_command"]
+            self.assertIn("--debug-problem-only", command)
+            self.assertTrue(payload["expected"]["debug_problem_only"])
+
+    def test_native_summary_accepts_taroz_p_shape(self) -> None:
+        summary = {
+            "preset": "taroz-p",
+            "backend": "eigen",
+            "use_spp_seed": False,
+            "use_pseudorange_factors": True,
+            "pseudorange_sigma_m": 3,
+            "pseudorange_elevation_sigma_power": 0.5,
+            "position_prior_sigma_m": 1000,
+            "clock_prior_sigma_m": 1_000_000,
+            "clock_motion_sigma_m": 100,
+            "use_position_motion_factors": False,
+            "use_clock_motion_factors": True,
+            "optimized_epochs": 80,
+            "valid_solutions": 80,
+            "pseudorange_factors": 2492,
+            "tdcp_factors": 0,
+            "carrier_phase_factors": 0,
+            "double_difference_pseudorange_factors": 0,
+            "double_difference_carrier_factors": 0,
+            "ambiguity_states": 0,
+            "motion_factors": 79,
+            "iterations": 8,
+            "converged": True,
+            "final_cost": 288.7,
+            "residual_rms_m": 1.5,
+        }
+
+        failures = gnss_taroz_p_dogfood.verify_native_summary(
+            summary,
+            expected_max_epochs=80,
+            expected_max_iterations=40,
+        )
+
+        self.assertEqual(failures, [])
+
+    def test_native_summary_accepts_debug_problem_only_shape(self) -> None:
+        summary = {
+            "preset": "taroz-p",
+            "backend": "eigen",
+            "debug_problem_only": True,
+            "use_spp_seed": False,
+            "use_pseudorange_factors": True,
+            "pseudorange_sigma_m": 3,
+            "pseudorange_elevation_sigma_power": 0.5,
+            "position_prior_sigma_m": 1000,
+            "clock_prior_sigma_m": 1_000_000,
+            "clock_motion_sigma_m": 100,
+            "use_position_motion_factors": False,
+            "use_clock_motion_factors": True,
+            "optimized_epochs": 1141,
+            "valid_solutions": 1141,
+            "pseudorange_factors": 24092,
+            "tdcp_factors": 0,
+            "carrier_phase_factors": 0,
+            "double_difference_pseudorange_factors": 0,
+            "double_difference_carrier_factors": 0,
+            "ambiguity_states": 0,
+            "motion_factors": 1140,
+            "iterations": 0,
+            "converged": False,
+            "final_cost": 0.0,
+            "residual_rms_m": 0.0,
+        }
+
+        failures = gnss_taroz_p_dogfood.verify_native_summary(
+            summary,
+            expected_max_epochs=0,
+            expected_max_iterations=40,
+            debug_problem_only=True,
+        )
+
+        self.assertEqual(failures, [])
+
+    def test_native_summary_flags_wrong_factor_family(self) -> None:
+        summary = {
+            "preset": "taroz-p",
+            "backend": "eigen",
+            "use_spp_seed": False,
+            "use_pseudorange_factors": True,
+            "pseudorange_sigma_m": 3,
+            "pseudorange_elevation_sigma_power": 0.5,
+            "position_prior_sigma_m": 1000,
+            "clock_prior_sigma_m": 1_000_000,
+            "clock_motion_sigma_m": 100,
+            "use_position_motion_factors": False,
+            "use_clock_motion_factors": True,
+            "optimized_epochs": 80,
+            "valid_solutions": 80,
+            "pseudorange_factors": 2492,
+            "tdcp_factors": 2,
+            "carrier_phase_factors": 0,
+            "double_difference_pseudorange_factors": 0,
+            "double_difference_carrier_factors": 0,
+            "ambiguity_states": 0,
+            "motion_factors": 79,
+            "iterations": 8,
+            "converged": True,
+            "final_cost": 288.7,
+            "residual_rms_m": 1.5,
+        }
+
+        failures = gnss_taroz_p_dogfood.verify_native_summary(
+            summary,
+            expected_max_epochs=80,
+            expected_max_iterations=40,
+        )
+
+        self.assertEqual(failures, ["taroz-p must keep tdcp_factors=0"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_taroz_p_internal_parity.py
+++ b/tests/test_taroz_p_internal_parity.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""Optional parity checks against taroz MATLAB P dogfood dumps."""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+import os
+from pathlib import Path
+import unittest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def configured_path(env_name: str, default_relative_path: str) -> Path:
+    configured = os.environ.get(env_name)
+    if configured:
+        path = Path(configured)
+        return path if path.is_absolute() else ROOT_DIR / path
+    return ROOT_DIR / default_relative_path
+
+
+CPP_DIR = configured_path(
+    "GNSSPP_TAROZ_P_CPP_DIR",
+    "output/dogfood/taroz_p_dogfood_current",
+)
+MATLAB_DIR = configured_path(
+    "GNSSPP_TAROZ_P_MATLAB_DIR",
+    "output/dogfood/taroz_matlab_p_debug",
+)
+
+
+def finite_float(value: str | None) -> float | None:
+    if value is None or value == "":
+        return None
+    parsed = float(value)
+    return parsed if math.isfinite(parsed) else None
+
+
+def read_csv_by_tow(path: Path) -> dict[int, dict[str, str]]:
+    with path.open(newline="") as handle:
+        return {
+            round(float(row["gps_tow"])): row
+            for row in csv.DictReader(handle)
+        }
+
+
+def read_pos_by_tow(path: Path) -> dict[int, tuple[float, float, float, int]]:
+    rows: dict[int, tuple[float, float, float, int]] = {}
+    with path.open(encoding="ascii", errors="ignore") as handle:
+        for line in handle:
+            if not line.strip() or line.startswith("%"):
+                continue
+            parts = line.split()
+            rows[round(float(parts[1]))] = (
+                float(parts[2]),
+                float(parts[3]),
+                float(parts[4]),
+                int(float(parts[8])),
+            )
+    return rows
+
+
+def count_valid_pseudorange_rows(path: Path, allowed_tows: set[int]) -> int:
+    count = 0
+    with path.open(newline="") as handle:
+        for row in csv.DictReader(handle):
+            tow = round(float(row["gps_tow"]))
+            if tow in allowed_tows and row.get("valid_pseudorange", "").lower() in {"1", "true"}:
+                count += 1
+    return count
+
+
+def read_raw_factor_debug_by_key(path: Path) -> dict[tuple[int, str], dict[str, str]]:
+    rows: dict[tuple[int, str], dict[str, str]] = {}
+    with path.open(newline="") as handle:
+        for row in csv.DictReader(handle):
+            key = (round(float(row["gps_tow"])), row["satellite"])
+            rows[key] = row
+    return rows
+
+
+def read_valid_taroz_p_sat_rows_by_key(
+    path: Path,
+    allowed_tows: set[int],
+) -> dict[tuple[int, str], dict[str, str]]:
+    rows: dict[tuple[int, str], dict[str, str]] = {}
+    with path.open(newline="") as handle:
+        for row in csv.DictReader(handle):
+            tow = round(float(row["gps_tow"]))
+            if tow not in allowed_tows:
+                continue
+            if row.get("valid_pseudorange", "").lower() not in {"1", "true"}:
+                continue
+            key = (tow, row["satellite"])
+            rows[key] = row
+    return rows
+
+
+def read_json(path: Path) -> dict[str, object]:
+    with path.open() as handle:
+        return json.load(handle)
+
+
+def max_abs_diff(
+    keys: list[tuple[int, str]],
+    left: dict[tuple[int, str], dict[str, str]],
+    right: dict[tuple[int, str], dict[str, str]],
+    left_column: str,
+    right_column: str,
+) -> float:
+    return max(
+        abs(float(left[key][left_column]) - float(right[key][right_column]))
+        for key in keys
+    )
+
+
+def mean_abs_diff(
+    keys: list[tuple[int, str]],
+    left: dict[tuple[int, str], dict[str, str]],
+    right: dict[tuple[int, str], dict[str, str]],
+    left_column: str,
+    right_column: str,
+) -> float:
+    return sum(
+        abs(float(left[key][left_column]) - float(right[key][right_column]))
+        for key in keys
+    ) / len(keys)
+
+
+class TarozPInternalParityTest(unittest.TestCase):
+    def require_dogfood_files(self, *paths: Path) -> None:
+        missing = [str(path.relative_to(ROOT_DIR)) for path in paths if not path.exists()]
+        if missing:
+            self.skipTest("missing optional taroz P dogfood files: " + ", ".join(missing))
+
+    def test_final_positions_stay_close_to_taroz_p_dump(self) -> None:
+        cpp_summary_path = CPP_DIR / "fgo_taroz_p_summary.json"
+        cpp_pos_path = CPP_DIR / "fgo_taroz_p.pos"
+        taroz_epoch_path = MATLAB_DIR / "per_epoch_est.csv"
+        self.require_dogfood_files(cpp_summary_path, cpp_pos_path, taroz_epoch_path)
+        if read_json(cpp_summary_path).get("debug_problem_only") is True:
+            self.skipTest("debug-only taroz P output intentionally keeps seed positions")
+
+        cpp_positions = read_pos_by_tow(cpp_pos_path)
+        taroz_epochs = read_csv_by_tow(taroz_epoch_path)
+        common_tows = sorted(set(cpp_positions) & set(taroz_epochs))
+        self.assertGreaterEqual(len(common_tows), 50)
+
+        position_diffs: list[float] = []
+        for tow in common_tows:
+            x, y, z, status = cpp_positions[tow]
+            self.assertEqual(status, 1)
+            taroz_row = taroz_epochs[tow]
+            tx = finite_float(taroz_row["fgo_x_m"])
+            ty = finite_float(taroz_row["fgo_y_m"])
+            tz = finite_float(taroz_row["fgo_z_m"])
+            if tx is None or ty is None or tz is None:
+                continue
+            position_diffs.append(math.dist((x, y, z), (tx, ty, tz)))
+
+        self.assertGreaterEqual(len(position_diffs), 50)
+        self.assertLessEqual(sum(position_diffs) / len(position_diffs), 10.0)
+        max_allowed_diff = 50.0 if len(position_diffs) > 1000 else 35.0
+        self.assertLessEqual(max(position_diffs), max_allowed_diff)
+
+    def test_graph_and_factor_counts_are_consistent(self) -> None:
+        cpp_summary_path = CPP_DIR / "fgo_taroz_p_summary.json"
+        cpp_pos_path = CPP_DIR / "fgo_taroz_p.pos"
+        taroz_graph_path = MATLAB_DIR / "graph_detail.csv"
+        taroz_sat_path = MATLAB_DIR / "per_sat_detail.csv"
+        self.require_dogfood_files(
+            cpp_summary_path,
+            cpp_pos_path,
+            taroz_graph_path,
+            taroz_sat_path,
+        )
+
+        cpp = read_json(cpp_summary_path)
+        with taroz_graph_path.open(newline="") as handle:
+            taroz = next(csv.DictReader(handle))
+        cpp_tows = set(read_pos_by_tow(cpp_pos_path))
+
+        self.assertEqual(cpp["preset"], "taroz-p")
+        self.assertEqual(cpp["backend"], "eigen")
+        self.assertFalse(cpp["use_spp_seed"])
+        self.assertTrue(cpp["use_pseudorange_factors"])
+        self.assertEqual(cpp["tdcp_factors"], 0)
+        self.assertEqual(cpp["carrier_phase_factors"], 0)
+        self.assertEqual(cpp["double_difference_pseudorange_factors"], 0)
+        self.assertEqual(cpp["double_difference_carrier_factors"], 0)
+
+        valid_pseudorange_rows = count_valid_pseudorange_rows(taroz_sat_path, cpp_tows)
+        self.assertGreaterEqual(valid_pseudorange_rows, cpp["pseudorange_factors"])
+        self.assertLessEqual(
+            abs(valid_pseudorange_rows - cpp["pseudorange_factors"]) /
+            max(1, valid_pseudorange_rows),
+            0.02,
+        )
+
+        taroz_graph_factors = int(float(taroz["graph_factors"]))
+        taroz_graph_values = int(float(taroz["graph_values"]))
+        self.assertGreater(taroz_graph_factors, valid_pseudorange_rows)
+        self.assertGreater(taroz_graph_values, int(cpp["optimized_epochs"]))
+        if (
+            cpp.get("debug_problem_only") is not True and
+            int(cpp["optimized_epochs"]) == int(float(taroz["n"]))
+        ):
+            self.assertLessEqual(
+                abs(float(cpp["final_cost"]) - float(taroz["final_cost"])) /
+                max(1.0, abs(float(taroz["final_cost"]))),
+                0.50,
+            )
+
+    def test_raw_pseudorange_factors_match_taroz_p_dump(self) -> None:
+        cpp_summary_path = CPP_DIR / "fgo_taroz_p_summary.json"
+        cpp_pos_path = CPP_DIR / "fgo_taroz_p.pos"
+        cpp_factor_path = CPP_DIR / "fgo_taroz_p_factor_debug.csv"
+        taroz_sat_path = MATLAB_DIR / "per_sat_detail.csv"
+        self.require_dogfood_files(
+            cpp_summary_path,
+            cpp_pos_path,
+            cpp_factor_path,
+            taroz_sat_path,
+        )
+
+        cpp_summary = read_json(cpp_summary_path)
+        cpp_tows = set(read_pos_by_tow(cpp_pos_path))
+        cpp_factors = read_raw_factor_debug_by_key(cpp_factor_path)
+        taroz_factors = read_valid_taroz_p_sat_rows_by_key(taroz_sat_path, cpp_tows)
+
+        self.assertEqual(len(cpp_factors), cpp_summary["pseudorange_factors"])
+        self.assertGreaterEqual(len(cpp_factors), 2400)
+        self.assertEqual(set(cpp_factors), set(taroz_factors))
+
+        keys = sorted(cpp_factors)
+        self.assertLessEqual(
+            max_abs_diff(
+                keys,
+                cpp_factors,
+                taroz_factors,
+                "elevation_deg",
+                "elevation_deg",
+            ),
+            1e-3,
+        )
+        self.assertLessEqual(
+            max_abs_diff(keys, cpp_factors, taroz_factors, "sigma_p_m", "sigma_p_m"),
+            1e-4,
+        )
+        self.assertLessEqual(
+            mean_abs_diff(keys, cpp_factors, taroz_factors, "initial_res_pc_m", "res_pc_m"),
+            6.0,
+        )
+        self.assertLessEqual(
+            max_abs_diff(keys, cpp_factors, taroz_factors, "initial_res_pc_m", "res_pc_m"),
+            10.0,
+        )
+        for column in ("los_x", "los_y", "los_z"):
+            self.assertLessEqual(
+                max_abs_diff(keys, cpp_factors, taroz_factors, column, column),
+                1e-5,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_taroz_pc_dogfood.py
+++ b/tests/test_taroz_pc_dogfood.py
@@ -1,0 +1,155 @@
+#!/usr/bin/env python3
+"""Tests for the taroz PC dogfood harness."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+APPS_DIR = ROOT_DIR / "apps"
+sys.path.insert(0, str(APPS_DIR))
+
+import gnss_taroz_pc_dogfood  # noqa: E402
+
+
+class TarozPcDogfoodTest(unittest.TestCase):
+    def touch_inputs(self, root: Path) -> tuple[Path, Path, Path, Path]:
+        obs = root / "rover.obs"
+        base = root / "base.obs"
+        nav = root / "base.nav"
+        seed_pos = root / "seed.pos"
+        for path in (obs, base, nav, seed_pos):
+            path.write_text("", encoding="ascii")
+        return obs, base, nav, seed_pos
+
+    def test_dry_run_writes_reproducible_plan(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_taroz_pc_dogfood_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            obs, base, nav, seed_pos = self.touch_inputs(temp_root)
+            summary_json = temp_root / "summary.json"
+            out_dir = temp_root / "out"
+
+            result = gnss_taroz_pc_dogfood.main(
+                [
+                    "--obs",
+                    str(obs),
+                    "--base",
+                    str(base),
+                    "--nav",
+                    str(nav),
+                    "--seed-pos",
+                    str(seed_pos),
+                    "--out-dir",
+                    str(out_dir),
+                    "--summary-json",
+                    str(summary_json),
+                    "--fgo-bin",
+                    str(temp_root / "gnss_fgo"),
+                    "--dry-run",
+                ]
+            )
+
+            self.assertEqual(result, 0)
+            payload = json.loads(summary_json.read_text(encoding="utf-8"))
+            command = payload["fgo_command"]
+            self.assertEqual(payload["status"], "dry-run")
+            self.assertIn("--preset", command)
+            self.assertIn("taroz-pc", command)
+            self.assertIn("--backend", command)
+            self.assertIn("gtsam-pc", command)
+            self.assertIn("--lambda-debug-csv", command)
+            self.assertNotIn("--no-spp-seed", command)
+            self.assertFalse(payload["expected"]["use_spp_seed"])
+
+    def test_byte_compare_reports_matching_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_taroz_pc_compare_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            out_dir = temp_root / "out"
+            baseline_cpp = temp_root / "baseline_cpp"
+            baseline_lambda = temp_root / "baseline_lambda"
+            for directory in (out_dir, baseline_cpp, baseline_lambda):
+                directory.mkdir()
+
+            for name in (
+                gnss_taroz_pc_dogfood.POS_NAME,
+                gnss_taroz_pc_dogfood.EPOCH_DEBUG_NAME,
+                gnss_taroz_pc_dogfood.FACTOR_DEBUG_NAME,
+            ):
+                (baseline_cpp / name).write_text("same\n", encoding="ascii")
+                (out_dir / name).write_text("same\n", encoding="ascii")
+            (baseline_lambda / gnss_taroz_pc_dogfood.LAMBDA_DEBUG_NAME).write_text(
+                "same\n",
+                encoding="ascii",
+            )
+            (out_dir / gnss_taroz_pc_dogfood.LAMBDA_DEBUG_NAME).write_text(
+                "same\n",
+                encoding="ascii",
+            )
+
+            results = gnss_taroz_pc_dogfood.compare_file_pairs(
+                out_dir,
+                baseline_cpp,
+                baseline_lambda,
+            )
+
+            self.assertEqual({result["status"] for result in results.values()}, {"same"})
+            self.assertEqual(gnss_taroz_pc_dogfood.byte_comparison_failures(results), [])
+
+    def test_byte_compare_failures_flag_differences(self) -> None:
+        failures = gnss_taroz_pc_dogfood.byte_comparison_failures(
+            {
+                "pos": {"status": "same"},
+                "factor_debug": {"status": "different"},
+                "lambda_debug": {"status": "missing"},
+            }
+        )
+
+        self.assertEqual(failures, ["factor_debug differs from baseline"])
+
+    def test_summary_compare_allows_generated_metadata_additions(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_taroz_pc_summary_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            baseline_summary = temp_root / "baseline.json"
+            generated_summary = temp_root / "generated.json"
+            baseline_summary.write_text(
+                json.dumps({"preset": "taroz-pc", "iterations": 23}),
+                encoding="ascii",
+            )
+            generated_summary.write_text(
+                json.dumps(
+                    {
+                        "preset": "taroz-pc",
+                        "iterations": 23,
+                        "pseudorange_elevation_sigma_power": 1.0,
+                    }
+                ),
+                encoding="ascii",
+            )
+
+            result = gnss_taroz_pc_dogfood.compare_summaries(
+                generated_summary,
+                baseline_summary,
+            )
+
+            self.assertEqual(result["status"], "same")
+            self.assertEqual(result["diffs"], [])
+            self.assertIn(
+                "pseudorange_elevation_sigma_power",
+                result["extra_generated_keys"],
+            )
+
+    def test_native_summary_requires_taroz_seed_behavior(self) -> None:
+        failures = gnss_taroz_pc_dogfood.verify_native_summary(
+            {"preset": "taroz-pc", "backend": "gtsam-pc", "use_spp_seed": True}
+        )
+
+        self.assertEqual(failures, ["taroz-pc must report use_spp_seed=false"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_taroz_pc_internal_parity.py
+++ b/tests/test_taroz_pc_internal_parity.py
@@ -1,0 +1,308 @@
+#!/usr/bin/env python3
+"""Optional parity checks against taroz MATLAB PPC dogfood dumps."""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+import os
+from pathlib import Path
+import unittest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def configured_path(env_name: str, default_relative_path: str) -> Path:
+    configured = os.environ.get(env_name)
+    if configured:
+        path = Path(configured)
+        return path if path.is_absolute() else ROOT_DIR / path
+    return ROOT_DIR / default_relative_path
+
+
+CPP_DIR = configured_path(
+    "GNSSPP_TAROZ_PC_CPP_DIR",
+    "output/dogfood/taroz_pc_full_gtsam_fixed_taroz_nocorr",
+)
+CPP_LAMBDA_DIR = configured_path(
+    "GNSSPP_TAROZ_PC_CPP_LAMBDA_DIR",
+    "output/dogfood/taroz_pc_lambda_debug",
+)
+MATLAB_DIR = configured_path(
+    "GNSSPP_TAROZ_PC_MATLAB_DIR",
+    "output/dogfood/taroz_matlab_pc_debug",
+)
+
+
+def finite_float(value: str | None) -> float | None:
+    if value is None or value == "":
+        return None
+    parsed = float(value)
+    return parsed if math.isfinite(parsed) else None
+
+
+def percentile(values: list[float], percent: float) -> float:
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    position = (len(ordered) - 1) * percent / 100.0
+    lower = int(math.floor(position))
+    upper = int(math.ceil(position))
+    if lower == upper:
+        return ordered[lower]
+    fraction = position - lower
+    return ordered[lower] * (1.0 - fraction) + ordered[upper] * fraction
+
+
+def read_csv_by_tow(path: Path) -> dict[int, dict[str, str]]:
+    with path.open(newline="") as handle:
+        return {
+            round(float(row["gps_tow"])): row
+            for row in csv.DictReader(handle)
+        }
+
+
+def read_pos_by_tow(path: Path) -> dict[int, tuple[float, float, float, int]]:
+    rows: dict[int, tuple[float, float, float, int]] = {}
+    with path.open(encoding="ascii", errors="ignore") as handle:
+        for line in handle:
+            if not line.strip() or line.startswith("%"):
+                continue
+            parts = line.split()
+            rows[round(float(parts[1]))] = (
+                float(parts[2]),
+                float(parts[3]),
+                float(parts[4]),
+                int(float(parts[8])),
+            )
+    return rows
+
+
+class TarozPcInternalParityTest(unittest.TestCase):
+    def require_dogfood_files(self, *paths: Path) -> None:
+        missing = [str(path.relative_to(ROOT_DIR)) for path in paths if not path.exists()]
+        if missing:
+            self.skipTest("missing optional taroz dogfood files: " + ", ".join(missing))
+
+    def test_epoch_fix_ratio_and_position_match_taroz_dump(self) -> None:
+        cpp_epoch_path = CPP_DIR / "fgo_taroz_pc_gtsam_fixed_epoch_debug.csv"
+        cpp_pos_path = CPP_DIR / "fgo_taroz_pc_gtsam_fixed.pos"
+        taroz_epoch_path = MATLAB_DIR / "per_epoch_fix_detail.csv"
+        self.require_dogfood_files(cpp_epoch_path, cpp_pos_path, taroz_epoch_path)
+
+        cpp_epochs = read_csv_by_tow(cpp_epoch_path)
+        cpp_positions = read_pos_by_tow(cpp_pos_path)
+        taroz_epochs = read_csv_by_tow(taroz_epoch_path)
+        common_tows = sorted(set(cpp_epochs) & set(cpp_positions) & set(taroz_epochs))
+        self.assertGreaterEqual(len(common_tows), 1000)
+
+        candidate_mismatches: list[int] = []
+        fixed_mismatches: list[int] = []
+        cxx_only_fixed: list[int] = []
+        ratio_diffs: list[float] = []
+        same_status_position_diffs: list[float] = []
+        allowed_taroz_only_fixed = {554262, 554360}
+        for tow in common_tows:
+            cpp_epoch = cpp_epochs[tow]
+            taroz_epoch = taroz_epochs[tow]
+            if int(cpp_epoch["ambiguity_candidates"]) != int(taroz_epoch["candidate_count"]):
+                candidate_mismatches.append(tow)
+
+            cpp_fixed = int(cpp_epoch["status"]) == 4
+            taroz_fixed = int(float(taroz_epoch["idxfix"])) == 1
+            if cpp_fixed != taroz_fixed:
+                fixed_mismatches.append(tow)
+                if cpp_fixed:
+                    cxx_only_fixed.append(tow)
+
+            ratio_diffs.append(abs(float(cpp_epoch["ratio"]) - float(taroz_epoch["ratio"])))
+
+            if cpp_fixed == taroz_fixed:
+                x, y, z, _status = cpp_positions[tow]
+                tx = float(taroz_epoch["fixed_x_m"])
+                ty = float(taroz_epoch["fixed_y_m"])
+                tz = float(taroz_epoch["fixed_z_m"])
+                same_status_position_diffs.append(math.dist((x, y, z), (tx, ty, tz)))
+
+        self.assertEqual(candidate_mismatches, [])
+        self.assertLessEqual(set(fixed_mismatches), allowed_taroz_only_fixed)
+        self.assertEqual(cxx_only_fixed, [])
+        self.assertLessEqual(sum(ratio_diffs) / len(ratio_diffs), 0.004)
+        self.assertLessEqual(max(ratio_diffs), 0.07)
+        self.assertLessEqual(max(same_status_position_diffs), 0.01)
+
+    def test_factor_residuals_match_taroz_per_satellite_dump(self) -> None:
+        cpp_factor_path = CPP_DIR / "fgo_taroz_pc_gtsam_fixed_factor_debug.csv"
+        taroz_sat_path = MATLAB_DIR / "per_sat_detail.csv"
+        self.require_dogfood_files(cpp_factor_path, taroz_sat_path)
+
+        def key(row: dict[str, str]) -> tuple[int, str, str]:
+            return (
+                round(float(row["gps_tow"])),
+                row["satellite"],
+                row["reference"],
+            )
+
+        with cpp_factor_path.open(newline="") as handle:
+            cpp_rows = {key(row): row for row in csv.DictReader(handle)}
+        with taroz_sat_path.open(newline="") as handle:
+            taroz_rows = {key(row): row for row in csv.DictReader(handle)}
+
+        common_keys = sorted(set(cpp_rows) & set(taroz_rows))
+        self.assertGreaterEqual(len(common_keys), 14000)
+        self.assertEqual(sorted(set(cpp_rows) - set(taroz_rows)), [])
+
+        def abs_diffs(column: str) -> list[float]:
+            diffs: list[float] = []
+            for row_key in common_keys:
+                cpp_value = finite_float(cpp_rows[row_key].get(column))
+                taroz_value = finite_float(taroz_rows[row_key].get(column))
+                if cpp_value is None or taroz_value is None:
+                    continue
+                diffs.append(abs(cpp_value - taroz_value))
+            return diffs
+
+        res_pdd = abs_diffs("res_pdd")
+        res_ldd = abs_diffs("res_ldd")
+        elevation = abs_diffs("elevation_deg")
+        sigma_pdd = abs_diffs("sigma_pdd_m")
+        sigma_ldd = abs_diffs("sigma_ldd_m")
+        ambiguity_initial = abs_diffs("ambiguity_initial")
+        ambiguity_estimate = abs_diffs("ambiguity_estimate")
+        self.assertGreaterEqual(len(res_ldd), 13000)
+        self.assertLessEqual(max(elevation), 1e-3)
+        self.assertLessEqual(max(sigma_pdd), 2e-5)
+        self.assertLessEqual(max(sigma_ldd), 1e-7)
+        self.assertLessEqual(max(res_pdd), 3e-4)
+        self.assertLessEqual(max(res_ldd), 3e-4)
+        self.assertLessEqual(max(ambiguity_initial), 1e-6)
+        self.assertLessEqual(percentile(ambiguity_estimate, 95.0), 5e-4)
+        self.assertLessEqual(max(ambiguity_estimate), 0.03)
+
+    def test_graph_diagnostics_stay_close_to_taroz_dump(self) -> None:
+        cpp_summary_path = CPP_DIR / "fgo_taroz_pc_gtsam_fixed_summary.json"
+        taroz_graph_path = MATLAB_DIR / "graph_detail.csv"
+        self.require_dogfood_files(cpp_summary_path, taroz_graph_path)
+
+        with cpp_summary_path.open() as handle:
+            cpp = json.load(handle)
+        with taroz_graph_path.open(newline="") as handle:
+            taroz = next(csv.DictReader(handle))
+
+        self.assertFalse(cpp["use_spp_seed"])
+
+        taroz_graph_factors = int(taroz["graph_factors"])
+        taroz_graph_values = int(taroz["graph_values"])
+        taroz_initial_cost = float(taroz["initial_cost"])
+        taroz_final_cost = float(taroz["final_cost"])
+
+        self.assertEqual(int(cpp["iterations"]), int(taroz["iterations"]))
+        self.assertLessEqual(int(cpp["optimized_epochs"]), int(taroz["n"]))
+        self.assertLessEqual(
+            abs(int(cpp["optimized_epochs"]) - int(taroz["valid_solution_epochs"])),
+            30,
+        )
+        self.assertLessEqual(
+            abs(int(cpp["ambiguity_states"]) - int(taroz["valid_ambiguity_states"])),
+            20,
+        )
+        self.assertLessEqual(
+            abs(int(cpp["graph_factors"]) - taroz_graph_factors) / taroz_graph_factors,
+            0.01,
+        )
+        self.assertLessEqual(
+            abs(int(cpp["graph_values"]) - taroz_graph_values) / taroz_graph_values,
+            0.06,
+        )
+        self.assertLessEqual(
+            abs(float(cpp["initial_cost"]) - taroz_initial_cost) / taroz_initial_cost,
+            0.002,
+        )
+        self.assertLessEqual(
+            abs(float(cpp["final_cost"]) - taroz_final_cost) / taroz_final_cost,
+            0.01,
+        )
+
+    def test_lambda_inputs_match_taroz_internal_dump(self) -> None:
+        cpp_lambda_path = (
+            CPP_LAMBDA_DIR / "fgo_taroz_pc_gtsam_fixed_lambda_debug.csv"
+        )
+        taroz_lambda_path = MATLAB_DIR / "per_lambda_detail.csv"
+        self.require_dogfood_files(cpp_lambda_path, taroz_lambda_path)
+
+        def key(row: dict[str, str]) -> tuple[int, int, int, str, str]:
+            return (
+                round(float(row["gps_tow"])),
+                int(row["row"]),
+                int(row["col"]),
+                row["satellite"],
+                row["other_satellite"],
+            )
+
+        with cpp_lambda_path.open(newline="") as handle:
+            cpp_rows = {key(row): row for row in csv.DictReader(handle)}
+        with taroz_lambda_path.open(newline="") as handle:
+            taroz_rows = {key(row): row for row in csv.DictReader(handle)}
+
+        common_keys = sorted(set(cpp_rows) & set(taroz_rows))
+        self.assertGreaterEqual(len(common_keys), 200000)
+        self.assertEqual(sorted(set(cpp_rows) - set(taroz_rows)), [])
+        self.assertEqual(sorted(set(taroz_rows) - set(cpp_rows)), [])
+
+        def abs_diffs(column: str) -> list[float]:
+            return [
+                abs(float(cpp_rows[row_key][column]) - float(taroz_rows[row_key][column]))
+                for row_key in common_keys
+            ]
+
+        ambiguity_float = abs_diffs("ambiguity_float")
+        covariance = abs_diffs("covariance")
+        position_cov_x = abs_diffs("position_covariance_x")
+        position_cov_y = abs_diffs("position_covariance_y")
+        position_cov_z = abs_diffs("position_covariance_z")
+
+        ratio_diffs: list[float] = []
+        used_fixed_ambiguity_diffs: list[float] = []
+        unused_fixed_ambiguity_mismatch_rows = 0
+        seen_tows: set[int] = set()
+        for row_key in common_keys:
+            fixed_ambiguity_diff = abs(
+                float(cpp_rows[row_key]["fixed_ambiguity"]) -
+                float(taroz_rows[row_key]["fixed_ambiguity"])
+            )
+            if (int(cpp_rows[row_key]["fixed_epoch"]) == 1 or
+                    int(taroz_rows[row_key]["fixed_epoch"]) == 1):
+                used_fixed_ambiguity_diffs.append(fixed_ambiguity_diff)
+            elif fixed_ambiguity_diff > 1e-6:
+                unused_fixed_ambiguity_mismatch_rows += 1
+
+            tow = row_key[0]
+            if tow in seen_tows:
+                continue
+            seen_tows.add(tow)
+            ratio_diffs.append(
+                abs(float(cpp_rows[row_key]["ratio"]) -
+                    float(taroz_rows[row_key]["ratio"]))
+            )
+
+        self.assertGreaterEqual(len(seen_tows), 900)
+        self.assertLessEqual(percentile(ambiguity_float, 95.0), 4e-4)
+        self.assertLessEqual(max(ambiguity_float), 0.03)
+        self.assertLessEqual(max(used_fixed_ambiguity_diffs), 1e-6)
+        self.assertLessEqual(unused_fixed_ambiguity_mismatch_rows, 300)
+        self.assertLessEqual(percentile(covariance, 95.0), 1e-4)
+        self.assertLessEqual(max(covariance), 0.02)
+        self.assertLessEqual(percentile(position_cov_x, 95.0), 3e-5)
+        self.assertLessEqual(max(position_cov_x), 0.003)
+        self.assertLessEqual(percentile(position_cov_y, 95.0), 4e-5)
+        self.assertLessEqual(max(position_cov_y), 0.002)
+        self.assertLessEqual(percentile(position_cov_z, 95.0), 2e-5)
+        self.assertLessEqual(max(position_cov_z), 0.002)
+        self.assertLessEqual(sum(ratio_diffs) / len(ratio_diffs), 0.005)
+        self.assertLessEqual(max(ratio_diffs), 0.07)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_taroz_pd_internal_parity.py
+++ b/tests/test_taroz_pd_internal_parity.py
@@ -1,0 +1,376 @@
+#!/usr/bin/env python3
+"""Optional parity checks against taroz MATLAB position/velocity PD dumps."""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+import os
+from pathlib import Path
+import statistics
+import unittest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def configured_path(env_name: str, default_relative_path: str) -> Path:
+    configured = os.environ.get(env_name)
+    if configured:
+        path = Path(configured)
+        return path if path.is_absolute() else ROOT_DIR / path
+    return ROOT_DIR / default_relative_path
+
+
+CPP_DIR = configured_path(
+    "GNSSPP_TAROZ_PD_CPP_DIR",
+    "output/dogfood/taroz_pd_dogfood_current",
+)
+MATLAB_DIR = configured_path(
+    "GNSSPP_TAROZ_PD_MATLAB_DIR",
+    "output/dogfood/taroz_matlab_pd_debug",
+)
+
+
+def display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT_DIR))
+    except ValueError:
+        return str(path)
+
+
+def read_json(path: Path) -> dict[str, object]:
+    with path.open() as handle:
+        return json.load(handle)
+
+
+def read_csv_rows(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def read_csv_by_tow(path: Path) -> dict[int, dict[str, str]]:
+    return {
+        round(float(row["gps_tow"])): row
+        for row in read_csv_rows(path)
+    }
+
+
+def read_graph(path: Path) -> dict[str, str]:
+    with path.open(newline="") as handle:
+        return next(csv.DictReader(handle))
+
+
+def percentile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    return ordered[int(fraction * (len(ordered) - 1))]
+
+
+def max_abs_diff(
+    keys: list[tuple[str, int, str]],
+    left: dict[tuple[str, int, str], dict[str, str]],
+    right: dict[tuple[str, int, str], dict[str, str]],
+    left_column: str,
+    right_column: str,
+) -> float:
+    return max(
+        abs(float(left[key][left_column]) - float(right[key][right_column]))
+        for key in keys
+    )
+
+
+def mean_abs_diff(
+    keys: list[tuple[str, int, str]],
+    left: dict[tuple[str, int, str], dict[str, str]],
+    right: dict[tuple[str, int, str], dict[str, str]],
+    left_column: str,
+    right_column: str,
+) -> float:
+    return statistics.mean(
+        abs(float(left[key][left_column]) - float(right[key][right_column]))
+        for key in keys
+    )
+
+
+def read_cpp_factor_rows(path: Path) -> dict[tuple[str, int, str], dict[str, str]]:
+    rows: dict[tuple[str, int, str], dict[str, str]] = {}
+    for row in read_csv_rows(path):
+        key = (row["factor_type"], round(float(row["gps_tow"])), row["satellite"])
+        rows[key] = row
+    return rows
+
+
+def read_taroz_factor_rows(
+    path: Path,
+    allowed_tows: set[int] | None = None,
+) -> dict[tuple[str, int, str], dict[str, str]]:
+    rows: dict[tuple[str, int, str], dict[str, str]] = {}
+    for row in read_csv_rows(path):
+        tow = round(float(row["gps_tow"]))
+        if allowed_tows is not None and tow not in allowed_tows:
+            continue
+        if row.get("valid_pseudorange", "").lower() in {"1", "true"}:
+            rows[("P", tow, row["satellite"])] = row
+        if row.get("valid_doppler", "").lower() in {"1", "true"}:
+            rows[("D", tow, row["satellite"])] = row
+    return rows
+
+
+def clock_group_from_system(system: str) -> int:
+    return {
+        "SYS_GPS": 0,
+        "SYS_GLO": 1,
+        "SYS_GAL": 2,
+        "SYS_QZS": 3,
+        "SYS_CMP": 4,
+    }.get(system, 0)
+
+
+def taroz_pseudorange_prediction(
+    epoch: dict[str, str],
+    factor: dict[str, str],
+) -> float:
+    delta_position = [
+        float(epoch[f"fgo_{axis}_m"]) - float(epoch[f"spp_{axis}_m"])
+        for axis in "xyz"
+    ]
+    los = [float(factor[f"los_{axis}"]) for axis in "xyz"]
+    clock_columns = [
+        "fgo_c_gps_m",
+        "fgo_c_glo_m",
+        "fgo_c_gal_m",
+        "fgo_c_qzs_m",
+        "fgo_c_bds_m",
+    ]
+    group = clock_group_from_system(factor["system"])
+    clock = float(epoch["fgo_c_gps_m"])
+    if group != 0:
+        clock += float(epoch[clock_columns[group]])
+    return sum(l * dx for l, dx in zip(los, delta_position)) + clock
+
+
+def taroz_doppler_prediction(
+    epoch: dict[str, str],
+    factor: dict[str, str],
+) -> float:
+    velocity = [float(epoch[f"fgo_v{axis}_mps"]) for axis in "xyz"]
+    los = [float(factor[f"los_{axis}"]) for axis in "xyz"]
+    return sum(l * v for l, v in zip(los, velocity)) + float(epoch["fgo_clock_drift_mps"])
+
+
+class TarozPDInternalParityTest(unittest.TestCase):
+    def require_dogfood_files(self, *paths: Path) -> None:
+        missing = [display_path(path) for path in paths if not path.exists()]
+        if missing:
+            self.skipTest("missing optional taroz PD dogfood files: " + ", ".join(missing))
+
+    def test_graph_and_factor_counts_match_taroz_pd_dump(self) -> None:
+        cpp_summary_path = CPP_DIR / "summary.json"
+        cpp_graph_path = CPP_DIR / "graph_detail.csv"
+        cpp_factor_path = CPP_DIR / "factor_debug.csv"
+        cpp_epoch_path = CPP_DIR / "per_epoch_state.csv"
+        taroz_graph_path = MATLAB_DIR / "graph_detail.csv"
+        taroz_sat_path = MATLAB_DIR / "per_sat_detail.csv"
+        self.require_dogfood_files(
+            cpp_summary_path,
+            cpp_graph_path,
+            cpp_factor_path,
+            cpp_epoch_path,
+            taroz_graph_path,
+            taroz_sat_path,
+        )
+
+        cpp_summary = read_json(cpp_summary_path)
+        cpp_graph = read_graph(cpp_graph_path)
+        taroz_graph = read_graph(taroz_graph_path)
+        cpp_factors = read_cpp_factor_rows(cpp_factor_path)
+        cpp_tows = set(read_csv_by_tow(cpp_epoch_path))
+        taroz_factors = read_taroz_factor_rows(taroz_sat_path, cpp_tows)
+        pseudorange_keys = [key for key in cpp_factors if key[0] == "P"]
+        doppler_keys = [key for key in cpp_factors if key[0] == "D"]
+        optimized_epochs = int(cpp_summary["optimized_epochs"])
+
+        self.assertEqual(cpp_summary["preset"], "taroz-pd")
+        self.assertEqual(cpp_summary["backend"], "eigen")
+        self.assertEqual(optimized_epochs, len(cpp_tows))
+        self.assertLessEqual(optimized_epochs, int(float(taroz_graph["n"])))
+        self.assertEqual(cpp_summary["valid_position_epochs"], optimized_epochs)
+        self.assertEqual(cpp_summary["valid_velocity_epochs"], optimized_epochs)
+        self.assertEqual(cpp_summary["pseudorange_factors"], len(pseudorange_keys))
+        self.assertEqual(cpp_summary["doppler_factors"], len(doppler_keys))
+        self.assertGreater(len(pseudorange_keys), 0)
+        self.assertGreater(len(doppler_keys), 0)
+        if optimized_epochs == int(float(taroz_graph["n"])):
+            self.assertEqual(len(pseudorange_keys), 24092)
+            self.assertEqual(len(doppler_keys), 24092)
+        self.assertEqual(set(cpp_factors), set(taroz_factors))
+        self.assertEqual(int(float(cpp_graph["graph_values"])), 4 * optimized_epochs)
+        if optimized_epochs == int(float(taroz_graph["n"])):
+            self.assertEqual(int(float(cpp_graph["graph_factors"])), int(float(taroz_graph["graph_factors"])))
+            self.assertLessEqual(
+                abs(float(cpp_graph["initial_cost"]) - float(taroz_graph["initial_cost"])) /
+                max(1.0, abs(float(taroz_graph["initial_cost"]))),
+                1e-4,
+            )
+            self.assertLessEqual(
+                abs(float(cpp_graph["final_cost"]) - float(taroz_graph["final_cost"])) /
+                max(1.0, abs(float(taroz_graph["final_cost"]))),
+                0.35,
+            )
+
+    def test_raw_pd_factors_match_taroz_pd_dump(self) -> None:
+        cpp_factor_path = CPP_DIR / "factor_debug.csv"
+        cpp_epoch_path = CPP_DIR / "per_epoch_state.csv"
+        taroz_sat_path = MATLAB_DIR / "per_sat_detail.csv"
+        self.require_dogfood_files(cpp_factor_path, cpp_epoch_path, taroz_sat_path)
+
+        cpp_factors = read_cpp_factor_rows(cpp_factor_path)
+        cpp_tows = set(read_csv_by_tow(cpp_epoch_path))
+        taroz_factors = read_taroz_factor_rows(taroz_sat_path, cpp_tows)
+        self.assertEqual(set(cpp_factors), set(taroz_factors))
+
+        pseudorange_keys = sorted(key for key in cpp_factors if key[0] == "P")
+        doppler_keys = sorted(key for key in cpp_factors if key[0] == "D")
+        self.assertGreater(len(pseudorange_keys), 0)
+        self.assertGreater(len(doppler_keys), 0)
+        if len(cpp_tows) == 1141:
+            self.assertEqual(len(pseudorange_keys), 24092)
+            self.assertEqual(len(doppler_keys), 24092)
+
+        self.assertLessEqual(
+            max_abs_diff(pseudorange_keys, cpp_factors, taroz_factors, "elevation_deg", "elevation_deg"),
+            1e-3,
+        )
+        self.assertLessEqual(
+            max_abs_diff(pseudorange_keys, cpp_factors, taroz_factors, "sigma_p_m", "sigma_p_m"),
+            1e-4,
+        )
+        self.assertLessEqual(
+            mean_abs_diff(pseudorange_keys, cpp_factors, taroz_factors, "res_pc_m", "res_pc_m"),
+            6.0,
+        )
+        self.assertLessEqual(
+            max_abs_diff(pseudorange_keys, cpp_factors, taroz_factors, "res_pc_m", "res_pc_m"),
+            10.0,
+        )
+
+        self.assertLessEqual(
+            max_abs_diff(doppler_keys, cpp_factors, taroz_factors, "elevation_deg", "elevation_deg"),
+            1e-4,
+        )
+        self.assertLessEqual(
+            max_abs_diff(doppler_keys, cpp_factors, taroz_factors, "sigma_d_mps", "sigma_d_mps"),
+            1e-6,
+        )
+        self.assertLessEqual(
+            mean_abs_diff(doppler_keys, cpp_factors, taroz_factors, "res_d_mps", "res_d_mps"),
+            1e-3,
+        )
+        self.assertLessEqual(
+            max_abs_diff(doppler_keys, cpp_factors, taroz_factors, "res_d_mps", "res_d_mps"),
+            0.02,
+        )
+        for axis in "xyz":
+            self.assertLessEqual(
+                max_abs_diff(doppler_keys, cpp_factors, taroz_factors, f"los_{axis}", f"los_{axis}"),
+                1e-6,
+            )
+
+    def test_final_state_matches_taroz_pd_dump(self) -> None:
+        cpp_epoch_path = CPP_DIR / "per_epoch_state.csv"
+        taroz_epoch_path = MATLAB_DIR / "per_epoch_state.csv"
+        self.require_dogfood_files(cpp_epoch_path, taroz_epoch_path)
+
+        cpp_epochs = read_csv_by_tow(cpp_epoch_path)
+        taroz_epochs = read_csv_by_tow(taroz_epoch_path)
+        common_tows = sorted(set(cpp_epochs) & set(taroz_epochs))
+        self.assertEqual(len(common_tows), len(cpp_epochs))
+        self.assertGreater(len(common_tows), 0)
+        if len(cpp_epochs) == len(taroz_epochs):
+            self.assertEqual(len(common_tows), 1141)
+
+        position_diffs: list[float] = []
+        velocity_diffs: list[float] = []
+        drift_diffs: list[float] = []
+        clock_diffs: list[float] = []
+        for tow in common_tows:
+            cpp = cpp_epochs[tow]
+            taroz = taroz_epochs[tow]
+            position_diffs.append(
+                math.dist(
+                    tuple(float(cpp[f"fgo_{axis}_m"]) for axis in "xyz"),
+                    tuple(float(taroz[f"fgo_{axis}_m"]) for axis in "xyz"),
+                )
+            )
+            velocity_diffs.append(
+                math.dist(
+                    tuple(float(cpp[f"fgo_v{axis}_mps"]) for axis in "xyz"),
+                    tuple(float(taroz[f"fgo_v{axis}_mps"]) for axis in "xyz"),
+                )
+            )
+            drift_diffs.append(
+                abs(float(cpp["fgo_clock_drift_mps"]) - float(taroz["fgo_clock_drift_mps"]))
+            )
+            for column in (
+                "fgo_c_gps_m",
+                "fgo_c_glo_m",
+                "fgo_c_gal_m",
+                "fgo_c_qzs_m",
+                "fgo_c_bds_m",
+            ):
+                clock_diffs.append(abs(float(cpp[column]) - float(taroz[column])))
+
+        self.assertLessEqual(statistics.mean(position_diffs), 3.0)
+        self.assertLessEqual(percentile(position_diffs, 0.95), 4.0)
+        self.assertLessEqual(max(position_diffs), 6.0)
+        self.assertLessEqual(statistics.mean(velocity_diffs), 0.05)
+        self.assertLessEqual(percentile(velocity_diffs, 0.95), 0.10)
+        self.assertLessEqual(max(velocity_diffs), 3.5)
+        self.assertLessEqual(statistics.mean(drift_diffs), 0.02)
+        self.assertLessEqual(max(drift_diffs), 0.15)
+        self.assertLessEqual(statistics.mean(clock_diffs), 3.5)
+        self.assertLessEqual(max(clock_diffs), 8.0)
+
+    def test_final_factor_residuals_match_taroz_pd_dump(self) -> None:
+        cpp_factor_path = CPP_DIR / "factor_debug.csv"
+        cpp_epoch_path = CPP_DIR / "per_epoch_state.csv"
+        taroz_sat_path = MATLAB_DIR / "per_sat_detail.csv"
+        taroz_epoch_path = MATLAB_DIR / "per_epoch_state.csv"
+        self.require_dogfood_files(cpp_factor_path, cpp_epoch_path, taroz_sat_path, taroz_epoch_path)
+
+        cpp_factors = read_cpp_factor_rows(cpp_factor_path)
+        cpp_tows = set(read_csv_by_tow(cpp_epoch_path))
+        taroz_factors = read_taroz_factor_rows(taroz_sat_path, cpp_tows)
+        taroz_epochs = read_csv_by_tow(taroz_epoch_path)
+        self.assertEqual(set(cpp_factors), set(taroz_factors))
+
+        pseudorange_diffs: list[float] = []
+        doppler_diffs: list[float] = []
+        for key in sorted(cpp_factors):
+            factor_type, tow, _satellite = key
+            cpp = cpp_factors[key]
+            taroz = taroz_factors[key]
+            epoch = taroz_epochs[tow]
+            if factor_type == "P":
+                taroz_residual = taroz_pseudorange_prediction(epoch, taroz) - float(taroz["res_pc_m"])
+                pseudorange_diffs.append(abs(float(cpp["final_residual_m"]) - taroz_residual))
+            else:
+                taroz_residual = taroz_doppler_prediction(epoch, taroz) - float(taroz["res_d_mps"])
+                doppler_diffs.append(abs(float(cpp["final_residual_m"]) - taroz_residual))
+
+        self.assertGreater(len(pseudorange_diffs), 0)
+        self.assertGreater(len(doppler_diffs), 0)
+        if len(cpp_tows) == 1141:
+            self.assertEqual(len(pseudorange_diffs), 24092)
+            self.assertEqual(len(doppler_diffs), 24092)
+        self.assertLessEqual(statistics.mean(pseudorange_diffs), 2.0)
+        self.assertLessEqual(percentile(pseudorange_diffs, 0.95), 4.0)
+        self.assertLessEqual(max(pseudorange_diffs), 5.0)
+        self.assertLessEqual(statistics.mean(doppler_diffs), 0.01)
+        self.assertLessEqual(percentile(doppler_diffs, 0.95), 0.02)
+        self.assertLessEqual(max(doppler_diffs), 0.15)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_taroz_pos_pd_internal_parity.py
+++ b/tests/test_taroz_pos_pd_internal_parity.py
@@ -1,0 +1,233 @@
+#!/usr/bin/env python3
+"""Optional parity checks against taroz MATLAB position PD dumps."""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+import os
+from pathlib import Path
+import statistics
+import unittest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def configured_path(env_name: str, default_relative_path: str) -> Path:
+    configured = os.environ.get(env_name)
+    if configured:
+        path = Path(configured)
+        return path if path.is_absolute() else ROOT_DIR / path
+    return ROOT_DIR / default_relative_path
+
+
+CPP_DIR = configured_path(
+    "GNSSPP_TAROZ_POS_PD_CPP_DIR",
+    "output/dogfood/taroz_pos_pd_dogfood_current",
+)
+MATLAB_DIR = configured_path(
+    "GNSSPP_TAROZ_POS_PD_MATLAB_DIR",
+    "output/dogfood/taroz_matlab_pos_pd_debug",
+)
+
+
+def display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT_DIR))
+    except ValueError:
+        return str(path)
+
+
+def read_json(path: Path) -> dict[str, object]:
+    with path.open() as handle:
+        return json.load(handle)
+
+
+def read_rows(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def read_graph(path: Path) -> dict[str, str]:
+    with path.open(newline="") as handle:
+        return next(csv.DictReader(handle))
+
+
+def read_epochs(path: Path) -> dict[int, dict[str, str]]:
+    return {
+        round(float(row["gps_tow"])): row
+        for row in read_rows(path)
+    }
+
+
+def percentile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    return ordered[int(fraction * (len(ordered) - 1))]
+
+
+def read_cpp_factors(path: Path) -> dict[tuple[str, int, str], dict[str, str]]:
+    factors: dict[tuple[str, int, str], dict[str, str]] = {}
+    for row in read_rows(path):
+        epoch = int(row["epoch_index"]) + 1
+        factors[(row["factor_type"], epoch, row["satellite"])] = row
+    return factors
+
+
+def read_taroz_factors(path_p: Path, path_d: Path) -> dict[tuple[str, int, str], dict[str, str]]:
+    factors: dict[tuple[str, int, str], dict[str, str]] = {}
+    for row in read_rows(path_p):
+        if row.get("valid_pseudorange", "").lower() in {"1", "true"}:
+            factors[("P", int(float(row["epoch"])), row["satellite"])] = row
+    for row in read_rows(path_d):
+        if row.get("valid_doppler", "").lower() in {"1", "true"}:
+            factors[("D", int(float(row["epoch"])), row["satellite"])] = row
+    return factors
+
+
+def max_abs_diff(
+    keys: list[tuple[str, int, str]],
+    left: dict[tuple[str, int, str], dict[str, str]],
+    right: dict[tuple[str, int, str], dict[str, str]],
+    left_column: str,
+    right_column: str,
+) -> float:
+    return max(abs(float(left[key][left_column]) - float(right[key][right_column])) for key in keys)
+
+
+def mean_abs_diff(
+    keys: list[tuple[str, int, str]],
+    left: dict[tuple[str, int, str], dict[str, str]],
+    right: dict[tuple[str, int, str], dict[str, str]],
+    left_column: str,
+    right_column: str,
+) -> float:
+    return statistics.mean(
+        abs(float(left[key][left_column]) - float(right[key][right_column]))
+        for key in keys
+    )
+
+
+class TarozPosPDInternalParityTest(unittest.TestCase):
+    def require_dogfood_files(self, *paths: Path) -> None:
+        missing = [display_path(path) for path in paths if not path.exists()]
+        if missing:
+            self.skipTest("missing optional taroz position PD dogfood files: " + ", ".join(missing))
+
+    def test_graph_and_factor_counts_match_taroz_dump(self) -> None:
+        cpp_summary_path = CPP_DIR / "summary.json"
+        cpp_graph_path = CPP_DIR / "graph_detail.csv"
+        cpp_factor_path = CPP_DIR / "factor_debug.csv"
+        taroz_graph_path = MATLAB_DIR / "graph_detail.csv"
+        taroz_p_path = MATLAB_DIR / "per_sat_detail.csv"
+        taroz_d_path = MATLAB_DIR / "per_doppler_detail.csv"
+        self.require_dogfood_files(
+            cpp_summary_path,
+            cpp_graph_path,
+            cpp_factor_path,
+            taroz_graph_path,
+            taroz_p_path,
+            taroz_d_path,
+        )
+
+        cpp_summary = read_json(cpp_summary_path)
+        cpp_graph = read_graph(cpp_graph_path)
+        taroz_graph = read_graph(taroz_graph_path)
+        cpp_factors = read_cpp_factors(cpp_factor_path)
+        taroz_factors = read_taroz_factors(taroz_p_path, taroz_d_path)
+        p_keys = [key for key in cpp_factors if key[0] == "P"]
+        d_keys = [key for key in cpp_factors if key[0] == "D"]
+
+        self.assertEqual(cpp_summary["preset"], "taroz-pos-pd")
+        self.assertEqual(cpp_summary["backend"], "eigen")
+        self.assertEqual(cpp_summary["optimized_epochs"], int(float(taroz_graph["n"])))
+        self.assertEqual(cpp_summary["pseudorange_factors"], len(p_keys))
+        self.assertEqual(cpp_summary["doppler_factors"], len(d_keys))
+        self.assertEqual(len(p_keys), 24092)
+        self.assertEqual(len(d_keys), 29371)
+        self.assertEqual(set(cpp_factors), set(taroz_factors))
+        self.assertEqual(int(float(cpp_graph["graph_factors"])), int(float(taroz_graph["graph_factors"])))
+        self.assertEqual(int(float(cpp_graph["graph_values"])), int(float(taroz_graph["graph_values"])))
+        self.assertLessEqual(
+            abs(float(cpp_graph["initial_cost"]) - float(taroz_graph["initial_cost"])) /
+            max(1.0, abs(float(taroz_graph["initial_cost"]))),
+            1e-4,
+        )
+        self.assertLessEqual(
+            abs(float(cpp_graph["final_cost"]) - float(taroz_graph["final_cost"])) /
+            max(1.0, abs(float(taroz_graph["final_cost"]))),
+            0.15,
+        )
+
+    def test_raw_factors_match_taroz_dump(self) -> None:
+        cpp_factor_path = CPP_DIR / "factor_debug.csv"
+        taroz_p_path = MATLAB_DIR / "per_sat_detail.csv"
+        taroz_d_path = MATLAB_DIR / "per_doppler_detail.csv"
+        self.require_dogfood_files(cpp_factor_path, taroz_p_path, taroz_d_path)
+
+        cpp_factors = read_cpp_factors(cpp_factor_path)
+        taroz_factors = read_taroz_factors(taroz_p_path, taroz_d_path)
+        self.assertEqual(set(cpp_factors), set(taroz_factors))
+
+        p_keys = sorted(key for key in cpp_factors if key[0] == "P")
+        d_keys = sorted(key for key in cpp_factors if key[0] == "D")
+        self.assertEqual(len(p_keys), 24092)
+        self.assertEqual(len(d_keys), 29371)
+
+        self.assertLessEqual(max_abs_diff(p_keys, cpp_factors, taroz_factors, "sigma_p_m", "sigma_p_m"), 1e-4)
+        self.assertLessEqual(mean_abs_diff(p_keys, cpp_factors, taroz_factors, "res_pc_m", "res_pc_m"), 6.0)
+        self.assertLessEqual(max_abs_diff(p_keys, cpp_factors, taroz_factors, "res_pc_m", "res_pc_m"), 10.0)
+
+        self.assertLessEqual(max_abs_diff(d_keys, cpp_factors, taroz_factors, "sigma_d_mps", "sigma_d_mps"), 1e-5)
+        self.assertLessEqual(mean_abs_diff(d_keys, cpp_factors, taroz_factors, "res_d_mps", "res_d_mps"), 1e-3)
+        self.assertLessEqual(max_abs_diff(d_keys, cpp_factors, taroz_factors, "res_d_mps", "res_d_mps"), 0.01)
+        self.assertLessEqual(max_abs_diff(d_keys, cpp_factors, taroz_factors, "midpoint_gps_tow", "midpoint_gps_tow"), 1e-9)
+        for axis in "xyz":
+            self.assertLessEqual(
+                max_abs_diff(d_keys, cpp_factors, taroz_factors, f"los_{axis}", f"los_{axis}"),
+                1e-6,
+            )
+
+    def test_final_position_matches_taroz_dump(self) -> None:
+        cpp_epoch_path = CPP_DIR / "per_epoch_state.csv"
+        taroz_epoch_path = MATLAB_DIR / "per_epoch_state.csv"
+        self.require_dogfood_files(cpp_epoch_path, taroz_epoch_path)
+
+        cpp_epochs = read_epochs(cpp_epoch_path)
+        taroz_epochs = read_epochs(taroz_epoch_path)
+        common_tows = sorted(set(cpp_epochs) & set(taroz_epochs))
+        self.assertEqual(len(common_tows), 1141)
+
+        position_diffs: list[float] = []
+        clock_diffs: list[float] = []
+        for tow in common_tows:
+            cpp = cpp_epochs[tow]
+            taroz = taroz_epochs[tow]
+            taroz_position = tuple(float(taroz[f"fgo_{axis}_m"]) for axis in "xyz")
+            if all(math.isfinite(value) for value in taroz_position):
+                position_diffs.append(
+                    math.dist(
+                        tuple(float(cpp[f"fgo_{axis}_m"]) for axis in "xyz"),
+                        taroz_position,
+                    )
+                )
+            for column in (
+                "fgo_c_gps_m",
+                "fgo_c_glo_m",
+                "fgo_c_gal_m",
+                "fgo_c_qzs_m",
+                "fgo_c_bds_m",
+            ):
+                clock_diffs.append(abs(float(cpp[column]) - float(taroz[column])))
+
+        self.assertEqual(len(position_diffs), 1129)
+        self.assertLessEqual(statistics.mean(position_diffs), 3.0)
+        self.assertLessEqual(percentile(position_diffs, 0.95), 4.0)
+        self.assertLessEqual(max(position_diffs), 5.0)
+        self.assertLessEqual(statistics.mean(clock_diffs), 3.0)
+        self.assertLessEqual(max(clock_diffs), 8.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_taroz_pos_pdc_internal_parity.py
+++ b/tests/test_taroz_pos_pdc_internal_parity.py
@@ -1,0 +1,262 @@
+#!/usr/bin/env python3
+"""Optional parity checks against taroz MATLAB position PDC dumps."""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+import os
+from pathlib import Path
+import statistics
+import unittest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def configured_path(env_name: str, default_relative_path: str) -> Path:
+    configured = os.environ.get(env_name)
+    if configured:
+        path = Path(configured)
+        return path if path.is_absolute() else ROOT_DIR / path
+    return ROOT_DIR / default_relative_path
+
+
+CPP_DIR = configured_path(
+    "GNSSPP_TAROZ_POS_PDC_CPP_DIR",
+    "output/dogfood/taroz_pos_pdc_dogfood_current",
+)
+MATLAB_DIR = configured_path(
+    "GNSSPP_TAROZ_POS_PDC_MATLAB_DIR",
+    "output/dogfood/taroz_matlab_pos_pdc_debug",
+)
+
+
+def display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT_DIR))
+    except ValueError:
+        return str(path)
+
+
+def read_json(path: Path) -> dict[str, object]:
+    with path.open() as handle:
+        return json.load(handle)
+
+
+def read_rows(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def read_graph(path: Path) -> dict[str, str]:
+    with path.open(newline="") as handle:
+        return next(csv.DictReader(handle))
+
+
+def read_epochs(path: Path) -> dict[int, dict[str, str]]:
+    return {
+        round(float(row["gps_tow"])): row
+        for row in read_rows(path)
+    }
+
+
+def percentile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    return ordered[int(fraction * (len(ordered) - 1))]
+
+
+def read_cpp_factors(path: Path) -> dict[tuple[str, int, str], dict[str, str]]:
+    factors: dict[tuple[str, int, str], dict[str, str]] = {}
+    for row in read_rows(path):
+        epoch = int(row["epoch_index"]) + 1
+        factors[(row["factor_type"], epoch, row["satellite"])] = row
+    return factors
+
+
+def read_taroz_factors(
+    path_p: Path,
+    path_d: Path,
+    path_c: Path,
+) -> dict[tuple[str, int, str], dict[str, str]]:
+    factors: dict[tuple[str, int, str], dict[str, str]] = {}
+    for row in read_rows(path_p):
+        if row.get("valid_pseudorange", "").lower() in {"1", "true"}:
+            factors[("P", int(float(row["epoch"])), row["satellite"])] = row
+    for row in read_rows(path_d):
+        if row.get("valid_doppler", "").lower() in {"1", "true"}:
+            factors[("D", int(float(row["epoch"])), row["satellite"])] = row
+    for row in read_rows(path_c):
+        if row.get("valid_tdcp", "").lower() in {"1", "true"}:
+            factors[("C", int(float(row["epoch"])), row["satellite"])] = row
+    return factors
+
+
+def max_abs_diff(
+    keys: list[tuple[str, int, str]],
+    left: dict[tuple[str, int, str], dict[str, str]],
+    right: dict[tuple[str, int, str], dict[str, str]],
+    left_column: str,
+    right_column: str,
+) -> float:
+    return max(abs(float(left[key][left_column]) - float(right[key][right_column])) for key in keys)
+
+
+def mean_abs_diff(
+    keys: list[tuple[str, int, str]],
+    left: dict[tuple[str, int, str], dict[str, str]],
+    right: dict[tuple[str, int, str], dict[str, str]],
+    left_column: str,
+    right_column: str,
+) -> float:
+    return statistics.mean(
+        abs(float(left[key][left_column]) - float(right[key][right_column]))
+        for key in keys
+    )
+
+
+class TarozPosPDCInternalParityTest(unittest.TestCase):
+    def require_dogfood_files(self, *paths: Path) -> None:
+        missing = [display_path(path) for path in paths if not path.exists()]
+        if missing:
+            self.skipTest("missing optional taroz position PDC dogfood files: " + ", ".join(missing))
+
+    def test_graph_and_factor_counts_match_taroz_dump(self) -> None:
+        cpp_summary_path = CPP_DIR / "summary.json"
+        cpp_graph_path = CPP_DIR / "graph_detail.csv"
+        cpp_factor_path = CPP_DIR / "factor_debug.csv"
+        taroz_graph_path = MATLAB_DIR / "graph_detail.csv"
+        taroz_p_path = MATLAB_DIR / "per_sat_detail.csv"
+        taroz_d_path = MATLAB_DIR / "per_doppler_detail.csv"
+        taroz_c_path = MATLAB_DIR / "per_tdcp_detail.csv"
+        self.require_dogfood_files(
+            cpp_summary_path,
+            cpp_graph_path,
+            cpp_factor_path,
+            taroz_graph_path,
+            taroz_p_path,
+            taroz_d_path,
+            taroz_c_path,
+        )
+
+        cpp_summary = read_json(cpp_summary_path)
+        cpp_graph = read_graph(cpp_graph_path)
+        taroz_graph = read_graph(taroz_graph_path)
+        cpp_factors = read_cpp_factors(cpp_factor_path)
+        taroz_factors = read_taroz_factors(taroz_p_path, taroz_d_path, taroz_c_path)
+        p_keys = [key for key in cpp_factors if key[0] == "P"]
+        d_keys = [key for key in cpp_factors if key[0] == "D"]
+        c_keys = [key for key in cpp_factors if key[0] == "C"]
+
+        self.assertEqual(cpp_summary["preset"], "taroz-pos-pdc")
+        self.assertEqual(cpp_summary["backend"], "eigen")
+        self.assertEqual(cpp_summary["optimized_epochs"], int(float(taroz_graph["n"])))
+        self.assertEqual(cpp_summary["pseudorange_factors"], len(p_keys))
+        self.assertEqual(cpp_summary["doppler_factors"], len(d_keys))
+        self.assertEqual(cpp_summary["tdcp_factors"], len(c_keys))
+        self.assertEqual(len(p_keys), 24092)
+        self.assertEqual(len(d_keys), 29371)
+        self.assertEqual(len(c_keys), 21832)
+        self.assertEqual(set(cpp_factors), set(taroz_factors))
+        self.assertEqual(int(float(cpp_graph["graph_factors"])), int(float(taroz_graph["graph_factors"])))
+        self.assertEqual(int(float(cpp_graph["graph_values"])), int(float(taroz_graph["graph_values"])))
+        self.assertLessEqual(
+            abs(float(cpp_graph["initial_cost"]) - float(taroz_graph["initial_cost"])) /
+            max(1.0, abs(float(taroz_graph["initial_cost"]))),
+            1e-4,
+        )
+        self.assertLessEqual(
+            abs(float(cpp_graph["final_cost"]) - float(taroz_graph["final_cost"])) /
+            max(1.0, abs(float(taroz_graph["final_cost"]))),
+            0.15,
+        )
+
+    def test_raw_factors_match_taroz_dump(self) -> None:
+        cpp_factor_path = CPP_DIR / "factor_debug.csv"
+        taroz_p_path = MATLAB_DIR / "per_sat_detail.csv"
+        taroz_d_path = MATLAB_DIR / "per_doppler_detail.csv"
+        taroz_c_path = MATLAB_DIR / "per_tdcp_detail.csv"
+        self.require_dogfood_files(cpp_factor_path, taroz_p_path, taroz_d_path, taroz_c_path)
+
+        cpp_factors = read_cpp_factors(cpp_factor_path)
+        taroz_factors = read_taroz_factors(taroz_p_path, taroz_d_path, taroz_c_path)
+        self.assertEqual(set(cpp_factors), set(taroz_factors))
+
+        p_keys = sorted(key for key in cpp_factors if key[0] == "P")
+        d_keys = sorted(key for key in cpp_factors if key[0] == "D")
+        c_keys = sorted(key for key in cpp_factors if key[0] == "C")
+        self.assertEqual(len(p_keys), 24092)
+        self.assertEqual(len(d_keys), 29371)
+        self.assertEqual(len(c_keys), 21832)
+
+        self.assertLessEqual(max_abs_diff(p_keys, cpp_factors, taroz_factors, "sigma_p_m", "sigma_p_m"), 1e-4)
+        self.assertLessEqual(mean_abs_diff(p_keys, cpp_factors, taroz_factors, "res_pc_m", "res_pc_m"), 6.0)
+        self.assertLessEqual(max_abs_diff(p_keys, cpp_factors, taroz_factors, "res_pc_m", "res_pc_m"), 10.0)
+
+        self.assertLessEqual(max_abs_diff(d_keys, cpp_factors, taroz_factors, "sigma_d_mps", "sigma_d_mps"), 1e-5)
+        self.assertLessEqual(mean_abs_diff(d_keys, cpp_factors, taroz_factors, "res_d_mps", "res_d_mps"), 1e-3)
+        self.assertLessEqual(max_abs_diff(d_keys, cpp_factors, taroz_factors, "res_d_mps", "res_d_mps"), 0.01)
+        self.assertLessEqual(max_abs_diff(d_keys, cpp_factors, taroz_factors, "midpoint_gps_tow", "midpoint_gps_tow"), 1e-9)
+        for axis in "xyz":
+            self.assertLessEqual(
+                max_abs_diff(d_keys, cpp_factors, taroz_factors, f"los_{axis}", f"los_{axis}"),
+                1e-6,
+            )
+
+        self.assertLessEqual(max_abs_diff(c_keys, cpp_factors, taroz_factors, "sigma_c_m", "sigma_c_m"), 1e-5)
+        tdcp_diffs = [
+            abs(float(cpp_factors[key]["res_tdcp_m"]) - float(taroz_factors[key]["tdcp_m"]))
+            for key in c_keys
+        ]
+        self.assertLessEqual(statistics.mean(tdcp_diffs), 0.003)
+        self.assertLessEqual(percentile(tdcp_diffs, 0.95), 0.01)
+        self.assertLessEqual(max(tdcp_diffs), 4.0)
+        for axis in "xyz":
+            self.assertLessEqual(
+                max_abs_diff(c_keys, cpp_factors, taroz_factors, f"los_{axis}", f"los_{axis}"),
+                1e-6,
+            )
+
+    def test_final_position_matches_taroz_dump(self) -> None:
+        cpp_epoch_path = CPP_DIR / "per_epoch_state.csv"
+        taroz_epoch_path = MATLAB_DIR / "per_epoch_state.csv"
+        self.require_dogfood_files(cpp_epoch_path, taroz_epoch_path)
+
+        cpp_epochs = read_epochs(cpp_epoch_path)
+        taroz_epochs = read_epochs(taroz_epoch_path)
+        common_tows = sorted(set(cpp_epochs) & set(taroz_epochs))
+        self.assertEqual(len(common_tows), 1141)
+
+        position_diffs: list[float] = []
+        clock_diffs: list[float] = []
+        for tow in common_tows:
+            cpp = cpp_epochs[tow]
+            taroz = taroz_epochs[tow]
+            taroz_position = tuple(float(taroz[f"fgo_{axis}_m"]) for axis in "xyz")
+            if all(math.isfinite(value) for value in taroz_position):
+                position_diffs.append(
+                    math.dist(
+                        tuple(float(cpp[f"fgo_{axis}_m"]) for axis in "xyz"),
+                        taroz_position,
+                    )
+                )
+            for column in (
+                "fgo_c_gps_m",
+                "fgo_c_glo_m",
+                "fgo_c_gal_m",
+                "fgo_c_qzs_m",
+                "fgo_c_bds_m",
+            ):
+                clock_diffs.append(abs(float(cpp[column]) - float(taroz[column])))
+
+        self.assertEqual(len(position_diffs), 1129)
+        self.assertLessEqual(statistics.mean(position_diffs), 3.0)
+        self.assertLessEqual(percentile(position_diffs, 0.95), 4.0)
+        self.assertLessEqual(max(position_diffs), 5.5)
+        self.assertLessEqual(statistics.mean(clock_diffs), 3.0)
+        self.assertLessEqual(max(clock_diffs), 10.0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_taroz_pos_vel_amb_pdc_dogfood.py
+++ b/tests/test_taroz_pos_vel_amb_pdc_dogfood.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+"""Tests for the taroz position/velocity ambiguity PDC dogfood harness."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+APPS_DIR = ROOT_DIR / "apps"
+sys.path.insert(0, str(APPS_DIR))
+
+import gnss_taroz_pos_vel_amb_pdc_dogfood  # noqa: E402
+
+
+class TarozPosVelAmbPdcDogfoodTest(unittest.TestCase):
+    def touch_inputs(self, root: Path) -> tuple[Path, Path, Path, Path]:
+        obs = root / "rover.obs"
+        base = root / "base.obs"
+        nav = root / "base.nav"
+        seed_pos = root / "seed.pos"
+        for path in (obs, base, nav, seed_pos):
+            path.write_text("", encoding="ascii")
+        return obs, base, nav, seed_pos
+
+    def canonical_summary(self) -> dict[str, object]:
+        summary: dict[str, object] = {
+            "preset": "taroz-amb-pdc",
+            "backend": "eigen",
+            "debug_problem_only": False,
+            "use_spp_seed": False,
+            "use_pseudorange_factors": False,
+            "use_single_difference_doppler_factors": True,
+            "use_single_difference_tdcp_factors": True,
+            "use_velocity_states": True,
+            "use_velocity_motion_factors": True,
+            "use_ambiguity_between_factors": True,
+            "linearize_double_difference_factors_at_seed": True,
+            "use_epoch_lambda_fixed_output": True,
+            "dd_ambiguity_per_epoch": True,
+            "use_ambiguity_priors": False,
+            "reject_rover_carrier_lli": True,
+            "insert_fixed_interval_gaps": True,
+            "exclude_glonass_qzss_sbas": True,
+            "pseudorange_huber_threshold_sigma": 1.234,
+            "carrier_phase_huber_threshold_sigma": 1.234,
+            "tdcp_huber_threshold_sigma": 1.234,
+            "velocity_motion_sigma_m": 0.01,
+            "ambiguity_between_sigma_cycles": 0.001,
+            "min_snr_dbhz": 35.0,
+            "min_satellites_per_epoch": 0,
+            "min_output_dd_carrier_factors_per_epoch": 6,
+            "lambda_ambiguity_fix_solved": True,
+            "lambda_ambiguity_fix_used": True,
+            "partial_lambda_ambiguity_fix_used": False,
+            "fixed_solution": True,
+            "converged": True,
+            "final_cost": 57158.72726,
+            "total_processing_time_ms": 41508.1587,
+        }
+        summary.update(gnss_taroz_pos_vel_amb_pdc_dogfood.EXPECTED_FULL_COUNTS)
+        return summary
+
+    def test_dry_run_writes_full_parity_plan(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_taroz_amb_pdc_dogfood_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            obs, base, nav, seed_pos = self.touch_inputs(temp_root)
+            summary_json = temp_root / "summary.json"
+            out_dir = temp_root / "out"
+
+            result = gnss_taroz_pos_vel_amb_pdc_dogfood.main(
+                [
+                    "--obs",
+                    str(obs),
+                    "--base",
+                    str(base),
+                    "--nav",
+                    str(nav),
+                    "--seed-pos",
+                    str(seed_pos),
+                    "--out-dir",
+                    str(out_dir),
+                    "--summary-json",
+                    str(summary_json),
+                    "--fgo-bin",
+                    str(temp_root / "gnss_fgo"),
+                    "--dry-run",
+                ]
+            )
+
+            self.assertEqual(result, 0)
+            payload = json.loads(summary_json.read_text(encoding="utf-8"))
+            command = payload["fgo_command"]
+            self.assertEqual(payload["status"], "dry-run")
+            self.assertIn("--preset", command)
+            self.assertIn("taroz-amb-pdc", command)
+            self.assertIn("--base", command)
+            self.assertIn("--factor-debug-csv", command)
+            self.assertIn("--sd-factor-debug-csv", command)
+            self.assertIn("--lambda-debug-csv", command)
+            self.assertEqual(payload["expected"]["counts"]["fixed_solutions"], 721)
+            self.assertEqual(payload["expected"]["counts"]["float_solutions"], 243)
+
+    def test_native_summary_accepts_canonical_full_run(self) -> None:
+        failures = gnss_taroz_pos_vel_amb_pdc_dogfood.verify_native_summary(
+            self.canonical_summary()
+        )
+
+        self.assertEqual(failures, [])
+
+    def test_native_summary_flags_count_drift(self) -> None:
+        summary = self.canonical_summary()
+        summary["fixed_solutions"] = 720
+
+        failures = gnss_taroz_pos_vel_amb_pdc_dogfood.verify_native_summary(summary)
+
+        self.assertEqual(failures, ["taroz-amb-pdc fixed_solutions must be 721"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_taroz_pos_vel_amb_pdc_factor_parity.py
+++ b/tests/test_taroz_pos_vel_amb_pdc_factor_parity.py
@@ -1,0 +1,522 @@
+#!/usr/bin/env python3
+"""Optional raw-factor parity checks for taroz position/velocity ambiguity PDC."""
+
+from __future__ import annotations
+
+import csv
+from collections import Counter
+import json
+import math
+import os
+from pathlib import Path
+import statistics
+import unittest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def configured_path(env_name: str, default_relative_path: str) -> Path:
+    configured = os.environ.get(env_name)
+    if configured:
+        path = Path(configured)
+        return path if path.is_absolute() else ROOT_DIR / path
+    return ROOT_DIR / default_relative_path
+
+
+CPP_DIR = configured_path(
+    "GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_DIR",
+    "output/dogfood/taroz_pos_vel_amb_pdc_debug_current",
+)
+MATLAB_DIR = configured_path(
+    "GNSSPP_TAROZ_POS_VEL_AMB_PDC_MATLAB_DIR",
+    "output/dogfood/taroz_matlab_pos_vel_amb_pdc_debug",
+)
+CPP_OPT_POS = configured_path(
+    "GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_OPT_POS",
+    "output/dogfood/taroz_pos_vel_amb_pdc_current/opt.pos",
+)
+CPP_OPT_EPOCH_DEBUG = configured_path(
+    "GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_OPT_EPOCH_DEBUG",
+    "output/dogfood/taroz_pos_vel_amb_pdc_current/epoch_debug.csv",
+)
+CPP_OPT_LAMBDA_DEBUG = configured_path(
+    "GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_OPT_LAMBDA_DEBUG",
+    "output/dogfood/taroz_pos_vel_amb_pdc_current/lambda_debug.csv",
+)
+
+
+def display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT_DIR))
+    except ValueError:
+        return str(path)
+
+
+def read_rows(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def read_json(path: Path) -> dict[str, object]:
+    with path.open() as handle:
+        return json.load(handle)
+
+
+def read_pos_rows(path: Path) -> dict[tuple[int, int], dict[str, float | int]]:
+    rows: dict[tuple[int, int], dict[str, float | int]] = {}
+    with path.open() as handle:
+        for line in handle:
+            if not line.strip() or line.startswith("%"):
+                continue
+            parts = line.split()
+            if len(parts) < 10:
+                continue
+            key = (int(float(parts[0])), round(float(parts[1])))
+            rows[key] = {
+                "x": float(parts[2]),
+                "y": float(parts[3]),
+                "z": float(parts[4]),
+                "status": int(float(parts[8])),
+                "satellites": int(float(parts[9])),
+            }
+    return rows
+
+
+def keyed_epoch_rows(path: Path) -> dict[tuple[int, int], dict[str, str]]:
+    return {
+        (int(float(row["gps_week"])), round(float(row["gps_tow"]))): row
+        for row in read_rows(path)
+    }
+
+
+def percentile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    return ordered[int(fraction * (len(ordered) - 1))]
+
+
+def finite(value: str) -> bool:
+    try:
+        return math.isfinite(float(value))
+    except ValueError:
+        return False
+
+
+def keyed_cpp_rows(path: Path) -> dict[tuple[int, str, str], dict[str, str]]:
+    return {
+        (round(float(row["gps_tow"])), row["satellite"], row["reference"]): row
+        for row in read_rows(path)
+    }
+
+
+def keyed_taroz_rows(path: Path) -> dict[tuple[int, str, str], dict[str, str]]:
+    rows: dict[tuple[int, str, str], dict[str, str]] = {}
+    for row in read_rows(path):
+        if row.get("valid_pseudorange_dd", "").lower() in {"1", "true"}:
+            rows[(round(float(row["gps_tow"])), row["satellite"], row["reference"])] = row
+    return rows
+
+
+def keyed_valid_rows(
+    path: Path,
+    valid_column: str,
+) -> dict[tuple[int, str, str], dict[str, str]]:
+    rows: dict[tuple[int, str, str], dict[str, str]] = {}
+    for row in read_rows(path):
+        if row.get(valid_column, "").lower() in {"1", "true"}:
+            rows[(round(float(row["gps_tow"])), row["satellite"], row["reference"])] = row
+    return rows
+
+
+def keyed_lambda_rows(
+    path: Path,
+) -> dict[tuple[int, int, int, int, str, str], dict[str, str]]:
+    return {
+        (
+            int(float(row["gps_week"])),
+            round(float(row["gps_tow"])),
+            int(row["row"]),
+            int(row["col"]),
+            row["satellite"],
+            row["other_satellite"],
+        ): row
+        for row in read_rows(path)
+    }
+
+
+def abs_diffs(
+    keys: list[tuple[int, str, str]],
+    cpp_rows: dict[tuple[int, str, str], dict[str, str]],
+    taroz_rows: dict[tuple[int, str, str], dict[str, str]],
+    cpp_column: str,
+    taroz_column: str,
+) -> list[float]:
+    return [
+        abs(float(cpp_rows[key][cpp_column]) - float(taroz_rows[key][taroz_column]))
+        for key in keys
+        if finite(cpp_rows[key][cpp_column]) and finite(taroz_rows[key][taroz_column])
+    ]
+
+
+def ecef_error_m(
+    cpp_row: dict[str, float | int],
+    taroz_row: dict[str, str],
+    taroz_prefix: str,
+) -> float:
+    dx = float(cpp_row["x"]) - float(taroz_row[f"{taroz_prefix}_x_m"])
+    dy = float(cpp_row["y"]) - float(taroz_row[f"{taroz_prefix}_y_m"])
+    dz = float(cpp_row["z"]) - float(taroz_row[f"{taroz_prefix}_z_m"])
+    return math.sqrt(dx * dx + dy * dy + dz * dz)
+
+
+def epoch_debug_ecef_error_m(
+    cpp_row: dict[str, str],
+    taroz_row: dict[str, str],
+    taroz_prefix: str,
+) -> float:
+    dx = float(cpp_row["position_x_m"]) - float(taroz_row[f"{taroz_prefix}_x_m"])
+    dy = float(cpp_row["position_y_m"]) - float(taroz_row[f"{taroz_prefix}_y_m"])
+    dz = float(cpp_row["position_z_m"]) - float(taroz_row[f"{taroz_prefix}_z_m"])
+    return math.sqrt(dx * dx + dy * dy + dz * dz)
+
+
+def epoch_debug_velocity_error_mps(
+    cpp_row: dict[str, str],
+    taroz_row: dict[str, str],
+) -> float:
+    dx = float(cpp_row["velocity_x_mps"]) - float(taroz_row["fgo_vx_mps"])
+    dy = float(cpp_row["velocity_y_mps"]) - float(taroz_row["fgo_vy_mps"])
+    dz = float(cpp_row["velocity_z_mps"]) - float(taroz_row["fgo_vz_mps"])
+    return math.sqrt(dx * dx + dy * dy + dz * dz)
+
+
+def lambda_diffs(
+    keys: list[tuple[int, int, int, int, str, str]],
+    cpp_rows: dict[tuple[int, int, int, int, str, str], dict[str, str]],
+    taroz_rows: dict[tuple[int, int, int, int, str, str], dict[str, str]],
+    column: str,
+) -> list[float]:
+    return [
+        abs(float(cpp_rows[key][column]) - float(taroz_rows[key][column]))
+        for key in keys
+        if finite(cpp_rows[key][column]) and finite(taroz_rows[key][column])
+    ]
+
+
+class TarozPosVelAmbPdcFactorParityTest(unittest.TestCase):
+    def require_dogfood_files(self, *paths: Path) -> None:
+        missing = [display_path(path) for path in paths if not path.exists()]
+        if missing:
+            self.skipTest(
+                "missing optional taroz position/velocity ambiguity PDC files: "
+                + ", ".join(missing)
+            )
+
+    def test_counts_match_taroz_dump(self) -> None:
+        summary_path = CPP_DIR / "summary.json"
+        cpp_epoch_path = CPP_DIR / "epoch_debug.csv"
+        cpp_factor_path = CPP_DIR / "factor_debug.csv"
+        taroz_graph_path = MATLAB_DIR / "graph_detail.csv"
+        taroz_epoch_path = MATLAB_DIR / "per_epoch_state.csv"
+        taroz_factor_path = MATLAB_DIR / "per_sat_detail.csv"
+        self.require_dogfood_files(
+            summary_path,
+            cpp_epoch_path,
+            cpp_factor_path,
+            taroz_graph_path,
+            taroz_epoch_path,
+            taroz_factor_path,
+        )
+
+        summary = read_json(summary_path)
+        taroz_graph = read_rows(taroz_graph_path)[0]
+        cpp_epoch_rows = keyed_epoch_rows(cpp_epoch_path)
+        taroz_epoch_rows = keyed_epoch_rows(taroz_epoch_path)
+        cpp_rows = keyed_cpp_rows(cpp_factor_path)
+        taroz_rows = keyed_taroz_rows(taroz_factor_path)
+        carrier_keys = [
+            key for key, row in cpp_rows.items()
+            if finite(row["res_ldd"])
+        ]
+
+        self.assertEqual(summary["preset"], "taroz-amb-pdc")
+        self.assertIsInstance(summary["debug_problem_only"], bool)
+        self.assertEqual(summary["insert_fixed_interval_gaps"], True)
+        self.assertEqual(summary["min_satellites_per_epoch"], 0)
+        self.assertEqual(summary["min_output_dd_carrier_factors_per_epoch"], 6)
+        self.assertEqual(summary["optimized_epochs"], int(float(taroz_graph["n"])))
+        self.assertEqual(summary["use_single_difference_doppler_factors"], True)
+        self.assertEqual(summary["use_single_difference_tdcp_factors"], True)
+        self.assertIsInstance(summary["use_epoch_lambda_fixed_output"], bool)
+        self.assertEqual(summary["double_difference_pseudorange_factors"], 15013)
+        self.assertEqual(summary["double_difference_carrier_factors"], 13826)
+        self.assertEqual(summary["single_difference_doppler_factors"], 18330)
+        self.assertEqual(summary["single_difference_tdcp_factors"], 13509)
+        self.assertEqual(summary["ambiguity_states"], 13826)
+        self.assertEqual(len(cpp_rows), 15013)
+        self.assertEqual(len(carrier_keys), 13826)
+        self.assertEqual(set(cpp_rows), set(taroz_rows))
+        self.assertEqual(set(cpp_epoch_rows), set(taroz_epoch_rows))
+        for key, row in cpp_epoch_rows.items():
+            self.assertEqual(
+                int(row["ambiguity_candidates"]),
+                int(float(taroz_epoch_rows[key]["candidate_count"])),
+            )
+
+    def test_raw_dd_factors_match_taroz_dump(self) -> None:
+        cpp_factor_path = CPP_DIR / "factor_debug.csv"
+        taroz_factor_path = MATLAB_DIR / "per_sat_detail.csv"
+        self.require_dogfood_files(cpp_factor_path, taroz_factor_path)
+
+        cpp_rows = keyed_cpp_rows(cpp_factor_path)
+        taroz_rows = keyed_taroz_rows(taroz_factor_path)
+        self.assertEqual(set(cpp_rows), set(taroz_rows))
+        keys = sorted(cpp_rows)
+        carrier_keys = sorted(key for key in keys if finite(cpp_rows[key]["res_ldd"]))
+
+        self.assertEqual(len(keys), 15013)
+        self.assertEqual(len(carrier_keys), 13826)
+        checks = [
+            ("elevation_deg", "elevation_deg", 1e-3, 1e-3, 1e-3),
+            ("sigma_pdd_m", "sigma_pdd_m", 1e-5, 2e-5, 2e-5),
+            ("res_pdd", "res_pdd", 1e-4, 2e-4, 3e-4),
+        ]
+        for cpp_column, taroz_column, mean_limit, p95_limit, max_limit in checks:
+            diffs = abs_diffs(keys, cpp_rows, taroz_rows, cpp_column, taroz_column)
+            self.assertEqual(len(diffs), len(keys))
+            self.assertLessEqual(statistics.mean(diffs), mean_limit)
+            self.assertLessEqual(percentile(diffs, 0.95), p95_limit)
+            self.assertLessEqual(max(diffs), max_limit)
+
+        carrier_checks = [
+            ("sigma_ldd_m", "sigma_ldd_m", 1e-7, 1e-7, 1e-7),
+            ("res_ldd", "res_ldd", 1e-4, 2e-4, 3e-4),
+            ("ambiguity_initial", "ambiguity_initial", 1e-8, 1e-8, 5e-8),
+        ]
+        for cpp_column, taroz_column, mean_limit, p95_limit, max_limit in carrier_checks:
+            diffs = abs_diffs(carrier_keys, cpp_rows, taroz_rows, cpp_column, taroz_column)
+            self.assertEqual(len(diffs), len(carrier_keys))
+            self.assertLessEqual(statistics.mean(diffs), mean_limit)
+            self.assertLessEqual(percentile(diffs, 0.95), p95_limit)
+            self.assertLessEqual(max(diffs), max_limit)
+
+    def test_optimized_solution_tracks_taroz_fixed_output_on_well_constrained_epochs(self) -> None:
+        taroz_epoch_path = MATLAB_DIR / "per_epoch_state.csv"
+        self.require_dogfood_files(CPP_OPT_POS, taroz_epoch_path)
+
+        cpp_rows = read_pos_rows(CPP_OPT_POS)
+        taroz_rows = {
+            (int(float(row["gps_week"])), round(float(row["gps_tow"]))): row
+            for row in read_rows(taroz_epoch_path)
+        }
+        self.assertEqual(set(cpp_rows), set(taroz_rows))
+
+        well_constrained_keys = [
+            key for key, row in taroz_rows.items()
+            if int(float(row["candidate_count"])) >= 6
+        ]
+        self.assertEqual(len(well_constrained_keys), 964)
+        self.assertEqual(
+            Counter(int(row["status"]) for row in cpp_rows.values()),
+            Counter({4: 721, 3: 243, 0: 177}),
+        )
+        valid_cpp_keys = {
+            key for key, row in cpp_rows.items()
+            if int(row["status"]) != 0 and int(row["satellites"]) >= 4
+        }
+        self.assertEqual(valid_cpp_keys, set(well_constrained_keys))
+        cpp_fixed_keys = {
+            key for key, row in cpp_rows.items()
+            if int(row["status"]) == 4
+        }
+        taroz_fixed_valid_keys = {
+            key for key, row in taroz_rows.items()
+            if int(float(row["idxfix"])) == 1 and key in valid_cpp_keys
+        }
+        self.assertEqual(len(cpp_fixed_keys), 721)
+        self.assertEqual(len(valid_cpp_keys - cpp_fixed_keys), 243)
+        self.assertEqual(cpp_fixed_keys, taroz_fixed_valid_keys)
+
+        errors = [
+            ecef_error_m(cpp_rows[key], taroz_rows[key], "fixed")
+            for key in well_constrained_keys
+        ]
+        self.assertLessEqual(statistics.mean(errors), 0.001)
+        self.assertLessEqual(statistics.median(errors), 0.0002)
+        self.assertLessEqual(percentile(errors, 0.95), 0.0012)
+        self.assertLessEqual(max(errors), 0.012)
+
+    def test_optimized_epoch_debug_tracks_taroz_fixed_output(self) -> None:
+        taroz_epoch_path = MATLAB_DIR / "per_epoch_state.csv"
+        self.require_dogfood_files(CPP_OPT_EPOCH_DEBUG, taroz_epoch_path)
+
+        cpp_rows = keyed_epoch_rows(CPP_OPT_EPOCH_DEBUG)
+        taroz_rows = keyed_epoch_rows(taroz_epoch_path)
+        self.assertEqual(set(cpp_rows), set(taroz_rows))
+
+        well_constrained_keys = [
+            key for key, row in taroz_rows.items()
+            if int(float(row["candidate_count"])) >= 6
+        ]
+        self.assertEqual(len(well_constrained_keys), 964)
+        self.assertEqual(
+            Counter(int(row["status"]) for row in cpp_rows.values()),
+            Counter({4: 721, 3: 243, 0: 177}),
+        )
+        valid_cpp_keys = {
+            key for key, row in cpp_rows.items()
+            if (
+                int(row["status"]) != 0 and
+                int(row["ambiguity_candidates"]) >= 6
+            )
+        }
+        self.assertEqual(valid_cpp_keys, set(well_constrained_keys))
+        cpp_fixed_keys = {
+            key for key, row in cpp_rows.items()
+            if int(row["status"]) == 4
+        }
+        taroz_fixed_valid_keys = {
+            key for key, row in taroz_rows.items()
+            if int(float(row["idxfix"])) == 1 and key in valid_cpp_keys
+        }
+        self.assertEqual(len(cpp_fixed_keys), 721)
+        self.assertEqual(len(valid_cpp_keys - cpp_fixed_keys), 243)
+        self.assertEqual(cpp_fixed_keys, taroz_fixed_valid_keys)
+        for key, row in cpp_rows.items():
+            self.assertEqual(
+                int(row["ambiguity_candidates"]),
+                int(float(taroz_rows[key]["candidate_count"])),
+            )
+
+        position_errors = [
+            epoch_debug_ecef_error_m(cpp_rows[key], taroz_rows[key], "fixed")
+            for key in well_constrained_keys
+        ]
+        self.assertLessEqual(statistics.mean(position_errors), 0.001)
+        self.assertLessEqual(statistics.median(position_errors), 0.0002)
+        self.assertLessEqual(percentile(position_errors, 0.95), 0.0012)
+        self.assertLessEqual(max(position_errors), 0.012)
+
+        velocity_errors = [
+            epoch_debug_velocity_error_mps(cpp_rows[key], taroz_rows[key])
+            for key in well_constrained_keys
+            if (
+                finite(cpp_rows[key]["velocity_x_mps"]) and
+                finite(cpp_rows[key]["velocity_y_mps"]) and
+                finite(cpp_rows[key]["velocity_z_mps"])
+            )
+        ]
+        self.assertGreaterEqual(len(velocity_errors), len(well_constrained_keys) - 2)
+        self.assertLessEqual(statistics.mean(velocity_errors), 0.001)
+        self.assertLessEqual(statistics.median(velocity_errors), 0.0003)
+        self.assertLessEqual(percentile(velocity_errors, 0.95), 0.003)
+        self.assertLessEqual(max(velocity_errors), 0.012)
+
+    def test_lambda_debug_tracks_taroz_internal_ambiguity_state(self) -> None:
+        taroz_lambda_path = MATLAB_DIR / "per_lambda_detail.csv"
+        self.require_dogfood_files(CPP_OPT_LAMBDA_DEBUG, taroz_lambda_path)
+
+        cpp_rows = keyed_lambda_rows(CPP_OPT_LAMBDA_DEBUG)
+        taroz_rows = keyed_lambda_rows(taroz_lambda_path)
+        self.assertEqual(len(cpp_rows), 208172)
+        self.assertEqual(set(cpp_rows), set(taroz_rows))
+        keys = sorted(cpp_rows)
+
+        for key in keys:
+            self.assertEqual(
+                int(cpp_rows[key]["candidate_count"]),
+                int(float(taroz_rows[key]["candidate_count"])),
+            )
+
+        diagonal_keys = [
+            key for key in keys
+            if key[2] == 0 and key[3] == 0
+        ]
+        self.assertEqual(len(diagonal_keys), 964)
+        self.assertTrue(all(int(cpp_rows[key]["solved"]) == 1 for key in diagonal_keys))
+        cpp_fixed_epochs = sum(int(cpp_rows[key]["fixed_epoch"]) for key in diagonal_keys)
+        taroz_fixed_epochs = sum(
+            int(float(taroz_rows[key]["fixed_epoch"])) for key in diagonal_keys
+        )
+        self.assertEqual(cpp_fixed_epochs, 721)
+        self.assertEqual(cpp_fixed_epochs, taroz_fixed_epochs)
+        for key in diagonal_keys:
+            self.assertEqual(
+                int(cpp_rows[key]["fixed_epoch"]),
+                int(float(taroz_rows[key]["fixed_epoch"])),
+            )
+
+        checks = [
+            ("ambiguity_float", 0.0015, 0.0012, 0.003, 0.03),
+            ("fixed_ambiguity", 1e-8, 1e-8, 1e-8, 1e-8),
+            ("covariance", 3e-6, 2e-6, 8e-6, 5e-4),
+            ("position_covariance_x", 1e-6, 6e-7, 2e-6, 1e-4),
+            ("position_covariance_y", 1e-6, 6e-7, 2e-6, 1e-4),
+            ("position_covariance_z", 1e-6, 6e-7, 2e-6, 1e-4),
+            ("ratio", 0.007, 0.004, 0.025, 0.08),
+        ]
+        for column, mean_limit, median_limit, p95_limit, max_limit in checks:
+            diffs = lambda_diffs(keys, cpp_rows, taroz_rows, column)
+            self.assertEqual(len(diffs), len(keys))
+            self.assertLessEqual(statistics.mean(diffs), mean_limit)
+            self.assertLessEqual(statistics.median(diffs), median_limit)
+            self.assertLessEqual(percentile(diffs, 0.95), p95_limit)
+            self.assertLessEqual(max(diffs), max_limit)
+
+    def test_raw_sd_doppler_tdcp_match_taroz_dump(self) -> None:
+        cpp_sd_path = CPP_DIR / "sd_factor_debug.csv"
+        taroz_factor_path = MATLAB_DIR / "per_sat_detail.csv"
+        self.require_dogfood_files(cpp_sd_path, taroz_factor_path)
+
+        cpp_doppler_rows = keyed_valid_rows(cpp_sd_path, "valid_doppler_sd")
+        cpp_tdcp_rows = keyed_valid_rows(cpp_sd_path, "valid_tdcp_sd")
+        taroz_doppler_rows = keyed_valid_rows(taroz_factor_path, "valid_doppler_sd")
+        taroz_tdcp_rows = keyed_valid_rows(taroz_factor_path, "valid_tdcp_sd")
+
+        self.assertEqual(len(cpp_doppler_rows), 18330)
+        self.assertEqual(len(cpp_tdcp_rows), 13509)
+        self.assertEqual(set(cpp_doppler_rows), set(taroz_doppler_rows))
+        self.assertEqual(set(cpp_tdcp_rows), set(taroz_tdcp_rows))
+
+        doppler_keys = sorted(cpp_doppler_rows)
+        tdcp_keys = sorted(cpp_tdcp_rows)
+        doppler_checks = [
+            ("sigma_dsd_mps", "sigma_dsd_mps", 1e-6, 3e-6, 4e-6),
+            ("res_dsd_mps", "res_dsd_mps", 1e-4, 2e-4, 5e-4),
+            ("los_x", "los_x", 4e-6, 8e-6, 8e-6),
+            ("los_y", "los_y", 4e-6, 8e-6, 8e-6),
+            ("los_z", "los_z", 5e-7, 1e-6, 1e-6),
+        ]
+        for cpp_column, taroz_column, mean_limit, p95_limit, max_limit in doppler_checks:
+            diffs = abs_diffs(
+                doppler_keys,
+                cpp_doppler_rows,
+                taroz_doppler_rows,
+                cpp_column,
+                taroz_column,
+            )
+            self.assertEqual(len(diffs), len(doppler_keys))
+            self.assertLessEqual(statistics.mean(diffs), mean_limit)
+            self.assertLessEqual(percentile(diffs, 0.95), p95_limit)
+            self.assertLessEqual(max(diffs), max_limit)
+
+        tdcp_checks = [
+            ("sigma_tdcp_m", "sigma_ldd_m", 1e-7, 1e-7, 1e-7),
+            ("tdcp_sd_m", "tdcp_sd_m", 1e-4, 2e-4, 3e-1),
+        ]
+        for cpp_column, taroz_column, mean_limit, p95_limit, max_limit in tdcp_checks:
+            diffs = abs_diffs(
+                tdcp_keys,
+                cpp_tdcp_rows,
+                taroz_tdcp_rows,
+                cpp_column,
+                taroz_column,
+            )
+            self.assertEqual(len(diffs), len(tdcp_keys))
+            self.assertLessEqual(statistics.mean(diffs), mean_limit)
+            self.assertLessEqual(percentile(diffs, 0.95), p95_limit)
+            self.assertLessEqual(max(diffs), max_limit)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_taroz_pos_vel_pdc_internal_parity.py
+++ b/tests/test_taroz_pos_vel_pdc_internal_parity.py
@@ -1,0 +1,436 @@
+#!/usr/bin/env python3
+"""Optional parity checks against taroz MATLAB position/velocity PDC dumps."""
+
+from __future__ import annotations
+
+import csv
+import json
+import math
+import os
+from pathlib import Path
+import statistics
+import unittest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+
+
+def configured_path(env_name: str, default_relative_path: str) -> Path:
+    configured = os.environ.get(env_name)
+    if configured:
+        path = Path(configured)
+        return path if path.is_absolute() else ROOT_DIR / path
+    return ROOT_DIR / default_relative_path
+
+
+CPP_DIR = configured_path(
+    "GNSSPP_TAROZ_POS_VEL_PDC_CPP_DIR",
+    "output/dogfood/taroz_pos_vel_pdc_dogfood_current",
+)
+MATLAB_DIR = configured_path(
+    "GNSSPP_TAROZ_POS_VEL_PDC_MATLAB_DIR",
+    "output/dogfood/taroz_matlab_pos_vel_pdc_debug",
+)
+
+
+def display_path(path: Path) -> str:
+    try:
+        return str(path.relative_to(ROOT_DIR))
+    except ValueError:
+        return str(path)
+
+
+def read_json(path: Path) -> dict[str, object]:
+    with path.open() as handle:
+        return json.load(handle)
+
+
+def read_csv_rows(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="") as handle:
+        return list(csv.DictReader(handle))
+
+
+def read_epochs_by_tow(path: Path) -> dict[int, dict[str, str]]:
+    return {
+        round(float(row["gps_tow"])): row
+        for row in read_csv_rows(path)
+    }
+
+
+def read_epochs_by_epoch(path: Path) -> dict[int, dict[str, str]]:
+    return {
+        int(float(row["epoch"])): row
+        for row in read_csv_rows(path)
+    }
+
+
+def read_graph(path: Path) -> dict[str, str]:
+    with path.open(newline="") as handle:
+        return next(csv.DictReader(handle))
+
+
+def percentile(values: list[float], fraction: float) -> float:
+    ordered = sorted(values)
+    return ordered[int(fraction * (len(ordered) - 1))]
+
+
+def max_abs_diff(
+    keys: list[tuple[str, int, str]],
+    left: dict[tuple[str, int, str], dict[str, str]],
+    right: dict[tuple[str, int, str], dict[str, str]],
+    left_column: str,
+    right_column: str,
+) -> float:
+    return max(
+        abs(float(left[key][left_column]) - float(right[key][right_column]))
+        for key in keys
+    )
+
+
+def mean_abs_diff(
+    keys: list[tuple[str, int, str]],
+    left: dict[tuple[str, int, str], dict[str, str]],
+    right: dict[tuple[str, int, str], dict[str, str]],
+    left_column: str,
+    right_column: str,
+) -> float:
+    return statistics.mean(
+        abs(float(left[key][left_column]) - float(right[key][right_column]))
+        for key in keys
+    )
+
+
+def read_cpp_factor_rows(path: Path) -> dict[tuple[str, int, str], dict[str, str]]:
+    rows: dict[tuple[str, int, str], dict[str, str]] = {}
+    for row in read_csv_rows(path):
+        key = (row["factor_type"], round(float(row["gps_tow"])), row["satellite"])
+        rows[key] = row
+    return rows
+
+
+def read_taroz_factor_rows(
+    satellite_path: Path,
+    tdcp_path: Path,
+    allowed_tows: set[int] | None = None,
+) -> dict[tuple[str, int, str], dict[str, str]]:
+    rows: dict[tuple[str, int, str], dict[str, str]] = {}
+    for row in read_csv_rows(satellite_path):
+        tow = round(float(row["gps_tow"]))
+        if allowed_tows is not None and tow not in allowed_tows:
+            continue
+        if row.get("valid_pseudorange", "").lower() in {"1", "true"}:
+            rows[("P", tow, row["satellite"])] = row
+        if row.get("valid_doppler", "").lower() in {"1", "true"}:
+            rows[("D", tow, row["satellite"])] = row
+    for row in read_csv_rows(tdcp_path):
+        tow = round(float(row["gps_tow"]))
+        if allowed_tows is not None and tow not in allowed_tows:
+            continue
+        if row.get("valid_tdcp", "").lower() in {"1", "true"}:
+            rows[("C", tow, row["satellite"])] = row
+    return rows
+
+
+def clock_group_from_system(system: str) -> int:
+    return {
+        "SYS_GPS": 0,
+        "SYS_GLO": 1,
+        "SYS_GAL": 2,
+        "SYS_QZS": 3,
+        "SYS_CMP": 4,
+    }.get(system, 0)
+
+
+def taroz_position_delta(epoch: dict[str, str]) -> list[float]:
+    return [
+        float(epoch[f"fgo_{axis}_m"]) - float(epoch[f"spp_{axis}_m"])
+        for axis in "xyz"
+    ]
+
+
+def taroz_pseudorange_prediction(
+    epoch: dict[str, str],
+    factor: dict[str, str],
+) -> float:
+    delta_position = taroz_position_delta(epoch)
+    los = [float(factor[f"los_{axis}"]) for axis in "xyz"]
+    clock_columns = [
+        "fgo_c_gps_m",
+        "fgo_c_glo_m",
+        "fgo_c_gal_m",
+        "fgo_c_qzs_m",
+        "fgo_c_bds_m",
+    ]
+    group = clock_group_from_system(factor["system"])
+    clock = float(epoch["fgo_c_gps_m"])
+    if group != 0:
+        clock += float(epoch[clock_columns[group]])
+    return sum(l * dx for l, dx in zip(los, delta_position)) + clock
+
+
+def taroz_doppler_prediction(
+    epoch: dict[str, str],
+    factor: dict[str, str],
+) -> float:
+    velocity = [float(epoch[f"fgo_v{axis}_mps"]) for axis in "xyz"]
+    los = [float(factor[f"los_{axis}"]) for axis in "xyz"]
+    return sum(l * v for l, v in zip(los, velocity)) + float(epoch["fgo_clock_drift_mps"])
+
+
+def taroz_tdcp_prediction(
+    current_epoch: dict[str, str],
+    previous_epoch: dict[str, str],
+    factor: dict[str, str],
+) -> float:
+    current_delta = taroz_position_delta(current_epoch)
+    previous_delta = taroz_position_delta(previous_epoch)
+    los = [float(factor[f"los_{axis}"]) for axis in "xyz"]
+    return (
+        sum(
+            l * (current - previous)
+            for l, current, previous in zip(los, current_delta, previous_delta)
+        )
+        + float(current_epoch["fgo_c_gps_m"])
+        - float(previous_epoch["fgo_c_gps_m"])
+    )
+
+
+class TarozPosVelPDCInternalParityTest(unittest.TestCase):
+    def require_dogfood_files(self, *paths: Path) -> None:
+        missing = [display_path(path) for path in paths if not path.exists()]
+        if missing:
+            self.skipTest(
+                "missing optional taroz position/velocity PDC dogfood files: "
+                + ", ".join(missing)
+            )
+
+    def test_graph_and_factor_counts_match_taroz_dump(self) -> None:
+        cpp_summary_path = CPP_DIR / "summary.json"
+        cpp_graph_path = CPP_DIR / "graph_detail.csv"
+        cpp_factor_path = CPP_DIR / "factor_debug.csv"
+        cpp_epoch_path = CPP_DIR / "per_epoch_state.csv"
+        taroz_graph_path = MATLAB_DIR / "graph_detail.csv"
+        taroz_sat_path = MATLAB_DIR / "per_sat_detail.csv"
+        taroz_tdcp_path = MATLAB_DIR / "per_tdcp_detail.csv"
+        self.require_dogfood_files(
+            cpp_summary_path,
+            cpp_graph_path,
+            cpp_factor_path,
+            cpp_epoch_path,
+            taroz_graph_path,
+            taroz_sat_path,
+            taroz_tdcp_path,
+        )
+
+        cpp_summary = read_json(cpp_summary_path)
+        cpp_graph = read_graph(cpp_graph_path)
+        taroz_graph = read_graph(taroz_graph_path)
+        cpp_factors = read_cpp_factor_rows(cpp_factor_path)
+        cpp_tows = set(read_epochs_by_tow(cpp_epoch_path))
+        taroz_factors = read_taroz_factor_rows(taroz_sat_path, taroz_tdcp_path, cpp_tows)
+        p_keys = [key for key in cpp_factors if key[0] == "P"]
+        d_keys = [key for key in cpp_factors if key[0] == "D"]
+        c_keys = [key for key in cpp_factors if key[0] == "C"]
+        optimized_epochs = int(cpp_summary["optimized_epochs"])
+        taroz_epochs = int(float(taroz_graph["n"]))
+
+        self.assertEqual(cpp_summary["preset"], "taroz-pdc")
+        self.assertEqual(cpp_summary["backend"], "eigen")
+        self.assertEqual(optimized_epochs, len(cpp_tows))
+        self.assertLessEqual(optimized_epochs, taroz_epochs)
+        self.assertEqual(cpp_summary["valid_position_epochs"], optimized_epochs)
+        self.assertEqual(cpp_summary["valid_velocity_epochs"], optimized_epochs)
+        self.assertEqual(cpp_summary["pseudorange_factors"], len(p_keys))
+        self.assertEqual(cpp_summary["doppler_factors"], len(d_keys))
+        self.assertEqual(cpp_summary["tdcp_factors"], len(c_keys))
+        self.assertGreater(len(p_keys), 0)
+        self.assertGreater(len(d_keys), 0)
+        self.assertGreater(len(c_keys), 0)
+        self.assertEqual(set(cpp_factors), set(taroz_factors))
+        self.assertEqual(int(float(cpp_graph["graph_values"])), 4 * optimized_epochs)
+        self.assertEqual(int(cpp_summary["graph_values"]), int(float(cpp_graph["graph_values"])))
+        self.assertEqual(int(cpp_summary["graph_factors"]), int(float(cpp_graph["graph_factors"])))
+        if optimized_epochs == taroz_epochs:
+            self.assertEqual(len(p_keys), 24092)
+            self.assertEqual(len(d_keys), 24092)
+            self.assertEqual(len(c_keys), 21832)
+            self.assertEqual(int(float(cpp_graph["graph_factors"])), int(float(taroz_graph["graph_factors"])))
+            self.assertEqual(int(float(cpp_graph["graph_values"])), int(float(taroz_graph["graph_values"])))
+            self.assertLessEqual(
+                abs(float(cpp_graph["initial_cost"]) - float(taroz_graph["initial_cost"])) /
+                max(1.0, abs(float(taroz_graph["initial_cost"]))),
+                1e-4,
+            )
+            self.assertLessEqual(
+                abs(float(cpp_graph["final_cost"]) - float(taroz_graph["final_cost"])) /
+                max(1.0, abs(float(taroz_graph["final_cost"]))),
+                0.35,
+            )
+
+    def test_raw_factors_match_taroz_dump(self) -> None:
+        cpp_factor_path = CPP_DIR / "factor_debug.csv"
+        cpp_epoch_path = CPP_DIR / "per_epoch_state.csv"
+        taroz_sat_path = MATLAB_DIR / "per_sat_detail.csv"
+        taroz_tdcp_path = MATLAB_DIR / "per_tdcp_detail.csv"
+        self.require_dogfood_files(cpp_factor_path, cpp_epoch_path, taroz_sat_path, taroz_tdcp_path)
+
+        cpp_factors = read_cpp_factor_rows(cpp_factor_path)
+        cpp_tows = set(read_epochs_by_tow(cpp_epoch_path))
+        taroz_factors = read_taroz_factor_rows(taroz_sat_path, taroz_tdcp_path, cpp_tows)
+        self.assertEqual(set(cpp_factors), set(taroz_factors))
+
+        p_keys = sorted(key for key in cpp_factors if key[0] == "P")
+        d_keys = sorted(key for key in cpp_factors if key[0] == "D")
+        c_keys = sorted(key for key in cpp_factors if key[0] == "C")
+        self.assertGreater(len(p_keys), 0)
+        self.assertGreater(len(d_keys), 0)
+        self.assertGreater(len(c_keys), 0)
+        if len(cpp_tows) == 1141:
+            self.assertEqual(len(p_keys), 24092)
+            self.assertEqual(len(d_keys), 24092)
+            self.assertEqual(len(c_keys), 21832)
+
+        self.assertLessEqual(max_abs_diff(p_keys, cpp_factors, taroz_factors, "elevation_deg", "elevation_deg"), 1e-3)
+        self.assertLessEqual(max_abs_diff(p_keys, cpp_factors, taroz_factors, "sigma_p_m", "sigma_p_m"), 1e-4)
+        self.assertLessEqual(mean_abs_diff(p_keys, cpp_factors, taroz_factors, "res_pc_m", "res_pc_m"), 6.0)
+        self.assertLessEqual(max_abs_diff(p_keys, cpp_factors, taroz_factors, "res_pc_m", "res_pc_m"), 10.0)
+
+        self.assertLessEqual(max_abs_diff(d_keys, cpp_factors, taroz_factors, "elevation_deg", "elevation_deg"), 1e-4)
+        self.assertLessEqual(max_abs_diff(d_keys, cpp_factors, taroz_factors, "sigma_d_mps", "sigma_d_mps"), 1e-6)
+        self.assertLessEqual(mean_abs_diff(d_keys, cpp_factors, taroz_factors, "res_d_mps", "res_d_mps"), 1e-3)
+        self.assertLessEqual(max_abs_diff(d_keys, cpp_factors, taroz_factors, "res_d_mps", "res_d_mps"), 0.02)
+        for axis in "xyz":
+            self.assertLessEqual(
+                max_abs_diff(d_keys, cpp_factors, taroz_factors, f"los_{axis}", f"los_{axis}"),
+                1e-6,
+            )
+
+        self.assertLessEqual(max_abs_diff(c_keys, cpp_factors, taroz_factors, "sigma_c_m", "sigma_c_m"), 1e-5)
+        tdcp_diffs = [
+            abs(float(cpp_factors[key]["res_tdcp_m"]) - float(taroz_factors[key]["tdcp_m"]))
+            for key in c_keys
+        ]
+        self.assertLessEqual(statistics.mean(tdcp_diffs), 0.003)
+        self.assertLessEqual(percentile(tdcp_diffs, 0.95), 0.01)
+        self.assertLessEqual(max(tdcp_diffs), 4.0)
+        for axis in "xyz":
+            self.assertLessEqual(
+                max_abs_diff(c_keys, cpp_factors, taroz_factors, f"los_{axis}", f"los_{axis}"),
+                1e-6,
+            )
+
+    def test_final_state_matches_taroz_dump(self) -> None:
+        cpp_epoch_path = CPP_DIR / "per_epoch_state.csv"
+        taroz_epoch_path = MATLAB_DIR / "per_epoch_state.csv"
+        self.require_dogfood_files(cpp_epoch_path, taroz_epoch_path)
+
+        cpp_epochs = read_epochs_by_tow(cpp_epoch_path)
+        taroz_epochs = read_epochs_by_tow(taroz_epoch_path)
+        common_tows = sorted(set(cpp_epochs) & set(taroz_epochs))
+        self.assertEqual(len(common_tows), len(cpp_epochs))
+        self.assertGreater(len(common_tows), 0)
+        if len(cpp_epochs) == len(taroz_epochs):
+            self.assertEqual(len(common_tows), 1141)
+
+        position_diffs: list[float] = []
+        velocity_diffs: list[float] = []
+        drift_diffs: list[float] = []
+        clock_diffs: list[float] = []
+        for tow in common_tows:
+            cpp = cpp_epochs[tow]
+            taroz = taroz_epochs[tow]
+            position_diffs.append(
+                math.dist(
+                    tuple(float(cpp[f"fgo_{axis}_m"]) for axis in "xyz"),
+                    tuple(float(taroz[f"fgo_{axis}_m"]) for axis in "xyz"),
+                )
+            )
+            velocity_diffs.append(
+                math.dist(
+                    tuple(float(cpp[f"fgo_v{axis}_mps"]) for axis in "xyz"),
+                    tuple(float(taroz[f"fgo_v{axis}_mps"]) for axis in "xyz"),
+                )
+            )
+            drift_diffs.append(
+                abs(float(cpp["fgo_clock_drift_mps"]) - float(taroz["fgo_clock_drift_mps"]))
+            )
+            for column in (
+                "fgo_c_gps_m",
+                "fgo_c_glo_m",
+                "fgo_c_gal_m",
+                "fgo_c_qzs_m",
+                "fgo_c_bds_m",
+            ):
+                clock_diffs.append(abs(float(cpp[column]) - float(taroz[column])))
+
+        self.assertLessEqual(statistics.mean(position_diffs), 3.0)
+        self.assertLessEqual(percentile(position_diffs, 0.95), 4.0)
+        self.assertLessEqual(max(position_diffs), 5.5)
+        self.assertLessEqual(statistics.mean(velocity_diffs), 0.05)
+        self.assertLessEqual(percentile(velocity_diffs, 0.95), 0.10)
+        self.assertLessEqual(max(velocity_diffs), 3.5)
+        self.assertLessEqual(statistics.mean(drift_diffs), 0.02)
+        self.assertLessEqual(max(drift_diffs), 0.20)
+        self.assertLessEqual(statistics.mean(clock_diffs), 3.0)
+        self.assertLessEqual(max(clock_diffs), 8.0)
+
+    def test_final_factor_residuals_match_taroz_dump(self) -> None:
+        cpp_factor_path = CPP_DIR / "factor_debug.csv"
+        cpp_epoch_path = CPP_DIR / "per_epoch_state.csv"
+        taroz_sat_path = MATLAB_DIR / "per_sat_detail.csv"
+        taroz_tdcp_path = MATLAB_DIR / "per_tdcp_detail.csv"
+        taroz_epoch_path = MATLAB_DIR / "per_epoch_state.csv"
+        self.require_dogfood_files(
+            cpp_factor_path,
+            cpp_epoch_path,
+            taroz_sat_path,
+            taroz_tdcp_path,
+            taroz_epoch_path,
+        )
+
+        cpp_factors = read_cpp_factor_rows(cpp_factor_path)
+        cpp_tows = set(read_epochs_by_tow(cpp_epoch_path))
+        taroz_factors = read_taroz_factor_rows(taroz_sat_path, taroz_tdcp_path, cpp_tows)
+        taroz_epochs_by_tow = read_epochs_by_tow(taroz_epoch_path)
+        taroz_epochs_by_epoch = read_epochs_by_epoch(taroz_epoch_path)
+        self.assertEqual(set(cpp_factors), set(taroz_factors))
+
+        pseudorange_diffs: list[float] = []
+        doppler_diffs: list[float] = []
+        tdcp_diffs: list[float] = []
+        for key in sorted(cpp_factors):
+            factor_type, tow, _satellite = key
+            cpp = cpp_factors[key]
+            taroz = taroz_factors[key]
+            if factor_type == "P":
+                residual = taroz_pseudorange_prediction(taroz_epochs_by_tow[tow], taroz) - float(taroz["res_pc_m"])
+                pseudorange_diffs.append(abs(float(cpp["final_residual_m"]) - residual))
+            elif factor_type == "D":
+                residual = taroz_doppler_prediction(taroz_epochs_by_tow[tow], taroz) - float(taroz["res_d_mps"])
+                doppler_diffs.append(abs(float(cpp["final_residual_m"]) - residual))
+            else:
+                current_epoch = taroz_epochs_by_epoch[int(float(taroz["epoch"]))]
+                previous_epoch = taroz_epochs_by_epoch[int(float(taroz["previous_epoch"]))]
+                residual = taroz_tdcp_prediction(current_epoch, previous_epoch, taroz) - float(taroz["tdcp_m"])
+                tdcp_diffs.append(abs(float(cpp["final_residual_m"]) - residual))
+
+        self.assertGreater(len(pseudorange_diffs), 0)
+        self.assertGreater(len(doppler_diffs), 0)
+        self.assertGreater(len(tdcp_diffs), 0)
+        if len(cpp_tows) == 1141:
+            self.assertEqual(len(pseudorange_diffs), 24092)
+            self.assertEqual(len(doppler_diffs), 24092)
+            self.assertEqual(len(tdcp_diffs), 21832)
+        self.assertLessEqual(statistics.mean(pseudorange_diffs), 1.5)
+        self.assertLessEqual(percentile(pseudorange_diffs, 0.95), 3.2)
+        self.assertLessEqual(max(pseudorange_diffs), 4.0)
+        self.assertLessEqual(statistics.mean(doppler_diffs), 0.002)
+        self.assertLessEqual(percentile(doppler_diffs, 0.95), 0.005)
+        self.assertLessEqual(max(doppler_diffs), 1.1)
+        self.assertLessEqual(statistics.mean(tdcp_diffs), 0.002)
+        self.assertLessEqual(percentile(tdcp_diffs, 0.95), 0.005)
+        self.assertLessEqual(max(tdcp_diffs), 2.5)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_types.cpp
+++ b/tests/test_types.cpp
@@ -1,5 +1,8 @@
 #include <gtest/gtest.h>
+#include <libgnss++/core/solution.hpp>
 #include <libgnss++/core/types.hpp>
+#include <filesystem>
+#include <fstream>
 
 using namespace libgnss;
 
@@ -73,4 +76,75 @@ TEST_F(TypesTest, Constants) {
     EXPECT_GT(constants::WGS84_A, 6.3e6);
     EXPECT_GT(constants::WGS84_F, 0.0);
     EXPECT_LT(constants::WGS84_F, 1.0);
+}
+
+TEST_F(TypesTest, SolutionFileRoundTripsFgoQualityColumns) {
+    Solution solution;
+    PositionSolution sol;
+    sol.time = GNSSTime(2300, 12345.0);
+    sol.status = SolutionStatus::FIXED;
+    sol.position_ecef = Vector3d(1.0, 2.0, 3.0);
+    sol.position_geodetic = GeodeticCoord(0.1, 0.2, 3.5);
+    sol.num_satellites = 12;
+    sol.pdop = 1.25;
+    sol.ratio = 4.5;
+    sol.num_fixed_ambiguities = 9;
+    sol.iterations = 7;
+    solution.addSolution(sol);
+
+    const std::filesystem::path path =
+        std::filesystem::path(GNSSPP_BINARY_DIR) / "solution_roundtrip_test.pos";
+    std::filesystem::remove(path);
+
+    ASSERT_TRUE(solution.writeToFile(path.string()));
+
+    Solution loaded;
+    ASSERT_TRUE(loaded.loadFromFile(path.string()));
+    std::filesystem::remove(path);
+
+    ASSERT_EQ(loaded.solutions.size(), 1u);
+    const PositionSolution& loaded_sol = loaded.solutions.front();
+    EXPECT_DOUBLE_EQ(loaded_sol.ratio, sol.ratio);
+    EXPECT_EQ(loaded_sol.num_fixed_ambiguities, sol.num_fixed_ambiguities);
+    EXPECT_EQ(loaded_sol.iterations, sol.iterations);
+}
+
+TEST_F(TypesTest, SolutionLoaderMapsNamedOptionalColumns) {
+    const std::filesystem::path path =
+        std::filesystem::path(GNSSPP_BINARY_DIR) / "solution_named_optional_columns_test.pos";
+    std::filesystem::remove(path);
+
+    {
+        std::ofstream file(path);
+        ASSERT_TRUE(file.is_open());
+        file << "% GPS_Week GPS_TOW X(m) Y(m) Z(m) Lat(deg) Lon(deg) Height(m) "
+                "Status NumSat PDOP Ratio Baseline(m) RTKIter RTKObs RTKPhaseObs "
+                "RTKCodeObs RTKOutliers RTKPrefitRMS(m) RTKPrefitMax(m) "
+                "RTKPostSuppressRMS(m) RTKPostSuppressMax(m) RTKUpdateNIS "
+                "RTKUpdateNISPerObs RTKUpdateNISRejected\n";
+        file << "2300 12346.000 1 2 3 5 6 7 4 10 1.2 8.5 12.25 4 "
+                "20 11 9 3 0.5 2.0 0.25 1.5 7.0 0.35 1\n";
+    }
+
+    Solution loaded;
+    ASSERT_TRUE(loaded.loadFromFile(path.string()));
+    std::filesystem::remove(path);
+
+    ASSERT_EQ(loaded.solutions.size(), 1u);
+    const PositionSolution& sol = loaded.solutions.front();
+    EXPECT_DOUBLE_EQ(sol.ratio, 8.5);
+    EXPECT_DOUBLE_EQ(sol.baseline_length, 12.25);
+    EXPECT_EQ(sol.iterations, 4);
+    EXPECT_EQ(sol.num_fixed_ambiguities, 0);
+    EXPECT_EQ(sol.rtk_update_observations, 20);
+    EXPECT_EQ(sol.rtk_update_phase_observations, 11);
+    EXPECT_EQ(sol.rtk_update_code_observations, 9);
+    EXPECT_EQ(sol.rtk_update_suppressed_outliers, 3);
+    EXPECT_DOUBLE_EQ(sol.rtk_update_prefit_residual_rms_m, 0.5);
+    EXPECT_DOUBLE_EQ(sol.rtk_update_prefit_residual_max_m, 2.0);
+    EXPECT_DOUBLE_EQ(sol.rtk_update_post_suppression_residual_rms_m, 0.25);
+    EXPECT_DOUBLE_EQ(sol.rtk_update_post_suppression_residual_max_m, 1.5);
+    EXPECT_DOUBLE_EQ(sol.rtk_update_normalized_innovation_squared, 7.0);
+    EXPECT_DOUBLE_EQ(sol.rtk_update_normalized_innovation_squared_per_observation, 0.35);
+    EXPECT_EQ(sol.rtk_update_rejected_by_innovation_gate, 1);
 }


### PR DESCRIPTION
## Summary
- Add the taroz-style FGO solver path, CLI tools, CMake targets, and diagnostics for P/PD/PC/PDC and ambiguity PDC validation.
- Add MATLAB/taroz parity and dogfood harnesses, including factor and lambda parity checks.
- Add PPC-Dataset taroz ambiguity PDC smoke runner with shifted-window support, optional SPP seed generation, and reference-error gates.
- Document lightweight CI vs local heavy PPC/parity/dogfood validation.
- Make local CTest less dependent on a fixed `build/` directory, missing external sample data, and Python 3.11-only `tomllib`.

## Validation
- `cmake --build build-codex -j2`
- `ctest --test-dir build-codex --output-on-failure` -> 22/22 passed
- `python3 tests/test_ppc_taroz_amb_pdc_smoke.py` -> 5 tests passed
- PPC 6-run 200 epoch smoke with SPP seed and `--require-valid-p95-3d-max 2.0` -> passed
- `nagoya/run3 --skip-epochs 400 --max-epochs 200 --generate-spp-seed --require-valid-p95-3d-max 2.0` -> passed, fixed 164/200, p95 1.180 m

## Notes
- `nagoya/run3` is strongly segment-dependent: the first 200 epochs only fixed 18/200, while the shifted `skip=400` window fixed 164/200. Some intermediate shifted windows produced large FLOAT errors, so the PPC runner now supports explicit reference-error gates instead of judging only by fix rate.