### PR TITLE
Add taroz PD MATLAB oracle runner

### DIFF
--- a/README.md
+++ b/README.md
@@ -469,6 +469,18 @@ previous raw output, are written as no-solution. The summary reports
 `float_rejected_seed_position_divergence` and
 `float_rejected_position_jump`.
 
+The single-receiver P/PD and ambiguity PDC dogfood harnesses can regenerate the
+taroz MATLAB oracle before running C++ parity. Point `--taroz-root` at a taroz
+checkout with `gtsam` and `readobs` on the MATLAB path:
+
+```bash
+python3 apps/gnss.py taroz-pd-dogfood \
+  --generate-matlab-dump \
+  --taroz-root /tmp/taroz_gtsam_gnss \
+  --out-dir output/dogfood/taroz_pd_dogfood_current \
+  --matlab-dir output/dogfood/taroz_matlab_pd_debug
+```
+
 The current beta sign-off is:
 
 - CI: C++ FGO unit tests plus the lightweight 20-epoch PPC smoke.
@@ -476,9 +488,11 @@ The current beta sign-off is:
   generated SPP seeds and `--require-valid-p95-3d-max 2.0`.
 - Shifted-window guard check: `nagoya/run3 --skip-epochs 400 --max-epochs 200`
   with the same generated SPP seed path.
-- Remaining parity work: expand optional taroz MATLAB dumps into internal
-  parity tests for seed state, ambiguity candidates, residuals, and final
-  FLOAT/FIXED output before calling the port complete.
+- Current MATLAB-oracle dogfood: generated P, PD, and ambiguity PDC dumps are
+  compared against C++ diagnostics locally.
+- Remaining parity work: add generated oracle coverage for the PC/PDC variants
+  and broaden intermediate seed state, ambiguity candidates, solver costs, and
+  final epoch-output checks before calling the port complete.
 
 Other benchmark artifacts and checked sign-offs are documented in
 [Benchmarks](docs/benchmarks.md) and [Validation](docs/validation.md).

--- a/apps/gnss_taroz_pd_dogfood.py
+++ b/apps/gnss_taroz_pd_dogfood.py
@@ -20,8 +20,10 @@ EXE_SUFFIX = ".exe" if os.name == "nt" else ""
 BUILD_CONFIGS = ("Release", "RelWithDebInfo", "Debug", "MinSizeRel")
 
 DEFAULT_DATA_DIR = Path("/tmp/taroz_gtsam_gnss/examples/data")
+DEFAULT_TAROZ_ROOT = Path("/tmp/taroz_gtsam_gnss")
 DEFAULT_OUT_DIR = ROOT_DIR / "output/dogfood/taroz_pd_dogfood_current"
 DEFAULT_MATLAB_DIR = ROOT_DIR / "output/dogfood/taroz_matlab_pd_debug"
+DEFAULT_MATLAB_DUMP_SCRIPT = ROOT_DIR / "scripts/dump_taroz_pd_debug.m"
 DEFAULT_PARITY_TEST = ROOT_DIR / "tests/test_taroz_pd_internal_parity.py"
 DEFAULT_MAX_EPOCHS = 80
 DEFAULT_MAX_ITERATIONS = 40
@@ -124,6 +126,52 @@ def validate_inputs(args: argparse.Namespace) -> None:
     if missing:
         joined = ", ".join(str(path) for path in missing)
         raise SystemExit(f"missing taroz PD input file(s): {joined}")
+
+
+def _matlab_single_quoted_path(path: Path) -> str:
+    return str(path).replace("'", "''")
+
+
+def repo_relative_path(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT_DIR / path
+
+
+def matlab_example_dir(args: argparse.Namespace) -> Path:
+    return args.taroz_example_dir or (args.taroz_root / "examples")
+
+
+def matlab_output_dir(args: argparse.Namespace) -> Path:
+    return repo_relative_path(args.matlab_dir).resolve()
+
+
+def build_matlab_dump_command(args: argparse.Namespace) -> list[str]:
+    script = _matlab_single_quoted_path(repo_relative_path(args.matlab_dump_script))
+    return [str(args.matlab_bin), "-batch", f"run('{script}')"]
+
+
+def matlab_dump_env(args: argparse.Namespace) -> dict[str, str]:
+    env = os.environ.copy()
+    env["GNSSPP_TAROZ_ROOT"] = str(repo_relative_path(args.taroz_root).resolve())
+    env["GNSSPP_TAROZ_PD_EXAMPLE_DIR"] = str(
+        repo_relative_path(matlab_example_dir(args)).resolve()
+    )
+    env["GNSSPP_TAROZ_PD_OUT_DIR"] = str(matlab_output_dir(args))
+    return env
+
+
+def validate_matlab_dump_inputs(args: argparse.Namespace) -> None:
+    missing = [
+        path
+        for path in (
+            args.matlab_dump_script,
+            args.taroz_root,
+            matlab_example_dir(args),
+        )
+        if not repo_relative_path(path).exists()
+    ]
+    if missing:
+        joined = ", ".join(str(path) for path in missing)
+        raise SystemExit(f"missing taroz PD MATLAB oracle input path(s): {joined}")
 
 
 def run_command(command: list[str], *, env: dict[str, str] | None = None) -> int:
@@ -302,6 +350,38 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Extra single argument passed to gnss_pos_vel_pd. Repeat for multiple tokens.",
     )
     parser.add_argument("--matlab-dir", type=Path, default=DEFAULT_MATLAB_DIR)
+    parser.add_argument(
+        "--generate-matlab-dump",
+        action="store_true",
+        help=(
+            "Run the taroz MATLAB dump script before C++ and parity checks, so "
+            "--matlab-dir is regenerated from the reference implementation."
+        ),
+    )
+    parser.add_argument(
+        "--matlab-bin",
+        type=Path,
+        default=Path("matlab"),
+        help="MATLAB executable used with --generate-matlab-dump.",
+    )
+    parser.add_argument(
+        "--taroz-root",
+        type=Path,
+        default=DEFAULT_TAROZ_ROOT,
+        help="Root of the taroz/PPC-Dataset MATLAB checkout.",
+    )
+    parser.add_argument(
+        "--taroz-example-dir",
+        type=Path,
+        default=None,
+        help="Directory containing estimate_pos_vel_PD.m (default: <taroz-root>/examples).",
+    )
+    parser.add_argument(
+        "--matlab-dump-script",
+        type=Path,
+        default=DEFAULT_MATLAB_DUMP_SCRIPT,
+        help="MATLAB script that exports taroz PD oracle CSVs.",
+    )
     parser.add_argument("--parity-test", type=Path, default=DEFAULT_PARITY_TEST)
     parser.add_argument("--skip-parity", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
@@ -329,6 +409,16 @@ def main(argv: list[str] | None = None) -> int:
         "outputs": {name: str(path) for name, path in paths.items()},
         "harness_summary_json": str(harness_summary),
         "matlab_dir": str(args.matlab_dir),
+        "matlab_dump": {
+            "enabled": args.generate_matlab_dump,
+            "command": build_matlab_dump_command(args)
+            if args.generate_matlab_dump
+            else None,
+            "dump_script": str(args.matlab_dump_script),
+            "taroz_root": str(args.taroz_root),
+            "example_dir": str(matlab_example_dir(args)),
+            "out_dir": str(matlab_output_dir(args)),
+        },
         "expected": {
             "preset": "taroz-pd",
             "backend": "eigen",
@@ -344,12 +434,26 @@ def main(argv: list[str] | None = None) -> int:
         payload["status"] = "dry-run"
         write_run_summary(harness_summary, payload)
         print("Dry run. Planned taroz PD dogfood command:")
+        if args.generate_matlab_dump:
+            print(" ".join(payload["matlab_dump"]["command"]))
         print(" ".join(command))
         print(f"Harness summary: {harness_summary}")
         return 0
 
     validate_inputs(args)
+    if args.generate_matlab_dump:
+        validate_matlab_dump_inputs(args)
     out_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.generate_matlab_dump:
+        matlab_output_dir(args).mkdir(parents=True, exist_ok=True)
+        matlab_command = build_matlab_dump_command(args)
+        matlab_returncode = run_command(matlab_command, env=matlab_dump_env(args))
+        payload["matlab_dump"]["returncode"] = matlab_returncode
+        if matlab_returncode != 0:
+            payload["status"] = "failed"
+            write_run_summary(harness_summary, payload)
+            return matlab_returncode
 
     pd_returncode = run_command(command)
     payload["pd_returncode"] = pd_returncode

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -184,9 +184,12 @@ no-solution and counted in the summary JSON as
 
 The beta scope is intentionally narrow. The C++ path covers generated SPP
 seeding, double-difference FGO, FLOAT/FIXED output, and diagnostic summaries for
-the PPC `amb-pdc` workflow. A complete taroz port still needs broader MATLAB
-dump parity for intermediate seed state, ambiguity candidates, factor residuals,
-solver costs, and final epoch output across more taroz modes.
+the PPC `amb-pdc` workflow. The P, PD, and ambiguity PDC dogfood harnesses can
+also regenerate taroz MATLAB oracle dumps with `--generate-matlab-dump` and run
+the matching optional parity tests locally. A complete taroz port still needs
+generated oracle coverage for the PC/PDC variants and broader MATLAB dump parity
+for intermediate seed state, ambiguity candidates, solver costs, and final epoch
+output across more taroz modes.
 
 When `--generate-spp-seed` is used, the PPC harness treats the generated seed as
 part of the sign-off. The native summary must report a seed path,

--- a/tests/test_taroz_pd_dogfood.py
+++ b/tests/test_taroz_pd_dogfood.py
@@ -1,0 +1,212 @@
+#!/usr/bin/env python3
+"""Tests for the taroz PD dogfood harness."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+import sys
+import tempfile
+import unittest
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+APPS_DIR = ROOT_DIR / "apps"
+sys.path.insert(0, str(APPS_DIR))
+
+import gnss_taroz_pd_dogfood  # noqa: E402
+
+
+class TarozPdDogfoodTest(unittest.TestCase):
+    def touch_inputs(self, root: Path) -> tuple[Path, Path, Path]:
+        obs = root / "rover.obs"
+        nav = root / "base.nav"
+        seed_pos = root / "seed.pos"
+        for path in (obs, nav, seed_pos):
+            path.write_text("", encoding="ascii")
+        return obs, nav, seed_pos
+
+    def test_dry_run_writes_bounded_smoke_plan(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_taroz_pd_dogfood_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            obs, nav, seed_pos = self.touch_inputs(temp_root)
+            summary_json = temp_root / "summary.json"
+            out_dir = temp_root / "out"
+            taroz_root = temp_root / "taroz"
+            taroz_example_dir = taroz_root / "examples"
+            matlab_dump_script = temp_root / "dump_taroz_pd.m"
+            matlab_dir = temp_root / "matlab_oracle"
+
+            result = gnss_taroz_pd_dogfood.main(
+                [
+                    "--obs",
+                    str(obs),
+                    "--nav",
+                    str(nav),
+                    "--seed-pos",
+                    str(seed_pos),
+                    "--out-dir",
+                    str(out_dir),
+                    "--summary-json",
+                    str(summary_json),
+                    "--pd-bin",
+                    str(temp_root / "gnss_pos_vel_pd"),
+                    "--generate-matlab-dump",
+                    "--matlab-bin",
+                    str(temp_root / "matlab"),
+                    "--taroz-root",
+                    str(taroz_root),
+                    "--taroz-example-dir",
+                    str(taroz_example_dir),
+                    "--matlab-dump-script",
+                    str(matlab_dump_script),
+                    "--matlab-dir",
+                    str(matlab_dir),
+                    "--dry-run",
+                ]
+            )
+
+            self.assertEqual(result, 0)
+            payload = json.loads(summary_json.read_text(encoding="utf-8"))
+            command = payload["pd_command"]
+            matlab_dump = payload["matlab_dump"]
+            self.assertEqual(payload["status"], "dry-run")
+            self.assertTrue(matlab_dump["enabled"])
+            self.assertEqual(matlab_dump["dump_script"], str(matlab_dump_script))
+            self.assertEqual(matlab_dump["taroz_root"], str(taroz_root))
+            self.assertEqual(matlab_dump["example_dir"], str(taroz_example_dir))
+            self.assertEqual(matlab_dump["out_dir"], str(matlab_dir))
+            self.assertEqual(matlab_dump["command"][0], str(temp_root / "matlab"))
+            self.assertEqual(matlab_dump["command"][1], "-batch")
+            self.assertIn(str(matlab_dump_script), matlab_dump["command"][2])
+            self.assertIn("--max-epochs", command)
+            self.assertIn(str(gnss_taroz_pd_dogfood.DEFAULT_MAX_EPOCHS), command)
+            self.assertIn("--max-iterations", command)
+            self.assertIn(str(gnss_taroz_pd_dogfood.DEFAULT_MAX_ITERATIONS), command)
+            self.assertIn("--factor-debug-csv", command)
+            self.assertIn("factor_debug.csv", " ".join(command))
+
+    def test_matlab_dump_env_uses_requested_oracle_paths(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_taroz_pd_dogfood_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            args = gnss_taroz_pd_dogfood.parse_args(
+                [
+                    "--generate-matlab-dump",
+                    "--taroz-root",
+                    str(temp_root / "taroz"),
+                    "--taroz-example-dir",
+                    str(temp_root / "taroz" / "examples"),
+                    "--matlab-dir",
+                    str(temp_root / "matlab_oracle"),
+                ]
+            )
+
+            env = gnss_taroz_pd_dogfood.matlab_dump_env(args)
+
+            self.assertEqual(env["GNSSPP_TAROZ_ROOT"], str(temp_root / "taroz"))
+            self.assertEqual(
+                env["GNSSPP_TAROZ_PD_EXAMPLE_DIR"],
+                str(temp_root / "taroz" / "examples"),
+            )
+            self.assertEqual(
+                env["GNSSPP_TAROZ_PD_OUT_DIR"],
+                str(temp_root / "matlab_oracle"),
+            )
+
+    def test_matlab_dump_env_resolves_relative_output_under_repo(self) -> None:
+        args = gnss_taroz_pd_dogfood.parse_args(
+            [
+                "--generate-matlab-dump",
+                "--taroz-root",
+                "relative_taroz_root",
+                "--matlab-dir",
+                "relative_matlab_oracle",
+            ]
+        )
+
+        env = gnss_taroz_pd_dogfood.matlab_dump_env(args)
+
+        self.assertEqual(
+            env["GNSSPP_TAROZ_ROOT"],
+            str(ROOT_DIR / "relative_taroz_root"),
+        )
+        self.assertEqual(
+            env["GNSSPP_TAROZ_PD_EXAMPLE_DIR"],
+            str(ROOT_DIR / "relative_taroz_root" / "examples"),
+        )
+        self.assertEqual(
+            env["GNSSPP_TAROZ_PD_OUT_DIR"],
+            str(ROOT_DIR / "relative_matlab_oracle"),
+        )
+
+    def test_dry_run_can_keep_native_runtime_limits(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_taroz_pd_dogfood_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            obs, nav, seed_pos = self.touch_inputs(temp_root)
+            summary_json = temp_root / "summary.json"
+
+            result = gnss_taroz_pd_dogfood.main(
+                [
+                    "--obs",
+                    str(obs),
+                    "--nav",
+                    str(nav),
+                    "--seed-pos",
+                    str(seed_pos),
+                    "--summary-json",
+                    str(summary_json),
+                    "--pd-bin",
+                    str(temp_root / "gnss_pos_vel_pd"),
+                    "--max-epochs",
+                    "0",
+                    "--max-iterations",
+                    "0",
+                    "--dry-run",
+                ]
+            )
+
+            self.assertEqual(result, 0)
+            command = json.loads(summary_json.read_text(encoding="utf-8"))["pd_command"]
+            self.assertNotIn("--max-epochs", command)
+            self.assertNotIn("--max-iterations", command)
+
+    def test_native_summary_accepts_taroz_pd_shape(self) -> None:
+        summary = {
+            "preset": "taroz-pd",
+            "backend": "eigen",
+            "pseudorange_sigma_zenith_m": 3,
+            "doppler_sigma_zenith_mps": 0.2,
+            "position_prior_sigma_m": 1000,
+            "clock_prior_sigma_m": 1_000_000,
+            "velocity_prior_sigma_mps": 1000,
+            "clock_drift_prior_sigma_mps": 1000,
+            "motion_sigma_m": 0.1,
+            "clock_motion_sigma_m": 0.1,
+            "clock_drift_between_sigma_mps": 0.1,
+            "optimized_epochs": 80,
+            "valid_position_epochs": 80,
+            "valid_velocity_epochs": 80,
+            "motion_factors": 79,
+            "clock_motion_factors": 79,
+            "clock_drift_between_factors": 79,
+            "graph_values": 320,
+            "pseudorange_factors": 2492,
+            "doppler_factors": 2492,
+            "iterations": 8,
+            "converged": True,
+            "initial_cost": 1000.0,
+            "final_cost": 288.7,
+            "residual_rms_mps": 1.5,
+        }
+
+        failures = gnss_taroz_pd_dogfood.verify_native_summary(
+            summary,
+            expected_max_epochs=80,
+            expected_max_iterations=40,
+        )
+
+        self.assertEqual(failures, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `--generate-matlab-dump` support to `taroz-pd-dogfood` so PD oracle CSVs can be regenerated from taroz MATLAB before C++ parity
- resolve PD MATLAB dump paths under the repo root for relative `--matlab-dir` values
- add PD dogfood harness tests and document generated-oracle dogfood coverage

## Validation
- `python3 -m pytest tests/test_taroz_pd_dogfood.py tests/test_taroz_p_dogfood.py tests/test_taroz_pos_vel_amb_pdc_dogfood.py tests/test_taroz_pc_dogfood.py -q`
- `GNSSPP_TAROZ_PD_CPP_DIR=output/dogfood/taroz_pd_dogfood_current GNSSPP_TAROZ_PD_MATLAB_DIR=output/dogfood/taroz_matlab_pd_debug python3 -m pytest tests/test_taroz_pd_internal_parity.py -q`
- `python3 -m pytest tests/test_docs_site.py -q`
- `python3 tests/test_cli_tools.py`
- `git diff --check`

## Dogfood
- `python3 apps/gnss.py taroz-pd-dogfood --generate-matlab-dump --taroz-root $workspace/arxiv/tier1/gnss_gpu_ws/ref/gtsam_gnss --obs $workspace/arxiv/tier1/gnss_gpu_ws/ref/gtsam_gnss/examples/data/rover_1Hz.obs --nav $workspace/arxiv/tier1/gnss_gpu_ws/ref/gtsam_gnss/examples/data/base.nav --seed-pos $workspace/arxiv/tier1/gnss_gpu_ws/ref/gtsam_gnss/examples/data/rover_1Hz_spp.pos --pd-bin build-codex/apps/gnss_pos_vel_pd --out-dir output/dogfood/taroz_pd_dogfood_current --matlab-dir output/dogfood/taroz_matlab_pd_debug`