### PR TITLE
fix(clas): include slant trop + NL iono in the fixed-position solve

### DIFF
--- a/include/libgnss++/algorithms/ppp_ar.hpp
+++ b/include/libgnss++/algorithms/ppp_ar.hpp
@@ -123,12 +123,18 @@ WlnlFixAttempt tryWlnlFix(
     bool debug_enabled);
 
 struct FixedNlObservation {
+    SatelliteId satellite;
     double nl_phase_m = 0.0;
     double fixed_nl_cycles = 0.0;
     double lambda_nl_m = 0.0;
     Vector3d sat_pos = Vector3d::Zero();
     double sat_clk = 0.0;
     bool use_trop_model = true;
+    double extra_prediction_m = 0.0;
+    double cpc_nl_m = 0.0;
+    double osr_trop_correction_m = 0.0;
+    double osr_nl_iono_m = 0.0;
+    double receiver_ant_nl_m = 0.0;
 };
 
 using FixedNlObservationProvider = std::function<bool(
@@ -150,7 +156,8 @@ bool solveFixedNlPosition(
     const GNSSTime& time,
     const TropMappingFunction& trop_mapping_function,
     Vector3d& fixed_position,
-    double* position_shift_norm_m = nullptr);
+    double* position_shift_norm_m = nullptr,
+    double* final_clock_m = nullptr);
 
 struct FixedCarrierObservation {
     Vector3d satellite_position = Vector3d::Zero();

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -139,6 +139,13 @@ struct PPPEnvOverrides {
     // GNSS_PPP_CLAS_NL_DEBUG: path for CLAS DD-WLNL narrow-lane component
     // diagnostic CSV. Empty disables it.
     std::string clas_nl_debug_path;
+    // GNSS_PPP_CLAS_FIX_DEBUG: path for CLAS DD-WLNL fixed-position WLS
+    // diagnostic CSV. Empty disables it.
+    std::string clas_fix_debug_path;
+    // GNSS_PPP_CLAS_VERTICAL_FIX: make CLAS DD-WLNL NL prediction consistent
+    // with full-CPC-corrected phase before fixed-position WLS. Default true;
+    // set exactly "0" for bit-exact opt-out.
+    bool clas_vertical_fix = true;
     // GNSS_PPP_CLAS_NL_DATUM_FIX: CLAS DD-WLNL NL datum preview.
     // Default enables datum reset + CPC unification. Values "datum" or
     // "cpc" enable one component for diagnostics; "0", "false", or "off"

--- a/src/algorithms/ppp_ar.cpp
+++ b/src/algorithms/ppp_ar.cpp
@@ -716,7 +716,8 @@ bool solveFixedNlPosition(
     const GNSSTime& time,
     const TropMappingFunction& trop_mapping_function,
     Vector3d& fixed_position,
-    double* position_shift_norm_m) {
+    double* position_shift_norm_m,
+    double* final_clock_m) {
     if (fixed_observations.size() < 4) {
         return false;
     }
@@ -742,6 +743,7 @@ bool solveFixedNlPosition(
             const double predicted = geo + clock_m
                                      - constants::SPEED_OF_LIGHT * fixed_observation.sat_clk
                                      + trop_delay
+                                     + fixed_observation.extra_prediction_m
                                      + fixed_observation.fixed_nl_cycles *
                                            fixed_observation.lambda_nl_m;
             residuals(i) = fixed_observation.nl_phase_m - predicted;
@@ -767,6 +769,9 @@ bool solveFixedNlPosition(
     fixed_position = position;
     if (position_shift_norm_m != nullptr) {
         *position_shift_norm_m = (position - initial_position).norm();
+    }
+    if (final_clock_m != nullptr) {
+        *final_clock_m = clock_m;
     }
     return true;
 }

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -109,6 +109,10 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
     overrides.ar_dddump = envPresent("GNSS_PPP_AR_DDDUMP");
     overrides.clas_nl_debug_path =
         envStringOrEmpty("GNSS_PPP_CLAS_NL_DEBUG");
+    overrides.clas_fix_debug_path =
+        envStringOrEmpty("GNSS_PPP_CLAS_FIX_DEBUG");
+    overrides.clas_vertical_fix =
+        !envExactZero("GNSS_PPP_CLAS_VERTICAL_FIX");
     const std::string clas_nl_datum_fix =
         envStringOrEmpty("GNSS_PPP_CLAS_NL_DATUM_FIX");
     std::string clas_nl_datum_fix_lower = clas_nl_datum_fix;

--- a/src/algorithms/ppp_wlnl.cpp
+++ b/src/algorithms/ppp_wlnl.cpp
@@ -15,6 +15,8 @@
 #include <iomanip>
 #include <iostream>
 #include <limits>
+#include <map>
+#include <vector>
 
 namespace libgnss {
 
@@ -62,6 +64,31 @@ std::ofstream* clasNlDebugStream() {
                    << "current_minus_full_cpc_cycles,phase_bias_nl_cycles,"
                    << "windup_nl_cycles,phase_comp_nl_cycles,receiver_ant_nl_cycles,"
                    << "relativity_nl_cycles,iono_cpc_nl_cycles,trop_correction_cycles\n";
+        }
+    }
+    return stream ? &stream : nullptr;
+}
+
+std::ofstream* clasFixDebugStream() {
+    const auto& path = pppEnvOverrides().clas_fix_debug_path;
+    if (path.empty()) {
+        return nullptr;
+    }
+
+    static std::ofstream stream;
+    static bool initialized = false;
+    if (!initialized) {
+        initialized = true;
+        stream.open(path, std::ios::out | std::ios::trunc);
+        if (stream) {
+            stream << "record,week,tow,sat,ref_sat,nobs,"
+                   << "initial_x_m,initial_y_m,initial_z_m,"
+                   << "fixed_x_m,fixed_y_m,fixed_z_m,position_shift_m,"
+                   << "final_clock_m,residual_m,dd_residual_m,"
+                   << "geo_m,satellite_clock_m,trop_applied_m,extra_prediction_m,"
+                   << "fixed_nl_m,nl_phase_m,cpc_nl_m,"
+                   << "osr_trop_correction_m,osr_nl_iono_m,receiver_ant_nl_m,"
+                   << "lambda_nl_m,fixed_nl_cycles,use_trop_model\n";
         }
     }
     return stream ? &stream : nullptr;
@@ -159,6 +186,7 @@ bool PPPProcessor::solveFixedPosition(const ObservationData& obs,
     });
 
     double position_shift_norm_m = 0.0;
+    double fixed_clock_m = clock_m;
     const bool solved = ppp_ar::solveFixedNlPosition(
         fixed_observations,
         position,
@@ -169,7 +197,96 @@ bool PPPProcessor::solveFixedPosition(const ObservationData& obs,
             return calculateMappingFunction(receiver_position, elevation, time);
         },
         fixed_position,
-        &position_shift_norm_m);
+        &position_shift_norm_m,
+        &fixed_clock_m);
+    if (solved) {
+        if (auto* debug = clasFixDebugStream(); debug != nullptr) {
+            struct ResidualRecord {
+                const ppp_ar::FixedNlObservation* observation = nullptr;
+                double residual_m = 0.0;
+                double geo_m = 0.0;
+                double trop_applied_m = 0.0;
+            };
+            std::vector<ResidualRecord> residual_records;
+            residual_records.reserve(fixed_observations.size());
+            for (const auto& fixed_observation : fixed_observations) {
+                const double geo = geodist(fixed_observation.sat_pos, fixed_position);
+                const Vector3d los =
+                    (fixed_observation.sat_pos - fixed_position).normalized();
+                const double elevation = std::asin(los.dot(fixed_position.normalized()));
+                const double trop_applied =
+                    fixed_observation.use_trop_model
+                        ? calculateMappingFunction(fixed_position, elevation, obs.time) *
+                              trop_zenith
+                        : 0.0;
+                const double predicted =
+                    geo + fixed_clock_m -
+                    constants::SPEED_OF_LIGHT * fixed_observation.sat_clk +
+                    trop_applied +
+                    fixed_observation.extra_prediction_m +
+                    fixed_observation.fixed_nl_cycles *
+                        fixed_observation.lambda_nl_m;
+                residual_records.push_back({
+                    &fixed_observation,
+                    fixed_observation.nl_phase_m - predicted,
+                    geo,
+                    trop_applied,
+                });
+            }
+
+            std::map<GNSSSystem, size_t> reference_by_system;
+            for (size_t index = 0; index < residual_records.size(); ++index) {
+                const auto system = residual_records[index].observation->satellite.system;
+                if (reference_by_system.find(system) == reference_by_system.end()) {
+                    reference_by_system[system] = index;
+                }
+            }
+
+            for (const auto& record : residual_records) {
+                const auto& fixed_observation = *record.observation;
+                const auto ref_it =
+                    reference_by_system.find(fixed_observation.satellite.system);
+                const ResidualRecord* ref_record =
+                    ref_it != reference_by_system.end()
+                        ? &residual_records[ref_it->second]
+                        : &record;
+                const double dd_residual =
+                    ref_record->residual_m - record.residual_m;
+                *debug << std::setprecision(17)
+                       << "SAT,"
+                       << obs.time.week << ','
+                       << obs.time.tow << ','
+                       << fixed_observation.satellite.toString() << ','
+                       << ref_record->observation->satellite.toString() << ','
+                       << fixed_observations.size() << ','
+                       << position.x() << ','
+                       << position.y() << ','
+                       << position.z() << ','
+                       << fixed_position.x() << ','
+                       << fixed_position.y() << ','
+                       << fixed_position.z() << ','
+                       << position_shift_norm_m << ','
+                       << fixed_clock_m << ','
+                       << record.residual_m << ','
+                       << dd_residual << ','
+                       << record.geo_m << ','
+                       << constants::SPEED_OF_LIGHT * fixed_observation.sat_clk << ','
+                       << record.trop_applied_m << ','
+                       << fixed_observation.extra_prediction_m << ','
+                       << fixed_observation.fixed_nl_cycles *
+                              fixed_observation.lambda_nl_m << ','
+                       << fixed_observation.nl_phase_m << ','
+                       << fixed_observation.cpc_nl_m << ','
+                       << fixed_observation.osr_trop_correction_m << ','
+                       << fixed_observation.osr_nl_iono_m << ','
+                       << fixed_observation.receiver_ant_nl_m << ','
+                       << fixed_observation.lambda_nl_m << ','
+                       << fixed_observation.fixed_nl_cycles << ','
+                       << (fixed_observation.use_trop_model ? 1 : 0)
+                       << '\n';
+            }
+        }
+    }
     if (pppDebugEnabled() && solved) {
         std::cerr << "[PPP-WLNL] fixedWLS: sats=" << fixed_observations.size()
                   << " pos_shift=" << position_shift_norm_m << "m\n";
@@ -643,12 +760,23 @@ bool PPPProcessor::buildFixedNlObservationForSatellite(
         const double alpha1 = f1 / (f1 + f2);
         const double alpha2 = f2 / (f1 + f2);
         lambda_nl = constants::SPEED_OF_LIGHT / (f1 + f2);
+        const double cpc_nl_m = alpha1 * osr.CPC[0] + alpha2 * osr.CPC[1];
         const double l1_corr_m = l1->carrier_phase * osr.wavelengths[0] - osr.CPC[0];
         const double l2_corr_m = l2->carrier_phase * osr.wavelengths[1] - osr.CPC[1];
         nl_phase_m = alpha1 * l1_corr_m + alpha2 * l2_corr_m;
         sat_pos = osr.satellite_position;
         sat_clk = osr.satellite_clock_bias_s;
         use_trop_model = false;
+        fixed_observation.cpc_nl_m = cpc_nl_m;
+        fixed_observation.osr_trop_correction_m = osr.trop_correction_m;
+        fixed_observation.osr_nl_iono_m = osr.has_iono ? osr.iono_l1_m * f1 / f2 : 0.0;
+        fixed_observation.extra_prediction_m =
+            pppEnvOverrides().clas_vertical_fix && ppp_config_.use_clas_osr_filter
+                ? fixed_observation.osr_trop_correction_m +
+                      fixed_observation.osr_nl_iono_m
+                : 0.0;
+        fixed_observation.receiver_ant_nl_m =
+            alpha1 * osr.receiver_antenna_m[0] + alpha2 * osr.receiver_antenna_m[1];
     } else {
         const Observation* l1 = ppp_utils::findCarrierObservation(
             obs, satellite, {SignalType::GPS_L1CA, SignalType::GAL_E1, SignalType::QZS_L1CA});
@@ -697,6 +825,7 @@ bool PPPProcessor::buildFixedNlObservationForSatellite(
         return false;
     }
 
+    fixed_observation.satellite = satellite;
     fixed_observation.nl_phase_m = nl_phase_m;
     fixed_observation.fixed_nl_cycles = fixed_nl;
     fixed_observation.lambda_nl_m = lambda_nl;


### PR DESCRIPTION
## Summary

S22 — root-causes and fixes the issue #8 fixed-epoch vertical bias.

### Root cause

The fixed vertical error is **not constant** — it jumps per fix window (+18.6…+25.1 m Up early, −16.2…+4.8 m later), excluding a static antenna/datum bias. Attribution: the CLAS OSR WLNL **fixed-position WLS omitted the CLAS slant troposphere + NL ionosphere terms** that the NL integer prediction chain included (debug extra-prediction RMS 6.43 m). The solve absorbed those per-satellite terms mostly into height. Antenna excluded (blank header, 0.0 NL term); NL datum excluded (#151 disabling makes it worse); false fixes excluded (same 269 epochs, delta collapses once the model is consistent).

### Fix (default ON)

`GNSS_PPP_CLAS_VERTICAL_FIX` (=0 bit-exact opt-out): the fixed-position prediction now includes `osr_trop_correction_m + osr_nl_iono_m`. Plus default-off `GNSS_PPP_CLAS_FIX_DEBUG=<csv>` fixed-solve instrumentation.

### Results (2019-08-27 CLAS OSR WLNL, 3599 epochs)

| metric | before | after |
|---|---|---|
| fixed count | 269 | 269 |
| all-epoch H/V/3D | 5.68 / 4.44 / 7.21 m | **5.22 / 2.71 / 5.88 m** |
| fixed-only H/V/3D | 9.75 / 13.15 / 16.37 m | **5.27 / 2.66 / 5.90 m** |
| vs CLASLIB same-epoch trajectory (fixed) | 9.63 / 15.35 / 18.12 m | **0.98 / 0.60 / 1.15 m** |
| mean Up delta vs CLASLIB | +11.04 m | **+0.50 m** |

Post-fix DD residual RMS: 1.73 cm. The remaining few-meter offset vs the single static ECEF reference is dominated by the reference itself (CLASLIB's own static solution sits ~5.8 m 3D from it) — the follow-up for #8 should use the CLASLIB same-epoch trajectory as the oracle.

## Verification

- `GNSS_PPP_CLAS_VERTICAL_FIX=0` `cmp` **bit-exact** vs pre-change reference; default metrics independently reproduced (269 / 5.8805 / 5.8999)
- `GNSS_PPP_CLAS_FIX_DEBUG` **bit-exact** on `.pos`
- MADOCA 1h **bit-exact** (path untouched)
- `run_tests`: 319 passed / 43 skipped; CLI `-k clas / qzss_l6 / madoca`: pass; `git diff --check`: clean

Refs #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)