### PR TITLE
Require generated PPC SPP seed parity

### DIFF
--- a/apps/gnss_ppc_taroz_amb_pdc_smoke.py
+++ b/apps/gnss_ppc_taroz_amb_pdc_smoke.py
@@ -409,6 +409,20 @@ def validate_native_summary(args: argparse.Namespace, summary: dict[str, Any]) -
         failures.append(
             f"optimized_epochs {summary.get('optimized_epochs')} != {args.max_epochs}"
         )
+    if args.generate_spp_seed:
+        optimized_epochs = summary.get("optimized_epochs")
+        seed_matched_epochs = summary.get("seed_matched_epochs")
+        seed_interpolated_epochs = summary.get("seed_interpolated_epochs")
+        if not summary.get("seed_pos"):
+            failures.append("generated SPP seed path is missing from summary")
+        if isinstance(optimized_epochs, int) and seed_matched_epochs != optimized_epochs:
+            failures.append(
+                f"seed_matched_epochs {seed_matched_epochs} != {optimized_epochs}"
+            )
+        if seed_interpolated_epochs != 0:
+            failures.append(
+                f"seed_interpolated_epochs {seed_interpolated_epochs} != 0"
+            )
     if int(summary.get("valid_solutions", 0)) < args.require_valid_min:
         failures.append(
             f"valid_solutions {summary.get('valid_solutions')} < {args.require_valid_min}"

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -188,6 +188,11 @@ the PPC `amb-pdc` workflow. A complete taroz port still needs broader MATLAB
 dump parity for intermediate seed state, ambiguity candidates, factor residuals,
 solver costs, and final epoch output across more taroz modes.
 
+When `--generate-spp-seed` is used, the PPC harness treats the generated seed as
+part of the sign-off. The native summary must report a seed path,
+`seed_matched_epochs` must equal the optimized epoch count, and
+`seed_interpolated_epochs` must remain zero.
+
 `gnss smartloc-adapter` widens the public matrix beyond UrbanNav by exporting
 smartLoc `NAV-POSLLH.csv` into a `reference.csv` plus a normalized u-blox
 receiver CSV, and by exporting `RXM-RAWX.csv` into a normalized raw observation

--- a/tests/test_ppc_taroz_amb_pdc_smoke.py
+++ b/tests/test_ppc_taroz_amb_pdc_smoke.py
@@ -82,6 +82,7 @@ class PpcTarozAmbPdcSmokeTest(unittest.TestCase):
 
     def test_native_summary_validation_flags_low_candidate_run(self) -> None:
         class Args:
+            generate_spp_seed = False
             max_epochs = 20
             require_valid_min = 1
             require_dd_carrier_min = 1
@@ -109,6 +110,71 @@ class PpcTarozAmbPdcSmokeTest(unittest.TestCase):
                 "valid_solutions 0 < 1",
                 "double_difference_carrier_factors 0 < 1",
                 "lambda_ambiguity_attempts 0 < 1",
+            ],
+        )
+
+    def test_native_summary_validation_accepts_generated_seed_match(self) -> None:
+        class Args:
+            generate_spp_seed = True
+            max_epochs = 20
+            require_valid_min = 1
+            require_dd_carrier_min = 1
+            require_lambda_attempts_min = 1
+            require_fix_rate_min = 0.0
+            allow_not_converged = False
+
+        failures = gnss_ppc_taroz_amb_pdc_smoke.validate_native_summary(
+            Args(),
+            {
+                "preset": "taroz-amb-pdc",
+                "backend": "eigen",
+                "optimized_epochs": 20,
+                "seed_pos": "out/run/spp_seed.pos",
+                "seed_matched_epochs": 20,
+                "seed_interpolated_epochs": 0,
+                "valid_solutions": 20,
+                "double_difference_carrier_factors": 120,
+                "lambda_ambiguity_attempts": 20,
+                "fix_rate_percent": 100.0,
+                "converged": True,
+            },
+        )
+
+        self.assertEqual(failures, [])
+
+    def test_native_summary_validation_flags_generated_seed_drift(self) -> None:
+        class Args:
+            generate_spp_seed = True
+            max_epochs = 20
+            require_valid_min = 1
+            require_dd_carrier_min = 1
+            require_lambda_attempts_min = 1
+            require_fix_rate_min = 0.0
+            allow_not_converged = False
+
+        failures = gnss_ppc_taroz_amb_pdc_smoke.validate_native_summary(
+            Args(),
+            {
+                "preset": "taroz-amb-pdc",
+                "backend": "eigen",
+                "optimized_epochs": 20,
+                "seed_pos": "",
+                "seed_matched_epochs": 19,
+                "seed_interpolated_epochs": 1,
+                "valid_solutions": 20,
+                "double_difference_carrier_factors": 120,
+                "lambda_ambiguity_attempts": 20,
+                "fix_rate_percent": 100.0,
+                "converged": True,
+            },
+        )
+
+        self.assertEqual(
+            failures,
+            [
+                "generated SPP seed path is missing from summary",
+                "seed_matched_epochs 19 != 20",
+                "seed_interpolated_epochs 1 != 0",
             ],
         )
 


### PR DESCRIPTION
## Summary
- require generated PPC SPP seed runs to report a seed path
- require generated seed matches to cover every optimized epoch with zero interpolation
- add unit coverage for accepted seed parity and seed drift failures
- document the generated-seed sign-off contract

## Local PPC dogfood
- all six PPC runs, 200 epochs, generated SPP seed: OK
  - seed_matched_epochs=200 and seed_interpolated_epochs=0 for every run
  - p95 3D error range: 0.028179541 m to 1.594397089 m
- nagoya/run3 shifted window, skip 400, 200 epochs, generated SPP seed: OK
  - valid=200, fixed=164, float=36, fix_rate=82%, p95=1.179894293 m

## Tests
- python3 -m pytest tests/test_ppc_taroz_amb_pdc_smoke.py -q
- python3 tests/test_cli_tools.py
- python3 -m mkdocs build --strict
- git diff --check
- python3 apps/gnss.py ppc-taroz-amb-pdc-smoke --dataset-root $workspace/arxiv/tier1/gnss_gpu_ws/ref/PPC-Dataset --max-epochs 200 --generate-spp-seed --fgo-bin build-codex/apps/gnss_fgo --spp-bin build-codex/apps/gnss_spp --summary-json output/dogfood/ppc_taroz_amb_pdc_smoke_200_seed/summary.json --out-dir output/dogfood/ppc_taroz_amb_pdc_smoke_200_seed
- python3 apps/gnss.py ppc-taroz-amb-pdc-smoke --dataset-root $workspace/arxiv/tier1/gnss_gpu_ws/ref/PPC-Dataset --run nagoya/run3 --skip-epochs 400 --max-epochs 200 --generate-spp-seed --require-valid-p95-3d-max 2.0 --fgo-bin build-codex/apps/gnss_fgo --spp-bin build-codex/apps/gnss_spp --summary-json output/dogfood/ppc_taroz_amb_pdc_nagoya_run3_shifted_seed/summary.json --out-dir output/dogfood/ppc_taroz_amb_pdc_nagoya_run3_shifted_seed