### PR TITLE
Add taroz amb PDC fixed ambiguity count parity

### DIFF
--- a/tests/test_taroz_pos_vel_amb_pdc_factor_parity.py
+++ b/tests/test_taroz_pos_vel_amb_pdc_factor_parity.py
@@ -463,6 +463,15 @@ class TarozPosVelAmbPdcFactorParityTest(unittest.TestCase):
                 int(row["ambiguity_candidates"]),
                 int(float(taroz_rows[key]["candidate_count"])),
             )
+            self.assertEqual(
+                int(row["num_fixed_ambiguities"]),
+                int(float(taroz_rows[key]["fixed_ambiguity_count"])),
+            )
+
+        self.assertEqual(
+            sum(int(row["num_fixed_ambiguities"]) for row in cpp_rows.values()),
+            10737,
+        )
 
         position_errors = [
             epoch_debug_ecef_error_m(cpp_rows[key], taroz_rows[key], "fixed")


### PR DESCRIPTION
## Summary
- compare per-epoch C++ num_fixed_ambiguities against taroz MATLAB fixed_ambiguity_count
- pin the total fixed ambiguity count in the optional taroz amb-pdc epoch-debug parity path

## Tests
- git diff --check
- python3 -m pytest tests/test_taroz_pos_vel_amb_pdc_factor_parity.py tests/test_taroz_pos_vel_amb_pdc_dogfood.py -q

Note: optional taroz MATLAB parity files are not present locally, so the full parity check skips without those artifacts.