### PR TITLE
Add taroz amb PDC MATLAB oracle runner

### DIFF
--- a/apps/gnss_taroz_pos_vel_amb_pdc_dogfood.py
+++ b/apps/gnss_taroz_pos_vel_amb_pdc_dogfood.py
@@ -20,9 +20,13 @@ EXE_SUFFIX = ".exe" if os.name == "nt" else ""
 BUILD_CONFIGS = ("Release", "RelWithDebInfo", "Debug", "MinSizeRel")
 
 DEFAULT_DATA_DIR = Path("/tmp/taroz_gtsam_gnss/examples/data")
+DEFAULT_TAROZ_ROOT = Path("/tmp/taroz_gtsam_gnss")
 DEFAULT_OUT_DIR = ROOT_DIR / "output/dogfood/taroz_pos_vel_amb_pdc_current"
 DEFAULT_MATLAB_DIR = (
     ROOT_DIR / "output/dogfood/taroz_matlab_pos_vel_amb_pdc_debug"
+)
+DEFAULT_MATLAB_DUMP_SCRIPT = (
+    ROOT_DIR / "scripts/dump_taroz_pos_vel_ambiguity_pdc_debug.m"
 )
 DEFAULT_PARITY_TEST = ROOT_DIR / "tests/test_taroz_pos_vel_amb_pdc_factor_parity.py"
 
@@ -149,6 +153,27 @@ def build_fgo_command(args: argparse.Namespace, paths: dict[str, Path]) -> list[
     return command
 
 
+def _matlab_single_quoted_path(path: Path) -> str:
+    return str(path).replace("'", "''")
+
+
+def matlab_example_dir(args: argparse.Namespace) -> Path:
+    return args.taroz_example_dir or (args.taroz_root / "examples")
+
+
+def build_matlab_dump_command(args: argparse.Namespace) -> list[str]:
+    script = _matlab_single_quoted_path(args.matlab_dump_script)
+    return [str(args.matlab_bin), "-batch", f"run('{script}')"]
+
+
+def matlab_dump_env(args: argparse.Namespace) -> dict[str, str]:
+    env = os.environ.copy()
+    env["GNSSPP_TAROZ_ROOT"] = str(args.taroz_root)
+    env["GNSSPP_TAROZ_POS_VEL_AMB_PDC_EXAMPLE_DIR"] = str(matlab_example_dir(args))
+    env["GNSSPP_TAROZ_POS_VEL_AMB_PDC_OUT_DIR"] = str(args.matlab_dir)
+    return env
+
+
 def validate_inputs(args: argparse.Namespace) -> None:
     missing = [
         path
@@ -158,6 +183,21 @@ def validate_inputs(args: argparse.Namespace) -> None:
     if missing:
         joined = ", ".join(str(path) for path in missing)
         raise SystemExit(f"missing taroz ambiguity PDC input file(s): {joined}")
+
+
+def validate_matlab_dump_inputs(args: argparse.Namespace) -> None:
+    missing = [
+        path
+        for path in (
+            args.matlab_dump_script,
+            args.taroz_root,
+            matlab_example_dir(args),
+        )
+        if not Path(path).exists()
+    ]
+    if missing:
+        joined = ", ".join(str(path) for path in missing)
+        raise SystemExit(f"missing taroz MATLAB oracle input path(s): {joined}")
 
 
 def run_command(command: list[str], *, env: dict[str, str] | None = None) -> int:
@@ -341,6 +381,41 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Extra single argument passed to gnss_fgo. Repeat for multiple tokens.",
     )
     parser.add_argument("--matlab-dir", type=Path, default=DEFAULT_MATLAB_DIR)
+    parser.add_argument(
+        "--generate-matlab-dump",
+        action="store_true",
+        help=(
+            "Run the taroz MATLAB dump script before C++ and parity checks, so "
+            "--matlab-dir is regenerated from the reference implementation."
+        ),
+    )
+    parser.add_argument(
+        "--matlab-bin",
+        type=Path,
+        default=Path("matlab"),
+        help="MATLAB executable used with --generate-matlab-dump.",
+    )
+    parser.add_argument(
+        "--taroz-root",
+        type=Path,
+        default=DEFAULT_TAROZ_ROOT,
+        help="Root of the taroz/PPC-Dataset MATLAB checkout.",
+    )
+    parser.add_argument(
+        "--taroz-example-dir",
+        type=Path,
+        default=None,
+        help=(
+            "Directory containing estimate_pos_vel_ambiguity_PDC.m "
+            "(default: <taroz-root>/examples)."
+        ),
+    )
+    parser.add_argument(
+        "--matlab-dump-script",
+        type=Path,
+        default=DEFAULT_MATLAB_DUMP_SCRIPT,
+        help="MATLAB script that exports taroz ambiguity PDC oracle CSVs.",
+    )
     parser.add_argument("--parity-test", type=Path, default=DEFAULT_PARITY_TEST)
     parser.add_argument("--skip-parity", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
@@ -366,6 +441,16 @@ def main(argv: list[str] | None = None) -> int:
         "outputs": {name: str(path) for name, path in paths.items()},
         "harness_summary_json": str(harness_summary),
         "matlab_dir": str(args.matlab_dir),
+        "matlab_dump": {
+            "enabled": args.generate_matlab_dump,
+            "command": build_matlab_dump_command(args)
+            if args.generate_matlab_dump
+            else None,
+            "dump_script": str(args.matlab_dump_script),
+            "taroz_root": str(args.taroz_root),
+            "example_dir": str(matlab_example_dir(args)),
+            "out_dir": str(args.matlab_dir),
+        },
         "expected": {
             "preset": "taroz-amb-pdc",
             "backend": "eigen",
@@ -380,12 +465,26 @@ def main(argv: list[str] | None = None) -> int:
         payload["status"] = "dry-run"
         write_run_summary(harness_summary, payload)
         print("Dry run. Planned taroz ambiguity PDC dogfood command:")
+        if args.generate_matlab_dump:
+            print(" ".join(payload["matlab_dump"]["command"]))
         print(" ".join(command))
         print(f"Harness summary: {harness_summary}")
         return 0
 
     validate_inputs(args)
+    if args.generate_matlab_dump:
+        validate_matlab_dump_inputs(args)
     out_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.generate_matlab_dump:
+        args.matlab_dir.mkdir(parents=True, exist_ok=True)
+        matlab_command = build_matlab_dump_command(args)
+        matlab_returncode = run_command(matlab_command, env=matlab_dump_env(args))
+        payload["matlab_dump"]["returncode"] = matlab_returncode
+        if matlab_returncode != 0:
+            payload["status"] = "failed"
+            write_run_summary(harness_summary, payload)
+            return matlab_returncode
 
     fgo_returncode = run_command(command)
     payload["fgo_returncode"] = fgo_returncode

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -49,7 +49,9 @@ Keep taroz FGO validation split by cost:
 
 - Light unit coverage belongs in CTest, such as `python_ppc_taroz_amb_pdc_smoke_tests`
   dry-run checks and focused C++ factor tests.
-- Heavy local checks include `python3 apps/gnss.py taroz-pos-vel-amb-pdc-dogfood`,
+- Heavy local checks include
+  `python3 apps/gnss.py taroz-pos-vel-amb-pdc-dogfood --generate-matlab-dump`
+  when MATLAB and the taroz checkout are available,
   `python3 apps/gnss.py ppc-taroz-amb-pdc-smoke --max-epochs 200 --generate-spp-seed`,
   and optional MATLAB/taroz parity tests when their external artifacts are present.
 - External PPC-Dataset runs are dataset-gated and should not be required for the

--- a/tests/test_taroz_pos_vel_amb_pdc_dogfood.py
+++ b/tests/test_taroz_pos_vel_amb_pdc_dogfood.py
@@ -73,6 +73,10 @@ class TarozPosVelAmbPdcDogfoodTest(unittest.TestCase):
             obs, base, nav, seed_pos = self.touch_inputs(temp_root)
             summary_json = temp_root / "summary.json"
             out_dir = temp_root / "out"
+            taroz_root = temp_root / "taroz"
+            taroz_example_dir = taroz_root / "examples"
+            matlab_dump_script = temp_root / "dump_taroz.m"
+            matlab_dir = temp_root / "matlab_oracle"
 
             result = gnss_taroz_pos_vel_amb_pdc_dogfood.main(
                 [
@@ -90,6 +94,17 @@ class TarozPosVelAmbPdcDogfoodTest(unittest.TestCase):
                     str(summary_json),
                     "--fgo-bin",
                     str(temp_root / "gnss_fgo"),
+                    "--generate-matlab-dump",
+                    "--matlab-bin",
+                    str(temp_root / "matlab"),
+                    "--taroz-root",
+                    str(taroz_root),
+                    "--taroz-example-dir",
+                    str(taroz_example_dir),
+                    "--matlab-dump-script",
+                    str(matlab_dump_script),
+                    "--matlab-dir",
+                    str(matlab_dir),
                     "--dry-run",
                 ]
             )
@@ -97,7 +112,16 @@ class TarozPosVelAmbPdcDogfoodTest(unittest.TestCase):
             self.assertEqual(result, 0)
             payload = json.loads(summary_json.read_text(encoding="utf-8"))
             command = payload["fgo_command"]
+            matlab_dump = payload["matlab_dump"]
             self.assertEqual(payload["status"], "dry-run")
+            self.assertTrue(matlab_dump["enabled"])
+            self.assertEqual(matlab_dump["dump_script"], str(matlab_dump_script))
+            self.assertEqual(matlab_dump["taroz_root"], str(taroz_root))
+            self.assertEqual(matlab_dump["example_dir"], str(taroz_example_dir))
+            self.assertEqual(matlab_dump["out_dir"], str(matlab_dir))
+            self.assertEqual(matlab_dump["command"][0], str(temp_root / "matlab"))
+            self.assertEqual(matlab_dump["command"][1], "-batch")
+            self.assertIn(str(matlab_dump_script), matlab_dump["command"][2])
             self.assertIn("--preset", command)
             self.assertIn("taroz-amb-pdc", command)
             self.assertIn("--base", command)
@@ -108,6 +132,36 @@ class TarozPosVelAmbPdcDogfoodTest(unittest.TestCase):
             self.assertIn("--max-float-position-jump", command)
             self.assertEqual(payload["expected"]["counts"]["fixed_solutions"], 721)
             self.assertEqual(payload["expected"]["counts"]["float_solutions"], 243)
+
+    def test_matlab_dump_env_uses_requested_oracle_paths(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_taroz_amb_pdc_dogfood_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            args = gnss_taroz_pos_vel_amb_pdc_dogfood.parse_args(
+                [
+                    "--generate-matlab-dump",
+                    "--taroz-root",
+                    str(temp_root / "taroz"),
+                    "--taroz-example-dir",
+                    str(temp_root / "taroz" / "examples"),
+                    "--matlab-dir",
+                    str(temp_root / "matlab_oracle"),
+                ]
+            )
+
+            env = gnss_taroz_pos_vel_amb_pdc_dogfood.matlab_dump_env(args)
+
+            self.assertEqual(
+                env["GNSSPP_TAROZ_ROOT"],
+                str(temp_root / "taroz"),
+            )
+            self.assertEqual(
+                env["GNSSPP_TAROZ_POS_VEL_AMB_PDC_EXAMPLE_DIR"],
+                str(temp_root / "taroz" / "examples"),
+            )
+            self.assertEqual(
+                env["GNSSPP_TAROZ_POS_VEL_AMB_PDC_OUT_DIR"],
+                str(temp_root / "matlab_oracle"),
+            )
 
     def test_native_summary_accepts_canonical_full_run(self) -> None:
         failures = gnss_taroz_pos_vel_amb_pdc_dogfood.verify_native_summary(


### PR DESCRIPTION
## Summary
- add --generate-matlab-dump to the taroz position/velocity ambiguity PDC dogfood runner
- record MATLAB oracle command/env details and return code in the harness summary
- cover the new dry-run plan/env wiring in unit tests and document the heavy local check

## Tests
- python3 -m pytest tests/test_taroz_pos_vel_amb_pdc_dogfood.py -q
- python3 -m pytest tests/test_taroz_pos_vel_amb_pdc_factor_parity.py -q
- python3 -m pytest tests/test_taroz_pos_vel_amb_pdc_dogfood.py tests/test_taroz_pos_vel_amb_pdc_factor_parity.py -q
- python3 tests/test_cli_tools.py
- python3 -m mkdocs build --strict
- python3 apps/gnss.py taroz-pos-vel-amb-pdc-dogfood --generate-matlab-dump --taroz-root $workspace/arxiv/tier1/gnss_gpu_ws/ref/gtsam_gnss --obs $workspace/arxiv/tier1/gnss_gpu_ws/ref/gtsam_gnss/examples/data/rover_1Hz.obs --base $workspace/arxiv/tier1/gnss_gpu_ws/ref/gtsam_gnss/examples/data/base.obs --nav $workspace/arxiv/tier1/gnss_gpu_ws/ref/gtsam_gnss/examples/data/base.nav --seed-pos $workspace/arxiv/tier1/gnss_gpu_ws/ref/gtsam_gnss/examples/data/rover_1Hz_spp.pos --fgo-bin build-codex/apps/gnss_fgo --out-dir output/dogfood/taroz_pos_vel_amb_pdc_current --matlab-dir output/dogfood/taroz_matlab_pos_vel_amb_pdc_debug