### PR TITLE
feat(ppp): QZSS L1+L5 pair preview; close secondary-signal hypothesis

### DIFF
--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -770,6 +770,10 @@ int main(int argc, char* argv[]) {
             !ppp_env_overrides.qzss_prefer_l1l_present) {
             obs_reader.setQzssL1Preference(true);
         }
+        if (!options.madoca_l6_paths.empty() &&
+            ppp_env_overrides.madoca_qzss_l5) {
+            obs_reader.setQzssSecondaryL5Preference(true);
+        }
         if (!obs_reader.open(options.obs_path)) {
             std::cerr << "Error: failed to open observation file: " << options.obs_path << "\n";
             return 1;

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -57,6 +57,9 @@ struct PPPEnvOverrides {
     // GNSS_PPP_MADOCA_QZSS_PHASE: allow QZSS phase rows in MADOCA when set
     // exactly to "1". Default false.
     bool madoca_qzss_phase = false;
+    // GNSS_PPP_MADOCA_QZSS_L5: prefer QZSS L1/L5 over L1/L2 in coherent
+    // MADOCA when set exactly to "1". Default false while measured.
+    bool madoca_qzss_l5 = false;
     // GNSS_PPP_MADOCA_GLONASS: include GLONASS in coherent MADOCA unless set
     // exactly to "0". Default true.
     bool madoca_glonass = true;

--- a/include/libgnss++/io/rinex.hpp
+++ b/include/libgnss++/io/rinex.hpp
@@ -73,6 +73,18 @@ public:
      * @brief Check whether QZSS L1L/L1X preference is enabled.
      */
     bool qzssL1Preference() const { return qzss_prefer_l1l_; }
+
+    /**
+     * @brief Prefer QZSS L5Q/L5X observations over L2L for the secondary PPP signal.
+     */
+    void setQzssSecondaryL5Preference(bool prefer_l5) {
+        qzss_prefer_l5_secondary_ = prefer_l5;
+    }
+
+    /**
+     * @brief Check whether QZSS secondary L5 preference is enabled.
+     */
+    bool qzssSecondaryL5Preference() const { return qzss_prefer_l5_secondary_; }
     
     /**
      * @brief Open RINEX file
@@ -129,6 +141,7 @@ private:
     RINEXHeader header_;
     int current_line_ = 0;
     bool qzss_prefer_l1l_ = false;
+    bool qzss_prefer_l5_secondary_ = false;
 
     // State for parsing RINEX 3 "SYS / # / OBS TYPES" records that span
     // continuation lines (systems with more than 13 observation types, e.g.

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -68,6 +68,7 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
         !envExactOne("GNSS_PPP_DISABLE_QZSS_SSR_PRN_FIX");
     overrides.madoca_qzss_clock = !envExactZero("GNSS_PPP_MADOCA_QZSS_CLOCK");
     overrides.madoca_qzss_phase = envExactOne("GNSS_PPP_MADOCA_QZSS_PHASE");
+    overrides.madoca_qzss_l5 = envExactOne("GNSS_PPP_MADOCA_QZSS_L5");
     overrides.madoca_glonass = !envExactZero("GNSS_PPP_MADOCA_GLONASS");
     overrides.madoca_glonass_phase = envExactOne("GNSS_PPP_MADOCA_GLONASS_PHASE");
     overrides.madoca_low_elev = !envExactZero("GNSS_PPP_MADOCA_LOW_ELEV");

--- a/src/algorithms/ppp_observations.cpp
+++ b/src/algorithms/ppp_observations.cpp
@@ -19,6 +19,14 @@ std::string biasObservationType(const Observation& observation) {
                : observation.carrier_phase_observation_type;
 }
 
+std::vector<SignalType> secondarySignalsForObservation(const SatelliteId& sat,
+                                                       bool prefer_qzss_l5) {
+    if (prefer_qzss_l5 && sat.system == GNSSSystem::QZSS) {
+        return {SignalType::QZS_L5, SignalType::QZS_L2C};
+    }
+    return secondarySignals(sat.system);
+}
+
 }  // namespace
 
 std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
@@ -106,8 +114,10 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
             // But skip IFLC formation — keep L1-only entry.
         }
 
-        const Observation* secondary =
-            findObservationForSignals(obs, sat, secondarySignals(sat.system));
+        const bool prefer_qzss_l5 =
+            require_coherent_ssr_ && env_overrides_.madoca_qzss_l5;
+        const Observation* secondary = findObservationForSignals(
+            obs, sat, secondarySignalsForObservation(sat, prefer_qzss_l5));
 
         // Per-frequency mode: carry BOTH L1 and L2 raw observables.
         // SSR corrections (orbit/clock/bias/iono) still applied below.

--- a/src/io/rinex.cpp
+++ b/src/io/rinex.cpp
@@ -183,6 +183,15 @@ bool sameTrackingCode(char selected, char candidate) {
     return selected == '\0' || candidate == '\0' || selected == candidate;
 }
 
+int qzssL5TrackingPriority(char tracking_code) {
+    switch (tracking_code) {
+        case 'Q': return 0;
+        case 'X': return 1;
+        case 'I': return 2;
+        default: return 100;
+    }
+}
+
 struct ObservationSelection {
     Observation observation;
     bool has_data = false;
@@ -198,6 +207,7 @@ void maybeAssignSelectedObservation(ObservationSelection& selection,
                                     int lli,
                                     int signal_strength,
                                     bool prefer_qzss_l1l,
+                                    bool prefer_qzss_l5_secondary,
                                     bool primary) {
     if (value == 0.0) {
         return;
@@ -218,6 +228,14 @@ void maybeAssignSelectedObservation(ObservationSelection& selection,
             candidate_priority -= 2;
         } else if (tracking_code != 'C') {
             candidate_priority += 1;
+        }
+    }
+    if (prefer_qzss_l5_secondary && sat.system == GNSSSystem::QZSS && !primary &&
+        band == 5) {
+        const int tracking_priority = qzssL5TrackingPriority(tracking_code);
+        if (tracking_priority < 100) {
+            candidate_priority -= 4;
+            candidate_priority += tracking_priority;
         }
     }
     const bool starts_better_track = candidate_priority < selection.priority;
@@ -987,6 +1005,7 @@ bool RINEXReader::parseObservationEpochV2(const std::string& line, ObservationDa
                                            lli_flags[i],
                                            signal_strength[i],
                                            qzss_prefer_l1l_,
+                                           qzss_prefer_l5_secondary_,
                                            true);
             maybeAssignSelectedObservation(secondary_selection,
                                            sat,
@@ -995,6 +1014,7 @@ bool RINEXReader::parseObservationEpochV2(const std::string& line, ObservationDa
                                            lli_flags[i],
                                            signal_strength[i],
                                            qzss_prefer_l1l_,
+                                           qzss_prefer_l5_secondary_,
                                            false);
         }
 
@@ -1126,6 +1146,7 @@ bool RINEXReader::parseObservationEpochV3(const std::string& epoch_line, Observa
                                                lli_flags[i],
                                                signal_strength[i],
                                                qzss_prefer_l1l_,
+                                               qzss_prefer_l5_secondary_,
                                                true);
                 maybeAssignSelectedObservation(secondary_selection,
                                                sat,
@@ -1134,6 +1155,7 @@ bool RINEXReader::parseObservationEpochV3(const std::string& epoch_line, Observa
                                                lli_flags[i],
                                                signal_strength[i],
                                                qzss_prefer_l1l_,
+                                               qzss_prefer_l5_secondary_,
                                                false);
             }
 

--- a/tests/test_rinex_writer.cpp
+++ b/tests/test_rinex_writer.cpp
@@ -447,3 +447,59 @@ TEST(RINEXReaderTest, KeepsRinex3TrackingCodeFieldsTogether) {
     reader.close();
     std::filesystem::remove(temp_path);
 }
+
+TEST(RINEXReaderTest, QzssSecondaryL5PreferenceSelectsL5Q) {
+    const auto temp_path =
+        std::filesystem::temp_directory_path() / "libgnss_qzss_l5_preference_test.obs";
+    std::filesystem::remove(temp_path);
+
+    std::ofstream output(temp_path);
+    ASSERT_TRUE(output.is_open());
+    output << rinexHeaderLine(
+        "     3.04           OBSERVATION DATA    M",
+        "RINEX VERSION / TYPE");
+    output << rinexHeaderLine(
+        "J    8 C1L L1L C2L L2L C5P L5P C5Q L5Q",
+        "SYS / # / OBS TYPES");
+    output << rinexHeaderLine("", "END OF HEADER");
+    output << "> 2025 04 01 00 00 00.0000000  0  1\n";
+    output << "J02"
+           << rinexObsField("21000001.000")
+           << rinexObsField("110000001.000")
+           << rinexObsField("22000002.000")
+           << rinexObsField("120000002.000")
+           << rinexObsField("23000003.000")
+           << rinexObsField("130000003.000")
+           << rinexObsField("24000004.000")
+           << rinexObsField("140000004.000")
+           << "\n";
+    output.close();
+
+    auto read_epoch = [&](bool prefer_l5) {
+        io::RINEXReader reader;
+        reader.setQzssSecondaryL5Preference(prefer_l5);
+        EXPECT_TRUE(reader.open(temp_path.string()));
+        io::RINEXReader::RINEXHeader header;
+        EXPECT_TRUE(reader.readHeader(header));
+        ObservationData epoch;
+        EXPECT_TRUE(reader.readObservationEpoch(epoch));
+        reader.close();
+        return epoch;
+    };
+
+    const SatelliteId qzss_2(GNSSSystem::QZSS, 2);
+    const ObservationData default_epoch = read_epoch(false);
+    EXPECT_NE(default_epoch.getObservation(qzss_2, SignalType::QZS_L2C), nullptr);
+    EXPECT_EQ(default_epoch.getObservation(qzss_2, SignalType::QZS_L5), nullptr);
+
+    const ObservationData l5_epoch = read_epoch(true);
+    EXPECT_EQ(l5_epoch.getObservation(qzss_2, SignalType::QZS_L2C), nullptr);
+    const auto* qzss_l5 = l5_epoch.getObservation(qzss_2, SignalType::QZS_L5);
+    ASSERT_NE(qzss_l5, nullptr);
+    EXPECT_NEAR(qzss_l5->pseudorange, 24000004.000, 1e-3);
+    EXPECT_NEAR(qzss_l5->carrier_phase, 140000004.000, 1e-3);
+    EXPECT_EQ(qzss_l5->pseudorange_observation_type, "C5Q");
+    EXPECT_EQ(qzss_l5->carrier_phase_observation_type, "L5Q");
+
+    std::filesystem::remove(temp_path);
+}


### PR DESCRIPTION
## Summary

S12 of the MADOCA-PPP parity series — closes the dual-frequency pair-selection hypothesis from #141's audit.

### Audit result

| System | Bridge pair | Native pair | Difference |
|---|---|---|---|
| GPS | L1+L2 (C2W) | L1+L2 | none (tracking-code identity only — #141 surface) |
| Galileo | E1+E5a (C5Q→C5X) | E1+E5a | none |
| QZSS | **L1+L5** (C1L/C1X + C5Q/C5X) | **L1+L2** (C1L + C2L/C2X) | real pair difference |

### Measured outcome — default OFF

Mirroring the bridge's QZSS L1+L5 pair slightly **worsens** trajectory parity, so the decision rule keeps it off:

| Run | all-epoch RMS 3D | tail(1800s) RMS 3D |
|---|---:|---:|
| default (L1+L2) | **1.82047 m** | **1.19583 m** |
| `GNSS_PPP_MADOCA_QZSS_L5=1` | 1.82626 m | 1.19645 m |

Residual nuance: aggregate QZSS L1 code prefit RMS improves (1.838 → 1.722) but J04 worsens (1.632 → 1.695). The knob stays available for broader-window experiments.

### What ships

- `GNSS_PPP_MADOCA_QZSS_L5=1` (default OFF): RINEX reader prefers QZSS `C5Q/L5Q` over `C2L/L2L`, PPP IFLC searches `QZS_L5` before `QZS_L2C`; scoped to `--madoca-l6`
- RINEX reader regression test for the preference

## Verification

- Default path **bit-exact**: all 12 env-matrix cases `cmp` clean vs pre-change reference
- `run_tests`: 319 passed / 43 skipped
- `tests/test_cli_tools.py -k qzss_l6 / madoca / clas`: pass
- `git diff --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)