### PR TITLE
feat(clas): residual phase-trop preview + trop tuning envs

### DIFF
--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -177,6 +177,18 @@ struct PPPEnvOverrides {
     // GNSS_PPP_CLAS_AMB_DATUM_DUMP: path for native CLAS phase-row ambiguity
     // convention diagnostics. Empty disables it.
     std::string clas_amb_datum_dump_path;
+    // GNSS_PPP_CLAS_AMB_DATUM_RESIDUAL_PHASE_TROP: with AMB_DATUM full-CPC
+    // phase rows, keep only the residual trop model
+    // (native mapped ZTD - CLAS CPC trop) and its Jacobian. Default false
+    // while measured.
+    bool clas_amb_datum_residual_phase_trop = false;
+    // GNSS_PPP_CLAS_TROP_PRIOR_VARIANCE /
+    // GNSS_PPP_CLAS_TROP_INITIAL_VARIANCE /
+    // GNSS_PPP_CLAS_TROP_PROCESS_NOISE: CLAS trop state tuning overrides.
+    // Values <= 0 leave PPPConfig defaults.
+    double clas_trop_prior_variance = 0.0;
+    double clas_trop_initial_variance = 0.0;
+    double clas_trop_process_noise = 0.0;
     // GNSS_PPP_CLAS_TX_TIME_SIGN_FIX: preview RTKLIB/CLASLIB transmit-time
     // iteration for CLAS SSR satellite positions. Default false; set exactly
     // "1" to enable. The default and exact "0" preserve legacy bit-exact

--- a/src/algorithms/ppp_clas.cpp
+++ b/src/algorithms/ppp_clas.cpp
@@ -193,6 +193,39 @@ bool usesClasTropospherePrior(
            ppp_shared::PPPConfig::ClasCorrectionApplicationPolicy::FULL_OSR;
 }
 
+bool suppressesClasAmbDatumPhaseTrop(
+    ppp_shared::PPPConfig::ClasCorrectionApplicationPolicy policy) {
+    const auto& env = pppEnvOverrides();
+    return env.clas_amb_datum &&
+           !env.clas_amb_datum_residual_phase_trop &&
+           policy ==
+               ppp_shared::PPPConfig::ClasCorrectionApplicationPolicy::FULL_OSR;
+}
+
+bool usesResidualClasAmbDatumPhaseTrop(
+    ppp_shared::PPPConfig::ClasCorrectionApplicationPolicy policy) {
+    const auto& env = pppEnvOverrides();
+    return env.clas_amb_datum &&
+           env.clas_amb_datum_residual_phase_trop &&
+           policy ==
+               ppp_shared::PPPConfig::ClasCorrectionApplicationPolicy::FULL_OSR;
+}
+
+double effectiveClasTropPriorVariance(const ppp_shared::PPPConfig& config) {
+    const double value = pppEnvOverrides().clas_trop_prior_variance;
+    return value > 0.0 ? value : config.clas_trop_prior_variance;
+}
+
+double effectiveClasTropInitialVariance(const ppp_shared::PPPConfig& config) {
+    const double value = pppEnvOverrides().clas_trop_initial_variance;
+    return value > 0.0 ? value : config.clas_trop_initial_variance;
+}
+
+double effectiveClasTropProcessNoise(const ppp_shared::PPPConfig& config) {
+    const double value = pppEnvOverrides().clas_trop_process_noise;
+    return value > 0.0 ? value : config.clas_trop_process_noise;
+}
+
 std::vector<SatelliteId> collectResidualIonoSatellites(
     const ObservationData& obs,
     const SSRProducts& ssr_products) {
@@ -294,7 +327,7 @@ void initializeFilterState(
     filter_state.covariance.block(0, 0, 3, 3) *= config.clas_initial_position_variance;
     filter_state.covariance(6, 6) = config.clas_clock_variance;
     filter_state.covariance(7, 7) = config.clas_clock_variance;
-    filter_state.covariance(8, 8) = config.clas_trop_initial_variance;
+    filter_state.covariance(8, 8) = effectiveClasTropInitialVariance(config);
     filter_state.iono_index = 9;
     for (size_t index = 0; index < iono_satellites.size(); ++index) {
         const int state_index = filter_state.iono_index + static_cast<int>(index);
@@ -371,7 +404,8 @@ void predictFilterState(
     MatrixXd Q = MatrixXd::Zero(nx, nx);
     Q(filter_state.clock_index, filter_state.clock_index) = config.clas_clock_variance;
     Q(filter_state.glo_clock_index, filter_state.glo_clock_index) = config.clas_clock_variance;
-    Q(filter_state.trop_index, filter_state.trop_index) = config.clas_trop_process_noise * dt;
+    Q(filter_state.trop_index, filter_state.trop_index) =
+        effectiveClasTropProcessNoise(config) * dt;
     if (config.estimate_ionosphere) {
         for (const auto& [_, state_index] : filter_state.ionosphere_indices) {
             if (state_index >= 0 && state_index < nx) {
@@ -649,11 +683,16 @@ MeasurementBuildResult buildEpochMeasurements(
                           << '\n';
                 }
                 const bool claslib_amb_datum_phase =
-                    pppEnvOverrides().clas_amb_datum &&
-                    config.clas_correction_application_policy ==
-                        ppp_shared::PPPConfig::ClasCorrectionApplicationPolicy::FULL_OSR;
-                const double phase_trop_modeled =
-                    claslib_amb_datum_phase ? 0.0 : trop_modeled;
+                    suppressesClasAmbDatumPhaseTrop(
+                        config.clas_correction_application_policy);
+                const bool residual_amb_datum_phase_trop =
+                    usesResidualClasAmbDatumPhaseTrop(
+                        config.clas_correction_application_policy);
+                const double phase_trop_modeled = claslib_amb_datum_phase
+                    ? 0.0
+                    : (residual_amb_datum_phase_trop
+                          ? trop_modeled - osr.trop_correction_m
+                          : trop_modeled);
                 const double phase_trop_partial =
                     claslib_amb_datum_phase ? 0.0 : trop_mapping;
 
@@ -756,7 +795,7 @@ MeasurementBuildResult buildEpochMeasurements(
             row.H = Eigen::RowVectorXd::Zero(filter_state.total_states);
             row.H(filter_state.trop_index) = 1.0;
             row.residual = clas_trop_zenith - trop_zenith;
-            row.variance = config.clas_trop_prior_variance;
+            row.variance = effectiveClasTropPriorVariance(config);
             row.satellite = SatelliteId{};
             row.is_phase = false;
             row.freq_index = -1;

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -145,6 +145,14 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
         envBoolOr("GNSS_PPP_CLAS_AMB_DATUM", false);
     overrides.clas_amb_datum_dump_path =
         envStringOrEmpty("GNSS_PPP_CLAS_AMB_DATUM_DUMP");
+    overrides.clas_amb_datum_residual_phase_trop =
+        envExactOne("GNSS_PPP_CLAS_AMB_DATUM_RESIDUAL_PHASE_TROP");
+    overrides.clas_trop_prior_variance =
+        envDoubleOr("GNSS_PPP_CLAS_TROP_PRIOR_VARIANCE", 0.0);
+    overrides.clas_trop_initial_variance =
+        envDoubleOr("GNSS_PPP_CLAS_TROP_INITIAL_VARIANCE", 0.0);
+    overrides.clas_trop_process_noise =
+        envDoubleOr("GNSS_PPP_CLAS_TROP_PROCESS_NOISE", 0.0);
     overrides.clas_tx_time_sign_fix =
         envExactOne("GNSS_PPP_CLAS_TX_TIME_SIGN_FIX");
     overrides.clas_geom_dump_path =


### PR DESCRIPTION
## Summary

S30 (issue #8) — measures the trop-convention lever and lands the best design as a default-OFF preview, with a finding about the decision rule itself.

### Lost-fix forensics (why AMB_DATUM costs fixes)

Under `AMB_DATUM` the fixed set churns: 226 baseline-fixed epochs lose fix, 177 gain (net 269→220). Every lost epoch forms NL candidates then fails **ratio** (`ratio=0`, no fixed-WLS rows) — NL LAMBDA/ratio failure, not WL pre-gates. 126/269 baseline fixed epochs carry fallback modelled-trop rows (the fallback-row sensitivity confirmed).

### Design table

| design | fixed | oracle H/V/3D | static-ECEF 3D |
|---|---:|---|---|
| baseline | 269 | 0.868 / 0.539 / 1.022 | 5.881249 |
| AMB_DATUM control | 220 | 0.938 / 0.280 / 0.979 | 6.208 |
| keep phase trop | 235 | 0.796 / 1.191 / 1.433 | 6.536 |
| reinit trop/amb | 222 | 0.989 / 0.328 / 1.042 | 6.169 |
| OSR-only NL rows | 247 | 0.948 / 0.274 / 0.987 | 6.208 |
| **residual phase trop + init var 1e-4** | **301** | **0.856 / 0.376 / 0.935** | 5.991 |

### What ships (default OFF)

`GNSS_PPP_CLAS_AMB_DATUM_RESIDUAL_PHASE_TROP=1` — model the full-CPC phase trop as `(native mapped ZTD − CLAS CPC trop)`, keeping the trop Jacobian without double-counting — plus tuning envs `GNSS_PPP_CLAS_TROP_{PRIOR,INITIAL}_VARIANCE` / `_PROCESS_NOISE`.

### Rule finding

The winning design improves fixed count (+32), oracle 3D (−0.087) and V (−0.163) **simultaneously** and is blocked only by +0.11 m on the static-ECEF gate — a coordinate measured (S23) to sit ~5.8 m from CLASLIB's own static solution. The gate is now the binding constraint and likely miscalibrated; recalibrating it to an all-epoch oracle comparison is the recorded next step before re-judging this preview.

## Verification

- Default and MADOCA 1h **bit-exact**; `run_tests` 319 passed; CLI `-k clas / qzss_l6 / madoca` pass; `git diff --check` clean

Refs #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)