### PR TITLE
[codex] Add SPP iteration dump summary tool

### DIFF
--- a/scripts/analysis/spp_iteration_dump_summary.py
+++ b/scripts/analysis/spp_iteration_dump_summary.py
@@ -1,0 +1,221 @@
+#!/usr/bin/env python3
+"""Summarize SPP least-squares iteration dumps."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from collections import Counter, defaultdict
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from pathlib import Path
+from typing import Any, DefaultDict, Dict, List, Optional, Sequence, Tuple
+
+
+REQUIRED_COLUMNS = [
+    "week",
+    "tow",
+    "iteration",
+    "sat",
+    "residual_m",
+    "residual_rms_m",
+    "dx_norm_m",
+    "rejected_after",
+    "abs_residual_gt_threshold",
+]
+
+Row = Dict[str, str]
+EpochKey = Tuple[int, int]
+SatKey = Tuple[str, str]
+
+
+def tow_to_millis(value: str) -> int:
+    try:
+        tow = Decimal(str(value))
+    except InvalidOperation as exc:
+        raise ValueError(f"invalid tow value: {value}") from exc
+    return int((tow * Decimal("1000")).to_integral_value(rounding=ROUND_HALF_UP))
+
+
+def to_int(value: str) -> int:
+    if value == "":
+        return 0
+    try:
+        return int(float(value))
+    except ValueError:
+        return 0
+
+
+def to_float(value: str) -> float:
+    if value == "":
+        return math.nan
+    try:
+        parsed = float(value)
+    except ValueError:
+        return math.nan
+    return parsed if math.isfinite(parsed) else math.nan
+
+
+def truthy(value: str) -> bool:
+    return str(value).strip().lower() in {"1", "true", "yes", "y"}
+
+
+def read_csv(path: Path) -> List[Row]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            raise ValueError(f"{path}: missing CSV header")
+        missing = [column for column in REQUIRED_COLUMNS if column not in reader.fieldnames]
+        if missing:
+            raise ValueError(f"{path}: missing required columns: {', '.join(missing)}")
+        return [dict(row) for row in reader]
+
+
+def epoch_key(row: Row) -> EpochKey:
+    return (to_int(row["week"]), tow_to_millis(row["tow"]))
+
+
+def epoch_to_dict(key: EpochKey) -> Dict[str, Any]:
+    return {"week": key[0], "tow": key[1] / 1000.0}
+
+
+def select_last_iteration_per_epoch(rows: Sequence[Row]) -> List[Row]:
+    max_iteration_by_epoch: Dict[EpochKey, int] = {}
+    for row in rows:
+        key = epoch_key(row)
+        max_iteration_by_epoch[key] = max(
+            max_iteration_by_epoch.get(key, -1),
+            to_int(row["iteration"]),
+        )
+    return [
+        row for row in rows
+        if to_int(row["iteration"]) == max_iteration_by_epoch[epoch_key(row)]
+    ]
+
+
+def summarize(
+    rows: Sequence[Row],
+    *,
+    top: int = 20,
+    last_iteration_per_epoch: bool = False,
+) -> Dict[str, Any]:
+    if last_iteration_per_epoch:
+        rows = select_last_iteration_per_epoch(rows)
+
+    epoch_iterations: DefaultDict[EpochKey, set[int]] = defaultdict(set)
+    epoch_max_rms: DefaultDict[EpochKey, float] = defaultdict(float)
+    epoch_max_dx: DefaultDict[EpochKey, float] = defaultdict(float)
+    sat_abs_residual_sum: DefaultDict[SatKey, float] = defaultdict(float)
+    sat_abs_residual_max: DefaultDict[SatKey, float] = defaultdict(float)
+    sat_rows: Counter[SatKey] = Counter()
+    rejected: Counter[SatKey] = Counter()
+    over_threshold: Counter[SatKey] = Counter()
+    top_rows: List[Dict[str, Any]] = []
+
+    for row in rows:
+        key = epoch_key(row)
+        iteration = to_int(row["iteration"])
+        epoch_iterations[key].add(iteration)
+        epoch_max_rms[key] = max(epoch_max_rms[key], abs(to_float(row["residual_rms_m"])))
+        epoch_max_dx[key] = max(epoch_max_dx[key], abs(to_float(row["dx_norm_m"])))
+
+        sat_key = (row.get("sat", ""), row.get("signal", ""))
+        residual = to_float(row["residual_m"])
+        abs_residual = abs(residual) if math.isfinite(residual) else math.nan
+        if math.isfinite(abs_residual):
+            sat_abs_residual_sum[sat_key] += abs_residual
+            sat_abs_residual_max[sat_key] = max(sat_abs_residual_max[sat_key], abs_residual)
+            top_rows.append(
+                {
+                    **epoch_to_dict(key),
+                    "iteration": iteration,
+                    "sat": sat_key[0],
+                    "signal": sat_key[1],
+                    "residual_m": residual,
+                    "abs_residual_m": abs_residual,
+                    "residual_rms_m": to_float(row["residual_rms_m"]),
+                    "dx_norm_m": to_float(row["dx_norm_m"]),
+                    "rejected_after": truthy(row["rejected_after"]),
+                    "abs_residual_gt_threshold": truthy(row["abs_residual_gt_threshold"]),
+                }
+            )
+        sat_rows[sat_key] += 1
+        if truthy(row["rejected_after"]):
+            rejected[sat_key] += 1
+        if truthy(row["abs_residual_gt_threshold"]):
+            over_threshold[sat_key] += 1
+
+    sat_summaries: List[Dict[str, Any]] = []
+    for sat_key, count in sat_rows.items():
+        sat_summaries.append(
+            {
+                "sat": sat_key[0],
+                "signal": sat_key[1],
+                "rows": count,
+                "mean_abs_residual_m": sat_abs_residual_sum[sat_key] / count if count else math.nan,
+                "max_abs_residual_m": sat_abs_residual_max[sat_key],
+                "rejected_rows": rejected[sat_key],
+                "over_threshold_rows": over_threshold[sat_key],
+            }
+        )
+    sat_summaries.sort(
+        key=lambda item: (
+            -item["rejected_rows"],
+            -item["over_threshold_rows"],
+            -item["max_abs_residual_m"],
+            item["sat"],
+            item["signal"],
+        )
+    )
+    top_rows.sort(key=lambda item: item["abs_residual_m"], reverse=True)
+
+    worst_epoch_key: Optional[EpochKey] = None
+    if epoch_max_rms:
+        worst_epoch_key = max(epoch_max_rms, key=lambda key: epoch_max_rms[key])
+
+    return {
+        "rows": len(rows),
+        "last_iteration_per_epoch": last_iteration_per_epoch,
+        "epochs": len(epoch_iterations),
+        "max_iterations_per_epoch": max((len(value) for value in epoch_iterations.values()), default=0),
+        "worst_epoch_by_rms": (
+            {**epoch_to_dict(worst_epoch_key), "max_residual_rms_m": epoch_max_rms[worst_epoch_key]}
+            if worst_epoch_key is not None else None
+        ),
+        "max_dx_norm_m": max(epoch_max_dx.values(), default=0.0),
+        "satellites": sat_summaries[:top],
+        "top_residual_rows": top_rows[:top],
+    }
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("dump_csv", type=Path)
+    parser.add_argument("--top", type=int, default=20)
+    parser.add_argument(
+        "--last-iteration-per-epoch",
+        action="store_true",
+        help="Summarize only the highest iteration number observed for each epoch.",
+    )
+    parser.add_argument("--json-out", type=Path)
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    report = summarize(
+        read_csv(args.dump_csv),
+        top=args.top,
+        last_iteration_per_epoch=args.last_iteration_per_epoch,
+    )
+    text = json.dumps(report, indent=2, sort_keys=True) + "\n"
+    if args.json_out is not None:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(text, encoding="utf-8")
+    print(text, end="")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -101,6 +101,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_spp_residual_dump_summary.py
     )
     add_test(
+        NAME python_spp_iteration_dump_summary_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_spp_iteration_dump_summary.py
+    )
+    add_test(
         NAME python_ppc_taroz_amb_pdc_smoke_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_ppc_taroz_amb_pdc_smoke.py
     )
@@ -214,6 +218,7 @@ if(GTest_FOUND)
         python_mode_compare_tests
         python_ppp_residual_row_set_diff_tests
         python_spp_residual_dump_summary_tests
+        python_spp_iteration_dump_summary_tests
         python_experiment_runner_tests
     )
     set(GNSSPP_EXTENDED_TESTS

--- a/tests/test_spp_iteration_dump_summary.py
+++ b/tests/test_spp_iteration_dump_summary.py
@@ -1,0 +1,131 @@
+#!/usr/bin/env python3
+"""Tests for SPP iteration dump summaries."""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT_DIR / "scripts" / "analysis" / "spp_iteration_dump_summary.py"
+
+spec = importlib.util.spec_from_file_location("spp_iteration_dump_summary", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+summary_mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(summary_mod)
+
+
+FIELDNAMES = [
+    "week",
+    "tow",
+    "iteration",
+    "sat",
+    "signal",
+    "residual_m",
+    "residual_rms_m",
+    "dx_norm_m",
+    "rejected_after",
+    "abs_residual_gt_threshold",
+]
+
+
+def row(
+    *,
+    tow: str = "10.000",
+    iteration: str = "0",
+    sat: str,
+    signal: str = "GPS_L1CA",
+    residual_m: str,
+    residual_rms_m: str = "5.0",
+    dx_norm_m: str = "1.0",
+    rejected_after: str = "0",
+    over: str = "0",
+) -> dict[str, str]:
+    return {
+        "week": "2360",
+        "tow": tow,
+        "iteration": iteration,
+        "sat": sat,
+        "signal": signal,
+        "residual_m": residual_m,
+        "residual_rms_m": residual_rms_m,
+        "dx_norm_m": dx_norm_m,
+        "rejected_after": rejected_after,
+        "abs_residual_gt_threshold": over,
+    }
+
+
+def write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+class SppIterationDumpSummaryTest(unittest.TestCase):
+    def test_summarizes_top_satellites_and_residual_rows(self) -> None:
+        rows = [
+            row(sat="G01", residual_m="1.0"),
+            row(sat="G02", residual_m="-30.0", rejected_after="1", over="1", residual_rms_m="20"),
+            row(sat="G02", tow="11.000", iteration="1", residual_m="-10.0", over="1"),
+        ]
+
+        report = summary_mod.summarize(rows, top=2)
+
+        self.assertEqual(report["rows"], 3)
+        self.assertEqual(report["epochs"], 2)
+        self.assertEqual(report["worst_epoch_by_rms"]["tow"], 10.0)
+        self.assertEqual(report["satellites"][0]["sat"], "G02")
+        self.assertEqual(report["satellites"][0]["rejected_rows"], 1)
+        self.assertEqual(report["top_residual_rows"][0]["sat"], "G02")
+        self.assertAlmostEqual(report["top_residual_rows"][0]["residual_m"], -30.0)
+
+    def test_can_select_last_iteration_per_epoch(self) -> None:
+        rows = [
+            row(sat="G01", tow="10.000", iteration="0", residual_m="100.0"),
+            row(sat="G01", tow="10.000", iteration="1", residual_m="2.0"),
+            row(sat="G02", tow="11.000", iteration="0", residual_m="-50.0"),
+        ]
+
+        report = summary_mod.summarize(rows, top=3, last_iteration_per_epoch=True)
+
+        self.assertTrue(report["last_iteration_per_epoch"])
+        self.assertEqual(report["rows"], 2)
+        self.assertEqual(report["top_residual_rows"][0]["sat"], "G02")
+        self.assertAlmostEqual(report["top_residual_rows"][1]["residual_m"], 2.0)
+
+    def test_cli_writes_json(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="spp_iteration_summary_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            dump_path = temp_root / "spp.csv"
+            json_path = temp_root / "summary.json"
+            write_csv(dump_path, [row(sat="G01", residual_m="2.5")])
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    str(dump_path),
+                    "--json-out",
+                    str(json_path),
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            report = json.loads(json_path.read_text(encoding="utf-8"))
+            self.assertEqual(report["rows"], 1)
+            self.assertIn('"rows": 1', result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Add `scripts/analysis/spp_iteration_dump_summary.py` for summarizing SPP least-squares iteration dumps.
- Add unit coverage for satellite ordering, top residual rows, last-iteration filtering, and CLI JSON output.
- Register the Python test in CTest and the core test label.

## Validation

- `python3 -m py_compile scripts/analysis/spp_iteration_dump_summary.py tests/test_spp_iteration_dump_summary.py`
- `python3 tests/test_spp_iteration_dump_summary.py`
- `cmake -S . -B build-codex -DCMAKE_BUILD_TYPE=Debug`
- `ctest --test-dir build-codex -R python_spp_iteration_dump_summary_tests --output-on-failure`
- `git diff --check -- scripts/analysis/spp_iteration_dump_summary.py tests/test_spp_iteration_dump_summary.py tests/CMakeLists.txt`

Part of #123.