### PR TITLE
feat(ppp): GLONASS phase residual characterization; extend postfit shadow

### DIFF
--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -335,6 +335,9 @@ private:
         std::string secondary_observation_type;
         double primary_code_bias_coeff = 1.0;
         double secondary_code_bias_coeff = 0.0;
+        double primary_frequency_hz = 0.0;
+        double secondary_frequency_hz = 0.0;
+        int glonass_frequency_channel = -99;
         double pseudorange_if = 0.0;
         double carrier_phase_if = 0.0;
         double pseudorange_code_bias_m = 0.0;
@@ -361,6 +364,11 @@ private:
         double ambiguity_scale_m = 0.0;
         double atmospheric_trop_correction_m = 0.0;
         double atmospheric_iono_correction_m = 0.0;
+        double ssr_orbit_age_s = -1.0;
+        double ssr_clock_age_s = -1.0;
+        int ssr_orbit_iod = -1;
+        int ssr_clock_iod = -1;
+        int ssr_orbit_iode = -1;
         std::map<std::string, std::string> ssr_atmos_tokens;
         bool has_carrier_phase = false;
         bool valid = false;
@@ -582,8 +590,19 @@ private:
         std::vector<SatelliteId> row_satellites;  ///< Satellite for each row
         std::vector<bool> row_is_phase;           ///< true=carrier phase, false=code
         std::vector<double> row_elevations;        ///< Elevation angle in radians
+        std::vector<double> row_azimuths;          ///< Azimuth angle in radians
         std::vector<SignalType> row_signals;       ///< Signal identity for each row
         std::vector<std::string> row_signal_bands; ///< IF/L1/L2 label for each row
+        std::vector<int> row_glonass_frequency_channels;
+        std::vector<double> row_primary_frequencies_hz;
+        std::vector<double> row_secondary_frequencies_hz;
+        std::vector<double> row_primary_if_coefficients;
+        std::vector<double> row_secondary_if_coefficients;
+        std::vector<double> row_ssr_orbit_ages_s;
+        std::vector<double> row_ssr_clock_ages_s;
+        std::vector<int> row_ssr_orbit_iods;
+        std::vector<int> row_ssr_clock_iods;
+        std::vector<int> row_ssr_orbit_iodes;
     };
     
     MeasurementEquation formMeasurementEquations(

--- a/src/algorithms/ppp_corrections.cpp
+++ b/src/algorithms/ppp_corrections.cpp
@@ -811,6 +811,8 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
     const int preferred_network_id = preferredClasNetworkId(epoch_atmos_tokens);
     const bool madoca_bias_identity =
         require_coherent_ssr_ && env_overrides_.madoca_bias_identity;
+    const bool capture_shadow_metadata =
+        !env_overrides_.madoca_postfit_shadow_path.empty();
 
     // Sun position is needed for the satellite body frame in phase wind-up.
     // We compute it once per epoch and reuse for every satellite.
@@ -973,6 +975,19 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                     nullptr,
                     &ssr_status,
                     !require_coherent_ssr_);
+            if (ssr_ok && capture_shadow_metadata) {
+                if (ssr_status.orbit_reference_time.week != 0) {
+                    observation.ssr_orbit_age_s =
+                        time - ssr_status.orbit_reference_time;
+                }
+                if (ssr_status.clock_reference_time.week != 0) {
+                    observation.ssr_clock_age_s =
+                        time - ssr_status.clock_reference_time;
+                }
+                observation.ssr_orbit_iod = ssr_status.ssr_orbit_iod;
+                observation.ssr_clock_iod = ssr_status.ssr_clock_iod;
+                observation.ssr_orbit_iode = ssr_status.orbit_iode;
+            }
             // Fall back to epoch-wide atmosphere tokens when per-satellite
             // atmos are empty (CLAS broadcasts network-wide corrections).
             if (atmos_tokens.empty() && !epoch_atmos_tokens.empty()) {

--- a/src/algorithms/ppp_measurement.cpp
+++ b/src/algorithms/ppp_measurement.cpp
@@ -30,8 +30,37 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
     std::vector<SatelliteId> row_satellites;
     std::vector<bool> row_is_phase;
     std::vector<double> row_elevations;
+    std::vector<double> row_azimuths;
     std::vector<SignalType> row_signals;
     std::vector<std::string> row_signal_bands;
+    std::vector<int> row_glonass_frequency_channels;
+    std::vector<double> row_primary_frequencies_hz;
+    std::vector<double> row_secondary_frequencies_hz;
+    std::vector<double> row_primary_if_coefficients;
+    std::vector<double> row_secondary_if_coefficients;
+    std::vector<double> row_ssr_orbit_ages_s;
+    std::vector<double> row_ssr_clock_ages_s;
+    std::vector<int> row_ssr_orbit_iods;
+    std::vector<int> row_ssr_clock_iods;
+    std::vector<int> row_ssr_orbit_iodes;
+    const bool capture_shadow_metadata =
+        !env_overrides_.madoca_postfit_shadow_path.empty();
+    const auto appendShadowMetadata = [&](const IonosphereFreeObs& observation) {
+        if (!capture_shadow_metadata) {
+            return;
+        }
+        row_azimuths.push_back(observation.azimuth);
+        row_glonass_frequency_channels.push_back(observation.glonass_frequency_channel);
+        row_primary_frequencies_hz.push_back(observation.primary_frequency_hz);
+        row_secondary_frequencies_hz.push_back(observation.secondary_frequency_hz);
+        row_primary_if_coefficients.push_back(observation.primary_code_bias_coeff);
+        row_secondary_if_coefficients.push_back(observation.secondary_code_bias_coeff);
+        row_ssr_orbit_ages_s.push_back(observation.ssr_orbit_age_s);
+        row_ssr_clock_ages_s.push_back(observation.ssr_clock_age_s);
+        row_ssr_orbit_iods.push_back(observation.ssr_orbit_iod);
+        row_ssr_clock_iods.push_back(observation.ssr_clock_iod);
+        row_ssr_orbit_iodes.push_back(observation.ssr_orbit_iode);
+    };
 
     const double zenith_delay = filter_state_.state(filter_state_.trop_index);
     const bool use_phase_rows =
@@ -188,6 +217,7 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
         row_elevations.push_back(observation.elevation);
         row_signals.push_back(observation.primary_signal);
         row_signal_bands.push_back(ppp_config_.use_ionosphere_free ? "IF" : "L1");
+        appendShadowMetadata(observation);
 
         const bool qzss_code_only =
             env_overrides_.qzss_code_only ||
@@ -273,6 +303,7 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
                     row_elevations.push_back(observation.elevation);
                     row_signals.push_back(observation.primary_signal);
                     row_signal_bands.push_back(ppp_config_.use_ionosphere_free ? "IF" : "L1");
+                    appendShadowMetadata(observation);
                 }
             }
         }
@@ -327,6 +358,7 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
                     row_elevations.push_back(observation.elevation);
                     row_signals.push_back(observation.secondary_signal);
                     row_signal_bands.push_back("L2");
+                    appendShadowMetadata(observation);
                 }
             }
 
@@ -375,6 +407,7 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
                     row_elevations.push_back(observation.elevation);
                     row_signals.push_back(observation.secondary_signal);
                     row_signal_bands.push_back("L2");
+                    appendShadowMetadata(observation);
                 }
             }
         }
@@ -399,8 +432,19 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
     equation.row_satellites = row_satellites;
     equation.row_is_phase = row_is_phase;
     equation.row_elevations = row_elevations;
+    equation.row_azimuths = row_azimuths;
     equation.row_signals = row_signals;
     equation.row_signal_bands = row_signal_bands;
+    equation.row_glonass_frequency_channels = row_glonass_frequency_channels;
+    equation.row_primary_frequencies_hz = row_primary_frequencies_hz;
+    equation.row_secondary_frequencies_hz = row_secondary_frequencies_hz;
+    equation.row_primary_if_coefficients = row_primary_if_coefficients;
+    equation.row_secondary_if_coefficients = row_secondary_if_coefficients;
+    equation.row_ssr_orbit_ages_s = row_ssr_orbit_ages_s;
+    equation.row_ssr_clock_ages_s = row_ssr_clock_ages_s;
+    equation.row_ssr_orbit_iods = row_ssr_orbit_iods;
+    equation.row_ssr_clock_iods = row_ssr_clock_iods;
+    equation.row_ssr_orbit_iodes = row_ssr_orbit_iodes;
     return equation;
 }
 

--- a/src/algorithms/ppp_observations.cpp
+++ b/src/algorithms/ppp_observations.cpp
@@ -34,6 +34,8 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
     const NavigationData& nav) {
     std::vector<IonosphereFreeObs> combined;
     combined.reserve(obs.getSatellites().size());
+    const bool capture_shadow_metadata =
+        !env_overrides_.madoca_postfit_shadow_path.empty();
 
     for (const auto& sat : obs.getSatellites()) {
         // Keep the native MADOCA parity path on systems whose L6 SSR handling is
@@ -80,17 +82,25 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
 
         IonosphereFreeObs entry;
         entry.satellite = sat;
+        if (capture_shadow_metadata && eph != nullptr &&
+            sat.system == GNSSSystem::GLONASS) {
+            entry.glonass_frequency_channel = eph->glonass_frequency_channel;
+        }
 
         if (!ppp_config_.use_ionosphere_free) {
+            const double primary_frequency_hz = signalFrequencyHz(primary->signal, eph);
             entry.pseudorange_if = primary->pseudorange;
             entry.primary_signal = primary->signal;
             entry.primary_observation_type = biasObservationType(*primary);
             entry.primary_code_bias_coeff = 1.0;
             entry.secondary_code_bias_coeff = 0.0;
+            if (capture_shadow_metadata) {
+                entry.primary_frequency_hz = primary_frequency_hz;
+            }
             // Per-frequency L1 raw observable (biases applied later in
             // applyPreciseCorrections).
             entry.pseudorange_l1 = primary->pseudorange;
-            entry.freq_l1 = signalFrequencyHz(primary->signal, eph);
+            entry.freq_l1 = primary_frequency_hz;
             entry.variance_pr_l1 = safeVariance(
                 ppp_config_.pseudorange_sigma * ppp_config_.pseudorange_sigma, 1e-6);
             entry.variance_cp_l1 = safeVariance(
@@ -127,6 +137,10 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
                 entry.secondary_observation_type = biasObservationType(*secondary);
                 const double f1 = signalFrequencyHz(primary->signal, eph);
                 const double f2 = signalFrequencyHz(secondary->signal, eph);
+                if (capture_shadow_metadata) {
+                    entry.primary_frequency_hz = f1;
+                    entry.secondary_frequency_hz = f2;
+                }
                 if (f1 > 0.0 && f2 > 0.0) {
                     entry.primary_code_bias_coeff = 1.0;
                     entry.secondary_code_bias_coeff = 0.0;
@@ -179,6 +193,9 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
             entry.primary_observation_type = biasObservationType(*primary);
             entry.primary_code_bias_coeff = 1.0;
             entry.secondary_code_bias_coeff = 0.0;
+            if (capture_shadow_metadata) {
+                entry.primary_frequency_hz = signalFrequencyHz(primary->signal, eph);
+            }
             if (primary->has_carrier_phase) {
                 const double wavelength = signalWavelengthMeters(primary->signal, eph);
                 if (wavelength > 0.0) {
@@ -211,6 +228,10 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
         entry.secondary_observation_type = biasObservationType(*secondary);
         entry.primary_code_bias_coeff = coefficients.first;
         entry.secondary_code_bias_coeff = coefficients.second;
+        if (capture_shadow_metadata) {
+            entry.primary_frequency_hz = f1;
+            entry.secondary_frequency_hz = f2;
+        }
         entry.pseudorange_code_bias_m = 0.0;
         entry.variance_pr = safeVariance(
             (coefficients.first * coefficients.first +

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -95,6 +95,10 @@ public:
             out_ << "record,week,tow,iteration_count,row,row_count,"
                     "sat,system,signal_type,signal_band,obs_type,"
                     "residual_m,variance_m2,sigma_m,abs_norm,elevation_deg,"
+                    "azimuth_deg,glonass_fcn,primary_frequency_hz,"
+                    "secondary_frequency_hz,primary_if_coeff,secondary_if_coeff,"
+                    "ssr_orbit_age_s,ssr_clock_age_s,ssr_orbit_iod,"
+                    "ssr_clock_iod,ssr_orbit_iode,"
                     "chi_square,normalized_row_count,rms_norm,max_norm,"
                     "position_update_norm_m,converged,anchor_active\n";
             header_written_ = true;
@@ -151,8 +155,22 @@ void writeMadocaPostfitShadow(const std::string& path,
     };
 
     writeCommonPrefix("epoch", -1);
-    out << ",,,,,,,,,";
+    constexpr int kRowSpecificShadowColumns = 21;
+    for (int column = 1; column < kRowSpecificShadowColumns; ++column) {
+        out << ',';
+    }
     writeAggregateSuffix();
+
+    const auto rowDouble = [](const std::vector<double>& values,
+                              size_t row_index,
+                              double fallback) {
+        return row_index < values.size() ? values[row_index] : fallback;
+    };
+    const auto rowInt = [](const std::vector<int>& values,
+                           size_t row_index,
+                           int fallback) {
+        return row_index < values.size() ? values[row_index] : fallback;
+    };
 
     for (int row = 0; row < postfit_eq.residuals.size(); ++row) {
         const size_t row_index = static_cast<size_t>(row);
@@ -175,6 +193,10 @@ void writeMadocaPostfitShadow(const std::string& path,
             row_index < postfit_eq.row_elevations.size()
                 ? postfit_eq.row_elevations[row_index]
                 : std::numeric_limits<double>::quiet_NaN();
+        const double azimuth_rad = rowDouble(
+            postfit_eq.row_azimuths,
+            row_index,
+            std::numeric_limits<double>::quiet_NaN());
         const double residual_m = postfit_eq.residuals(row);
         const double variance_m2 = postfit_eq.weight_matrix(row, row);
         const double sigma_m =
@@ -195,7 +217,18 @@ void writeMadocaPostfitShadow(const std::string& path,
             << variance_m2 << ','
             << sigma_m << ','
             << abs_norm << ','
-            << (elevation_rad * kRadiansToDegrees);
+            << (elevation_rad * kRadiansToDegrees) << ','
+            << (azimuth_rad * kRadiansToDegrees) << ','
+            << rowInt(postfit_eq.row_glonass_frequency_channels, row_index, -99) << ','
+            << rowDouble(postfit_eq.row_primary_frequencies_hz, row_index, 0.0) << ','
+            << rowDouble(postfit_eq.row_secondary_frequencies_hz, row_index, 0.0) << ','
+            << rowDouble(postfit_eq.row_primary_if_coefficients, row_index, 0.0) << ','
+            << rowDouble(postfit_eq.row_secondary_if_coefficients, row_index, 0.0) << ','
+            << rowDouble(postfit_eq.row_ssr_orbit_ages_s, row_index, -1.0) << ','
+            << rowDouble(postfit_eq.row_ssr_clock_ages_s, row_index, -1.0) << ','
+            << rowInt(postfit_eq.row_ssr_orbit_iods, row_index, -1) << ','
+            << rowInt(postfit_eq.row_ssr_clock_iods, row_index, -1) << ','
+            << rowInt(postfit_eq.row_ssr_orbit_iodes, row_index, -1);
         writeAggregateSuffix();
     }
 }


### PR DESCRIPTION
## Summary

S19 of the MADOCA-PPP parity series (tracker: #148) — localizes the GLONASS phase blocker measured in #137 using the #147 shadow instrumentation, and extends that instrumentation. No behavioral change.

### Characterization (24h, GLONASS phase enabled, 14,262 rows / 18 sats)

| hypothesis | evidence | verdict |
|---|---|---|
| azimuth geometry | **cos(az) r=+0.739**; R09−R21 relative residual vs elevation **r=−0.97** | the signal |
| elevation weighting | r=−0.18 raw / +0.23 vs 1/sin(el) | secondary |
| FCN (inter-channel) | row-level r=0.000 | excluded |
| SSR age / IOD switches / file boundaries | constant ages; step sizes indistinguishable | excluded |

The R09−R21 relative residual (constant-removed RMS 0.555 m) is geometry-shaped, not FDMA-channel-shaped — so the remaining suspects are the **phase windup model** and **receiver antenna phase-center terms**, where native (`ppp.cpp:889`) and MADOCALIB (`ppp.c:271`) differ structurally. Also confirmed: MADOCALIB treats absent GLONASS phase biases as non-fatal and excludes GLONASS from AR; native IFLC already uses FCN-correct frequencies.

### What ships

`GNSS_PPP_MADOCA_POSTFIT_SHADOW` CSV gains azimuth, GLONASS FCN, per-row frequencies, IF coefficients, SSR ages/IODs (34 columns), all gated. GLONASS phase remains preview OFF (enabled: 1h 2.033/1.250, 6h 1.362/1.152, 24h 1.986/1.222 — fails the both-metrics rule on 1h/6h).

## Verification

- Defaults **bit-exact** on 1h/6h/24h vs pre-change references
- `run_tests`: 319 passed / 43 skipped
- `tests/test_cli_tools.py -k qzss_l6 / madoca / clas`: pass
- `git diff --check`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)