### PR TITLE
feat(clas): transmit-time iteration preview; geometry forensics

### DIFF
--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -171,6 +171,17 @@ struct PPPEnvOverrides {
     // GNSS_PPP_CLAS_AMB_DATUM_DUMP: path for native CLAS phase-row ambiguity
     // convention diagnostics. Empty disables it.
     std::string clas_amb_datum_dump_path;
+    // GNSS_PPP_CLAS_TX_TIME_SIGN_FIX: preview RTKLIB/CLASLIB transmit-time
+    // iteration for CLAS SSR satellite positions. Default false; set exactly
+    // "1" to enable. The default and exact "0" preserve legacy bit-exact
+    // behavior because the S28 rollout rule rejected this term as default-on.
+    bool clas_tx_time_sign_fix = false;
+    // GNSS_PPP_CLAS_GEOM_DUMP: path for CLAS geometry-row forensic dump.
+    // Empty disables it.
+    std::string clas_geom_dump_path;
+    // GNSS_PPP_CLAS_GEOM_DUMP_RX_XYZ: optional forced receiver ECEF
+    // "x,y,z" for GNSS_PPP_CLAS_GEOM_DUMP.
+    std::string clas_geom_dump_rx_xyz;
     // GNSS_PPP_DEBUG: general PPP debug logging. Default false.
     bool debug = false;
 

--- a/include/libgnss++/algorithms/ppp_osr_types.hpp
+++ b/include/libgnss++/algorithms/ppp_osr_types.hpp
@@ -32,6 +32,7 @@ struct OSRCorrection {
     Vector3d satellite_position = Vector3d::Zero();
     Vector3d satellite_velocity = Vector3d::Zero();
     double satellite_clock_bias_s = 0.0;
+    GNSSTime signal_transmit_time;
     double elevation = 0.0;
     double azimuth = 0.0;
 

--- a/src/algorithms/ppp_clas.cpp
+++ b/src/algorithms/ppp_clas.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <sstream>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
@@ -89,6 +90,57 @@ std::ofstream* ambDatumDumpStream() {
         }
     }
     return stream ? &stream : nullptr;
+}
+
+std::ofstream* clasGeometryDumpStream() {
+    const auto& path = pppEnvOverrides().clas_geom_dump_path;
+    if (path.empty()) {
+        return nullptr;
+    }
+
+    static std::ofstream stream;
+    static bool initialized = false;
+    if (!initialized) {
+        initialized = true;
+        stream.open(path, std::ios::out | std::ios::trunc);
+        if (stream) {
+            stream << "record,week,tow,tx_tow,sat,freq,signal,"
+                   << "rx_state_x_m,rx_state_y_m,rx_state_z_m,"
+                   << "rx_row_x_m,rx_row_y_m,rx_row_z_m,"
+                   << "rx_forced_x_m,rx_forced_y_m,rx_forced_z_m,"
+                   << "tide_x_m,tide_y_m,tide_z_m,"
+                   << "sat_x_m,sat_y_m,sat_z_m,sat_vx_mps,sat_vy_mps,sat_vz_mps,"
+                   << "sat_clk_m,euclidean_m,sagnac_m,rho_m,az_rad,el_rad,"
+                   << "cpc_m,model_phase_m\n";
+        }
+    }
+    return stream ? &stream : nullptr;
+}
+
+bool selectedClasGeometryDumpTow(double tow) {
+    constexpr std::array<double, 3> kTargets{230572.0, 232034.0, 234018.0};
+    for (double target : kTargets) {
+        if (std::abs(tow - target) < 0.01) {
+            return true;
+        }
+    }
+    return false;
+}
+
+Vector3d clasGeometryDumpReceiverPosition(const Vector3d& fallback) {
+    const auto& spec = pppEnvOverrides().clas_geom_dump_rx_xyz;
+    if (spec.empty()) {
+        return fallback;
+    }
+
+    std::string normalized = spec;
+    std::replace(normalized.begin(), normalized.end(), ',', ' ');
+    std::istringstream input(normalized);
+    Vector3d parsed = fallback;
+    if (input >> parsed.x() >> parsed.y() >> parsed.z()) {
+        return parsed;
+    }
+    return fallback;
 }
 
 }  // namespace
@@ -535,6 +587,67 @@ MeasurementBuildResult buildEpochMeasurements(
                 const double l_m = raw->carrier_phase * osr.wavelengths[f];
                 const double l_corr =
                     l_m - applied_corrections.carrier_phase_correction_m;
+                if (auto* dump = clasGeometryDumpStream();
+                    dump != nullptr && selectedClasGeometryDumpTow(obs.time.tow)) {
+                    const Vector3d forced_receiver_position =
+                        clasGeometryDumpReceiverPosition(receiver_position);
+                    const double forced_rho =
+                        geodist(osr.satellite_position, forced_receiver_position);
+                    const double euclidean =
+                        (osr.satellite_position - forced_receiver_position).norm();
+                    const double forced_sagnac = forced_rho - euclidean;
+                    const double forced_sat_clk_m =
+                        constants::SPEED_OF_LIGHT * osr.satellite_clock_bias_s;
+                    double forced_lat = 0.0;
+                    double forced_lon = 0.0;
+                    double forced_h = 0.0;
+                    ecef2geodetic(
+                        forced_receiver_position, forced_lat, forced_lon, forced_h);
+                    const Vector3d forced_los_enu = ecef2enu(
+                        osr.satellite_position - forced_receiver_position,
+                        forced_lat,
+                        forced_lon);
+                    const double forced_el = std::atan2(
+                        forced_los_enu.z(),
+                        std::hypot(forced_los_enu.x(), forced_los_enu.y()));
+                    const double forced_az =
+                        std::atan2(forced_los_enu.x(), forced_los_enu.y());
+                    *dump << std::setprecision(17)
+                          << "GEOM,"
+                          << obs.time.week << ','
+                          << obs.time.tow << ','
+                          << osr.signal_transmit_time.tow << ','
+                          << osr.satellite.toString() << ','
+                          << f << ','
+                          << static_cast<int>(raw->signal) << ','
+                          << receiver_position.x() << ','
+                          << receiver_position.y() << ','
+                          << receiver_position.z() << ','
+                          << receiver_position.x() << ','
+                          << receiver_position.y() << ','
+                          << receiver_position.z() << ','
+                          << forced_receiver_position.x() << ','
+                          << forced_receiver_position.y() << ','
+                          << forced_receiver_position.z() << ','
+                          << 0.0 << ','
+                          << 0.0 << ','
+                          << 0.0 << ','
+                          << osr.satellite_position.x() << ','
+                          << osr.satellite_position.y() << ','
+                          << osr.satellite_position.z() << ','
+                          << osr.satellite_velocity.x() << ','
+                          << osr.satellite_velocity.y() << ','
+                          << osr.satellite_velocity.z() << ','
+                          << forced_sat_clk_m << ','
+                          << euclidean << ','
+                          << forced_sagnac << ','
+                          << forced_rho << ','
+                          << forced_az << ','
+                          << forced_el << ','
+                          << osr.CPC[f] << ','
+                          << forced_rho - forced_sat_clk_m + osr.CPC[f]
+                          << '\n';
+                }
                 const bool claslib_amb_datum_phase =
                     pppEnvOverrides().clas_amb_datum &&
                     config.clas_correction_application_policy ==

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -143,6 +143,12 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
         envBoolOr("GNSS_PPP_CLAS_AMB_DATUM", false);
     overrides.clas_amb_datum_dump_path =
         envStringOrEmpty("GNSS_PPP_CLAS_AMB_DATUM_DUMP");
+    overrides.clas_tx_time_sign_fix =
+        envExactOne("GNSS_PPP_CLAS_TX_TIME_SIGN_FIX");
+    overrides.clas_geom_dump_path =
+        envStringOrEmpty("GNSS_PPP_CLAS_GEOM_DUMP");
+    overrides.clas_geom_dump_rx_xyz =
+        envStringOrEmpty("GNSS_PPP_CLAS_GEOM_DUMP_RX_XYZ");
     const std::string clas_nl_datum_fix =
         envStringOrEmpty("GNSS_PPP_CLAS_NL_DATUM_FIX");
     std::string clas_nl_datum_fix_lower = clas_nl_datum_fix;

--- a/src/algorithms/ppp_osr.cpp
+++ b/src/algorithms/ppp_osr.cpp
@@ -634,11 +634,32 @@ std::vector<OSRCorrection> computeOSR(
         // this, CLAS per-frequency residuals stay at the 20-40 m level.
         if (l1_obs->pseudorange > 0.0) {
             const double travel_time = l1_obs->pseudorange / constants::SPEED_OF_LIGHT;
-            const GNSSTime emission_time = obs.time - travel_time + sat_clk;
+            GNSSTime emission_time;
+            if (pppEnvOverrides().clas_tx_time_sign_fix) {
+                const GNSSTime approximate_transmit_time = obs.time - travel_time;
+                if (!nav.calculateSatelliteState(
+                        sat,
+                        approximate_transmit_time,
+                        sat_pos,
+                        sat_vel,
+                        sat_clk,
+                        sat_drift)) {
+                    continue;
+                }
+                emission_time = approximate_transmit_time - sat_clk;
+            } else {
+                emission_time = obs.time - travel_time + sat_clk;
+            }
             if (!nav.calculateSatelliteState(
-                    sat, emission_time, sat_pos, sat_vel, sat_clk, sat_drift)) {
+                    sat,
+                    emission_time,
+                    sat_pos,
+                    sat_vel,
+                    sat_clk,
+                    sat_drift)) {
                 continue;
             }
+            osr.signal_transmit_time = emission_time;
         }
 
         // Apply SSR orbit/clock corrections


### PR DESCRIPTION
## Summary

S28 (issue #8) — geometry-row forensics at identical receiver position against a patched disposable CLASLIB, indicting the satellite transmission-time convention; ships the fix as a default-OFF preview with a decisive interaction signature.

### Forensics

Per-satellite deltas (native − CLASLIB) at forced identical receiver XYZ: **Sagnac exonerated** (≈1e-6 m). The structural difference is transmit-time iteration: CLASLIB uses `t = obs − P/c`, `dt = ephclk(t)`, satpos at `t − dt`; native legacy used `obs − P/c **+** sat_clk` — opposite clock sign → meter-scale **along-track** satellite deltas. Geometry-only fit of the deltas: ENU **+0.40 / −0.79 / −0.08 m** (H 0.88 m) — the magnitude class of the stubborn datum.

### Preview result (default OFF)

`GNSS_PPP_CLAS_TX_TIME_SIGN_FIX=1`:

| metric | off | on |
|---|---|---|
| fixed | 269 | **292** |
| static all-epoch 3D | 5.881 m | **5.637 m** |
| oracle H/V/3D | 0.968/0.591/1.134 m | 1.172/3.490/3.681 m |

More fixes and better absolute accuracy, but worse oracle parity → the expanded-CSV OSR/CPC chain partially **compensates** the old convention. The terms must move together; next slice is a convention **combination matrix** across the accumulated default-off knobs (TX fix × `AMB_DATUM` × `REQUIRE_OSR` × `RESAMB`) — the pattern that worked for MADOCA in #140.

## Verification

- Default and MADOCA 1h **bit-exact**; `run_tests` 319 passed; CLI `-k clas / qzss_l6 / madoca` pass; `git diff --check` clean

Refs #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)