### PR TITLE
feat(clas): STEC-constraint preview; iono-state model audit (negative result)

### DIFF
--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -233,6 +233,8 @@ private:
     std::vector<Vector3d> recent_positions_;
     GNSSTime last_processed_time_;
     bool has_last_processed_time_ = false;
+    int last_clas_atmos_network_id_ = -1;
+    bool has_last_clas_atmos_network_id_ = false;
     bool precise_products_loaded_ = false;
     bool ssr_products_loaded_ = false;
     bool require_coherent_ssr_ = false;

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -229,6 +229,10 @@ struct PPPEnvOverrides {
     // selection when set exactly to "1". Default false while issue #8 parity
     // is measured; exact "0" preserves legacy CSV artifact semantics.
     bool clas_atmos_lifecycle = false;
+    // GNSS_PPP_CLAS_STEC_CONSTRAINT: preview CLASLIB-style STEC constraints
+    // on estimated CLAS ionosphere states when set exactly to "1". Default
+    // false while issue #8 filter-side parity is measured.
+    bool clas_stec_constraint = false;
     // GNSS_PPP_CLAS_QZSS_S_PRN_FIX: map compact CLAS legacy S120..S122
     // correction labels to QZSS J01..J03 when set exactly to "1".
     // Default false while row-set parity is measured.

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -711,6 +711,8 @@ void PPPProcessor::reset() {
     recent_positions_.clear();
     has_last_processed_time_ = false;
     last_processed_time_ = GNSSTime();
+    last_clas_atmos_network_id_ = -1;
+    has_last_clas_atmos_network_id_ = false;
     precise_products_loaded_ = !precise_products_.orbit_clock_data.empty();
     ssr_products_loaded_ = !ssr_products_.orbit_clock_corrections.empty();
     ionex_products_loaded_ = !ionex_products_.tec_maps.empty();

--- a/src/algorithms/ppp_clas.cpp
+++ b/src/algorithms/ppp_clas.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <cstdlib>
 #include <sstream>
 #include <fstream>
 #include <iomanip>
@@ -67,6 +68,65 @@ struct PhasePairInfo {
 double elevationWeight(double elevation_rad) {
     const double s = std::sin(elevation_rad);
     return 1.0 / (s * s);
+}
+
+bool usesClasStecConstraint(const ppp_shared::PPPConfig& config) {
+    return pppEnvOverrides().clas_stec_constraint &&
+           config.estimate_ionosphere &&
+           config.use_clas_osr_filter;
+}
+
+double cssrStecQualityStdTecu(int quality) {
+    const int cls = (quality >> 3) & 0x7;
+    const int val = quality & 0x7;
+    if ((cls == 0 && val == 0) || (cls == 7 && val == 7)) {
+        return std::numeric_limits<double>::infinity();
+    }
+    return (1.0 + 0.25 * static_cast<double>(val)) *
+               std::pow(3.0, static_cast<double>(cls)) -
+           1.0;
+}
+
+double tecuStdToDelayVarianceM2(double sigma_tecu, double frequency_hz) {
+    if (!std::isfinite(sigma_tecu) || sigma_tecu < 0.0 || frequency_hz <= 0.0) {
+        return std::numeric_limits<double>::infinity();
+    }
+    constexpr double kTecuToElectrons = 1e16;
+    const double sigma_m =
+        40.3 * kTecuToElectrons * sigma_tecu / (frequency_hz * frequency_hz);
+    return sigma_m * sigma_m;
+}
+
+double clasStecConstraintVariance(
+    const std::map<std::string, std::string>& epoch_atmos,
+    const OSRCorrection& osr,
+    const ppp_shared::PPPConfig& config) {
+    constexpr double kClaslibStdIonoM = 0.010;
+    constexpr double kClaslibMinVarianceM2 = kClaslibStdIonoM * kClaslibStdIonoM;
+    const std::string key = "atmos_stec_quality:" + osr.satellite.toString();
+    const auto quality_it = epoch_atmos.find(key);
+    if (quality_it != epoch_atmos.end()) {
+        const int quality = std::atoi(quality_it->second.c_str());
+        const double quality_variance =
+            tecuStdToDelayVarianceM2(
+                cssrStecQualityStdTecu(quality),
+                osr.frequencies[0]);
+        if (std::isfinite(quality_variance) && quality_variance > 0.0) {
+            return std::max(kClaslibMinVarianceM2, quality_variance);
+        }
+    }
+    if (config.clas_iono_prior_variance > 0.0) {
+        return std::min(config.clas_iono_prior_variance, kClaslibMinVarianceM2);
+    }
+    return kClaslibMinVarianceM2;
+}
+
+double effectiveClasIonoProcessNoise(const ppp_shared::PPPConfig& config) {
+    if (usesClasStecConstraint(config)) {
+        constexpr double kClaslibPrnIonoStdM = 0.001;
+        return kClaslibPrnIonoStdM * kClaslibPrnIonoStdM;
+    }
+    return config.process_noise_ionosphere;
 }
 
 std::ofstream* ambDatumDumpStream() {
@@ -554,9 +614,11 @@ void predictFilterState(
     Q(filter_state.trop_index, filter_state.trop_index) =
         effectiveClasTropProcessNoise(config) * dt;
     if (config.estimate_ionosphere) {
+        const double iono_process_noise =
+            effectiveClasIonoProcessNoise(config);
         for (const auto& [_, state_index] : filter_state.ionosphere_indices) {
             if (state_index >= 0 && state_index < nx) {
-                Q(state_index, state_index) = config.process_noise_ionosphere * dt;
+                Q(state_index, state_index) = iono_process_noise * dt;
             }
         }
     }
@@ -694,6 +756,9 @@ MeasurementBuildResult buildEpochMeasurements(
     const AmbiguityResetFunction& ambiguity_reset_function,
     bool debug_enabled) {
     MeasurementBuildResult result;
+    const bool stec_constraint = usesClasStecConstraint(config);
+    std::map<SatelliteId, double> iono_state_targets_m;
+    std::map<SatelliteId, double> iono_state_variances_m2;
 
     for (const auto& osr : osr_corrections) {
         if (!osr.valid) {
@@ -728,12 +793,21 @@ MeasurementBuildResult buildEpochMeasurements(
             if (!raw || !raw->valid) {
                 continue;
             }
-            const auto applied_corrections = selectAppliedOsrCorrections(
-                osr, f, config.clas_correction_application_policy);
             const double iono_scale =
                 (osr.frequencies[f] > 0.0 && osr.wavelengths[0] > 0.0)
                     ? std::pow(osr.wavelengths[f] / osr.wavelengths[0], 2)
                     : 1.0;
+            auto applied_corrections = selectAppliedOsrCorrections(
+                osr, f, config.clas_correction_application_policy);
+            if (stec_constraint && use_residual_iono_state &&
+                osr.has_iono && std::isfinite(osr.iono_l1_m)) {
+                const double iono_scaled = iono_scale * osr.iono_l1_m;
+                applied_corrections.pseudorange_correction_m -= iono_scaled;
+                applied_corrections.carrier_phase_correction_m += iono_scaled;
+                iono_state_targets_m[osr.satellite] = osr.iono_l1_m;
+                iono_state_variances_m2[osr.satellite] =
+                    clasStecConstraintVariance(epoch_atmos, osr, config);
+            }
             const double iono_state_m =
                 use_residual_iono_state ? filter_state.state(iono_state_index) : 0.0;
 
@@ -972,8 +1046,14 @@ MeasurementBuildResult buildEpochMeasurements(
             MeasurementRow row;
             row.H = Eigen::RowVectorXd::Zero(filter_state.total_states);
             row.H(iono_state_index) = 1.0;
-            row.residual = -filter_state.state(iono_state_index);
-            row.variance = config.clas_iono_prior_variance;
+            const auto target_it = iono_state_targets_m.find(satellite);
+            const double target_m =
+                target_it != iono_state_targets_m.end() ? target_it->second : 0.0;
+            row.residual = target_m - filter_state.state(iono_state_index);
+            const auto variance_it = iono_state_variances_m2.find(satellite);
+            row.variance = variance_it != iono_state_variances_m2.end()
+                ? variance_it->second
+                : config.clas_iono_prior_variance;
             row.satellite = satellite;
             row.is_phase = false;
             row.freq_index = -1;

--- a/src/algorithms/ppp_clas_epoch.cpp
+++ b/src/algorithms/ppp_clas_epoch.cpp
@@ -10,6 +10,7 @@
 #include <libgnss++/core/signals.hpp>
 
 #include <algorithm>
+#include <cstdlib>
 #include <cmath>
 #include <fstream>
 #include <iomanip>
@@ -152,6 +153,25 @@ void dumpClasFloatPosition(
           << dx.z() << '\n';
 }
 
+bool readClasAtmosNetworkId(
+    const std::map<std::string, std::string>& epoch_atmos,
+    int& network_id) {
+    const auto network_it = epoch_atmos.find("atmos_network_id");
+    if (network_it == epoch_atmos.end()) {
+        return false;
+    }
+    network_id = std::atoi(network_it->second.c_str());
+    return true;
+}
+
+void resetClasIonosphereStateValues(PPPState& filter_state) {
+    for (const auto& [_, state_index] : filter_state.ionosphere_indices) {
+        if (state_index >= 0 && state_index < filter_state.total_states) {
+            filter_state.state(state_index) = 0.0;
+        }
+    }
+}
+
 }  // namespace
 
 PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
@@ -187,6 +207,8 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         std::map<SatelliteId, CLASPhaseBiasRepairInfo> phase_bias_repair;
         bool has_last_processed_time = false;
         GNSSTime last_processed_time;
+        int last_clas_atmos_network_id = -1;
+        bool has_last_clas_atmos_network_id = false;
     };
     const ClasFallbackSnapshot fallback_snapshot{
         filter_state_,
@@ -201,6 +223,8 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         clas_phase_bias_repair_,
         has_last_processed_time_,
         last_processed_time_,
+        last_clas_atmos_network_id_,
+        has_last_clas_atmos_network_id_,
     };
     const auto restore_clas_snapshot = [&]() {
         filter_state_ = fallback_snapshot.filter_state;
@@ -215,6 +239,10 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         clas_phase_bias_repair_ = fallback_snapshot.phase_bias_repair;
         has_last_processed_time_ = fallback_snapshot.has_last_processed_time;
         last_processed_time_ = fallback_snapshot.last_processed_time;
+        last_clas_atmos_network_id_ =
+            fallback_snapshot.last_clas_atmos_network_id;
+        has_last_clas_atmos_network_id_ =
+            fallback_snapshot.has_last_clas_atmos_network_id;
     };
     const bool allow_hybrid_fallback =
         ppp_config_.clas_epoch_policy ==
@@ -264,6 +292,20 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         clas_phase_bias_repair_);
     const auto& epoch_atmos = epoch_context.epoch_atmos_tokens;
     const auto& osr_corrections = epoch_context.osr_corrections;
+
+    if (pppEnvOverrides().clas_stec_constraint &&
+        ppp_config_.estimate_ionosphere &&
+        ppp_config_.use_clas_osr_filter) {
+        int network_id = -1;
+        if (readClasAtmosNetworkId(epoch_atmos, network_id)) {
+            if (has_last_clas_atmos_network_id_ &&
+                network_id != last_clas_atmos_network_id_) {
+                resetClasIonosphereStateValues(filter_state_);
+            }
+            last_clas_atmos_network_id_ = network_id;
+            has_last_clas_atmos_network_id_ = true;
+        }
+    }
 
     if (osr_corrections.size() < 4) {
         if (allow_hybrid_fallback) {

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -246,6 +246,8 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
         envExactOne("GNSS_PPP_CLAS_ATMOS_GRID_MATRIX");
     overrides.clas_atmos_lifecycle =
         envExactOne("GNSS_PPP_CLAS_ATMOS_LIFECYCLE");
+    overrides.clas_stec_constraint =
+        envExactOne("GNSS_PPP_CLAS_STEC_CONSTRAINT");
     overrides.clas_code_sd =
         envExactOne("GNSS_PPP_CLAS_CODE_SD") ||
         overrides.clas_code_row_sd;


### PR DESCRIPTION
## Summary

S37 (issue #8) — audits CLASLIB's iono-state model and tests a native STEC-constraint equivalent. Negative result: the exact-content + constraint stack still fails the standing rule, so it ships default OFF.

### CLASLIB iono-state audit

`pos1-ionoopt=est-adaptive` — there is **no standalone STEC pseudo-observation row** in `ppprtk.c`. STEC is applied through OSR code/phase corrections; iono residual states are estimated in the DD filter (init 1e-6, `stats-stdiono` 0.010 m, adaptive process noise 0.001…0.050), **zeroed** (values only) on CSSR network change. AR fixes ambiguities only; iono states ride unfixed in the head copy.

### Preview result (default OFF)

| run | fixed | fixed H/V/3D | all 3D |
|---|---:|---|---|
| baseline | 301 | 0.856 / 0.376 / 0.935 | 0.998 |
| lifecycle+matrix (exact content) | 249 | 0.783 / 2.855 / 2.960 | 2.946 |
| + STEC constraint | 247 | 2.449 / 2.257 / 3.330 | 3.041 |
| legacy + STEC constraint | 292 | 1.449 / 1.252 / 1.915 | 1.896 |

The constraint loses 238 baseline-fixed epochs; NL ratios collapse (G14-ref 2.36/2.57 → 1.03/1.00). The blocker is **AR/filter equilibrium under exact CLAS iono**, not STEC content or absolute-STEC state constraints.

## Verification

- Default and MADOCA 1h **bit-exact**; `run_tests` 319 passed; CLI `-k clas / qzss_l6 / madoca` pass; `git diff --check` clean

Refs #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)