### PR TITLE
feat(clas): require-OSR fixed-WLS preview; oracle delta attribution

### DIFF
--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -142,6 +142,10 @@ struct PPPEnvOverrides {
     // GNSS_PPP_CLAS_FIX_DEBUG: path for CLAS DD-WLNL fixed-position WLS
     // diagnostic CSV. Empty disables it.
     std::string clas_fix_debug_path;
+    // GNSS_PPP_CLAS_FIX_REQUIRE_OSR: require a current CLAS OSR correction for
+    // every DD-WLNL fixed-position observation when set exactly to "1".
+    // Default false while measured.
+    bool clas_fix_require_osr = false;
     // GNSS_PPP_CLAS_VERTICAL_FIX: make CLAS DD-WLNL NL prediction consistent
     // with full-CPC-corrected phase before fixed-position WLS. Default true;
     // set exactly "0" for bit-exact opt-out.

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -111,6 +111,8 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
         envStringOrEmpty("GNSS_PPP_CLAS_NL_DEBUG");
     overrides.clas_fix_debug_path =
         envStringOrEmpty("GNSS_PPP_CLAS_FIX_DEBUG");
+    overrides.clas_fix_require_osr =
+        envExactOne("GNSS_PPP_CLAS_FIX_REQUIRE_OSR");
     overrides.clas_vertical_fix =
         !envExactZero("GNSS_PPP_CLAS_VERTICAL_FIX");
     const std::string clas_nl_datum_fix =

--- a/src/algorithms/ppp_wlnl.cpp
+++ b/src/algorithms/ppp_wlnl.cpp
@@ -778,6 +778,9 @@ bool PPPProcessor::buildFixedNlObservationForSatellite(
         fixed_observation.receiver_ant_nl_m =
             alpha1 * osr.receiver_antenna_m[0] + alpha2 * osr.receiver_antenna_m[1];
     } else {
+        if (ppp_config_.use_clas_osr_filter && env_overrides_.clas_fix_require_osr) {
+            return false;
+        }
         const Observation* l1 = ppp_utils::findCarrierObservation(
             obs, satellite, {SignalType::GPS_L1CA, SignalType::GAL_E1, SignalType::QZS_L1CA});
         const Observation* l2 = ppp_utils::findCarrierObservation(


### PR DESCRIPTION
## Summary

S23 — diagnosis slice toward CLASLIB's ~0.06 m fix accuracy (issue #8, re-baselined after #152). No default behavior change.

### Oracle harness (now standing)

Disposable CLASLIB build + `rnx2rtkp` recipe documented in the report; native baseline reproduced (269/3599 fixed, same-epoch oracle **H 0.966 / V 0.597 / 3D 1.136 m**).

### Delta decomposition

- Constant datum: mean ENU **+0.643 / +0.448 / +0.493 m** (~half the power)
- Time-varying: demeaned H/V/3D 0.566/0.337/0.659 m, horizontal drift time-correlated at r≈−0.9 over the hour (decays from ~+1.06/+0.73 to ~+0.10/−0.02 m by quarter-hour)

### Attribution

| suspect | evidence | verdict |
|---|---|---|
| receiver antenna | CLASLIB no-rx-ant sweep 0.016 m | excluded |
| tides/loading | CLASLIB tide-off 0.119 m; native no-IERS-tides bit-exact here | excluded |
| trop/filter coupling | 124/269 fixed epochs carry modeled trop on fallback rows; CLASLIB `tropopt=off`; `--no-estimate-troposphere`: 286 fixes, oracle 1.070 m | **best suspect** |
| receiver clock datum | native fixed-WLS clock +3.79 m vs CLASLIB $CLK −5.68 m (different conventions) | open |

Both candidate fixes improved the oracle metrics but strictly regressed static all-epoch 3D by 0.02–0.08 **mm** — the decision rule treats that as a fail, so nothing flips by default. Ships `GNSS_PPP_CLAS_FIX_REQUIRE_OSR=1` (default OFF, bit-exact off): rejects fallback non-OSR satellites in fixed WLS (preview: 269 fixed, V/3D 0.592/1.134 m).

### Recommended next step

Row-level fixed-WLS oracle: dump CLASLIB's corrected NL phase inputs, sat pos/clock, trop/iono/antenna terms and WLS rows on the disposable build, and diff per epoch/satellite against `GNSS_PPP_CLAS_FIX_DEBUG`. Shortest path from the structured ~1 m datum error to 0.06 m.

## Verification

- Default and MADOCA 1h **bit-exact**; `run_tests` 319 passed; CLI `-k clas / qzss_l6 / madoca` pass; `git diff --check` clean

Refs #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)