### PR TITLE
feat(clas): re-datum WL/MW on phase-bias datum jumps; unify CPC convention

### DIFF
--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -139,6 +139,12 @@ struct PPPEnvOverrides {
     // GNSS_PPP_CLAS_NL_DEBUG: path for CLAS DD-WLNL narrow-lane component
     // diagnostic CSV. Empty disables it.
     std::string clas_nl_debug_path;
+    // GNSS_PPP_CLAS_NL_DATUM_FIX: CLAS DD-WLNL NL datum preview.
+    // Default enables datum reset + CPC unification. Values "datum" or
+    // "cpc" enable one component for diagnostics; "0", "false", or "off"
+    // disable both for bit-exact opt-out.
+    bool clas_nl_datum_reset = true;
+    bool clas_nl_cpc_unified = true;
     // GNSS_PPP_DEBUG: general PPP debug logging. Default false.
     bool debug = false;
 

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -326,6 +326,8 @@ struct PPPAmbiguityInfo {
     bool wl_is_fixed = false;
     double nl_fixed_cycles = 0.0;
     bool nl_is_fixed = false;
+    double clas_nl_phase_bias_datum_cycles = 0.0;
+    bool has_clas_nl_phase_bias_datum = false;
     // Per-frequency (est-stec) float ambiguities in meters, surfaced for WL/N1
     // AR without re-indexing the state vector. Zero in IFLC mode.
     double float_value_l1 = 0.0;

--- a/src/algorithms/ppp_clas_epoch.cpp
+++ b/src/algorithms/ppp_clas_epoch.cpp
@@ -4,12 +4,15 @@
 #include <libgnss++/algorithms/ppp.hpp>
 #include <libgnss++/algorithms/ppp_ar.hpp>
 #include <libgnss++/algorithms/ppp_clas.hpp>
+#include <libgnss++/algorithms/ppp_env_overrides.hpp>
 #include <libgnss++/algorithms/ppp_osr.hpp>
 #include <libgnss++/core/constants.hpp>
 #include <libgnss++/core/signals.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <iostream>
+#include <limits>
 
 namespace libgnss {
 
@@ -21,6 +24,78 @@ namespace {
 
 bool pppDebugEnabled() {
     return ppp_shared::pppDebugEnabled();
+}
+
+constexpr double kClasNlDatumJumpThresholdCycles = 0.5;
+
+double clasNlPhaseBiasDatumCycles(const OSRCorrection& osr) {
+    if (osr.num_frequencies < 2 ||
+        osr.frequencies[0] <= 0.0 ||
+        osr.frequencies[1] <= 0.0 ||
+        std::abs(osr.frequencies[0] - osr.frequencies[1]) < 1.0) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    const double f1 = osr.frequencies[0];
+    const double f2 = osr.frequencies[1];
+    const double lambda_nl = constants::SPEED_OF_LIGHT / (f1 + f2);
+    const double alpha1 = f1 / (f1 + f2);
+    const double alpha2 = f2 / (f1 + f2);
+    return (alpha1 * osr.phase_bias_m[0] + alpha2 * osr.phase_bias_m[1]) /
+           lambda_nl;
+}
+
+void clearClasWlnlFixedDatumState(PPPAmbiguityInfo& ambiguity) {
+    ambiguity.is_fixed = false;
+    ambiguity.fixed_value = 0.0;
+    ambiguity.wl_is_fixed = false;
+    ambiguity.wl_fixed_integer = 0;
+    ambiguity.nl_is_fixed = false;
+    ambiguity.nl_fixed_cycles = 0.0;
+    ambiguity.mw_sum_cycles = 0.0;
+    ambiguity.mw_count = 0;
+    ambiguity.mw_mean_cycles = 0.0;
+}
+
+void applyClasNlDatumReset(
+    const GNSSTime& time,
+    const std::vector<OSRCorrection>& osr_corrections,
+    std::map<SatelliteId, PPPAmbiguityInfo>& ambiguity_states,
+    bool debug_enabled) {
+    for (const auto& osr : osr_corrections) {
+        if (!osr.valid || osr.num_frequencies < 2) {
+            continue;
+        }
+        const double datum_cycles = clasNlPhaseBiasDatumCycles(osr);
+        if (!std::isfinite(datum_cycles)) {
+            continue;
+        }
+
+        auto& ambiguity = ambiguity_states[osr.satellite];
+        if (ambiguity.has_clas_nl_phase_bias_datum) {
+            const double step_cycles =
+                datum_cycles - ambiguity.clas_nl_phase_bias_datum_cycles;
+            if (std::abs(step_cycles) > kClasNlDatumJumpThresholdCycles) {
+                clearClasWlnlFixedDatumState(ambiguity);
+                const SatelliteId l2_satellite(
+                    osr.satellite.system,
+                    static_cast<uint8_t>(std::min(255, osr.satellite.prn + 100)));
+                const auto l2_it = ambiguity_states.find(l2_satellite);
+                if (l2_it != ambiguity_states.end()) {
+                    clearClasWlnlFixedDatumState(l2_it->second);
+                }
+                if (debug_enabled) {
+                    std::cerr << "[CLAS-NL-DATUM] reset "
+                              << osr.satellite.toString()
+                              << " tow=" << time.tow
+                              << " step_cycles=" << step_cycles
+                              << " datum_cycles=" << datum_cycles
+                              << "\n";
+                }
+            }
+        }
+        ambiguity.clas_nl_phase_bias_datum_cycles = datum_cycles;
+        ambiguity.has_clas_nl_phase_bias_datum = true;
+    }
 }
 
 }  // namespace
@@ -144,6 +219,15 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
     }
 
     ppp_clas::ensureAmbiguityStates(filter_state_, osr_corrections);
+    if (pppEnvOverrides().clas_nl_datum_reset &&
+        ppp_config_.enable_ambiguity_resolution &&
+        ppp_config_.ar_method == PPPConfig::ARMethod::DD_WLNL &&
+        ppp_config_.use_clas_osr_filter &&
+        !ppp_config_.use_ionosphere_free &&
+        ppp_config_.estimate_ionosphere) {
+        applyClasNlDatumReset(
+            obs.time, osr_corrections, ambiguity_states_, pppDebugEnabled());
+    }
     ppp_clas::applyPendingPhaseBiasStateShifts(
         filter_state_, osr_corrections, clas_phase_bias_repair_, pppDebugEnabled());
 

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -1,6 +1,9 @@
 #include <libgnss++/algorithms/ppp_env_overrides.hpp>
 
+#include <algorithm>
+#include <cctype>
 #include <cstdlib>
+#include <string>
 
 namespace libgnss {
 namespace {
@@ -106,6 +109,35 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
     overrides.ar_dddump = envPresent("GNSS_PPP_AR_DDDUMP");
     overrides.clas_nl_debug_path =
         envStringOrEmpty("GNSS_PPP_CLAS_NL_DEBUG");
+    const std::string clas_nl_datum_fix =
+        envStringOrEmpty("GNSS_PPP_CLAS_NL_DATUM_FIX");
+    std::string clas_nl_datum_fix_lower = clas_nl_datum_fix;
+    std::transform(
+        clas_nl_datum_fix_lower.begin(),
+        clas_nl_datum_fix_lower.end(),
+        clas_nl_datum_fix_lower.begin(),
+        [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    if (clas_nl_datum_fix_lower == "0" ||
+        clas_nl_datum_fix_lower == "false" ||
+        clas_nl_datum_fix_lower == "off" ||
+        clas_nl_datum_fix_lower == "none") {
+        overrides.clas_nl_datum_reset = false;
+        overrides.clas_nl_cpc_unified = false;
+    } else if (clas_nl_datum_fix_lower == "1" ||
+        clas_nl_datum_fix_lower == "both" ||
+        clas_nl_datum_fix_lower == "all" ||
+        clas_nl_datum_fix_lower == "true" ||
+        clas_nl_datum_fix_lower == "on") {
+        overrides.clas_nl_datum_reset = true;
+        overrides.clas_nl_cpc_unified = true;
+    } else if (clas_nl_datum_fix_lower == "datum" ||
+               clas_nl_datum_fix_lower == "reset") {
+        overrides.clas_nl_datum_reset = true;
+        overrides.clas_nl_cpc_unified = false;
+    } else if (clas_nl_datum_fix_lower == "cpc") {
+        overrides.clas_nl_datum_reset = false;
+        overrides.clas_nl_cpc_unified = true;
+    }
     overrides.debug = envPresent("GNSS_PPP_DEBUG");
 
     return overrides;

--- a/src/algorithms/ppp_wlnl.cpp
+++ b/src/algorithms/ppp_wlnl.cpp
@@ -324,14 +324,21 @@ bool PPPProcessor::buildWlnlNlInfoForSatellite(
         iono_cpc1_m = -iono_scale1 * osr.iono_l1_m;
         iono_cpc2_m = -iono_scale2 * osr.iono_l1_m;
         raw_nl_m = alpha1 * phase1_m + alpha2 * phase2_m;
+        const bool use_full_cpc_for_nl =
+            pppEnvOverrides().clas_nl_cpc_unified &&
+            ppp_config_.use_clas_osr_filter;
         applied_cpc_minus_windup_comp_m =
             alpha1 * (osr.CPC[0] - osr.windup_m[0] - osr.phase_compensation_m[0]) +
             alpha2 * (osr.CPC[1] - osr.windup_m[1] - osr.phase_compensation_m[1]);
         full_cpc_m = alpha1 * osr.CPC[0] + alpha2 * osr.CPC[1];
-        const double l1_corr_m = phase1_m
-                                - (osr.CPC[0] - osr.windup_m[0] - osr.phase_compensation_m[0]);
-        const double l2_corr_m = phase2_m
-                                - (osr.CPC[1] - osr.windup_m[1] - osr.phase_compensation_m[1]);
+        const double l1_nl_cpc_m = use_full_cpc_for_nl
+            ? osr.CPC[0]
+            : (osr.CPC[0] - osr.windup_m[0] - osr.phase_compensation_m[0]);
+        const double l2_nl_cpc_m = use_full_cpc_for_nl
+            ? osr.CPC[1]
+            : (osr.CPC[1] - osr.windup_m[1] - osr.phase_compensation_m[1]);
+        const double l1_corr_m = phase1_m - l1_nl_cpc_m;
+        const double l2_corr_m = phase2_m - l2_nl_cpc_m;
         nl_phase_m = alpha1 * l1_corr_m + alpha2 * l2_corr_m;
         full_cpc_nl_phase_m = raw_nl_m - full_cpc_m;
         sat_pos = osr.satellite_position;


### PR DESCRIPTION
## Summary

S21 — implements #7 from the #150 diagnosis (#6). Default **ON**, `GNSS_PPP_CLAS_NL_DATUM_FIX=0` bit-exact opt-out (`datum` / `cpc` select single components).

### What it does

1. **WL/MW re-datum on phase-bias datum jumps**: per-satellite weighted NL phase-bias step > 0.5 cycles (TOW 230430 steps: G25 +60.8, G26 +47.8, G29 +29.5) → reset MW averaging + clear WL/NL fixed flags for that satellite so it refixes against the new datum. Filter ambiguity states untouched.
2. **CPC convention unification**: WLNL NL float construction subtracts full CPC, matching the fixed-position solve and CLASLIB (`cssr2osr.c:282-285`).

### Results (2019-08-27 CLAS OSR WLNL, 3599 epochs, CLASLIB float ref)

| mode | fixed | all 3D | fixed-only 3D |
|---|---:|---:|---:|
| baseline (opt-out) | 247 | 8.6317 m | 24.8441 m |
| datum only | **269** | **7.1170 m** | **15.7815 m** |
| CPC only | 195 | 7.4251 m | 20.3576 m |
| both (default) | 269 | 7.2111 m | 16.3670 m |

Decision rule (fixed ≥ 247 AND fixed-RMS AND all-RMS improve) passes. Datum-only is metric-optimal; the combined default is chosen because the CPC convention then matches the fixed-position solve and CLASLIB — mechanism over metrics, as in #140. NL datum spread (G14/G26/G29/G25) collapses from 7.83 cycles post-jump to **0.14–0.20 cycles** after refix.

### Issue #8 outlook

Vertical improves materially (all-epoch V 6.72→4.44 m, fixed-only V 23.66→13.15 m) but remains large — #8 likely has additional vertical/trop/geometry contributors beyond the NL datum.

## Verification

- Opt-out `cmp` **bit-exact** vs pre-change refs (CLAS OSR WLNL, literal WLNL, literal IFLC); default metrics independently reproduced (269 / 7.2111 / 16.3670)
- MADOCA 1h output **bit-exact** (path untouched)
- `run_tests`: 319 passed / 43 skipped; CLI `-k clas / qzss_l6 / madoca`: pass; `git diff --check`: clean

Refs #7. Diagnosis: #150 / #6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)