### PR TITLE
Document taroz FGO beta scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -431,9 +431,14 @@ Full replay, RTKLIB comparison, and historical diagnostic commands are in
 [PPC reproduction commands](docs/ppc_reproduction.md). Dataset source:
 [taroz/PPC-Dataset](https://github.com/taroz/PPC-Dataset).
 
-The taroz ambiguity PDC FGO port has a separate PPC dogfood harness. Keep the
-20-epoch form for lightweight smoke, and use the longer form locally when
-checking public-run behavior or shifted windows:
+The taroz ambiguity PDC FGO port is currently a beta port of the PPC
+`amb-pdc` path. The C++ runner builds SPP seeds, runs the double-difference FGO
+pipeline, emits FLOAT/FIXED `.pos` output, and records per-epoch/debug summary
+diagnostics. It is not yet a full bit-for-bit port of every taroz MATLAB mode or
+every internal MATLAB state dump.
+
+Keep the 20-epoch form for lightweight smoke, and use the longer forms locally
+when checking public-run behavior or shifted windows:
 
 ```bash
 python3 apps/gnss.py ppc-taroz-amb-pdc-smoke \
@@ -463,6 +468,17 @@ FLOAT epochs more than 100 m from the seed, or jumping more than 100 m from the
 previous raw output, are written as no-solution. The summary reports
 `float_rejected_seed_position_divergence` and
 `float_rejected_position_jump`.
+
+The current beta sign-off is:
+
+- CI: C++ FGO unit tests plus the lightweight 20-epoch PPC smoke.
+- Local dogfood: all six public PPC Tokyo/Nagoya runs at 200 epochs with
+  generated SPP seeds and `--require-valid-p95-3d-max 2.0`.
+- Shifted-window guard check: `nagoya/run3 --skip-epochs 400 --max-epochs 200`
+  with the same generated SPP seed path.
+- Remaining parity work: expand optional taroz MATLAB dumps into internal
+  parity tests for seed state, ambiguity candidates, residuals, and final
+  FLOAT/FIXED output before calling the port complete.
 
 Other benchmark artifacts and checked sign-offs are documented in
 [Benchmarks](docs/benchmarks.md) and [Validation](docs/validation.md).

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -16,6 +16,7 @@ Main sign-off entrypoints:
 - `gnss moving-base-signoff`
 - `gnss ppc-rtk-signoff`
 - `gnss ppc-coverage-matrix`
+- `gnss ppc-taroz-amb-pdc-smoke`
 - `gnss odaiba-benchmark --require-*`
 - `gnss public-rtk-benchmarks`
 - `gnss smartloc-adapter`
@@ -137,6 +138,55 @@ Use `--max-hold-div`, `--max-pos-jump`, `--max-pos-jump-min`, and
 `--max-pos-jump-rate` for explicit fixed-solution validation sweeps; summaries
 record the jump settings as `rtk_max_position_jump_m`,
 `rtk_max_position_jump_min_m`, and `rtk_max_position_jump_rate_mps`.
+
+## Taroz ambiguity PDC FGO beta validation
+
+`gnss ppc-taroz-amb-pdc-smoke` is the validation harness for the beta C++ port
+of taroz's PPC `amb-pdc` FGO path. It is separate from the production RTK
+sign-off commands above: its job is to dogfood the taroz-style FGO runner on
+PPC-Dataset and to keep the port's intermediate diagnostics inspectable.
+
+Use the short command in CI or quick local checks:
+
+```bash
+python3 apps/gnss.py ppc-taroz-amb-pdc-smoke \
+  --dataset-root /datasets/PPC-Dataset \
+  --max-epochs 20 \
+  --summary-json output/dogfood/ppc_taroz_amb_pdc_smoke/summary.json
+```
+
+Use longer local sign-offs before treating the beta path as healthy:
+
+```bash
+python3 apps/gnss.py ppc-taroz-amb-pdc-smoke \
+  --dataset-root /datasets/PPC-Dataset \
+  --max-epochs 200 \
+  --generate-spp-seed \
+  --require-valid-p95-3d-max 2.0 \
+  --summary-json output/dogfood/ppc_taroz_amb_pdc_smoke_200/summary.json
+
+python3 apps/gnss.py ppc-taroz-amb-pdc-smoke \
+  --dataset-root /datasets/PPC-Dataset \
+  --run nagoya/run3 \
+  --skip-epochs 400 \
+  --max-epochs 200 \
+  --generate-spp-seed \
+  --require-valid-p95-3d-max 2.0 \
+  --summary-json output/dogfood/ppc_taroz_amb_pdc_nagoya_run3_shifted/summary.json
+```
+
+The `taroz-amb-pdc` preset enables two truth-free FLOAT output guards by
+default: `--max-float-seed-divergence 100` and
+`--max-float-position-jump 100`. Rejected FLOAT epochs are emitted as
+no-solution and counted in the summary JSON as
+`float_rejected_seed_position_divergence` and
+`float_rejected_position_jump`.
+
+The beta scope is intentionally narrow. The C++ path covers generated SPP
+seeding, double-difference FGO, FLOAT/FIXED output, and diagnostic summaries for
+the PPC `amb-pdc` workflow. A complete taroz port still needs broader MATLAB
+dump parity for intermediate seed state, ambiguity candidates, factor residuals,
+solver costs, and final epoch output across more taroz modes.
 
 `gnss smartloc-adapter` widens the public matrix beyond UrbanNav by exporting
 smartLoc `NAV-POSLLH.csv` into a `reference.csv` plus a normalized u-blox


### PR DESCRIPTION
## Summary
- document the taroz amb-pdc FGO beta scope in README
- add validation guidance for short CI smoke and longer PPC dogfood runs
- call out the remaining MATLAB internal parity work before complete-port status

## Tests
- python3 -m pytest tests/test_docs_site.py -q