### PR TITLE
feat(ppp): add per-stream L6 SSR replay decoder preview (negative parity result)

### DIFF
--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -11,6 +11,9 @@ struct PPPEnvOverrides {
     // GNSS_PPP_MADOCA_ALLOW_PARTIAL_SSR: accept incomplete MADOCA SSR epochs
     // when set exactly to "1". Default false.
     bool madoca_allow_partial_ssr = false;
+    // GNSS_PPP_MADOCA_SSR_REPLAY: select native MADOCA L6 SSR corrections from
+    // per-PRN replay snapshots when set exactly to "1". Default false.
+    bool madoca_ssr_replay = false;
     // GNSS_PPP_REQUIRE_SSR_ORBIT: drop satellites missing SSR orbit
     // corrections when set to a value whose first char is not '0'. Default false.
     bool require_ssr_orbit = false;

--- a/include/libgnss++/io/madoca_l6.hpp
+++ b/include/libgnss++/io/madoca_l6.hpp
@@ -146,4 +146,12 @@ int decodeMadocaL6eFilesToProducts(const std::vector<std::string>& files,
                                    int gps_week,
                                    libgnss::SSRProducts& products);
 
+// Decode MADOCA L6E files as independent PRN streams and emit full per-stream
+// snapshots whenever any SSR component timestamp changes. This mirrors
+// MADOCALIB's per-epoch update_qzssl6e() replay more closely than the legacy
+// whole-file orbit/clock snapshot loader.
+int decodeMadocaL6eFilesToProductsReplay(const std::vector<std::string>& files,
+                                         int gps_week,
+                                         libgnss::SSRProducts& products);
+
 }  // namespace libgnss::io

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -40,6 +40,7 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
 
     overrides.madoca_bias_subtract = envPresent("GNSS_PPP_MADOCA_BIAS_SUBTRACT");
     overrides.madoca_allow_partial_ssr = envExactOne("GNSS_PPP_MADOCA_ALLOW_PARTIAL_SSR");
+    overrides.madoca_ssr_replay = envExactOne("GNSS_PPP_MADOCA_SSR_REPLAY");
     overrides.require_ssr_orbit = envFirstCharNotZero("GNSS_PPP_REQUIRE_SSR_ORBIT");
     overrides.disable_madoca_static_anchor =
         envExactOne("GNSS_PPP_DISABLE_MADOCA_STATIC_ANCHOR");

--- a/src/algorithms/ppp_products.cpp
+++ b/src/algorithms/ppp_products.cpp
@@ -211,7 +211,8 @@ bool PPPProcessor::loadMadocaL6Products(const std::vector<std::string>& l6_files
     }
     const int gps_week = ppp_config_.l6_gps_week > 0 ? ppp_config_.l6_gps_week
                                                      : last_obs_gps_week_;
-    const int added =
+    const int added = env_overrides_.madoca_ssr_replay ?
+        io::decodeMadocaL6eFilesToProductsReplay(l6_files, gps_week, ssr_products_) :
         io::decodeMadocaL6eFilesToProducts(l6_files, gps_week, ssr_products_);
     ssr_products_loaded_ = added > 0;
     require_coherent_ssr_ =

--- a/src/io/madoca_l6.cpp
+++ b/src/io/madoca_l6.cpp
@@ -4,6 +4,7 @@
 #include <libgnss++/core/navigation.hpp>
 #include <libgnss++/core/types.hpp>
 
+#include <array>
 #include <cmath>
 #include <cstdint>
 #include <fstream>
@@ -729,9 +730,33 @@ libgnss::GNSSSystem mpSysToGnss(int mpsys) {
 // Returns false when the satellite carries no orbit/clock or maps to no system.
 // The sample is time-stamped at the most recent of the orbit/clock t0 so a live
 // stream of orbit- and clock-paced updates yields a monotonic time series.
+bool madocaTimeLess(const MadocaGtime& lhs, const MadocaGtime& rhs) {
+    if (lhs.time != rhs.time) {
+        return lhs.time < rhs.time;
+    }
+    return lhs.sec < rhs.sec;
+}
+
+MadocaGtime latestComponentTime(const MadocaSsrCorrection& c, bool include_bias_times) {
+    MadocaGtime latest = c.t0[0];
+    if (latest.time == 0 || madocaTimeLess(latest, c.t0[1])) {
+        latest = c.t0[1];
+    }
+    if (include_bias_times) {
+        for (int index : {3, 4, 5}) {
+            if (c.t0[index].time != 0 &&
+                (latest.time == 0 || madocaTimeLess(latest, c.t0[index]))) {
+                latest = c.t0[index];
+            }
+        }
+    }
+    return latest;
+}
+
 bool buildMadocaSsrCorrection(int sat, const MadocaSsrCorrection& c,
                               const PPPEnvOverrides& env_overrides,
-                              libgnss::SSROrbitClockCorrection& out) {
+                              libgnss::SSROrbitClockCorrection& out,
+                              bool include_bias_times = false) {
     const bool has_orbit = c.t0[0].time != 0;  // t0[eph]
     const bool has_clock = c.t0[1].time != 0;  // t0[clk]
     if (!has_orbit && !has_clock) {
@@ -763,9 +788,7 @@ bool buildMadocaSsrCorrection(int sat, const MadocaSsrCorrection& c,
     out = libgnss::SSROrbitClockCorrection{};
     out.satellite = libgnss::SatelliteId(gsys, static_cast<std::uint8_t>(prn));
 
-    const bool clock_is_later =
-        has_clock && (!has_orbit || c.t0[1].time >= c.t0[0].time);
-    const MadocaGtime& t0 = clock_is_later ? c.t0[1] : c.t0[0];
+    const MadocaGtime t0 = latestComponentTime(c, include_bias_times);
     int week = 0;
     const double tow = time2gpst(t0, &week);
     out.time = libgnss::GNSSTime(week, tow);
@@ -940,6 +963,62 @@ int decodeMadocaL6eFilesToProducts(const std::vector<std::string>& files,
                 last_clock[sat] = ct;
                 libgnss::SSROrbitClockCorrection corr;
                 if (buildMadocaSsrCorrection(sat, c, decoder.envOverrides(), corr)) {
+                    products.addCorrection(corr);
+                    ++added;
+                }
+            }
+        }
+    }
+    return added;
+}
+
+int decodeMadocaL6eFilesToProductsReplay(const std::vector<std::string>& files,
+                                         int gps_week,
+                                         libgnss::SSRProducts& products) {
+    products.setOrbitCorrectionsAreRac(true);
+    double ref_ep[6];
+    referenceEpochForWeek(gps_week, ref_ep);
+
+    constexpr int kN = MadocaL6eDecoder::kMaxSat;
+    int added = 0;
+    for (const std::string& file : files) {
+        std::ifstream in(file, std::ios::binary);
+        if (!in) {
+            continue;
+        }
+
+        MadocaL6eDecoder decoder;
+        decoder.setReferenceEpoch(ref_ep);
+        std::vector<std::array<std::int64_t, 6>> last_t0(kN + 1);
+        for (auto& sat_t0 : last_t0) {
+            sat_t0.fill(-1);
+        }
+
+        char raw = 0;
+        while (in.get(raw)) {
+            if (decoder.inputByte(static_cast<std::uint8_t>(raw)) != 10) {
+                continue;
+            }
+            for (int sat = 1; sat <= kN; ++sat) {
+                const MadocaSsrCorrection& c = decoder.correction(sat);
+                bool changed = false;
+                bool has_any_component = false;
+                for (int index = 0; index < 6; ++index) {
+                    const std::int64_t t0 = c.t0[index].time;
+                    has_any_component = has_any_component || t0 != 0;
+                    if (t0 != last_t0[sat][index]) {
+                        changed = true;
+                    }
+                }
+                if (!has_any_component || !changed) {
+                    continue;
+                }
+                for (int index = 0; index < 6; ++index) {
+                    last_t0[sat][index] = c.t0[index].time;
+                }
+                libgnss::SSROrbitClockCorrection corr;
+                if (buildMadocaSsrCorrection(
+                        sat, c, decoder.envOverrides(), corr, true)) {
                     products.addCorrection(corr);
                     ++added;
                 }


### PR DESCRIPTION
## Summary
- Adds `GNSS_PPP_MADOCA_SSR_REPLAY=1` (default **off**) routing MADOCA L6 loading through a per-stream replay decoder mirroring MADOCALIB's per-epoch `update_qzssl6e` semantics (postpos.c:448-452): independent PRN streams, product snapshot whenever any SSR component timestamp changes.

## Why merge a default-off knob
This slice **closes the replay-semantics hypothesis with executable evidence**: in the default coherent path, replay selection is **bit-identical** to the bulk decode — the #130 coherence gate (orbit+clock required, non-future, 60 s age, IOD match) already enforces MADOCALIB's selection behavior. Multi-PRN file order is likewise inert on MIZU (verified by reversing file order). The decoder is kept as future real-time streaming infrastructure.

Audit table (selection / age gates / dt propagation / multi-PRN merge / future leakage, with code refs both sides) in `/tmp/codex_l6replay_report.md` methodology; key facts now recorded in the project memory.

## Measurements (MIZU 1h vs MADOCALIB bridge)
| Run | all-epoch RMS 3D | tail 1800s |
|---|---:|---:|
| default (replay off) | 1.900 m | 1.732 m |
| replay on | bit-identical | bit-identical |
| partial-SSR + replay (diagnostic, non-target) | 96.0 → 41.5 m | 1.30 → 1.83 m |

## Validation
- 6-case env matrix bit-exact vs pre-edit references (independently re-verified)
- run_tests 318 passed; test_cli_tools -k qzss_l6 / madoca / clas: pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)