### PR TITLE
feat(ppp): postfit commit-on-success preview; diagnose variance mismatch

### DIFF
--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -586,7 +586,8 @@ private:
     MeasurementEquation formMeasurementEquations(
         const std::vector<IonosphereFreeObs>& observations,
         const NavigationData& nav,
-        const GNSSTime& time);
+        const GNSSTime& time,
+        bool apply_outlier_detection = true);
     
     /**
      * @brief Check convergence

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -32,6 +32,10 @@ struct PPPEnvOverrides {
     // GNSS_PPP_MADOCA_BOUNDARY_GUARD: reject smaller coherent-MADOCA
     // file-boundary update jumps unless set exactly to "0". Default true.
     bool madoca_boundary_guard = true;
+    // GNSS_PPP_MADOCA_POSTFIT_COMMIT: preview RTKLIB/MADOCALIB-style
+    // postfit validation with commit-on-success semantics for coherent MADOCA
+    // when set exactly to "1". Default false.
+    bool madoca_postfit_commit = false;
     // GNSS_PPP_ESTIMATE_ISB: comma/space-style spec parsed by substring
     // checks for "gal", "qzs", "bds", "all", or exact "1". Defaults false.
     bool estimate_isb_all = false;

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -48,6 +48,8 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
     overrides.madoca_early_window = !envExactZero("GNSS_PPP_MADOCA_EARLY_WINDOW");
     overrides.madoca_spike_guard = !envExactZero("GNSS_PPP_MADOCA_SPIKE_GUARD");
     overrides.madoca_boundary_guard = !envExactZero("GNSS_PPP_MADOCA_BOUNDARY_GUARD");
+    overrides.madoca_postfit_commit =
+        envExactOne("GNSS_PPP_MADOCA_POSTFIT_COMMIT");
 
     const char* isb = envValue("GNSS_PPP_ESTIMATE_ISB");
     const std::string isb_spec = isb != nullptr ? std::string(isb) : std::string();

--- a/src/algorithms/ppp_measurement.cpp
+++ b/src/algorithms/ppp_measurement.cpp
@@ -17,7 +17,8 @@ using namespace ppp_internal;
 PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
     const std::vector<IonosphereFreeObs>& observations,
     const NavigationData& nav,
-    const GNSSTime& time) {
+    const GNSSTime& time,
+    bool apply_outlier_detection) {
     (void)nav;
     (void)time;
 
@@ -150,7 +151,7 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
                       << "\n";
         }
 
-        if (ppp_config_.enable_outlier_detection) {
+        if (apply_outlier_detection && ppp_config_.enable_outlier_detection) {
             const double sigma = std::sqrt(std::max(
                 safeVariance(observation.variance_pr, 1e-6),
                 (row * filter_state_.covariance * row.transpose())(0, 0)));
@@ -239,7 +240,8 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
                         ppp_config_.outlier_threshold *
                             std::sqrt(safeVariance(observation.variance_cp, 1e-8)) * 10.0,
                         phase_residual_floor);
-                if (!ppp_config_.enable_outlier_detection ||
+                if (!apply_outlier_detection ||
+                    !ppp_config_.enable_outlier_detection ||
                     std::abs(phase_residual) <= phase_limit) {
                     Eigen::RowVectorXd phase_row = Eigen::RowVectorXd::Zero(filter_state_.total_states);
                     phase_row.segment(filter_state_.pos_index, 3) = -line_of_sight;
@@ -303,7 +305,8 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
                 const double code_limit = std::max(
                     ppp_config_.outlier_threshold * std::sqrt(var_pr_l2) * 10.0,
                     code_floor);
-                if (!ppp_config_.enable_outlier_detection ||
+                if (!apply_outlier_detection ||
+                    !ppp_config_.enable_outlier_detection ||
                     std::abs(l2_code_resid) <= code_limit) {
                     rows.push_back(l2_code);
                     measured_values.push_back(observation.pseudorange_l2);
@@ -347,7 +350,8 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
                 const double phase_limit = std::max(
                     ppp_config_.outlier_threshold * std::sqrt(var_cp_l2) * 10.0,
                     phase_floor);
-                if (!ppp_config_.enable_outlier_detection ||
+                if (!apply_outlier_detection ||
+                    !ppp_config_.enable_outlier_detection ||
                     std::abs(l2_phase_resid) <= phase_limit) {
                     rows.push_back(l2_phase);
                     measured_values.push_back(observation.carrier_phase_l2);

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -21,6 +21,7 @@ namespace {
 
 constexpr double kMadocaStaticSpikeGuardPositionDeltaM = 100.0;
 constexpr double kMadocaBoundaryGuardPositionJumpM = 10.0;
+constexpr double kMadocaPostfitRejectSigma = 4.0;
 
 bool validReceiverSeed(const Vector3d& receiver_position) {
     return std::isfinite(receiver_position.x()) &&
@@ -340,6 +341,13 @@ bool PPPProcessor::updateFilter(const ObservationData& obs, const NavigationData
         env_overrides_.madoca_boundary_guard &&
         converged_ &&
         (!ppp_config_.kinematic_mode || ppp_config_.low_dynamics_mode);
+    const bool madoca_postfit_commit =
+        require_coherent_ssr_ && ssr_products_loaded_ &&
+        env_overrides_.madoca_postfit_commit;
+    const auto restorePostfitFailedEpoch = [&]() {
+        filter_state_ = pre_update_state;
+        pre_anchor_covariance_ = filter_state_.covariance;
+    };
     for (int iteration = 0; iteration < filter_iterations; ++iteration) {
         MeasurementEquation meas_eq = formMeasurementEquations(if_obs, nav, obs.time);
 
@@ -347,6 +355,9 @@ bool PPPProcessor::updateFilter(const ObservationData& obs, const NavigationData
             if (pppDebugEnabled()) {
                 std::cerr << "[PPP] insufficient measurement rows: " << meas_eq.observations.size()
                           << " < " << config_.min_satellites << "\n";
+            }
+            if (madoca_postfit_commit) {
+                restorePostfitFailedEpoch();
             }
             return false;
         }
@@ -405,6 +416,83 @@ bool PPPProcessor::updateFilter(const ObservationData& obs, const NavigationData
             std::abs(delta_state(filter_state_.clock_index)) < 1e-3 &&
             std::abs(delta_state(filter_state_.trop_index)) < 1e-3) {
             break;
+        }
+    }
+
+    if (madoca_postfit_commit) {
+        const MeasurementEquation postfit_eq =
+            formMeasurementEquations(if_obs, nav, obs.time, false);
+        if (postfit_eq.observations.size() < config_.min_satellites) {
+            if (pppDebugEnabled()) {
+                std::cerr << "[PPP] MADOCA postfit commit rejected epoch at week="
+                          << obs.time.week
+                          << " tow=" << obs.time.tow
+                          << " rows=" << postfit_eq.observations.size()
+                          << " min_rows=" << config_.min_satellites
+                          << "\n";
+            }
+            restorePostfitFailedEpoch();
+            return false;
+        }
+
+        int failing_rows = 0;
+        int worst_row = -1;
+        double worst_abs_residual_m = 0.0;
+        double worst_residual_m = 0.0;
+        double worst_sigma_m = 0.0;
+        for (int row = 0; row < postfit_eq.residuals.size(); ++row) {
+            const bool is_phase =
+                static_cast<size_t>(row) < postfit_eq.row_is_phase.size() &&
+                postfit_eq.row_is_phase[static_cast<size_t>(row)];
+            const double variance_floor = is_phase ? 1e-8 : 1e-6;
+            const double sigma_m =
+                std::sqrt(std::max(postfit_eq.weight_matrix(row, row), variance_floor));
+            const double residual_m = postfit_eq.residuals(row);
+            if (!std::isfinite(residual_m) || !std::isfinite(sigma_m) ||
+                sigma_m <= 0.0) {
+                continue;
+            }
+            const double abs_residual_m = std::abs(residual_m);
+            if (abs_residual_m <= sigma_m * kMadocaPostfitRejectSigma) {
+                continue;
+            }
+            ++failing_rows;
+            if (abs_residual_m > worst_abs_residual_m) {
+                worst_abs_residual_m = abs_residual_m;
+                worst_residual_m = residual_m;
+                worst_sigma_m = sigma_m;
+                worst_row = row;
+            }
+        }
+        if (failing_rows > 0) {
+            if (pppDebugEnabled()) {
+                std::cerr << "[PPP] MADOCA postfit commit rejected epoch at week="
+                          << obs.time.week
+                          << " tow=" << obs.time.tow
+                          << " rows=" << postfit_eq.observations.size()
+                          << " failing_rows=" << failing_rows;
+                if (worst_row >= 0) {
+                    const size_t row_index = static_cast<size_t>(worst_row);
+                    std::cerr << " worst_sat="
+                              << (row_index < postfit_eq.row_satellites.size()
+                                      ? postfit_eq.row_satellites[row_index].toString()
+                                      : std::string("unknown"))
+                              << " type="
+                              << (row_index < postfit_eq.row_is_phase.size() &&
+                                          postfit_eq.row_is_phase[row_index]
+                                      ? "phase"
+                                      : "code")
+                              << " residual=" << worst_residual_m
+                              << " sigma=" << worst_sigma_m
+                              << " normalized="
+                              << (worst_sigma_m > 0.0
+                                      ? worst_abs_residual_m / worst_sigma_m
+                                      : 0.0);
+                }
+                std::cerr << "\n";
+            }
+            restorePostfitFailedEpoch();
+            return false;
         }
     }
 


### PR DESCRIPTION
## Summary

S17 of the MADOCA-PPP parity series — stage-1 port of MADOCALIB's commit-on-success epoch discipline, closing with a precise diagnosis of why it cannot be enabled yet (and why the S16 prototype regressed).

### MADOCALIB mechanism (audited)

`ppp.c:1359-1379`: each retry copies the committed state into `xp/Pp`, recomputes the filter update, validates **postfit** residuals (`|v| > 4·sqrt(var)` → record, exclude worst, retry, MAX_ITER=8), and commits only after success; a finally-failed epoch leaves the committed state untouched and emits no PPP solution.

### What ships (default OFF)

`GNSS_PPP_MADOCA_POSTFIT_COMMIT=1`: pre-epoch snapshot, MADOCALIB 4-sigma postfit validation, restore-and-skip on failure. Postfit row formation bypasses the existing prefit outlier suppression so validation actually sees the rows.

### Measured blocker — residual variance model mismatch

Enabled, the 1h window emits **1 row and rejects 117 epochs**. First rejection is the *second epoch*: G31 phase residual −0.150 m against a formal sigma of 0.018 m = **8.35σ** — i.e. perfectly normal converging residuals fail the literal test. MADOCALIB passes the same test because its variance bookkeeping differs structurally (kinematic `VAR_POS` process noise, 3.0× IFLC variance scale, eratio-scaled code). Porting the commit discipline first requires reconciling native's formal residual variances; a shadow-mode native postfit statistic is the recorded next experiment. Stage-2 exclusion retry deferred — it would just churn the satellite set on healthy residuals.

### Metrics

Default OFF **bit-exact** on all three windows (1h 1.820/1.196, 6h 1.297/1.169, 24h 1.316/1.286 vs pre-change references).

## Verification

- 1h/6h/24h default outputs `cmp` bit-exact vs pre-change references
- `run_tests`: 319 passed / 43 skipped
- `tests/test_cli_tools.py -k qzss_l6 / madoca / clas`: pass
- `git diff --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)