### PR TITLE
Add taroz PC MATLAB oracle dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,12 @@ python3 apps/gnss.py taroz-pd-dogfood \
   --out-dir output/dogfood/taroz_pd_dogfood_current \
   --matlab-dir output/dogfood/taroz_matlab_pd_debug
 
+python3 apps/gnss.py taroz-pc-dogfood \
+  --generate-matlab-dump \
+  --taroz-root /tmp/taroz_gtsam_gnss \
+  --out-dir output/dogfood/taroz_pc_dogfood_current \
+  --matlab-dir output/dogfood/taroz_matlab_pc_debug
+
 python3 apps/gnss.py taroz-observable-dogfood \
   --mode pos-pdc \
   --generate-matlab-dump \
@@ -497,11 +503,10 @@ The current beta sign-off is:
 - Shifted-window guard check: `nagoya/run3 --skip-epochs 400 --max-epochs 200`
   with the same generated SPP seed path.
 - Current MATLAB-oracle dogfood: generated P, D, position PD/PDC,
-  position/velocity PD/PDC, and ambiguity PDC dumps are compared against C++
-  diagnostics locally.
-- Remaining parity work: add generated oracle coverage for the PC mode and
-  broaden intermediate seed state, ambiguity candidates, solver costs, and final
-  epoch-output checks before calling the port complete.
+  position/velocity PD/PDC, PC, and ambiguity PDC dumps are compared against
+  C++ diagnostics locally.
+- Remaining parity work: broaden intermediate seed state, ambiguity candidates,
+  solver costs, and final epoch-output checks before calling the port complete.
 
 Other benchmark artifacts and checked sign-offs are documented in
 [Benchmarks](docs/benchmarks.md) and [Validation](docs/validation.md).

--- a/apps/gnss_taroz_pc_dogfood.py
+++ b/apps/gnss_taroz_pc_dogfood.py
@@ -20,12 +20,14 @@ EXE_SUFFIX = ".exe" if os.name == "nt" else ""
 BUILD_CONFIGS = ("Release", "RelWithDebInfo", "Debug", "MinSizeRel")
 
 DEFAULT_DATA_DIR = Path("/tmp/taroz_gtsam_gnss/examples/data")
+DEFAULT_TAROZ_ROOT = Path("/tmp/taroz_gtsam_gnss")
 DEFAULT_OUT_DIR = ROOT_DIR / "output/dogfood/taroz_pc_dogfood_current"
 DEFAULT_BASELINE_CPP_DIR = (
     ROOT_DIR / "output/dogfood/taroz_pc_full_gtsam_fixed_taroz_nocorr"
 )
 DEFAULT_BASELINE_LAMBDA_DIR = ROOT_DIR / "output/dogfood/taroz_pc_lambda_debug"
 DEFAULT_MATLAB_DIR = ROOT_DIR / "output/dogfood/taroz_matlab_pc_debug"
+DEFAULT_MATLAB_DUMP_SCRIPT = ROOT_DIR / "scripts/dump_taroz_pc_debug.m"
 DEFAULT_PARITY_TEST = ROOT_DIR / "tests/test_taroz_pc_internal_parity.py"
 
 POS_NAME = "fgo_taroz_pc_gtsam_fixed.pos"
@@ -133,6 +135,52 @@ def validate_inputs(args: argparse.Namespace) -> None:
     if missing:
         joined = ", ".join(str(path) for path in missing)
         raise SystemExit(f"missing taroz PC input file(s): {joined}")
+
+
+def _matlab_single_quoted_path(path: Path) -> str:
+    return str(path).replace("'", "''")
+
+
+def repo_relative_path(path: Path) -> Path:
+    return path if path.is_absolute() else ROOT_DIR / path
+
+
+def matlab_example_dir(args: argparse.Namespace) -> Path:
+    return args.taroz_example_dir or (args.taroz_root / "examples")
+
+
+def matlab_output_dir(args: argparse.Namespace) -> Path:
+    return repo_relative_path(args.matlab_dir).resolve()
+
+
+def build_matlab_dump_command(args: argparse.Namespace) -> list[str]:
+    script = _matlab_single_quoted_path(repo_relative_path(args.matlab_dump_script))
+    return [str(args.matlab_bin), "-batch", f"run('{script}')"]
+
+
+def matlab_dump_env(args: argparse.Namespace) -> dict[str, str]:
+    env = os.environ.copy()
+    env["GNSSPP_TAROZ_ROOT"] = str(repo_relative_path(args.taroz_root).resolve())
+    env["GNSSPP_TAROZ_PC_EXAMPLE_DIR"] = str(
+        repo_relative_path(matlab_example_dir(args)).resolve()
+    )
+    env["GNSSPP_TAROZ_PC_OUT_DIR"] = str(matlab_output_dir(args))
+    return env
+
+
+def validate_matlab_dump_inputs(args: argparse.Namespace) -> None:
+    missing = [
+        path
+        for path in (
+            args.matlab_dump_script,
+            args.taroz_root,
+            matlab_example_dir(args),
+        )
+        if not repo_relative_path(path).exists()
+    ]
+    if missing:
+        joined = ", ".join(str(path) for path in missing)
+        raise SystemExit(f"missing taroz PC MATLAB oracle input path(s): {joined}")
 
 
 def run_command(command: list[str], *, env: dict[str, str] | None = None) -> int:
@@ -261,7 +309,7 @@ def run_parity(args: argparse.Namespace, out_dir: Path) -> int:
     env = os.environ.copy()
     env["GNSSPP_TAROZ_PC_CPP_DIR"] = str(out_dir)
     env["GNSSPP_TAROZ_PC_CPP_LAMBDA_DIR"] = str(out_dir)
-    env["GNSSPP_TAROZ_PC_MATLAB_DIR"] = str(args.matlab_dir)
+    env["GNSSPP_TAROZ_PC_MATLAB_DIR"] = str(matlab_output_dir(args))
     return run_command([sys.executable, str(args.parity_test)], env=env)
 
 
@@ -301,6 +349,38 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="Extra single argument passed to gnss_fgo. Repeat for multiple tokens.",
     )
     parser.add_argument("--matlab-dir", type=Path, default=DEFAULT_MATLAB_DIR)
+    parser.add_argument(
+        "--generate-matlab-dump",
+        action="store_true",
+        help=(
+            "Run the taroz MATLAB PC dump script before C++ and parity checks, "
+            "so --matlab-dir is regenerated from the reference implementation."
+        ),
+    )
+    parser.add_argument(
+        "--matlab-bin",
+        type=Path,
+        default=Path("matlab"),
+        help="MATLAB executable used with --generate-matlab-dump.",
+    )
+    parser.add_argument(
+        "--taroz-root",
+        type=Path,
+        default=DEFAULT_TAROZ_ROOT,
+        help="Root of the taroz/PPC-Dataset MATLAB checkout.",
+    )
+    parser.add_argument(
+        "--taroz-example-dir",
+        type=Path,
+        default=None,
+        help="Directory containing the taroz MATLAB example (default: <taroz-root>/examples).",
+    )
+    parser.add_argument(
+        "--matlab-dump-script",
+        type=Path,
+        default=DEFAULT_MATLAB_DUMP_SCRIPT,
+        help="MATLAB script that exports the taroz PC oracle CSVs.",
+    )
     parser.add_argument("--parity-test", type=Path, default=DEFAULT_PARITY_TEST)
     parser.add_argument("--skip-parity", action="store_true")
     parser.add_argument("--baseline-cpp-dir", type=Path, default=DEFAULT_BASELINE_CPP_DIR)
@@ -330,6 +410,17 @@ def main(argv: list[str] | None = None) -> int:
         "out_dir": str(out_dir),
         "outputs": {name: str(path) for name, path in paths.items()},
         "harness_summary_json": str(harness_summary),
+        "matlab_dir": str(args.matlab_dir),
+        "matlab_dump": {
+            "enabled": args.generate_matlab_dump,
+            "command": build_matlab_dump_command(args)
+            if args.generate_matlab_dump
+            else None,
+            "dump_script": str(args.matlab_dump_script),
+            "taroz_root": str(args.taroz_root),
+            "example_dir": str(matlab_example_dir(args)),
+            "out_dir": str(matlab_output_dir(args)),
+        },
         "expected": {
             "preset": "taroz-pc",
             "backend": "gtsam-pc",
@@ -344,12 +435,26 @@ def main(argv: list[str] | None = None) -> int:
         payload["status"] = "dry-run"
         write_run_summary(harness_summary, payload)
         print("Dry run. Planned taroz PC dogfood command:")
+        if args.generate_matlab_dump:
+            print(" ".join(payload["matlab_dump"]["command"]))
         print(" ".join(command))
         print(f"Harness summary: {harness_summary}")
         return 0
 
     validate_inputs(args)
+    if args.generate_matlab_dump:
+        validate_matlab_dump_inputs(args)
     out_dir.mkdir(parents=True, exist_ok=True)
+
+    if args.generate_matlab_dump:
+        matlab_output_dir(args).mkdir(parents=True, exist_ok=True)
+        matlab_command = build_matlab_dump_command(args)
+        matlab_returncode = run_command(matlab_command, env=matlab_dump_env(args))
+        payload["matlab_dump"]["returncode"] = matlab_returncode
+        if matlab_returncode != 0:
+            payload["status"] = "failed"
+            write_run_summary(harness_summary, payload)
+            return matlab_returncode
 
     fgo_returncode = run_command(command)
     payload["fgo_returncode"] = fgo_returncode
@@ -369,8 +474,13 @@ def main(argv: list[str] | None = None) -> int:
             print(f"Error: {failure}", file=sys.stderr)
         return 1
 
-    if args.no_byte_compare:
-        payload["byte_comparison"] = {"status": "skipped"}
+    if args.no_byte_compare or args.generate_matlab_dump:
+        reason = (
+            "disabled by --no-byte-compare"
+            if args.no_byte_compare
+            else "generated MATLAB oracle requested"
+        )
+        payload["byte_comparison"] = {"status": "skipped", "reason": reason}
     else:
         byte_comparison = compare_file_pairs(
             out_dir,

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -50,6 +50,8 @@ Keep taroz FGO validation split by cost:
 - Light unit coverage belongs in CTest, such as `python_ppc_taroz_amb_pdc_smoke_tests`
   dry-run checks and focused C++ factor tests.
 - Heavy local checks include
+  `python3 apps/gnss.py taroz-pc-dogfood --generate-matlab-dump`
+  for the PC ambiguity mode,
   `python3 apps/gnss.py taroz-observable-dogfood --mode pos-pdc --generate-matlab-dump`
   for single-receiver observable modes,
   `python3 apps/gnss.py taroz-pos-vel-amb-pdc-dogfood --generate-matlab-dump`

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -186,11 +186,11 @@ no-solution and counted in the summary JSON as
 The beta scope is intentionally narrow. The C++ path covers generated SPP
 seeding, double-difference FGO, FLOAT/FIXED output, and diagnostic summaries for
 the PPC `amb-pdc` workflow. The P, D, position PD/PDC, position/velocity PD/PDC,
-and ambiguity PDC dogfood harnesses can also regenerate taroz MATLAB oracle
+PC, and ambiguity PDC dogfood harnesses can also regenerate taroz MATLAB oracle
 dumps with `--generate-matlab-dump` and run the matching optional parity tests
-locally. A complete taroz port still needs generated oracle coverage for the PC
-mode and broader MATLAB dump parity for intermediate seed state, ambiguity
-candidates, solver costs, and final epoch output across more taroz modes.
+locally. A complete taroz port still needs broader MATLAB dump parity for
+intermediate seed state, ambiguity candidates, solver costs, and final epoch
+output across more taroz modes.
 
 When `--generate-spp-seed` is used, the PPC harness treats the generated seed as
 part of the sign-off. The native summary must report a seed path,

--- a/scripts/dump_taroz_pc_debug.m
+++ b/scripts/dump_taroz_pc_debug.m
@@ -1,0 +1,230 @@
+% Dump taroz estimate_pos_ambiguity_PC internals for LibGNSS++ parity checks.
+%
+% Environment overrides:
+%   GNSSPP_TAROZ_ROOT           Root of taroz/PPC-Dataset checkout.
+%   GNSSPP_TAROZ_PC_EXAMPLE_DIR Directory containing estimate_pos_ambiguity_PC.m.
+%   GNSSPP_TAROZ_PC_OUT_DIR     Output directory for CSV dumps.
+
+taroz_root = getenv("GNSSPP_TAROZ_ROOT");
+if strlength(taroz_root) == 0
+    taroz_root = "/tmp/taroz_gtsam_gnss";
+end
+
+example_dir = getenv("GNSSPP_TAROZ_PC_EXAMPLE_DIR");
+if strlength(example_dir) == 0
+    example_dir = fullfile(taroz_root, "examples");
+end
+
+out_dir = getenv("GNSSPP_TAROZ_PC_OUT_DIR");
+if strlength(out_dir) == 0
+    out_dir = fullfile(pwd, "output", "dogfood", "taroz_matlab_pc_debug");
+end
+if ~isfolder(out_dir)
+    mkdir(out_dir);
+end
+
+set(0, "DefaultFigureVisible", "off");
+cd(example_dir);
+estimate_pos_ambiguity_PC;
+close all force;
+
+out_dir = getenv("GNSSPP_TAROZ_PC_OUT_DIR");
+if strlength(out_dir) == 0
+    out_dir = fullfile(pwd, "output", "dogfood", "taroz_matlab_pc_debug");
+end
+if ~isfolder(out_dir)
+    mkdir(out_dir);
+end
+
+graph_factors = scalar_or_nan(@() graph.size);
+graph_values = scalar_or_nan(@() initials.size);
+initial_cost = scalar_or_nan(@() graph.error(initials));
+final_cost = scalar_or_nan(@() graph.error(results));
+optimizer_error = scalar_or_nan(@() optimizer.error);
+iterations = scalar_or_nan(@() optimizer.iterations);
+valid_ambiguity_states = nnz(b_est ~= 0 & isfinite(b_est));
+valid_solution_epochs = nnz(all(isfinite(x_est), 2));
+
+graph_table = table(n, nsat, graph_factors, graph_values, initial_cost, ...
+                    final_cost, optimizer_error, iterations, ...
+                    valid_ambiguity_states, valid_solution_epochs);
+writetable(graph_table, fullfile(out_dir, "graph_detail.csv"));
+
+satstr = string(obs.satstr);
+
+candidate_counts = zeros(n, 1);
+candidate_lists = strings(n, 1);
+fixed_counts = zeros(n, 1);
+fixed_lists = strings(n, 1);
+position_delta_m = nan(n, 1);
+float_x_m = x_est(:,1);
+float_y_m = x_est(:,2);
+float_z_m = x_est(:,3);
+fixed_x_m = xa_est(:,1);
+fixed_y_m = xa_est(:,2);
+fixed_z_m = xa_est(:,3);
+
+for i = 1:n
+    candidates = find(b_est(i,:) ~= 0 & isfinite(b_est(i,:)));
+    candidate_counts(i) = numel(candidates);
+    if ~isempty(candidates)
+        candidate_lists(i) = strjoin(satstr(candidates), ';');
+    else
+        candidate_lists(i) = "";
+    end
+
+    fixed = find(isfinite(ba_est(i,:)));
+    fixed_counts(i) = numel(fixed);
+    if ~isempty(fixed)
+        fixed_lists(i) = strjoin(satstr(fixed), ';');
+    else
+        fixed_lists(i) = "";
+    end
+
+    if all(isfinite(x_est(i,:))) && all(isfinite(xa_est(i,:)))
+        position_delta_m(i) = norm(xa_est(i,:) - x_est(i,:));
+    end
+end
+
+epoch_table = table((1:n)', obs.time.week, obs.time.tow, ratio, idxfix, ...
+                    candidate_counts, candidate_lists, fixed_counts, fixed_lists, ...
+                    position_delta_m, float_x_m, float_y_m, float_z_m, ...
+                    fixed_x_m, fixed_y_m, fixed_z_m, ...
+                    'VariableNames', {'epoch','gps_week','gps_tow','ratio','idxfix', ...
+                                      'candidate_count','candidate_list', ...
+                                      'fixed_count','fixed_list','position_delta_m', ...
+                                      'float_x_m','float_y_m','float_z_m', ...
+                                      'fixed_x_m','fixed_y_m','fixed_z_m'});
+writetable(epoch_table, fullfile(out_dir, "per_epoch_fix_detail.csv"));
+
+rows = n * nsat;
+epoch_col = zeros(rows, 1);
+gps_week_col = zeros(rows, 1);
+gps_tow_col = zeros(rows, 1);
+satellite = strings(rows, 1);
+reference = strings(rows, 1);
+rover_snr = nan(rows, 1);
+elevation_deg = nan(rows, 1);
+sigma_pdd_m = nan(rows, 1);
+sigma_ldd_m = nan(rows, 1);
+res_pdd = nan(rows, 1);
+res_ldd = nan(rows, 1);
+ambiguity_initial = nan(rows, 1);
+ambiguity_estimate = nan(rows, 1);
+
+k = 0;
+for i = 1:n
+    for j = 1:nsat
+        k = k + 1;
+        ref_idx = reference_index_for_observation(refsatidx, i, j);
+        epoch_col(k) = i;
+        gps_week_col(k) = obs.time.week(i);
+        gps_tow_col(k) = obs.time.tow(i);
+        satellite(k) = satstr(j);
+        if isfinite(ref_idx) && ref_idx >= 1 && ref_idx <= nsat
+            reference(k) = satstr(ref_idx);
+        else
+            reference(k) = "";
+        end
+        rover_snr(k) = obs.L1.S(i,j);
+        elevation_deg(k) = sat.el(i,j);
+        sigma_pdd_m(k) = sigmaP(i,j);
+        sigma_ldd_m(k) = sigmaL(i,j);
+        res_pdd(k) = obs.L1.resPdd(i,j);
+        res_ldd(k) = obs.L1.resLdd(i,j);
+        ambiguity_initial(k) = b_ini(i,j);
+        ambiguity_estimate(k) = b_est(i,j);
+    end
+end
+
+sat_table = table(epoch_col, gps_week_col, gps_tow_col, satellite, reference, ...
+                  rover_snr, elevation_deg, sigma_pdd_m, sigma_ldd_m, ...
+                  res_pdd, res_ldd, ambiguity_initial, ambiguity_estimate, ...
+                  'VariableNames', {'epoch','gps_week','gps_tow', ...
+                                    'satellite','reference','rover_snr', ...
+                                    'elevation_deg','sigma_pdd_m','sigma_ldd_m', ...
+                                    'res_pdd','res_ldd','ambiguity_initial', ...
+                                    'ambiguity_estimate'});
+writetable(sat_table, fullfile(out_dir, "per_sat_detail.csv"));
+
+lambda_path = fullfile(out_dir, "per_lambda_detail.csv");
+fid = fopen(lambda_path, 'w');
+assert(fid > 0);
+cleanup = onCleanup(@() fclose(fid));
+
+fprintf(fid, ['epoch_index,gps_week,gps_tow,solved,fixed_epoch,ratio,' ...
+              'candidate_count,row,col,satellite,other_satellite,local_index,' ...
+              'other_local_index,ambiguity_float,fixed_ambiguity,covariance,' ...
+              'position_covariance_x,position_covariance_y,position_covariance_z\n']);
+
+for i = 1:n
+    candidate_idx = find(b_est(i,:) ~= 0 & isfinite(b_est(i,:)));
+    candidate_n = length(candidate_idx);
+    if candidate_n <= minobs_th
+        continue;
+    end
+
+    Qfafa = covxb_est(candidate_idx, candidate_idx, i);
+    Qxfa = covxb_est(end-2:end, candidate_idx, i);
+    lambda_solved = false;
+    lambda_fixed = false;
+    lambda_ratio = NaN;
+    a = nan(2, candidate_n);
+    try
+        [a,s] = rtklib.lambda(2, b_est(i,candidate_idx), Qfafa);
+        lambda_solved = true;
+        lambda_ratio = s(2) / s(1);
+        lambda_fixed = lambda_ratio > ratio_th;
+    catch
+        lambda_solved = false;
+    end
+
+    for row = 1:candidate_n
+        local_index = candidate_idx(row) - 1;
+        for col = 1:candidate_n
+            other_local_index = candidate_idx(col) - 1;
+            fprintf(fid, ['%d,%d,%.15f,%d,%d,%.15f,%d,%d,%d,%s,%s,%d,%d,' ...
+                          '%.15f,%.15f,%.15f,%.15f,%.15f,%.15f\n'], ...
+                    i - 1, obs.time.week(i), obs.time.tow(i), ...
+                    lambda_solved, lambda_fixed, lambda_ratio, candidate_n, ...
+                    row - 1, col - 1, char(satstr(candidate_idx(row))), ...
+                    char(satstr(candidate_idx(col))), local_index, ...
+                    other_local_index, b_est(i,candidate_idx(row)), ...
+                    a(1,row), Qfafa(row,col), Qxfa(1,row), Qxfa(2,row), ...
+                    Qxfa(3,row));
+        end
+    end
+end
+
+fprintf("Wrote taroz PC debug CSVs to %s\n", out_dir);
+
+function value = scalar_or_nan(callback)
+    try
+        value = callback();
+    catch
+        value = NaN;
+    end
+end
+
+function ref_idx = reference_index_for_observation(refsatidx, epoch_index, satellite_index)
+    if isscalar(refsatidx)
+        ref_idx = refsatidx;
+    elseif isvector(refsatidx)
+        ref_values = refsatidx(:);
+        if numel(ref_values) >= satellite_index
+            ref_idx = ref_values(satellite_index);
+        elseif numel(ref_values) >= epoch_index
+            ref_idx = ref_values(epoch_index);
+        else
+            ref_idx = NaN;
+        end
+    elseif size(refsatidx, 1) >= epoch_index && size(refsatidx, 2) >= satellite_index
+        ref_idx = refsatidx(epoch_index, satellite_index);
+    elseif size(refsatidx, 1) >= epoch_index
+        ref_idx = refsatidx(epoch_index, 1);
+    elseif size(refsatidx, 2) >= satellite_index
+        ref_idx = refsatidx(1, satellite_index);
+    else
+        ref_idx = NaN;
+    end
+end

--- a/tests/test_taroz_pc_dogfood.py
+++ b/tests/test_taroz_pc_dogfood.py
@@ -33,6 +33,10 @@ class TarozPcDogfoodTest(unittest.TestCase):
             obs, base, nav, seed_pos = self.touch_inputs(temp_root)
             summary_json = temp_root / "summary.json"
             out_dir = temp_root / "out"
+            taroz_root = temp_root / "taroz"
+            taroz_example_dir = taroz_root / "examples"
+            matlab_dump_script = temp_root / "dump_pc.m"
+            matlab_dir = temp_root / "matlab_oracle"
 
             result = gnss_taroz_pc_dogfood.main(
                 [
@@ -50,6 +54,17 @@ class TarozPcDogfoodTest(unittest.TestCase):
                     str(summary_json),
                     "--fgo-bin",
                     str(temp_root / "gnss_fgo"),
+                    "--generate-matlab-dump",
+                    "--matlab-bin",
+                    str(temp_root / "matlab"),
+                    "--taroz-root",
+                    str(taroz_root),
+                    "--taroz-example-dir",
+                    str(taroz_example_dir),
+                    "--matlab-dump-script",
+                    str(matlab_dump_script),
+                    "--matlab-dir",
+                    str(matlab_dir),
                     "--dry-run",
                 ]
             )
@@ -57,7 +72,16 @@ class TarozPcDogfoodTest(unittest.TestCase):
             self.assertEqual(result, 0)
             payload = json.loads(summary_json.read_text(encoding="utf-8"))
             command = payload["fgo_command"]
+            matlab_dump = payload["matlab_dump"]
             self.assertEqual(payload["status"], "dry-run")
+            self.assertTrue(matlab_dump["enabled"])
+            self.assertEqual(matlab_dump["dump_script"], str(matlab_dump_script))
+            self.assertEqual(matlab_dump["taroz_root"], str(taroz_root))
+            self.assertEqual(matlab_dump["example_dir"], str(taroz_example_dir))
+            self.assertEqual(matlab_dump["out_dir"], str(matlab_dir))
+            self.assertEqual(matlab_dump["command"][0], str(temp_root / "matlab"))
+            self.assertEqual(matlab_dump["command"][1], "-batch")
+            self.assertIn(str(matlab_dump_script), matlab_dump["command"][2])
             self.assertIn("--preset", command)
             self.assertIn("taroz-pc", command)
             self.assertIn("--backend", command)
@@ -65,6 +89,59 @@ class TarozPcDogfoodTest(unittest.TestCase):
             self.assertIn("--lambda-debug-csv", command)
             self.assertNotIn("--no-spp-seed", command)
             self.assertFalse(payload["expected"]["use_spp_seed"])
+
+    def test_matlab_dump_env_resolves_requested_paths(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_taroz_pc_dogfood_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            args = gnss_taroz_pc_dogfood.parse_args(
+                [
+                    "--generate-matlab-dump",
+                    "--taroz-root",
+                    str(temp_root / "taroz"),
+                    "--taroz-example-dir",
+                    str(temp_root / "taroz" / "examples"),
+                    "--matlab-dir",
+                    str(temp_root / "matlab_oracle"),
+                ]
+            )
+
+            env = gnss_taroz_pc_dogfood.matlab_dump_env(args)
+
+            self.assertEqual(env["GNSSPP_TAROZ_ROOT"], str(temp_root / "taroz"))
+            self.assertEqual(
+                env["GNSSPP_TAROZ_PC_EXAMPLE_DIR"],
+                str(temp_root / "taroz" / "examples"),
+            )
+            self.assertEqual(
+                env["GNSSPP_TAROZ_PC_OUT_DIR"],
+                str(temp_root / "matlab_oracle"),
+            )
+
+    def test_matlab_dump_env_resolves_relative_paths_under_repo(self) -> None:
+        args = gnss_taroz_pc_dogfood.parse_args(
+            [
+                "--generate-matlab-dump",
+                "--taroz-root",
+                "relative_taroz_root",
+                "--matlab-dir",
+                "relative_matlab_oracle",
+            ]
+        )
+
+        env = gnss_taroz_pc_dogfood.matlab_dump_env(args)
+
+        self.assertEqual(
+            env["GNSSPP_TAROZ_ROOT"],
+            str(ROOT_DIR / "relative_taroz_root"),
+        )
+        self.assertEqual(
+            env["GNSSPP_TAROZ_PC_EXAMPLE_DIR"],
+            str(ROOT_DIR / "relative_taroz_root" / "examples"),
+        )
+        self.assertEqual(
+            env["GNSSPP_TAROZ_PC_OUT_DIR"],
+            str(ROOT_DIR / "relative_matlab_oracle"),
+        )
 
     def test_byte_compare_reports_matching_artifacts(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_taroz_pc_compare_test_") as temp_dir:


### PR DESCRIPTION
## Summary
- add `scripts/dump_taroz_pc_debug.m` to regenerate taroz `estimate_pos_ambiguity_PC` oracle CSVs
- teach `taroz-pc-dogfood` to run MATLAB oracle generation before native parity
- skip brittle C++ byte-baseline comparison when a fresh MATLAB oracle is generated, while keeping the legacy byte-compare path for non-generated runs
- update docs to remove PC from the generated-oracle gap

## Local validation
- `python3 -m pytest tests/test_taroz_pc_dogfood.py -q`
- `python3 tests/test_cli_tools.py`
- `python3 apps/gnss.py taroz-pc-dogfood --generate-matlab-dump --taroz-root $workspace/arxiv/tier1/gnss_gpu_ws/ref/gtsam_gnss --obs ... --base ... --nav ... --seed-pos ... --fgo-bin build-codex/apps/gnss_fgo --out-dir output/dogfood/taroz_pc_dogfood_current --matlab-dir output/dogfood/taroz_matlab_pc_debug`
- `python3 -m pytest tests/test_taroz_pc_dogfood.py tests/test_taroz_pc_internal_parity.py tests/test_docs_site.py -q`
- `git diff --check`

The generated PC oracle dogfood passed 4 parity tests against the regenerated MATLAB dump. MATLAB still prints the existing non-fatal X11/GL shutdown warning in this headless environment.
