### PR TITLE
feat(clas): atmosphere lifecycle materialization; STEC content parity exact

### DIFF
--- a/apps/gnss_qzss_l6_info.py
+++ b/apps/gnss_qzss_l6_info.py
@@ -8,7 +8,7 @@ import csv
 import errno
 import math
 import os
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 if os.name != "nt":
@@ -36,6 +36,8 @@ CSSR_SUBTYPE_GRIDDED = 9
 CSSR_SUBTYPE_SERVICE_INFO = 10
 CSSR_SUBTYPE_COMBINED = 11
 CSSR_SUBTYPE_ATMOS = 12
+CLAS_ATMOS_BANK_VALID_SECONDS = 30.0
+CLAS_ATMOS_LATEST_VALID_SECONDS = 3600.0
 
 COMPACT_SSR_FLUSH_POLICY_LAG_TOLERANT = "lag-tolerant-union"
 COMPACT_SSR_FLUSH_POLICY_ORBIT_OR_CLOCK_ONLY = "orbit-or-clock-only"
@@ -418,6 +420,18 @@ class CSSRServiceInfoPacket:
 
 
 @dataclass
+class AtmosLifecycleCoeff:
+    stec_type: int = 0
+    quality: str | None = None
+    c00: float = 0.0
+    c01: float = 0.0
+    c10: float = 0.0
+    c11: float = 0.0
+    c02: float = 0.0
+    c20: float = 0.0
+
+
+@dataclass
 class CSSRDecoderState:
     mask: CSSRMaskState | None = None
     message_index: int = 0
@@ -437,6 +451,13 @@ class CSSRDecoderState:
     pending_bias_network_id: int | None = None
     pending_atmos: dict[str, str] | None = None
     pending_atmos_subtypes: set[int] | None = None
+    atmos_lifecycle_coeffs: dict[int, dict[str, AtmosLifecycleCoeff]] = field(default_factory=dict)
+    atmos_lifecycle_stec_values: dict[int, dict[str, list[float]]] = field(default_factory=dict)
+    atmos_lifecycle_stec_times: dict[int, dict[str, list[int]]] = field(default_factory=dict)
+    atmos_lifecycle_trop_tokens: dict[int, dict[str, str]] = field(default_factory=dict)
+    atmos_lifecycle_trop_time: dict[int, int] = field(default_factory=dict)
+    atmos_lifecycle_grid_count: dict[int, int] = field(default_factory=dict)
+    atmos_lifecycle_pending_emits: set[tuple[int, int]] = field(default_factory=set)
     service_info_chunks: list[tuple[int, bytes, int]] | None = None
     service_packet_index: int = 0
 
@@ -657,6 +678,339 @@ def require_mask_state(state: CSSRDecoderState, subtype: int) -> CSSRMaskState:
     return state.mask
 
 
+def compact_atmos_lifecycle_enabled() -> bool:
+    value = os.environ.get("GNSS_PPP_CLAS_ATMOS_LIFECYCLE")
+    if value is None:
+        return False
+    return value.strip().lower() in {"1", "true", "on", "yes"}
+
+
+def _try_float(text: str | None) -> float:
+    if text is None:
+        return math.nan
+    try:
+        value = float(text)
+    except (TypeError, ValueError):
+        return math.nan
+    return value if math.isfinite(value) else math.nan
+
+
+def _try_int(text: str | None, default: int = 0) -> int:
+    if text is None:
+        return default
+    try:
+        return int(text)
+    except (TypeError, ValueError):
+        return default
+
+
+def _format_optional_float(value: float) -> str:
+    return "nan" if not math.isfinite(value) else f"{value:.6f}"
+
+
+def _parse_float_list(text: str | None) -> list[float]:
+    if not text:
+        return []
+    return [_try_float(token) for token in text.split(";")]
+
+
+def _stec_satellites_in_tokens(atmos_tokens: dict[str, str]) -> set[str]:
+    satellites: set[str] = set()
+    for key in atmos_tokens:
+        if key.startswith("atmos_stec_") and ":" in key:
+            satellites.add(key.split(":", 1)[1])
+    return satellites
+
+
+def _clas_grid_points_by_network() -> dict[int, list[tuple[int, float, float, float]]]:
+    cache = getattr(_clas_grid_points_by_network, "_cache", None)
+    if cache is not None:
+        return cache
+    grid_path = Path(__file__).resolve().parent.parent / "src" / "algorithms" / "clas_grid_points.inc"
+    networks: dict[int, list[tuple[int, float, float, float]]] = {}
+    if grid_path.exists():
+        for raw_line in grid_path.read_text(encoding="ascii").splitlines():
+            line = raw_line.strip()
+            if not line.startswith("{"):
+                continue
+            line = line.strip("{},")
+            parts = [part.strip() for part in line.split(",")]
+            if len(parts) < 5:
+                continue
+            try:
+                network_id = int(parts[0])
+                grid_no = int(parts[1])
+                lat_deg = float(parts[2])
+                lon_deg = float(parts[3])
+                height_m = float(parts[4])
+            except ValueError:
+                continue
+            networks.setdefault(network_id, []).append((grid_no, lat_deg, lon_deg, height_m))
+    for points in networks.values():
+        points.sort(key=lambda item: item[0])
+    setattr(_clas_grid_points_by_network, "_cache", networks)
+    return networks
+
+
+def _grid_offsets_for_network(network_id: int, grid_count: int) -> list[tuple[float, float]]:
+    points = _clas_grid_points_by_network().get(network_id, [])
+    if not points or grid_count <= 0:
+        return [(0.0, 0.0) for _ in range(max(grid_count, 0))]
+    selected = points[:grid_count]
+    if not selected:
+        return [(0.0, 0.0) for _ in range(grid_count)]
+    origin_lat = selected[0][1]
+    origin_lon = selected[0][2]
+    offsets = [(lat - origin_lat, lon - origin_lon) for _grid, lat, lon, _height in selected]
+    while len(offsets) < grid_count:
+        offsets.append((0.0, 0.0))
+    return offsets
+
+
+def _update_lifecycle_coeffs(
+    state: CSSRDecoderState,
+    tow: int,
+    network_id: int,
+    atmos_tokens: dict[str, str],
+) -> None:
+    del tow  # Coefficients persist until replaced, matching CLASLIB ssr_ion state.
+    coeff_bank = state.atmos_lifecycle_coeffs.setdefault(network_id, {})
+    for sat_key in _stec_satellites_in_tokens(atmos_tokens):
+        has_coeff = any(
+            f"atmos_stec_{name}:{sat_key}" in atmos_tokens
+            for name in (
+                "type",
+                "c00_tecu",
+                "c01_tecu_per_deg",
+                "c10_tecu_per_deg",
+                "c11_tecu_per_deg2",
+                "c02_tecu_per_deg2",
+                "c20_tecu_per_deg2",
+            )
+        )
+        if not has_coeff:
+            continue
+        coeff = AtmosLifecycleCoeff()
+        coeff.stec_type = _try_int(atmos_tokens.get(f"atmos_stec_type:{sat_key}"), 0)
+        coeff.quality = atmos_tokens.get(f"atmos_stec_quality:{sat_key}")
+        coeff.c00 = _try_float(atmos_tokens.get(f"atmos_stec_c00_tecu:{sat_key}"))
+        coeff.c01 = _try_float(atmos_tokens.get(f"atmos_stec_c01_tecu_per_deg:{sat_key}"))
+        coeff.c10 = _try_float(atmos_tokens.get(f"atmos_stec_c10_tecu_per_deg:{sat_key}"))
+        coeff.c11 = _try_float(atmos_tokens.get(f"atmos_stec_c11_tecu_per_deg2:{sat_key}"))
+        coeff.c02 = _try_float(atmos_tokens.get(f"atmos_stec_c02_tecu_per_deg2:{sat_key}"))
+        coeff.c20 = _try_float(atmos_tokens.get(f"atmos_stec_c20_tecu_per_deg2:{sat_key}"))
+        for attr in ("c00", "c01", "c10", "c11", "c02", "c20"):
+            if not math.isfinite(getattr(coeff, attr)):
+                setattr(coeff, attr, 0.0)
+        coeff_bank[sat_key] = coeff
+
+
+def _evaluate_lifecycle_stec_coeff(coeff: AtmosLifecycleCoeff | None, dlat: float, dlon: float) -> float:
+    if coeff is None:
+        return 0.0
+    value = coeff.c00
+    if coeff.stec_type > 0:
+        value += coeff.c01 * dlat + coeff.c10 * dlon
+    if coeff.stec_type > 1:
+        value += coeff.c11 * dlat * dlon
+    if coeff.stec_type > 2:
+        value += coeff.c02 * dlat * dlat + coeff.c20 * dlon * dlon
+    return value
+
+
+def _tokens_have_trop_grid(atmos_tokens: dict[str, str]) -> bool:
+    return (
+        "atmos_trop_hs_residuals_m" in atmos_tokens
+        and "atmos_trop_wet_residuals_m" in atmos_tokens
+    ) or "atmos_trop_residuals_m" in atmos_tokens
+
+
+def _update_lifecycle_trop(
+    state: CSSRDecoderState,
+    tow: int,
+    network_id: int,
+    atmos_tokens: dict[str, str],
+) -> None:
+    if not _tokens_have_trop_grid(atmos_tokens):
+        return
+    trop_tokens = {
+        key: value
+        for key, value in atmos_tokens.items()
+        if key.startswith("atmos_trop_")
+        or key in {"atmos_trop_avail", "atmos_grid_count"}
+    }
+    state.atmos_lifecycle_trop_tokens[network_id] = trop_tokens
+    state.atmos_lifecycle_trop_time[network_id] = tow
+
+
+def _grid_has_valid_trop(trop_tokens: dict[str, str], index: int) -> bool:
+    hs = _parse_float_list(trop_tokens.get("atmos_trop_hs_residuals_m"))
+    wet = _parse_float_list(trop_tokens.get("atmos_trop_wet_residuals_m"))
+    if index < len(hs) and index < len(wet):
+        return math.isfinite(hs[index]) and math.isfinite(wet[index])
+    residual = _parse_float_list(trop_tokens.get("atmos_trop_residuals_m"))
+    if index < len(residual):
+        return math.isfinite(residual[index])
+    return False
+
+
+def _materialize_lifecycle_stec(
+    state: CSSRDecoderState,
+    tow: int,
+    network_id: int,
+    atmos_tokens: dict[str, str],
+    source_subtype: int,
+) -> None:
+    grid_count = _try_int(atmos_tokens.get("atmos_grid_count"), 0)
+    if grid_count <= 0:
+        return
+    state.atmos_lifecycle_grid_count[network_id] = grid_count
+    offsets = _grid_offsets_for_network(network_id, grid_count)
+    value_bank = state.atmos_lifecycle_stec_values.setdefault(network_id, {})
+    time_bank = state.atmos_lifecycle_stec_times.setdefault(network_id, {})
+    residual_sats = {
+        key.split(":", 1)[1]
+        for key in atmos_tokens
+        if key.startswith("atmos_stec_residuals_tecu:")
+    }
+    coeff_sats = {
+        key.split(":", 1)[1]
+        for key in atmos_tokens
+        if key.startswith("atmos_stec_c00_tecu:") or key.startswith("atmos_stec_type:")
+    }
+    # Subtype 12 can carry polynomial-only gridded STEC. Subtype 8 cannot,
+    # because it has no grid payload and only updates the coefficient state.
+    sats_to_update = set(residual_sats)
+    if source_subtype == CSSR_SUBTYPE_ATMOS and not residual_sats:
+        sats_to_update.update(coeff_sats)
+    coeff_bank = state.atmos_lifecycle_coeffs.get(network_id, {})
+    for sat_key in sats_to_update:
+        values = value_bank.setdefault(sat_key, [math.nan] * grid_count)
+        times = time_bank.setdefault(sat_key, [-10**9] * grid_count)
+        if len(values) != grid_count:
+            values[:] = (values + [math.nan] * grid_count)[:grid_count]
+            times[:] = (times + [-10**9] * grid_count)[:grid_count]
+        residuals = _parse_float_list(atmos_tokens.get(f"atmos_stec_residuals_tecu:{sat_key}"))
+        coeff = coeff_bank.get(sat_key)
+        for index, (dlat, dlon) in enumerate(offsets):
+            stec0 = _evaluate_lifecycle_stec_coeff(coeff, dlat, dlon)
+            if residuals:
+                if index >= len(residuals) or not math.isfinite(residuals[index]):
+                    continue
+                value = stec0 + residuals[index]
+            else:
+                value = stec0
+            values[index] = value
+            times[index] = tow
+
+
+def _lifecycle_tokens_for_network(
+    state: CSSRDecoderState,
+    tow: int,
+    network_id: int,
+) -> dict[str, str] | None:
+    grid_count = state.atmos_lifecycle_grid_count.get(network_id, 0)
+    if grid_count <= 0:
+        return None
+    trop_tokens = state.atmos_lifecycle_trop_tokens.get(network_id)
+    trop_time = state.atmos_lifecycle_trop_time.get(network_id)
+    if (
+        trop_tokens is None
+        or trop_time is None
+        or tow - trop_time < -1e-9
+        or tow - trop_time > CLAS_ATMOS_BANK_VALID_SECONDS + 1e-9
+    ):
+        return None
+    value_bank = state.atmos_lifecycle_stec_values.get(network_id, {})
+    time_bank = state.atmos_lifecycle_stec_times.get(network_id, {})
+    valid_grids: list[int] = []
+    for index in range(grid_count):
+        valid_stec = 0
+        for sat_key, values in value_bank.items():
+            times = time_bank.get(sat_key, [])
+            if (
+                index < len(values)
+                and index < len(times)
+                and math.isfinite(values[index])
+                and 0.0 <= tow - times[index] <= CLAS_ATMOS_LATEST_VALID_SECONDS
+            ):
+                valid_stec += 1
+        if _grid_has_valid_trop(trop_tokens, index) and valid_stec >= 8:
+            valid_grids.append(index + 1)
+    if not valid_grids:
+        return None
+    selected_sats = 0
+    tokens: dict[str, str] = {
+        "atmos_lifecycle": "1",
+        "atmos_lifecycle_tow": str(trop_time),
+        "atmos_network_id": str(network_id),
+        "atmos_grid_count": str(grid_count),
+        "atmos_valid_grids": ";".join(str(grid_no) for grid_no in valid_grids),
+        "atmos_trop_avail": trop_tokens.get("atmos_trop_avail", "1"),
+        "atmos_stec_avail": "2",
+    }
+    tokens.update(trop_tokens)
+    valid_grid_indexes = {grid_no - 1 for grid_no in valid_grids}
+    for sat_key in sorted(value_bank):
+        values = value_bank[sat_key]
+        times = time_bank.get(sat_key, [])
+        encoded: list[str] = []
+        sat_has_value = False
+        for index in range(grid_count):
+            valid = (
+                index in valid_grid_indexes
+                and index < len(values)
+                and index < len(times)
+                and math.isfinite(values[index])
+                and 0.0 <= tow - times[index] <= CLAS_ATMOS_LATEST_VALID_SECONDS
+            )
+            if valid:
+                sat_has_value = True
+                encoded.append(f"{values[index]:.6f}")
+            else:
+                encoded.append("nan")
+        if sat_has_value:
+            tokens[f"atmos_stec_grid_tecu:{sat_key}"] = ";".join(encoded)
+            selected_sats += 1
+    if selected_sats == 0:
+        return None
+    tokens["atmos_selected_satellites"] = str(selected_sats)
+    return tokens
+
+
+def _set_pending_lifecycle_atmos(
+    state: CSSRDecoderState,
+    tokens: dict[str, str] | None,
+    source_subtype: int,
+) -> None:
+    if tokens:
+        state.pending_atmos = dict(tokens)
+        state.pending_atmos_subtypes = {source_subtype}
+    else:
+        state.pending_atmos = None
+        state.pending_atmos_subtypes = None
+
+
+def update_pending_lifecycle_atmos(
+    state: CSSRDecoderState,
+    tow: int,
+    network_id: int,
+    atmos_tokens: dict[str, str],
+    source_subtype: int,
+) -> None:
+    _update_lifecycle_coeffs(state, tow, network_id, atmos_tokens)
+    _update_lifecycle_trop(state, tow, network_id, atmos_tokens)
+    if source_subtype in {CSSR_SUBTYPE_GRIDDED, CSSR_SUBTYPE_ATMOS}:
+        _materialize_lifecycle_stec(state, tow, network_id, atmos_tokens, source_subtype)
+    if _lifecycle_tokens_for_network(state, tow, network_id):
+        state.atmos_lifecycle_pending_emits.add((network_id, tow))
+    _set_pending_lifecycle_atmos(
+        state,
+        _lifecycle_tokens_for_network(state, tow, network_id),
+        source_subtype,
+    )
+
+
 def reset_pending_corrections(state: CSSRDecoderState) -> None:
     state.pending_orbit = None
     state.pending_clock = None
@@ -670,6 +1024,11 @@ def reset_pending_corrections(state: CSSRDecoderState) -> None:
     state.pending_phase_bias_source = None
     state.pending_base_phase_bias = None
     state.pending_bias_network_id = None
+    if compact_atmos_lifecycle_enabled():
+        state.pending_atmos = None
+        state.pending_atmos_subtypes = None
+        return
+
     # Preserve STEC polynomial coefficients (c00, c01, c10, etc.) across epochs.
     # These arrive from subtype 8 at ~30s intervals, while gridded residuals
     # (subtype 9) arrive every second.  Without carry-forward the c00 terms
@@ -690,6 +1049,10 @@ def carry_forward_atmos_tokens(
     merge_policy: str,
 ) -> dict[str, str] | None:
     if merge_policy == COMPACT_ATMOS_MERGE_POLICY_NO_CARRY or atmos_tokens is None:
+        return None
+    if compact_atmos_lifecycle_enabled():
+        if atmos_tokens.get("atmos_lifecycle") == "1":
+            return dict(atmos_tokens)
         return None
     if merge_policy not in COMPACT_ATMOS_MERGE_POLICIES:
         raise ValueError(f"unsupported Compact SSR atmos merge policy: {merge_policy}")
@@ -1422,6 +1785,19 @@ def flush_pending_corrections(
     code_bias_map = state.pending_code_bias or {}
     phase_bias_map = state.pending_phase_bias or {}
     atmos = state.pending_atmos or {}
+    lifecycle_atmos_rows: list[dict[str, str]] = []
+    if compact_atmos_lifecycle_enabled():
+        atmos = {}
+        emitted: set[tuple[int, int]] = set()
+        expired: set[tuple[int, int]] = set()
+        for network_id, bank_tow in sorted(state.atmos_lifecycle_pending_emits):
+            tokens = _lifecycle_tokens_for_network(state, bank_tow, network_id)
+            if tokens:
+                lifecycle_atmos_rows.append(tokens)
+                emitted.add((network_id, bank_tow))
+            elif int(state.pending_tow) - bank_tow > CLAS_ATMOS_BANK_VALID_SECONDS:
+                expired.add((network_id, bank_tow))
+        state.atmos_lifecycle_pending_emits.difference_update(emitted | expired)
     sat_index = {satellite.sat: satellite for satellite in satellites}
     rows: list[CompactSSRCorrection] = []
     # Include satellites from atmosphere data that may not have orbit/clock corrections
@@ -1482,6 +1858,54 @@ def flush_pending_corrections(
                 atmos_tokens=dict(atmos) if atmos else None,
             )
         )
+    for atmos_tokens in lifecycle_atmos_rows:
+        atmos_sat_tokens = {
+            key.split(":", 1)[1]
+            for key in atmos_tokens
+            if key.startswith("atmos_stec_grid_tecu:")
+        }
+        for sat_token in sorted(atmos_sat_tokens):
+            satellite = sat_index.get(sat_token)
+            if satellite is None:
+                continue
+            rows.append(
+                CompactSSRCorrection(
+                    week=gps_week,
+                    tow=float(_try_int(atmos_tokens.get("atmos_lifecycle_tow"), int(state.pending_tow))),
+                    system=satellite.system,
+                    prn=satellite.prn,
+                    dx=0.0,
+                    dy=0.0,
+                    dz=0.0,
+                    dclock_m=0.0,
+                    atmos_network_id=(
+                        int(atmos_tokens["atmos_network_id"])
+                        if "atmos_network_id" in atmos_tokens
+                        else None
+                    ),
+                    atmos_trop_avail=(
+                        int(atmos_tokens["atmos_trop_avail"])
+                        if "atmos_trop_avail" in atmos_tokens
+                        else None
+                    ),
+                    atmos_stec_avail=(
+                        int(atmos_tokens["atmos_stec_avail"])
+                        if "atmos_stec_avail" in atmos_tokens
+                        else None
+                    ),
+                    atmos_grid_count=(
+                        int(atmos_tokens["atmos_grid_count"])
+                        if "atmos_grid_count" in atmos_tokens
+                        else None
+                    ),
+                    atmos_selected_satellites=(
+                        int(atmos_tokens["atmos_selected_satellites"])
+                        if "atmos_selected_satellites" in atmos_tokens
+                        else None
+                    ),
+                    atmos_tokens=dict(atmos_tokens),
+                )
+            )
     reset_pending_corrections(state)
     return rows
 
@@ -2071,13 +2495,22 @@ def decode_cssr_stec_message(
         atmos_merge_policy,
     )
     atmos_tokens["atmos_selected_satellites"] = str(selected_satellites)
-    merge_pending_atmos(
-        state,
-        atmos_tokens,
-        atmos_merge_policy,
-        atmos_subtype_merge_policy,
-        CSSR_SUBTYPE_STEC,
-    )
+    if compact_atmos_lifecycle_enabled():
+        update_pending_lifecycle_atmos(
+            state,
+            int(header["tow"]),
+            network_id,
+            atmos_tokens,
+            CSSR_SUBTYPE_STEC,
+        )
+    else:
+        merge_pending_atmos(
+            state,
+            atmos_tokens,
+            atmos_merge_policy,
+            atmos_subtype_merge_policy,
+            CSSR_SUBTYPE_STEC,
+        )
 
     state.message_index += 1
     return (
@@ -2178,13 +2611,22 @@ def decode_cssr_gridded_message(
         float(header["udi_seconds"]),
         atmos_merge_policy,
     )
-    merge_pending_atmos(
-        state,
-        atmos_tokens,
-        atmos_merge_policy,
-        atmos_subtype_merge_policy,
-        CSSR_SUBTYPE_GRIDDED,
-    )
+    if compact_atmos_lifecycle_enabled():
+        update_pending_lifecycle_atmos(
+            state,
+            int(header["tow"]),
+            network_id,
+            atmos_tokens,
+            CSSR_SUBTYPE_GRIDDED,
+        )
+    else:
+        merge_pending_atmos(
+            state,
+            atmos_tokens,
+            atmos_merge_policy,
+            atmos_subtype_merge_policy,
+            CSSR_SUBTYPE_GRIDDED,
+        )
 
     state.message_index += 1
     return (
@@ -2503,13 +2945,22 @@ def decode_cssr_atmos_message(
         atmos_merge_policy,
     )
     atmos_tokens["atmos_selected_satellites"] = str(selected_satellites)
-    merge_pending_atmos(
-        state,
-        atmos_tokens,
-        atmos_merge_policy,
-        atmos_subtype_merge_policy,
-        CSSR_SUBTYPE_ATMOS,
-    )
+    if compact_atmos_lifecycle_enabled():
+        update_pending_lifecycle_atmos(
+            state,
+            int(header["tow"]),
+            network_id,
+            atmos_tokens,
+            CSSR_SUBTYPE_ATMOS,
+        )
+    else:
+        merge_pending_atmos(
+            state,
+            atmos_tokens,
+            atmos_merge_policy,
+            atmos_subtype_merge_policy,
+            CSSR_SUBTYPE_ATMOS,
+        )
 
     state.message_index += 1
     return (

--- a/include/libgnss++/algorithms/ppp_atmosphere.hpp
+++ b/include/libgnss++/algorithms/ppp_atmosphere.hpp
@@ -18,6 +18,7 @@ struct ClasGridReference {
     size_t residual_index = 0;
     int network_id = 0;
     int grid_no = 0;
+    double nearest_grid_distance_m = 0.0;
     // Historical 4-grid fields kept for diagnostics. With the CLASLIB matrix
     // policy enabled these hold the effective matrix weights in selected-grid
     // order, not quadrant bilinear SW/SE/NW/NE order.

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -224,6 +224,11 @@ struct PPPEnvOverrides {
     // and matrix interpolation path for expanded CLAS atmosphere rows when
     // set exactly to "1". Default false while issue #8 parity is measured.
     bool clas_atmos_grid_matrix = false;
+    // GNSS_PPP_CLAS_ATMOS_LIFECYCLE: consume regenerated CLAS atmosphere
+    // lifecycle grid-bank tokens and pair them with CLASLIB matrix grid
+    // selection when set exactly to "1". Default false while issue #8 parity
+    // is measured; exact "0" preserves legacy CSV artifact semantics.
+    bool clas_atmos_lifecycle = false;
     // GNSS_PPP_CLAS_QZSS_S_PRN_FIX: map compact CLAS legacy S120..S122
     // correction labels to QZSS J01..J03 when set exactly to "1".
     // Default false while row-set parity is measured.

--- a/src/algorithms/ppp_atmosphere.cpp
+++ b/src/algorithms/ppp_atmosphere.cpp
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <ctime>
 #include <limits>
+#include <set>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -120,6 +121,34 @@ bool sampleAtmosResidualList(const std::map<std::string, std::string>& atmos_tok
         return true;
     }
     return false;
+}
+
+std::set<int> parseAtmosValidGridNumbers(
+    const std::map<std::string, std::string>& atmos_tokens) {
+    std::set<int> valid_grids;
+    const auto it = atmos_tokens.find("atmos_valid_grids");
+    if (it == atmos_tokens.end() || it->second.empty()) {
+        return valid_grids;
+    }
+    size_t start = 0;
+    while (start <= it->second.size()) {
+        const size_t delimiter = it->second.find(';', start);
+        const std::string token =
+            delimiter == std::string::npos ? it->second.substr(start)
+                                           : it->second.substr(start, delimiter - start);
+        try {
+            const int grid_no = std::stoi(token);
+            if (grid_no > 0) {
+                valid_grids.insert(grid_no);
+            }
+        } catch (...) {
+        }
+        if (delimiter == std::string::npos) {
+            break;
+        }
+        start = delimiter + 1;
+    }
+    return valid_grids;
 }
 
 struct GridCandidate {
@@ -348,6 +377,7 @@ void fillGridReference(const std::array<const GridCandidate*, 4>& selected,
         static_cast<size_t>(std::max(selected[0]->point->grid_no - 1, 0));
     reference.network_id = selected[0]->point->network_id;
     reference.grid_no = selected[0]->point->grid_no;
+    reference.nearest_grid_distance_m = selected[0]->distance_m;
     reference.interpolation_grid_count = count;
     reference.has_bilinear = count == 4;
     for (int i = 0; i < 4; ++i) {
@@ -471,6 +501,19 @@ bool resolveClasGridReference(const std::map<std::string, std::string>& atmos_to
 
     int grid_count = 0;
     parseAtmosTokenInt(atmos_tokens, "atmos_grid_count", grid_count);
+    const bool lifecycle_enabled = pppEnvOverrides().clas_atmos_lifecycle;
+    if (lifecycle_enabled && grid_count <= 0) {
+        return false;
+    }
+    const std::set<int> valid_grid_numbers =
+        lifecycle_enabled ? parseAtmosValidGridNumbers(atmos_tokens) : std::set<int>{};
+    if (lifecycle_enabled && valid_grid_numbers.empty()) {
+        return false;
+    }
+    const auto gridAllowed = [&](const ClasGridPoint& point) {
+        return !lifecycle_enabled ||
+               valid_grid_numbers.find(point.grid_no) != valid_grid_numbers.end();
+    };
 
     double receiver_lat_rad = 0.0;
     double receiver_lon_rad = 0.0;
@@ -483,7 +526,8 @@ bool resolveClasGridReference(const std::map<std::string, std::string>& atmos_to
     const double receiver_lat_deg = receiver_lat_rad / kDegreesToRadians;
     const double receiver_lon_deg = receiver_lon_rad / kDegreesToRadians;
 
-    if (!pppEnvOverrides().clas_atmos_grid_matrix) {
+    const bool use_grid_matrix = pppEnvOverrides().clas_atmos_grid_matrix;
+    if (!use_grid_matrix) {
         struct LegacyGridCandidate {
             const ClasGridPoint* point = nullptr;
             double distance_sq = 0.0;
@@ -492,6 +536,7 @@ bool resolveClasGridReference(const std::map<std::string, std::string>& atmos_to
         for (const auto& point : clasGridPoints()) {
             if (point.network_id != network_id) continue;
             if (grid_count > 0 && point.grid_no > grid_count) continue;
+            if (!gridAllowed(point)) continue;
             const double dlat = receiver_lat_deg - point.latitude_deg;
             const double dlon = receiver_lon_deg - point.longitude_deg;
             candidates.push_back({&point, dlat * dlat + dlon * dlon});
@@ -551,6 +596,8 @@ bool resolveClasGridReference(const std::map<std::string, std::string>& atmos_to
         reference.residual_index = static_cast<size_t>(std::max(nearest->grid_no - 1, 0));
         reference.network_id = nearest->network_id;
         reference.grid_no = nearest->grid_no;
+        reference.nearest_grid_distance_m =
+            std::sqrt(candidates[0].distance_sq) * kDegreesToRadians * constants::WGS84_A;
         return true;
     }
 
@@ -563,6 +610,7 @@ bool resolveClasGridReference(const std::map<std::string, std::string>& atmos_to
         }
         if (grid_count > 0 && point.grid_no > grid_count) continue;
         if (std::fabs(point.height_m) > 0.0001) continue;
+        if (!gridAllowed(point)) continue;
         const double distance_m =
             clasGridMetricDistanceMeters(receiver_lat_rad, receiver_lon_rad, point);
         if (distance_m > kClasMaxGridDistanceM) {
@@ -765,6 +813,57 @@ double atmosphericStecTecu(const std::map<std::string, std::string>& atmos_token
     const bool subtype12_row = isSubtype12StecRow(atmos_tokens, satellite);
     int stec_type = -1;
     parseAtmosTokenInt(atmos_tokens, "atmos_stec_type" + suffix, stec_type);
+
+    const std::string materialized_grid_key =
+        "atmos_stec_grid_tecu" + suffix;
+    if (have_grid_reference &&
+        atmos_tokens.find(materialized_grid_key) != atmos_tokens.end()) {
+        auto sampleMaterializedGrid = [&](size_t grid_index, double& grid_value) {
+            return parseAtmosListValueAtIndex(
+                atmos_tokens, materialized_grid_key, grid_index, grid_value) &&
+                   std::isfinite(grid_value);
+        };
+        double materialized_stec = 0.0;
+        bool have_materialized = false;
+        if (grid_reference.interpolation_grid_count > 1) {
+            bool ok = true;
+            for (int g = 0; g < grid_reference.interpolation_grid_count; ++g) {
+                double grid_value = 0.0;
+                if (!sampleMaterializedGrid(
+                        grid_reference.interpolation_grid_indices[g],
+                        grid_value)) {
+                    ok = false;
+                    break;
+                }
+                materialized_stec +=
+                    grid_reference.interpolation_weights[g] * grid_value;
+            }
+            have_materialized = ok;
+        } else if (grid_reference.has_bilinear) {
+            bool ok = true;
+            for (int g = 0; g < 4; ++g) {
+                double grid_value = 0.0;
+                if (!sampleMaterializedGrid(
+                        grid_reference.bilinear_grid_indices[g],
+                        grid_value)) {
+                    ok = false;
+                    break;
+                }
+                materialized_stec +=
+                    grid_reference.bilinear_weights[g] * grid_value;
+            }
+            have_materialized = ok;
+        } else {
+            have_materialized =
+                sampleMaterializedGrid(grid_reference.residual_index, materialized_stec);
+        }
+        if (have_materialized) {
+            return materialized_stec;
+        }
+    }
+    if (pppEnvOverrides().clas_atmos_lifecycle) {
+        return 0.0;
+    }
 
     // STEC polynomial: c00 + c01*dlat + c10*dlon + c11*dlat*dlon [+ c02*dlat² + c20*dlon²]
     // When 4-grid bilinear is available, evaluate the polynomial at each grid

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -244,6 +244,8 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
     }
     overrides.clas_atmos_grid_matrix =
         envExactOne("GNSS_PPP_CLAS_ATMOS_GRID_MATRIX");
+    overrides.clas_atmos_lifecycle =
+        envExactOne("GNSS_PPP_CLAS_ATMOS_LIFECYCLE");
     overrides.clas_code_sd =
         envExactOne("GNSS_PPP_CLAS_CODE_SD") ||
         overrides.clas_code_row_sd;

--- a/src/algorithms/ppp_osr.cpp
+++ b/src/algorithms/ppp_osr.cpp
@@ -499,6 +499,10 @@ std::map<std::string, std::string> selectClasEpochAtmosTokens(
             if (!correction.atmos_valid || correction.atmos_tokens.empty()) {
                 continue;
             }
+            if (pppEnvOverrides().clas_atmos_lifecycle &&
+                correction.time > time + 1e-9) {
+                continue;
+            }
             const double time_gap = std::abs(correction.time - time);
             if (time_gap > kAtmosSelectionGapSeconds) {
                 continue;
@@ -509,8 +513,11 @@ std::map<std::string, std::string> selectClasEpochAtmosTokens(
                 correction.atmos_tokens, receiver_position, grid_reference);
             const double grid_distance_sq =
                 has_grid
-                    ? (grid_reference.dlat_deg * grid_reference.dlat_deg +
-                       grid_reference.dlon_deg * grid_reference.dlon_deg)
+                    ? (pppEnvOverrides().clas_atmos_lifecycle
+                           ? grid_reference.nearest_grid_distance_m *
+                                 grid_reference.nearest_grid_distance_m
+                           : grid_reference.dlat_deg * grid_reference.dlat_deg +
+                                 grid_reference.dlon_deg * grid_reference.dlon_deg)
                     : std::numeric_limits<double>::infinity();
             const ClasAtmosCandidate candidate{
                 correction.atmos_tokens,
@@ -591,7 +598,7 @@ std::vector<OSRCorrection> computeOSR(
     const ObservationData& obs,
     const NavigationData& nav,
     const SSRProducts& ssr,
-    const std::map<std::string, std::string>& atmos_tokens,
+    const std::map<std::string, std::string>& epoch_atmos_tokens,
     const Vector3d& receiver_pos,
     double receiver_clk,
     double trop_zenith,
@@ -604,7 +611,7 @@ std::vector<OSRCorrection> computeOSR(
     std::vector<OSRCorrection> corrections;
     int preferred_network_id = 0;
     ppp_atmosphere::parseAtmosTokenInt(
-        atmos_tokens, "atmos_network_id", preferred_network_id);
+        epoch_atmos_tokens, "atmos_network_id", preferred_network_id);
 
     for (const auto& sat : obs.getSatellites()) {
         OSRCorrection osr;
@@ -764,6 +771,17 @@ std::vector<OSRCorrection> computeOSR(
             }
             continue;
         }
+        if (pppEnvOverrides().clas_atmos_lifecycle &&
+            !epoch_atmos_tokens.empty()) {
+            atmos_tokens = epoch_atmos_tokens;
+            int lifecycle_tow = 0;
+            if (ppp_atmosphere::parseAtmosTokenInt(
+                    atmos_tokens, "atmos_lifecycle_tow", lifecycle_tow)) {
+                osr.atmos_reference_time = GNSSTime(obs.time.week, lifecycle_tow);
+            } else {
+                osr.atmos_reference_time = obs.time;
+            }
+        }
 
         const auto ssr_timing_policy = config.clas_ssr_timing_policy;
         const bool clock_ref_valid = gnsstimeIsSet(osr.clock_reference_time);
@@ -780,8 +798,15 @@ std::vector<OSRCorrection> computeOSR(
             clock_ref_valid &&
             atmos_ref_valid &&
             osr.atmos_reference_time != osr.clock_reference_time) {
-            atmos_tokens.clear();
-            osr.atmos_reference_time = GNSSTime();
+            const bool lifecycle_atmos =
+                pppEnvOverrides().clas_atmos_lifecycle &&
+                atmos_tokens.find("atmos_lifecycle") != atmos_tokens.end();
+            const double atmos_clock_gap =
+                std::abs(osr.atmos_reference_time - osr.clock_reference_time);
+            if (!lifecycle_atmos || atmos_clock_gap > 30.0) {
+                atmos_tokens.clear();
+                osr.atmos_reference_time = GNSSTime();
+            }
         }
 
         osr.satellite_position = sat_pos;

--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -2218,7 +2218,8 @@ bool SSRProducts::loadCSVFile(const std::string& filename) {
                 last_atmos = entry.atmos_tokens;
                 last_atmos_network_id = entry.atmos_network_id;
                 has_last_atmos = true;
-            } else if (has_last_atmos && !entry.atmos_valid && entry.clock_valid) {
+            } else if (has_last_atmos && !entry.atmos_valid && entry.clock_valid &&
+                       last_atmos.find("atmos_lifecycle") == last_atmos.end()) {
                 entry.atmos_tokens = last_atmos;
                 entry.atmos_network_id = last_atmos_network_id;
                 entry.atmos_valid = true;


### PR DESCRIPTION
## Summary

S36 (issue #8) — closes the STEC content surface completely, and in doing so isolates the true remaining blocker.

### What ships (default OFF, end-to-end bit-exact off)

`GNSS_PPP_CLAS_ATMOS_LIFECYCLE=1`: the CSV generator materializes CLASLIB-style **latest-bank** atmosphere rows (network/grid/sat keys, subtype 8/9/12 updates, 30 s trop validity, 3600 s STEC lifetime, coefficient-only snapshots never grid-backed); native consumes per-grid STEC with causal bank selection.

### Content parity: solved exactly

| run | applied-iono diff RMS vs CLASLIB | early window |
|---|---:|---:|
| baseline | 5.2166 m | 4.0766 m |
| #164 matrix gate | 0.9157 m | 1.0077 m |
| **lifecycle (±matrix)** | **0.000000 m** | **0.000001 m** |

Remaining content deltas anywhere: trop 0.039 m RMS, total `prc` 0.336 m RMS.

### The paradox that defines the next slice

With CLASLIB-identical iono applied, **position regresses** (249 fixed, fixed V/3D 2.855/2.960 m vs baseline 301/0.376/0.935). The correction chain is exonerated end-to-end; the blocker is the **iono state handling**: native free-estimates ionosphere on top of the corrections (`--estimate-ionosphere`), while CLASLIB constrains its iono states with the STEC values and variances. Filter-side STEC-constraint parity is the next surface.

## Verification

- Default CLAS and MADOCA 1h **bit-exact** (full rebuild); `run_tests` 319 passed; CLI `-k clas / qzss_l6 / madoca` pass; `git diff --check` clean

Refs #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)