### PR TITLE
ppp/madoca: apply SSR biases with MADOCALIB add convention by default

### DIFF
--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -2676,13 +2676,14 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                     code_bias_m,
                     observation.primary_code_bias_coeff,
                     observation.secondary_code_bias_coeff);
-                // MADOCALIB adds SSR biases to the observables (ppp.c:432-451);
-                // the native convention has subtracted them. Keep the flip
-                // env-gated so the sign parity lands as its own slice.
-                static const bool kMadocaBiasAdd =
-                    (std::getenv("GNSS_PPP_MADOCA_BIAS_ADD") != nullptr);
+                // MADOCALIB adds SSR biases to the observables (ppp.c:432-451).
+                // The MADOCA L6 path follows that convention by default;
+                // GNSS_PPP_MADOCA_BIAS_SUBTRACT restores the legacy subtraction
+                // for diagnostics. Non-MADOCA SSR paths keep subtracting.
+                static const bool kMadocaBiasSubtract =
+                    (std::getenv("GNSS_PPP_MADOCA_BIAS_SUBTRACT") != nullptr);
                 const double ssr_bias_sign =
-                    (require_coherent_ssr_ && kMadocaBiasAdd) ? +1.0 : -1.0;
+                    (require_coherent_ssr_ && !kMadocaBiasSubtract) ? +1.0 : -1.0;
                 observation.pseudorange_if += ssr_bias_sign * code_bias;
                 observation.pseudorange_code_bias_m = code_bias;
                 applied_ssr_code_bias = std::abs(code_bias) > 0.0;
@@ -2720,12 +2721,13 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                         (std::getenv("GNSS_PPP_PB_APPLY_DUMP") != nullptr);
                     // MADOCALIB ppp.c:451 ADDS the SSR phase bias to the carrier
                     // phase (L[i]+=pb); applying it with the opposite sign pushes
-                    // the per-frequency ambiguity away from its integer. Env-gated
-                    // sign flip while validating the convention fix.
+                    // the per-frequency ambiguity away from its integer. Non-MADOCA
+                    // paths keep the legacy subtraction unless GNSS_PPP_PB_ADD is
+                    // set while their convention is validated.
                     static const double kPbSign =
                         (std::getenv("GNSS_PPP_PB_ADD") != nullptr) ? +1.0 : -1.0;
                     const double phase_bias_sign =
-                        (require_coherent_ssr_ && kMadocaBiasAdd) ? +1.0 : kPbSign;
+                        (require_coherent_ssr_ && !kMadocaBiasSubtract) ? +1.0 : kPbSign;
                     if (!phase_bias_m.empty() && !kNoPhaseBias) {
                         if (observation.has_carrier_phase) {
                             const double pb_l1 = observationPhaseBiasMeters(


### PR DESCRIPTION
## Summary

Follow-up slice to #130. MADOCALIB `corr_meas()` adds SSR code and phase biases to the observables (`external/madocalib/src/ppp.c:432-451`); the native path subtracted them. Float solutions mostly absorb the difference in ambiguity/clock states, but the wrong sign pushes per-frequency ambiguities away from their integers, which matters once PPP-AR enters the picture.

The MADOCA L6 coherent mode (introduced in #130) now applies SSR biases with the add convention by default:
- `GNSS_PPP_MADOCA_BIAS_SUBTRACT=1` restores the legacy subtraction for diagnostics,
- non-MADOCA SSR paths are unchanged (their per-frequency preview knob `GNSS_PPP_PB_ADD` remains as before).

## MIZU 1h native-vs-bridge A/B

| metric | subtract (legacy) | add (this PR) |
|---|---|---|
| all-epoch delta RMS 3D | 6.31 m | 5.73 m |
| last-epoch delta 3D | 1.30 m | 1.25 m |
| tail-30min delta RMS 3D | 2.24 m | 2.23 m |

## Slice provenance

Fresh implementation. Gap identified by the codex 5.5 (xhigh) parity audit against `external/madocalib` @ `0089f7dc` (both code and phase bias signs); the flip shipped env-gated in #130 and is promoted to the default here as its own behavioral slice.

## Runtime behavior

Changes runtime behavior only for native `--madoca-l6` runs.

## Tests run locally

- `./build-madoca-parity/tests/run_tests` — 318/318 passed (parity-link build)
- `python3 tests/test_cli_tools.py -k qzss_l6` — OK (52 ran, 13 skipped); `-k madoca` — OK
- MIZU A/B via `scripts/analysis/madoca_solution_diff.py` (numbers above)
- `git diff --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)