### PR TITLE
Tighten taroz ambiguity PDC cost parity

### DIFF
--- a/tests/test_taroz_pos_vel_amb_pdc_factor_parity.py
+++ b/tests/test_taroz_pos_vel_amb_pdc_factor_parity.py
@@ -105,6 +105,10 @@ def finite(value: str) -> bool:
         return False
 
 
+def relative_error(actual: float, expected: float) -> float:
+    return abs(actual - expected) / max(1.0, abs(expected))
+
+
 def keyed_cpp_rows(path: Path) -> dict[tuple[int, str, str], dict[str, str]]:
     return {
         (round(float(row["gps_tow"])), row["satellite"], row["reference"]): row
@@ -314,10 +318,25 @@ class TarozPosVelAmbPdcFactorParityTest(unittest.TestCase):
         self.assertEqual(int(summary["float_solutions"]), 243)
         self.assertEqual(int(summary["graph_factors"]), 76357)
         self.assertEqual(int(summary["graph_values"]), 21813)
-        self.assertGreater(int(summary["iterations"]), 0)
-        self.assertGreater(int(float(taroz_graph["iterations"])), 0)
+        self.assertLessEqual(
+            abs(int(summary["iterations"]) - int(float(taroz_graph["iterations"]))),
+            2,
+        )
+        self.assertTrue(math.isfinite(float(summary["initial_cost"])))
         self.assertTrue(math.isfinite(float(summary["final_cost"])))
+        self.assertTrue(math.isfinite(float(taroz_graph["initial_cost"])))
         self.assertTrue(math.isfinite(float(taroz_graph["final_cost"])))
+        self.assertLess(
+            float(summary["final_cost"]),
+            float(taroz_graph["initial_cost"]),
+        )
+        self.assertLessEqual(
+            relative_error(
+                float(summary["final_cost"]),
+                float(taroz_graph["final_cost"]),
+            ),
+            0.30,
+        )
 
     def test_seed_positions_match_taroz_spp_seed_dump(self) -> None:
         cpp_epoch_path = CPP_DIR / "epoch_debug.csv"


### PR DESCRIPTION
## Summary
- strengthen the taroz position/velocity ambiguity PDC parity test from finite-only solver cost checks to calibrated regression guards
- require optimizer iterations to stay within two iterations of the taroz MATLAB oracle
- require C++ final cost to remain below taroz initial cost and within 30% relative error of taroz final cost

## Validation
- `GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_DIR=output/dogfood/taroz_oracle_suite_current/pos_vel_amb_pdc GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_OPT_POS=output/dogfood/taroz_oracle_suite_current/pos_vel_amb_pdc/opt.pos GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_OPT_EPOCH_DEBUG=output/dogfood/taroz_oracle_suite_current/pos_vel_amb_pdc/epoch_debug.csv GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_OPT_LAMBDA_DEBUG=output/dogfood/taroz_oracle_suite_current/pos_vel_amb_pdc/lambda_debug.csv GNSSPP_TAROZ_POS_VEL_AMB_PDC_MATLAB_DIR=output/dogfood/taroz_matlab_pos_vel_amb_pdc_debug python3 tests/test_taroz_pos_vel_amb_pdc_factor_parity.py`
- `ctest --test-dir build-codex -R python_taroz_pos_vel_amb_pdc_factor_parity_tests --output-on-failure`
- `git diff --check`