### PR TITLE
feat(clas): publish accepted filter-state position for fixed epochs

### DIFF
--- a/include/libgnss++/algorithms/ppp_ar.hpp
+++ b/include/libgnss++/algorithms/ppp_ar.hpp
@@ -124,6 +124,24 @@ WlnlFixAttempt tryWlnlFix(
 
 struct FixedNlObservation {
     SatelliteId satellite;
+    SignalType signal1 = SignalType::SIGNAL_TYPE_COUNT;
+    SignalType signal2 = SignalType::SIGNAL_TYPE_COUNT;
+    double frequency1_hz = 0.0;
+    double frequency2_hz = 0.0;
+    double raw_phase1_m = 0.0;
+    double raw_phase2_m = 0.0;
+    double corrected_phase1_m = 0.0;
+    double corrected_phase2_m = 0.0;
+    double raw_code1_m = 0.0;
+    double raw_code2_m = 0.0;
+    double corrected_code1_m = 0.0;
+    double corrected_code2_m = 0.0;
+    double cpc1_m = 0.0;
+    double cpc2_m = 0.0;
+    double prc1_m = 0.0;
+    double prc2_m = 0.0;
+    double receiver_ant1_m = 0.0;
+    double receiver_ant2_m = 0.0;
     double nl_phase_m = 0.0;
     double fixed_nl_cycles = 0.0;
     double lambda_nl_m = 0.0;

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -156,6 +156,10 @@ struct PPPEnvOverrides {
     // disable both for bit-exact opt-out.
     bool clas_nl_datum_reset = true;
     bool clas_nl_cpc_unified = true;
+    // GNSS_PPP_CLAS_FIXED_STATE_OUTPUT: keep the accepted CLAS filter-state
+    // position instead of replacing it with the standalone DD-WLNL fixed-WLS
+    // position. Default true; set exactly "0" for bit-exact opt-out.
+    bool clas_fixed_state_output = true;
     // GNSS_PPP_DEBUG: general PPP debug logging. Default false.
     bool debug = false;
 

--- a/src/algorithms/ppp_clas_epoch.cpp
+++ b/src/algorithms/ppp_clas_epoch.cpp
@@ -349,7 +349,7 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         last_fixed_ambiguities_,
         static_cast<int>(osr_corrections.size()));
 
-    if (wlnl_fixed_position_ok) {
+    if (wlnl_fixed_position_ok && !env_overrides_.clas_fixed_state_output) {
         solution.position_ecef = wlnl_fixed_position;
     }
 

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -115,6 +115,8 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
         envExactOne("GNSS_PPP_CLAS_FIX_REQUIRE_OSR");
     overrides.clas_vertical_fix =
         !envExactZero("GNSS_PPP_CLAS_VERTICAL_FIX");
+    overrides.clas_fixed_state_output =
+        !envExactZero("GNSS_PPP_CLAS_FIXED_STATE_OUTPUT");
     const std::string clas_nl_datum_fix =
         envStringOrEmpty("GNSS_PPP_CLAS_NL_DATUM_FIX");
     std::string clas_nl_datum_fix_lower = clas_nl_datum_fix;

--- a/src/algorithms/ppp_wlnl.cpp
+++ b/src/algorithms/ppp_wlnl.cpp
@@ -82,13 +82,21 @@ std::ofstream* clasFixDebugStream() {
         stream.open(path, std::ios::out | std::ios::trunc);
         if (stream) {
             stream << "record,week,tow,sat,ref_sat,nobs,"
+                   << "row_index,row_type,weight,"
                    << "initial_x_m,initial_y_m,initial_z_m,"
                    << "fixed_x_m,fixed_y_m,fixed_z_m,position_shift_m,"
                    << "final_clock_m,residual_m,dd_residual_m,"
-                   << "geo_m,satellite_clock_m,trop_applied_m,extra_prediction_m,"
+                   << "sat_x_m,sat_y_m,sat_z_m,satellite_clock_s,satellite_clock_m,"
+                   << "geo_m,trop_applied_m,extra_prediction_m,"
                    << "fixed_nl_m,nl_phase_m,cpc_nl_m,"
                    << "osr_trop_correction_m,osr_nl_iono_m,receiver_ant_nl_m,"
-                   << "lambda_nl_m,fixed_nl_cycles,use_trop_model\n";
+                   << "lambda_nl_m,fixed_nl_cycles,use_trop_model,"
+                   << "signal1,signal2,frequency1_hz,frequency2_hz,"
+                   << "raw_phase1_m,raw_phase2_m,corrected_phase1_m,corrected_phase2_m,"
+                   << "raw_code1_m,raw_code2_m,corrected_code1_m,corrected_code2_m,"
+                   << "cpc1_m,cpc2_m,prc1_m,prc2_m,"
+                   << "receiver_ant1_m,receiver_ant2_m,"
+                   << "tide_x_m,tide_y_m,tide_z_m\n";
         }
     }
     return stream ? &stream : nullptr;
@@ -242,7 +250,8 @@ bool PPPProcessor::solveFixedPosition(const ObservationData& obs,
                 }
             }
 
-            for (const auto& record : residual_records) {
+            for (size_t row_index = 0; row_index < residual_records.size(); ++row_index) {
+                const auto& record = residual_records[row_index];
                 const auto& fixed_observation = *record.observation;
                 const auto ref_it =
                     reference_by_system.find(fixed_observation.satellite.system);
@@ -259,6 +268,9 @@ bool PPPProcessor::solveFixedPosition(const ObservationData& obs,
                        << fixed_observation.satellite.toString() << ','
                        << ref_record->observation->satellite.toString() << ','
                        << fixed_observations.size() << ','
+                       << row_index << ','
+                       << "nl_phase,"
+                       << 1.0 << ','
                        << position.x() << ','
                        << position.y() << ','
                        << position.z() << ','
@@ -269,8 +281,12 @@ bool PPPProcessor::solveFixedPosition(const ObservationData& obs,
                        << fixed_clock_m << ','
                        << record.residual_m << ','
                        << dd_residual << ','
-                       << record.geo_m << ','
+                       << fixed_observation.sat_pos.x() << ','
+                       << fixed_observation.sat_pos.y() << ','
+                       << fixed_observation.sat_pos.z() << ','
+                       << fixed_observation.sat_clk << ','
                        << constants::SPEED_OF_LIGHT * fixed_observation.sat_clk << ','
+                       << record.geo_m << ','
                        << record.trop_applied_m << ','
                        << fixed_observation.extra_prediction_m << ','
                        << fixed_observation.fixed_nl_cycles *
@@ -282,7 +298,28 @@ bool PPPProcessor::solveFixedPosition(const ObservationData& obs,
                        << fixed_observation.receiver_ant_nl_m << ','
                        << fixed_observation.lambda_nl_m << ','
                        << fixed_observation.fixed_nl_cycles << ','
-                       << (fixed_observation.use_trop_model ? 1 : 0)
+                       << (fixed_observation.use_trop_model ? 1 : 0) << ','
+                       << static_cast<int>(fixed_observation.signal1) << ','
+                       << static_cast<int>(fixed_observation.signal2) << ','
+                       << fixed_observation.frequency1_hz << ','
+                       << fixed_observation.frequency2_hz << ','
+                       << fixed_observation.raw_phase1_m << ','
+                       << fixed_observation.raw_phase2_m << ','
+                       << fixed_observation.corrected_phase1_m << ','
+                       << fixed_observation.corrected_phase2_m << ','
+                       << fixed_observation.raw_code1_m << ','
+                       << fixed_observation.raw_code2_m << ','
+                       << fixed_observation.corrected_code1_m << ','
+                       << fixed_observation.corrected_code2_m << ','
+                       << fixed_observation.cpc1_m << ','
+                       << fixed_observation.cpc2_m << ','
+                       << fixed_observation.prc1_m << ','
+                       << fixed_observation.prc2_m << ','
+                       << fixed_observation.receiver_ant1_m << ','
+                       << fixed_observation.receiver_ant2_m << ','
+                       << 0.0 << ','
+                       << 0.0 << ','
+                       << 0.0
                        << '\n';
             }
         }
@@ -767,6 +804,28 @@ bool PPPProcessor::buildFixedNlObservationForSatellite(
         sat_pos = osr.satellite_position;
         sat_clk = osr.satellite_clock_bias_s;
         use_trop_model = false;
+        fixed_observation.signal1 = l1->signal;
+        fixed_observation.signal2 = l2->signal;
+        fixed_observation.frequency1_hz = f1;
+        fixed_observation.frequency2_hz = f2;
+        fixed_observation.raw_phase1_m = l1->carrier_phase * osr.wavelengths[0];
+        fixed_observation.raw_phase2_m = l2->carrier_phase * osr.wavelengths[1];
+        fixed_observation.corrected_phase1_m = l1_corr_m;
+        fixed_observation.corrected_phase2_m = l2_corr_m;
+        fixed_observation.raw_code1_m =
+            l1->has_pseudorange ? l1->pseudorange : quietNaN();
+        fixed_observation.raw_code2_m =
+            l2->has_pseudorange ? l2->pseudorange : quietNaN();
+        fixed_observation.corrected_code1_m =
+            l1->has_pseudorange ? l1->pseudorange - osr.PRC[0] : quietNaN();
+        fixed_observation.corrected_code2_m =
+            l2->has_pseudorange ? l2->pseudorange - osr.PRC[1] : quietNaN();
+        fixed_observation.cpc1_m = osr.CPC[0];
+        fixed_observation.cpc2_m = osr.CPC[1];
+        fixed_observation.prc1_m = osr.PRC[0];
+        fixed_observation.prc2_m = osr.PRC[1];
+        fixed_observation.receiver_ant1_m = osr.receiver_antenna_m[0];
+        fixed_observation.receiver_ant2_m = osr.receiver_antenna_m[1];
         fixed_observation.cpc_nl_m = cpc_nl_m;
         fixed_observation.osr_trop_correction_m = osr.trop_correction_m;
         fixed_observation.osr_nl_iono_m = osr.has_iono ? osr.iono_l1_m * f1 / f2 : 0.0;
@@ -803,6 +862,20 @@ bool PPPProcessor::buildFixedNlObservationForSatellite(
         const double alpha2 = f2 / (f1 + f2);
         lambda_nl = constants::SPEED_OF_LIGHT / (f1 + f2);
         nl_phase_m = alpha1 * l1->carrier_phase * lam1 + alpha2 * l2->carrier_phase * lam2;
+        fixed_observation.signal1 = l1->signal;
+        fixed_observation.signal2 = l2->signal;
+        fixed_observation.frequency1_hz = f1;
+        fixed_observation.frequency2_hz = f2;
+        fixed_observation.raw_phase1_m = l1->carrier_phase * lam1;
+        fixed_observation.raw_phase2_m = l2->carrier_phase * lam2;
+        fixed_observation.corrected_phase1_m = fixed_observation.raw_phase1_m;
+        fixed_observation.corrected_phase2_m = fixed_observation.raw_phase2_m;
+        fixed_observation.raw_code1_m =
+            l1->has_pseudorange ? l1->pseudorange : quietNaN();
+        fixed_observation.raw_code2_m =
+            l2->has_pseudorange ? l2->pseudorange : quietNaN();
+        fixed_observation.corrected_code1_m = fixed_observation.raw_code1_m;
+        fixed_observation.corrected_code2_m = fixed_observation.raw_code2_m;
 
         Vector3d sat_vel;
         double sat_drift = 0.0;


### PR DESCRIPTION
## Summary

S24 — row-level fixed-WLS oracle diff for issue #8. Builds the per-row comparison harness against CLASLIB and lands the structural output-convention alignment it indicts.

### Row-level oracle

A disposable CLASLIB copy (patches archived in the report, oracle output verified byte-identical to the unpatched one) now dumps per-row fixed-solve content; native side via `GNSS_PPP_CLAS_FIX_DEBUG` (extended). Rows aligned per epoch/satellite.

### What the rows say

| term | delta (ENU projection) |
|---|---|
| CLASLIB tide | −0.018 / −0.001 / −0.128 m (mostly U) |
| trop scalar | −0.007 / +0.008 / −0.404 m (mostly U) |
| receiver antenna | −0.002 / −0.003 / −0.068 m |
| common carrier DD residuals | **3.5–10 mm RMS** (already agree) |
| fixed-state output | **+0.64E / +0.45N / +0.49U m** |

None of the scalar suspects can produce the horizontal component. The structural culprit: native accepts WLNL fixes but **publishes a standalone NL fixed-WLS position tied to the float datum**; CLASLIB publishes its **constrained fixed state**.

### Change (default ON)

Fixed-epoch output now keeps the accepted CLAS filter-state position; `GNSS_PPP_CLAS_FIXED_STATE_OUTPUT=0` restores the previous WLS output bit-exactly.

| variant | fixed | oracle H/V/3D | static all 3D |
|---|---:|---|---|
| opt-out (old) | 269 | 0.966 / 0.597 / 1.136 m | 5.880461 m |
| default (new) | 269 | 0.968 / **0.591** / **1.134** m | 5.881249 m (+0.79 mm) |

Passes the calibrated decision rule (static regression under the 1 mm noise threshold). This is deliberately a small step — its value is the harness plus the verdict. The remaining ~1.07 m toward CLASLIB's 0.06 m needs a true CLASLIB-style constrained fixed-state update (DD phase+code rows, weights, ambiguity constraints) — next slice.

## Verification

- Opt-out **bit-exact** vs pre-change baseline; default static metric independently reproduced (5.881249)
- MADOCA 1h **bit-exact**; `run_tests` 319 passed; CLI `-k clas / qzss_l6 / madoca` pass; `git diff --check` clean

Refs #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)