### PR TITLE
feat(ppp): explicit MADOCA bias-identity selection preview; close identity hypothesis

### DIFF
--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -331,6 +331,8 @@ private:
         SatelliteId satellite;
         SignalType primary_signal = SignalType::SIGNAL_TYPE_COUNT;
         SignalType secondary_signal = SignalType::SIGNAL_TYPE_COUNT;
+        std::string primary_observation_type;
+        std::string secondary_observation_type;
         double primary_code_bias_coeff = 1.0;
         double secondary_code_bias_coeff = 0.0;
         double pseudorange_if = 0.0;

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -71,6 +71,10 @@ struct PPPEnvOverrides {
     // or when GNSS_PPP_MADOCA_EARLY_WINDOW is enabled. Default follows
     // GNSS_PPP_MADOCA_EARLY_WINDOW.
     bool madoca_galileo_gate = false;
+    // GNSS_PPP_MADOCA_BIAS_IDENTITY: preserve MADOCA SSR code/phase-bias
+    // signal identity instead of collapsed RTCM band ids when set exactly to
+    // "1". Default false while the parity impact is measured.
+    bool madoca_bias_identity = false;
     // GNSS_PPP_PB_ADD: add non-MADOCA SSR phase biases instead of subtracting.
     // Default false.
     bool pb_add = false;

--- a/include/libgnss++/core/observation.hpp
+++ b/include/libgnss++/core/observation.hpp
@@ -3,6 +3,7 @@
 #include <vector>
 #include <map>
 #include <memory>
+#include <string>
 #include "types.hpp"
 
 namespace libgnss {
@@ -18,6 +19,8 @@ struct Observation {
     double carrier_phase = 0.0;     ///< Carrier phase in cycles
     double doppler = 0.0;           ///< Doppler frequency in Hz
     double snr = 0.0;               ///< Signal-to-noise ratio in dB-Hz
+    std::string pseudorange_observation_type;   ///< RINEX code observation type, e.g. C1C
+    std::string carrier_phase_observation_type; ///< RINEX carrier observation type, e.g. L1C
 
     // Data availability flags
     bool has_pseudorange = false;   ///< Pseudorange data available

--- a/include/libgnss++/io/madoca_l6.hpp
+++ b/include/libgnss++/io/madoca_l6.hpp
@@ -121,12 +121,12 @@ private:
     PPPEnvOverrides env_overrides_;
 };
 
-// Map a MADOCA Compact SSR bias code (an RTKLIB CODE_* enum value, i.e. the
-// 1-based index used by MadocaSsrCorrection::cbias/pbias) to the RTCM SSR signal
-// id that keys SSRProducts code/phase biases (see core/signals.hpp
+// Legacy map from a MADOCA Compact SSR bias code (an RTKLIB CODE_* enum value,
+// i.e. the 1-based index used by MadocaSsrCorrection::cbias/pbias) to the RTCM
+// SSR signal id that keys SSRProducts code/phase biases (see core/signals.hpp
 // rtcmSsrSignalId). Returns 0 when the code has no native RTCM SSR id for the
-// system. Only the per-band representative codes emitted by mcssr_sel_biascode
-// are mapped, so distinct codes never collide on one id.
+// system. Several MADOCA tracking-mode identities intentionally collapse to one
+// RTCM band id on this legacy path.
 std::uint8_t madocaBiasCodeToRtcmSsrId(libgnss::GNSSSystem system, int code);
 
 // Convert the decoder's current per-satellite Compact SSR snapshot into native

--- a/src/algorithms/ppp_corrections.cpp
+++ b/src/algorithms/ppp_corrections.cpp
@@ -1,5 +1,6 @@
 #include "ppp_internal.hpp"
 
+#include <libgnss++/algorithms/madoca_parity.hpp>
 #include <libgnss++/algorithms/ppp_atmosphere.hpp>
 #include <libgnss++/algorithms/ppp_osr.hpp>
 #include <libgnss++/algorithms/ppp_utils.hpp>
@@ -51,6 +52,81 @@ constexpr std::array<double, 11> kOceanLoadingPeriodsSeconds = {
     661.3111655 * 3600.0,  // Mm
     4382.905 * 3600.0      // Ssa
 };
+
+namespace mp = libgnss::algorithms::madoca_parity;
+
+struct MadocaObservationCodeMapEntry {
+    const char* observation_type;
+    int rtklib_code;
+};
+
+constexpr MadocaObservationCodeMapEntry kMadocaObservationCodeMap[] = {
+    {"C1C", mp::kCodeL1C}, {"L1C", mp::kCodeL1C},
+    {"C1P", mp::kCodeL1P}, {"L1P", mp::kCodeL1P},
+    {"C1W", mp::kCodeL1W}, {"L1W", mp::kCodeL1W},
+    {"C1S", mp::kCodeL1S}, {"L1S", mp::kCodeL1S},
+    {"C1L", mp::kCodeL1L}, {"L1L", mp::kCodeL1L},
+    {"C1E", mp::kCodeL1E}, {"L1E", mp::kCodeL1E},
+    {"C1B", mp::kCodeL1B}, {"L1B", mp::kCodeL1B},
+    {"C1X", mp::kCodeL1X}, {"L1X", mp::kCodeL1X},
+    {"C2C", mp::kCodeL2C}, {"L2C", mp::kCodeL2C},
+    {"C2S", mp::kCodeL2S}, {"L2S", mp::kCodeL2S},
+    {"C2L", mp::kCodeL2L}, {"L2L", mp::kCodeL2L},
+    {"C2X", mp::kCodeL2X}, {"L2X", mp::kCodeL2X},
+    {"C2P", mp::kCodeL2P}, {"L2P", mp::kCodeL2P},
+    {"C2W", mp::kCodeL2W}, {"L2W", mp::kCodeL2W},
+    {"C5I", mp::kCodeL5I}, {"L5I", mp::kCodeL5I},
+    {"C5Q", mp::kCodeL5Q}, {"L5Q", mp::kCodeL5Q},
+    {"C5X", mp::kCodeL5X}, {"L5X", mp::kCodeL5X},
+    {"C5D", mp::kCodeL5D}, {"L5D", mp::kCodeL5D},
+    {"C5P", mp::kCodeL5P}, {"L5P", mp::kCodeL5P},
+    {"C6B", mp::kCodeL6B}, {"L6B", mp::kCodeL6B},
+    {"C6C", mp::kCodeL6C}, {"L6C", mp::kCodeL6C},
+    {"C6X", mp::kCodeL6X}, {"L6X", mp::kCodeL6X},
+    {"C6I", mp::kCodeL6I}, {"L6I", mp::kCodeL6I},
+    {"C6Q", mp::kCodeL6Q}, {"L6Q", mp::kCodeL6Q},
+    {"C7I", mp::kCodeL7I}, {"L7I", mp::kCodeL7I},
+    {"C7Q", mp::kCodeL7Q}, {"L7Q", mp::kCodeL7Q},
+    {"C7X", mp::kCodeL7X}, {"L7X", mp::kCodeL7X},
+    {"C7D", mp::kCodeL7D}, {"L7D", mp::kCodeL7D},
+};
+
+int madocaSystemId(GNSSSystem system) {
+    switch (system) {
+        case GNSSSystem::GPS: return mp::kSysGps;
+        case GNSSSystem::Galileo: return mp::kSysGal;
+        case GNSSSystem::QZSS: return mp::kSysQzs;
+        default: return mp::kSysNone;
+    }
+}
+
+int madocaRtklibCodeForObservationType(const std::string& observation_type) {
+    for (const auto& entry : kMadocaObservationCodeMap) {
+        if (observation_type == entry.observation_type) {
+            return entry.rtklib_code;
+        }
+    }
+    return mp::kCodeNone;
+}
+
+uint8_t ssrBiasIdentityId(GNSSSystem system,
+                          SignalType signal,
+                          const std::string& observation_type,
+                          bool madoca_bias_identity) {
+    if (!madoca_bias_identity) {
+        return rtcmSsrSignalId(system, signal);
+    }
+    const int madoca_sys = madocaSystemId(system);
+    if (madoca_sys == mp::kSysNone) {
+        return rtcmSsrSignalId(system, signal);
+    }
+    const int rtklib_code = madocaRtklibCodeForObservationType(observation_type);
+    const int bias_code = mp::mcssrSelBiascode(madoca_sys, rtklib_code);
+    if (bias_code <= 0 || bias_code > 255) {
+        return 0U;
+    }
+    return static_cast<uint8_t>(bias_code);
+}
 
 bool madocaSsrReferenceIsCurrent(const GNSSTime& epoch, const GNSSTime& reference) {
     if (reference.week == 0) {
@@ -259,12 +335,13 @@ double modeledTroposphereDelayMeters(const Vector3d& receiver_position,
 // transmitted L2 bias regardless of which L2 signal the receiver tracked.
 inline double ssrBiasLookup(const std::map<uint8_t, double>& m,
                             GNSSSystem system,
-                            uint8_t id) {
+                            uint8_t id,
+                            bool madoca_bias_identity) {
     const auto it = m.find(id);
     if (it != m.end()) {
         return it->second;
     }
-    if (system == GNSSSystem::GPS && (id == 8U || id == 9U)) {
+    if (!madoca_bias_identity && system == GNSSSystem::GPS && (id == 8U || id == 9U)) {
         const auto sibling = m.find(id == 8U ? 9U : 8U);
         if (sibling != m.end()) {
             return sibling->second;
@@ -279,21 +356,28 @@ double observationCodeBiasMeters(GNSSSystem system,
                                  bool use_ionosphere_free,
                                  const std::map<uint8_t, double>& code_bias_m,
                                  double coeff_primary,
-                                 double coeff_secondary) {
-    const uint8_t primary_id = rtcmSsrSignalId(system, primary_signal);
+                                 double coeff_secondary,
+                                 const std::string& primary_observation_type,
+                                 const std::string& secondary_observation_type,
+                                 bool madoca_bias_identity) {
+    const uint8_t primary_id = ssrBiasIdentityId(
+        system, primary_signal, primary_observation_type, madoca_bias_identity);
     if (primary_id == 0U) {
         return 0.0;
     }
-    const double primary_bias = ssrBiasLookup(code_bias_m, system, primary_id);
+    const double primary_bias =
+        ssrBiasLookup(code_bias_m, system, primary_id, madoca_bias_identity);
     if (!use_ionosphere_free || secondary_signal == SignalType::SIGNAL_TYPE_COUNT) {
         return primary_bias;
     }
 
-    const uint8_t secondary_id = rtcmSsrSignalId(system, secondary_signal);
+    const uint8_t secondary_id = ssrBiasIdentityId(
+        system, secondary_signal, secondary_observation_type, madoca_bias_identity);
     if (secondary_id == 0U) {
         return coeff_primary * primary_bias;
     }
-    const double secondary_bias = ssrBiasLookup(code_bias_m, system, secondary_id);
+    const double secondary_bias =
+        ssrBiasLookup(code_bias_m, system, secondary_id, madoca_bias_identity);
     return coeff_primary * primary_bias + coeff_secondary * secondary_bias;
 }
 
@@ -303,35 +387,44 @@ double observationPhaseBiasMeters(GNSSSystem system,
                                   bool use_ionosphere_free,
                                   const std::map<uint8_t, double>& phase_bias_m,
                                   double coeff_primary,
-                                  double coeff_secondary) {
-    const uint8_t primary_id = rtcmSsrSignalId(system, primary_signal);
+                                  double coeff_secondary,
+                                  const std::string& primary_observation_type,
+                                  const std::string& secondary_observation_type,
+                                  bool madoca_bias_identity) {
+    const uint8_t primary_id = ssrBiasIdentityId(
+        system, primary_signal, primary_observation_type, madoca_bias_identity);
     if (primary_id == 0U) {
         return 0.0;
     }
-    const double primary_bias = ssrBiasLookup(phase_bias_m, system, primary_id);
+    const double primary_bias =
+        ssrBiasLookup(phase_bias_m, system, primary_id, madoca_bias_identity);
     if (!use_ionosphere_free || secondary_signal == SignalType::SIGNAL_TYPE_COUNT) {
         return primary_bias;
     }
 
-    const uint8_t secondary_id = rtcmSsrSignalId(system, secondary_signal);
+    const uint8_t secondary_id = ssrBiasIdentityId(
+        system, secondary_signal, secondary_observation_type, madoca_bias_identity);
     if (secondary_id == 0U) {
         return coeff_primary * primary_bias;
     }
-    const double secondary_bias = ssrBiasLookup(phase_bias_m, system, secondary_id);
+    const double secondary_bias =
+        ssrBiasLookup(phase_bias_m, system, secondary_id, madoca_bias_identity);
     return coeff_primary * primary_bias + coeff_secondary * secondary_bias;
 }
 
 bool ssrBiasPresent(const std::map<uint8_t, double>& bias_m,
                     GNSSSystem system,
-                    SignalType signal) {
-    const uint8_t id = rtcmSsrSignalId(system, signal);
+                    SignalType signal,
+                    const std::string& observation_type,
+                    bool madoca_bias_identity) {
+    const uint8_t id = ssrBiasIdentityId(system, signal, observation_type, madoca_bias_identity);
     if (id == 0U) {
         return false;
     }
     if (bias_m.find(id) != bias_m.end()) {
         return true;
     }
-    if (system == GNSSSystem::GPS && (id == 8U || id == 9U)) {
+    if (!madoca_bias_identity && system == GNSSSystem::GPS && (id == 8U || id == 9U)) {
         return bias_m.find(id == 8U ? 9U : 8U) != bias_m.end();
     }
     return false;
@@ -341,32 +434,55 @@ bool madocaSsrMeasurementBiasesAreCoherent(
     const SatelliteId& satellite,
     SignalType primary_signal,
     SignalType secondary_signal,
+    const std::string& primary_observation_type,
+    const std::string& secondary_observation_type,
     bool has_l2,
     bool has_carrier_phase,
     bool has_carrier_phase_l2,
     const std::map<uint8_t, double>& code_bias_m,
     const std::map<uint8_t, double>& phase_bias_m,
-    bool use_ionosphere_free) {
-    if (!ssrBiasPresent(code_bias_m, satellite.system, primary_signal)) {
+    bool use_ionosphere_free,
+    bool madoca_bias_identity) {
+    if (!ssrBiasPresent(
+            code_bias_m,
+            satellite.system,
+            primary_signal,
+            primary_observation_type,
+            madoca_bias_identity)) {
         return false;
     }
     const bool needs_secondary =
         secondary_signal != SignalType::SIGNAL_TYPE_COUNT &&
         (use_ionosphere_free || has_l2);
     if (needs_secondary &&
-        !ssrBiasPresent(code_bias_m, satellite.system, secondary_signal)) {
+        !ssrBiasPresent(
+            code_bias_m,
+            satellite.system,
+            secondary_signal,
+            secondary_observation_type,
+            madoca_bias_identity)) {
         return false;
     }
     if (satellite.system == GNSSSystem::GLONASS) {
         return true;
     }
     if (has_carrier_phase &&
-        !ssrBiasPresent(phase_bias_m, satellite.system, primary_signal)) {
+        !ssrBiasPresent(
+            phase_bias_m,
+            satellite.system,
+            primary_signal,
+            primary_observation_type,
+            madoca_bias_identity)) {
         return false;
     }
     if (needs_secondary &&
         (has_carrier_phase || has_carrier_phase_l2) &&
-        !ssrBiasPresent(phase_bias_m, satellite.system, secondary_signal)) {
+        !ssrBiasPresent(
+            phase_bias_m,
+            satellite.system,
+            secondary_signal,
+            secondary_observation_type,
+            madoca_bias_identity)) {
         return false;
     }
     return true;
@@ -552,6 +668,8 @@ bool PPPProcessor::hasEnoughCoherentSsrObservations(const ObservationData& obs,
     }
 
     const auto if_obs = formIonosphereFree(obs, nav);
+    const bool madoca_bias_identity =
+        require_coherent_ssr_ && env_overrides_.madoca_bias_identity;
     size_t coherent_count = 0;
     for (const auto& observation : if_obs) {
         if (!observation.valid) {
@@ -590,12 +708,15 @@ bool PPPProcessor::hasEnoughCoherentSsrObservations(const ObservationData& obs,
                 observation.satellite,
                 observation.primary_signal,
                 observation.secondary_signal,
+                observation.primary_observation_type,
+                observation.secondary_observation_type,
                 observation.has_l2,
                 observation.has_carrier_phase,
                 observation.has_carrier_phase_l2,
                 code_bias_m,
                 phase_bias_m,
-                ppp_config_.use_ionosphere_free)) {
+                ppp_config_.use_ionosphere_free,
+                madoca_bias_identity)) {
             ++coherent_count;
         }
     }
@@ -688,6 +809,8 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                 ssr_products_, epoch_satellites, time, receiver_marker_position, ppp_config_);
     }
     const int preferred_network_id = preferredClasNetworkId(epoch_atmos_tokens);
+    const bool madoca_bias_identity =
+        require_coherent_ssr_ && env_overrides_.madoca_bias_identity;
 
     // Sun position is needed for the satellite body frame in phase wind-up.
     // We compute it once per epoch and reuse for every satellite.
@@ -862,12 +985,15 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                      observation.satellite,
                      observation.primary_signal,
                      observation.secondary_signal,
+                     observation.primary_observation_type,
+                     observation.secondary_observation_type,
                      observation.has_l2,
                      observation.has_carrier_phase,
                      observation.has_carrier_phase_l2,
                      code_bias_m,
                      phase_bias_m,
-                     ppp_config_.use_ionosphere_free))) {
+                     ppp_config_.use_ionosphere_free,
+                     madoca_bias_identity))) {
                 observation.valid = false;
                 continue;
             }
@@ -887,7 +1013,10 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                     ppp_config_.use_ionosphere_free,
                     code_bias_m,
                     observation.primary_code_bias_coeff,
-                    observation.secondary_code_bias_coeff);
+                    observation.secondary_code_bias_coeff,
+                    observation.primary_observation_type,
+                    observation.secondary_observation_type,
+                    madoca_bias_identity);
                 // MADOCALIB adds SSR biases to the observables (ppp.c:432-451).
                 // The MADOCA L6 path follows that convention by default;
                 // GNSS_PPP_MADOCA_BIAS_SUBTRACT restores the legacy subtraction
@@ -907,7 +1036,10 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                         ppp_config_.use_ionosphere_free,
                         phase_bias_m,
                         observation.primary_code_bias_coeff,
-                        observation.secondary_code_bias_coeff);
+                        observation.secondary_code_bias_coeff,
+                        observation.primary_observation_type,
+                        observation.secondary_observation_type,
+                        madoca_bias_identity);
                     observation.carrier_phase_if += ssr_bias_sign * phase_bias;
                     observation.carrier_phase_bias_m = phase_bias;
                 }
@@ -917,13 +1049,19 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                 if (!ppp_config_.use_ionosphere_free) {
                     const double cb_l1 = observationCodeBiasMeters(
                         observation.satellite.system, observation.primary_signal,
-                        SignalType::SIGNAL_TYPE_COUNT, false, code_bias_m, 1.0, 0.0);
+                        SignalType::SIGNAL_TYPE_COUNT, false, code_bias_m, 1.0, 0.0,
+                        observation.primary_observation_type,
+                        std::string(),
+                        madoca_bias_identity);
                     observation.pseudorange_l1 += ssr_bias_sign * cb_l1;
                     observation.code_bias_l1_m = cb_l1;
                     if (observation.has_l2) {
                         const double cb_l2 = observationCodeBiasMeters(
                             observation.satellite.system, observation.secondary_signal,
-                            SignalType::SIGNAL_TYPE_COUNT, false, code_bias_m, 1.0, 0.0);
+                            SignalType::SIGNAL_TYPE_COUNT, false, code_bias_m, 1.0, 0.0,
+                            observation.secondary_observation_type,
+                            std::string(),
+                            madoca_bias_identity);
                         observation.pseudorange_l2 += ssr_bias_sign * cb_l2;
                         observation.code_bias_l2_m = cb_l2;
                     }
@@ -941,7 +1079,10 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                         if (observation.has_carrier_phase) {
                             const double pb_l1 = observationPhaseBiasMeters(
                                 observation.satellite.system, observation.primary_signal,
-                                SignalType::SIGNAL_TYPE_COUNT, false, phase_bias_m, 1.0, 0.0);
+                                SignalType::SIGNAL_TYPE_COUNT, false, phase_bias_m, 1.0, 0.0,
+                                observation.primary_observation_type,
+                                std::string(),
+                                madoca_bias_identity);
                             observation.carrier_phase_l1 += phase_bias_sign * pb_l1;
                             observation.phase_bias_l1_m = pb_l1;
                             if (env_overrides_.pb_apply_dump) {
@@ -952,7 +1093,10 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                         if (observation.has_carrier_phase_l2) {
                             const double pb_l2 = observationPhaseBiasMeters(
                                 observation.satellite.system, observation.secondary_signal,
-                                SignalType::SIGNAL_TYPE_COUNT, false, phase_bias_m, 1.0, 0.0);
+                                SignalType::SIGNAL_TYPE_COUNT, false, phase_bias_m, 1.0, 0.0,
+                                observation.secondary_observation_type,
+                                std::string(),
+                                madoca_bias_identity);
                             observation.carrier_phase_l2 += phase_bias_sign * pb_l2;
                             observation.phase_bias_l2_m = pb_l2;
                         }

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -74,6 +74,7 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
     overrides.madoca_galileo_gate =
         envExactOne("GNSS_PPP_MADOCA_GALILEO_GATE") ||
         overrides.madoca_early_window;
+    overrides.madoca_bias_identity = envExactOne("GNSS_PPP_MADOCA_BIAS_IDENTITY");
     overrides.pb_add = envPresent("GNSS_PPP_PB_ADD");
     overrides.no_phase_bias = envPresent("GNSS_PPP_NO_PHASE_BIAS");
     overrides.l2_reset_fix = envFirstCharNotZero("GNSS_PPP_L2_RESET_FIX");

--- a/src/algorithms/ppp_observations.cpp
+++ b/src/algorithms/ppp_observations.cpp
@@ -11,6 +11,16 @@ namespace libgnss {
 
 using namespace ppp_internal;
 
+namespace {
+
+std::string biasObservationType(const Observation& observation) {
+    return !observation.pseudorange_observation_type.empty()
+               ? observation.pseudorange_observation_type
+               : observation.carrier_phase_observation_type;
+}
+
+}  // namespace
+
 std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
     const ObservationData& obs,
     const NavigationData& nav) {
@@ -66,6 +76,7 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
         if (!ppp_config_.use_ionosphere_free) {
             entry.pseudorange_if = primary->pseudorange;
             entry.primary_signal = primary->signal;
+            entry.primary_observation_type = biasObservationType(*primary);
             entry.primary_code_bias_coeff = 1.0;
             entry.secondary_code_bias_coeff = 0.0;
             // Per-frequency L1 raw observable (biases applied later in
@@ -103,6 +114,7 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
         if (!ppp_config_.use_ionosphere_free) {
             if (secondary != nullptr) {
                 entry.secondary_signal = secondary->signal;
+                entry.secondary_observation_type = biasObservationType(*secondary);
                 const double f1 = signalFrequencyHz(primary->signal, eph);
                 const double f2 = signalFrequencyHz(secondary->signal, eph);
                 if (f1 > 0.0 && f2 > 0.0) {
@@ -154,6 +166,7 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
         if (secondary == nullptr) {
             entry.pseudorange_if = primary->pseudorange;
             entry.primary_signal = primary->signal;
+            entry.primary_observation_type = biasObservationType(*primary);
             entry.primary_code_bias_coeff = 1.0;
             entry.secondary_code_bias_coeff = 0.0;
             if (primary->has_carrier_phase) {
@@ -184,6 +197,8 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
             coefficients.first * primary->pseudorange + coefficients.second * secondary->pseudorange;
         entry.primary_signal = primary->signal;
         entry.secondary_signal = secondary->signal;
+        entry.primary_observation_type = biasObservationType(*primary);
+        entry.secondary_observation_type = biasObservationType(*secondary);
         entry.primary_code_bias_coeff = coefficients.first;
         entry.secondary_code_bias_coeff = coefficients.second;
         entry.pseudorange_code_bias_m = 0.0;

--- a/src/io/madoca_l6.cpp
+++ b/src/io/madoca_l6.cpp
@@ -753,6 +753,9 @@ MadocaGtime latestComponentTime(const MadocaSsrCorrection& c, bool include_bias_
     return latest;
 }
 
+bool useMadocaBiasIdentityKey(libgnss::GNSSSystem system,
+                              const PPPEnvOverrides& env_overrides);
+
 bool buildMadocaSsrCorrection(int sat, const MadocaSsrCorrection& c,
                               const PPPEnvOverrides& env_overrides,
                               libgnss::SSROrbitClockCorrection& out,
@@ -815,7 +818,10 @@ bool buildMadocaSsrCorrection(int sat, const MadocaSsrCorrection& c,
     for (int k = 0; k < MadocaSsrCorrection::kMaxCode; ++k) {
         const int code = k + 1;  // cbias/pbias are held by CODE_*-1
         if (c.vcbias[k]) {
-            const std::uint8_t id = madocaBiasCodeToRtcmSsrId(gsys, code);
+            const std::uint8_t id =
+                useMadocaBiasIdentityKey(gsys, env_overrides)
+                    ? static_cast<std::uint8_t>(code)
+                    : madocaBiasCodeToRtcmSsrId(gsys, code);
             if (env_overrides.madoca_cbias_dump) {
                 std::fprintf(stderr,
                              "[MADOCA-CBIAS] sys=%d prn=%d code=%d id=%u cbias=%.4f\n",
@@ -827,7 +833,10 @@ bool buildMadocaSsrCorrection(int sat, const MadocaSsrCorrection& c,
             }
         }
         if (c.vpbias[k]) {
-            const std::uint8_t id = madocaBiasCodeToRtcmSsrId(gsys, code);
+            const std::uint8_t id =
+                useMadocaBiasIdentityKey(gsys, env_overrides)
+                    ? static_cast<std::uint8_t>(code)
+                    : madocaBiasCodeToRtcmSsrId(gsys, code);
             if (env_overrides.madoca_cbias_dump) {
                 std::fprintf(stderr,
                              "[MADOCA-PBIAS] sys=%d prn=%d code=%d id=%u pbias=%.4f\n",
@@ -906,6 +915,16 @@ std::uint8_t madocaBiasCodeToRtcmSsrId(libgnss::GNSSSystem system, int code) {
             break;
     }
     return 0;
+}
+
+bool useMadocaBiasIdentityKey(libgnss::GNSSSystem system,
+                              const libgnss::PPPEnvOverrides& env_overrides) {
+    if (!env_overrides.madoca_bias_identity) {
+        return false;
+    }
+    return system == libgnss::GNSSSystem::GPS ||
+           system == libgnss::GNSSSystem::Galileo ||
+           system == libgnss::GNSSSystem::QZSS;
 }
 
 int madocaL6eSnapshotToProducts(const MadocaL6eDecoder& decoder,

--- a/src/io/rinex.cpp
+++ b/src/io/rinex.cpp
@@ -327,9 +327,11 @@ void assignObservationField(Observation& obs,
     if (isCodeObservationType(obs_type)) {
         obs.pseudorange = value;
         obs.has_pseudorange = true;
+        obs.pseudorange_observation_type = obs_type;
     } else if (isCarrierObservationType(obs_type)) {
         obs.carrier_phase = value;
         obs.has_carrier_phase = true;
+        obs.carrier_phase_observation_type = obs_type;
         obs.lli = static_cast<uint8_t>(lli);
         obs.loss_of_lock = (lli & 0x01) != 0;
     } else if (isDopplerObservationType(obs_type)) {


### PR DESCRIPTION
## Summary

S11 of the MADOCA-PPP parity series — closes the bias signal-identity hypothesis with executable evidence, and ships the explicit-identity machinery as a default-OFF preview.

### Hypothesis closed

Suspicion from #139's audit: native collapses Galileo/QZSS bias signal ids to band level, so a C1C observation might receive an L1X bias (different tracking mode) than the bridge applies. Traced per observation code against MADOCALIB `mcssr_sel_biascode` (bridge trace level 4):

| Obs | Bridge id/value | Native id/value | Impact |
|---|---|---|---|
| E C1C/L1C | C1X +0.92 m | band id 2 (L1X) +0.92 m | identical |
| E C5Q/L5Q | C5X +1.62 m | band id 22 (L5X) +1.62 m | identical |
| J L1L | C1X +0.98 m | id-2 collision resolves to L1X +0.98 m | identical |
| J C2L | C2X −1.92 m | id 8 −1.92 m | identical |
| G C2W | C2W +0.16 m | would pick L2X +0.38 m | **0.000000 m** (C2W not the selected L2 obs) |

In this stream the per-band values never collide, so band collapsing is value-equivalent. Result: enabled run is **bit-identical** to default on MIZU (1.820470 / 1.195830 both).

### What ships

`GNSS_PPP_MADOCA_BIAS_IDENTITY=1` (default OFF): raw observation-code bias keys for GPS/Galileo/QZSS with an explicit `mcssrSelBiascode`-style lookup, and the selected RINEX observation type preserved through PPP combined observations. Correctness infrastructure for streams that do carry colliding per-tracking-mode bias values.

### Deferred lead (next slice)

The bridge trace revealed a real selection difference outside this surface: **QZSS secondary signal** — bridge pairs J L1 with **C5Q→C5X (L5)**, native selects **C2L→C2X (L2)**. Different iono-free pair → different geometry per QZSS row.

## Verification

- Full env matrix **bit-exact** vs pre-change reference; enabled run bit-identical to default
- `run_tests`: 318 passed / 43 skipped
- `tests/test_cli_tools.py -k qzss_l6 / madoca / clas`: pass
- `git diff --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)