### PR TITLE
Guard taroz position PD output contract

### DIFF
--- a/tests/test_taroz_pos_pd_internal_parity.py
+++ b/tests/test_taroz_pos_pd_internal_parity.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import csv
+from collections import Counter
 import json
 import math
 import os
@@ -159,6 +160,69 @@ class TarozPosPDInternalParityTest(unittest.TestCase):
             max(1.0, abs(float(taroz_graph["final_cost"]))),
             0.15,
         )
+
+    def test_final_epoch_state_file_matches_summary_contract(self) -> None:
+        cpp_summary_path = CPP_DIR / "summary.json"
+        cpp_graph_path = CPP_DIR / "graph_detail.csv"
+        cpp_epoch_path = CPP_DIR / "per_epoch_state.csv"
+        self.require_dogfood_files(cpp_summary_path, cpp_graph_path, cpp_epoch_path)
+
+        cpp_summary = read_json(cpp_summary_path)
+        cpp_graph = read_graph(cpp_graph_path)
+        rows = read_rows(cpp_epoch_path)
+        optimized_epochs = int(cpp_summary["optimized_epochs"])
+        self.assertEqual(len(rows), optimized_epochs)
+        self.assertEqual(int(cpp_summary["valid_position_epochs"]), optimized_epochs)
+        self.assertEqual(int(cpp_summary["valid_clock_epochs"]), optimized_epochs)
+        self.assertEqual(int(cpp_summary["graph_values"]), 2 * optimized_epochs)
+        self.assertEqual(int(float(cpp_graph["graph_values"])), 2 * optimized_epochs)
+        self.assertEqual(int(float(cpp_graph["n"])), optimized_epochs)
+        self.assertEqual(int(float(cpp_graph["valid_position_epochs"])), optimized_epochs)
+        self.assertEqual(int(float(cpp_graph["valid_clock_epochs"])), optimized_epochs)
+        self.assertEqual(int(cpp_summary["iterations"]), int(float(cpp_graph["iterations"])))
+        self.assertEqual(float(cpp_summary["final_cost"]), float(cpp_graph["final_cost"]))
+        self.assertEqual(float(cpp_graph["final_cost"]), float(cpp_graph["optimizer_error"]))
+
+        epoch_indices = [int(float(row["epoch"])) for row in rows]
+        self.assertEqual(epoch_indices, list(range(1, optimized_epochs + 1)))
+        gps_tows = [round(float(row["gps_tow"])) for row in rows]
+        self.assertEqual(len(gps_tows), len(set(gps_tows)))
+        self.assertTrue(
+            all(current < following for current, following in zip(gps_tows, gps_tows[1:]))
+        )
+        if optimized_epochs == 1141:
+            self.assertEqual(gps_tows[0], 553950)
+            self.assertEqual(gps_tows[-1], 555090)
+            self.assertEqual(
+                Counter(
+                    following - current
+                    for current, following in zip(gps_tows, gps_tows[1:])
+                ),
+                Counter({1: 1140}),
+            )
+            self.assertEqual(
+                Counter(row["clock_jump"] for row in rows),
+                Counter({"0": 1140, "1": 1}),
+            )
+
+        finite_columns = (
+            "spp_x_m",
+            "spp_y_m",
+            "spp_z_m",
+            "fgo_x_m",
+            "fgo_y_m",
+            "fgo_z_m",
+            "fgo_c_gps_m",
+            "fgo_c_glo_m",
+            "fgo_c_gal_m",
+            "fgo_c_qzs_m",
+            "fgo_c_bds_m",
+        )
+        for row in rows:
+            self.assertEqual(int(row["gps_week"]), 2323)
+            self.assertIn(row["clock_jump"], {"0", "1"})
+            for column in finite_columns:
+                self.assertTrue(math.isfinite(float(row[column])), column)
 
     def test_raw_factors_match_taroz_dump(self) -> None:
         cpp_factor_path = CPP_DIR / "factor_debug.csv"


### PR DESCRIPTION
## Summary
- add a final epoch CSV contract check for taroz position PD
- require `per_epoch_state.csv` row count, epoch sequence, TOW monotonicity, graph values, valid epoch counts, final cost, and iteration count to match summary/graph diagnostics
- pin the full taroz dogfood clock-jump and one-second epoch cadence while keeping subset artifacts structurally valid

## Validation
- `GNSSPP_TAROZ_POS_PD_CPP_DIR=output/dogfood/taroz_pos_pd_dogfood_current GNSSPP_TAROZ_POS_PD_MATLAB_DIR=output/dogfood/taroz_matlab_pos_pd_debug python3 tests/test_taroz_pos_pd_internal_parity.py`
- `ctest --test-dir build-codex -R python_taroz_pos_pd_internal_parity_tests --output-on-failure`
- `git diff --check`