### PR TITLE
feat(ppp): include GLONASS code observations in coherent MADOCA mode

### DIFF
--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -51,6 +51,9 @@ struct PPPEnvOverrides {
     // GNSS_PPP_MADOCA_QZSS_PHASE: allow QZSS phase rows in MADOCA when set
     // exactly to "1". Default false.
     bool madoca_qzss_phase = false;
+    // GNSS_PPP_MADOCA_GLONASS: include GLONASS in coherent MADOCA unless set
+    // exactly to "0". Default true.
+    bool madoca_glonass = true;
     // GNSS_PPP_PB_ADD: add non-MADOCA SSR phase biases instead of subtracting.
     // Default false.
     bool pb_add = false;

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -66,6 +66,7 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
         !envExactOne("GNSS_PPP_DISABLE_QZSS_SSR_PRN_FIX");
     overrides.madoca_qzss_clock = !envExactZero("GNSS_PPP_MADOCA_QZSS_CLOCK");
     overrides.madoca_qzss_phase = envExactOne("GNSS_PPP_MADOCA_QZSS_PHASE");
+    overrides.madoca_glonass = !envExactZero("GNSS_PPP_MADOCA_GLONASS");
     overrides.pb_add = envPresent("GNSS_PPP_PB_ADD");
     overrides.no_phase_bias = envPresent("GNSS_PPP_NO_PHASE_BIAS");
     overrides.l2_reset_fix = envFirstCharNotZero("GNSS_PPP_L2_RESET_FIX");

--- a/src/algorithms/ppp_measurement.cpp
+++ b/src/algorithms/ppp_measurement.cpp
@@ -184,10 +184,16 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
         const bool qzss_code_only =
             env_overrides_.qzss_code_only ||
             (require_coherent_ssr_ && !env_overrides_.madoca_qzss_phase);
+        // GLONASS FDMA phase rows need an inter-channel phase-bias treatment
+        // that native does not yet model; code rows improve MADOCA bridge parity.
+        const bool glonass_code_only =
+            require_coherent_ssr_ && env_overrides_.madoca_glonass &&
+            observation.satellite.system == GNSSSystem::GLONASS;
         const bool use_observation_phase =
             use_phase_rows &&
             observation.has_carrier_phase &&
-            !(qzss_code_only && observation.satellite.system == GNSSSystem::QZSS);
+            !(qzss_code_only && observation.satellite.system == GNSSSystem::QZSS) &&
+            !glonass_code_only;
         if (use_observation_phase) {
             const int ambiguity_index = ambiguityStateIndex(observation.satellite);
             if (ambiguity_index >= 0 && ambiguity_index < filter_state_.total_states) {

--- a/src/algorithms/ppp_observations.cpp
+++ b/src/algorithms/ppp_observations.cpp
@@ -20,8 +20,11 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
     for (const auto& sat : obs.getSatellites()) {
         // Keep the native MADOCA parity path on systems whose L6 SSR handling is
         // coherent with the MADOCALIB bridge for this loader.
-        if (require_coherent_ssr_ &&
-            (sat.system == GNSSSystem::BeiDou || sat.system == GNSSSystem::GLONASS)) {
+        if (require_coherent_ssr_ && sat.system == GNSSSystem::BeiDou) {
+            continue;
+        }
+        if (require_coherent_ssr_ && sat.system == GNSSSystem::GLONASS &&
+            !env_overrides_.madoca_glonass) {
             continue;
         }
 


### PR DESCRIPTION
## Summary
- Admits GLONASS satellites in the native MADOCA-PPP coherent path (previously skipped with BeiDou), default ON with `GNSS_PPP_MADOCA_GLONASS=0` opt-out (new `PPPEnvOverrides` field).
- Chain audit (codex 5.5 xhigh) found the existing GLONASS infrastructure already coherent with the MADOCALIB bridge: R01-based SSR slot keying, tb-derived IODE matching, FCN-aware FDMA frequencies, dedicated GLONASS receiver clock state, RTKLIB 1.5 variance factor.
- GLONASS enters **code-only**: FDMA phase rows need inter-channel phase-bias modeling we don't have; measured phase inclusion regressed tail parity, code rows improve both metrics.

## Parity (MIZU 1h, native vs MADOCALIB bridge, delta RMS 3D)
| | all-epoch | tail 1800s |
|---|---:|---:|
| before | 1.942 m | 1.752 m |
| after (default ON) | **1.900 m** | **1.732 m** |

Opt-out run is bit-exact with the pre-change default. Native now uses R09/R21/R22 (bridge additionally uses low-elevation R01/R19 — forcing the bridge's 10° mask caused convergence failure; deferred).

## Validation
- run_tests: 318 passed / 43 skipped
- tests/test_cli_tools.py -k qzss_l6 (52 ran) and -k madoca: pass
- `GNSS_PPP_MADOCA_GLONASS=0` bit-exact vs pre-edit reference matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)