### PR TITLE
feat(clas): float/code forensic gates; locate the datum in float code rows

### DIFF
--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -203,6 +203,20 @@ struct PPPEnvOverrides {
     // GNSS_PPP_CLAS_GEOM_DUMP_RX_XYZ: optional forced receiver ECEF
     // "x,y,z" for GNSS_PPP_CLAS_GEOM_DUMP.
     std::string clas_geom_dump_rx_xyz;
+    // GNSS_PPP_CLAS_CODE_DUMP: path for CLAS float code-row diagnostics.
+    // Empty disables it.
+    std::string clas_code_dump_path;
+    // GNSS_PPP_CLAS_FLOAT_DUMP: path for CLAS float-position diagnostics.
+    // Empty disables it.
+    std::string clas_float_dump_path;
+    // GNSS_PPP_CLAS_CODE_SD: form CLAS OSR code rows as same-system
+    // single differences when set exactly to "1". Default false while
+    // float-datum parity is measured.
+    bool clas_code_sd = false;
+    // GNSS_PPP_CLAS_QZSS_S_PRN_FIX: map compact CLAS legacy S120..S122
+    // correction labels to QZSS J01..J03 when set exactly to "1".
+    // Default false while row-set parity is measured.
+    bool clas_qzss_s_prn_fix = false;
     // GNSS_PPP_DEBUG: general PPP debug logging. Default false.
     bool debug = false;
 

--- a/src/algorithms/ppp_clas.cpp
+++ b/src/algorithms/ppp_clas.cpp
@@ -117,6 +117,31 @@ std::ofstream* clasGeometryDumpStream() {
     return stream ? &stream : nullptr;
 }
 
+std::ofstream* clasCodeDumpStream() {
+    const auto& path = pppEnvOverrides().clas_code_dump_path;
+    if (path.empty()) {
+        return nullptr;
+    }
+
+    static std::ofstream stream;
+    static bool initialized = false;
+    if (!initialized) {
+        initialized = true;
+        stream.open(path, std::ios::out | std::ios::trunc);
+        if (stream) {
+            stream << "record,stage,week,tow,sat,freq,signal,"
+                   << "raw_p_m,corrected_p_m,applied_pr_corr_m,prc_m,"
+                   << "prc_minus_trop_m,trop_correction_m,iono_l1_m,"
+                   << "iono_scaled_m,code_bias_m,receiver_ant_m,relativity_m,"
+                   << "geo_m,sat_clk_m,receiver_clock_m,trop_model_m,"
+                   << "iono_state_m,iono_scale,predicted_m,residual_m,"
+                   << "variance_m2,los_e_m,los_n_m,los_u_m,az_rad,el_rad,"
+                   << "rx_x_m,rx_y_m,rx_z_m\n";
+        }
+    }
+    return stream ? &stream : nullptr;
+}
+
 bool selectedClasGeometryDumpTow(double tow) {
     constexpr std::array<double, 3> kTargets{230572.0, 232034.0, 234018.0};
     for (double target : kTargets) {
@@ -141,6 +166,118 @@ Vector3d clasGeometryDumpReceiverPosition(const Vector3d& fallback) {
         return parsed;
     }
     return fallback;
+}
+
+void dumpClasCodeRows(
+    const char* stage,
+    const ObservationData& obs,
+    const std::vector<OSRCorrection>& osr_corrections,
+    const ppp_shared::PPPState& filter_state,
+    const ppp_shared::PPPConfig& config,
+    const TropMappingFunction& trop_mapping_function) {
+    auto* dump = clasCodeDumpStream();
+    if (dump == nullptr) {
+        return;
+    }
+    if (filter_state.total_states <= filter_state.trop_index ||
+        filter_state.state.size() < filter_state.total_states) {
+        return;
+    }
+
+    const Vector3d receiver_position =
+        filter_state.state.segment(filter_state.pos_index, 3);
+    const double receiver_clock_m = filter_state.state(filter_state.clock_index);
+    const double trop_zenith = filter_state.state(filter_state.trop_index);
+    double rx_lat = 0.0;
+    double rx_lon = 0.0;
+    double rx_h = 0.0;
+    ecef2geodetic(receiver_position, rx_lat, rx_lon, rx_h);
+
+    for (const auto& osr : osr_corrections) {
+        if (!osr.valid) {
+            continue;
+        }
+        const double geo = geodist(osr.satellite_position, receiver_position);
+        const Vector3d range_vector = osr.satellite_position - receiver_position;
+        if (!std::isfinite(geo) || range_vector.norm() <= 0.0) {
+            continue;
+        }
+        const Vector3d los = range_vector.normalized();
+        const Vector3d los_enu = ecef2enu(los, rx_lat, rx_lon);
+        const double sat_clk_m =
+            constants::SPEED_OF_LIGHT * osr.satellite_clock_bias_s;
+        const double trop_mapping =
+            trop_mapping_function(receiver_position, osr.elevation, obs.time);
+        const double trop_model = trop_mapping * trop_zenith;
+        const auto iono_state_it = filter_state.ionosphere_indices.find(osr.satellite);
+        const bool have_iono_state =
+            config.estimate_ionosphere &&
+            iono_state_it != filter_state.ionosphere_indices.end() &&
+            iono_state_it->second >= 0 &&
+            iono_state_it->second < filter_state.total_states;
+        const double iono_state_l1_m =
+            have_iono_state ? filter_state.state(iono_state_it->second) : 0.0;
+
+        for (int f = 0; f < osr.num_frequencies; ++f) {
+            const Observation* raw = obs.getObservation(osr.satellite, osr.signals[f]);
+            if (raw == nullptr || !raw->valid || !raw->has_pseudorange ||
+                !std::isfinite(raw->pseudorange)) {
+                continue;
+            }
+            const auto applied = selectAppliedOsrCorrections(
+                osr, f, config.clas_correction_application_policy);
+            const double corrected_p =
+                raw->pseudorange - applied.pseudorange_correction_m;
+            const double iono_scale =
+                (osr.frequencies[f] > 0.0 && osr.wavelengths[0] > 0.0)
+                    ? std::pow(osr.wavelengths[f] / osr.wavelengths[0], 2)
+                    : 1.0;
+            const double iono_scaled = iono_scale * osr.iono_l1_m;
+            const double predicted =
+                geo - sat_clk_m + receiver_clock_m + trop_model +
+                iono_scale * iono_state_l1_m;
+            const double residual = corrected_p - predicted;
+            const double variance =
+                config.clas_code_variance_scale * elevationWeight(osr.elevation);
+
+            *dump << std::setprecision(17)
+                  << "CODE,"
+                  << stage << ','
+                  << obs.time.week << ','
+                  << obs.time.tow << ','
+                  << osr.satellite.toString() << ','
+                  << f << ','
+                  << static_cast<int>(raw->signal) << ','
+                  << raw->pseudorange << ','
+                  << corrected_p << ','
+                  << applied.pseudorange_correction_m << ','
+                  << osr.PRC[f] << ','
+                  << (osr.PRC[f] - osr.trop_correction_m) << ','
+                  << osr.trop_correction_m << ','
+                  << osr.iono_l1_m << ','
+                  << iono_scaled << ','
+                  << osr.code_bias_m[f] << ','
+                  << osr.receiver_antenna_m[f] << ','
+                  << osr.relativity_correction_m << ','
+                  << geo << ','
+                  << sat_clk_m << ','
+                  << receiver_clock_m << ','
+                  << trop_model << ','
+                  << iono_state_l1_m << ','
+                  << iono_scale << ','
+                  << predicted << ','
+                  << residual << ','
+                  << variance << ','
+                  << los_enu.x() << ','
+                  << los_enu.y() << ','
+                  << los_enu.z() << ','
+                  << osr.azimuth << ','
+                  << osr.elevation << ','
+                  << receiver_position.x() << ','
+                  << receiver_position.y() << ','
+                  << receiver_position.z() << '\n';
+        }
+    }
 }
 
 }  // namespace
@@ -842,7 +979,9 @@ MeasurementBuildResult buildEpochMeasurements(
             }
         }
 
-        // Group phase measurements by GNSS system and frequency
+        // Group same-system measurements by signal. CLASLIB's ddres()
+        // single-differences both phase and code; keep native's historical
+        // undifferenced code path unless the parity gate is explicitly set.
         struct SdGroupKey {
             GNSSSystem system;
             int freq_index;
@@ -853,24 +992,27 @@ MeasurementBuildResult buildEpochMeasurements(
                 return is_phase < rhs.is_phase;
             }
         };
-        std::map<SdGroupKey, std::vector<size_t>> phase_groups;
+        const bool code_sd = pppEnvOverrides().clas_code_sd;
+        std::map<SdGroupKey, std::vector<size_t>> sd_groups;
         for (size_t i = 0; i < result.measurements.size(); ++i) {
             const auto& m = result.measurements[i];
-            if (m.freq_index < 0 || !m.is_phase) continue;
-            phase_groups[{m.satellite.system, m.freq_index, m.is_phase}].push_back(i);
+            if (m.freq_index < 0) continue;
+            if (!m.is_phase && !code_sd) continue;
+            sd_groups[{m.satellite.system, m.freq_index, m.is_phase}].push_back(i);
         }
 
-        // Start with undifferenced code measurements and prior constraints
+        // Start with prior constraints, plus undifferenced code rows on the
+        // default path. The gated path lets code rows be rebuilt as SD below.
         std::vector<MeasurementRow> sd_measurements;
         for (size_t i = 0; i < result.measurements.size(); ++i) {
             const auto& m = result.measurements[i];
-            if (!m.is_phase || m.freq_index < 0) {
+            if (m.freq_index < 0 || (!m.is_phase && !code_sd)) {
                 sd_measurements.push_back(m);
             }
         }
 
-        // Form SD for each phase group
-        for (auto& [group_key, member_indices] : phase_groups) {
+        // Form SD for each selected group.
+        for (auto& [group_key, member_indices] : sd_groups) {
             if (member_indices.size() < 2) continue;
 
             // Select reference satellite: highest elevation
@@ -894,7 +1036,7 @@ MeasurementBuildResult buildEpochMeasurements(
                 sd_row.residual = ref_row.residual - sat_row.residual;
                 sd_row.variance = ref_row.variance + sat_row.variance;
                 sd_row.satellite = sat_row.satellite;
-                sd_row.is_phase = true;
+                sd_row.is_phase = group_key.is_phase;
                 sd_row.freq_index = group_key.freq_index;
                 sd_measurements.push_back(sd_row);
             }
@@ -1001,6 +1143,13 @@ EpochUpdateResult runEpochMeasurementUpdate(
     if (!result.update_stats.updated) {
         return result;
     }
+    dumpClasCodeRows(
+        "post",
+        obs,
+        epoch_context.osr_corrections,
+        filter_state,
+        config,
+        trop_mapping_function);
 
     updateObservedAmbiguities(
         obs.time,

--- a/src/algorithms/ppp_clas_epoch.cpp
+++ b/src/algorithms/ppp_clas_epoch.cpp
@@ -11,6 +11,8 @@
 
 #include <algorithm>
 #include <cmath>
+#include <fstream>
+#include <iomanip>
 #include <iostream>
 #include <limits>
 
@@ -27,6 +29,25 @@ bool pppDebugEnabled() {
 }
 
 constexpr double kClasNlDatumJumpThresholdCycles = 0.5;
+
+std::ofstream* clasFloatDumpStream() {
+    const auto& path = pppEnvOverrides().clas_float_dump_path;
+    if (path.empty()) {
+        return nullptr;
+    }
+
+    static std::ofstream stream;
+    static bool initialized = false;
+    if (!initialized) {
+        initialized = true;
+        stream.open(path, std::ios::out | std::ios::trunc);
+        if (stream) {
+            stream << "record,week,tow,x_m,y_m,z_m,clock_m,trop_z_m,"
+                   << "num_osr,num_rows,dx_m,dx_y_m,dx_z_m\n";
+        }
+    }
+    return stream ? &stream : nullptr;
+}
 
 double clasNlPhaseBiasDatumCycles(const OSRCorrection& osr) {
     if (osr.num_frequencies < 2 ||
@@ -96,6 +117,39 @@ void applyClasNlDatumReset(
         ambiguity.clas_nl_phase_bias_datum_cycles = datum_cycles;
         ambiguity.has_clas_nl_phase_bias_datum = true;
     }
+}
+
+void dumpClasFloatPosition(
+    const GNSSTime& time,
+    const PPPState& filter_state,
+    const ppp_clas::EpochUpdateResult& epoch_update,
+    size_t num_osr) {
+    auto* dump = clasFloatDumpStream();
+    if (dump == nullptr || !epoch_update.update_stats.updated ||
+        filter_state.state.size() < filter_state.total_states ||
+        filter_state.total_states <= filter_state.trop_index) {
+        return;
+    }
+    const Vector3d position =
+        filter_state.state.segment(filter_state.pos_index, 3);
+    Vector3d dx = Vector3d::Zero();
+    if (epoch_update.update_stats.dx.size() >= filter_state.pos_index + 3) {
+        dx = epoch_update.update_stats.dx.segment(filter_state.pos_index, 3);
+    }
+    *dump << std::setprecision(17)
+          << "FLOAT,"
+          << time.week << ','
+          << time.tow << ','
+          << position.x() << ','
+          << position.y() << ','
+          << position.z() << ','
+          << filter_state.state(filter_state.clock_index) << ','
+          << filter_state.state(filter_state.trop_index) << ','
+          << num_osr << ','
+          << epoch_update.update_stats.nobs << ','
+          << dx.x() << ','
+          << dx.y() << ','
+          << dx.z() << '\n';
 }
 
 }  // namespace
@@ -256,6 +310,7 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         solution = seed;
         return solution;
     }
+    dumpClasFloatPosition(obs.time, filter_state_, epoch_update, osr_corrections.size());
     const auto& update_stats = epoch_update.update_stats;
     pre_anchor_covariance_ = update_stats.pre_anchor_covariance;
 

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -163,6 +163,14 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
         envStringOrEmpty("GNSS_PPP_CLAS_GEOM_DUMP");
     overrides.clas_geom_dump_rx_xyz =
         envStringOrEmpty("GNSS_PPP_CLAS_GEOM_DUMP_RX_XYZ");
+    overrides.clas_code_dump_path =
+        envStringOrEmpty("GNSS_PPP_CLAS_CODE_DUMP");
+    overrides.clas_float_dump_path =
+        envStringOrEmpty("GNSS_PPP_CLAS_FLOAT_DUMP");
+    overrides.clas_code_sd =
+        envExactOne("GNSS_PPP_CLAS_CODE_SD");
+    overrides.clas_qzss_s_prn_fix =
+        envExactOne("GNSS_PPP_CLAS_QZSS_S_PRN_FIX");
     const std::string clas_nl_datum_fix =
         envStringOrEmpty("GNSS_PPP_CLAS_NL_DATUM_FIX");
     if (clas_nl_datum_fix.empty()) {

--- a/src/algorithms/ppp_osr.cpp
+++ b/src/algorithms/ppp_osr.cpp
@@ -621,12 +621,22 @@ std::vector<OSRCorrection> computeOSR(
 
         const Observation* l1_obs = findSignal(l1_cands);
         const Observation* l2_obs = findSignal(l2_cands);
-        if (!l1_obs) continue;
+        if (!l1_obs) {
+            if (pppDebugEnabled() && sat.system == GNSSSystem::QZSS) {
+                std::cerr << "[OSR-QZSS-SKIP] " << sat.toString()
+                          << " reason=no_l1_code_phase\n";
+            }
+            continue;
+        }
 
         // --- 2. Satellite position/clock from broadcast + SSR ---
         Vector3d sat_pos, sat_vel;
         double sat_clk = 0.0, sat_drift = 0.0;
         if (!nav.calculateSatelliteState(sat, obs.time, sat_pos, sat_vel, sat_clk, sat_drift)) {
+            if (pppDebugEnabled() && sat.system == GNSSSystem::QZSS) {
+                std::cerr << "[OSR-QZSS-SKIP] " << sat.toString()
+                          << " reason=no_broadcast_state\n";
+            }
             continue;
         }
 
@@ -644,6 +654,10 @@ std::vector<OSRCorrection> computeOSR(
                         sat_vel,
                         sat_clk,
                         sat_drift)) {
+                    if (pppDebugEnabled() && sat.system == GNSSSystem::QZSS) {
+                        std::cerr << "[OSR-QZSS-SKIP] " << sat.toString()
+                                  << " reason=no_tx_broadcast_state_approx\n";
+                    }
                     continue;
                 }
                 emission_time = approximate_transmit_time - sat_clk;
@@ -657,6 +671,10 @@ std::vector<OSRCorrection> computeOSR(
                     sat_vel,
                     sat_clk,
                     sat_drift)) {
+                if (pppDebugEnabled() && sat.system == GNSSSystem::QZSS) {
+                    std::cerr << "[OSR-QZSS-SKIP] " << sat.toString()
+                              << " reason=no_tx_broadcast_state\n";
+                }
                 continue;
             }
             osr.signal_transmit_time = emission_time;
@@ -721,6 +739,10 @@ std::vector<OSRCorrection> computeOSR(
             osr.clock_reference_time = clock_reference_time;
             osr.clock_correction_m = clock_corr;
         } else {
+            if (pppDebugEnabled() && sat.system == GNSSSystem::QZSS) {
+                std::cerr << "[OSR-QZSS-SKIP] " << sat.toString()
+                          << " reason=no_ssr_correction\n";
+            }
             continue;
         }
 

--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -72,6 +72,43 @@ bool parseSatelliteToken(const std::string& token, SatelliteId& satellite) {
     }
 }
 
+bool parseCompactSsrSatelliteToken(const std::string& token, SatelliteId& satellite) {
+    if (pppEnvOverrides().clas_qzss_s_prn_fix &&
+        token.size() >= 2 &&
+        token[0] == 'S') {
+        try {
+            const int prn = std::stoi(token.substr(1));
+            if (prn >= 120 && prn <= 122) {
+                satellite = SatelliteId(
+                    GNSSSystem::QZSS,
+                    static_cast<uint8_t>(1 + (prn - 120)));
+                return true;
+            }
+        } catch (const std::exception&) {
+        }
+    }
+    return parseSatelliteToken(token, satellite);
+}
+
+std::string remapCompactSsrAtmosKey(std::string key) {
+    if (!pppEnvOverrides().clas_qzss_s_prn_fix) {
+        return key;
+    }
+    const std::pair<const char*, const char*> remaps[] = {
+        {":S120", ":J01"},
+        {":S121", ":J02"},
+        {":S122", ":J03"},
+    };
+    for (const auto& [from, to] : remaps) {
+        size_t pos = 0;
+        while ((pos = key.find(from, pos)) != std::string::npos) {
+            key.replace(pos, std::string(from).size(), to);
+            pos += std::string(to).size();
+        }
+    }
+    return key;
+}
+
 int parsePositiveIntToken(const std::map<std::string, std::string>& tokens,
                           const std::string& key) {
     const auto it = tokens.find(key);
@@ -2041,7 +2078,7 @@ bool SSRProducts::loadCSVFile(const std::string& filename) {
         }
 
         SatelliteId satellite;
-        if (!parseSatelliteToken(sat_token, satellite)) {
+        if (!parseCompactSsrSatelliteToken(sat_token, satellite)) {
             continue;
         }
 
@@ -2110,7 +2147,8 @@ bool SSRProducts::loadCSVFile(const std::string& filename) {
                 if (equal_pos == std::string::npos || equal_pos <= 6) {
                     continue;
                 }
-                const std::string key = extra.substr(0, equal_pos);
+                const std::string key =
+                    remapCompactSsrAtmosKey(extra.substr(0, equal_pos));
                 const std::string value = extra.substr(equal_pos + 1);
                 correction.atmos_tokens[key] = value;
                 if (key == "atmos_network_id") {


### PR DESCRIPTION
## Summary

S33 (issue #8) — moves the datum hunt from the (exonerated) fixed chain into the float solve, and finds two concrete differences. Diagnostic gates only; no default behavior change.

### Findings

1. **The offset exists from epoch 1** — native−CLASLIB float starts at +0.59E/+0.80N and averages +0.66E/+0.57N over 280 common epochs. Not a convergence effect.
2. **Row-set difference**: native float code rows are GPS+Galileo only; CLASLIB also carries **QZSS J01/J02/J03** (J02 in 280/280 epochs). Root cause is QZSS S-PRN token handling in the compact-CSV chain; the gated remap (`GNSS_PPP_CLAS_QZSS_S_PRN_FIX=1`) admits them but worsens metrics (fixed 225 / 1.97 m) because the QZSS correction content is not yet right — preview only.
3. **Code-row content**: corrected pseudorange deltas are **meter-level on every common row** (+3.6…+6.2 m) with per-satellite structure beyond the common clock term, plus visible GPS L2 code-bias identity mismatches. Native float uses undifferenced code rows; CLASLIB `ddres()` single-differences code as well.

### What ships (all default-off, bit-exact)

`GNSS_PPP_CLAS_CODE_DUMP`, `GNSS_PPP_CLAS_FLOAT_DUMP`, `GNSS_PPP_CLAS_CODE_SD=1`, `GNSS_PPP_CLAS_QZSS_S_PRN_FIX=1`.

### Next slice

CLASLIB-style float **code-row parity**: code SD formation, code-bias signal identity, per-system clock/ISB semantics before AR.

(Note: the in-run MADOCA cmp failure in the agent report was a stale-build artifact — after a full rebuild the patched tree's MADOCA 1h output is md5-identical to the reference.)

## Verification

- Default CLAS and MADOCA 1h **bit-exact** (MADOCA re-verified post-rebuild, md5 match)
- `run_tests` 319 passed; CLI `-k clas / qzss_l6 / madoca` pass; `git diff --check` clean

Refs #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)