### PR TITLE
feat(ppp): Galileo ephemeris-availability gate preview for coherent MADOCA

### DIFF
--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -63,6 +63,10 @@ struct PPPEnvOverrides {
     // GNSS_PPP_MADOCA_LOW_ELEV: admit coherent MADOCA observations down to the
     // MADOCALIB 10 degree mask unless set exactly to "0". Default true.
     bool madoca_low_elev = true;
+    // GNSS_PPP_MADOCA_GALILEO_GATE: apply MADOCALIB Galileo broadcast
+    // ephemeris admission semantics in coherent MADOCA when set exactly to "1".
+    // Default false.
+    bool madoca_galileo_gate = false;
     // GNSS_PPP_PB_ADD: add non-MADOCA SSR phase biases instead of subtracting.
     // Default false.
     bool pb_add = false;

--- a/include/libgnss++/core/navigation.hpp
+++ b/include/libgnss++/core/navigation.hpp
@@ -178,6 +178,14 @@ public:
                                   int desired_iode) const;
 
     /**
+     * @brief True when MADOCALIB seleph() would admit a Galileo broadcast
+     * ephemeris for MADOCA SSR at this epoch.
+     */
+    bool hasMadocaGalileoEphemeris(const SatelliteId& sat,
+                                   const GNSSTime& time,
+                                   int desired_iode) const;
+
+    /**
      * @brief Get all ephemeris for satellite
      */
     std::vector<Ephemeris> getEphemeris(const SatelliteId& sat) const;

--- a/src/algorithms/ppp_corrections.cpp
+++ b/src/algorithms/ppp_corrections.cpp
@@ -579,6 +579,12 @@ bool PPPProcessor::hasEnoughCoherentSsrObservations(const ObservationData& obs,
             nullptr,
             &status,
             false);
+        if (env_overrides_.madoca_galileo_gate &&
+            observation.satellite.system == GNSSSystem::Galileo &&
+            !nav.hasMadocaGalileoEphemeris(
+                observation.satellite, obs.time, status.orbit_iode)) {
+            continue;
+        }
         if (ssr_ok && madocaSsrCorrectionIsCoherent(status, obs.time) &&
             madocaSsrMeasurementBiasesAreCoherent(
                 observation.satellite,
@@ -766,6 +772,14 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
             if (require_coherent_ssr_ && ssr_products_loaded_ &&
                 (!ssr_status_ok ||
                  !madocaSsrCorrectionIsCoherent(ssr_status, time))) {
+                observation.valid = false;
+                continue;
+            }
+            if (env_overrides_.madoca_galileo_gate &&
+                require_coherent_ssr_ &&
+                observation.satellite.system == GNSSSystem::Galileo &&
+                !nav.hasMadocaGalileoEphemeris(
+                    observation.satellite, time, ssr_status.orbit_iode)) {
                 observation.valid = false;
                 continue;
             }

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -70,6 +70,7 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
     overrides.madoca_glonass = !envExactZero("GNSS_PPP_MADOCA_GLONASS");
     overrides.madoca_glonass_phase = envExactOne("GNSS_PPP_MADOCA_GLONASS_PHASE");
     overrides.madoca_low_elev = !envExactZero("GNSS_PPP_MADOCA_LOW_ELEV");
+    overrides.madoca_galileo_gate = envExactOne("GNSS_PPP_MADOCA_GALILEO_GATE");
     overrides.pb_add = envPresent("GNSS_PPP_PB_ADD");
     overrides.no_phase_bias = envPresent("GNSS_PPP_NO_PHASE_BIAS");
     overrides.l2_reset_fix = envFirstCharNotZero("GNSS_PPP_L2_RESET_FIX");

--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -654,6 +654,35 @@ const Ephemeris* NavigationData::getEphemeris(const SatelliteId& sat,
     return best_match != nullptr ? best_match : getEphemeris(sat, time);
 }
 
+bool NavigationData::hasMadocaGalileoEphemeris(const SatelliteId& sat,
+                                               const GNSSTime& time,
+                                               int desired_iode) const {
+    if (sat.system != GNSSSystem::Galileo) {
+        return true;
+    }
+    auto it = ephemeris_data.find(sat);
+    if (it == ephemeris_data.end()) {
+        return false;
+    }
+    constexpr int kGalInavClockBit = 1 << 9;
+    for (const auto& eph : it->second) {
+        if (desired_iode >= 0 && static_cast<int>(eph.iode) != desired_iode) {
+            continue;
+        }
+        if (!(eph.data_source_code & kGalInavClockBit)) {
+            continue;
+        }
+        if (eph.toe - time >= 0.0) {
+            continue;
+        }
+        if (!eph.isValid(time)) {
+            continue;
+        }
+        return true;
+    }
+    return false;
+}
+
 bool NavigationData::calculateSatelliteState(const SatelliteId& sat,
                                            const GNSSTime& time,
                                            Vector3d& position,


### PR DESCRIPTION
## Summary

S9 of the MADOCA-PPP parity series — root-causes the Galileo satellite-set gap and adds a default-off preview gate.

### Root cause of the row gap

Native admitted **1011 Galileo rows / 9 sats** vs the bridge's **603 / 8** on the MIZU window. All 408 native-only sat-epochs (E23 ×118, E24 ×59, E09 ×50, E33 ×46, …) trace to MADOCALIB's `seleph()` rejecting them for **lack of usable broadcast ephemeris** (Galileo I/NAV bit required, no future TOE, exact IODnav match) — not elevation (they sit at 41–60°) and not bias availability. Native's ephemeris lookup prefers IODE but falls back instead of rejecting.

### Preview knob (default OFF)

`GNSS_PPP_MADOCA_GALILEO_GATE=1` mirrors the bridge's ephemeris-availability gate in the coherent-MADOCA admission path and **exactly closes row/sat parity** (E 603/8; G/J/R already matched).

| Mode | all-epoch RMS 3D | tail(1800s) RMS 3D |
|---|---:|---:|
| default (gate off) | **1.82877 m** | 1.65044 m |
| gate on | 1.91680 m | **1.48044 m** |

Tail improves strongly; all-epoch regresses — the decision rule (beat both) keeps it OFF. The native-only rows are not toxic (code RMS 2.09 m vs 1.98 m for common Galileo rows); the early static-anchor-shaped window simply benefits from the extra geometry. This is the second lever with this exact signature (after eratio 300), making a combined early-window/convergence slice the natural follow-up.

A `GNSS_PPP_GAL_INAV=1` probe measured 2.125/1.837 and was rejected.

## Verification

- Default path **bit-exact**: all 9 env-matrix cases `cmp` clean vs pre-change reference
- `run_tests`: 318 passed / 43 skipped
- `tests/test_cli_tools.py -k qzss_l6 / madoca / clas`: pass
- `git diff --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)