### PR TITLE
docs(readme): note C++20 toolkit standard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # libgnss++
 
-Modern C++17 GNSS toolkit for non-GUI positioning.
+Modern C++20 GNSS toolkit for non-GUI positioning.
 
 Native `SPP`, `RTK`, `PPP`, `CLAS/MADOCA`, `RTCM`, `UBX`, and direct `QZSS L6`
 handling without an external RTKLIB runtime.


### PR DESCRIPTION
Follow-up to #169. The README tagline still said "Modern C++17"; updated to "Modern C++20" to match `CMAKE_CXX_STANDARD 20` in the root and ros2 CMakeLists.

No code change. Sole edit is the README line 3 tagline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)