### PR TITLE
Add taroz ambiguity option signoff profiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -521,9 +521,12 @@ The current beta sign-off is:
   position/velocity PD/PDC, PC, and ambiguity PDC dumps are compared against
   C++ diagnostics locally; `taroz-oracle-suite` is the consolidated local
   entrypoint for rerunning that gate.
+- Non-default ambiguity PDC option sign-offs: `taroz-pos-vel-amb-pdc-dogfood`
+  can enforce the `no-epoch-lambda-fixed-output` and `strict-lambda-ratio`
+  expectation profiles when those matching FGO flags are supplied.
 - Remaining parity work: broaden seed-state edge cases, solver-cost
-  trajectories across more windows, and non-default option coverage before
-  calling the port complete.
+  trajectories across more windows, and additional non-default option profiles
+  before calling the port complete.
 
 Other benchmark artifacts and checked sign-offs are documented in
 [Benchmarks](docs/benchmarks.md) and [Validation](docs/validation.md).

--- a/apps/gnss_fgo.cpp
+++ b/apps/gnss_fgo.cpp
@@ -1803,6 +1803,8 @@ void writeSummaryJson(const Options& options,
            << options.carrier_phase_huber_threshold_sigma << ",\n";
     output << "  \"tdcp_huber_threshold_sigma\": "
            << options.tdcp_huber_threshold_sigma << ",\n";
+    output << "  \"lambda_ratio_threshold\": "
+           << options.lambda_ratio_threshold << ",\n";
     output << "  \"position_prior_sigma_m\": "
            << options.position_prior_sigma_m << ",\n";
     output << "  \"clock_prior_sigma_m\": "

--- a/apps/gnss_taroz_pos_vel_amb_pdc_dogfood.py
+++ b/apps/gnss_taroz_pos_vel_amb_pdc_dogfood.py
@@ -61,6 +61,58 @@ EXPECTED_FULL_COUNTS = {
 }
 
 
+def _counts_with(**overrides: int) -> dict[str, int]:
+    counts = dict(EXPECTED_FULL_COUNTS)
+    counts.update(overrides)
+    return counts
+
+
+EXPECTATION_PROFILES: dict[str, dict[str, Any]] = {
+    "default": {
+        "counts": EXPECTED_FULL_COUNTS,
+        "lambda_ratio_threshold": 2.0,
+        "use_epoch_lambda_fixed_output": True,
+        "lambda_ambiguity_fix_used": True,
+        "fixed_solution": True,
+    },
+    "no-epoch-lambda-fixed-output": {
+        "counts": _counts_with(
+            fixed_solutions=0,
+            float_solutions=964,
+            lambda_ambiguity_used_candidates=0,
+            fixed_ambiguities=0,
+        ),
+        "lambda_ratio_threshold": 2.0,
+        "use_epoch_lambda_fixed_output": False,
+        "lambda_ambiguity_fix_used": False,
+        "fixed_solution": False,
+    },
+    "strict-lambda-ratio": {
+        "counts": _counts_with(
+            fixed_solutions=0,
+            float_solutions=964,
+            lambda_ambiguity_used_candidates=0,
+            fixed_ambiguities=0,
+        ),
+        "lambda_ratio_threshold": 100.0,
+        "use_epoch_lambda_fixed_output": True,
+        "lambda_ambiguity_fix_used": False,
+        "fixed_solution": False,
+    },
+}
+
+
+def expectation_profile(name: str) -> dict[str, Any]:
+    try:
+        return EXPECTATION_PROFILES[name]
+    except KeyError as exc:
+        valid = ", ".join(sorted(EXPECTATION_PROFILES))
+        raise SystemExit(
+            f"unsupported taroz ambiguity PDC expectation profile {name!r}; "
+            f"expected one of: {valid}"
+        ) from exc
+
+
 def default_path(name: str) -> Path:
     return DEFAULT_DATA_DIR / name
 
@@ -245,6 +297,7 @@ def selected_native_summary(summary: dict[str, Any]) -> dict[str, Any]:
         "max_float_position_jump_m",
         "float_rejected_seed_position_divergence",
         "float_rejected_position_jump",
+        "lambda_ratio_threshold",
         "iterations",
         "cost_trace_csv",
         "converged",
@@ -270,8 +323,12 @@ def _is_finite_number(value: Any) -> bool:
     return isinstance(value, (int, float)) and math.isfinite(float(value))
 
 
-def verify_native_summary(summary: dict[str, Any]) -> list[str]:
+def verify_native_summary(
+    summary: dict[str, Any],
+    profile_name: str = "default",
+) -> list[str]:
     failures: list[str] = []
+    profile = expectation_profile(profile_name)
     if summary.get("preset") != "taroz-amb-pdc":
         failures.append("native summary preset is not taroz-amb-pdc")
     if summary.get("backend") != "eigen":
@@ -294,8 +351,15 @@ def verify_native_summary(summary: dict[str, Any]) -> list[str]:
         failures.append("taroz-amb-pdc must enable ambiguity between factors")
     if summary.get("linearize_double_difference_factors_at_seed") is not True:
         failures.append("taroz-amb-pdc must seed-linearize DD factors")
-    if summary.get("use_epoch_lambda_fixed_output") is not True:
-        failures.append("taroz-amb-pdc must enable epoch LAMBDA fixed output")
+    if (
+        summary.get("use_epoch_lambda_fixed_output")
+        is not profile["use_epoch_lambda_fixed_output"]
+    ):
+        failures.append(
+            "taroz-amb-pdc use_epoch_lambda_fixed_output must be "
+            f"{str(profile['use_epoch_lambda_fixed_output']).lower()} "
+            f"for profile {profile_name}"
+        )
     if summary.get("dd_ambiguity_per_epoch") is not True:
         failures.append("taroz-amb-pdc must use per-epoch DD ambiguity states")
     if summary.get("use_ambiguity_priors") is not False:
@@ -313,6 +377,7 @@ def verify_native_summary(summary: dict[str, Any]) -> list[str]:
         "tdcp_huber_threshold_sigma": 1.234,
         "velocity_motion_sigma_m": 0.01,
         "ambiguity_between_sigma_cycles": 0.001,
+        "lambda_ratio_threshold": profile["lambda_ratio_threshold"],
         "min_snr_dbhz": 35.0,
         "min_satellites_per_epoch": 0,
         "min_output_dd_carrier_factors_per_epoch": 6,
@@ -323,18 +388,32 @@ def verify_native_summary(summary: dict[str, Any]) -> list[str]:
         if not _close(summary.get(key), expected):
             failures.append(f"taroz-amb-pdc {key} must be {expected}")
 
-    for key, expected in EXPECTED_FULL_COUNTS.items():
+    for key, expected in profile["counts"].items():
         if summary.get(key) != expected:
-            failures.append(f"taroz-amb-pdc {key} must be {expected}")
+            failures.append(
+                f"taroz-amb-pdc {key} must be {expected} "
+                f"for profile {profile_name}"
+            )
 
     if summary.get("lambda_ambiguity_fix_solved") is not True:
         failures.append("taroz-amb-pdc LAMBDA must solve")
-    if summary.get("lambda_ambiguity_fix_used") is not True:
-        failures.append("taroz-amb-pdc LAMBDA fixed output must be used")
+    if (
+        summary.get("lambda_ambiguity_fix_used")
+        is not profile["lambda_ambiguity_fix_used"]
+    ):
+        failures.append(
+            "taroz-amb-pdc lambda_ambiguity_fix_used must be "
+            f"{str(profile['lambda_ambiguity_fix_used']).lower()} "
+            f"for profile {profile_name}"
+        )
     if summary.get("partial_lambda_ambiguity_fix_used") is not False:
         failures.append("taroz-amb-pdc must not require partial LAMBDA retry")
-    if summary.get("fixed_solution") is not True:
-        failures.append("taroz-amb-pdc summary must report fixed_solution=true")
+    if summary.get("fixed_solution") is not profile["fixed_solution"]:
+        failures.append(
+            "taroz-amb-pdc fixed_solution must be "
+            f"{str(profile['fixed_solution']).lower()} "
+            f"for profile {profile_name}"
+        )
     if summary.get("converged") is not True:
         failures.append("taroz-amb-pdc optimization must converge")
     if not _is_finite_number(summary.get("final_cost")):
@@ -436,6 +515,15 @@ def parse_args(argv: list[str]) -> argparse.Namespace:
         help="MATLAB script that exports taroz ambiguity PDC oracle CSVs.",
     )
     parser.add_argument("--parity-test", type=Path, default=DEFAULT_PARITY_TEST)
+    parser.add_argument(
+        "--expectation-profile",
+        choices=sorted(EXPECTATION_PROFILES),
+        default="default",
+        help=(
+            "Native summary contract to enforce. Use non-default profiles with "
+            "matching --fgo-extra-arg overrides."
+        ),
+    )
     parser.add_argument("--skip-parity", action="store_true")
     parser.add_argument("--dry-run", action="store_true")
     return parser.parse_args(argv)
@@ -445,6 +533,7 @@ def main(argv: list[str] | None = None) -> int:
     args = parse_args(sys.argv[1:] if argv is None else argv)
     out_dir = args.out_dir
     paths = output_paths(out_dir)
+    profile = expectation_profile(args.expectation_profile)
     harness_summary = args.summary_json or (
         out_dir / "taroz_pos_vel_amb_pdc_dogfood_summary.json"
     )
@@ -471,9 +560,16 @@ def main(argv: list[str] | None = None) -> int:
             "out_dir": str(matlab_output_dir(args)),
         },
         "expected": {
+            "profile": args.expectation_profile,
             "preset": "taroz-amb-pdc",
             "backend": "eigen",
-            "counts": EXPECTED_FULL_COUNTS,
+            "counts": profile["counts"],
+            "lambda_ratio_threshold": profile["lambda_ratio_threshold"],
+            "use_epoch_lambda_fixed_output": profile[
+                "use_epoch_lambda_fixed_output"
+            ],
+            "lambda_ambiguity_fix_used": profile["lambda_ambiguity_fix_used"],
+            "fixed_solution": profile["fixed_solution"],
         },
     }
 
@@ -514,7 +610,10 @@ def main(argv: list[str] | None = None) -> int:
 
     native_summary = load_native_summary(paths["summary"])
     payload["native_summary"] = selected_native_summary(native_summary)
-    native_failures = verify_native_summary(native_summary)
+    native_failures = verify_native_summary(
+        native_summary,
+        args.expectation_profile,
+    )
     payload["native_summary_failures"] = native_failures
     if native_failures:
         payload["status"] = "failed"

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -240,6 +240,23 @@ python3 apps/gnss.py taroz-observable-dogfood --mode pos-pdc --generate-matlab-d
 python3 apps/gnss.py taroz-pos-vel-amb-pdc-dogfood --generate-matlab-dump
 ```
 
+The ambiguity PDC dogfood also has non-default expectation profiles for
+option-level sign-offs that should not be judged with the default FIX/FLOAT
+counts:
+
+```bash
+python3 apps/gnss.py taroz-pos-vel-amb-pdc-dogfood \
+  --fgo-extra-arg=--no-epoch-lambda-fixed-output \
+  --expectation-profile no-epoch-lambda-fixed-output \
+  --skip-parity
+
+python3 apps/gnss.py taroz-pos-vel-amb-pdc-dogfood \
+  --fgo-extra-arg=--lambda-ratio-threshold \
+  --fgo-extra-arg=100 \
+  --expectation-profile strict-lambda-ratio \
+  --skip-parity
+```
+
 The matching CTest parity tests are optional-artifact tests: they skip cleanly
 when the local `output/dogfood/...` oracle files are absent and become strict
 regressions after a dogfood run has generated them.
@@ -254,8 +271,8 @@ ctest --test-dir build-codex -R 'python_taroz_.*(internal_parity|factor_parity)_
 
 The remaining beta-hardening work is broader than final-output shape: keep
 expanding seed-state edge cases, solver-cost trajectories across more windows,
-non-default option coverage, and longer PPC-Dataset windows before treating the
-taroz port as complete.
+additional non-default option profiles, and longer PPC-Dataset windows before
+treating the taroz port as complete.
 
 When `--generate-spp-seed` is used, the PPC harness treats the generated seed as
 part of the sign-off. The native summary must report a seed path,

--- a/tests/test_taroz_pos_vel_amb_pdc_dogfood.py
+++ b/tests/test_taroz_pos_vel_amb_pdc_dogfood.py
@@ -27,7 +27,10 @@ class TarozPosVelAmbPdcDogfoodTest(unittest.TestCase):
             path.write_text("", encoding="ascii")
         return obs, base, nav, seed_pos
 
-    def canonical_summary(self) -> dict[str, object]:
+    def canonical_summary(self, profile_name: str = "default") -> dict[str, object]:
+        profile = gnss_taroz_pos_vel_amb_pdc_dogfood.expectation_profile(
+            profile_name
+        )
         summary: dict[str, object] = {
             "preset": "taroz-amb-pdc",
             "backend": "eigen",
@@ -40,7 +43,9 @@ class TarozPosVelAmbPdcDogfoodTest(unittest.TestCase):
             "use_velocity_motion_factors": True,
             "use_ambiguity_between_factors": True,
             "linearize_double_difference_factors_at_seed": True,
-            "use_epoch_lambda_fixed_output": True,
+            "use_epoch_lambda_fixed_output": profile[
+                "use_epoch_lambda_fixed_output"
+            ],
             "dd_ambiguity_per_epoch": True,
             "use_ambiguity_priors": False,
             "reject_rover_carrier_lli": True,
@@ -49,6 +54,7 @@ class TarozPosVelAmbPdcDogfoodTest(unittest.TestCase):
             "pseudorange_huber_threshold_sigma": 1.234,
             "carrier_phase_huber_threshold_sigma": 1.234,
             "tdcp_huber_threshold_sigma": 1.234,
+            "lambda_ratio_threshold": profile["lambda_ratio_threshold"],
             "velocity_motion_sigma_m": 0.01,
             "ambiguity_between_sigma_cycles": 0.001,
             "min_snr_dbhz": 35.0,
@@ -57,14 +63,14 @@ class TarozPosVelAmbPdcDogfoodTest(unittest.TestCase):
             "max_float_seed_position_divergence_m": 0.0,
             "max_float_position_jump_m": 0.0,
             "lambda_ambiguity_fix_solved": True,
-            "lambda_ambiguity_fix_used": True,
+            "lambda_ambiguity_fix_used": profile["lambda_ambiguity_fix_used"],
             "partial_lambda_ambiguity_fix_used": False,
-            "fixed_solution": True,
+            "fixed_solution": profile["fixed_solution"],
             "converged": True,
             "final_cost": 57158.72726,
             "total_processing_time_ms": 41508.1587,
         }
-        summary.update(gnss_taroz_pos_vel_amb_pdc_dogfood.EXPECTED_FULL_COUNTS)
+        summary.update(profile["counts"])
         return summary
 
     def test_dry_run_writes_full_parity_plan(self) -> None:
@@ -131,8 +137,55 @@ class TarozPosVelAmbPdcDogfoodTest(unittest.TestCase):
             self.assertIn("--cost-trace-csv", command)
             self.assertIn("--max-float-seed-divergence", command)
             self.assertIn("--max-float-position-jump", command)
+            self.assertEqual(payload["expected"]["profile"], "default")
+            self.assertEqual(payload["expected"]["lambda_ratio_threshold"], 2.0)
+            self.assertTrue(payload["expected"]["use_epoch_lambda_fixed_output"])
             self.assertEqual(payload["expected"]["counts"]["fixed_solutions"], 721)
             self.assertEqual(payload["expected"]["counts"]["float_solutions"], 243)
+
+    def test_dry_run_records_nondefault_expectation_profile(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_taroz_amb_pdc_dogfood_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            obs, base, nav, seed_pos = self.touch_inputs(temp_root)
+            summary_json = temp_root / "summary.json"
+            out_dir = temp_root / "out"
+
+            result = gnss_taroz_pos_vel_amb_pdc_dogfood.main(
+                [
+                    "--obs",
+                    str(obs),
+                    "--base",
+                    str(base),
+                    "--nav",
+                    str(nav),
+                    "--seed-pos",
+                    str(seed_pos),
+                    "--out-dir",
+                    str(out_dir),
+                    "--summary-json",
+                    str(summary_json),
+                    "--fgo-bin",
+                    str(temp_root / "gnss_fgo"),
+                    "--fgo-extra-arg=--lambda-ratio-threshold",
+                    "--fgo-extra-arg=100",
+                    "--expectation-profile",
+                    "strict-lambda-ratio",
+                    "--dry-run",
+                ]
+            )
+
+            self.assertEqual(result, 0)
+            payload = json.loads(summary_json.read_text(encoding="utf-8"))
+            command = payload["fgo_command"]
+            self.assertIn("--lambda-ratio-threshold", command)
+            self.assertIn("100", command)
+            self.assertEqual(payload["expected"]["profile"], "strict-lambda-ratio")
+            self.assertEqual(payload["expected"]["lambda_ratio_threshold"], 100.0)
+            self.assertTrue(payload["expected"]["use_epoch_lambda_fixed_output"])
+            self.assertFalse(payload["expected"]["lambda_ambiguity_fix_used"])
+            self.assertFalse(payload["expected"]["fixed_solution"])
+            self.assertEqual(payload["expected"]["counts"]["fixed_solutions"], 0)
+            self.assertEqual(payload["expected"]["counts"]["float_solutions"], 964)
 
     def test_matlab_dump_env_uses_requested_oracle_paths(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_taroz_amb_pdc_dogfood_test_") as temp_dir:
@@ -197,13 +250,52 @@ class TarozPosVelAmbPdcDogfoodTest(unittest.TestCase):
 
         self.assertEqual(failures, [])
 
+    def test_native_summary_accepts_no_epoch_lambda_output_profile(self) -> None:
+        failures = gnss_taroz_pos_vel_amb_pdc_dogfood.verify_native_summary(
+            self.canonical_summary("no-epoch-lambda-fixed-output"),
+            "no-epoch-lambda-fixed-output",
+        )
+
+        self.assertEqual(failures, [])
+
+    def test_native_summary_accepts_strict_lambda_ratio_profile(self) -> None:
+        failures = gnss_taroz_pos_vel_amb_pdc_dogfood.verify_native_summary(
+            self.canonical_summary("strict-lambda-ratio"),
+            "strict-lambda-ratio",
+        )
+
+        self.assertEqual(failures, [])
+
+    def test_native_summary_rejects_nondefault_profile_as_default(self) -> None:
+        failures = gnss_taroz_pos_vel_amb_pdc_dogfood.verify_native_summary(
+            self.canonical_summary("no-epoch-lambda-fixed-output")
+        )
+
+        self.assertIn(
+            "taroz-amb-pdc use_epoch_lambda_fixed_output must be true "
+            "for profile default",
+            failures,
+        )
+        self.assertIn(
+            "taroz-amb-pdc fixed_solutions must be 721 for profile default",
+            failures,
+        )
+        self.assertIn(
+            "taroz-amb-pdc lambda_ambiguity_fix_used must be true "
+            "for profile default",
+            failures,
+        )
+
     def test_native_summary_flags_count_drift(self) -> None:
         summary = self.canonical_summary()
         summary["fixed_solutions"] = 720
 
         failures = gnss_taroz_pos_vel_amb_pdc_dogfood.verify_native_summary(summary)
 
-        self.assertEqual(failures, ["taroz-amb-pdc fixed_solutions must be 721"])
+        self.assertEqual(
+            failures,
+            ["taroz-amb-pdc fixed_solutions must be 721 for profile default"],
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- include `lambda_ratio_threshold` in `gnss_fgo` summary JSON so LAMBDA option sweeps are reproducible
- add `taroz-pos-vel-amb-pdc-dogfood --expectation-profile` contracts for default, `no-epoch-lambda-fixed-output`, and `strict-lambda-ratio` runs
- document the non-default ambiguity PDC signoff commands and cover the new profiles in dogfood unit tests

## Validation
- `cmake --build build-codex --target gnss_fgo -j2`
- `python3 tests/test_taroz_pos_vel_amb_pdc_dogfood.py -v`
- `ctest --test-dir build-codex -R "python_taroz_pos_vel_amb_pdc_(dogfood|factor_parity)_tests|fgo" --output-on-failure`
- `ctest --test-dir build-codex -R "^run_tests$" --output-on-failure`
- `ctest --test-dir build-codex -R "python_cli_tests|python_taroz_pos_vel_amb_pdc_dogfood_tests" --output-on-failure`
- default `taroz-pos-vel-amb-pdc-dogfood` on local taroz data with parity: OK
- `no-epoch-lambda-fixed-output` profile on local taroz data with `--skip-parity`: OK
- `strict-lambda-ratio` profile on local taroz data with `--skip-parity`: OK
- `git diff --check`