### PR TITLE
feat(clas): bridge-convention switch; datum-only NL fix wins the matrix

### DIFF
--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -150,10 +150,16 @@ struct PPPEnvOverrides {
     // with full-CPC-corrected phase before fixed-position WLS. Default true;
     // set exactly "0" for bit-exact opt-out.
     bool clas_vertical_fix = true;
+    // GNSS_PPP_CLAS_BRIDGE_CONVENTION: enable the coherent CLAS bridge
+    // convention set unless set exactly to "0". Default true; the opt-out
+    // restores current develop behavior for comparison.
+    bool clas_bridge_convention = true;
     // GNSS_PPP_CLAS_NL_DATUM_FIX: CLAS DD-WLNL NL datum preview.
-    // Default enables datum reset + CPC unification. Values "datum" or
-    // "cpc" enable one component for diagnostics; "0", "false", or "off"
-    // disable both for bit-exact opt-out.
+    // Under GNSS_PPP_CLAS_BRIDGE_CONVENTION default, datum reset is enabled
+    // without CPC unification. With GNSS_PPP_CLAS_BRIDGE_CONVENTION=0, the
+    // default restores the current develop datum reset + CPC unification
+    // behavior. Values "datum" or "cpc" enable one component for diagnostics;
+    // "0", "false", or "off" disable both.
     bool clas_nl_datum_reset = true;
     bool clas_nl_cpc_unified = true;
     // GNSS_PPP_CLAS_FIXED_STATE_OUTPUT: keep the accepted CLAS filter-state

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -135,6 +135,8 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
         envExactOne("GNSS_PPP_CLAS_FIX_REQUIRE_OSR");
     overrides.clas_vertical_fix =
         !envExactZero("GNSS_PPP_CLAS_VERTICAL_FIX");
+    overrides.clas_bridge_convention =
+        !envExactZero("GNSS_PPP_CLAS_BRIDGE_CONVENTION");
     overrides.clas_fixed_state_output =
         !envExactZero("GNSS_PPP_CLAS_FIXED_STATE_OUTPUT");
     overrides.clas_resamb =
@@ -151,6 +153,10 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
         envStringOrEmpty("GNSS_PPP_CLAS_GEOM_DUMP_RX_XYZ");
     const std::string clas_nl_datum_fix =
         envStringOrEmpty("GNSS_PPP_CLAS_NL_DATUM_FIX");
+    if (clas_nl_datum_fix.empty()) {
+        overrides.clas_nl_datum_reset = true;
+        overrides.clas_nl_cpc_unified = !overrides.clas_bridge_convention;
+    }
     std::string clas_nl_datum_fix_lower = clas_nl_datum_fix;
     std::transform(
         clas_nl_datum_fix_lower.begin(),


### PR DESCRIPTION
## Summary

S29 (issue #8) — the #140-style combination matrix across all accumulated CLAS preview knobs. Lands a default improvement: oracle **1.134 → 1.022 m** at unchanged fixed count and byte-unchanged static metric.

### Matrix verdicts (full 23-row table in the report)

| row | fixed | oracle H/V/3D | static 3D |
|---|---:|---|---|
| baseline | 269 | 0.968 / 0.591 / 1.134 | 5.881249 |
| **NL_DATUM=datum (winner)** | **269** | **0.868 / 0.539 / 1.022** | **5.881249** |
| NL_DATUM=cpc | 195 | 1.031 / 0.529 / 1.159 | 5.881249 |
| TX+AMB(+REQ+RESAMB) | 239 | ~1.36 / ~3.83 / ~4.06 | ~5.93 |
| datum+AMB | 220 | 0.938 / 0.280 / 0.979 | 6.208 |

- The **TX/AMB convention family is closed** as a default candidate — every combination regresses heavily.
- The winner is the #151 datum re-datum **without** its CPC-unification half, which has been costing fixes since #152 moved trop/iono into the fixed solve. (Vindicates the S21 "datum-only is metric-optimal" note under the post-#152 landscape.)
- `datum+AMB` reaches 0.979 m / V 0.280 but fails on fixes (220) and static (+0.33 m) — recorded as the tradeoff frontier.

### What ships

`GNSS_PPP_CLAS_BRIDGE_CONVENTION` (default ON) pins the winning surface; `=0` restores current develop **bit-exactly**. Component envs remain for diagnosis. OSR-generation audit: the Python CSV chain carries no tx-time geometry (regenerated CSVs byte-identical) — the S28 compensation lives in the C++ solve chain only.

## Verification

- Opt-out **bit-exact** vs pre-change baseline; default **byte-identical** to the matrix `NL_DATUM_datum` row; static metric independently reproduced (5.881249, 269 fixed)
- MADOCA 1h **bit-exact**; `run_tests` 319 passed; CLI `-k clas / qzss_l6 / madoca` pass; `git diff --check` clean

Refs #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)