### PR TITLE
feat(ppp): bridge convergence parity switch for coherent MADOCA

### DIFF
--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -843,6 +843,11 @@ int main(int argc, char* argv[]) {
         ppp_config.kinematic_mode = options.kinematic_mode;
         ppp_config.low_dynamics_mode = options.low_dynamics_mode;
         ppp_config.apply_static_anchor_blend = options.apply_static_anchor_blend;
+        if (!options.madoca_l6_paths.empty() &&
+            ppp_env_overrides.madoca_early_window) {
+            ppp_config.code_phase_error_ratio_l1 = 300.0;
+            ppp_config.code_phase_error_ratio_l2 = 300.0;
+        }
         ppp_config.enable_ambiguity_resolution = options.enable_ar;
         ppp_config.convergence_min_epochs = options.convergence_min_epochs;
         ppp_config.ar_ratio_threshold = options.ar_ratio_threshold;

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -23,6 +23,9 @@ struct PPPEnvOverrides {
     // GNSS_PPP_STATIC_ANCHOR_BLEND: override static anchor blend fraction;
     // values outside [0,1] are ignored at use sites. Default -1.0 (inactive).
     double static_anchor_blend = -1.0;
+    // GNSS_PPP_MADOCA_EARLY_WINDOW: enable coherent MADOCA bridge-convergence
+    // parity defaults unless set exactly to "0". Default true.
+    bool madoca_early_window = true;
     // GNSS_PPP_ESTIMATE_ISB: comma/space-style spec parsed by substring
     // checks for "gal", "qzs", "bds", "all", or exact "1". Defaults false.
     bool estimate_isb_all = false;
@@ -64,8 +67,9 @@ struct PPPEnvOverrides {
     // MADOCALIB 10 degree mask unless set exactly to "0". Default true.
     bool madoca_low_elev = true;
     // GNSS_PPP_MADOCA_GALILEO_GATE: apply MADOCALIB Galileo broadcast
-    // ephemeris admission semantics in coherent MADOCA when set exactly to "1".
-    // Default false.
+    // ephemeris admission semantics in coherent MADOCA when set exactly to "1",
+    // or when GNSS_PPP_MADOCA_EARLY_WINDOW is enabled. Default follows
+    // GNSS_PPP_MADOCA_EARLY_WINDOW.
     bool madoca_galileo_gate = false;
     // GNSS_PPP_PB_ADD: add non-MADOCA SSR phase biases instead of subtracting.
     // Default false.

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -45,6 +45,7 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
     overrides.disable_madoca_static_anchor =
         envExactOne("GNSS_PPP_DISABLE_MADOCA_STATIC_ANCHOR");
     overrides.static_anchor_blend = envDoubleOr("GNSS_PPP_STATIC_ANCHOR_BLEND", -1.0);
+    overrides.madoca_early_window = !envExactZero("GNSS_PPP_MADOCA_EARLY_WINDOW");
 
     const char* isb = envValue("GNSS_PPP_ESTIMATE_ISB");
     const std::string isb_spec = isb != nullptr ? std::string(isb) : std::string();
@@ -70,7 +71,9 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
     overrides.madoca_glonass = !envExactZero("GNSS_PPP_MADOCA_GLONASS");
     overrides.madoca_glonass_phase = envExactOne("GNSS_PPP_MADOCA_GLONASS_PHASE");
     overrides.madoca_low_elev = !envExactZero("GNSS_PPP_MADOCA_LOW_ELEV");
-    overrides.madoca_galileo_gate = envExactOne("GNSS_PPP_MADOCA_GALILEO_GATE");
+    overrides.madoca_galileo_gate =
+        envExactOne("GNSS_PPP_MADOCA_GALILEO_GATE") ||
+        overrides.madoca_early_window;
     overrides.pb_add = envPresent("GNSS_PPP_PB_ADD");
     overrides.no_phase_bias = envPresent("GNSS_PPP_NO_PHASE_BIAS");
     overrides.l2_reset_fix = envFirstCharNotZero("GNSS_PPP_L2_RESET_FIX");

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -1077,9 +1077,11 @@ void PPPProcessor::constrainStaticAnchorPosition() {
     // Root cause of 4m floor is 20-40m SSR residual spread (light travel time).
     // Fix the residuals first, then loosen the anchor.
 
+    const double default_madoca_anchor_blend =
+        env_overrides_.madoca_early_window ? 0.26 : 0.30;
     const double default_anchor_blend =
         madoca_static_anchor_blend && !ppp_config_.apply_static_anchor_blend
-            ? 0.30
+            ? default_madoca_anchor_blend
             : (ppp_config_.low_dynamics_mode
                    ? (precise_products_loaded_ ? (converged_ ? 0.65 : 0.9) : 0.95)
                    : (precise_products_loaded_ ? (converged_ ? 0.5 : 0.85)


### PR DESCRIPTION
## Summary

S10 of the MADOCA-PPP parity series. Two prior levers (eratio 300 in the eratio A/B, Galileo `seleph` gate in #139) each improved the converged tail but regressed all-epoch because of the early window. This slice audits the early window per-epoch, fixes its structural cause, and ships the combination as one default-ON switch.

`GNSS_PPP_MADOCA_EARLY_WINDOW` (default ON, `=0` opt-out bit-exact) enables, for `--madoca-l6` only:
- static anchor blend **0.26** (from 0.30) — the per-epoch curve audit shows the anchor must stay (anchor-off diverges to 76 m; mirroring the bridge's kinematic `udpos_ppp` process noise gives 6.3 m), but the weaker blend stabilizes the early window enough for the parity levers to win
- the **#139 Galileo ephemeris gate** becomes effective (closes E row parity at 603/8 = bridge)
- **eratio 300/300** (MADOCALIB sample weighting, `ppp.c varerr`)

## Results (MIZU 1h window vs MADOCALIB bridge)

| config | all-epoch RMS 3D | tail(1800s) RMS 3D |
|---|---:|---:|
| old baseline | 1.829 m | 1.650 m |
| **new default** | **1.820 m** | **1.196 m** |

Full interaction table (early fix × gate × eratio):

| early fix | gate | eratio300 | all | tail |
|---|---|---|---:|---:|
| off | off | off | 1.829 | 1.650 |
| off | on | off | 1.917 | 1.480 |
| off | off | on | 1.932 | 1.668 |
| off | on | on | 2.022 | 1.461 |
| on | off | off | 1.677 | 1.404 |
| on | on | off | 1.743 | 1.213 |
| on | off | on | 1.761 | 1.435 |
| on | on | on | 1.820 | 1.196 |

Every early-window-on combination beats the old baseline on both metrics. The full combination is the default because the gate and eratio both mirror actual MADOCALIB mechanisms (better generalization beyond MIZU than the metric-optimal row alone).

## Verification

- `GNSS_PPP_MADOCA_EARLY_WINDOW=0` run `cmp` **bit-exact** vs pre-change reference
- `run_tests`: 318 passed / 43 skipped
- `tests/test_cli_tools.py -k qzss_l6 / madoca / clas`: pass
- `git diff --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)