### PR TITLE
fix(ppp): GLONASS FDMA chain fixes + default-off phase-row preview

### DIFF
--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -418,7 +418,7 @@ private:
     /**
      * @brief Detect cycle slips
      */
-    void detectCycleSlips(const ObservationData& obs);
+    void detectCycleSlips(const ObservationData& obs, const NavigationData& nav);
 
     /**
      * @brief Ensure ambiguity states exist for valid carrier-phase observations.

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -57,6 +57,9 @@ struct PPPEnvOverrides {
     // GNSS_PPP_MADOCA_GLONASS: include GLONASS in coherent MADOCA unless set
     // exactly to "0". Default true.
     bool madoca_glonass = true;
+    // GNSS_PPP_MADOCA_GLONASS_PHASE: allow GLONASS phase rows in MADOCA when
+    // set exactly to "1". Default false.
+    bool madoca_glonass_phase = false;
     // GNSS_PPP_PB_ADD: add non-MADOCA SSR phase biases instead of subtracting.
     // Default false.
     bool pb_add = false;

--- a/include/libgnss++/core/signal_policy.hpp
+++ b/include/libgnss++/core/signal_policy.hpp
@@ -55,9 +55,18 @@ inline bool trySignalForObservationType(GNSSSystem system,
             if (band == 5) { signal = SignalType::GPS_L5; return true; }
             break;
         case GNSSSystem::GLONASS:
-            if (band == 1) { signal = SignalType::GLO_L1CA; return true; }
-            if (band == 2) { signal = SignalType::GLO_L2CA; return true; }
-            if (band == 3) { signal = SignalType::GLO_L2P; return true; }
+            if (band == 1) {
+                signal = obs_type.size() >= 3 && obs_type[2] == 'P'
+                             ? SignalType::GLO_L1P
+                             : SignalType::GLO_L1CA;
+                return true;
+            }
+            if (band == 2) {
+                signal = obs_type.size() >= 3 && obs_type[2] == 'P'
+                             ? SignalType::GLO_L2P
+                             : SignalType::GLO_L2CA;
+                return true;
+            }
             break;
         case GNSSSystem::Galileo:
             if (band == 1) { signal = SignalType::GAL_E1; return true; }

--- a/include/libgnss++/io/rinex.hpp
+++ b/include/libgnss++/io/rinex.hpp
@@ -52,6 +52,7 @@ public:
         std::vector<std::string> observation_types;
         // RINEX 3: per-system observation types (key = system char, e.g. "G", "R", "E")
         std::map<char, std::vector<std::string>> system_obs_types;
+        std::map<SatelliteId, int> glonass_frequency_channels;
         double interval = 0.0;
         GNSSTime first_obs;
         GNSSTime last_obs;

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -531,7 +531,7 @@ PositionSolution PPPProcessor::processEpochStandard(
 
         if (filter_initialized_) {
             const double dt = has_last_processed_time_ ? clampDt(obs.time - last_processed_time_) : 1.0;
-            detectCycleSlips(obs);
+            detectCycleSlips(obs, nav);
             predictState(dt, seed_ptr);
 
             bool updated = updateFilter(obs, nav);

--- a/src/algorithms/ppp_clas_epoch.cpp
+++ b/src/algorithms/ppp_clas_epoch.cpp
@@ -95,7 +95,7 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
     };
 
     PositionSolution seed = spp_processor_.processEpoch(obs, nav);
-    detectCycleSlips(obs);
+    detectCycleSlips(obs, nav);
     const auto epoch_preparation = ppp_clas::prepareEpochState(
         obs,
         seed,

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -68,6 +68,7 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
     overrides.madoca_qzss_clock = !envExactZero("GNSS_PPP_MADOCA_QZSS_CLOCK");
     overrides.madoca_qzss_phase = envExactOne("GNSS_PPP_MADOCA_QZSS_PHASE");
     overrides.madoca_glonass = !envExactZero("GNSS_PPP_MADOCA_GLONASS");
+    overrides.madoca_glonass_phase = envExactOne("GNSS_PPP_MADOCA_GLONASS_PHASE");
     overrides.pb_add = envPresent("GNSS_PPP_PB_ADD");
     overrides.no_phase_bias = envPresent("GNSS_PPP_NO_PHASE_BIAS");
     overrides.l2_reset_fix = envFirstCharNotZero("GNSS_PPP_L2_RESET_FIX");

--- a/src/algorithms/ppp_measurement.cpp
+++ b/src/algorithms/ppp_measurement.cpp
@@ -184,10 +184,12 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
         const bool qzss_code_only =
             env_overrides_.qzss_code_only ||
             (require_coherent_ssr_ && !env_overrides_.madoca_qzss_phase);
-        // GLONASS FDMA phase rows need an inter-channel phase-bias treatment
-        // that native does not yet model; code rows improve MADOCA bridge parity.
+        // GLONASS FDMA phase rows remain preview-only in coherent MADOCA:
+        // full-row enablement exposes a time-varying relative phase residual,
+        // while code rows improve bridge parity.
         const bool glonass_code_only =
             require_coherent_ssr_ && env_overrides_.madoca_glonass &&
+            !env_overrides_.madoca_glonass_phase &&
             observation.satellite.system == GNSSSystem::GLONASS;
         const bool use_observation_phase =
             use_phase_rows &&

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -389,7 +389,7 @@ bool PPPProcessor::updateFilter(const ObservationData& obs, const NavigationData
     return true;
 }
 
-void PPPProcessor::detectCycleSlips(const ObservationData& obs) {
+void PPPProcessor::detectCycleSlips(const ObservationData& obs, const NavigationData& nav) {
     if (!ppp_config_.enable_cycle_slip_detection) {
         return;
     }
@@ -483,8 +483,13 @@ void PPPProcessor::detectCycleSlips(const ObservationData& obs) {
                 findCarrierObservationForSignals(obs, satellite, secondary_candidates) :
                 nullptr;
         if (secondary != nullptr) {
-            const double lambda1 = signalWavelengthMeters(*primary);
-            const double lambda2 = signalWavelengthMeters(*secondary);
+            const Ephemeris* eph = nav.getEphemeris(satellite, obs.time);
+            const double lambda1 =
+                eph != nullptr ? signalWavelengthMeters(primary->signal, eph)
+                               : signalWavelengthMeters(*primary);
+            const double lambda2 =
+                eph != nullptr ? signalWavelengthMeters(secondary->signal, eph)
+                               : signalWavelengthMeters(*secondary);
             if (lambda1 > 0.0 && lambda2 > 0.0) {
                 gf_m = primary->carrier_phase * lambda1 - secondary->carrier_phase * lambda2;
                 have_gf = std::isfinite(gf_m);

--- a/src/io/rinex.cpp
+++ b/src/io/rinex.cpp
@@ -156,6 +156,19 @@ bool isSnrObservationType(const std::string& obs_type) {
     return !obs_type.empty() && obs_type[0] == 'S';
 }
 
+void annotateGlonassFrequencyChannel(Observation& observation,
+                                     const std::map<SatelliteId, int>& channels) {
+    if (observation.satellite.system != GNSSSystem::GLONASS) {
+        return;
+    }
+    const auto it = channels.find(observation.satellite);
+    if (it == channels.end()) {
+        return;
+    }
+    observation.has_glonass_frequency_channel = true;
+    observation.glonass_frequency_channel = it->second;
+}
+
 void assignObservationField(Observation& obs,
                             const std::string& obs_type,
                             double value,
@@ -755,6 +768,28 @@ bool RINEXReader::parseHeaderLine(const std::string& line, RINEXHeader& header) 
             }
         }
     }
+    else if (label.find("GLONASS SLOT / FRQ #") != std::string::npos) {
+        for (int i = 0; i < 8; ++i) {
+            const size_t pos = 4 + static_cast<size_t>(i) * 7;
+            if (pos + 6 > line.size()) {
+                break;
+            }
+            if (line[pos] != 'R') {
+                continue;
+            }
+            const std::string prn_text = trimCopy(line.substr(pos + 1, 2));
+            const std::string channel_text = trimCopy(line.substr(pos + 4, 3));
+            if (prn_text.empty() || channel_text.empty()) {
+                continue;
+            }
+            try {
+                const int prn = std::stoi(prn_text);
+                const int channel = std::stoi(channel_text);
+                header.glonass_frequency_channels[SatelliteId(GNSSSystem::GLONASS, prn)] = channel;
+            } catch (...) {
+            }
+        }
+    }
 
     return true;
 }
@@ -963,9 +998,13 @@ bool RINEXReader::parseObservationEpochV2(const std::string& line, ObservationDa
 
         // Add observations if they have data
         if (primary_selection.has_data) {
+            annotateGlonassFrequencyChannel(primary_selection.observation,
+                                            header_.glonass_frequency_channels);
             obs_data.addObservation(primary_selection.observation);
         }
         if (secondary_selection.has_data) {
+            annotateGlonassFrequencyChannel(secondary_selection.observation,
+                                            header_.glonass_frequency_channels);
             obs_data.addObservation(secondary_selection.observation);
         }
     }
@@ -1097,9 +1136,13 @@ bool RINEXReader::parseObservationEpochV3(const std::string& epoch_line, Observa
             }
 
             if (primary_selection.has_data) {
+                annotateGlonassFrequencyChannel(primary_selection.observation,
+                                                header_.glonass_frequency_channels);
                 obs_data.addObservation(primary_selection.observation);
             }
             if (secondary_selection.has_data) {
+                annotateGlonassFrequencyChannel(secondary_selection.observation,
+                                                header_.glonass_frequency_channels);
                 obs_data.addObservation(secondary_selection.observation);
             }
         }


### PR DESCRIPTION
## Summary

S7 of the MADOCA-PPP parity series. Root-causes the GLONASS phase-row regression seen in #135 and fixes the underlying FDMA chain bugs; phase rows themselves remain a default-off preview because they still regress parity for a different (now precisely measured) reason.

### Real bugs fixed (unconditional, bit-exact in default paths)

- **GLONASS signal mapping**: `signal_policy.hpp` misrouted RINEX band-3 (`L3Q/C3Q`) to `GLO_L2P` and mapped all band-1/2 observations to C/A. Now P-code (`C1P/L1P`, `C2P/L2P`) maps correctly and the bogus band-3 mapping is removed. The misread caused ~840 km geometry-free jumps → constant GLONASS ambiguity resets.
- **FCN plumbing**: RINEX `GLONASS SLOT / FRQ #` header is now parsed and each GLONASS observation annotated with its frequency channel number.
- **Cycle-slip GF wavelengths**: `detectCycleSlips` now uses FCN-correct per-satellite wavelengths from the ephemeris when available (inert for CDMA systems).

After these fixes, GLONASS ambiguity reset counts drop to zero.

### Preview knob (default OFF)

`GNSS_PPP_MADOCA_GLONASS_PHASE=1` enables GLONASS phase rows in coherent MADOCA mode.

| Run | all-epoch RMS 3D | tail(1800s) RMS 3D |
|---|---:|---:|
| default (code-only) | **1.89976 m** | **1.73247 m** |
| phase preview | 1.92562 m | 1.76123 m |

Measured blocker: not a constant inter-channel bias (that would be absorbed by float ambiguities) but a **time-varying relative phase residual** across GLONASS satellites (R09−R21 common residual RMS 0.41 m, range −0.10…0.90 m). Single-satellite phase helps slightly; multi-satellite regresses. Documented for a future slice.

## Verification

- 7-case env matrix (`default`, `BIAS_SUBTRACT`, `ALLOW_PARTIAL_SSR`, `DISABLE_MADOCA_STATIC_ANCHOR`, `MADOCA_GLONASS=0`, `MADOCA_QZSS_PHASE=1`, `MADOCA_SSR_REPLAY=1`) regenerated and `cmp` **bit-exact** vs pre-change reference
- `run_tests`: 318 passed / 43 skipped
- `tests/test_cli_tools.py -k qzss_l6 / madoca / clas`: pass
- `git diff --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)