### PR TITLE
Add taroz amb PDC cost trace parity

### DIFF
--- a/apps/gnss_taroz_pos_vel_amb_pdc_dogfood.py
+++ b/apps/gnss_taroz_pos_vel_amb_pdc_dogfood.py
@@ -36,6 +36,7 @@ EPOCH_DEBUG_NAME = "epoch_debug.csv"
 FACTOR_DEBUG_NAME = "factor_debug.csv"
 SD_FACTOR_DEBUG_NAME = "sd_factor_debug.csv"
 LAMBDA_DEBUG_NAME = "lambda_debug.csv"
+COST_TRACE_NAME = "cost_trace.csv"
 
 EXPECTED_FULL_COUNTS = {
     "input_epochs": 1141,
@@ -105,6 +106,7 @@ def output_paths(out_dir: Path) -> dict[str, Path]:
         "factor_debug": out_dir / FACTOR_DEBUG_NAME,
         "sd_factor_debug": out_dir / SD_FACTOR_DEBUG_NAME,
         "lambda_debug": out_dir / LAMBDA_DEBUG_NAME,
+        "cost_trace": out_dir / COST_TRACE_NAME,
     }
 
 
@@ -143,6 +145,8 @@ def build_fgo_command(args: argparse.Namespace, paths: dict[str, Path]) -> list[
         str(paths["sd_factor_debug"]),
         "--lambda-debug-csv",
         str(paths["lambda_debug"]),
+        "--cost-trace-csv",
+        str(paths["cost_trace"]),
         "--max-float-seed-divergence",
         "0",
         "--max-float-position-jump",
@@ -242,7 +246,9 @@ def selected_native_summary(summary: dict[str, Any]) -> dict[str, Any]:
         "float_rejected_seed_position_divergence",
         "float_rejected_position_jump",
         "iterations",
+        "cost_trace_csv",
         "converged",
+        "initial_cost",
         "final_cost",
         "epoch_lambda_processing_time_ms",
         "epoch_lambda_covariance_solve_time_ms",
@@ -353,6 +359,9 @@ def run_parity(args: argparse.Namespace, paths: dict[str, Path], out_dir: Path) 
     )
     env["GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_OPT_LAMBDA_DEBUG"] = str(
         paths["lambda_debug"]
+    )
+    env["GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_OPT_COST_TRACE"] = str(
+        paths["cost_trace"]
     )
     return run_command([sys.executable, str(args.parity_test)], env=env)
 

--- a/tests/test_taroz_pos_vel_amb_pdc_dogfood.py
+++ b/tests/test_taroz_pos_vel_amb_pdc_dogfood.py
@@ -128,6 +128,7 @@ class TarozPosVelAmbPdcDogfoodTest(unittest.TestCase):
             self.assertIn("--factor-debug-csv", command)
             self.assertIn("--sd-factor-debug-csv", command)
             self.assertIn("--lambda-debug-csv", command)
+            self.assertIn("--cost-trace-csv", command)
             self.assertIn("--max-float-seed-divergence", command)
             self.assertIn("--max-float-position-jump", command)
             self.assertEqual(payload["expected"]["counts"]["fixed_solutions"], 721)

--- a/tests/test_taroz_pos_vel_amb_pdc_factor_parity.py
+++ b/tests/test_taroz_pos_vel_amb_pdc_factor_parity.py
@@ -44,6 +44,10 @@ CPP_OPT_LAMBDA_DEBUG = configured_path(
     "GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_OPT_LAMBDA_DEBUG",
     "output/dogfood/taroz_pos_vel_amb_pdc_current/lambda_debug.csv",
 )
+CPP_OPT_COST_TRACE = configured_path(
+    "GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_OPT_COST_TRACE",
+    "output/dogfood/taroz_pos_vel_amb_pdc_current/cost_trace.csv",
+)
 
 
 def display_path(path: Path) -> str:
@@ -349,6 +353,41 @@ class TarozPosVelAmbPdcFactorParityTest(unittest.TestCase):
                 float(summary["final_cost"]),
                 float(taroz_graph["final_cost"]),
             ),
+            0.30,
+        )
+
+    def test_cost_trace_matches_summary_and_taroz_graph_costs(self) -> None:
+        summary_path = CPP_DIR / "summary.json"
+        taroz_graph_path = MATLAB_DIR / "graph_detail.csv"
+        self.require_dogfood_files(summary_path, CPP_OPT_COST_TRACE, taroz_graph_path)
+
+        summary = read_json(summary_path)
+        rows = read_rows(CPP_OPT_COST_TRACE)
+        taroz_graph = read_rows(taroz_graph_path)[0]
+
+        self.assertGreater(len(rows), 0)
+        self.assertEqual(rows[0]["phase"], "float")
+        self.assertEqual(int(rows[0]["local_iteration"]), 0)
+        self.assertEqual(int(rows[0]["global_iteration"]), 0)
+        self.assertTrue(all(row["phase"] in {"float", "fixed"} for row in rows))
+        self.assertTrue(all(math.isfinite(float(row["cost"])) for row in rows))
+        self.assertTrue(all(float(row["cost"]) >= 0.0 for row in rows))
+
+        global_iterations = [int(row["global_iteration"]) for row in rows]
+        self.assertEqual(global_iterations, sorted(global_iterations))
+        self.assertEqual(len(global_iterations), len(set(global_iterations)))
+        phase_count = len({row["phase"] for row in rows})
+        self.assertLessEqual(len(rows), int(summary["iterations"]) + phase_count)
+
+        self.assertEqual(float(rows[0]["cost"]), float(summary["initial_cost"]))
+        self.assertEqual(float(rows[-1]["cost"]), float(summary["final_cost"]))
+        self.assertLess(float(rows[-1]["cost"]), float(rows[0]["cost"]))
+        self.assertLess(
+            float(taroz_graph["final_cost"]),
+            float(taroz_graph["initial_cost"]),
+        )
+        self.assertLessEqual(
+            relative_error(float(rows[-1]["cost"]), float(taroz_graph["final_cost"])),
             0.30,
         )
 


### PR DESCRIPTION
## Summary
- emit `cost_trace.csv` from the taroz position/velocity ambiguity PDC dogfood harness
- include `cost_trace_csv` and `initial_cost` in the harness selected native summary
- add optional parity coverage tying C++ cost trace to C++ summary and MATLAB taroz graph final-cost scale

## Validation
- `python3 tests/test_taroz_pos_vel_amb_pdc_dogfood.py`
- `python3 tests/test_taroz_pos_vel_amb_pdc_factor_parity.py`
- `GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_DIR=output/dogfood/taroz_pos_vel_amb_pdc_current GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_OPT_POS=output/dogfood/taroz_pos_vel_amb_pdc_current/opt.pos GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_OPT_EPOCH_DEBUG=output/dogfood/taroz_pos_vel_amb_pdc_current/epoch_debug.csv GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_OPT_LAMBDA_DEBUG=output/dogfood/taroz_pos_vel_amb_pdc_current/lambda_debug.csv GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_OPT_COST_TRACE=output/dogfood/taroz_pos_vel_amb_pdc_current/cost_trace.csv GNSSPP_TAROZ_POS_VEL_AMB_PDC_MATLAB_DIR=output/dogfood/taroz_matlab_pos_vel_amb_pdc_debug python3 tests/test_taroz_pos_vel_amb_pdc_factor_parity.py`
- `python3 apps/gnss.py taroz-pos-vel-amb-pdc-dogfood --obs $workspace/arxiv/tier1/gnss_gpu_ws/ref/gtsam_gnss/examples/data/rover_1Hz.obs --base $workspace/arxiv/tier1/gnss_gpu_ws/ref/gtsam_gnss/examples/data/base.obs --nav $workspace/arxiv/tier1/gnss_gpu_ws/ref/gtsam_gnss/examples/data/base.nav --seed-pos $workspace/arxiv/tier1/gnss_gpu_ws/ref/gtsam_gnss/examples/data/rover_1Hz_spp.pos --fgo-bin build-codex/apps/gnss_fgo --out-dir output/dogfood/taroz_pos_vel_amb_pdc_current --summary-json output/dogfood/taroz_pos_vel_amb_pdc_current/taroz_pos_vel_amb_pdc_dogfood_summary.json`
- `ctest --test-dir build-codex -R 'python_taroz_pos_vel_amb_pdc_(factor_parity|dogfood)_tests' --output-on-failure`
- `git diff --check`

Note: local `docs/libgnsspp_architecture.png` remains an unrelated dirty file and is not part of this PR.
