### PR TITLE
Guard taroz P and PD output contracts

### DIFF
--- a/tests/test_taroz_p_internal_parity.py
+++ b/tests/test_taroz_p_internal_parity.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import csv
+from collections import Counter
 import json
 import math
 import os
@@ -60,6 +61,35 @@ def read_pos_by_tow(path: Path) -> dict[int, tuple[float, float, float, int]]:
                 float(parts[4]),
                 int(float(parts[8])),
             )
+    return rows
+
+
+def read_pos_rows(path: Path) -> list[dict[str, str]]:
+    fields = (
+        "gps_week",
+        "gps_tow",
+        "x_m",
+        "y_m",
+        "z_m",
+        "lat_deg",
+        "lon_deg",
+        "height_m",
+        "status",
+        "satellites",
+        "pdop",
+        "ratio",
+        "fixed_ambiguities",
+        "iterations",
+    )
+    rows: list[dict[str, str]] = []
+    with path.open(encoding="ascii", errors="ignore") as handle:
+        for line in handle:
+            if not line.strip() or line.startswith("%"):
+                continue
+            parts = line.split()
+            if len(parts) != len(fields):
+                raise ValueError(f"unexpected taroz P pos row width in {path}: {line.rstrip()}")
+            rows.append(dict(zip(fields, parts)))
     return rows
 
 
@@ -165,6 +195,79 @@ class TarozPInternalParityTest(unittest.TestCase):
         self.assertLessEqual(sum(position_diffs) / len(position_diffs), 10.0)
         max_allowed_diff = 50.0 if len(position_diffs) > 1000 else 35.0
         self.assertLessEqual(max(position_diffs), max_allowed_diff)
+
+    def test_final_position_file_matches_summary_contract(self) -> None:
+        cpp_summary_path = CPP_DIR / "fgo_taroz_p_summary.json"
+        cpp_pos_path = CPP_DIR / "fgo_taroz_p.pos"
+        cpp_epoch_path = CPP_DIR / "fgo_taroz_p_epoch_debug.csv"
+        self.require_dogfood_files(cpp_summary_path, cpp_pos_path, cpp_epoch_path)
+
+        cpp_summary = read_json(cpp_summary_path)
+        pos_rows = read_pos_rows(cpp_pos_path)
+        with cpp_epoch_path.open(newline="") as handle:
+            epoch_rows = list(csv.DictReader(handle))
+
+        optimized_epochs = int(cpp_summary["optimized_epochs"])
+        self.assertEqual(len(pos_rows), optimized_epochs)
+        self.assertEqual(len(epoch_rows), optimized_epochs)
+        self.assertEqual(int(cpp_summary["input_epochs"]), optimized_epochs)
+        self.assertEqual(int(cpp_summary["valid_solutions"]), optimized_epochs)
+        self.assertEqual(int(cpp_summary["seed_matched_epochs"]), optimized_epochs)
+        self.assertEqual(int(cpp_summary["fixed_solutions"]), 0)
+        self.assertEqual(int(cpp_summary["float_solutions"]), 0)
+
+        epoch_indices = [int(float(row["epoch_index"])) for row in epoch_rows]
+        self.assertEqual(epoch_indices, list(range(optimized_epochs)))
+        pos_tows = [round(float(row["gps_tow"])) for row in pos_rows]
+        epoch_tows = [round(float(row["gps_tow"])) for row in epoch_rows]
+        self.assertEqual(pos_tows, epoch_tows)
+        self.assertEqual(len(pos_tows), len(set(pos_tows)))
+        self.assertTrue(
+            all(current < following for current, following in zip(pos_tows, pos_tows[1:]))
+        )
+        if optimized_epochs in {80, 1141}:
+            self.assertEqual(pos_tows[0], 553950)
+            self.assertEqual(pos_tows[-1], 553950 + optimized_epochs - 1)
+            self.assertEqual(
+                Counter(
+                    following - current
+                    for current, following in zip(pos_tows, pos_tows[1:])
+                ),
+                Counter({1: optimized_epochs - 1}),
+            )
+
+        status_counts = Counter(int(float(row["status"])) for row in pos_rows)
+        self.assertEqual(status_counts, Counter({1: optimized_epochs}))
+        finite_pos_columns = ("x_m", "y_m", "z_m", "lat_deg", "lon_deg", "height_m", "pdop")
+        finite_epoch_columns = (
+            "position_x_m",
+            "position_y_m",
+            "position_z_m",
+            "seed_position_x_m",
+            "seed_position_y_m",
+            "seed_position_z_m",
+            "velocity_x_mps",
+            "velocity_y_mps",
+            "velocity_z_mps",
+        )
+        for pos, epoch in zip(pos_rows, epoch_rows):
+            self.assertEqual(int(pos["gps_week"]), 2323)
+            self.assertEqual(int(epoch["gps_week"]), 2323)
+            self.assertEqual(int(float(pos["status"])), int(float(epoch["status"])))
+            self.assertEqual(int(float(pos["fixed_ambiguities"])), int(epoch["num_fixed_ambiguities"]))
+            self.assertEqual(int(float(pos["iterations"])), int(cpp_summary["iterations"]))
+            self.assertGreaterEqual(
+                int(float(pos["satellites"])),
+                int(cpp_summary["min_satellites_per_epoch"]),
+            )
+            self.assertAlmostEqual(float(pos["x_m"]), float(epoch["position_x_m"]), places=6)
+            self.assertAlmostEqual(float(pos["y_m"]), float(epoch["position_y_m"]), places=6)
+            self.assertAlmostEqual(float(pos["z_m"]), float(epoch["position_z_m"]), places=6)
+            self.assertAlmostEqual(float(pos["ratio"]), float(epoch["ratio"]), places=6)
+            for column in finite_pos_columns:
+                self.assertTrue(math.isfinite(float(pos[column])), column)
+            for column in finite_epoch_columns:
+                self.assertTrue(math.isfinite(float(epoch[column])), column)
 
     def test_graph_and_factor_counts_are_consistent(self) -> None:
         cpp_summary_path = CPP_DIR / "fgo_taroz_p_summary.json"

--- a/tests/test_taroz_pd_internal_parity.py
+++ b/tests/test_taroz_pd_internal_parity.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import csv
+from collections import Counter
 import json
 import math
 import os
@@ -218,6 +219,70 @@ class TarozPDInternalParityTest(unittest.TestCase):
                 max(1.0, abs(float(taroz_graph["final_cost"]))),
                 0.35,
             )
+
+    def test_final_epoch_state_file_matches_summary_contract(self) -> None:
+        cpp_summary_path = CPP_DIR / "summary.json"
+        cpp_graph_path = CPP_DIR / "graph_detail.csv"
+        cpp_epoch_path = CPP_DIR / "per_epoch_state.csv"
+        self.require_dogfood_files(cpp_summary_path, cpp_graph_path, cpp_epoch_path)
+
+        cpp_summary = read_json(cpp_summary_path)
+        cpp_graph = read_graph(cpp_graph_path)
+        rows = read_csv_rows(cpp_epoch_path)
+
+        optimized_epochs = int(cpp_summary["optimized_epochs"])
+        self.assertEqual(len(rows), optimized_epochs)
+        self.assertEqual(int(cpp_summary["valid_position_epochs"]), optimized_epochs)
+        self.assertEqual(int(cpp_summary["valid_velocity_epochs"]), optimized_epochs)
+        self.assertEqual(int(cpp_summary["graph_values"]), 4 * optimized_epochs)
+        self.assertEqual(int(float(cpp_graph["graph_values"])), 4 * optimized_epochs)
+        self.assertEqual(int(float(cpp_graph["n"])), optimized_epochs)
+        self.assertEqual(int(float(cpp_graph["valid_position_epochs"])), optimized_epochs)
+        self.assertEqual(int(float(cpp_graph["valid_velocity_epochs"])), optimized_epochs)
+        self.assertEqual(int(cpp_summary["iterations"]), int(float(cpp_graph["iterations"])))
+        self.assertEqual(float(cpp_summary["final_cost"]), float(cpp_graph["final_cost"]))
+        self.assertEqual(float(cpp_graph["final_cost"]), float(cpp_graph["optimizer_error"]))
+
+        epoch_indices = [int(float(row["epoch"])) for row in rows]
+        self.assertEqual(epoch_indices, list(range(1, optimized_epochs + 1)))
+        gps_tows = [round(float(row["gps_tow"])) for row in rows]
+        self.assertEqual(len(gps_tows), len(set(gps_tows)))
+        self.assertTrue(
+            all(current < following for current, following in zip(gps_tows, gps_tows[1:]))
+        )
+        if optimized_epochs in {80, 1141}:
+            self.assertEqual(gps_tows[0], 553950)
+            self.assertEqual(gps_tows[-1], 553950 + optimized_epochs - 1)
+            self.assertEqual(
+                Counter(
+                    following - current
+                    for current, following in zip(gps_tows, gps_tows[1:])
+                ),
+                Counter({1: optimized_epochs - 1}),
+            )
+
+        finite_columns = (
+            "spp_x_m",
+            "spp_y_m",
+            "spp_z_m",
+            "fgo_x_m",
+            "fgo_y_m",
+            "fgo_z_m",
+            "fgo_vx_mps",
+            "fgo_vy_mps",
+            "fgo_vz_mps",
+            "fgo_c_gps_m",
+            "fgo_c_glo_m",
+            "fgo_c_gal_m",
+            "fgo_c_qzs_m",
+            "fgo_c_bds_m",
+            "fgo_clock_drift_mps",
+        )
+        for row in rows:
+            self.assertEqual(int(row["gps_week"]), 2323)
+            self.assertIn(row["clock_jump"], {"0", "1"})
+            for column in finite_columns:
+                self.assertTrue(math.isfinite(float(row[column])), column)
 
     def test_raw_pd_factors_match_taroz_pd_dump(self) -> None:
         cpp_factor_path = CPP_DIR / "factor_debug.csv"


### PR DESCRIPTION
## Summary
- add a taroz P final .pos output contract test tying fgo_taroz_p.pos, epoch debug CSV, and summary counts together
- add a taroz PD per_epoch_state.csv contract test tying final state rows, graph_detail.csv, and summary counts/costs together
- keep the checks artifact-size aware: current 80-epoch dogfood and full 1141-epoch fixtures both pin the expected 1 Hz PPC timing shape

## Tests
- GNSSPP_TAROZ_P_CPP_DIR=output/dogfood/taroz_p_dogfood_current GNSSPP_TAROZ_P_MATLAB_DIR=output/dogfood/taroz_matlab_p_debug python3 tests/test_taroz_p_internal_parity.py
- GNSSPP_TAROZ_PD_CPP_DIR=output/dogfood/taroz_pd_dogfood_current GNSSPP_TAROZ_PD_MATLAB_DIR=output/dogfood/taroz_matlab_pd_debug python3 tests/test_taroz_pd_internal_parity.py
- ctest --test-dir build-codex -R python_taroz_p_internal_parity_tests --output-on-failure
- ctest --test-dir build-codex -R python_taroz_pd_internal_parity_tests --output-on-failure
- git diff --check