### PR TITLE
refactor(ppp): consolidate GNSS_PPP_* env knobs into PPPEnvOverrides

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,7 @@ set(GNSS_SOURCES
     src/algorithms/ppp_osr.cpp
     src/algorithms/ppp_wlnl.cpp
     src/algorithms/ppp_clas_epoch.cpp
+    src/algorithms/ppp_env_overrides.cpp
     src/algorithms/madoca_parity.cpp
     src/algorithms/madocalib_oracle.cpp
     src/algorithms/madocalib_bridge.cpp
@@ -93,6 +94,7 @@ set(GNSS_SOURCES_NO_OPTIMIZATION
     src/algorithms/rtk_update.cpp
     src/algorithms/rtk_validation.cpp
     src/algorithms/fgo.cpp
+    src/algorithms/ppp_env_overrides.cpp
     src/algorithms/rtk.cpp
     src/algorithms/spp.cpp
     src/algorithms/lambda.cpp

--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <cstdlib>
 #include <exception>
 #include <filesystem>
 #include <fstream>
@@ -10,6 +9,7 @@
 #include <vector>
 
 #include <libgnss++/algorithms/ppp.hpp>
+#include <libgnss++/algorithms/ppp_env_overrides.hpp>
 #include <libgnss++/core/solution.hpp>
 #include <libgnss++/external/madocalib_bridge.hpp>
 #include <libgnss++/io/rinex.hpp>
@@ -764,12 +764,12 @@ int main(int argc, char* argv[]) {
             return 0;
         }
 
-        if (!options.madoca_l6_paths.empty() &&
-            std::getenv("GNSS_PPP_QZSS_PREFER_L1L") == nullptr) {
-            setenv("GNSS_PPP_QZSS_PREFER_L1L", "1", 0);
-        }
-
         libgnss::io::RINEXReader obs_reader;
+        const auto& ppp_env_overrides = libgnss::pppEnvOverrides();
+        if (!options.madoca_l6_paths.empty() &&
+            !ppp_env_overrides.qzss_prefer_l1l_present) {
+            obs_reader.setQzssL1Preference(true);
+        }
         if (!obs_reader.open(options.obs_path)) {
             std::cerr << "Error: failed to open observation file: " << options.obs_path << "\n";
             return 1;

--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -216,6 +216,7 @@ public:
 
 private:
     PPPConfig ppp_config_;
+    PPPEnvOverrides env_overrides_;
     SPPProcessor spp_processor_;  ///< Fallback SPP processor
     PreciseProducts precise_products_;
     SSRProducts ssr_products_;

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -1,0 +1,107 @@
+#pragma once
+
+#include <string>
+
+namespace libgnss {
+
+struct PPPEnvOverrides {
+    // GNSS_PPP_MADOCA_BIAS_SUBTRACT: subtract MADOCA SSR code/phase biases
+    // instead of adding them. Default false.
+    bool madoca_bias_subtract = false;
+    // GNSS_PPP_MADOCA_ALLOW_PARTIAL_SSR: accept incomplete MADOCA SSR epochs
+    // when set exactly to "1". Default false.
+    bool madoca_allow_partial_ssr = false;
+    // GNSS_PPP_REQUIRE_SSR_ORBIT: drop satellites missing SSR orbit
+    // corrections when set to a value whose first char is not '0'. Default false.
+    bool require_ssr_orbit = false;
+    // GNSS_PPP_DISABLE_MADOCA_STATIC_ANCHOR: disable the MADOCA static anchor
+    // blend when set exactly to "1". Default false.
+    bool disable_madoca_static_anchor = false;
+    // GNSS_PPP_STATIC_ANCHOR_BLEND: override static anchor blend fraction;
+    // values outside [0,1] are ignored at use sites. Default -1.0 (inactive).
+    double static_anchor_blend = -1.0;
+    // GNSS_PPP_ESTIMATE_ISB: comma/space-style spec parsed by substring
+    // checks for "gal", "qzs", "bds", "all", or exact "1". Defaults false.
+    bool estimate_isb_all = false;
+    bool estimate_isb_gal = false;
+    bool estimate_isb_qzs = false;
+    bool estimate_isb_bds = false;
+    // GNSS_PPP_ISB_PROCESS_NOISE: ISB random-walk process noise in m^2/s.
+    // Default 1e-6.
+    double isb_process_noise = 1e-6;
+    // GNSS_PPP_INIT_IONO_VAR: initial ionosphere variance override; used only
+    // when > 0. Default 0.0 (inactive).
+    double init_iono_var = 0.0;
+    // GNSS_PPP_QZSS_CODE_ONLY: force QZSS code-only rows when set to a value
+    // whose first char is not '0'. Default false.
+    bool qzss_code_only = false;
+    // GNSS_PPP_QZSS_PREFER_L1L: prefer QZSS L1L/L1X RINEX observations when
+    // set to a value whose first char is not '0'. Default false.
+    bool qzss_prefer_l1l = false;
+    // GNSS_PPP_QZSS_PREFER_L1L presence bit so apps can preserve "env exists"
+    // semantics when applying explicit reader defaults. Default false.
+    bool qzss_prefer_l1l_present = false;
+    // GNSS_PPP_QZSS_SSR_PRN_FIX / GNSS_PPP_DISABLE_QZSS_SSR_PRN_FIX: normalize
+    // QZSS SSR PRNs unless the legacy var is exactly "0" or disable is exactly
+    // "1". Default true.
+    bool qzss_ssr_prn_fix = true;
+    // GNSS_PPP_MADOCA_QZSS_CLOCK: allow default QZSS ISB clock in coherent
+    // MADOCA unless set exactly to "0". Default true.
+    bool madoca_qzss_clock = true;
+    // GNSS_PPP_MADOCA_QZSS_PHASE: allow QZSS phase rows in MADOCA when set
+    // exactly to "1". Default false.
+    bool madoca_qzss_phase = false;
+    // GNSS_PPP_PB_ADD: add non-MADOCA SSR phase biases instead of subtracting.
+    // Default false.
+    bool pb_add = false;
+    // GNSS_PPP_NO_PHASE_BIAS: suppress per-frequency phase-bias application
+    // when present. Default false.
+    bool no_phase_bias = false;
+    // GNSS_PPP_L2_RESET_FIX: reset L2 ambiguity on slip when set to a value
+    // whose first char is not '0'. Default false.
+    bool l2_reset_fix = false;
+    // GNSS_PPP_GAL_INAV: apply Galileo I/NAV ephemeris selection when set to a
+    // value whose first char is not '0'. Default false.
+    bool gal_inav = false;
+    // GNSS_PPP_SSR_DISCNT_SLIP: detect SSR phase-bias discontinuity slips when
+    // present. Default false.
+    bool ssr_discnt_slip = false;
+    // GNSS_PPP_NO_SOLID_TIDE: skip solid-earth tides when present.
+    // Default false.
+    bool no_solid_tide = false;
+    // GNSS_PPP_TIDE_ITRS_SUN_MOON: rotate sun/moon vectors to ITRS before IERS
+    // solid tide when present. Default false.
+    bool tide_itrs_sun_moon = false;
+    // GNSS_PPP_PF_CODE_VAR_SCALE: per-frequency code variance scale.
+    // Default 9.0.
+    double pf_code_var_scale = 9.0;
+    // GNSS_PPP_PF_RX_ANTENNA: enable per-frequency receiver antenna correction
+    // when present. Default false.
+    bool pf_rx_antenna = false;
+    // GNSS_PPP_PF_WET_TROP: enable per-frequency wet trop split when present.
+    // Default false.
+    bool pf_wet_trop = false;
+
+    // GNSS_PPP_RES_DUMP: PPP residual diagnostic dump. Default false.
+    bool res_dump = false;
+    // GNSS_PPP_SATPOS_DUMP: satellite position diagnostic dump. Default false.
+    bool satpos_dump = false;
+    // GNSS_PPP_PFDUMP: per-frequency AR diagnostic dump. Default false.
+    bool pfdump = false;
+    // GNSS_PPP_PB_APPLY_DUMP: phase-bias application diagnostic dump.
+    // Default false.
+    bool pb_apply_dump = false;
+    // GNSS_PPP_MADOCA_CBIAS_DUMP: MADOCA code/phase-bias diagnostic dump.
+    // Default false.
+    bool madoca_cbias_dump = false;
+    // GNSS_PPP_AR_DDDUMP: double-difference AR diagnostic dump. Default false.
+    bool ar_dddump = false;
+    // GNSS_PPP_DEBUG: general PPP debug logging. Default false.
+    bool debug = false;
+
+    static PPPEnvOverrides fromEnvironment();
+};
+
+const PPPEnvOverrides& pppEnvOverrides();
+
+}  // namespace libgnss

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -1,18 +1,18 @@
 #pragma once
 
+#include <libgnss++/algorithms/ppp_env_overrides.hpp>
 #include <libgnss++/core/observation.hpp>
 #include <libgnss++/core/types.hpp>
 
 #include <array>
-#include <cstdlib>
 #include <map>
 #include <string>
 
 namespace libgnss::ppp_shared {
 
-/// Check if PPP debug output is enabled via GNSS_PPP_DEBUG environment variable.
+/// Check if PPP debug output is enabled via GNSS_PPP_DEBUG.
 inline bool pppDebugEnabled() {
-    return std::getenv("GNSS_PPP_DEBUG") != nullptr;
+    return pppEnvOverrides().debug;
 }
 
 struct PPPConfig {

--- a/include/libgnss++/io/madoca_l6.hpp
+++ b/include/libgnss++/io/madoca_l6.hpp
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <libgnss++/algorithms/ppp_env_overrides.hpp>
+
 #include <cstdint>
 #include <string>
 #include <vector>
@@ -72,6 +74,8 @@ public:
     // Out-of-range satellites return a static empty correction.
     const MadocaSsrCorrection& correction(int sat) const;
 
+    const PPPEnvOverrides& envOverrides() const { return env_overrides_; }
+
     // Clear all decoder and correction state.
     void reset();
 
@@ -114,6 +118,7 @@ private:
     MadocaGtime seed_;                 // week-determination reference epoch
     ChannelState channels_[kMaxPrn];
     MadocaSsrCorrection ssr_[kMaxSat];
+    PPPEnvOverrides env_overrides_;
 };
 
 // Map a MADOCA Compact SSR bias code (an RTKLIB CODE_* enum value, i.e. the

--- a/include/libgnss++/io/rinex.hpp
+++ b/include/libgnss++/io/rinex.hpp
@@ -60,8 +60,18 @@ public:
         std::map<std::string, std::string> comments;
     };
     
-    RINEXReader() = default;
+    RINEXReader();
     ~RINEXReader() = default;
+
+    /**
+     * @brief Prefer QZSS L1L/L1X observations over L1C when available.
+     */
+    void setQzssL1Preference(bool prefer_l1l) { qzss_prefer_l1l_ = prefer_l1l; }
+
+    /**
+     * @brief Check whether QZSS L1L/L1X preference is enabled.
+     */
+    bool qzssL1Preference() const { return qzss_prefer_l1l_; }
     
     /**
      * @brief Open RINEX file
@@ -117,6 +127,7 @@ private:
     std::ifstream file_;
     RINEXHeader header_;
     int current_line_ = 0;
+    bool qzss_prefer_l1l_ = false;
 
     // State for parsing RINEX 3 "SYS / # / OBS TYPES" records that span
     // continuation lines (systems with more than 13 observation types, e.g.

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -82,11 +82,6 @@ std::string normalizeStationName(const std::string& station_name) {
     return normalizeAntennaType(station_name);
 }
 
-bool envFlagOne(const char* name) {
-    const char* value = std::getenv(name);
-    return value != nullptr && value[0] == '1' && value[1] == '\0';
-}
-
 bool madocaSsrReferenceIsCurrent(const GNSSTime& epoch, const GNSSTime& reference) {
     if (reference.week == 0) {
         return false;
@@ -1094,12 +1089,15 @@ double PPPProcessor::modeledZenithTroposphereDelayMeters(
     return modeledZenithTroposphereDelayMetersImpl(receiver_position, time);
 }
 
-PPPProcessor::PPPProcessor() : spp_processor_() {
+PPPProcessor::PPPProcessor()
+    : env_overrides_(PPPEnvOverrides::fromEnvironment()), spp_processor_() {
     reset();
 }
 
 PPPProcessor::PPPProcessor(const PPPConfig& ppp_config)
-    : ppp_config_(ppp_config), spp_processor_() {
+    : ppp_config_(ppp_config),
+      env_overrides_(PPPEnvOverrides::fromEnvironment()),
+      spp_processor_() {
     reset();
 }
 
@@ -1530,7 +1528,7 @@ bool PPPProcessor::loadMadocaL6Products(const std::vector<std::string>& l6_files
         io::decodeMadocaL6eFilesToProducts(l6_files, gps_week, ssr_products_);
     ssr_products_loaded_ = added > 0;
     require_coherent_ssr_ =
-        ssr_products_loaded_ && !envFlagOne("GNSS_PPP_MADOCA_ALLOW_PARTIAL_SSR");
+        ssr_products_loaded_ && !env_overrides_.madoca_allow_partial_ssr;
     return ssr_products_loaded_;
 }
 
@@ -1826,35 +1824,22 @@ bool PPPProcessor::initializeFilter(const ObservationData& obs,
     // systems stay explicit env opt-ins so non-MADOCA paths remain unchanged.
     // Accepts a comma/space-separated system list ("qzs", "gal", "bds", "all")
     // for diagnostics or broader experiments.
-    const std::string isb_spec = [] {
-        const char* e = std::getenv("GNSS_PPP_ESTIMATE_ISB");
-        return std::string(e != nullptr ? e : "");
-    }();
-    const bool isb_all = isb_spec == "1" || isb_spec.find("all") != std::string::npos;
-    const bool isb_gal = isb_all || isb_spec.find("gal") != std::string::npos;
-    const bool isb_qzs = isb_all || isb_spec.find("qzs") != std::string::npos;
-    const bool isb_bds = isb_all || isb_spec.find("bds") != std::string::npos;
-    const char* madoca_qzs_clock = std::getenv("GNSS_PPP_MADOCA_QZSS_CLOCK");
-    const bool madoca_qzs_clock_disabled =
-        madoca_qzs_clock != nullptr &&
-        madoca_qzs_clock[0] == '0' &&
-        madoca_qzs_clock[1] == '\0';
     const bool default_madoca_qzs_clock =
-        require_coherent_ssr_ && !madoca_qzs_clock_disabled;
+        require_coherent_ssr_ && env_overrides_.madoca_qzss_clock;
     std::set<GNSSSystem> visible_systems;
     for (const auto& sat : obs.getSatellites()) {
         visible_systems.insert(sat.system);
     }
     filter_state_.trop_index = 8;  // keep original
     int isb_start = 9;
-    if (isb_gal && visible_systems.count(GNSSSystem::Galileo)) {
+    if (env_overrides_.estimate_isb_gal && visible_systems.count(GNSSSystem::Galileo)) {
         filter_state_.gal_clock_index = isb_start++;
     }
-    if ((isb_qzs || default_madoca_qzs_clock) &&
+    if ((env_overrides_.estimate_isb_qzs || default_madoca_qzs_clock) &&
         visible_systems.count(GNSSSystem::QZSS)) {
         filter_state_.qzs_clock_index = isb_start++;
     }
-    if (isb_bds && visible_systems.count(GNSSSystem::BeiDou)) {
+    if (env_overrides_.estimate_isb_bds && visible_systems.count(GNSSSystem::BeiDou)) {
         filter_state_.bds_clock_index = isb_start++;
     }
 
@@ -1930,12 +1915,8 @@ bool PPPProcessor::initializeFilter(const ObservationData& obs,
     // low-latitude station (ALIC) stack cleanly with the orbit-fix lever for
     // bridge-parity float, while the default (100) is correct at mid-latitude
     // (MIZU); the right value is station-dependent, so this is opt-in.
-    static const double kIonoVarOverride = [] {
-        const char* v = std::getenv("GNSS_PPP_INIT_IONO_VAR");
-        return v != nullptr ? std::atof(v) : 0.0;
-    }();
-    const double iono_init_var = kIonoVarOverride > 0.0
-                                     ? kIonoVarOverride
+    const double iono_init_var = env_overrides_.init_iono_var > 0.0
+                                     ? env_overrides_.init_iono_var
                                      : ppp_config_.initial_ionosphere_variance;
     if (ppp_config_.estimate_ionosphere) {
         for (const auto& [sat, idx] : filter_state_.ionosphere_indices) {
@@ -1997,16 +1978,15 @@ void PPPProcessor::predictState(double dt, const PositionSolution* seed_solution
     // every epoch, which strips the high-elevation QZSS geometry of its absolute
     // (vertical) leverage and degrades the solution. Tight Q (override-tunable)
     // lets the ISB converge to the true bias and then hold.
-    static const double kIsbProcessNoise = [] {
-        const char* e = std::getenv("GNSS_PPP_ISB_PROCESS_NOISE");
-        return e != nullptr ? std::atof(e) : 1e-6;  // m^2/s random walk
-    }();
     if (filter_state_.gal_clock_index >= 0)
-        Q(filter_state_.gal_clock_index, filter_state_.gal_clock_index) = kIsbProcessNoise * dt;
+        Q(filter_state_.gal_clock_index, filter_state_.gal_clock_index) =
+            env_overrides_.isb_process_noise * dt;
     if (filter_state_.qzs_clock_index >= 0)
-        Q(filter_state_.qzs_clock_index, filter_state_.qzs_clock_index) = kIsbProcessNoise * dt;
+        Q(filter_state_.qzs_clock_index, filter_state_.qzs_clock_index) =
+            env_overrides_.isb_process_noise * dt;
     if (filter_state_.bds_clock_index >= 0)
-        Q(filter_state_.bds_clock_index, filter_state_.bds_clock_index) = kIsbProcessNoise * dt;
+        Q(filter_state_.bds_clock_index, filter_state_.bds_clock_index) =
+            env_overrides_.isb_process_noise * dt;
     Q(filter_state_.trop_index, filter_state_.trop_index) =
         ppp_config_.process_noise_troposphere * dt;
     // Ambiguity process noise for every appended state. Ionosphere states may
@@ -2582,17 +2562,14 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
             // East offset versus the bridge). Mirror the bridge by dropping such
             // satellites upstream. Env-gated: GNSS_PPP_REQUIRE_SSR_ORBIT (unset
             // or 0 = legacy behaviour, keep the satellite on its broadcast orbit).
-            static const bool kRequireSsrOrbit = [] {
-                const char* v = std::getenv("GNSS_PPP_REQUIRE_SSR_ORBIT");
-                return v != nullptr && v[0] != '0';
-            }();
             if (require_coherent_ssr_ && ssr_products_loaded_ &&
                 (!ssr_status_ok ||
                  !madocaSsrCorrectionIsCoherent(ssr_status, time))) {
                 observation.valid = false;
                 continue;
             }
-            if (kRequireSsrOrbit && ssr_products_loaded_ && ssr_orbit_iode < 0) {
+            if (env_overrides_.require_ssr_orbit &&
+                ssr_products_loaded_ && ssr_orbit_iode < 0) {
                 observation.valid = false;
                 continue;
             }
@@ -2700,10 +2677,10 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                 // The MADOCA L6 path follows that convention by default;
                 // GNSS_PPP_MADOCA_BIAS_SUBTRACT restores the legacy subtraction
                 // for diagnostics. Non-MADOCA SSR paths keep subtracting.
-                static const bool kMadocaBiasSubtract =
-                    (std::getenv("GNSS_PPP_MADOCA_BIAS_SUBTRACT") != nullptr);
                 const double ssr_bias_sign =
-                    (require_coherent_ssr_ && !kMadocaBiasSubtract) ? +1.0 : -1.0;
+                    (require_coherent_ssr_ && !env_overrides_.madoca_bias_subtract)
+                        ? +1.0
+                        : -1.0;
                 observation.pseudorange_if += ssr_bias_sign * code_bias;
                 observation.pseudorange_code_bias_m = code_bias;
                 applied_ssr_code_bias = std::abs(code_bias) > 0.0;
@@ -2735,27 +2712,24 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                         observation.pseudorange_l2 += ssr_bias_sign * cb_l2;
                         observation.code_bias_l2_m = cb_l2;
                     }
-                    static const bool kNoPhaseBias =
-                        (std::getenv("GNSS_PPP_NO_PHASE_BIAS") != nullptr);
-                    static const bool kPbApplyDump =
-                        (std::getenv("GNSS_PPP_PB_APPLY_DUMP") != nullptr);
                     // MADOCALIB ppp.c:451 ADDS the SSR phase bias to the carrier
                     // phase (L[i]+=pb); applying it with the opposite sign pushes
                     // the per-frequency ambiguity away from its integer. Non-MADOCA
                     // paths keep the legacy subtraction unless GNSS_PPP_PB_ADD is
                     // set while their convention is validated.
-                    static const double kPbSign =
-                        (std::getenv("GNSS_PPP_PB_ADD") != nullptr) ? +1.0 : -1.0;
+                    const double pb_sign = env_overrides_.pb_add ? +1.0 : -1.0;
                     const double phase_bias_sign =
-                        (require_coherent_ssr_ && !kMadocaBiasSubtract) ? +1.0 : kPbSign;
-                    if (!phase_bias_m.empty() && !kNoPhaseBias) {
+                        (require_coherent_ssr_ && !env_overrides_.madoca_bias_subtract)
+                            ? +1.0
+                            : pb_sign;
+                    if (!phase_bias_m.empty() && !env_overrides_.no_phase_bias) {
                         if (observation.has_carrier_phase) {
                             const double pb_l1 = observationPhaseBiasMeters(
                                 observation.satellite.system, observation.primary_signal,
                                 SignalType::SIGNAL_TYPE_COUNT, false, phase_bias_m, 1.0, 0.0);
                             observation.carrier_phase_l1 += phase_bias_sign * pb_l1;
                             observation.phase_bias_l1_m = pb_l1;
-                            if (kPbApplyDump) {
+                            if (env_overrides_.pb_apply_dump) {
                                 std::cerr << "[PB-APPLY] " << observation.satellite.toString()
                                           << " pb_l1=" << pb_l1 << "\n";
                             }
@@ -2999,8 +2973,7 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
         // at emission time, APC frame — matching MADOCALIB satposs rs[]) so an
         // external script can match by epoch+sat and project the delta onto the
         // line of sight. clk in metres (sat_clock_bias * c).
-        static const bool kSatposDump = (std::getenv("GNSS_PPP_SATPOS_DUMP") != nullptr);
-        if (kSatposDump) {
+        if (env_overrides_.satpos_dump) {
             std::cerr << "[SATPOS] tow=" << std::fixed << std::setprecision(3) << time.tow
                       << " sat=" << observation.satellite.toString()
                       << std::setprecision(4)
@@ -3043,11 +3016,7 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
         // phase drives the converged solution. Env-overridable for tuning.
         if (!ppp_config_.use_ionosphere_free && ppp_config_.estimate_ionosphere &&
             !ppp_config_.use_clas_osr_filter) {
-            static const double code_var_scale = []() {
-                const char* s = std::getenv("GNSS_PPP_PF_CODE_VAR_SCALE");
-                return s != nullptr ? std::atof(s) : 9.0;
-            }();
-            observation.variance_pr *= code_var_scale;
+            observation.variance_pr *= env_overrides_.pf_code_var_scale;
         }
         observation.receiver_position = receiver_position;
         if (geometry.distance > 0.0) {
@@ -3068,9 +3037,7 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
         // position shift bit-identical (corrections stay 0).
         observation.rx_ant_corr_l1_m = 0.0;
         observation.rx_ant_corr_l2_m = 0.0;
-        static const bool per_freq_rx_antenna_enabled =
-            std::getenv("GNSS_PPP_PF_RX_ANTENNA") != nullptr;
-        if (per_freq_rx_antenna_enabled && receiver_antex_loaded_ &&
+        if (env_overrides_.pf_rx_antenna && receiver_antex_loaded_ &&
             !ppp_config_.use_ionosphere_free && ppp_config_.estimate_ionosphere &&
             !ppp_config_.use_clas_osr_filter && geometry.distance > 0.0 &&
             !ppp_config_.receiver_antenna_type.empty()) {
@@ -3212,9 +3179,7 @@ void PPPProcessor::detectCycleSlips(const ObservationData& obs) {
         // re-referenced and the carrier ambiguity consistent with the old bias
         // is stale (MADOCALIB detslip_cssr, ppp.c:558). env-gated, default OFF.
         bool discnt_slip = false;
-        static const bool kSsrDiscntSlip =
-            (std::getenv("GNSS_PPP_SSR_DISCNT_SLIP") != nullptr);
-        if (kSsrDiscntSlip && ssr_products_loaded_) {
+        if (env_overrides_.ssr_discnt_slip && ssr_products_loaded_) {
             Vector3d disc_orbit;
             double disc_clock = 0.0;
             std::map<uint8_t, double> disc_pbias;
@@ -3608,13 +3573,9 @@ int PPPProcessor::getOrCreateIonosphereState(const IonosphereFreeObs& observatio
         observation.has_iono_init ? observation.iono_init_m : 0.0;
     // Mirror the GNSS_PPP_INIT_IONO_VAR override at the lazy-create site so a
     // satellite appearing mid-run lands in the same anchored gauge.
-    static const double kIonoVarOverride = [] {
-        const char* v = std::getenv("GNSS_PPP_INIT_IONO_VAR");
-        return v != nullptr ? std::atof(v) : 0.0;
-    }();
     filter_state_.covariance(new_index, new_index) =
-        kIonoVarOverride > 0.0
-            ? kIonoVarOverride
+        env_overrides_.init_iono_var > 0.0
+            ? env_overrides_.init_iono_var
             : ppp_config_.initial_ionosphere_variance;
     filter_state_.ionosphere_indices[observation.satellite] = new_index;
     return new_index;
@@ -4079,8 +4040,6 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
     (void)nav;
     last_ar_ratio_ = 0.0;
     last_fixed_ambiguities_ = 0;
-    static const bool pf_dump = std::getenv("GNSS_PPP_PFDUMP") != nullptr;
-
     // Only attempt AR once the float has converged: a wide, ill-conditioned
     // ambiguity covariance makes the LAMBDA integer search explore an enormous
     // volume (effectively unbounded run time).
@@ -4185,7 +4144,7 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
                             cr1 * cs2 * P(ir1, is2) + cr2 * cs1 * P(ir2, is1) +
                             cr2 * cs2 * P(ir2, is2) + cs1 * cs2 * P(is1, is2));
         const double sd = var > 0.0 ? std::sqrt(var) : 9.9;
-        if (pf_dump) {
+        if (env_overrides_.pfdump) {
             std::cerr << "[PFWL] " << ref.sat.toString() << "-" << sat.sat.toString()
                       << " wl=" << wl_dd << " frac=" << frac << " std=" << sd << "\n";
         }
@@ -4195,7 +4154,7 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
             wl_frac_sum += frac;
         }
     }
-    if (pf_dump) {
+    if (env_overrides_.pfdump) {
         std::cerr << "[PFWL-SUM] cand=" << cands.size() << " wl_fixed=" << wl_fix_count
                   << " mean_frac=" << (wl_fix_count ? wl_frac_sum / wl_fix_count : 0.0) << "\n";
     }
@@ -4286,7 +4245,7 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
                 filter_state_.covariance(sk.l1_index, sl.l1_index) / (sk.lambda1 * sl.lambda1);
         }
     }
-    if (pf_dump) {
+    if (env_overrides_.pfdump) {
         for (int k = 0; k < nb; ++k) {
             const Cand& rk = cands[static_cast<size_t>(wl_pairs[static_cast<size_t>(n1_sel[static_cast<size_t>(k)])].ref)];
             const Cand& sk = cands[static_cast<size_t>(wl_pairs[static_cast<size_t>(n1_sel[static_cast<size_t>(k)])].sat)];
@@ -4302,7 +4261,7 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
         last_fixed_ambiguities_ = nwl;  // wide-lane already applied
         return true;
     }
-    if (pf_dump) {
+    if (env_overrides_.pfdump) {
         std::cerr << "[PFN1] nb=" << nb << " ratio=" << ratio
                   << " threshold=" << ppp_config_.ar_ratio_threshold << "\n";
     }
@@ -4390,9 +4349,7 @@ Vector3d PPPProcessor::applyGeophysicalCorrections(const Vector3d& position,
     // MIZU 7.5x gap vs bridge (cm-level systematic differences across the
     // three solid-tide implementations: legacy Step-1-Love, IERS Step-1+2,
     // and MADOCALIB Step-1+K1-only). Default OFF (bit-identical).
-    static const bool kNoSolidTide =
-        (std::getenv("GNSS_PPP_NO_SOLID_TIDE") != nullptr);
-    if (ppp_config_.apply_solid_earth_tides && !kNoSolidTide) {
+    if (ppp_config_.apply_solid_earth_tides && !env_overrides_.no_solid_tide) {
         corrected += calculateSolidEarthTides(position, time);
     }
     if (ppp_config_.apply_ocean_loading) {
@@ -4584,10 +4541,8 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
         // priori ZHD; the climatology ZHD is inaccurate at high/dry stations
         // (helped MIZU 0.42->0.385 m but hurt ALIC 0.34->0.585 m), so it is OFF
         // by default and opt-in via GNSS_PPP_PF_WET_TROP for experimentation.
-        static const bool wet_trop_enabled =
-            std::getenv("GNSS_PPP_PF_WET_TROP") != nullptr;
         const bool per_freq_wet_trop =
-            wet_trop_enabled && ppp_config_.estimate_troposphere &&
+            env_overrides_.pf_wet_trop && ppp_config_.estimate_troposphere &&
             !ppp_config_.use_ionosphere_free && ppp_config_.estimate_ionosphere &&
             !ppp_config_.use_clas_osr_filter && observation.trop_mapping_wet > 0.0;
         double troposphere_delay;
@@ -4630,7 +4585,6 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
         // Env-gated pre-fit residual dump for native-vs-bridge measurement diff.
         // Matches the bridge ppp_res (post=0) lines so per-system/per-signal
         // residual structure can be compared at convergence. el in degrees.
-        static const bool kResDump = (std::getenv("GNSS_PPP_RES_DUMP") != nullptr);
         auto dumpRes = [&](const char* band, const char* type, double res) {
             std::cerr << "[PPP-RES] tow=" << std::fixed << std::setprecision(1)
                       << time.tow << " sat=" << observation.satellite.toString()
@@ -4639,13 +4593,13 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
                       << " el=" << std::setprecision(1)
                       << (observation.elevation * 57.295779513) << "\n";
         };
-        if (kResDump) dumpRes("L1", "code", residual);
+        if (env_overrides_.res_dump) dumpRes("L1", "code", residual);
 
         // Deep state dump: the per-satellite (iono, N1, N2) split that the
         // est-stec filter settles into. Compared against the bridge ppp_res
         // dion/bias to find where native admits a wrong-but-self-consistent
         // (ambiguity, ionosphere) solution that the bridge does not.
-        if (kResDump) {
+        if (env_overrides_.res_dump) {
             const int n1_idx = ambiguityStateIndex(observation.satellite);
             const auto n2_it =
                 filter_state_.ambiguity_l2_indices.find(observation.satellite);
@@ -4709,15 +4663,9 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
         row_satellites.push_back(observation.satellite);
         row_is_phase.push_back(false);
 
-        static const bool kExplicitQzssCodeOnly = [] {
-            const char* e = std::getenv("GNSS_PPP_QZSS_CODE_ONLY");
-            return e != nullptr && e[0] != '0';
-        }();
-        static const bool kMadocaQzssPhase =
-            envFlagOne("GNSS_PPP_MADOCA_QZSS_PHASE");
         const bool qzss_code_only =
-            kExplicitQzssCodeOnly ||
-            (require_coherent_ssr_ && !kMadocaQzssPhase);
+            env_overrides_.qzss_code_only ||
+            (require_coherent_ssr_ && !env_overrides_.madoca_qzss_phase);
         const bool use_observation_phase =
             use_phase_rows &&
             observation.has_carrier_phase &&
@@ -4755,7 +4703,7 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
                 const double predicted_phase = predicted + iono_phase_correction
                                                + filter_state_.state(ambiguity_index);
                 const double phase_residual = observation.carrier_phase_if - predicted_phase;
-                if (kResDump) dumpRes("L1", "phase", phase_residual);
+                if (env_overrides_.res_dump) dumpRes("L1", "phase", phase_residual);
                 const double phase_residual_floor =
                     ppp_config_.kinematic_mode
                         ? (converged_ ? 20.0 : 200.0)
@@ -4819,7 +4767,7 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
                     troposphere_delay + ratio2 * iono_state_l1_m +
                     observation.rx_ant_corr_l2_m;
                 const double l2_code_resid = observation.pseudorange_l2 - l2_code_pred;
-                if (kResDump) dumpRes("L2", "code", l2_code_resid);
+                if (env_overrides_.res_dump) dumpRes("L2", "code", l2_code_resid);
                 // Use the elevation-weighted RTKLIB variance (same satellite, so
                 // identical elevation weighting as L1) rather than the flat seed.
                 const double var_pr_l2 = observation.variance_pr > 0.0
@@ -4865,7 +4813,7 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
                     troposphere_delay - ratio2 * iono_state_l1_m +
                     filter_state_.state(amb2_index) + observation.rx_ant_corr_l2_m;
                 const double l2_phase_resid = observation.carrier_phase_l2 - l2_phase_pred;
-                if (kResDump) dumpRes("L2", "phase", l2_phase_resid);
+                if (env_overrides_.res_dump) dumpRes("L2", "phase", l2_phase_resid);
                 const double var_cp_l2 = observation.variance_cp > 0.0
                     ? observation.variance_cp
                     : safeVariance(observation.variance_cp_l2, 1e-8);
@@ -5072,10 +5020,7 @@ void PPPProcessor::resetAmbiguity(const SatelliteId& satellite, SignalType signa
     // so resetAmbiguity is seldom called and the fix is bit-identical there (the
     // stuck ~10 m L2 residuals come from frozen wrong initial ambiguities, not
     // slip resets — process noise 1e-8). Kept opt-in, default behaviour = HEAD.
-    static const bool kL2ResetFix =
-        std::getenv("GNSS_PPP_L2_RESET_FIX") != nullptr &&
-        std::getenv("GNSS_PPP_L2_RESET_FIX")[0] != '0';
-    const auto l2_it = kL2ResetFix
+    const auto l2_it = env_overrides_.l2_reset_fix
                            ? filter_state_.ambiguity_l2_indices.find(satellite)
                            : filter_state_.ambiguity_l2_indices.end();
     if (l2_it != filter_state_.ambiguity_l2_indices.end()) {
@@ -5112,7 +5057,7 @@ void PPPProcessor::constrainStaticAnchorPosition() {
     }
     const bool madoca_static_anchor_blend =
         require_coherent_ssr_ &&
-        !envFlagOne("GNSS_PPP_DISABLE_MADOCA_STATIC_ANCHOR");
+        !env_overrides_.disable_madoca_static_anchor;
     if (!ppp_config_.apply_static_anchor_blend && !madoca_static_anchor_blend) {
         return;
     }
@@ -5134,13 +5079,7 @@ void PPPProcessor::constrainStaticAnchorPosition() {
                       : (ssr_products_loaded_
                              ? (converged_ ? 0.5 : 0.7)
                              : 1.0)));
-    const double configured_anchor_blend = [] {
-        const char* e = std::getenv("GNSS_PPP_STATIC_ANCHOR_BLEND");
-        if (e == nullptr) {
-            return -1.0;
-        }
-        return std::atof(e);
-    }();
+    const double configured_anchor_blend = env_overrides_.static_anchor_blend;
     const double anchor_blend =
         configured_anchor_blend >= 0.0 && configured_anchor_blend <= 1.0
             ? configured_anchor_blend

--- a/src/algorithms/ppp_ar.cpp
+++ b/src/algorithms/ppp_ar.cpp
@@ -1,6 +1,7 @@
 #include <libgnss++/algorithms/ppp_ar.hpp>
 
 #include <libgnss++/algorithms/lambda.hpp>
+#include <libgnss++/algorithms/ppp_env_overrides.hpp>
 #include <libgnss++/core/coordinates.hpp>
 
 #include <algorithm>
@@ -237,8 +238,7 @@ DdFixAttempt tryDirectDdFix(
     // integer-informativeness of the float solution can be measured (a mean
     // |frac| near 0.25 means the floats are uniformly spread = carry no integer
     // information). Gated by GNSS_PPP_AR_DDDUMP, default OFF.
-    static const bool kDdDump = (std::getenv("GNSS_PPP_AR_DDDUMP") != nullptr);
-    if (kDdDump && excluded_real_satellites.empty()) {
+    if (pppEnvOverrides().ar_dddump && excluded_real_satellites.empty()) {
         for (int k = 0; k < attempt.nb; ++k) {
             const int ri = dd_pairs[static_cast<size_t>(k)].ref_idx;
             const int si = dd_pairs[static_cast<size_t>(k)].sat_idx;

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -1,0 +1,96 @@
+#include <libgnss++/algorithms/ppp_env_overrides.hpp>
+
+#include <cstdlib>
+
+namespace libgnss {
+namespace {
+
+const char* envValue(const char* name) {
+    return std::getenv(name);
+}
+
+bool envPresent(const char* name) {
+    return envValue(name) != nullptr;
+}
+
+bool envExactOne(const char* name) {
+    const char* value = envValue(name);
+    return value != nullptr && value[0] == '1' && value[1] == '\0';
+}
+
+bool envFirstCharNotZero(const char* name) {
+    const char* value = envValue(name);
+    return value != nullptr && value[0] != '0';
+}
+
+bool envExactZero(const char* name) {
+    const char* value = envValue(name);
+    return value != nullptr && value[0] == '0' && value[1] == '\0';
+}
+
+double envDoubleOr(const char* name, double fallback) {
+    const char* value = envValue(name);
+    return value != nullptr ? std::atof(value) : fallback;
+}
+
+}  // namespace
+
+PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
+    PPPEnvOverrides overrides;
+
+    overrides.madoca_bias_subtract = envPresent("GNSS_PPP_MADOCA_BIAS_SUBTRACT");
+    overrides.madoca_allow_partial_ssr = envExactOne("GNSS_PPP_MADOCA_ALLOW_PARTIAL_SSR");
+    overrides.require_ssr_orbit = envFirstCharNotZero("GNSS_PPP_REQUIRE_SSR_ORBIT");
+    overrides.disable_madoca_static_anchor =
+        envExactOne("GNSS_PPP_DISABLE_MADOCA_STATIC_ANCHOR");
+    overrides.static_anchor_blend = envDoubleOr("GNSS_PPP_STATIC_ANCHOR_BLEND", -1.0);
+
+    const char* isb = envValue("GNSS_PPP_ESTIMATE_ISB");
+    const std::string isb_spec = isb != nullptr ? std::string(isb) : std::string();
+    overrides.estimate_isb_all =
+        isb_spec == "1" || isb_spec.find("all") != std::string::npos;
+    overrides.estimate_isb_gal =
+        overrides.estimate_isb_all || isb_spec.find("gal") != std::string::npos;
+    overrides.estimate_isb_qzs =
+        overrides.estimate_isb_all || isb_spec.find("qzs") != std::string::npos;
+    overrides.estimate_isb_bds =
+        overrides.estimate_isb_all || isb_spec.find("bds") != std::string::npos;
+
+    overrides.isb_process_noise = envDoubleOr("GNSS_PPP_ISB_PROCESS_NOISE", 1e-6);
+    overrides.init_iono_var = envDoubleOr("GNSS_PPP_INIT_IONO_VAR", 0.0);
+    overrides.qzss_code_only = envFirstCharNotZero("GNSS_PPP_QZSS_CODE_ONLY");
+    overrides.qzss_prefer_l1l_present = envPresent("GNSS_PPP_QZSS_PREFER_L1L");
+    overrides.qzss_prefer_l1l = envFirstCharNotZero("GNSS_PPP_QZSS_PREFER_L1L");
+    overrides.qzss_ssr_prn_fix =
+        !envExactZero("GNSS_PPP_QZSS_SSR_PRN_FIX") &&
+        !envExactOne("GNSS_PPP_DISABLE_QZSS_SSR_PRN_FIX");
+    overrides.madoca_qzss_clock = !envExactZero("GNSS_PPP_MADOCA_QZSS_CLOCK");
+    overrides.madoca_qzss_phase = envExactOne("GNSS_PPP_MADOCA_QZSS_PHASE");
+    overrides.pb_add = envPresent("GNSS_PPP_PB_ADD");
+    overrides.no_phase_bias = envPresent("GNSS_PPP_NO_PHASE_BIAS");
+    overrides.l2_reset_fix = envFirstCharNotZero("GNSS_PPP_L2_RESET_FIX");
+    overrides.gal_inav = envFirstCharNotZero("GNSS_PPP_GAL_INAV");
+    overrides.ssr_discnt_slip = envPresent("GNSS_PPP_SSR_DISCNT_SLIP");
+    overrides.no_solid_tide = envPresent("GNSS_PPP_NO_SOLID_TIDE");
+    overrides.tide_itrs_sun_moon = envPresent("GNSS_PPP_TIDE_ITRS_SUN_MOON");
+    overrides.pf_code_var_scale = envDoubleOr("GNSS_PPP_PF_CODE_VAR_SCALE", 9.0);
+    overrides.pf_rx_antenna = envPresent("GNSS_PPP_PF_RX_ANTENNA");
+    overrides.pf_wet_trop = envPresent("GNSS_PPP_PF_WET_TROP");
+
+    overrides.res_dump = envPresent("GNSS_PPP_RES_DUMP");
+    overrides.satpos_dump = envPresent("GNSS_PPP_SATPOS_DUMP");
+    overrides.pfdump = envPresent("GNSS_PPP_PFDUMP");
+    overrides.pb_apply_dump = envPresent("GNSS_PPP_PB_APPLY_DUMP");
+    overrides.madoca_cbias_dump = envPresent("GNSS_PPP_MADOCA_CBIAS_DUMP");
+    overrides.ar_dddump = envPresent("GNSS_PPP_AR_DDDUMP");
+    overrides.debug = envPresent("GNSS_PPP_DEBUG");
+
+    return overrides;
+}
+
+const PPPEnvOverrides& pppEnvOverrides() {
+    static const PPPEnvOverrides overrides = PPPEnvOverrides::fromEnvironment();
+    return overrides;
+}
+
+}  // namespace libgnss

--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -1,10 +1,10 @@
 #include <libgnss++/core/navigation.hpp>
+#include <libgnss++/algorithms/ppp_env_overrides.hpp>
 #include <algorithm>
 #include <cmath>
 #include <cctype>
 #include <ctime>
 #include <iostream>
-#include <cstdlib>
 #include <fstream>
 #include <limits>
 #include <sstream>
@@ -580,11 +580,7 @@ namespace {
 // impact). Kept as an opt-in for when the estimator layer is addressed.
 inline bool galileoSkip(const SatelliteId& sat, const Ephemeris& eph,
                         const GNSSTime& time) {
-    static const bool kEnabled = [] {
-        const char* v = std::getenv("GNSS_PPP_GAL_INAV");
-        return v != nullptr && v[0] != '0';
-    }();
-    if (!kEnabled || sat.system != GNSSSystem::Galileo) {
+    if (!pppEnvOverrides().gal_inav || sat.system != GNSSSystem::Galileo) {
         return false;
     }
     constexpr int kGalInavClockBit = 1 << 9;
@@ -1992,7 +1988,7 @@ bool SSRProducts::loadCSVFile(const std::string& filename) {
     }
 
     // Debug: count atmos entries after loading
-    if (std::getenv("GNSS_PPP_DEBUG") != nullptr) {
+    if (pppEnvOverrides().debug) {
         size_t atmos_entries = 0;
         size_t total_entries = 0;
         for (const auto& [sat, entries] : orbit_clock_corrections) {

--- a/src/iers/tides.cpp
+++ b/src/iers/tides.cpp
@@ -1,5 +1,7 @@
 #include "libgnss++/iers/tides.hpp"
 
+#include <libgnss++/algorithms/ppp_env_overrides.hpp>
+
 #include <cmath>
 #include <vector>
 
@@ -64,9 +66,7 @@ Eigen::Vector3d solidEarthTideDisplacement(
     // long-term choice (matches the routine's documented contract).
     Eigen::Vector3d xsun_used = xsun_icrs;
     Eigen::Vector3d xmon_used = xmon_icrs;
-    static const bool kRotateSunMoonToItrs =
-        (std::getenv("GNSS_PPP_TIDE_ITRS_SUN_MOON") != nullptr);
-    if (kRotateSunMoonToItrs) {
+    if (pppEnvOverrides().tide_itrs_sun_moon) {
         // Approximate ICRS -> ITRS rotation via GMST about z. This omits
         // precession-nutation (~arcsec) and polar motion (~0.3"), both
         // of which contribute well under 1 mm to the diurnal tide.

--- a/src/io/madoca_l6.cpp
+++ b/src/io/madoca_l6.cpp
@@ -6,7 +6,6 @@
 
 #include <cmath>
 #include <cstdint>
-#include <cstdlib>
 #include <fstream>
 #include <string>
 #include <vector>
@@ -247,7 +246,8 @@ int sigmask2list(std::uint16_t mask, int gnssid, int* siglist) {
 
 }  // namespace
 
-MadocaL6eDecoder::MadocaL6eDecoder() {
+MadocaL6eDecoder::MadocaL6eDecoder()
+    : env_overrides_(PPPEnvOverrides::fromEnvironment()) {
     const double ep[6] = {2025.0, 4.0, 1.0, 0.0, 0.0, 0.0};
     seed_ = epoch2time(ep);
     reset();
@@ -665,8 +665,7 @@ int MadocaL6eDecoder::decodeL6eMessage() {
             if ((ch.mgfid & 0x1) != (static_cast<int>(mgfid) & 0x1)) {
                 apply = 0;
             }
-            static const bool kStDump = (std::getenv("GNSS_PPP_MADOCA_CBIAS_DUMP") != nullptr);
-            if (kStDump) {
+            if (env_overrides_.madoca_cbias_dump) {
                 std::fprintf(stderr, "[MADOCA-ST] st=%d apply=%d mgfid=%d ch.mgfid=%d\n",
                              st, apply, static_cast<int>(mgfid), ch.mgfid);
             }
@@ -731,6 +730,7 @@ libgnss::GNSSSystem mpSysToGnss(int mpsys) {
 // The sample is time-stamped at the most recent of the orbit/clock t0 so a live
 // stream of orbit- and clock-paced updates yields a monotonic time series.
 bool buildMadocaSsrCorrection(int sat, const MadocaSsrCorrection& c,
+                              const PPPEnvOverrides& env_overrides,
                               libgnss::SSROrbitClockCorrection& out) {
     const bool has_orbit = c.t0[0].time != 0;  // t0[eph]
     const bool has_clock = c.t0[1].time != 0;  // t0[clk]
@@ -754,16 +754,9 @@ bool buildMadocaSsrCorrection(int sat, const MadocaSsrCorrection& c,
     // Enabled by default for native MADOCA parity. GNSS_PPP_QZSS_SSR_PRN_FIX=0
     // or GNSS_PPP_DISABLE_QZSS_SSR_PRN_FIX=1 restores the old keying for
     // diagnostics.
-    static const bool kQzssPrnFix = [] {
-        const char* legacy = std::getenv("GNSS_PPP_QZSS_SSR_PRN_FIX");
-        if (legacy != nullptr && legacy[0] == '0' && legacy[1] == '\0') {
-            return false;
-        }
-        const char* disable = std::getenv("GNSS_PPP_DISABLE_QZSS_SSR_PRN_FIX");
-        return !(disable != nullptr && disable[0] == '1' && disable[1] == '\0');
-    }();
     constexpr int kQzssPrnOffset = 192;  // 193 (RTKLIB) -> 1 (RINEX/native)
-    if (kQzssPrnFix && gsys == libgnss::GNSSSystem::QZSS && prn > kQzssPrnOffset) {
+    if (env_overrides.qzss_ssr_prn_fix &&
+        gsys == libgnss::GNSSSystem::QZSS && prn > kQzssPrnOffset) {
         prn -= kQzssPrnOffset;
     }
 
@@ -796,12 +789,11 @@ bool buildMadocaSsrCorrection(int sat, const MadocaSsrCorrection& c,
         out.clock_reference_time = libgnss::GNSSTime(clock_week, clock_tow);
     }
 
-    static const bool kCbiasDump = (std::getenv("GNSS_PPP_MADOCA_CBIAS_DUMP") != nullptr);
     for (int k = 0; k < MadocaSsrCorrection::kMaxCode; ++k) {
         const int code = k + 1;  // cbias/pbias are held by CODE_*-1
         if (c.vcbias[k]) {
             const std::uint8_t id = madocaBiasCodeToRtcmSsrId(gsys, code);
-            if (kCbiasDump) {
+            if (env_overrides.madoca_cbias_dump) {
                 std::fprintf(stderr,
                              "[MADOCA-CBIAS] sys=%d prn=%d code=%d id=%u cbias=%.4f\n",
                              static_cast<int>(gsys), prn, code,
@@ -813,7 +805,7 @@ bool buildMadocaSsrCorrection(int sat, const MadocaSsrCorrection& c,
         }
         if (c.vpbias[k]) {
             const std::uint8_t id = madocaBiasCodeToRtcmSsrId(gsys, code);
-            if (kCbiasDump) {
+            if (env_overrides.madoca_cbias_dump) {
                 std::fprintf(stderr,
                              "[MADOCA-PBIAS] sys=%d prn=%d code=%d id=%u pbias=%.4f\n",
                              static_cast<int>(gsys), prn, code,
@@ -899,7 +891,8 @@ int madocaL6eSnapshotToProducts(const MadocaL6eDecoder& decoder,
     int added = 0;
     for (int sat = 1; sat <= MadocaL6eDecoder::kMaxSat; ++sat) {
         libgnss::SSROrbitClockCorrection corr;
-        if (buildMadocaSsrCorrection(sat, decoder.correction(sat), corr)) {
+        if (buildMadocaSsrCorrection(
+                sat, decoder.correction(sat), decoder.envOverrides(), corr)) {
             products.addCorrection(corr);
             ++added;
         }
@@ -946,7 +939,7 @@ int decodeMadocaL6eFilesToProducts(const std::vector<std::string>& files,
                 last_orbit[sat] = ot;
                 last_clock[sat] = ct;
                 libgnss::SSROrbitClockCorrection corr;
-                if (buildMadocaSsrCorrection(sat, c, corr)) {
+                if (buildMadocaSsrCorrection(sat, c, decoder.envOverrides(), corr)) {
                     products.addCorrection(corr);
                     ++added;
                 }

--- a/src/io/rinex.cpp
+++ b/src/io/rinex.cpp
@@ -1,4 +1,5 @@
 #include <libgnss++/io/rinex.hpp>
+#include <libgnss++/algorithms/ppp_env_overrides.hpp>
 #include <libgnss++/core/signal_policy.hpp>
 #include <algorithm>
 #include <fstream>
@@ -6,7 +7,6 @@
 #include <iomanip>
 #include <iostream>
 #include <cmath>
-#include <cstdlib>
 
 namespace libgnss {
 namespace io {
@@ -184,6 +184,7 @@ void maybeAssignSelectedObservation(ObservationSelection& selection,
                                     double value,
                                     int lli,
                                     int signal_strength,
+                                    bool prefer_qzss_l1l,
                                     bool primary) {
     if (value == 0.0) {
         return;
@@ -196,9 +197,6 @@ void maybeAssignSelectedObservation(ObservationSelection& selection,
     }
 
     const char tracking_code = rinexTrackingCode(obs_type);
-    const char* qzss_prefer_l1l_env = std::getenv("GNSS_PPP_QZSS_PREFER_L1L");
-    const bool prefer_qzss_l1l =
-        qzss_prefer_l1l_env != nullptr && qzss_prefer_l1l_env[0] != '0';
     // Native MADOCA-PPP sets GNSS_PPP_QZSS_PREFER_L1L so QZSS L1 tracks the
     // L1L/L1X correction chain used by MADOCALIB. RINEX files often list
     // C1C/L1C before C1L/L1L; prefer L only when that mode is enabled.
@@ -337,6 +335,9 @@ void assignObservationField(Observation& obs,
 }
 
 }  // namespace
+
+RINEXReader::RINEXReader()
+    : qzss_prefer_l1l_(PPPEnvOverrides::fromEnvironment().qzss_prefer_l1l) {}
 
 bool RINEXReader::open(const std::string& filename) {
     file_.open(filename);
@@ -948,6 +949,7 @@ bool RINEXReader::parseObservationEpochV2(const std::string& line, ObservationDa
                                            obs_values[i],
                                            lli_flags[i],
                                            signal_strength[i],
+                                           qzss_prefer_l1l_,
                                            true);
             maybeAssignSelectedObservation(secondary_selection,
                                            sat,
@@ -955,6 +957,7 @@ bool RINEXReader::parseObservationEpochV2(const std::string& line, ObservationDa
                                            obs_values[i],
                                            lli_flags[i],
                                            signal_strength[i],
+                                           qzss_prefer_l1l_,
                                            false);
         }
 
@@ -1081,6 +1084,7 @@ bool RINEXReader::parseObservationEpochV3(const std::string& epoch_line, Observa
                                                obs_values[i],
                                                lli_flags[i],
                                                signal_strength[i],
+                                               qzss_prefer_l1l_,
                                                true);
                 maybeAssignSelectedObservation(secondary_selection,
                                                sat,
@@ -1088,6 +1092,7 @@ bool RINEXReader::parseObservationEpochV3(const std::string& epoch_line, Observa
                                                obs_values[i],
                                                lli_flags[i],
                                                signal_strength[i],
+                                               qzss_prefer_l1l_,
                                                false);
             }
 


### PR DESCRIPTION
## Summary

Refactor slice R1 (no behavior change). The PPP/MADOCA path had grown **31 `GNSS_PPP_*` env knobs** read through `getenv` calls scattered across 6+ translation units, plus a `setenv` bridge in `gnss_ppp.cpp` that abused the process environment to pass the QZSS L1L preference to the RINEX reader.

- All knobs now live in **`PPPEnvOverrides`** (`include/libgnss++/algorithms/ppp_env_overrides.hpp`): one typed field per knob with env name, exact parsing semantics, and default documented inline; behavior knobs and diagnostic dumps classified.
- `PPPEnvOverrides::fromEnvironment()` parses the environment in one place, preserving each knob's exact legacy semantics (present-bool vs exact-"1" vs first-char vs atof-range vs ISB substring list).
- `PPPProcessor`, `MadocaL6eDecoder`, `RINEXReader` take per-instance snapshots; shared helpers use a process singleton.
- The `setenv` hack is replaced by `RINEXReader::setQzssL1Preference()`.
- Every env var keeps working with identical semantics — consolidation, not removal.

## Behavior-preservation evidence

8-case MIZU env matrix **bit-exact** (`cmp`) against the pre-refactor binary: default, `MADOCA_BIAS_SUBTRACT`, `MADOCA_ALLOW_PARTIAL_SSR`, `DISABLE_MADOCA_STATIC_ANCHOR`, `DISABLE_QZSS_SSR_PRN_FIX`, `MADOCA_QZSS_PHASE`, `ESTIMATE_ISB=all`, `STATIC_ANCHOR_BLEND=0.5` — independently re-verified after review. `grep` confirms zero `getenv("GNSS_PPP_*")` sites outside the parser and zero `setenv` in the app.

## Slice provenance

Implementation by codex 5.5 (xhigh) with a generate-reference-matrix-first protocol; reviewed manually and bit-exactness re-verified independently.

## Tests run locally

- `./build-madoca-parity/tests/run_tests` — 318/318 passed
- `python3 tests/test_cli_tools.py -k qzss_l6` (52 ran) / `-k madoca` — OK
- `git diff --check` clean

## Follow-up

R2: structural split of the 5,500-line `ppp.cpp` (observation preparation / correction application / measurement formation / AR glue), now possible without entangling env policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)