### PR TITLE
fix(ppp): guard converged MADOCA filter against implausible updates

### DIFF
--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -26,6 +26,9 @@ struct PPPEnvOverrides {
     // GNSS_PPP_MADOCA_EARLY_WINDOW: enable coherent MADOCA bridge-convergence
     // parity defaults unless set exactly to "0". Default true.
     bool madoca_early_window = true;
+    // GNSS_PPP_MADOCA_SPIKE_GUARD: reject implausible converged static update
+    // jumps in coherent MADOCA unless set exactly to "0". Default true.
+    bool madoca_spike_guard = true;
     // GNSS_PPP_ESTIMATE_ISB: comma/space-style spec parsed by substring
     // checks for "gal", "qzs", "bds", "all", or exact "1". Defaults false.
     bool estimate_isb_all = false;

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -46,6 +46,7 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
         envExactOne("GNSS_PPP_DISABLE_MADOCA_STATIC_ANCHOR");
     overrides.static_anchor_blend = envDoubleOr("GNSS_PPP_STATIC_ANCHOR_BLEND", -1.0);
     overrides.madoca_early_window = !envExactZero("GNSS_PPP_MADOCA_EARLY_WINDOW");
+    overrides.madoca_spike_guard = !envExactZero("GNSS_PPP_MADOCA_SPIKE_GUARD");
 
     const char* isb = envValue("GNSS_PPP_ESTIMATE_ISB");
     const std::string isb_spec = isb != nullptr ? std::string(isb) : std::string();

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -19,6 +19,8 @@ using namespace ppp_internal;
 
 namespace {
 
+constexpr double kMadocaStaticSpikeGuardPositionDeltaM = 100.0;
+
 bool validReceiverSeed(const Vector3d& receiver_position) {
     return std::isfinite(receiver_position.x()) &&
            std::isfinite(receiver_position.y()) &&
@@ -326,6 +328,12 @@ bool PPPProcessor::updateFilter(const ObservationData& obs, const NavigationData
     }
 
     const int filter_iterations = precise_products_loaded_ ? 3 : ppp_config_.filter_iterations;
+    const PPPState pre_update_state = filter_state_;
+    const bool madoca_static_spike_guard =
+        require_coherent_ssr_ && ssr_products_loaded_ &&
+        env_overrides_.madoca_spike_guard &&
+        converged_ &&
+        (!ppp_config_.kinematic_mode || ppp_config_.low_dynamics_mode);
     for (int iteration = 0; iteration < filter_iterations; ++iteration) {
         MeasurementEquation meas_eq = formMeasurementEquations(if_obs, nav, obs.time);
 
@@ -346,11 +354,32 @@ bool PPPProcessor::updateFilter(const ObservationData& obs, const NavigationData
         const MatrixXd gain =
             filter_state_.covariance * meas_eq.design_matrix.transpose() * innovation_inverse;
         const VectorXd delta_state = gain * meas_eq.residuals;
+        const double position_delta_norm =
+            delta_state.segment(filter_state_.pos_index, 3).norm();
+
+        if (madoca_static_spike_guard &&
+            std::isfinite(position_delta_norm) &&
+            position_delta_norm > kMadocaStaticSpikeGuardPositionDeltaM) {
+            if (pppDebugEnabled()) {
+                std::cerr << "[PPP] MADOCA spike guard rejected update at week="
+                          << obs.time.week
+                          << " tow=" << obs.time.tow
+                          << " iter=" << iteration
+                          << " rows=" << meas_eq.observations.size()
+                          << " pos_delta=" << position_delta_norm
+                          << " clock_delta=" << delta_state(filter_state_.clock_index)
+                          << " trop_delta=" << delta_state(filter_state_.trop_index)
+                          << "\n";
+            }
+            filter_state_ = pre_update_state;
+            pre_anchor_covariance_ = filter_state_.covariance;
+            return true;
+        }
 
         if (pppDebugEnabled()) {
             std::cerr << "[PPP] iter=" << iteration
                       << " rows=" << meas_eq.observations.size()
-                      << " pos_delta=" << delta_state.segment(filter_state_.pos_index, 3).norm()
+                      << " pos_delta=" << position_delta_norm
                       << " clock_delta=" << delta_state(filter_state_.clock_index)
                       << " trop_delta=" << delta_state(filter_state_.trop_index)
                       << "\n";


### PR DESCRIPTION
## Summary

S15 of the MADOCA-PPP parity series — root-causes and fixes the dominant 24h parity spike found in #143.

### Attribution

The spike at GPST TOW 199320 (~07:22) is **native-side**: the bridge stayed stable (4.499 m absolute 3D error, Q=6, 30 sats) while native jumped to 89.2 m absolute. No satellite-count collapse or bridge outage — native's `updateFilter()` accepted a converged static iteration carrying an implausible update: **position correction 274 m, clock −290 m, troposphere +31 m**, which poisoned the following epochs.

### Fix

`GNSS_PPP_MADOCA_SPIKE_GUARD` (default ON, `=0` opt-out): in coherent SSR MADOCA mode, once the filter is converged in static/low-dynamics mode, the pre-update state is snapshotted and a single update whose position correction exceeds 100 m is rejected, restoring the snapshot instead of letting the filter jump.

### Metrics

| Window | all-epoch before → after | tail(1800s) | max 3D delta |
|---|---|---|---|
| 1h | 1.820 → 1.820 (**bit-exact**) | 1.196 | — |
| 6h | 1.297 → 1.297 (**bit-exact**) | 1.169 | — |
| 24h | **4.085 → 2.012 m** | 1.287 → 1.285 | **91.9 → 18.2 m** |

Deferred: a separate smaller disturbance remains at TOW 198870 (18 m max), near the same hourly L6 file boundary — next on the queue.

## Verification

- 1h and 6h native `.pos` **bit-exact** vs pre-change references (`cmp`)
- 24h metrics independently reproduced (2.01152 / 1.2853)
- `run_tests`: 319 passed / 43 skipped
- `tests/test_cli_tools.py -k qzss_l6 / madoca / clas`: pass
- `git diff --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)