### PR TITLE
feat(ppp): admit low-elevation satellites in coherent MADOCA mode

### DIFF
--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -906,6 +906,9 @@ int main(int argc, char* argv[]) {
         processor_config.use_precise_clocks = ppp_config.use_precise_clocks;
         processor_config.orbit_file_path = options.sp3_path;
         processor_config.clock_file_path = options.clk_path;
+        if (!options.madoca_l6_paths.empty() && ppp_env_overrides.madoca_low_elev) {
+            processor_config.elevation_mask = 10.0;
+        }
 
         libgnss::PPPProcessor processor(ppp_config);
         if (!processor.initialize(processor_config)) {

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -60,6 +60,9 @@ struct PPPEnvOverrides {
     // GNSS_PPP_MADOCA_GLONASS_PHASE: allow GLONASS phase rows in MADOCA when
     // set exactly to "1". Default false.
     bool madoca_glonass_phase = false;
+    // GNSS_PPP_MADOCA_LOW_ELEV: admit coherent MADOCA observations down to the
+    // MADOCALIB 10 degree mask unless set exactly to "0". Default true.
+    bool madoca_low_elev = true;
     // GNSS_PPP_PB_ADD: add non-MADOCA SSR phase biases instead of subtracting.
     // Default false.
     bool pb_add = false;

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -69,6 +69,7 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
     overrides.madoca_qzss_phase = envExactOne("GNSS_PPP_MADOCA_QZSS_PHASE");
     overrides.madoca_glonass = !envExactZero("GNSS_PPP_MADOCA_GLONASS");
     overrides.madoca_glonass_phase = envExactOne("GNSS_PPP_MADOCA_GLONASS_PHASE");
+    overrides.madoca_low_elev = !envExactZero("GNSS_PPP_MADOCA_LOW_ELEV");
     overrides.pb_add = envPresent("GNSS_PPP_PB_ADD");
     overrides.no_phase_bias = envPresent("GNSS_PPP_NO_PHASE_BIAS");
     overrides.l2_reset_fix = envFirstCharNotZero("GNSS_PPP_L2_RESET_FIX");


### PR DESCRIPTION
## Summary

S8 of the MADOCA-PPP parity series — closes the remaining low-elevation satellite-set gap (analysis ladder step 1).

The native coherent `--madoca-l6` path now uses MADOCALIB's 10° elevation mask (`pos1-elmask=10`) instead of the 15° processor default. Default **ON**, `GNSS_PPP_MADOCA_LOW_ELEV=0` opt-out (bit-exact when off). Gated at the app layer so precise-files/CLAS paths are untouched.

| Run | all-epoch RMS 3D | tail(1800s) RMS 3D |
|---|---:|---:|
| before | 1.89976 m | 1.73247 m |
| after (default ON) | **1.82877 m** | **1.65044 m** |

### Why this works now (it failed in #135)

Forcing the same 10° mask in #135 caused a large convergence failure. That failure **no longer reproduces** after the #137 GLONASS signal-mapping/FCN chain fixes: no filter reset, max internal `pos_delta` 2.7 m, low-elevation residuals bounded (worst code rows ~4–7 m at 10–15°). Audit confirmed the elevation weighting form already matches MADOCALIB (`a² + (b/sin el)²` with code `eratio`), so the mask constant was the only remaining gap.

### Satellite-set parity after the change

No bridge-only low-elevation satellites remain (previously R01/R19/J04/G28 at 10–15°):

| System | Bridge rows/sats | Native before | Native after |
|---|---:|---:|---:|
| G | 996 / 10 | 843 / 9 | 998 / 10 |
| J | 256 / 3 | 236 / 2 | 256 / 3 |
| R | 276 / 5 | 209 / 3 | 288 / 5 |
| E | 603 / 8 | 805 / 8 | 1011 / 9 |

(Galileo native-only extras like E23 are a separate, deferred difference.)

## Verification

- `GNSS_PPP_MADOCA_LOW_ELEV=0` run `cmp` **bit-exact** vs pre-change reference; full env matrix validated
- `run_tests`: 318 passed / 43 skipped
- `tests/test_cli_tools.py -k qzss_l6 / madoca / clas`: pass
- `git diff --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)