### PR TITLE
[codex] fix(rinex): parse TIME OF FIRST OBS header

### DIFF
--- a/src/io/rinex.cpp
+++ b/src/io/rinex.cpp
@@ -675,6 +675,13 @@ bool RINEXReader::parseHeaderLine(const std::string& line, RINEXHeader& header) 
         const double north = std::stod(line.substr(28, 14));
         header.antenna_delta = Vector3d(east, north, height);
     }
+    else if (label.find("TIME OF FIRST OBS") != std::string::npos) {
+        try {
+            header.first_obs = parseTime(line.substr(0, 43), header.version);
+        } catch (...) {
+            // Leave first_obs at its default if the optional header record is malformed.
+        }
+    }
     else if (label.find("# / TYPES OF OBSERV") != std::string::npos) {
         // RINEX 2: Parse number of observation types
         int num_types = std::stoi(line.substr(0, 6));

--- a/tests/test_rinex_writer.cpp
+++ b/tests/test_rinex_writer.cpp
@@ -164,6 +164,33 @@ Ephemeris makeGalileoEphemeris() {
 
 }  // namespace
 
+TEST(RINEXReaderTest, ParsesTimeOfFirstObsHeader) {
+    const auto temp_path = std::filesystem::temp_directory_path() / "libgnss_rinex_first_obs_test.obs";
+    std::filesystem::remove(temp_path);
+
+    {
+        std::ofstream file(temp_path);
+        ASSERT_TRUE(file.is_open());
+        file << rinexHeaderLine("     3.04           OBSERVATION DATA    G                   ",
+                                "RINEX VERSION / TYPE");
+        file << rinexHeaderLine("  2024    8   22    3   14  15.5000000     GPS         ",
+                                "TIME OF FIRST OBS");
+        file << rinexHeaderLine("", "END OF HEADER");
+    }
+
+    io::RINEXReader reader;
+    ASSERT_TRUE(reader.open(temp_path.string()));
+
+    io::RINEXReader::RINEXHeader header;
+    ASSERT_TRUE(reader.readHeader(header));
+
+    EXPECT_EQ(header.first_obs.week, 2328);
+    EXPECT_NEAR(header.first_obs.tow, 357255.5, 1e-9);
+
+    reader.close();
+    std::filesystem::remove(temp_path);
+}
+
 TEST(RINEXWriterTest, WritesGpsNavigationMessageReadableByReader) {
     const auto temp_path = std::filesystem::temp_directory_path() / "libgnss_rinex_writer_test.nav";
     std::filesystem::remove(temp_path);


### PR DESCRIPTION
## Summary

- Parse the RINEX `TIME OF FIRST OBS` header into `RINEXHeader::first_obs`.
- Reuse the existing RINEX time parser so raw observation headers populate GPS week/TOW consistently with epoch parsing.
- Add a regression test covering a RINEX 3 observation header with `TIME OF FIRST OBS`.

## Why

Closed PR #44 identified that raw `.l6` CLAS PPP paths can miss the observation GPS week when `first_obs` remains default-initialized. This keeps the focused fix on top of current `develop` instead of reviving the stale, conflicting branch history.

## Validation

- `cmake -S . -B build-codex -DCMAKE_BUILD_TYPE=Debug`
- `cmake --build build-codex --target run_tests -j8`
- `./build-codex/tests/run_tests --gtest_filter=RINEXReaderTest.ParsesTimeOfFirstObsHeader`
- `./build-codex/tests/run_tests --gtest_filter=RINEX*`
- `git diff --check`

Part of #123.