### PR TITLE
Add taroz P MATLAB oracle runner

### DIFF
--- a/apps/gnss_taroz_p_dogfood.py
+++ b/apps/gnss_taroz_p_dogfood.py
@@ -20,8 +20,10 @@ EXE_SUFFIX = ".exe" if os.name == "nt" else ""
 BUILD_CONFIGS = ("Release", "RelWithDebInfo", "Debug", "MinSizeRel")
 
 DEFAULT_DATA_DIR = Path("/tmp/taroz_gtsam_gnss/examples/data")
+DEFAULT_TAROZ_ROOT = Path("/tmp/taroz_gtsam_gnss")
 DEFAULT_OUT_DIR = ROOT_DIR / "output/dogfood/taroz_p_dogfood_current"
 DEFAULT_MATLAB_DIR = ROOT_DIR / "output/dogfood/taroz_matlab_p_debug"
+DEFAULT_MATLAB_DUMP_SCRIPT = ROOT_DIR / "scripts/dump_taroz_p_debug.m"
 DEFAULT_PARITY_TEST = ROOT_DIR / "tests/test_taroz_p_internal_parity.py"
 DEFAULT_MAX_EPOCHS = 80
 DEFAULT_MAX_ITERATIONS = 40
@@ -128,6 +130,52 @@ def validate_inputs(args: argparse.Namespace) -> None:
     if missing:
         joined = ", ".join(str(path) for path in missing)
         raise SystemExit(f"missing taroz P input file(s): {joined}")
+
+
+def _matlab_single_quoted_path(path: Path) -> str:
+    return str(path).replace("'", "''")
+
+
+def repo_relative_path(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT_DIR / path
+
+
+def matlab_example_dir(args: argparse.Namespace) -> Path:
+    return args.taroz_example_dir or (args.taroz_root / "examples")
+
+
+def matlab_output_dir(args: argparse.Namespace) -> Path:
+    return repo_relative_path(args.matlab_dir).resolve()
+
+
+def build_matlab_dump_command(args: argparse.Namespace) -> list[str]:
+    script = _matlab_single_quoted_path(repo_relative_path(args.matlab_dump_script))
+    return [str(args.matlab_bin), "-batch", f"run('{script}')"]
+
+
+def matlab_dump_env(args: argparse.Namespace) -> dict[str, str]:
+    env = os.environ.copy()
+    env["GNSSPP_TAROZ_ROOT"] = str(repo_relative_path(args.taroz_root).resolve())
+    env["GNSSPP_TAROZ_P_EXAMPLE_DIR"] = str(
+        repo_relative_path(matlab_example_dir(args)).resolve()
+    )
+    env["GNSSPP_TAROZ_P_OUT_DIR"] = str(matlab_output_dir(args))
+    return env
+
+
+def validate_matlab_dump_inputs(args: argparse.Namespace) -> None:
+    missing = [
+        path
+        for path in (
+            args.matlab_dump_script,
+            args.taroz_root,
+            matlab_example_dir(args),
+        )
+        if not repo_relative_path(path).exists()
+    ]
+    if missing:
+        joined = ", ".join(str(path) for path in missing)
+        raise SystemExit(f"missing taroz P MATLAB oracle input path(s): {joined}")
 
 
 def run_command(command: list[str], *, env: dict[str, str] | None = None) -> int:
@@ -312,6 +360,38 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Extra single argument passed to gnss_fgo. Repeat for multiple tokens.",
     )
     parser.add_argument("--matlab-dir", type=Path, default=DEFAULT_MATLAB_DIR)
+    parser.add_argument(
+        "--generate-matlab-dump",
+        action="store_true",
+        help=(
+            "Run the taroz MATLAB dump script before C++ and parity checks, so "
+            "--matlab-dir is regenerated from the reference implementation."
+        ),
+    )
+    parser.add_argument(
+        "--matlab-bin",
+        type=Path,
+        default=Path("matlab"),
+        help="MATLAB executable used with --generate-matlab-dump.",
+    )
+    parser.add_argument(
+        "--taroz-root",
+        type=Path,
+        default=DEFAULT_TAROZ_ROOT,
+        help="Root of the taroz/PPC-Dataset MATLAB checkout.",
+    )
+    parser.add_argument(
+        "--taroz-example-dir",
+        type=Path,
+        default=None,
+        help="Directory containing estimate_pos_P.m (default: <taroz-root>/examples).",
+    )
+    parser.add_argument(
+        "--matlab-dump-script",
+        type=Path,
+        default=DEFAULT_MATLAB_DUMP_SCRIPT,
+        help="MATLAB script that exports taroz P oracle CSVs.",
+    )
     parser.add_argument("--parity-test", type=Path, default=DEFAULT_PARITY_TEST)
     parser.add_argument(
         "--debug-problem-only",
@@ -344,6 +424,16 @@ def main(argv: list[str] | None = None) -> int:
         "outputs": {name: str(path) for name, path in paths.items()},
         "harness_summary_json": str(harness_summary),
         "matlab_dir": str(args.matlab_dir),
+        "matlab_dump": {
+            "enabled": args.generate_matlab_dump,
+            "command": build_matlab_dump_command(args)
+            if args.generate_matlab_dump
+            else None,
+            "dump_script": str(args.matlab_dump_script),
+            "taroz_root": str(args.taroz_root),
+            "example_dir": str(matlab_example_dir(args)),
+            "out_dir": str(matlab_output_dir(args)),
+        },
         "expected": {
             "preset": "taroz-p",
             "backend": "eigen",
@@ -361,12 +451,26 @@ def main(argv: list[str] | None = None) -> int:
         payload["status"] = "dry-run"
         write_run_summary(harness_summary, payload)
         print("Dry run. Planned taroz P dogfood command:")
+        if args.generate_matlab_dump:
+            print(" ".join(payload["matlab_dump"]["command"]))
         print(" ".join(command))
         print(f"Harness summary: {harness_summary}")
         return 0
 
     validate_inputs(args)
+    if args.generate_matlab_dump:
+        validate_matlab_dump_inputs(args)
     out_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.generate_matlab_dump:
+        matlab_output_dir(args).mkdir(parents=True, exist_ok=True)
+        matlab_command = build_matlab_dump_command(args)
+        matlab_returncode = run_command(matlab_command, env=matlab_dump_env(args))
+        payload["matlab_dump"]["returncode"] = matlab_returncode
+        if matlab_returncode != 0:
+            payload["status"] = "failed"
+            write_run_summary(harness_summary, payload)
+            return matlab_returncode
 
     fgo_returncode = run_command(command)
     payload["fgo_returncode"] = fgo_returncode

--- a/apps/gnss_taroz_pos_vel_amb_pdc_dogfood.py
+++ b/apps/gnss_taroz_pos_vel_amb_pdc_dogfood.py
@@ -157,20 +157,30 @@ def _matlab_single_quoted_path(path: Path) -> str:
     return str(path).replace("'", "''")
 
 
+def repo_relative_path(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT_DIR / path
+
+
 def matlab_example_dir(args: argparse.Namespace) -> Path:
     return args.taroz_example_dir or (args.taroz_root / "examples")
 
 
+def matlab_output_dir(args: argparse.Namespace) -> Path:
+    return repo_relative_path(args.matlab_dir).resolve()
+
+
 def build_matlab_dump_command(args: argparse.Namespace) -> list[str]:
-    script = _matlab_single_quoted_path(args.matlab_dump_script)
+    script = _matlab_single_quoted_path(repo_relative_path(args.matlab_dump_script))
     return [str(args.matlab_bin), "-batch", f"run('{script}')"]
 
 
 def matlab_dump_env(args: argparse.Namespace) -> dict[str, str]:
     env = os.environ.copy()
-    env["GNSSPP_TAROZ_ROOT"] = str(args.taroz_root)
-    env["GNSSPP_TAROZ_POS_VEL_AMB_PDC_EXAMPLE_DIR"] = str(matlab_example_dir(args))
-    env["GNSSPP_TAROZ_POS_VEL_AMB_PDC_OUT_DIR"] = str(args.matlab_dir)
+    env["GNSSPP_TAROZ_ROOT"] = str(repo_relative_path(args.taroz_root).resolve())
+    env["GNSSPP_TAROZ_POS_VEL_AMB_PDC_EXAMPLE_DIR"] = str(
+        repo_relative_path(matlab_example_dir(args)).resolve()
+    )
+    env["GNSSPP_TAROZ_POS_VEL_AMB_PDC_OUT_DIR"] = str(matlab_output_dir(args))
     return env
 
 
@@ -193,7 +203,7 @@ def validate_matlab_dump_inputs(args: argparse.Namespace) -> None:
             args.taroz_root,
             matlab_example_dir(args),
         )
-        if not Path(path).exists()
+        if not repo_relative_path(path).exists()
     ]
     if missing:
         joined = ", ".join(str(path) for path in missing)
@@ -449,7 +459,7 @@ def main(argv: list[str] | None = None) -> int:
             "dump_script": str(args.matlab_dump_script),
             "taroz_root": str(args.taroz_root),
             "example_dir": str(matlab_example_dir(args)),
-            "out_dir": str(args.matlab_dir),
+            "out_dir": str(matlab_output_dir(args)),
         },
         "expected": {
             "preset": "taroz-amb-pdc",
@@ -477,7 +487,7 @@ def main(argv: list[str] | None = None) -> int:
     out_dir.mkdir(parents=True, exist_ok=True)
 
     if args.generate_matlab_dump:
-        args.matlab_dir.mkdir(parents=True, exist_ok=True)
+        matlab_output_dir(args).mkdir(parents=True, exist_ok=True)
         matlab_command = build_matlab_dump_command(args)
         matlab_returncode = run_command(matlab_command, env=matlab_dump_env(args))
         payload["matlab_dump"]["returncode"] = matlab_returncode

--- a/tests/test_taroz_p_dogfood.py
+++ b/tests/test_taroz_p_dogfood.py
@@ -32,6 +32,10 @@ class TarozPDogfoodTest(unittest.TestCase):
             obs, nav, seed_pos = self.touch_inputs(temp_root)
             summary_json = temp_root / "summary.json"
             out_dir = temp_root / "out"
+            taroz_root = temp_root / "taroz"
+            taroz_example_dir = taroz_root / "examples"
+            matlab_dump_script = temp_root / "dump_taroz_p.m"
+            matlab_dir = temp_root / "matlab_oracle"
 
             result = gnss_taroz_p_dogfood.main(
                 [
@@ -47,6 +51,17 @@ class TarozPDogfoodTest(unittest.TestCase):
                     str(summary_json),
                     "--fgo-bin",
                     str(temp_root / "gnss_fgo"),
+                    "--generate-matlab-dump",
+                    "--matlab-bin",
+                    str(temp_root / "matlab"),
+                    "--taroz-root",
+                    str(taroz_root),
+                    "--taroz-example-dir",
+                    str(taroz_example_dir),
+                    "--matlab-dump-script",
+                    str(matlab_dump_script),
+                    "--matlab-dir",
+                    str(matlab_dir),
                     "--dry-run",
                 ]
             )
@@ -54,7 +69,16 @@ class TarozPDogfoodTest(unittest.TestCase):
             self.assertEqual(result, 0)
             payload = json.loads(summary_json.read_text(encoding="utf-8"))
             command = payload["fgo_command"]
+            matlab_dump = payload["matlab_dump"]
             self.assertEqual(payload["status"], "dry-run")
+            self.assertTrue(matlab_dump["enabled"])
+            self.assertEqual(matlab_dump["dump_script"], str(matlab_dump_script))
+            self.assertEqual(matlab_dump["taroz_root"], str(taroz_root))
+            self.assertEqual(matlab_dump["example_dir"], str(taroz_example_dir))
+            self.assertEqual(matlab_dump["out_dir"], str(matlab_dir))
+            self.assertEqual(matlab_dump["command"][0], str(temp_root / "matlab"))
+            self.assertEqual(matlab_dump["command"][1], "-batch")
+            self.assertIn(str(matlab_dump_script), matlab_dump["command"][2])
             self.assertIn("--preset", command)
             self.assertIn("taroz-p", command)
             self.assertIn("--max-epochs", command)
@@ -65,6 +89,59 @@ class TarozPDogfoodTest(unittest.TestCase):
             self.assertIn("fgo_taroz_p_factor_debug.csv", " ".join(command))
             self.assertFalse(payload["expected"]["use_spp_seed"])
             self.assertFalse(payload["expected"]["debug_problem_only"])
+
+    def test_matlab_dump_env_uses_requested_oracle_paths(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_taroz_p_dogfood_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            args = gnss_taroz_p_dogfood.parse_args(
+                [
+                    "--generate-matlab-dump",
+                    "--taroz-root",
+                    str(temp_root / "taroz"),
+                    "--taroz-example-dir",
+                    str(temp_root / "taroz" / "examples"),
+                    "--matlab-dir",
+                    str(temp_root / "matlab_oracle"),
+                ]
+            )
+
+            env = gnss_taroz_p_dogfood.matlab_dump_env(args)
+
+            self.assertEqual(env["GNSSPP_TAROZ_ROOT"], str(temp_root / "taroz"))
+            self.assertEqual(
+                env["GNSSPP_TAROZ_P_EXAMPLE_DIR"],
+                str(temp_root / "taroz" / "examples"),
+            )
+            self.assertEqual(
+                env["GNSSPP_TAROZ_P_OUT_DIR"],
+                str(temp_root / "matlab_oracle"),
+            )
+
+    def test_matlab_dump_env_resolves_relative_output_under_repo(self) -> None:
+        args = gnss_taroz_p_dogfood.parse_args(
+            [
+                "--generate-matlab-dump",
+                "--taroz-root",
+                "relative_taroz_root",
+                "--matlab-dir",
+                "relative_matlab_oracle",
+            ]
+        )
+
+        env = gnss_taroz_p_dogfood.matlab_dump_env(args)
+
+        self.assertEqual(
+            env["GNSSPP_TAROZ_ROOT"],
+            str(ROOT_DIR / "relative_taroz_root"),
+        )
+        self.assertEqual(
+            env["GNSSPP_TAROZ_P_EXAMPLE_DIR"],
+            str(ROOT_DIR / "relative_taroz_root" / "examples"),
+        )
+        self.assertEqual(
+            env["GNSSPP_TAROZ_P_OUT_DIR"],
+            str(ROOT_DIR / "relative_matlab_oracle"),
+        )
 
     def test_dry_run_can_keep_preset_runtime_limits(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_taroz_p_dogfood_test_") as temp_dir:

--- a/tests/test_taroz_pos_vel_amb_pdc_dogfood.py
+++ b/tests/test_taroz_pos_vel_amb_pdc_dogfood.py
@@ -163,6 +163,32 @@ class TarozPosVelAmbPdcDogfoodTest(unittest.TestCase):
                 str(temp_root / "matlab_oracle"),
             )
 
+    def test_matlab_dump_env_resolves_relative_output_under_repo(self) -> None:
+        args = gnss_taroz_pos_vel_amb_pdc_dogfood.parse_args(
+            [
+                "--generate-matlab-dump",
+                "--taroz-root",
+                "relative_taroz_root",
+                "--matlab-dir",
+                "relative_matlab_oracle",
+            ]
+        )
+
+        env = gnss_taroz_pos_vel_amb_pdc_dogfood.matlab_dump_env(args)
+
+        self.assertEqual(
+            env["GNSSPP_TAROZ_ROOT"],
+            str(ROOT_DIR / "relative_taroz_root"),
+        )
+        self.assertEqual(
+            env["GNSSPP_TAROZ_POS_VEL_AMB_PDC_EXAMPLE_DIR"],
+            str(ROOT_DIR / "relative_taroz_root" / "examples"),
+        )
+        self.assertEqual(
+            env["GNSSPP_TAROZ_POS_VEL_AMB_PDC_OUT_DIR"],
+            str(ROOT_DIR / "relative_matlab_oracle"),
+        )
+
     def test_native_summary_accepts_canonical_full_run(self) -> None:
         failures = gnss_taroz_pos_vel_amb_pdc_dogfood.verify_native_summary(
             self.canonical_summary()


### PR DESCRIPTION
## Summary
- add `--generate-matlab-dump` support to `taroz-p-dogfood` so the P oracle can be regenerated from taroz MATLAB before C++ parity
- resolve relative MATLAB output paths under the repo root for both P and pos/vel/amb PDC runners, preventing MATLAB `cd` from writing dumps into the taroz checkout
- add runner tests covering the new P dump command/env and relative oracle output path handling

## Validation
- `python3 -m pytest tests/test_taroz_p_dogfood.py tests/test_taroz_pos_vel_amb_pdc_dogfood.py -q`
- `python3 -m pytest tests/test_taroz_p_internal_parity.py -q`
- `GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_DIR=output/dogfood/taroz_pos_vel_amb_pdc_current GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_OPT_POS=output/dogfood/taroz_pos_vel_amb_pdc_current/opt.pos GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_OPT_EPOCH_DEBUG=output/dogfood/taroz_pos_vel_amb_pdc_current/epoch_debug.csv GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_OPT_LAMBDA_DEBUG=output/dogfood/taroz_pos_vel_amb_pdc_current/lambda_debug.csv GNSSPP_TAROZ_POS_VEL_AMB_PDC_MATLAB_DIR=output/dogfood/taroz_matlab_pos_vel_amb_pdc_debug python3 -m pytest tests/test_taroz_pos_vel_amb_pdc_factor_parity.py -q`
- `python3 tests/test_cli_tools.py`
- `git diff --check`