### PR TITLE
feat(clas): full-CPC filter-update preview; indict trop convention

### DIFF
--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -164,6 +164,13 @@ struct PPPEnvOverrides {
     // CLASLIB-style filter-state DD ambiguity conditioning copy when set
     // exactly to "1". Default false while measured.
     bool clas_resamb = false;
+    // GNSS_PPP_CLAS_AMB_DATUM: align CLAS OSR carrier phase ambiguity states
+    // with CLASLIB by subtracting the full CPC before ambiguity estimation.
+    // Default false while measured; set exactly "1"/"true"/"on" to preview.
+    bool clas_amb_datum = false;
+    // GNSS_PPP_CLAS_AMB_DATUM_DUMP: path for native CLAS phase-row ambiguity
+    // convention diagnostics. Empty disables it.
+    std::string clas_amb_datum_dump_path;
     // GNSS_PPP_DEBUG: general PPP debug logging. Default false.
     bool debug = false;
 

--- a/src/algorithms/ppp_clas.cpp
+++ b/src/algorithms/ppp_clas.cpp
@@ -1,12 +1,15 @@
 #include <libgnss++/algorithms/ppp_clas.hpp>
 
 #include <libgnss++/algorithms/ppp_ar.hpp>
+#include <libgnss++/algorithms/ppp_env_overrides.hpp>
 #include <libgnss++/core/constants.hpp>
 #include <libgnss++/core/coordinates.hpp>
 
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <limits>
 #include <map>
@@ -65,6 +68,29 @@ double elevationWeight(double elevation_rad) {
     return 1.0 / (s * s);
 }
 
+std::ofstream* ambDatumDumpStream() {
+    const auto& path = pppEnvOverrides().clas_amb_datum_dump_path;
+    if (path.empty()) {
+        return nullptr;
+    }
+
+    static std::ofstream stream;
+    static bool initialized = false;
+    if (!initialized) {
+        initialized = true;
+        stream.open(path, std::ios::out | std::ios::trunc);
+        if (stream) {
+            stream << "record,week,tow,sat,freq,signal,lambda_m,"
+                   << "raw_phase_cycles,raw_phase_m,carrier_correction_m,"
+                   << "cpc_m,cpc_minus_trop_m,trop_correction_m,relativity_m,"
+                   << "receiver_antenna_m,iono_cpc_m,phase_bias_m,windup_m,"
+                   << "phase_compensation_m,l_corr_m,predicted_no_amb_m,"
+                   << "amb_state_m,amb_state_cycles,residual_m\n";
+        }
+    }
+    return stream ? &stream : nullptr;
+}
+
 }  // namespace
 
 AppliedOsrCorrections selectAppliedOsrCorrections(
@@ -88,7 +114,9 @@ AppliedOsrCorrections selectAppliedOsrCorrections(
         corrections.pseudorange_correction_m =
             osr.PRC[freq_index] - osr.trop_correction_m;
         corrections.carrier_phase_correction_m =
-            osr.CPC[freq_index] - osr.trop_correction_m;
+            pppEnvOverrides().clas_amb_datum
+                ? osr.CPC[freq_index]
+                : osr.CPC[freq_index] - osr.trop_correction_m;
         break;
     case ppp_shared::PPPConfig::ClasCorrectionApplicationPolicy::ORBIT_CLOCK_BIAS:
         corrections.pseudorange_correction_m =
@@ -507,6 +535,14 @@ MeasurementBuildResult buildEpochMeasurements(
                 const double l_m = raw->carrier_phase * osr.wavelengths[f];
                 const double l_corr =
                     l_m - applied_corrections.carrier_phase_correction_m;
+                const bool claslib_amb_datum_phase =
+                    pppEnvOverrides().clas_amb_datum &&
+                    config.clas_correction_application_policy ==
+                        ppp_shared::PPPConfig::ClasCorrectionApplicationPolicy::FULL_OSR;
+                const double phase_trop_modeled =
+                    claslib_amb_datum_phase ? 0.0 : trop_modeled;
+                const double phase_trop_partial =
+                    claslib_amb_datum_phase ? 0.0 : trop_mapping;
 
                 const uint8_t amb_prn = f == 0 ? osr.satellite.prn
                     : static_cast<uint8_t>(std::min(255, osr.satellite.prn + 100));
@@ -523,13 +559,15 @@ MeasurementBuildResult buildEpochMeasurements(
 
                 if (filter_state.covariance(amb_idx, amb_idx) >= config.clas_ambiguity_reinit_threshold) {
                     filter_state.state(amb_idx) =
-                        l_corr - (geo - sat_clk_m + receiver_clock_m + trop_modeled
+                        l_corr - (geo - sat_clk_m + receiver_clock_m + phase_trop_modeled
                                   - iono_scale * iono_state_m);
                 }
 
+                const double predicted_no_amb =
+                    geo - sat_clk_m + receiver_clock_m + phase_trop_modeled
+                    - iono_scale * iono_state_m;
                 const double predicted =
-                    geo - sat_clk_m + receiver_clock_m + trop_modeled
-                    - iono_scale * iono_state_m + filter_state.state(amb_idx);
+                    predicted_no_amb + filter_state.state(amb_idx);
                 const double residual = l_corr - predicted;
 
                 const double el_weight = elevationWeight(osr.elevation);
@@ -538,7 +576,7 @@ MeasurementBuildResult buildEpochMeasurements(
                 row.H = Eigen::RowVectorXd::Zero(filter_state.total_states);
                 row.H.segment(0, 3) = -los.transpose();
                 row.H(filter_state.clock_index) = 1.0;
-                row.H(filter_state.trop_index) = trop_mapping;
+                row.H(filter_state.trop_index) = phase_trop_partial;
                 if (use_residual_iono_state) {
                     row.H(iono_state_index) = -iono_scale;
                     result.observed_iono_states.insert(osr.satellite);
@@ -552,6 +590,39 @@ MeasurementBuildResult buildEpochMeasurements(
                 result.measurements.push_back(row);
                 result.observed_ambiguities.push_back(
                     {amb_sat, raw->signal, osr.wavelengths[f], raw->carrier_phase, raw->snr});
+                if (auto* dump = ambDatumDumpStream(); dump != nullptr) {
+                    const double ambiguity_state_m = filter_state.state(amb_idx);
+                    const double ambiguity_state_cycles =
+                        osr.wavelengths[f] > 0.0
+                            ? ambiguity_state_m / osr.wavelengths[f]
+                            : 0.0;
+                    const double iono_cpc_m = -iono_scale * osr.iono_l1_m;
+                    *dump << std::setprecision(17)
+                          << "PHASE,"
+                          << obs.time.week << ','
+                          << obs.time.tow << ','
+                          << osr.satellite.toString() << ','
+                          << f << ','
+                          << static_cast<int>(raw->signal) << ','
+                          << osr.wavelengths[f] << ','
+                          << raw->carrier_phase << ','
+                          << l_m << ','
+                          << applied_corrections.carrier_phase_correction_m << ','
+                          << osr.CPC[f] << ','
+                          << (osr.CPC[f] - osr.trop_correction_m) << ','
+                          << osr.trop_correction_m << ','
+                          << osr.relativity_correction_m << ','
+                          << osr.receiver_antenna_m[f] << ','
+                          << iono_cpc_m << ','
+                          << osr.phase_bias_m[f] << ','
+                          << osr.windup_m[f] << ','
+                          << osr.phase_compensation_m[f] << ','
+                          << l_corr << ','
+                          << predicted_no_amb << ','
+                          << ambiguity_state_m << ','
+                          << ambiguity_state_cycles << ','
+                          << residual << '\n';
+                }
             }
         }
     }

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -31,6 +31,26 @@ bool envExactZero(const char* name) {
     return value != nullptr && value[0] == '0' && value[1] == '\0';
 }
 
+bool envBoolOr(const char* name, bool fallback) {
+    const char* value = envValue(name);
+    if (value == nullptr) {
+        return fallback;
+    }
+    std::string text(value);
+    std::transform(
+        text.begin(),
+        text.end(),
+        text.begin(),
+        [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+    if (text == "1" || text == "true" || text == "on" || text == "yes") {
+        return true;
+    }
+    if (text == "0" || text == "false" || text == "off" || text == "no") {
+        return false;
+    }
+    return fallback;
+}
+
 double envDoubleOr(const char* name, double fallback) {
     const char* value = envValue(name);
     return value != nullptr ? std::atof(value) : fallback;
@@ -119,6 +139,10 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
         !envExactZero("GNSS_PPP_CLAS_FIXED_STATE_OUTPUT");
     overrides.clas_resamb =
         envExactOne("GNSS_PPP_CLAS_RESAMB");
+    overrides.clas_amb_datum =
+        envBoolOr("GNSS_PPP_CLAS_AMB_DATUM", false);
+    overrides.clas_amb_datum_dump_path =
+        envStringOrEmpty("GNSS_PPP_CLAS_AMB_DATUM_DUMP");
     const std::string clas_nl_datum_fix =
         envStringOrEmpty("GNSS_PPP_CLAS_NL_DATUM_FIX");
     std::string clas_nl_datum_fix_lower = clas_nl_datum_fix;


### PR DESCRIPTION
## Summary

S27 (issue #8) — same-epoch ambiguity-state content diff against CLASLIB, indicting the filter-update trop/CPC convention; ships the alignment as a default-OFF preview with measured partial confirmation.

### Evidence

DD `N1/N2` deltas vs CLASLIB at epoch 230572 are satellite/elevation-shaped and match the **omitted CLAS trop DD term** per satellite (−0.97…−0.17 m). Native FULL_OSR phase rows used `CPC − trop` while estimating a phase trop state; CLASLIB's phase observables carry **full CPC (trop included), `tropopt=off`** — the difference lands in the ambiguity states.

### Preview result (default OFF)

`GNSS_PPP_CLAS_AMB_DATUM=1`: oracle **V 0.591 → 0.337 m, 3D 1.134 → 1.052 m** — but fixed 269 → 232 and static-ref 3D +0.33 m → fails the rule. `RESAMB=1` on top: no datum collapse (1.068 m).

### Where this leaves #8

The trop/CPC convention is a real contributor (vertical), but the stubborn remainder is the **constant ~0.8 m horizontal offset** that survives every ambiguity-side fix despite 3–10 mm DD residuals. Next surface: geometry/coordinate conventions (receiver position content in the rows, Sagnac/earth-rotation handling, satellite position epoch).

## Verification

- Default and MADOCA 1h **bit-exact**; `run_tests` 319 passed; CLI `-k clas / qzss_l6 / madoca` pass; `git diff --check` clean

Refs #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)