### PR TITLE
Add MATLAB taroz optimizer cost trace dump

### DIFF
--- a/README.md
+++ b/README.md
@@ -520,7 +520,8 @@ The current beta sign-off is:
   C++ diagnostics locally; `taroz-oracle-suite` is the consolidated local
   entrypoint for rerunning that gate.
 - Remaining parity work: broaden intermediate seed state, ambiguity candidates,
-  solver costs, and final epoch-output checks before calling the port complete.
+  additional solver-cost trajectories, and final epoch-output checks before
+  calling the port complete.
 
 Other benchmark artifacts and checked sign-offs are documented in
 [Benchmarks](docs/benchmarks.md) and [Validation](docs/validation.md).

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -201,7 +201,7 @@ parity artifacts are not checked into the repository.
 | position PDC | `taroz-observable-dogfood --mode pos-pdc` | position/clock `per_epoch_state.csv` and graph/summary counts |
 | position/velocity PDC | `taroz-observable-dogfood --mode pos-vel-pdc` | position/velocity/clock `per_epoch_state.csv` and graph/summary counts |
 | PC | `taroz-pc-dogfood` | final `.pos`, epoch debug, factor debug, LAMBDA debug, and summary counts |
-| position/velocity ambiguity PDC | `taroz-pos-vel-amb-pdc-dogfood` | epoch debug, factor debug, SD factor debug, LAMBDA debug, and summary counts |
+| position/velocity ambiguity PDC | `taroz-pos-vel-amb-pdc-dogfood` | epoch debug, factor debug, SD factor debug, LAMBDA debug, optimizer cost trace, and summary counts |
 
 Use the suite entrypoint for a broad local gate:
 
@@ -237,8 +237,8 @@ ctest --test-dir build-codex -R 'python_taroz_.*(internal_parity|factor_parity)_
 
 The remaining beta-hardening work is broader than final-output shape: keep
 expanding MATLAB dump parity for intermediate seed state, ambiguity candidate
-selection, solver cost trajectories, and longer PPC-Dataset windows before
-treating the taroz port as complete.
+selection, additional solver-cost trajectories, and longer PPC-Dataset windows
+before treating the taroz port as complete.
 
 When `--generate-spp-seed` is used, the PPC harness treats the generated seed as
 part of the sign-off. The native summary must report a seed path,

--- a/scripts/dump_taroz_pos_vel_ambiguity_pdc_debug.m
+++ b/scripts/dump_taroz_pos_vel_ambiguity_pdc_debug.m
@@ -23,6 +23,8 @@ if ~isfolder(out_dir)
     mkdir(out_dir);
 end
 
+configure_matlab_paths(taroz_root, example_dir);
+
 set(0, "DefaultFigureVisible", "off");
 cd(example_dir);
 estimate_pos_vel_ambiguity_PDC;
@@ -57,6 +59,7 @@ graph_table = table(n, nsat, graph_factors, graph_values, initial_cost, ...
                     valid_position_epochs, valid_velocity_epochs, ...
                     valid_ambiguity_states, fixed_epochs);
 writetable(graph_table, fullfile(out_dir, "graph_detail.csv"));
+write_optimizer_cost_trace(out_dir, graph, initials, initial_cost, final_cost, iterations);
 
 epoch = (1:n)';
 gps_week = obs.time.week(:);
@@ -294,6 +297,111 @@ lambda_table = table(lambda_epoch, lambda_gps_week, lambda_gps_tow, ...
 writetable(lambda_table, fullfile(out_dir, "per_lambda_detail.csv"));
 
 fprintf("Wrote taroz position/velocity ambiguity PDC debug CSVs to %s\n", out_dir);
+
+function configure_matlab_paths(taroz_root, example_dir)
+    add_matlab_path_if_folder(example_dir);
+    add_matlab_path_if_folder(fullfile(example_dir, "function"));
+    add_matlab_path_if_folder(fullfile(taroz_root, "examples"));
+    add_matlab_path_if_folder(fullfile(taroz_root, "examples", "function"));
+    add_matlab_path_if_folder(fullfile(taroz_root, "install", "gtsam_gnss", "gtsam_toolbox"));
+    add_matlab_path_if_folder(fullfile(taroz_root, "matlab_local", "gtsam_toolbox"));
+    add_matlab_path_if_folder(fullfile(taroz_root, "..", "matlab_local", "gtsam_toolbox"));
+    add_matlab_path_if_folder(fullfile(taroz_root, "..", "MatRTKLIB"));
+    add_matlab_path_if_folder("/usr/local/gtsam_toolbox");
+    add_matlab_path_list(getenv("GNSSPP_TAROZ_MATLAB_PATHS"));
+    add_matlab_path_list(getenv("GNSSPP_TAROZ_MATLAB_EXTRA_PATHS"));
+end
+
+function add_matlab_path_if_folder(path_value)
+    path_value = string(path_value);
+    if strlength(path_value) > 0 && isfolder(path_value)
+        addpath(char(path_value));
+    end
+end
+
+function add_matlab_path_list(path_list)
+    path_list = string(path_list);
+    if strlength(path_list) == 0
+        return;
+    end
+    paths = split(path_list, pathsep);
+    for i = 1:numel(paths)
+        add_matlab_path_if_folder(strtrim(paths(i)));
+    end
+end
+
+function write_optimizer_cost_trace(out_dir, graph, initials, initial_cost, final_cost, iterations)
+    max_iterations = 0;
+    if isfinite(iterations)
+        max_iterations = max(0, round(iterations));
+    end
+
+    phase = repmat("gtsam", max_iterations + 1, 1);
+    local_iteration = (0:max_iterations)';
+    global_iteration = local_iteration;
+    time_s = NaN(max_iterations + 1, 1);
+    cost = NaN(max_iterations + 1, 1);
+    absolute_decrease = NaN(max_iterations + 1, 1);
+    relative_decrease = NaN(max_iterations + 1, 1);
+    lambda = NaN(max_iterations + 1, 1);
+    actual_rows = 0;
+
+    try
+        trace_params = gtsam.LevenbergMarquardtParams;
+        trace_params.setVerbosity('TERMINATION');
+        trace_params.setMaxIterations(1000);
+        trace_optimizer = gtsam.LevenbergMarquardtOptimizer(graph, initials, trace_params);
+
+        trace_timer = tic;
+        actual_rows = 1;
+        time_s(1) = 0.0;
+        cost(1) = trace_optimizer.error;
+        lambda(1) = trace_optimizer.lambda;
+        for iter = 1:max_iterations
+            trace_optimizer.iterate();
+            actual_rows = iter + 1;
+            time_s(actual_rows) = toc(trace_timer);
+            cost(actual_rows) = trace_optimizer.error;
+            lambda(actual_rows) = trace_optimizer.lambda;
+        end
+    catch trace_error
+        warning("Failed to generate GTSAM optimizer cost trace: %s", trace_error.message);
+    end
+
+    if actual_rows == 0
+        phase = ["gtsam"; "gtsam"];
+        local_iteration = [0; max_iterations];
+        global_iteration = local_iteration;
+        time_s = [0.0; NaN];
+        cost = [initial_cost; final_cost];
+        absolute_decrease = [NaN; initial_cost - final_cost];
+        relative_decrease = [NaN; (initial_cost - final_cost) / max(1.0, initial_cost)];
+        lambda = [NaN; NaN];
+    else
+        phase = phase(1:actual_rows);
+        local_iteration = local_iteration(1:actual_rows);
+        global_iteration = global_iteration(1:actual_rows);
+        time_s = time_s(1:actual_rows);
+        cost = cost(1:actual_rows);
+        lambda = lambda(1:actual_rows);
+        absolute_decrease = absolute_decrease(1:actual_rows);
+        relative_decrease = relative_decrease(1:actual_rows);
+        for row = 2:actual_rows
+            if isfinite(cost(row - 1)) && isfinite(cost(row))
+                absolute_decrease(row) = cost(row - 1) - cost(row);
+                if cost(row - 1) > 0
+                    relative_decrease(row) = absolute_decrease(row) / cost(row - 1);
+                else
+                    relative_decrease(row) = absolute_decrease(row);
+                end
+            end
+        end
+    end
+
+    cost_trace_table = table(phase, local_iteration, global_iteration, time_s, ...
+                             cost, absolute_decrease, relative_decrease, lambda);
+    writetable(cost_trace_table, fullfile(out_dir, "optimizer_cost_trace.csv"));
+end
 
 function value = scalar_or_nan(callback)
     try

--- a/tests/test_taroz_pos_vel_amb_pdc_factor_parity.py
+++ b/tests/test_taroz_pos_vel_amb_pdc_factor_parity.py
@@ -48,6 +48,10 @@ CPP_OPT_COST_TRACE = configured_path(
     "GNSSPP_TAROZ_POS_VEL_AMB_PDC_CPP_OPT_COST_TRACE",
     "output/dogfood/taroz_pos_vel_amb_pdc_current/cost_trace.csv",
 )
+MATLAB_OPTIMIZER_COST_TRACE = configured_path(
+    "GNSSPP_TAROZ_POS_VEL_AMB_PDC_MATLAB_COST_TRACE",
+    "output/dogfood/taroz_matlab_pos_vel_amb_pdc_debug/optimizer_cost_trace.csv",
+)
 
 
 def display_path(path: Path) -> str:
@@ -390,6 +394,54 @@ class TarozPosVelAmbPdcFactorParityTest(unittest.TestCase):
             relative_error(float(rows[-1]["cost"]), float(taroz_graph["final_cost"])),
             0.30,
         )
+
+    def test_matlab_optimizer_cost_trace_matches_taroz_graph_and_cpp_scale(self) -> None:
+        summary_path = CPP_DIR / "summary.json"
+        taroz_graph_path = MATLAB_DIR / "graph_detail.csv"
+        self.require_dogfood_files(
+            summary_path,
+            CPP_OPT_COST_TRACE,
+            taroz_graph_path,
+            MATLAB_OPTIMIZER_COST_TRACE,
+        )
+
+        summary = read_json(summary_path)
+        cpp_rows = read_rows(CPP_OPT_COST_TRACE)
+        matlab_rows = read_rows(MATLAB_OPTIMIZER_COST_TRACE)
+        taroz_graph = read_rows(taroz_graph_path)[0]
+
+        self.assertGreater(len(matlab_rows), 1)
+        self.assertTrue(all(row["phase"] == "gtsam" for row in matlab_rows))
+        self.assertEqual(int(matlab_rows[0]["local_iteration"]), 0)
+        self.assertEqual(int(matlab_rows[0]["global_iteration"]), 0)
+        matlab_iterations = [int(row["global_iteration"]) for row in matlab_rows]
+        self.assertEqual(matlab_iterations, sorted(matlab_iterations))
+        self.assertEqual(len(matlab_iterations), len(set(matlab_iterations)))
+        self.assertEqual(len(matlab_rows), int(float(taroz_graph["iterations"])) + 1)
+        self.assertTrue(all(math.isfinite(float(row["cost"])) for row in matlab_rows))
+        self.assertTrue(all(float(row["cost"]) >= 0.0 for row in matlab_rows))
+        self.assertLess(float(matlab_rows[-1]["cost"]), float(matlab_rows[0]["cost"]))
+        self.assertLess(float(cpp_rows[-1]["cost"]), float(cpp_rows[0]["cost"]))
+
+        self.assertLessEqual(
+            relative_error(
+                float(matlab_rows[0]["cost"]),
+                float(taroz_graph["initial_cost"]),
+            ),
+            1e-9,
+        )
+        self.assertLessEqual(
+            relative_error(
+                float(matlab_rows[-1]["cost"]),
+                float(taroz_graph["final_cost"]),
+            ),
+            1e-9,
+        )
+        self.assertLessEqual(
+            relative_error(float(cpp_rows[-1]["cost"]), float(matlab_rows[-1]["cost"])),
+            0.30,
+        )
+        self.assertEqual(float(cpp_rows[-1]["cost"]), float(summary["final_cost"]))
 
     def test_seed_positions_match_taroz_spp_seed_dump(self) -> None:
         cpp_epoch_path = CPP_DIR / "epoch_debug.csv"


### PR DESCRIPTION
## Summary
- add MATLAB path setup for the taroz ambiguity PDC dump, including local GTSAM toolbox and MatRTKLIB/readobs candidates
- emit `optimizer_cost_trace.csv` from the MATLAB GTSAM optimizer trajectory
- add parity coverage that ties the MATLAB cost trace to taroz `graph_detail.csv` and compares final scale with the C++ cost trace
- update validation/README wording now that this cost trace is covered

## Validation
- `python3 apps/gnss.py taroz-pos-vel-amb-pdc-dogfood --generate-matlab-dump --taroz-root $workspace/arxiv/tier1/gnss_gpu_ws/ref/gtsam_gnss --taroz-example-dir $workspace/arxiv/tier1/gnss_gpu_ws/ref/gtsam_gnss/examples --matlab-dir output/dogfood/taroz_matlab_pos_vel_amb_pdc_debug --obs $workspace/arxiv/tier1/gnss_gpu_ws/ref/gtsam_gnss/examples/data/rover_1Hz.obs --base $workspace/arxiv/tier1/gnss_gpu_ws/ref/gtsam_gnss/examples/data/base.obs --nav $workspace/arxiv/tier1/gnss_gpu_ws/ref/gtsam_gnss/examples/data/base.nav --seed-pos $workspace/arxiv/tier1/gnss_gpu_ws/ref/gtsam_gnss/examples/data/rover_1Hz_spp.pos --fgo-bin build-codex/apps/gnss_fgo --out-dir output/dogfood/taroz_pos_vel_amb_pdc_current --summary-json output/dogfood/taroz_pos_vel_amb_pdc_current/taroz_pos_vel_amb_pdc_dogfood_summary.json`
- `python3 tests/test_taroz_pos_vel_amb_pdc_factor_parity.py`
- `python3 tests/test_taroz_pos_vel_amb_pdc_dogfood.py`
- `ctest --test-dir build-codex -R 'python_taroz_pos_vel_amb_pdc_(factor_parity|dogfood)_tests' --output-on-failure`
- `git diff --check`
