### PR TITLE
perf(ppp): make full-day MADOCA runs practical; fix bridge >7-file handling

### DIFF
--- a/include/libgnss++/core/navigation.hpp
+++ b/include/libgnss++/core/navigation.hpp
@@ -283,6 +283,40 @@ public:
     };
     
     NavigationStats getStats(const GNSSTime& current_time) const;
+
+private:
+    struct SatelliteStateCacheKey {
+        SatelliteId satellite;
+        GNSSTime time;
+        int desired_iode = -1;
+
+        bool operator<(const SatelliteStateCacheKey& other) const {
+            if (satellite < other.satellite) {
+                return true;
+            }
+            if (other.satellite < satellite) {
+                return false;
+            }
+            if (time < other.time) {
+                return true;
+            }
+            if (other.time < time) {
+                return false;
+            }
+            return desired_iode < other.desired_iode;
+        }
+    };
+
+    struct SatelliteStateCacheValue {
+        Vector3d position = Vector3d::Zero();
+        Vector3d velocity = Vector3d::Zero();
+        double clock_bias = 0.0;
+        double clock_drift = 0.0;
+        bool valid = false;
+    };
+
+    mutable std::map<SatelliteStateCacheKey, SatelliteStateCacheValue>
+        satellite_state_cache_;
 };
 
 /**
@@ -408,6 +442,7 @@ public:
     std::map<SatelliteId, std::vector<SSROrbitClockCorrection>> orbit_clock_corrections;
 
     void addCorrection(const SSROrbitClockCorrection& correction);
+    void addCorrections(const std::vector<SSROrbitClockCorrection>& corrections);
 
     bool interpolateCorrection(const SatelliteId& sat,
                                const GNSSTime& time,

--- a/src/algorithms/madocalib_bridge.cpp
+++ b/src/algorithms/madocalib_bridge.cpp
@@ -1,9 +1,12 @@
 #include <libgnss++/external/madocalib_bridge.hpp>
 
 #include <cstdarg>
+#include <cctype>
 #include <cstdio>
 #include <cstring>
 #include <filesystem>
+#include <map>
+#include <set>
 #include <sstream>
 #include <vector>
 
@@ -74,6 +77,90 @@ bool requireRegularFiles(const std::vector<std::string>& paths,
         }
     }
     return true;
+}
+
+struct L6ePatternInfo {
+    bool matched = false;
+    std::string pattern;
+};
+
+L6ePatternInfo hourlyL6ePattern(const std::string& input_path) {
+    const std::filesystem::path path(input_path);
+    const std::string filename = path.filename().string();
+    const auto dot_l6 = filename.rfind('.');
+    if (dot_l6 == std::string::npos) {
+        return {};
+    }
+    const std::string extension = filename.substr(dot_l6);
+    if (extension != ".l6" && extension != ".L6") {
+        return {};
+    }
+    const auto dot_prn = filename.rfind('.', dot_l6 - 1);
+    if (dot_prn == std::string::npos || dot_l6 <= dot_prn + 1) {
+        return {};
+    }
+    const std::string prn = filename.substr(dot_prn + 1, dot_l6 - dot_prn - 1);
+    if (prn.size() != 3 || prn == "200" || prn == "201") {
+        return {};
+    }
+    const std::string stem = filename.substr(0, dot_prn);
+    if (stem.size() != 8) {
+        return {};
+    }
+    for (size_t i = 0; i < 7; ++i) {
+        if (!std::isdigit(static_cast<unsigned char>(stem[i]))) {
+            return {};
+        }
+    }
+    const char hour_code = stem[7];
+    if (!((hour_code >= 'A' && hour_code <= 'X') ||
+          (hour_code >= 'a' && hour_code <= 'x'))) {
+        return {};
+    }
+
+    const std::string year = stem.substr(0, 4);
+    const std::string doy = stem.substr(4, 3);
+    const std::filesystem::path day_dir = path.parent_path();
+    const std::filesystem::path year_dir = day_dir.parent_path();
+    const std::string pattern_name = "%Y%n%HU." + prn + extension;
+    std::filesystem::path pattern_path;
+    if (day_dir.filename() == doy && year_dir.filename() == year) {
+        pattern_path = year_dir.parent_path() / "%Y" / "%n" / pattern_name;
+    } else {
+        pattern_path = day_dir / pattern_name;
+    }
+    return {true, pattern_path.string()};
+}
+
+std::vector<std::string> condenseHourlyL6eInputs(
+    const std::vector<std::string>& inputs) {
+    constexpr size_t kMadocalibL6eStreamSlots = 7;
+    std::map<std::string, size_t> pattern_counts;
+    std::vector<L6ePatternInfo> infos;
+    infos.reserve(inputs.size());
+    for (const std::string& input : inputs) {
+        L6ePatternInfo info = hourlyL6ePattern(input);
+        if (info.matched) {
+            ++pattern_counts[info.pattern];
+        }
+        infos.push_back(std::move(info));
+    }
+
+    std::vector<std::string> condensed;
+    condensed.reserve(inputs.size());
+    std::set<std::string> emitted_patterns;
+    for (size_t i = 0; i < inputs.size(); ++i) {
+        const L6ePatternInfo& info = infos[i];
+        if (!info.matched ||
+            pattern_counts[info.pattern] <= kMadocalibL6eStreamSlots) {
+            condensed.push_back(inputs[i]);
+            continue;
+        }
+        if (emitted_patterns.insert(info.pattern).second) {
+            condensed.push_back(info.pattern);
+        }
+    }
+    return condensed;
 }
 
 #if GNSSPP_HAS_MADOCALIB_BRIDGE
@@ -310,12 +397,15 @@ int runPostpos(const PostposOptions& options, std::string* error_message) {
     }
     solopt.trace = options.trace_level;
 
+    const std::vector<std::string> auxiliary_input_paths =
+        condenseHourlyL6eInputs(options.auxiliary_input_paths);
+
     std::vector<std::string> input_storage;
     input_storage.push_back(options.obs_path);
     if (!options.nav_path.empty()) {
         input_storage.push_back(options.nav_path);
     }
-    for (const std::string& input : options.auxiliary_input_paths) {
+    for (const std::string& input : auxiliary_input_paths) {
         if (!input.empty()) {
             input_storage.push_back(input);
         }

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -510,10 +510,30 @@ PositionSolution PPPProcessor::processEpochStandard(
         use_seed_assist ||
         !filter_initialized_;
     const PositionSolution* seed_ptr = nullptr;
+    const auto runSeedSpp = [&]() {
+        const SPPProcessor::SPPConfig original_spp_config = spp_processor_.getSPPConfig();
+        if (ssr_products_loaded_ && original_spp_config.enable_raim_fde) {
+            SPPProcessor::SPPConfig seed_spp_config = original_spp_config;
+            // The internal seed solve only initializes/resets the PPP clock.
+            // Full leave-one-out SPP FDE can dominate long SSR runs, while
+            // fallback SPP output still uses the normal processor settings.
+            seed_spp_config.enable_raim_fde = false;
+            spp_processor_.setSPPConfig(seed_spp_config);
+            try {
+                PositionSolution seed = spp_processor_.processEpoch(obs, nav);
+                spp_processor_.setSPPConfig(original_spp_config);
+                return seed;
+            } catch (...) {
+                spp_processor_.setSPPConfig(original_spp_config);
+                throw;
+            }
+        }
+        return spp_processor_.processEpoch(obs, nav);
+    };
 
     try {
         if (need_seed_solution) {
-            seed_solution = spp_processor_.processEpoch(obs, nav);
+            seed_solution = runSeedSpp();
             if (seed_solution.isValid()) {
                 seed_ptr = &seed_solution;
             }

--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -9,6 +9,7 @@
 #include <limits>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace libgnss {
@@ -89,6 +90,50 @@ bool sameCorrectionVariant(const SSROrbitClockCorrection& lhs,
                            const SSROrbitClockCorrection& rhs) {
     return lhs.atmos_network_id == rhs.atmos_network_id &&
            lhs.bias_network_id == rhs.bias_network_id;
+}
+
+void mergeCorrectionFields(SSROrbitClockCorrection& target,
+                           const SSROrbitClockCorrection& correction) {
+    if (correction.orbit_valid) {
+        target.orbit_correction_ecef = correction.orbit_correction_ecef;
+        target.orbit_valid = true;
+        target.orbit_reference_time = correction.orbit_reference_time.week != 0 ?
+            correction.orbit_reference_time : correction.time;
+        target.iode = correction.iode;
+        target.ssr_orbit_iod = correction.ssr_orbit_iod;
+    }
+    if (correction.clock_valid) {
+        target.clock_correction_m = correction.clock_correction_m;
+        target.clock_valid = true;
+        target.clock_reference_time = correction.clock_reference_time.week != 0 ?
+            correction.clock_reference_time : correction.time;
+        target.ssr_clock_iod = correction.ssr_clock_iod;
+    }
+    if (correction.ura_valid) {
+        target.ura_sigma_m = correction.ura_sigma_m;
+        target.ura_valid = true;
+    }
+    if (correction.code_bias_valid) {
+        for (const auto& [signal_id, bias_m] : correction.code_bias_m) {
+            target.code_bias_m[signal_id] = bias_m;
+        }
+        target.code_bias_valid = !target.code_bias_m.empty();
+    }
+    if (correction.phase_bias_valid) {
+        for (const auto& [signal_id, bias_m] : correction.phase_bias_m) {
+            target.phase_bias_m[signal_id] = bias_m;
+        }
+        for (const auto& [signal_id, discnt] : correction.phase_bias_discnt) {
+            target.phase_bias_discnt[signal_id] = discnt;
+        }
+        target.phase_bias_valid = !target.phase_bias_m.empty();
+    }
+    if (correction.atmos_valid) {
+        for (const auto& [token, value] : correction.atmos_tokens) {
+            target.atmos_tokens[token] = value;
+        }
+        target.atmos_valid = !target.atmos_tokens.empty();
+    }
 }
 
 GNSSTime orbitReferenceTime(const SSROrbitClockCorrection& correction) {
@@ -544,6 +589,7 @@ double Ephemeris::getAge(const GNSSTime& time) const {
 
 void NavigationData::addEphemeris(const Ephemeris& eph) {
     ephemeris_data[eph.satellite].push_back(eph);
+    satellite_state_cache_.clear();
     
     // Sort by time of ephemeris
     auto& eph_list = ephemeris_data[eph.satellite];
@@ -689,12 +735,34 @@ bool NavigationData::calculateSatelliteState(const SatelliteId& sat,
                                            Vector3d& velocity,
                                            double& clock_bias,
                                            double& clock_drift) const {
-    const Ephemeris* eph = getEphemeris(sat, time);
-    if (!eph) {
-        return false;
+    const SatelliteStateCacheKey cache_key{sat, time, -1};
+    const auto cache_it = satellite_state_cache_.find(cache_key);
+    if (cache_it != satellite_state_cache_.end()) {
+        const SatelliteStateCacheValue& cached = cache_it->second;
+        position = cached.position;
+        velocity = cached.velocity;
+        clock_bias = cached.clock_bias;
+        clock_drift = cached.clock_drift;
+        return cached.valid;
     }
 
-    return eph->calculateSatelliteState(time, position, velocity, clock_bias, clock_drift);
+    SatelliteStateCacheValue computed;
+    const Ephemeris* eph = getEphemeris(sat, time);
+    if (eph) {
+        computed.valid =
+            eph->calculateSatelliteState(
+                time,
+                computed.position,
+                computed.velocity,
+                computed.clock_bias,
+                computed.clock_drift);
+    }
+    satellite_state_cache_.emplace(cache_key, computed);
+    position = computed.position;
+    velocity = computed.velocity;
+    clock_bias = computed.clock_bias;
+    clock_drift = computed.clock_drift;
+    return computed.valid;
 }
 
 bool NavigationData::calculateSatelliteState(const SatelliteId& sat,
@@ -704,23 +772,44 @@ bool NavigationData::calculateSatelliteState(const SatelliteId& sat,
                                            double& clock_bias,
                                            double& clock_drift,
                                            int desired_iode) const {
-    const Ephemeris* eph = getEphemeris(sat, time, desired_iode);
-    if (!eph) {
-        return false;
+    const SatelliteStateCacheKey cache_key{sat, time, desired_iode};
+    const auto cache_it = satellite_state_cache_.find(cache_key);
+    if (cache_it != satellite_state_cache_.end()) {
+        const SatelliteStateCacheValue& cached = cache_it->second;
+        position = cached.position;
+        velocity = cached.velocity;
+        clock_bias = cached.clock_bias;
+        clock_drift = cached.clock_drift;
+        return cached.valid;
     }
-    return eph->calculateSatelliteState(time, position, velocity, clock_bias, clock_drift);
+
+    SatelliteStateCacheValue computed;
+    const Ephemeris* eph = getEphemeris(sat, time, desired_iode);
+    if (eph) {
+        computed.valid =
+            eph->calculateSatelliteState(
+                time,
+                computed.position,
+                computed.velocity,
+                computed.clock_bias,
+                computed.clock_drift);
+    }
+    satellite_state_cache_.emplace(cache_key, computed);
+    position = computed.position;
+    velocity = computed.velocity;
+    clock_bias = computed.clock_bias;
+    clock_drift = computed.clock_drift;
+    return computed.valid;
 }
 
 std::map<SatelliteId, Vector3d> NavigationData::calculateSatellitePositions(
     const std::vector<SatelliteId>& satellites,
     const GNSSTime& time) const {
-    
     std::map<SatelliteId, Vector3d> positions;
     
     for (const auto& sat : satellites) {
         Vector3d pos, vel;
         double clock_bias, clock_drift;
-        
         if (calculateSatelliteState(sat, time, pos, vel, clock_bias, clock_drift)) {
             positions[sat] = pos;
         }
@@ -732,7 +821,6 @@ std::map<SatelliteId, Vector3d> NavigationData::calculateSatellitePositions(
 NavigationData::SatelliteGeometry NavigationData::calculateGeometry(
     const Vector3d& receiver_pos,
     const Vector3d& satellite_pos) const {
-    
     SatelliteGeometry geom;
     
     Vector3d los = satellite_pos - receiver_pos;
@@ -786,6 +874,7 @@ NavigationData::NavigationData() {
 
 void NavigationData::clear() {
     ephemeris_data.clear();
+    satellite_state_cache_.clear();
 }
 
 bool NavigationData::isEmpty() const {
@@ -1171,50 +1260,80 @@ void SSRProducts::addCorrection(const SSROrbitClockCorrection& correction) {
         if (!sameCorrectionVariant(*it, correction)) {
             continue;
         }
-        if (correction.orbit_valid) {
-            it->orbit_correction_ecef = correction.orbit_correction_ecef;
-            it->orbit_valid = true;
-            it->orbit_reference_time = correction.orbit_reference_time.week != 0 ?
-                correction.orbit_reference_time : correction.time;
-            it->iode = correction.iode;
-            it->ssr_orbit_iod = correction.ssr_orbit_iod;
-        }
-        if (correction.clock_valid) {
-            it->clock_correction_m = correction.clock_correction_m;
-            it->clock_valid = true;
-            it->clock_reference_time = correction.clock_reference_time.week != 0 ?
-                correction.clock_reference_time : correction.time;
-            it->ssr_clock_iod = correction.ssr_clock_iod;
-        }
-        if (correction.ura_valid) {
-            it->ura_sigma_m = correction.ura_sigma_m;
-            it->ura_valid = true;
-        }
-        if (correction.code_bias_valid) {
-            for (const auto& [signal_id, bias_m] : correction.code_bias_m) {
-                it->code_bias_m[signal_id] = bias_m;
-            }
-            it->code_bias_valid = !it->code_bias_m.empty();
-        }
-        if (correction.phase_bias_valid) {
-            for (const auto& [signal_id, bias_m] : correction.phase_bias_m) {
-                it->phase_bias_m[signal_id] = bias_m;
-            }
-            for (const auto& [signal_id, discnt] : correction.phase_bias_discnt) {
-                it->phase_bias_discnt[signal_id] = discnt;
-            }
-            it->phase_bias_valid = !it->phase_bias_m.empty();
-        }
-        if (correction.atmos_valid) {
-            for (const auto& [token, value] : correction.atmos_tokens) {
-                it->atmos_tokens[token] = value;
-            }
-            it->atmos_valid = !it->atmos_tokens.empty();
-        }
+        mergeCorrectionFields(*it, correction);
         return;
     }
 
     entries.insert(upper, correction);
+}
+
+void SSRProducts::addCorrections(const std::vector<SSROrbitClockCorrection>& corrections) {
+    if (corrections.empty()) {
+        return;
+    }
+
+    struct CorrectionKey {
+        GNSSTime time;
+        int atmos_network_id = 0;
+        int bias_network_id = 0;
+
+        bool operator<(const CorrectionKey& other) const {
+            if (time < other.time) {
+                return true;
+            }
+            if (other.time < time) {
+                return false;
+            }
+            if (atmos_network_id != other.atmos_network_id) {
+                return atmos_network_id < other.atmos_network_id;
+            }
+            return bias_network_id < other.bias_network_id;
+        }
+    };
+
+    struct PendingSatelliteCorrections {
+        std::vector<SSROrbitClockCorrection> entries;
+        std::map<CorrectionKey, size_t> index_by_key;
+    };
+
+    std::map<SatelliteId, PendingSatelliteCorrections> pending;
+    for (const auto& [satellite, entries] : orbit_clock_corrections) {
+        PendingSatelliteCorrections& sat_pending = pending[satellite];
+        sat_pending.entries = entries;
+        for (size_t index = 0; index < sat_pending.entries.size(); ++index) {
+            const SSROrbitClockCorrection& entry = sat_pending.entries[index];
+            const CorrectionKey key{entry.time, entry.atmos_network_id, entry.bias_network_id};
+            sat_pending.index_by_key.emplace(key, index);
+        }
+    }
+
+    for (const SSROrbitClockCorrection& correction : corrections) {
+        PendingSatelliteCorrections& sat_pending = pending[correction.satellite];
+        const CorrectionKey key{
+            correction.time,
+            correction.atmos_network_id,
+            correction.bias_network_id,
+        };
+        const auto index_it = sat_pending.index_by_key.find(key);
+        if (index_it != sat_pending.index_by_key.end()) {
+            mergeCorrectionFields(sat_pending.entries[index_it->second], correction);
+            continue;
+        }
+        sat_pending.index_by_key.emplace(key, sat_pending.entries.size());
+        sat_pending.entries.push_back(correction);
+    }
+
+    orbit_clock_corrections.clear();
+    for (auto& [satellite, sat_pending] : pending) {
+        std::stable_sort(
+            sat_pending.entries.begin(),
+            sat_pending.entries.end(),
+            [](const SSROrbitClockCorrection& lhs,
+               const SSROrbitClockCorrection& rhs) {
+                return lhs.time < rhs.time;
+            });
+        orbit_clock_corrections.emplace(satellite, std::move(sat_pending.entries));
+    }
 }
 
 bool SSRProducts::interpolateCorrection(const SatelliteId& sat,

--- a/src/io/madoca_l6.cpp
+++ b/src/io/madoca_l6.cpp
@@ -956,6 +956,7 @@ int decodeMadocaL6eFilesToProducts(const std::vector<std::string>& files,
     // Per-satellite last-emitted orbit/clock t0 (snapshot only on a change).
     std::vector<std::int64_t> last_orbit(kN + 1, -1);
     std::vector<std::int64_t> last_clock(kN + 1, -1);
+    std::vector<libgnss::SSROrbitClockCorrection> corrections;
 
     int added = 0;
     for (const std::string& file : files) {
@@ -982,12 +983,13 @@ int decodeMadocaL6eFilesToProducts(const std::vector<std::string>& files,
                 last_clock[sat] = ct;
                 libgnss::SSROrbitClockCorrection corr;
                 if (buildMadocaSsrCorrection(sat, c, decoder.envOverrides(), corr)) {
-                    products.addCorrection(corr);
+                    corrections.push_back(corr);
                     ++added;
                 }
             }
         }
     }
+    products.addCorrections(corrections);
     return added;
 }
 
@@ -999,6 +1001,7 @@ int decodeMadocaL6eFilesToProductsReplay(const std::vector<std::string>& files,
     referenceEpochForWeek(gps_week, ref_ep);
 
     constexpr int kN = MadocaL6eDecoder::kMaxSat;
+    std::vector<libgnss::SSROrbitClockCorrection> corrections;
     int added = 0;
     for (const std::string& file : files) {
         std::ifstream in(file, std::ios::binary);
@@ -1038,12 +1041,13 @@ int decodeMadocaL6eFilesToProductsReplay(const std::vector<std::string>& files,
                 libgnss::SSROrbitClockCorrection corr;
                 if (buildMadocaSsrCorrection(
                         sat, c, decoder.envOverrides(), corr, true)) {
-                    products.addCorrection(corr);
+                    corrections.push_back(corr);
                     ++added;
                 }
             }
         }
     }
+    products.addCorrections(corrections);
     return added;
 }
 


### PR DESCRIPTION
## Summary

S14 of the MADOCA-PPP parity series — unblocks full-day (24h) validation, which S13 found impossible on both sides.

### Native performance (24h: 370+ s timeout → 60.7 s; 1h: ~6 s → 1.45 s)

Profiling (file-count bisection; decode-only 0.56/2.31/10.3/40.2/164.9 s for 2/6/12/24/48 files) found three hot sites:
1. **Per-correction sorted insertion** during L6E decode — now batched via `SSRProducts::addCorrections()`
2. **Repeated same-epoch satellite-state computation** — now cached in `NavigationData`
3. **Leave-one-out SPP RAIM/FDE in the internal PPP seed solve** (54–100 ms/epoch, 40+ attempts/epoch on 24h) — now skipped when SSR products are loaded. Note: this is a scoped behavioral change in principle (the seed only initializes/resets the PPP clock), but all tested windows (1h/24h) are byte-identical; fallback SPP output keeps normal RAIM settings.

### Bridge 24h truncation root cause

MADOCALIB caps L6E streams at `MCSSR_MAX_PRN = 7` — passing 24 hourly files per PRN silently used only the first 7, so bridge solutions ended at 07:01 (Q=0 after). The glue now condenses explicit hourly files into MADOCALIB `%Y/%n/%Y%n%HU.<prn>.l6` time-expanded patterns when >7 files share a PRN. 24h bridge: 13.6 s, full 2878 rows.

### First full-day parity numbers (native vs bridge, delta RMS 3D)

| Window | matched epochs | all-epoch | tail(1800s) | excl-first-hour |
|---|---:|---:|---:|---:|
| 1h | 118 | 1.820 m | 1.196 m | n/a |
| 6h | 597 | 1.297 m | 1.169 m | n/a |
| 24h | 2878 | 4.085 m | 1.287 m | 4.155 m |

The 24h all-epoch number is dominated by one spike near GPST TOW 199320 (~07:22, max 3D delta 91.9 m); tail convergence matches the shorter baselines. The spike is the next parity slice.

## Verification

- 1h native `.pos` **byte-identical** before/after (and 1.45 s runtime)
- 1h and 6h bridge `.pos` **byte-identical** to existing references
- `run_tests`: 319 passed / 43 skipped
- `tests/test_cli_tools.py -k qzss_l6 / madoca / clas`: pass
- `git diff --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)