### PR TITLE
feat(clas): constrained fixed-state preview; audit CLASLIB xa mechanism

### DIFF
--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -291,6 +291,8 @@ private:
     std::map<SatelliteId, CLASPhaseBiasRepairInfo> clas_phase_bias_repair_;
     ppp_clas_sd::SdFilterState clas_sd_state_;  ///< Clock-free SD filter
     ppp_clas_sd::DdAmbAccumulator clas_dd_accumulator_;  ///< Multi-epoch DD amb accumulator
+    PPPState last_clas_constrained_fixed_state_;
+    bool last_clas_constrained_fixed_state_valid_ = false;
     int last_obs_gps_week_ = 0;  ///< GPS week from latest observation (for L6 decode)
 
     // Statistics

--- a/include/libgnss++/algorithms/ppp_ar.hpp
+++ b/include/libgnss++/algorithms/ppp_ar.hpp
@@ -64,14 +64,19 @@ struct WlnlNlInfo {
     double lambda_nl_m = 0.0;
     double lambda_wl_m = 0.0;
     double beta = 0.0;
+    double alpha1 = 0.0;
+    double alpha2 = 0.0;
+    double iono_state_scale = 0.0;
     WlnlGroupKey group{};
     bool valid = false;
 };
 
 struct WlnlFixAttempt {
     bool fixed = false;
+    bool has_constrained_state = false;
     double ratio = 0.0;
     int nb = 0;
+    ppp_shared::PPPState constrained_state;
 };
 
 struct WlnlWideLaneFixSummary {
@@ -108,6 +113,15 @@ std::map<SatelliteId, WlnlNlInfo> buildWlnlNlInfoMap(
 WlnlFixAttempt resolveWlnlFix(
     const ppp_shared::PPPConfig& config,
     ppp_shared::PPPState& filter_state,
+    const MatrixXd& constraint_covariance,
+    std::map<SatelliteId, ppp_shared::PPPAmbiguityInfo>& ambiguity_states,
+    const EligibleAmbiguities& eligible_ambiguities,
+    const WlnlNlInfoProvider& provider,
+    bool debug_enabled);
+
+WlnlFixAttempt resolveWlnlFix(
+    const ppp_shared::PPPConfig& config,
+    ppp_shared::PPPState& filter_state,
     std::map<SatelliteId, ppp_shared::PPPAmbiguityInfo>& ambiguity_states,
     const EligibleAmbiguities& eligible_ambiguities,
     const WlnlNlInfoProvider& provider,
@@ -116,6 +130,7 @@ WlnlFixAttempt resolveWlnlFix(
 WlnlFixAttempt tryWlnlFix(
     const ppp_shared::PPPConfig& config,
     ppp_shared::PPPState& filter_state,
+    const MatrixXd& constraint_covariance,
     std::map<SatelliteId, ppp_shared::PPPAmbiguityInfo>& ambiguity_states,
     const std::vector<SatelliteId>& satellites,
     const std::vector<int>& state_indices,

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -160,6 +160,10 @@ struct PPPEnvOverrides {
     // position instead of replacing it with the standalone DD-WLNL fixed-WLS
     // position. Default true; set exactly "0" for bit-exact opt-out.
     bool clas_fixed_state_output = true;
+    // GNSS_PPP_CLAS_CONSTRAINED_FIX: publish the accepted CLAS DD-WLNL
+    // ambiguity-constrained state copy instead of the float filter state when
+    // set exactly to "1". Default false while measured.
+    bool clas_constrained_fix = false;
     // GNSS_PPP_DEBUG: general PPP debug logging. Default false.
     bool debug = false;
 

--- a/src/algorithms/ppp_ar.cpp
+++ b/src/algorithms/ppp_ar.cpp
@@ -444,11 +444,13 @@ DdFixAttempt tryDirectDdFixWithPar(
 WlnlFixAttempt tryWlnlFix(
     const ppp_shared::PPPConfig& config,
     ppp_shared::PPPState& filter_state,
+    const MatrixXd& constraint_covariance,
     std::map<SatelliteId, ppp_shared::PPPAmbiguityInfo>& ambiguity_states,
     const std::vector<SatelliteId>& satellites,
     const std::vector<int>& state_indices,
     const std::map<SatelliteId, WlnlNlInfo>& nl_info,
     bool debug_enabled) {
+    (void)state_indices;
     WlnlFixAttempt attempt;
 
     struct WlnlDdPair {
@@ -563,12 +565,48 @@ WlnlFixAttempt tryWlnlFix(
     VectorXd v = VectorXd::Zero(attempt.nb);
     MatrixXd R = MatrixXd::Zero(attempt.nb, attempt.nb);
 
+    auto addVirtualNlState = [&](const SatelliteId& satellite,
+                                 const WlnlNlInfo& info,
+                                 double sign,
+                                 Eigen::RowVectorXd& row,
+                                 double& value_m) {
+        const auto l1_state_it = filter_state.ambiguity_indices.find(satellite);
+        const SatelliteId l2_satellite(
+            satellite.system,
+            static_cast<uint8_t>(std::min(255, static_cast<int>(satellite.prn) + 100)));
+        const auto l2_state_it = filter_state.ambiguity_indices.find(l2_satellite);
+        if (l1_state_it == filter_state.ambiguity_indices.end() ||
+            l2_state_it == filter_state.ambiguity_indices.end()) {
+            return false;
+        }
+        const int l1_state = l1_state_it->second;
+        const int l2_state = l2_state_it->second;
+        if (l1_state < 0 || l1_state >= nx ||
+            l2_state < 0 || l2_state >= nx) {
+            return false;
+        }
+
+        value_m += sign * (
+            info.alpha1 * filter_state.state(l1_state) +
+            info.alpha2 * filter_state.state(l2_state));
+        row(l1_state) += sign * info.alpha1;
+        row(l2_state) += sign * info.alpha2;
+
+        const auto iono_it = filter_state.ionosphere_indices.find(satellite);
+        if (iono_it != filter_state.ionosphere_indices.end()) {
+            const int iono_state = iono_it->second;
+            if (iono_state >= 0 && iono_state < nx) {
+                value_m -= sign * info.iono_state_scale *
+                           filter_state.state(iono_state);
+                row(iono_state) -= sign * info.iono_state_scale;
+            }
+        }
+        return true;
+    };
+
     for (int k = 0; k < attempt.nb; ++k) {
         const int ri = dd_pairs[static_cast<size_t>(k)].ref_idx;
         const int si = dd_pairs[static_cast<size_t>(k)].sat_idx;
-        const int ref_state = state_indices[static_cast<size_t>(ri)];
-        const int sat_state = state_indices[static_cast<size_t>(si)];
-        const double float_dd_m = filter_state.state(ref_state) - filter_state.state(sat_state);
 
         const auto ref_nl_it = nl_info.find(satellites[static_cast<size_t>(ri)]);
         const auto sat_nl_it = nl_info.find(satellites[static_cast<size_t>(si)]);
@@ -576,16 +614,21 @@ WlnlFixAttempt tryWlnlFix(
             !ref_nl_it->second.valid || !sat_nl_it->second.valid) {
             continue;
         }
-        const auto& ref_amb = ambiguity_states.at(satellites[static_cast<size_t>(ri)]);
-        const auto& sat_amb = ambiguity_states.at(satellites[static_cast<size_t>(si)]);
-        const double fixed_dd_m =
-            dd_nl_fixed(k) * sat_nl_it->second.lambda_nl_m +
-            (ref_amb.wl_fixed_integer - sat_amb.wl_fixed_integer) *
-                sat_nl_it->second.beta * sat_nl_it->second.lambda_wl_m;
+        double float_dd_m = 0.0;
+        Eigen::RowVectorXd row = Eigen::RowVectorXd::Zero(nx);
+        if (!addVirtualNlState(
+                satellites[static_cast<size_t>(ri)], ref_nl_it->second,
+                1.0, row, float_dd_m) ||
+            !addVirtualNlState(
+                satellites[static_cast<size_t>(si)], sat_nl_it->second,
+                -1.0, row, float_dd_m)) {
+            continue;
+        }
+
+        const double fixed_dd_m = dd_nl_fixed(k) * sat_nl_it->second.lambda_nl_m;
 
         v(nv) = fixed_dd_m - float_dd_m;
-        H(nv, ref_state) = 1.0;
-        H(nv, sat_state) = -1.0;
+        H.row(nv) = row;
         R(nv, nv) = hold_variance;
         ++nv;
 
@@ -597,15 +640,49 @@ WlnlFixAttempt tryWlnlFix(
         }
     }
 
-    // Do NOT apply holdamb KF update.  The NL integer constraints are
-    // iono-free but the L1 ambiguity states are per-frequency (include
-    // iono residual).  Applying holdamb would corrupt the filter.
-    // Instead, fixed integers are stored in ambiguity_states and used
-    // by solveFixedPosition() for a clean WLS fixed solution.
-    (void)H;
-    (void)v;
-    (void)R;
-    (void)nv;
+    // Keep the live float filter untouched.  CLASLIB publishes a constrained
+    // fixed-state copy (xa) after AR; this mirrors that output path without
+    // feeding fixed ambiguities back into the next epoch.
+    if (nv > 0) {
+        const MatrixXd H_used = H.topRows(nv);
+        const VectorXd v_used = v.head(nv);
+        const MatrixXd R_used = R.topLeftCorner(nv, nv);
+        const bool has_constraint_covariance =
+            constraint_covariance.rows() == nx &&
+            constraint_covariance.cols() == nx;
+        const MatrixXd& P_constraint =
+            has_constraint_covariance ? constraint_covariance
+                                      : filter_state.covariance;
+        const MatrixXd S =
+            H_used * P_constraint * H_used.transpose() + R_used;
+        Eigen::LDLT<MatrixXd> ldlt(S);
+        if (ldlt.info() == Eigen::Success) {
+            const MatrixXd PHt = P_constraint * H_used.transpose();
+            const MatrixXd K = ldlt.solve(PHt.transpose()).transpose();
+            const VectorXd dx = K * v_used;
+            if (dx.allFinite()) {
+                attempt.constrained_state = filter_state;
+                attempt.constrained_state.state += dx;
+                const MatrixXd I_KH =
+                    MatrixXd::Identity(nx, nx) - K * H_used;
+                attempt.constrained_state.covariance =
+                    I_KH * P_constraint * I_KH.transpose() +
+                    K * R_used * K.transpose();
+                attempt.constrained_state.covariance =
+                    (attempt.constrained_state.covariance +
+                     attempt.constrained_state.covariance.transpose()) *
+                    0.5;
+                attempt.has_constrained_state = true;
+
+                if (debug_enabled) {
+                    std::cerr << "[PPP-WLNL] constrained state: rows=" << nv
+                              << " dx_pos="
+                              << dx.segment(filter_state.pos_index, 3).norm()
+                              << " dx_all=" << dx.norm() << "\n";
+                }
+            }
+        }
+    }
 
     for (const auto& [group, ref_idx] : system_ref_map) {
         (void)group;
@@ -658,6 +735,7 @@ std::map<SatelliteId, WlnlNlInfo> buildWlnlNlInfoMap(
 WlnlFixAttempt resolveWlnlFix(
     const ppp_shared::PPPConfig& config,
     ppp_shared::PPPState& filter_state,
+    const MatrixXd& constraint_covariance,
     std::map<SatelliteId, ppp_shared::PPPAmbiguityInfo>& ambiguity_states,
     const EligibleAmbiguities& eligible_ambiguities,
     const WlnlNlInfoProvider& provider,
@@ -669,10 +747,28 @@ WlnlFixAttempt resolveWlnlFix(
     return tryWlnlFix(
         config,
         filter_state,
+        constraint_covariance,
         ambiguity_states,
         eligible_ambiguities.satellites,
         eligible_ambiguities.state_indices,
         nl_info,
+        debug_enabled);
+}
+
+WlnlFixAttempt resolveWlnlFix(
+    const ppp_shared::PPPConfig& config,
+    ppp_shared::PPPState& filter_state,
+    std::map<SatelliteId, ppp_shared::PPPAmbiguityInfo>& ambiguity_states,
+    const EligibleAmbiguities& eligible_ambiguities,
+    const WlnlNlInfoProvider& provider,
+    bool debug_enabled) {
+    return resolveWlnlFix(
+        config,
+        filter_state,
+        MatrixXd{},
+        ambiguity_states,
+        eligible_ambiguities,
+        provider,
         debug_enabled);
 }
 

--- a/src/algorithms/ppp_clas_epoch.cpp
+++ b/src/algorithms/ppp_clas_epoch.cpp
@@ -109,6 +109,7 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
     last_clas_hybrid_fallback_reason_.clear();
     last_ar_ratio_ = 0.0;
     last_fixed_ambiguities_ = 0;
+    last_clas_constrained_fixed_state_valid_ = false;
     // CLAS per-frequency mode uses WL-NL AR: MW averaging resolves WL integers,
     // then NL integers are extracted from OSR-corrected dual-freq observations.
     if (ppp_config_.enable_ambiguity_resolution && !ppp_config_.use_ionosphere_free) {
@@ -342,14 +343,24 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         }
     }
 
+    const bool use_constrained_fixed_state =
+        ambiguity_resolution.accepted &&
+        ppp_config_.ar_method == PPPConfig::ARMethod::DD_WLNL &&
+        env_overrides_.clas_constrained_fix &&
+        last_clas_constrained_fixed_state_valid_;
+    const PPPState& solution_filter_state =
+        use_constrained_fixed_state ? last_clas_constrained_fixed_state_ : filter_state_;
+
     solution = ppp_clas::finalizeEpochSolution(
-        filter_state_,
+        solution_filter_state,
         ambiguity_resolution.accepted,
         last_ar_ratio_,
         last_fixed_ambiguities_,
         static_cast<int>(osr_corrections.size()));
 
-    if (wlnl_fixed_position_ok && !env_overrides_.clas_fixed_state_output) {
+    if (wlnl_fixed_position_ok &&
+        !env_overrides_.clas_fixed_state_output &&
+        !use_constrained_fixed_state) {
         solution.position_ecef = wlnl_fixed_position;
     }
 

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -117,6 +117,8 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
         !envExactZero("GNSS_PPP_CLAS_VERTICAL_FIX");
     overrides.clas_fixed_state_output =
         !envExactZero("GNSS_PPP_CLAS_FIXED_STATE_OUTPUT");
+    overrides.clas_constrained_fix =
+        envExactOne("GNSS_PPP_CLAS_CONSTRAINED_FIX");
     const std::string clas_nl_datum_fix =
         envStringOrEmpty("GNSS_PPP_CLAS_NL_DATUM_FIX");
     std::string clas_nl_datum_fix_lower = clas_nl_datum_fix;

--- a/src/algorithms/ppp_wlnl.cpp
+++ b/src/algorithms/ppp_wlnl.cpp
@@ -113,6 +113,7 @@ std::ofstream* clasFixDebugStream() {
 bool PPPProcessor::resolveAmbiguitiesWLNL(const ObservationData& obs, const NavigationData& nav) {
     last_ar_ratio_ = 0.0;
     last_fixed_ambiguities_ = 0;
+    last_clas_constrained_fixed_state_valid_ = false;
 
     const auto wlnl_preparation = ppp_ar::prepareWlnlCandidates(
         ppp_config_,
@@ -154,6 +155,7 @@ bool PPPProcessor::resolveAmbiguitiesWLNL(const ObservationData& obs, const Navi
     const ppp_ar::WlnlFixAttempt attempt = ppp_ar::resolveWlnlFix(
         ppp_config_,
         filter_state_,
+        pre_anchor_covariance_,
         ambiguity_states_,
         eligible_ambiguities,
         [&](const SatelliteId& sat, ppp_ar::WlnlNlInfo& info) {
@@ -168,6 +170,10 @@ bool PPPProcessor::resolveAmbiguitiesWLNL(const ObservationData& obs, const Navi
 
     last_ar_ratio_ = attempt.ratio;
     last_fixed_ambiguities_ = attempt.nb;
+    if (attempt.has_constrained_state) {
+        last_clas_constrained_fixed_state_ = attempt.constrained_state;
+        last_clas_constrained_fixed_state_valid_ = true;
+    }
     if (pppDebugEnabled()) {
         std::cerr << "[PPP-WLNL] NL fixed: nb=" << attempt.nb
                   << " ratio=" << attempt.ratio << "\n";
@@ -398,6 +404,7 @@ bool PPPProcessor::buildWlnlNlInfoForSatellite(
     double beta = 0.0;
     double alpha1 = 0.0;
     double alpha2 = 0.0;
+    double iono_state_scale = 0.0;
     double nl_phase_m = 0.0;
     double predicted_m = 0.0;
     double f1_hz = 0.0;
@@ -475,6 +482,7 @@ bool PPPProcessor::buildWlnlNlInfoForSatellite(
             (osr.frequencies[1] > 0.0 && osr.wavelengths[0] > 0.0)
                 ? std::pow(osr.wavelengths[1] / osr.wavelengths[0], 2)
                 : 1.0;
+        iono_state_scale = alpha1 * iono_scale1 + alpha2 * iono_scale2;
         iono_cpc1_m = -iono_scale1 * osr.iono_l1_m;
         iono_cpc2_m = -iono_scale2 * osr.iono_l1_m;
         raw_nl_m = alpha1 * phase1_m + alpha2 * phase2_m;
@@ -532,6 +540,8 @@ bool PPPProcessor::buildWlnlNlInfoForSatellite(
         lambda_nl = constants::SPEED_OF_LIGHT / (f1 + f2);
         lambda_wl = constants::SPEED_OF_LIGHT / std::abs(f1 - f2);
         beta = f1 * f2 / (f1 * f1 - f2 * f2);
+        iono_state_scale =
+            alpha1 + alpha2 * std::pow(lambda2 / lambda1, 2);
 
         const double l1_m = l1_obs->carrier_phase * lambda1;
         const double l2_m = l2_obs->carrier_phase * lambda2;
@@ -760,6 +770,9 @@ bool PPPProcessor::buildWlnlNlInfoForSatellite(
         lambda_nl,
         lambda_wl,
         beta,
+        alpha1,
+        alpha2,
+        iono_state_scale,
         {sat.system,
          {static_cast<int>(l1_obs->signal), static_cast<int>(l2_obs->signal)}},
         true


### PR DESCRIPTION
## Summary

S25 (issue #8) — full audit of CLASLIB's fixed-state (`xa`) mechanism plus a default-off native preview that measures exactly where the direct approach breaks.

### CLASLIB mechanism (audited, code refs)

- `ddres()` builds DD **phase + code** rows with elevation `varerr()` weights (`ppprtk.c:869`)
- `resamb_LAMBDA()` conditions the head state through DD ambiguity covariance `Qab/Qb`, updating only `rtk->xa/Pa` (`ppprtk.c:1217`); `restamb()` restores fixed entries (`:1142`)
- `holdamb()` is a separate, residual-gated fix-and-hold feedback to the live filter (`:1172`)
- Published fixed epochs use `xa`, never `x` (`:1842`)

### Preview result (default OFF)

`GNSS_PPP_CLAS_CONSTRAINED_FIX=1`: 269 fixes kept, but oracle worsens 1.134 → **4.590 m** (first fixed epoch +12.2 m Up). Verdict: native's observed-domain WLNL integer vector is **not state-compatible** with filter-covariance conditioning — the datum offset cannot be removed by constraining a virtual NL combination.

### Next step (recorded)

Mirror `resamb_LAMBDA()` directly: dump native `Qab/Qb`, float DD ambiguities, and fixed DD integers against CLASLIB's, then form `xa` from the **filter-state DD ambiguity vector**.

Default remains byte-identical to #154 (269 fixed, oracle 0.968/0.591/1.134 m; static-ref unchanged to the byte).

## Verification

- Default and MADOCA 1h **bit-exact**; `run_tests` 319 passed; CLI `-k clas / qzss_l6 / madoca` pass; `git diff --check` clean

Refs #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)