### PR TITLE
Add FGO cost trace artifact

### DIFF
--- a/apps/gnss_fgo.cpp
+++ b/apps/gnss_fgo.cpp
@@ -47,6 +47,7 @@ struct Options {
     std::string factor_debug_csv_path;
     std::string sd_factor_debug_csv_path;
     std::string lambda_debug_csv_path;
+    std::string cost_trace_csv_path;
     std::string seed_pos_path;
     std::string preset = "default";
     std::string backend = "eigen";
@@ -138,6 +139,7 @@ void printUsage(const char* program_name) {
         << "                                Write taroz SD Doppler/TDCP diagnostics\n"
         << "  --lambda-debug-csv <debug.csv>\n"
         << "                                Write per-LAMBDA ambiguity/covariance diagnostics\n"
+        << "  --cost-trace-csv <trace.csv>  Write optimizer cost by iteration\n"
         << "  --debug-problem-only          Build factors and debug outputs without optimizing\n"
         << "  --seed-pos <solution.pos>     Use LibGNSS++/RTKLIB POS rows as epoch initial positions\n"
         << "  --backend <name>              Optimizer backend: eigen, gtsam-pc (if built with GTSAM)\n"
@@ -448,6 +450,8 @@ Options parseArguments(int argc, char* argv[]) {
             options.sd_factor_debug_csv_path = argv[++i];
         } else if (arg == "--lambda-debug-csv" && i + 1 < argc) {
             options.lambda_debug_csv_path = argv[++i];
+        } else if (arg == "--cost-trace-csv" && i + 1 < argc) {
+            options.cost_trace_csv_path = argv[++i];
         } else if (arg == "--seed-pos" && i + 1 < argc) {
             options.seed_pos_path = argv[++i];
         } else if (arg == "--backend" && i + 1 < argc) {
@@ -1741,7 +1745,7 @@ void writeSummaryJson(const Options& options,
     }
 
     const auto& diagnostics = result.diagnostics;
-    output << std::setprecision(10);
+    output << std::setprecision(std::numeric_limits<double>::max_digits10);
     output << "{\n";
     output << "  \"obs\": \"" << jsonEscape(options.obs_path) << "\",\n";
     output << "  \"base\": \"" << jsonEscape(options.base_path) << "\",\n";
@@ -1765,6 +1769,8 @@ void writeSummaryJson(const Options& options,
            << jsonEscape(options.sd_factor_debug_csv_path) << "\",\n";
     output << "  \"lambda_debug_csv\": \""
            << jsonEscape(options.lambda_debug_csv_path) << "\",\n";
+    output << "  \"cost_trace_csv\": \""
+           << jsonEscape(options.cost_trace_csv_path) << "\",\n";
     output << "  \"seed_match_tolerance_s\": "
            << options.seed_match_tolerance_s << ",\n";
     output << "  \"seed_interpolation_max_gap_s\": "
@@ -2324,6 +2330,39 @@ bool writeLambdaDebugCsv(
         output << ',';
         writeCsvDouble(output, entry.position_covariance_z);
         output << '\n';
+    }
+    return true;
+}
+
+bool writeCostTraceCsv(
+    const std::string& path,
+    const std::vector<libgnss::FGOProcessor::CostTraceEntry>& entries) {
+    if (path.empty()) {
+        return true;
+    }
+
+    std::ofstream output(path);
+    if (!output.is_open()) {
+        return false;
+    }
+
+    output << "phase,local_iteration,global_iteration,cost,"
+              "absolute_decrease,relative_decrease,update_norm,converged\n";
+    output << std::fixed << std::setprecision(15);
+    for (const auto& entry : entries) {
+        output << entry.phase << ','
+               << entry.local_iteration << ','
+               << entry.global_iteration << ',';
+        writeCsvDouble(output, entry.cost);
+        output << ',';
+        writeCsvDouble(output, entry.absolute_decrease);
+        output << ',';
+        writeCsvDouble(output, entry.relative_decrease);
+        output << ',';
+        writeCsvDouble(output, entry.update_norm);
+        output << ','
+               << (entry.converged ? 1 : 0)
+               << '\n';
     }
     return true;
 }
@@ -3386,6 +3425,12 @@ int main(int argc, char* argv[]) {
                                  result.lambda_debug_entries)) {
             std::cerr << "Error: failed to write lambda debug CSV: "
                       << options.lambda_debug_csv_path << "\n";
+            return 1;
+        }
+        if (!writeCostTraceCsv(options.cost_trace_csv_path,
+                               result.cost_trace_entries)) {
+            std::cerr << "Error: failed to write cost trace CSV: "
+                      << options.cost_trace_csv_path << "\n";
             return 1;
         }
 

--- a/apps/gnss_ppc_taroz_amb_pdc_smoke.py
+++ b/apps/gnss_ppc_taroz_amb_pdc_smoke.py
@@ -151,6 +151,7 @@ def output_paths(out_dir: Path, run: PpcRun) -> dict[str, Path]:
         "summary": run_dir / "summary.json",
         "epoch_debug": run_dir / "epoch_debug.csv",
         "lambda_debug": run_dir / "lambda_debug.csv",
+        "cost_trace": run_dir / "cost_trace.csv",
     }
 
 
@@ -218,6 +219,8 @@ def build_fgo_command(
         str(paths["epoch_debug"]),
         "--lambda-debug-csv",
         str(paths["lambda_debug"]),
+        "--cost-trace-csv",
+        str(paths["cost_trace"]),
         "--quiet",
     ]
     if args.skip_epochs > 0:
@@ -395,7 +398,9 @@ def selected_native_summary(summary: dict[str, Any]) -> dict[str, Any]:
         "lambda_ambiguity_candidates",
         "lambda_ambiguity_used_candidates",
         "iterations",
+        "cost_trace_csv",
         "converged",
+        "initial_cost",
         "final_cost",
         "total_processing_time_ms",
     ]

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -8,6 +8,7 @@
 #include <cstddef>
 #include <map>
 #include <set>
+#include <string>
 #include <vector>
 
 namespace libgnss {
@@ -379,6 +380,17 @@ public:
         double position_covariance_z = 0.0;
     };
 
+    struct CostTraceEntry {
+        std::string phase;
+        int local_iteration = 0;
+        int global_iteration = 0;
+        double cost = 0.0;
+        double absolute_decrease = 0.0;
+        double relative_decrease = 0.0;
+        double update_norm = 0.0;
+        bool converged = false;
+    };
+
     struct FGOResult {
         Solution solution;
         FGODiagnostics diagnostics;
@@ -388,6 +400,7 @@ public:
         std::vector<std::map<SatelliteId, double>> ambiguity_estimate_cycles_by_epoch;
         std::vector<Vector3d> epoch_velocities_ecef_mps;
         std::vector<LambdaDebugEntry> lambda_debug_entries;
+        std::vector<CostTraceEntry> cost_trace_entries;
     };
 
     FGOProcessor() = default;

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -21,6 +21,7 @@
 #include <map>
 #include <numeric>
 #include <set>
+#include <string>
 #include <tuple>
 
 namespace libgnss {
@@ -2046,6 +2047,7 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
         std::size_t robust_double_difference_pseudorange_factors = 0;
         std::size_t robust_double_difference_carrier_factors = 0;
         std::size_t robust_tdcp_factors = 0;
+        std::vector<FGOProcessor::CostTraceEntry> cost_trace_entries;
     };
 
     auto robust_scale = [&](double normalized_residual,
@@ -2062,7 +2064,9 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
 
     auto run_optimizer =
         [&](const Eigen::VectorXd& start_state,
-            const std::vector<FixedAmbiguityConstraint>& fixed_constraints)
+            const std::vector<FixedAmbiguityConstraint>& fixed_constraints,
+            const std::string& phase,
+            int global_iteration_offset)
             -> OptimizationOutput {
         OptimizationOutput output;
         output.state = start_state;
@@ -2734,6 +2738,36 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
                 return output;
             }
 
+            auto cost_delta = [&]() -> std::pair<double, double> {
+                if (!std::isfinite(previous_cost) ||
+                    !std::isfinite(weighted_residual_square_sum)) {
+                    return {
+                        std::numeric_limits<double>::quiet_NaN(),
+                        std::numeric_limits<double>::quiet_NaN(),
+                    };
+                }
+                const double absolute_decrease =
+                    previous_cost - weighted_residual_square_sum;
+                const double relative_decrease =
+                    previous_cost > 0.0
+                        ? absolute_decrease / previous_cost
+                        : absolute_decrease;
+                return {absolute_decrease, relative_decrease};
+            };
+            auto record_cost_trace = [&](double update_norm, bool converged) {
+                const auto [absolute_decrease, relative_decrease] = cost_delta();
+                FGOProcessor::CostTraceEntry entry;
+                entry.phase = phase;
+                entry.local_iteration = iter;
+                entry.global_iteration = global_iteration_offset + iter;
+                entry.cost = weighted_residual_square_sum;
+                entry.absolute_decrease = absolute_decrease;
+                entry.relative_decrease = relative_decrease;
+                entry.update_norm = update_norm;
+                entry.converged = converged;
+                output.cost_trace_entries.push_back(std::move(entry));
+            };
+
             Eigen::VectorXd dx;
             bool solved = false;
             Eigen::SparseMatrix<double> current_sparse_normal;
@@ -2784,6 +2818,8 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
                     }
                     output.iterations = iter;
                     output.converged = true;
+                    record_cost_trace(
+                        std::numeric_limits<double>::quiet_NaN(), true);
                     break;
                 }
 
@@ -2815,6 +2851,8 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
                     store_current_linearization();
                     output.iterations = iter;
                     output.converged = true;
+                    record_cost_trace(
+                        std::numeric_limits<double>::quiet_NaN(), true);
                     break;
                 }
                 const double max_diagonal =
@@ -2848,9 +2886,12 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
                  config_.use_epoch_lambda_fixed_output)) {
                 output.sparse_normal_matrix = std::move(current_sparse_normal);
             }
+            const bool update_converged =
+                output.last_dx_norm < config_.convergence_threshold_m;
+            record_cost_trace(output.last_dx_norm, update_converged);
             previous_cost = weighted_residual_square_sum;
 
-            if (output.last_dx_norm < config_.convergence_threshold_m) {
+            if (update_converged) {
                 output.converged = true;
                 break;
             }
@@ -2864,7 +2905,8 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
         return output;
     };
 
-    OptimizationOutput optimization = run_optimizer(initial_state, {});
+    OptimizationOutput optimization = run_optimizer(initial_state, {}, "float", 0);
+    result.cost_trace_entries = optimization.cost_trace_entries;
     int total_iterations = optimization.iterations;
     double total_processing_ms = optimization.processing_ms;
     std::vector<FixedAmbiguityConstraint> fixed_constraints;
@@ -3104,10 +3146,21 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
 
         if (static_cast<int>(fixed_constraints.size()) >=
             std::max(1, config_.min_fixed_ambiguities)) {
+            const int fixed_global_iteration_offset =
+                result.cost_trace_entries.empty()
+                    ? total_iterations
+                    : result.cost_trace_entries.back().global_iteration + 1;
             OptimizationOutput fixed_optimization =
-                run_optimizer(optimization.state, fixed_constraints);
+                run_optimizer(optimization.state,
+                              fixed_constraints,
+                              "fixed",
+                              fixed_global_iteration_offset);
             total_iterations += fixed_optimization.iterations;
             total_processing_ms += fixed_optimization.processing_ms;
+            result.cost_trace_entries.insert(
+                result.cost_trace_entries.end(),
+                fixed_optimization.cost_trace_entries.begin(),
+                fixed_optimization.cost_trace_entries.end());
             optimization = std::move(fixed_optimization);
             result.diagnostics.fixed_solution = true;
             result.diagnostics.fixed_ambiguities = fixed_constraints.size();
@@ -3121,6 +3174,9 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
 
     const Eigen::VectorXd& state = optimization.state;
     result.diagnostics.iterations = total_iterations;
+    if (!result.cost_trace_entries.empty()) {
+        result.diagnostics.initial_cost = result.cost_trace_entries.front().cost;
+    }
     result.diagnostics.final_cost = optimization.final_cost;
     result.diagnostics.converged = optimization.converged;
     if (!result.diagnostics.converged &&

--- a/tests/test_ppc_taroz_amb_pdc_smoke.py
+++ b/tests/test_ppc_taroz_amb_pdc_smoke.py
@@ -251,6 +251,33 @@ class PpcTarozAmbPdcSmokeTest(unittest.TestCase):
         self.assertEqual(fixed_candidates, native["lambda_ambiguity_used_candidates"])
         self.assertEqual(fixed_epochs, native["fixed_solutions"])
 
+    def assert_cost_trace_matches_summary(self, run_payload: dict[str, object]) -> None:
+        outputs = run_payload["outputs"]
+        if "cost_trace" not in outputs:
+            self.skipTest("missing optional PPC taroz cost trace output path")
+        cost_path = Path(outputs["cost_trace"])
+        if not cost_path.exists():
+            self.skipTest(f"missing optional PPC taroz cost trace artifact: {cost_path}")
+
+        with cost_path.open(newline="") as handle:
+            rows = list(csv.DictReader(handle))
+        native = run_payload["native_summary"]
+
+        self.assertGreater(len(rows), 0)
+        self.assertEqual(rows[0]["phase"], "float")
+        self.assertEqual(int(rows[0]["local_iteration"]), 0)
+        self.assertEqual(int(rows[0]["global_iteration"]), 0)
+        self.assertAlmostEqual(float(rows[0]["cost"]), float(native["initial_cost"]), places=5)
+        self.assertAlmostEqual(float(rows[-1]["cost"]), float(native["final_cost"]), places=5)
+        phases = {row["phase"] for row in rows}
+        self.assertTrue(phases <= {"float", "fixed"})
+        self.assertTrue(all(math.isfinite(float(row["cost"])) for row in rows))
+        self.assertTrue(all(float(row["cost"]) >= 0.0 for row in rows))
+        global_iterations = [int(row["global_iteration"]) for row in rows]
+        self.assertEqual(global_iterations, sorted(global_iterations))
+        self.assertEqual(len(global_iterations), len(set(global_iterations)))
+        self.assertLessEqual(len(rows), int(native["iterations"]) + len(phases))
+
     def make_run(self, root: Path, spec: str) -> Path:
         site, run_name = spec.split("/")
         run_dir = root / site / run_name
@@ -311,6 +338,7 @@ class PpcTarozAmbPdcSmokeTest(unittest.TestCase):
             self.assertIn("--preset", command)
             self.assertIn("taroz-amb-pdc", command)
             self.assertIn("--lambda-debug-csv", command)
+            self.assertIn("--cost-trace-csv", command)
             self.assertIn("--max-epochs", command)
             self.assertIn("20", command)
 
@@ -592,6 +620,11 @@ class PpcTarozAmbPdcSmokeTest(unittest.TestCase):
         payload = self.require_summary(NAGOYA_RUN3_1000_SEED_SUMMARY)
 
         self.assert_lambda_debug_matches_epoch_debug(payload["runs"]["nagoya/run3"])
+
+    def test_optional_nagoya_run3_1000_epoch_cost_trace_contract(self) -> None:
+        payload = self.require_summary(NAGOYA_RUN3_1000_SEED_SUMMARY)
+
+        self.assert_cost_trace_matches_summary(payload["runs"]["nagoya/run3"])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- add Eigen FGO per-iteration cost trace entries and `--cost-trace-csv`
- include the trace path and full-precision double costs in `gnss_fgo` summary JSON
- emit and validate PPC taroz smoke `cost_trace.csv`, including the 1000-epoch nagoya/run3 dogfood artifact contract

## Validation
- `cmake --build build-codex --target gnss_fgo -j2`
- `python3 apps/gnss.py ppc-taroz-amb-pdc-smoke --dataset-root $workspace/arxiv/tier1/gnss_gpu_ws/ref/PPC-Dataset --fgo-bin build-codex/apps/gnss_fgo --spp-bin build-codex/apps/gnss_spp --run nagoya/run3 --max-epochs 1000 --generate-spp-seed --summary-json output/dogfood/ppc_taroz_amb_pdc_nagoya_run3_1000_seed_current/summary.json --out-dir output/dogfood/ppc_taroz_amb_pdc_nagoya_run3_1000_seed_current`
- `python3 tests/test_ppc_taroz_amb_pdc_smoke.py`
- `ctest --test-dir build-codex -R python_ppc_taroz_amb_pdc_smoke_tests --output-on-failure`
- `git diff --check`

Note: local `docs/libgnsspp_architecture.png` remains an unrelated dirty file and is not part of this PR.
