### PR TITLE
Add PPC taroz long optional signoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -276,11 +276,16 @@ jobs:
           output/ci_optional_rtk_signoffs/*.log
           output/ppc_nagoya_run1_rtk_summary.json
           output/ppc_nagoya_run1_rtk.pos
-          output/ppc_nagoya_run1_rtk_events.csv
           output/ppc_tokyo_run1_rtk_summary.json
           output/ppc_tokyo_run1_rtk.pos
-          output/ppc_tokyo_run1_rtk_events.csv
           output/ppc_tokyo_run1_rtk_rtklib.pos
+          output/dogfood/ppc_taroz_amb_pdc_nagoya_run3_1000_seed_current/summary.json
+          output/dogfood/ppc_taroz_amb_pdc_nagoya_run3_1000_seed_current/nagoya_run3/summary.json
+          output/dogfood/ppc_taroz_amb_pdc_nagoya_run3_1000_seed_current/nagoya_run3/spp_seed.pos
+          output/dogfood/ppc_taroz_amb_pdc_nagoya_run3_1000_seed_current/nagoya_run3/fgo.pos
+          output/dogfood/ppc_taroz_amb_pdc_nagoya_run3_1000_seed_current/nagoya_run3/epoch_debug.csv
+          output/dogfood/ppc_taroz_amb_pdc_nagoya_run3_1000_seed_current/nagoya_run3/lambda_debug.csv
+          output/dogfood/ppc_taroz_amb_pdc_nagoya_run3_1000_seed_current/nagoya_run3/cost_trace.csv
           output/scorpion_moving_base_summary.json
           output/scorpion_moving_base/prepare_summary.json
           output/scorpion_moving_base/products_summary.json

--- a/README.md
+++ b/README.md
@@ -510,7 +510,9 @@ the MATLAB oracles under the suite output root before each parity run.
 
 The current beta sign-off is:
 
-- CI: C++ FGO unit tests plus the lightweight 20-epoch PPC smoke.
+- CI: C++ FGO unit tests plus the lightweight 20-epoch PPC smoke; the
+  dataset-gated optional sign-off runner also exercises `nagoya/run3` for
+  1000 epochs with generated SPP seed when PPC-Dataset is configured.
 - Local dogfood: all six public PPC Tokyo/Nagoya runs at 200 epochs with
   generated SPP seeds and `--require-valid-p95-3d-max 2.0`.
 - Shifted-window guard check: `nagoya/run3 --skip-epochs 400 --max-epochs 200`

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -40,7 +40,9 @@ CI lanes are split as follows:
 - `bash scripts/ci/run_core_tests.sh` for the cross-platform gate
 - `bash scripts/ci/run_extended_tests.sh` for Linux-only heavy checks such as web, packaging, and ROS2 surfaces
 - `bash scripts/ci/run_optional_tests.sh` for broader Linux-only integration suites such as the full CLI and benchmark script regressions
-- `bash scripts/ci/run_optional_rtk_signoffs.sh` for dataset-gated RTK sign-offs with JSON/log artifacts under `output/ci_optional_rtk_signoffs*`
+- `bash scripts/ci/run_optional_rtk_signoffs.sh` for dataset-gated RTK,
+  SCORPION, and long PPC taroz FGO sign-offs with JSON/log artifacts under
+  `output/ci_optional_rtk_signoffs*`
 - `bash scripts/ci/generate_dashboard_artifacts.sh` for the dashboard/manifest artifact path used in CI
 
 Docs-only changes keep CI on the lightweight path: hygiene here, plus the separate Docs workflow.
@@ -63,6 +65,7 @@ Keep taroz FGO validation split by cost:
   `python3 apps/gnss.py taroz-pos-vel-amb-pdc-dogfood --generate-matlab-dump`
   when MATLAB and the taroz checkout are available,
   `python3 apps/gnss.py ppc-taroz-amb-pdc-smoke --max-epochs 200 --generate-spp-seed`,
+  `python3 apps/gnss.py ppc-taroz-amb-pdc-smoke --run nagoya/run3 --max-epochs 1000 --generate-spp-seed`,
   and optional MATLAB/taroz parity tests when their external artifacts are present.
 - Taroz final-output contract tests should be updated with every new dogfood
   output surface. At minimum, tie the final CSV/`.pos` rows to summary counts,

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -175,7 +175,20 @@ python3 apps/gnss.py ppc-taroz-amb-pdc-smoke \
   --generate-spp-seed \
   --require-valid-p95-3d-max 2.0 \
   --summary-json output/dogfood/ppc_taroz_amb_pdc_nagoya_run3_shifted/summary.json
+
+python3 apps/gnss.py ppc-taroz-amb-pdc-smoke \
+  --dataset-root /datasets/PPC-Dataset \
+  --run nagoya/run3 \
+  --max-epochs 1000 \
+  --generate-spp-seed \
+  --require-valid-p95-3d-max 1.1 \
+  --require-fixed-p95-3d-max 0.2 \
+  --summary-json output/dogfood/ppc_taroz_amb_pdc_nagoya_run3_1000_seed_current/summary.json
 ```
+
+The dataset-gated optional CI sign-off runner also includes the
+`nagoya/run3` 1000-epoch generated-seed check when `GNSSPP_PPC_DATASET_ROOT`
+is configured.
 
 The `taroz-amb-pdc` preset enables two truth-free FLOAT output guards by
 default: `--max-float-seed-divergence 100` and

--- a/scripts/ci/run_optional_rtk_signoffs.py
+++ b/scripts/ci/run_optional_rtk_signoffs.py
@@ -87,7 +87,6 @@ def make_ppc_rtk_step(context: SignoffContext, city: str, *, require_rtklib: boo
     outputs = [
         context.output_dir / f"{slug}_summary.json",
         context.output_dir / f"{slug}.pos",
-        context.output_dir / f"{slug}_events.csv",
     ]
     if require_rtklib:
         outputs.append(context.output_dir / f"{slug}_rtklib.pos")
@@ -108,8 +107,6 @@ def make_ppc_rtk_step(context: SignoffContext, city: str, *, require_rtklib: boo
         "120",
         "--out",
         str(context.output_dir / f"{slug}.pos"),
-        "--debug-epoch-log",
-        str(context.output_dir / f"{slug}_events.csv"),
         "--summary-json",
         str(context.output_dir / f"{slug}_summary.json"),
     ]
@@ -123,6 +120,46 @@ def make_ppc_rtk_step(context: SignoffContext, city: str, *, require_rtklib: boo
             ]
         )
     return make_step(step_name, slug, command, outputs)
+
+
+def make_ppc_taroz_amb_pdc_long_step(context: SignoffContext) -> SignoffStep:
+    slug = "ppc_taroz_amb_pdc_nagoya_run3_1000_seed"
+    name = "PPC taroz ambiguity PDC long generated-seed sign-off"
+    out_dir = context.output_dir / "dogfood" / f"{slug}_current"
+    run_dir = out_dir / "nagoya_run3"
+    outputs = [
+        out_dir / "summary.json",
+        run_dir / "spp_seed.pos",
+        run_dir / "fgo.pos",
+        run_dir / "summary.json",
+        run_dir / "epoch_debug.csv",
+        run_dir / "lambda_debug.csv",
+        run_dir / "cost_trace.csv",
+    ]
+
+    if context.dataset_root is None or not context.dataset_root.is_dir():
+        return skip_step(name, slug, outputs, "PPC-Dataset root is unavailable.")
+
+    command = [
+        *context.gnss_command,
+        "ppc-taroz-amb-pdc-smoke",
+        "--dataset-root",
+        str(context.dataset_root),
+        "--run",
+        "nagoya/run3",
+        "--max-epochs",
+        "1000",
+        "--generate-spp-seed",
+        "--require-valid-p95-3d-max",
+        "1.1",
+        "--require-fixed-p95-3d-max",
+        "0.2",
+        "--out-dir",
+        str(out_dir),
+        "--summary-json",
+        str(out_dir / "summary.json"),
+    ]
+    return make_step(name, slug, command, outputs)
 
 
 def make_scorpion_step(context: SignoffContext) -> SignoffStep:
@@ -186,6 +223,7 @@ def build_step_plan(
     return [
         make_ppc_rtk_step(context, "nagoya", require_rtklib=False),
         make_ppc_rtk_step(context, "tokyo", require_rtklib=True),
+        make_ppc_taroz_amb_pdc_long_step(context),
         make_scorpion_step(context),
     ]
 

--- a/tests/test_benchmark_scripts.py
+++ b/tests/test_benchmark_scripts.py
@@ -3039,12 +3039,18 @@ class OptionalRTKSignoffScriptTest(unittest.TestCase):
 
             self.assertEqual(
                 [step.slug for step in steps],
-                ["ppc_nagoya_run1_rtk", "ppc_tokyo_run1_rtk", "scorpion_moving_base"],
+                [
+                    "ppc_nagoya_run1_rtk",
+                    "ppc_tokyo_run1_rtk",
+                    "ppc_taroz_amb_pdc_nagoya_run3_1000_seed",
+                    "scorpion_moving_base",
+                ],
             )
             self.assertTrue(all(step.command is None for step in steps))
             self.assertEqual(steps[0].skip_reason, "PPC-Dataset root is unavailable.")
             self.assertEqual(steps[1].skip_reason, "PPC-Dataset root is unavailable.")
-            self.assertEqual(steps[2].skip_reason, "SCORPION moving-base input is unavailable.")
+            self.assertEqual(steps[2].skip_reason, "PPC-Dataset root is unavailable.")
+            self.assertEqual(steps[3].skip_reason, "SCORPION moving-base input is unavailable.")
 
     def test_build_step_plan_uses_dataset_rtklib_and_scorpion_url(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ci_rtk_plan_") as temp_dir:
@@ -3063,15 +3069,27 @@ class OptionalRTKSignoffScriptTest(unittest.TestCase):
 
             steps = ci_rtk_signoffs.build_step_plan(ROOT_DIR, output_dir, env)
 
-            nagoya, tokyo, scorpion = steps
+            nagoya, tokyo, taroz_long, scorpion = steps
             self.assertIsNotNone(nagoya.command)
             self.assertIn("--dataset-root", nagoya.command)
             self.assertIn(str(dataset_root), nagoya.command)
-            self.assertIn("--debug-epoch-log", nagoya.command)
             self.assertIsNotNone(tokyo.command)
             self.assertIn("--rtklib-bin", tokyo.command)
             self.assertIn(str(rtklib_bin), tokyo.command)
             self.assertIn("--rtklib-pos", tokyo.command)
+            self.assertIsNotNone(taroz_long.command)
+            self.assertIn("ppc-taroz-amb-pdc-smoke", taroz_long.command)
+            self.assertIn("--dataset-root", taroz_long.command)
+            self.assertIn(str(dataset_root), taroz_long.command)
+            self.assertIn("--run", taroz_long.command)
+            self.assertIn("nagoya/run3", taroz_long.command)
+            self.assertIn("--max-epochs", taroz_long.command)
+            self.assertIn("1000", taroz_long.command)
+            self.assertIn("--generate-spp-seed", taroz_long.command)
+            self.assertIn("--require-valid-p95-3d-max", taroz_long.command)
+            self.assertIn("1.1", taroz_long.command)
+            self.assertIn("--require-fixed-p95-3d-max", taroz_long.command)
+            self.assertIn("0.2", taroz_long.command)
             self.assertIsNotNone(scorpion.command)
             self.assertIn("--input-url", scorpion.command)
             self.assertIn("https://example.com/scorpion.ubx", scorpion.command)
@@ -3087,10 +3105,11 @@ class OptionalRTKSignoffScriptTest(unittest.TestCase):
                 {"GNSSPP_PPC_DATASET_ROOT": str(dataset_root)},
             )
 
-            nagoya, tokyo, _ = steps
+            nagoya, tokyo, taroz_long, _ = steps
             self.assertIsNotNone(nagoya.command)
             self.assertIsNone(tokyo.command)
             self.assertEqual(tokyo.skip_reason, "RTKLIB binary is unavailable.")
+            self.assertIsNotNone(taroz_long.command)
 
     def test_run_step_writes_log_for_skipped_and_passed_steps(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ci_rtk_exec_") as temp_dir:


### PR DESCRIPTION
## Summary
- add a dataset-gated optional signoff step for PPC taroz ambiguity PDC on `nagoya/run3` for 1000 epochs with generated SPP seed
- upload the long signoff summary, seed, solution, epoch debug, LAMBDA debug, and cost trace artifacts from CI
- remove the stale `--debug-epoch-log` argument from the existing optional PPC RTK signoff step
- document the long PPC taroz signoff path and update step-plan tests

## Validation
- `python3 tests/test_benchmark_scripts.py OptionalRTKSignoffScriptTest`
- `python3 tests/test_ppc_taroz_amb_pdc_smoke.py`
- `ctest --test-dir build-codex -R 'python_(benchmark|ppc_taroz_amb_pdc_smoke)_tests' --output-on-failure`
- `GNSSPP_PPC_DATASET_ROOT=data/PPC-Dataset python3 scripts/ci/run_optional_rtk_signoffs.py --output-dir output/ci_optional_rtk_signoffs_current --summary-json output/ci_optional_rtk_signoffs_current/summary.json`
- `git diff --check`

Dataset-gated optional runner result with local PPC-Dataset: passed 2, failed 0, skipped 2. The new taroz long signoff passed with `optimized_epochs=1000`, `valid_solutions=783`, `fixed_solutions=406`, `float_solutions=377`, `seed_matched_epochs=1000`, valid p95 3D error `1.026136344`, and fixed p95 3D error `0.172619751`.
