### PR TITLE
fix(ppp): epoch-level rollback for converged MADOCA boundary disturbances

### DIFF
--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -29,6 +29,9 @@ struct PPPEnvOverrides {
     // GNSS_PPP_MADOCA_SPIKE_GUARD: reject implausible converged static update
     // jumps in coherent MADOCA unless set exactly to "0". Default true.
     bool madoca_spike_guard = true;
+    // GNSS_PPP_MADOCA_BOUNDARY_GUARD: reject smaller coherent-MADOCA
+    // file-boundary update jumps unless set exactly to "0". Default true.
+    bool madoca_boundary_guard = true;
     // GNSS_PPP_ESTIMATE_ISB: comma/space-style spec parsed by substring
     // checks for "gal", "qzs", "bds", "all", or exact "1". Defaults false.
     bool estimate_isb_all = false;

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -47,6 +47,7 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
     overrides.static_anchor_blend = envDoubleOr("GNSS_PPP_STATIC_ANCHOR_BLEND", -1.0);
     overrides.madoca_early_window = !envExactZero("GNSS_PPP_MADOCA_EARLY_WINDOW");
     overrides.madoca_spike_guard = !envExactZero("GNSS_PPP_MADOCA_SPIKE_GUARD");
+    overrides.madoca_boundary_guard = !envExactZero("GNSS_PPP_MADOCA_BOUNDARY_GUARD");
 
     const char* isb = envValue("GNSS_PPP_ESTIMATE_ISB");
     const std::string isb_spec = isb != nullptr ? std::string(isb) : std::string();

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -20,6 +20,7 @@ using namespace ppp_internal;
 namespace {
 
 constexpr double kMadocaStaticSpikeGuardPositionDeltaM = 100.0;
+constexpr double kMadocaBoundaryGuardPositionJumpM = 10.0;
 
 bool validReceiverSeed(const Vector3d& receiver_position) {
     return std::isfinite(receiver_position.x()) &&
@@ -334,6 +335,11 @@ bool PPPProcessor::updateFilter(const ObservationData& obs, const NavigationData
         env_overrides_.madoca_spike_guard &&
         converged_ &&
         (!ppp_config_.kinematic_mode || ppp_config_.low_dynamics_mode);
+    const bool madoca_boundary_guard =
+        require_coherent_ssr_ && ssr_products_loaded_ &&
+        env_overrides_.madoca_boundary_guard &&
+        converged_ &&
+        (!ppp_config_.kinematic_mode || ppp_config_.low_dynamics_mode);
     for (int iteration = 0; iteration < filter_iterations; ++iteration) {
         MeasurementEquation meas_eq = formMeasurementEquations(if_obs, nav, obs.time);
 
@@ -399,6 +405,25 @@ bool PPPProcessor::updateFilter(const ObservationData& obs, const NavigationData
             std::abs(delta_state(filter_state_.clock_index)) < 1e-3 &&
             std::abs(delta_state(filter_state_.trop_index)) < 1e-3) {
             break;
+        }
+    }
+
+    if (madoca_boundary_guard) {
+        const double epoch_position_jump_m =
+            (filter_state_.state.segment(filter_state_.pos_index, 3) -
+             pre_update_state.state.segment(pre_update_state.pos_index, 3)).norm();
+        if (std::isfinite(epoch_position_jump_m) &&
+            epoch_position_jump_m > kMadocaBoundaryGuardPositionJumpM) {
+            if (pppDebugEnabled()) {
+                std::cerr << "[PPP] MADOCA boundary guard rejected update at week="
+                          << obs.time.week
+                          << " tow=" << obs.time.tow
+                          << " pos_jump=" << epoch_position_jump_m
+                          << "\n";
+            }
+            filter_state_ = pre_update_state;
+            pre_anchor_covariance_ = filter_state_.covariance;
+            return true;
         }
     }
 


### PR DESCRIPTION
## Summary

S16 of the MADOCA-PPP parity series — root-causes the L6 file-boundary disturbance behind both the #144 spike (91.9 m, suppressed) and the remaining 18 m event at TOW 198870.

### Root cause

Instrumentation around the 07:00 file-G/H boundary **refuted the SSR-data hypotheses**: accepted corrections were fresh and coherent (orbit/clock IOD pairs matched — 12/12 then 14/14 — ages 0–25 s), and the bridge sailed through on the same data (Q=6, 30–31 sats). The event is a boundary-wide residual chain (first-pass residuals 16–20 m across G22/G14/E16/E25/E24/J02) that native accepted as **cumulative iterative Kalman movement**. The structural difference: MADOCALIB **commits an epoch only after postfit-residual success**, retrying from the committed pre-epoch state (`ppp.c:1359-1379`); native accumulates iterations directly. The #144 guard only caught per-iteration jumps >100 m, so the cumulative 10 m-per-epoch chain slipped through.

### Fix

A full RTKLIB-style postfit retry loop was prototyped and **rejected** — it changed 1h/6h behavior badly (documented in Deferred). This slice approximates the commit-on-success mechanism with `GNSS_PPP_MADOCA_BOUNDARY_GUARD` (default ON, `=0` opt-out): for converged coherent-MADOCA static/low-dynamics updates, the epoch is rolled back when total position movement from the pre-update state exceeds 10 m (impossible for a truly static receiver).

### Metrics

| Window | all-epoch before → after | tail(1800s) | max 3D delta |
|---|---|---|---|
| 1h | 1.820 (**bit-exact**) | 1.196 | — |
| 6h | (**bit-exact**) | — | — |
| 24h | **2.012 → 1.349 m** | 1.285 → 1.286 | **18.2 → 5.2 m** |

The #144 spike guard is now subsumed: after this fix, default and `GNSS_PPP_MADOCA_SPIKE_GUARD=0` 24h outputs are **byte-identical** (the guard stays as a safety net). No ≥10 m epochs remain on the 24h window.

## Verification

- 1h and 6h native `.pos` **bit-exact** vs pre-change references (`cmp`)
- 24h metrics independently reproduced (1.34867 / 1.28613, max 5.21553)
- `run_tests`: 319 passed / 43 skipped
- `tests/test_cli_tools.py -k qzss_l6 / madoca / clas`: pass
- `git diff --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)