### PR TITLE
feat(clas): A0 DD PPP-RTK filter scaffold (gated, #168)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,6 +69,7 @@ set(GNSS_SOURCES
     src/algorithms/ppp_ar.cpp
     src/algorithms/ppp_atmosphere.cpp
     src/algorithms/ppp_clas.cpp
+    src/algorithms/ppp_clas_dd.cpp
     src/algorithms/ppp_clas_sd.cpp
     src/algorithms/ppp_osr.cpp
     src/algorithms/ppp_wlnl.cpp

--- a/docs/clas_dd_filter_audit.md
+++ b/docs/clas_dd_filter_audit.md
@@ -1,0 +1,259 @@
+# CLAS DD PPP-RTK Filter A0 Audit
+
+This note audits the CLASLIB DD PPP-RTK filter that Option A will port behind
+`GNSS_PPP_CLAS_DD_FILTER`, and maps it to the native CLAS PPP path in
+libgnss++. A0 only adds the gated scaffold; A1 is the DD measurement-update
+slice.
+
+## CLASLIB State Layout
+
+CLASLIB's CLAS PPP-RTK path lives in `/tmp/claslib/src/ppprtk.c` and uses the
+RTKLIB/CLAS state index macros from `/tmp/claslib/src/cssr2osr.h`.
+
+The relevant macros are:
+
+- `NP(opt) = dynamics ? 9 : 3`, position-only for static mode and
+  position/velocity/acceleration for dynamics
+  (`/tmp/claslib/src/cssr2osr.h:14`).
+- `NF(opt) = opt->nf` (`/tmp/claslib/src/cssr2osr.h:15`).
+- `IC(s,opt) = NP(opt) + s` and `IT(opt) = IC(0,opt) + NSYS`, inherited
+  receiver-clock/trop macros from the PPP family
+  (`/tmp/claslib/src/cssr2osr.h:16` and
+  `/tmp/claslib/src/cssr2osr.h:17`).
+- `NI(opt) = MAXSAT` only for `IONOOPT_EST` or `IONOOPT_EST_ADPT`;
+  otherwise zero (`/tmp/claslib/src/cssr2osr.h:18`).
+- `NT(opt) = 0/1/3` for no trop, ZTD, or ZTD+gradients
+  (`/tmp/claslib/src/cssr2osr.h:19`).
+- `NL(opt) = NFREQGLO` only for GLONASS autocal mode
+  (`/tmp/claslib/src/cssr2osr.h:20`).
+- `NR(opt) = NP + NI + NT + NL`, and `NX(opt) = NR + MAXSAT * NF`
+  (`/tmp/claslib/src/cssr2osr.h:21-23`).
+- `II(s,opt) = NP + s - 1` for per-satellite ionosphere, 1-based satno
+  (`/tmp/claslib/src/cssr2osr.h:24`).
+- `ITT(opt) = NP + NI` for the active troposphere block
+  (`/tmp/claslib/src/cssr2osr.h:25`).
+- `IB(s,f,opt) = NR + MAXSAT * f + s - 1` for per-satellite,
+  per-frequency phase-bias/ambiguity states
+  (`/tmp/claslib/src/cssr2osr.h:26`).
+
+Audit finding: although `IC()`/`IT()` are defined in the shared header,
+`ppprtk.c`'s active `NX()` layout does not include receiver-clock states because
+the CLAS measurement update is double-differenced and receiver clocks cancel.
+The active non-ambiguity block is `position/dynamics + II + ITT + optional NL`;
+`ppprtk.c` traces `x(0)` through `NR(opt)` before the ambiguity block
+(`/tmp/claslib/src/ppprtk.c:1558`), and `ppp_rtk_nx()` returns `NX(opt)`
+(`/tmp/claslib/src/ppprtk.c:1360-1364`).
+
+## CLASLIB State Time Update
+
+`initx()` sets one state value and zeros all covariance cross terms for that
+state (`/tmp/claslib/src/ppprtk.c:181-187`).
+
+Position and dynamics:
+
+- Fixed mode pins position to `opt.ru` with tiny variance
+  (`/tmp/claslib/src/ppprtk.c:201-204`).
+- First epoch initializes position from `rtk->sol.rr` with `VAR_POS`; dynamic
+  mode also initializes velocity and acceleration
+  (`/tmp/claslib/src/ppprtk.c:207-214`).
+- Large mean position variance resets position/velocity/acceleration
+  (`/tmp/claslib/src/ppprtk.c:217-228`).
+- Dynamic mode propagates position/velocity/acceleration with an `F` matrix
+  (`/tmp/claslib/src/ppprtk.c:230-295`).
+- Dynamic process noise uses `prn[3]` and `prn[4]` for acceleration
+  (`/tmp/claslib/src/ppprtk.c:297-304`).
+- Static/non-dynamic position process noise uses `prn[5]` and `prn[6]`;
+  if `prnadpt` is enabled, the accumulated adaptive `rtk->Q` block is used
+  instead (`/tmp/claslib/src/ppprtk.c:305-318`).
+
+Troposphere:
+
+- `udtrop()` initializes `ITT()` to `INIT_ZWD` with `std[2]^2`; gradients, when
+  enabled, initialize to `1E-6` with `VAR_GRA`
+  (`/tmp/claslib/src/ppprtk.c:323-338`).
+- Existing ZTD gets `prn[2]^2 * tt`; gradients get
+  `(0.3 * prn[2])^2 * |tt|` (`/tmp/claslib/src/ppprtk.c:339-345`).
+- When CLAS trop SSR is valid at first reset, `ppp_rtk_pos()` can zero the ZTD
+  state variance/process noise (`/tmp/claslib/src/ppprtk.c:1594-1601`).
+
+Ionosphere:
+
+- `udion()` resets `II(s)` to zero if an observed satellite exceeds the outage
+  counter (`/tmp/claslib/src/ppprtk.c:357-371`).
+- New ionosphere states initialize to `1E-6` with `std[1]^2`
+  (`/tmp/claslib/src/ppprtk.c:374-379`).
+- Normal iono process noise is `prn[1]^2 * cos(el)^2`.
+  `IONOOPT_EST_ADPT` keeps an adaptive per-state `rtk->Q`, clamped between
+  `prn[1]^2` and `prn[7]^2` before adding `qi * tt` to covariance
+  (`/tmp/claslib/src/ppprtk.c:381-401`).
+- After the float update, `IONOOPT_EST_ADPT` updates each iono process-noise
+  entry from the posterior covariance using `forgetion` and `afgainion`
+  (`/tmp/claslib/src/ppprtk.c:1653-1659`).
+- A CLAS grid/network change zeros every `II()` state
+  (`/tmp/claslib/src/ppprtk.c:1506-1511`).
+
+Ambiguities / phase bias:
+
+- `udbias_ppp()` clears slip/reset flags, detects LLI and geometry-free slips,
+  then increments outage counters (`/tmp/claslib/src/ppprtk.c:470-489`).
+- Instantaneous AR or max-outage resets an `IB(s,f)` state to zero and resets
+  lock count (`/tmp/claslib/src/ppprtk.c:491-509`).
+- Each observed ambiguity gets `prn[0]^2 * tt` process noise, and slip resets
+  the state to zero (`/tmp/claslib/src/ppprtk.c:511-520`).
+- Initial ambiguity value is `(phase_m - code_m - common_bias) / wavelength`,
+  so the `IB()` state is in cycles; `ddres()` later multiplies it by wavelength
+  (`/tmp/claslib/src/ppprtk.c:524-548` and
+  `/tmp/claslib/src/ppprtk.c:985-991`).
+
+Top-level reset semantics:
+
+- Time gaps beyond `maxobsloss` zero every state
+  (`/tmp/claslib/src/ppprtk.c:1471-1475`).
+- Periodic reset zeros every state, clears CSSR state, and returns a single
+  solution (`/tmp/claslib/src/ppprtk.c:1477-1489`).
+- `nav->filreset` zeros all non-position states in static mode, or all states
+  in dynamics mode (`/tmp/claslib/src/ppprtk.c:1493-1503`).
+- `udstate_ppp()` applies position, trop, ambiguity, then ionosphere time
+  updates in that order (`/tmp/claslib/src/ppprtk.c:557-578`).
+
+## CLASLIB DD Residual Model
+
+`ddres()` is the core CLAS DD measurement builder
+(`/tmp/claslib/src/ppprtk.c:794-1032`).
+
+Reference-satellite selection:
+
+- Rows are grouped by system group `m` and by `f` over phase and code
+  (`/tmp/claslib/src/ppprtk.c:832-847`).
+- For each group, the reference satellite is the valid satellite with highest
+  elevation; stale SSR channels and QZSS mode rules are filtered before
+  selection (`/tmp/claslib/src/ppprtk.c:847-880`).
+- The selected reference is remembered in `refsat`/`refsat2`; reference changes
+  are logged and can trigger phase-bias reinitialization in merged L6 channel
+  mode (`/tmp/claslib/src/ppprtk.c:884-946`).
+
+Row formation:
+
+- Each row is a single/double difference of zero-difference residuals:
+  reference minus target satellite (`/tmp/claslib/src/ppprtk.c:954-959`).
+- Position partials are `-e_ref + e_sat`
+  (`/tmp/claslib/src/ppprtk.c:961-963`).
+- Ionosphere contributes opposite signs for phase/code and scales by
+  `(lambda_f/lambda_L1)^2 * ionmapf`; `II(ref)` and `II(sat)` get opposite
+  columns (`/tmp/claslib/src/ppprtk.c:965-975`).
+- Troposphere subtracts mapped reference-target trop and writes derivatives
+  into `ITT()+k` (`/tmp/claslib/src/ppprtk.c:977-984`).
+- Phase rows subtract `lambda_ref * IB(ref,f) - lambda_sat * IB(sat,f)` and
+  write the same signed wavelengths into `H`
+  (`/tmp/claslib/src/ppprtk.c:985-991`).
+- Code rows have no ambiguity column.
+- Phase and code variances are elevation-weighted through `varerr()`; L2 phase
+  gets an extra `(2.55/1.55)^2` factor (`/tmp/claslib/src/ppprtk.c:997-1008`).
+- `ddcov()` combines per-satellite `Ri`/`Rj` terms into the DD covariance
+  (`/tmp/claslib/src/ppprtk.c:1026-1027`).
+
+`varerr()` itself switches between extended code/phase error models and the
+normal RTKLIB model, adds iono/trop error terms when those states are not
+estimated, and weights by `1/sin(el)^2`
+(`/tmp/claslib/src/ppprtk.c:130-178`).
+
+Filter and fixed-state publication:
+
+- `ppp_rtk_pos()` builds zero-difference OSR residuals, calls `ddres()` for the
+  DD design matrix, runs `filter2()`, re-evaluates postfit DD rows, and accepts
+  the float update when chi-square passes (`/tmp/claslib/src/ppprtk.c:1575-1640`).
+- On success it commits `xp/Pp` back to `rtk->x/P`
+  (`/tmp/claslib/src/ppprtk.c:1670-1675`).
+- `resamb_LAMBDA()` builds a single-to-DD ambiguity transform, extracts `Qb`
+  and `Qab`, runs LAMBDA, conditions `xa/Pa`, and restores single-difference
+  ambiguity states (`/tmp/claslib/src/ppprtk.c:1166-1265`).
+- Fixed postfit residuals call `ddres()` again on `xa`; accepted fixed states
+  become `SOLQ_FIX`, and hold feedback can apply ambiguity constraints
+  (`/tmp/claslib/src/ppprtk.c:1702-1768`).
+
+## Native CLAS Path
+
+Native PPP state:
+
+- `PPPState` stores position, velocity, receiver clocks, ZTD, optional
+  ionosphere states, and dynamically appended ambiguity maps
+  (`include/libgnss++/algorithms/ppp_shared.hpp:282-303`).
+- Standard PPP initialization reserves receiver clock states first, then
+  optional ionosphere states, then ambiguity states
+  (`src/algorithms/ppp_state.cpp:300-389`).
+- Standard prediction applies process noise to position/velocity, receiver
+  clocks, ISBs, ZTD, ambiguities, and ionosphere maps
+  (`src/algorithms/ppp_state.cpp:399-467`).
+
+Native CLAS float filter:
+
+- `processEpochCLAS()` drives CLAS epochs: SPP seed, cycle slips, CLAS
+  `prepareEpochState()`, OSR context construction, ambiguity-state allocation,
+  native measurement update, then optional WLNL AR
+  (`src/algorithms/ppp_clas_epoch.cpp:177-486`).
+- `prepareEpochState()` initializes and predicts the CLAS filter state, using
+  residual ionosphere satellites collected from observations/SSR products
+  (`src/algorithms/ppp_clas.cpp:459-517`).
+- CLAS initialization uses `[pos, GPS clock, GLO clock, ZTD, iono...]`, not the
+  CLASLIB fixed `II/IB` layout (`src/algorithms/ppp_clas.cpp:519-548`).
+- Native CLAS prediction uses white receiver-clock variance, ZTD process noise,
+  optional iono process noise, ambiguity process noise, and clock/position
+  decoupling (`src/algorithms/ppp_clas.cpp:604-647`).
+- OSR-corrected code/phase rows are built as undifferenced rows with receiver
+  clock columns, ZTD columns, iono columns, and ambiguity columns in meters
+  (`src/algorithms/ppp_clas.cpp:746-1005`).
+- Native CLAS adds trop and STEC pseudo-observation constraints
+  (`src/algorithms/ppp_clas.cpp:1008-1062`).
+- Carrier phase rows are single-differenced by system/signal by default, but
+  code rows stay undifferenced unless a parity gate requests code SD
+  (`src/algorithms/ppp_clas.cpp:1064-1140`).
+- The Kalman update is a normal linear update on native rows
+  (`src/algorithms/ppp_clas.cpp:1145-1205`).
+
+Current native AR:
+
+- CLAS per-frequency mode forces `DD_WLNL` in `processEpochCLAS()`
+  (`src/algorithms/ppp_clas_epoch.cpp:187-195`).
+- `resolveAmbiguitiesWLNL()` fixes WL integers from MW averages, then calls
+  `ppp_ar::resolveWlnlFix()` using native ambiguity states and OSR-derived NL
+  information (`src/algorithms/ppp_wlnl.cpp:113-212`).
+- `ppp_ar::tryDirectDdFix()` forms DD ambiguity pairs from the native ambiguity
+  map, builds DD covariance from native covariance, runs LAMBDA, and conditions
+  the native head state (`src/algorithms/ppp_ar.cpp:155-350`).
+- The current fixed-position WLS is post-hoc: `solveFixedPosition()` builds
+  fixed NL observations after the float filter state exists
+  (`src/algorithms/ppp_wlnl.cpp:214-240`).
+
+Architectural gap:
+
+- Native CLAS is an undifferenced/partly single-differenced float PPP filter
+  with receiver-clock states, meter-valued ambiguity states, and post-hoc
+  DD-WLNL AR.
+- CLASLIB `ppprtk.c` is a DD PPP-RTK filter: phase and code rows are DD before
+  the Kalman update, receiver-clock states cancel, `II()` and cycle-valued
+  `IB()` have fixed RTKLIB satno-indexed slots, and LAMBDA publishes a
+  constrained `xa` from that same DD covariance.
+- Therefore the A1 port should not only adjust AR. It must build the DD design
+  matrix and covariance first, then make AR consume that DD-native ambiguity
+  covariance.
+
+## A1 Entry Points
+
+1. `src/algorithms/ppp_clas_epoch.cpp`: the A0 hook returns immediately after
+   the native float update when `ppp_config_.use_clas_dd_filter` is true. A1
+   should replace this passthrough return with a DD prediction/update call fed
+   by `epoch_context`, `osr_corrections`, and `epoch_atmos`.
+2. `include/libgnss++/algorithms/ppp_clas_dd.hpp` and
+   `src/algorithms/ppp_clas_dd.cpp`: extend `DdFilterScaffold` from a
+   typed layout/snapshot into a persistent DD filter with CLASLIB-style
+   `udpos/udtrop/udion/udbias` equivalents.
+3. `src/algorithms/ppp_clas_dd.cpp`: add an A1 DD row builder matching
+   `ddres()` reference selection, phase+code differencing, `varerr()` weights,
+   and `II/ITT/IB` columns.
+4. `src/algorithms/ppp_atmosphere.cpp` / `prepareClasEpochContext()` wiring:
+   consume lifecycle atmosphere tokens already exposed as `epoch_atmos`; this is
+   where A1 should source the CLAS STEC/trop inputs instead of adding another
+   correction path.
+5. Keep `src/algorithms/ppp_wlnl.cpp` and `src/algorithms/ppp_ar.cpp` unchanged
+   until A2, when LAMBDA should be moved to the DD filter covariance rather than
+   the old native ambiguity datum.

--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -87,8 +87,10 @@ Proposed phases (each one slice, oracle-diffed, gated, reversible):
   layout (position, receiver clock per system, troposphere, per-sat iono `II`,
   DD ambiguities), process noise, and reset semantics with code refs.  Add the
   gated DD-filter skeleton that reproduces the float position of the current
-  path within noise when the integer step is disabled.  Reuse the lifecycle
-  atmosphere (#165) as the iono input.
+  path within noise when the integer step is disabled.  The A0 gate is
+  `GNSS_PPP_CLAS_DD_FILTER=1`; unset or exact `0` preserves the default
+  CLAS/MADOCA paths bit-exactly.  Reuse the lifecycle atmosphere (#165) as the
+  iono input.
 - **A1 — DD measurement update.** Form DD phase+code rows with reference-sat
   selection and elevation `varerr` weights matching `ddres()`; estimate the iono
   residual states under the `est-adaptive` process model rather than free

--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -6,6 +6,7 @@
 #include "../core/solution.hpp"
 #include "lambda.hpp"
 #include "ppp_ar.hpp"
+#include "ppp_clas_dd.hpp"
 #include "ppp_shared.hpp"
 #include "ppp_clas_sd.hpp"
 #include "ppp_osr_types.hpp"
@@ -65,7 +66,10 @@ public:
     /**
      * @brief Set PPP configuration
      */
-    void setPPPConfig(const PPPConfig& config) { ppp_config_ = config; }
+    void setPPPConfig(const PPPConfig& config) {
+        ppp_config_ = config;
+        applyEnvironmentOverridesToPPPConfig();
+    }
     
     /**
      * @brief Get PPP configuration
@@ -215,6 +219,8 @@ public:
     double getConvergenceTime() const { return convergence_time_; }
 
 private:
+    void applyEnvironmentOverridesToPPPConfig();
+
     PPPConfig ppp_config_;
     PPPEnvOverrides env_overrides_;
     SPPProcessor spp_processor_;  ///< Fallback SPP processor
@@ -293,6 +299,7 @@ private:
     std::map<SatelliteId, CLASPhaseBiasRepairInfo> clas_phase_bias_repair_;
     ppp_clas_sd::SdFilterState clas_sd_state_;  ///< Clock-free SD filter
     ppp_clas_sd::DdAmbAccumulator clas_dd_accumulator_;  ///< Multi-epoch DD amb accumulator
+    std::unique_ptr<ppp_clas_dd::DdFilterScaffold> clas_dd_filter_;
     PPPState last_clas_constrained_fixed_state_;
     bool last_clas_constrained_fixed_state_valid_ = false;
     int last_obs_gps_week_ = 0;  ///< GPS week from latest observation (for L6 decode)

--- a/include/libgnss++/algorithms/ppp_clas_dd.hpp
+++ b/include/libgnss++/algorithms/ppp_clas_dd.hpp
@@ -1,0 +1,98 @@
+#pragma once
+
+#include <libgnss++/algorithms/ppp_osr_types.hpp>
+#include <libgnss++/algorithms/ppp_shared.hpp>
+#include <libgnss++/core/solution.hpp>
+
+#include <map>
+#include <string>
+#include <vector>
+
+namespace libgnss::ppp_clas_dd {
+
+inline constexpr int kClaslibMaxSatellites = 221;
+inline constexpr int kClaslibSystemCount = 6;
+inline constexpr int kClaslibGlonassFrequencyBiasStates = 2;
+
+enum class IonosphereMode {
+    Off,
+    Estimate,
+    EstimateAdaptive,
+};
+
+enum class TroposphereMode {
+    Off,
+    EstimateZtd,
+    EstimateZtdGradients,
+};
+
+struct StateLayoutOptions {
+    bool dynamics = false;
+    int frequencies = 2;
+    IonosphereMode ionosphere_mode = IonosphereMode::EstimateAdaptive;
+    TroposphereMode troposphere_mode = TroposphereMode::EstimateZtd;
+    bool glonass_frequency_bias_states = false;
+    int max_satellites = kClaslibMaxSatellites;
+    int system_count = kClaslibSystemCount;
+};
+
+struct StateLayout {
+    StateLayoutOptions options;
+
+    int np() const;
+    int nf() const;
+    int ni() const;
+    int nt() const;
+    int nl() const;
+    int nb() const;
+    int nr() const;
+    int nx() const;
+
+    int receiverClockIndex(int system_index) const;
+    int macroTroposphereIndexAfterClocks() const;
+    int ionosphereIndex(int satno_one_based) const;
+    int troposphereIndex() const;
+    int ambiguityIndex(int satno_one_based, int frequency_index) const;
+    bool validSatelliteNumber(int satno_one_based) const;
+};
+
+int claslibSatelliteNumber(const SatelliteId& satellite);
+
+StateLayoutOptions layoutOptionsFromConfig(
+    const ppp_shared::PPPConfig& config,
+    const std::vector<OSRCorrection>& osr_corrections);
+
+struct StateSnapshot {
+    StateLayout layout;
+    GNSSTime time;
+    VectorXd state;
+    MatrixXd covariance;
+    std::vector<SatelliteId> observed_satellites;
+    bool seeded_from_native_float = false;
+    int native_total_states = 0;
+    int atmosphere_network_id = -1;
+    bool has_atmosphere_network_id = false;
+};
+
+class DdFilterScaffold {
+public:
+    PositionSolution processFloatPassthrough(
+        const GNSSTime& time,
+        const ppp_shared::PPPState& native_state,
+        const PositionSolution& native_float_solution,
+        const ppp_shared::PPPConfig& config,
+        const std::vector<OSRCorrection>& osr_corrections,
+        const std::map<std::string, std::string>& epoch_atmos);
+
+    const StateSnapshot& snapshot() const { return snapshot_; }
+    bool hasSnapshot() const { return has_snapshot_; }
+    void reset();
+
+private:
+    void ensureSnapshotStorage(const StateLayout& layout);
+
+    StateSnapshot snapshot_;
+    bool has_snapshot_ = false;
+};
+
+}  // namespace libgnss::ppp_clas_dd

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -170,6 +170,10 @@ struct PPPEnvOverrides {
     // CLASLIB-style filter-state DD ambiguity conditioning copy when set
     // exactly to "1". Default false while measured.
     bool clas_resamb = false;
+    // GNSS_PPP_CLAS_DD_FILTER: enable the experimental CLAS DD PPP-RTK filter
+    // scaffold when set exactly to "1". Default false; exact "0" and unset are
+    // no-ops for bit-exact legacy CLAS/MADOCA output.
+    bool clas_dd_filter = false;
     // GNSS_PPP_CLAS_AMB_DATUM: align CLAS OSR carrier phase ambiguity states
     // with CLASLIB by subtracting the full CPC before ambiguity estimation.
     // Default follows the residual-phase-trop surface; explicit boolean values

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -85,6 +85,7 @@ struct PPPConfig {
     std::string clock_file_path;
     bool use_ssr_corrections = false;
     bool use_clas_osr_filter = false;
+    bool use_clas_dd_filter = false;
     std::string ssr_file_path;
     int l6_gps_week = 0;  // GPS week for L6 binary decode (0 = auto-detect)
     Vector3d approximate_position = Vector3d::Zero();  // RINEX APPROX POS for L6 network selection

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -379,6 +379,7 @@ double clampDt(double dt) {
 
 PPPProcessor::PPPProcessor()
     : env_overrides_(PPPEnvOverrides::fromEnvironment()), spp_processor_() {
+    applyEnvironmentOverridesToPPPConfig();
     reset();
 }
 
@@ -386,7 +387,14 @@ PPPProcessor::PPPProcessor(const PPPConfig& ppp_config)
     : ppp_config_(ppp_config),
       env_overrides_(PPPEnvOverrides::fromEnvironment()),
       spp_processor_() {
+    applyEnvironmentOverridesToPPPConfig();
     reset();
+}
+
+void PPPProcessor::applyEnvironmentOverridesToPPPConfig() {
+    if (env_overrides_.clas_dd_filter) {
+        ppp_config_.use_clas_dd_filter = true;
+    }
 }
 
 bool PPPProcessor::initialize(const ProcessorConfig& config) {
@@ -708,6 +716,7 @@ void PPPProcessor::reset() {
     clas_dispersion_compensation_.clear();
     clas_sis_continuity_.clear();
     clas_phase_bias_repair_.clear();
+    clas_dd_filter_.reset();
     recent_positions_.clear();
     has_last_processed_time_ = false;
     last_processed_time_ = GNSSTime();

--- a/src/algorithms/ppp_clas_dd.cpp
+++ b/src/algorithms/ppp_clas_dd.cpp
@@ -1,0 +1,278 @@
+#include <libgnss++/algorithms/ppp_clas_dd.hpp>
+
+#include <algorithm>
+#include <cstdlib>
+
+namespace libgnss::ppp_clas_dd {
+namespace {
+
+constexpr int kMinPrnGps = 1;
+constexpr int kMaxPrnGps = 32;
+constexpr int kNsatGps = kMaxPrnGps - kMinPrnGps + 1;
+
+constexpr int kMinPrnGlo = 1;
+constexpr int kMaxPrnGlo = 27;
+constexpr int kNsatGlo = kMaxPrnGlo - kMinPrnGlo + 1;
+
+constexpr int kMinPrnGal = 1;
+constexpr int kMaxPrnGal = 36;
+constexpr int kNsatGal = kMaxPrnGal - kMinPrnGal + 1;
+
+constexpr int kMinPrnQzsClaslib = 193;
+constexpr int kMaxPrnQzsClaslib = 202;
+constexpr int kNsatQzs = kMaxPrnQzsClaslib - kMinPrnQzsClaslib + 1;
+
+constexpr int kMinPrnBds = 1;
+constexpr int kMaxPrnBds = 63;
+constexpr int kNsatBds = kMaxPrnBds - kMinPrnBds + 1;
+
+constexpr int kMinPrnSbas = 120;
+constexpr int kMaxPrnSbas = 158;
+constexpr int kNsatNavic = 14;
+
+int qzssPrnForClaslib(int prn) {
+    if (prn >= kMinPrnQzsClaslib && prn <= kMaxPrnQzsClaslib) {
+        return prn;
+    }
+    if (prn >= 1 && prn <= kNsatQzs) {
+        return kMinPrnQzsClaslib + prn - 1;
+    }
+    return 0;
+}
+
+bool readAtmosphereNetworkId(
+    const std::map<std::string, std::string>& epoch_atmos,
+    int& network_id) {
+    const auto it = epoch_atmos.find("atmos_network_id");
+    if (it == epoch_atmos.end()) {
+        return false;
+    }
+    char* end = nullptr;
+    const long parsed = std::strtol(it->second.c_str(), &end, 10);
+    if (end == it->second.c_str()) {
+        return false;
+    }
+    network_id = static_cast<int>(parsed);
+    return true;
+}
+
+}  // namespace
+
+int StateLayout::np() const {
+    return options.dynamics ? 9 : 3;
+}
+
+int StateLayout::nf() const {
+    return std::max(1, options.frequencies);
+}
+
+int StateLayout::ni() const {
+    return options.ionosphere_mode == IonosphereMode::Off ? 0 : options.max_satellites;
+}
+
+int StateLayout::nt() const {
+    switch (options.troposphere_mode) {
+        case TroposphereMode::Off:
+            return 0;
+        case TroposphereMode::EstimateZtd:
+            return 1;
+        case TroposphereMode::EstimateZtdGradients:
+            return 3;
+    }
+    return 0;
+}
+
+int StateLayout::nl() const {
+    return options.glonass_frequency_bias_states
+        ? kClaslibGlonassFrequencyBiasStates
+        : 0;
+}
+
+int StateLayout::nb() const {
+    return options.max_satellites * nf();
+}
+
+int StateLayout::nr() const {
+    return np() + ni() + nt() + nl();
+}
+
+int StateLayout::nx() const {
+    return nr() + nb();
+}
+
+int StateLayout::receiverClockIndex(int system_index) const {
+    return np() + system_index;
+}
+
+int StateLayout::macroTroposphereIndexAfterClocks() const {
+    return receiverClockIndex(0) + options.system_count;
+}
+
+int StateLayout::ionosphereIndex(int satno_one_based) const {
+    return validSatelliteNumber(satno_one_based) && ni() > 0
+        ? np() + satno_one_based - 1
+        : -1;
+}
+
+int StateLayout::troposphereIndex() const {
+    return nt() > 0 ? np() + ni() : -1;
+}
+
+int StateLayout::ambiguityIndex(int satno_one_based, int frequency_index) const {
+    if (!validSatelliteNumber(satno_one_based) ||
+        frequency_index < 0 ||
+        frequency_index >= nf()) {
+        return -1;
+    }
+    return nr() + options.max_satellites * frequency_index + satno_one_based - 1;
+}
+
+bool StateLayout::validSatelliteNumber(int satno_one_based) const {
+    return satno_one_based >= 1 && satno_one_based <= options.max_satellites;
+}
+
+int claslibSatelliteNumber(const SatelliteId& satellite) {
+    const int prn = static_cast<int>(satellite.prn);
+    if (prn <= 0) {
+        return 0;
+    }
+
+    switch (satellite.system) {
+        case GNSSSystem::GPS:
+            return prn <= kMaxPrnGps ? prn : 0;
+        case GNSSSystem::GLONASS:
+            return prn <= kMaxPrnGlo ? kNsatGps + prn : 0;
+        case GNSSSystem::Galileo:
+            return prn <= kMaxPrnGal ? kNsatGps + kNsatGlo + prn : 0;
+        case GNSSSystem::QZSS: {
+            const int claslib_prn = qzssPrnForClaslib(prn);
+            return claslib_prn == 0
+                ? 0
+                : kNsatGps + kNsatGlo + kNsatGal +
+                      (claslib_prn - kMinPrnQzsClaslib + 1);
+        }
+        case GNSSSystem::BeiDou:
+            return prn <= kMaxPrnBds
+                ? kNsatGps + kNsatGlo + kNsatGal + kNsatQzs + prn
+                : 0;
+        case GNSSSystem::SBAS:
+            return prn >= kMinPrnSbas && prn <= kMaxPrnSbas
+                ? kNsatGps + kNsatGlo + kNsatGal + kNsatQzs + kNsatBds +
+                      kNsatNavic + (prn - kMinPrnSbas + 1)
+                : 0;
+        default:
+            return 0;
+    }
+}
+
+StateLayoutOptions layoutOptionsFromConfig(
+    const ppp_shared::PPPConfig& config,
+    const std::vector<OSRCorrection>& osr_corrections) {
+    StateLayoutOptions options;
+    options.dynamics = config.kinematic_mode && config.use_dynamics_model;
+    options.ionosphere_mode = config.estimate_ionosphere
+        ? IonosphereMode::EstimateAdaptive
+        : IonosphereMode::Off;
+    options.troposphere_mode = config.estimate_troposphere
+        ? TroposphereMode::EstimateZtd
+        : TroposphereMode::Off;
+
+    int frequencies = config.use_ionosphere_free ? 1 : 2;
+    for (const auto& osr : osr_corrections) {
+        if (osr.valid) {
+            frequencies = std::max(frequencies, osr.num_frequencies);
+        }
+    }
+    options.frequencies = std::max(1, frequencies);
+    return options;
+}
+
+void DdFilterScaffold::ensureSnapshotStorage(const StateLayout& layout) {
+    const int nx = layout.nx();
+    if (!has_snapshot_ || snapshot_.state.size() != nx) {
+        snapshot_.state = VectorXd::Zero(nx);
+        snapshot_.covariance = MatrixXd::Zero(nx, nx);
+    } else {
+        snapshot_.state.setZero();
+        snapshot_.covariance.setZero();
+    }
+    snapshot_.layout = layout;
+    has_snapshot_ = true;
+}
+
+PositionSolution DdFilterScaffold::processFloatPassthrough(
+    const GNSSTime& time,
+    const ppp_shared::PPPState& native_state,
+    const PositionSolution& native_float_solution,
+    const ppp_shared::PPPConfig& config,
+    const std::vector<OSRCorrection>& osr_corrections,
+    const std::map<std::string, std::string>& epoch_atmos) {
+    const StateLayout layout{layoutOptionsFromConfig(config, osr_corrections)};
+    ensureSnapshotStorage(layout);
+
+    snapshot_.time = time;
+    snapshot_.observed_satellites.clear();
+    snapshot_.observed_satellites.reserve(osr_corrections.size());
+    snapshot_.seeded_from_native_float = true;
+    snapshot_.native_total_states = native_state.total_states;
+    snapshot_.has_atmosphere_network_id =
+        readAtmosphereNetworkId(epoch_atmos, snapshot_.atmosphere_network_id);
+
+    if (native_state.state.size() >= native_state.pos_index + 3) {
+        snapshot_.state.segment(0, 3) =
+            native_state.state.segment(native_state.pos_index, 3);
+    }
+    if (native_state.covariance.rows() >= native_state.pos_index + 3 &&
+        native_state.covariance.cols() >= native_state.pos_index + 3) {
+        snapshot_.covariance.block(0, 0, 3, 3) =
+            native_state.covariance.block(native_state.pos_index, native_state.pos_index, 3, 3);
+    }
+
+    const int trop_index = layout.troposphereIndex();
+    if (trop_index >= 0 &&
+        native_state.trop_index >= 0 &&
+        native_state.state.size() > native_state.trop_index) {
+        snapshot_.state(trop_index) = native_state.state(native_state.trop_index);
+        if (native_state.covariance.rows() > native_state.trop_index &&
+            native_state.covariance.cols() > native_state.trop_index) {
+            snapshot_.covariance(trop_index, trop_index) =
+                native_state.covariance(native_state.trop_index, native_state.trop_index);
+        }
+    }
+
+    for (const auto& [satellite, native_index] : native_state.ionosphere_indices) {
+        const int satno = claslibSatelliteNumber(satellite);
+        const int dd_index = layout.ionosphereIndex(satno);
+        if (dd_index < 0 || native_index < 0 ||
+            native_state.state.size() <= native_index) {
+            continue;
+        }
+        snapshot_.state(dd_index) = native_state.state(native_index);
+        if (native_state.covariance.rows() > native_index &&
+            native_state.covariance.cols() > native_index) {
+            snapshot_.covariance(dd_index, dd_index) =
+                native_state.covariance(native_index, native_index);
+        }
+    }
+
+    for (const auto& osr : osr_corrections) {
+        if (osr.valid) {
+            snapshot_.observed_satellites.push_back(osr.satellite);
+        }
+    }
+
+    PositionSolution solution = native_float_solution;
+    solution.time = time;
+    solution.status = SolutionStatus::PPP_FLOAT;
+    solution.ratio = 0.0;
+    solution.num_fixed_ambiguities = 0;
+    solution.num_satellites = static_cast<int>(snapshot_.observed_satellites.size());
+    return solution;
+}
+
+void DdFilterScaffold::reset() {
+    snapshot_ = StateSnapshot{};
+    has_snapshot_ = false;
+}
+
+}  // namespace libgnss::ppp_clas_dd

--- a/src/algorithms/ppp_clas_epoch.cpp
+++ b/src/algorithms/ppp_clas_epoch.cpp
@@ -4,6 +4,7 @@
 #include <libgnss++/algorithms/ppp.hpp>
 #include <libgnss++/algorithms/ppp_ar.hpp>
 #include <libgnss++/algorithms/ppp_clas.hpp>
+#include <libgnss++/algorithms/ppp_clas_dd.hpp>
 #include <libgnss++/algorithms/ppp_env_overrides.hpp>
 #include <libgnss++/algorithms/ppp_osr.hpp>
 #include <libgnss++/core/constants.hpp>
@@ -355,6 +356,29 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
     dumpClasFloatPosition(obs.time, filter_state_, epoch_update, osr_corrections.size());
     const auto& update_stats = epoch_update.update_stats;
     pre_anchor_covariance_ = update_stats.pre_anchor_covariance;
+
+    if (ppp_config_.use_clas_dd_filter) {
+        if (!clas_dd_filter_) {
+            clas_dd_filter_ = std::make_unique<ppp_clas_dd::DdFilterScaffold>();
+        }
+        const PositionSolution native_float_solution = ppp_clas::finalizeEpochSolution(
+            filter_state_,
+            false,
+            0.0,
+            0,
+            static_cast<int>(osr_corrections.size()));
+        solution = clas_dd_filter_->processFloatPassthrough(
+            obs.time,
+            filter_state_,
+            native_float_solution,
+            ppp_config_,
+            osr_corrections,
+            epoch_atmos);
+        has_last_processed_time_ = true;
+        last_processed_time_ = obs.time;
+        ++total_epochs_processed_;
+        return solution;
+    }
 
     // Accumulate Melbourne-Wübbena for WL-NL AR in CLAS per-frequency mode.
     if (ppp_config_.enable_ambiguity_resolution &&

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -190,6 +190,8 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
         !envExactZero("GNSS_PPP_CLAS_FIXED_STATE_OUTPUT");
     overrides.clas_resamb =
         envExactOne("GNSS_PPP_CLAS_RESAMB");
+    overrides.clas_dd_filter =
+        envExactOne("GNSS_PPP_CLAS_DD_FILTER");
     overrides.clas_amb_datum_residual_phase_trop =
         !envExactZero("GNSS_PPP_CLAS_AMB_DATUM_RESIDUAL_PHASE_TROP");
     overrides.clas_amb_datum =


### PR DESCRIPTION
Phase **A0** of Option A — CLAS DD PPP-RTK AR/Filter re-architecture (#168).

**Scope: audit + gated skeleton only.** No default output changes; bit-exact opt-out preserved until A5.

### What's here
- `docs/clas_dd_filter_audit.md` — CLASLIB `ppprtk.c` state layout (II/IT/IB macros), process noise, `ddres()` ref-sat selection + DD row formation, mapped to the native CLAS path (`ppp_state.cpp`/`ppp.cpp`/`ppp_clas*.cpp`/`ppp_wlnl.cpp`/`ppp_ar.cpp`) with an **A1 entry points** section.
- New TU `ppp_clas_dd.{hpp,cpp}` — DD state layout + float-passthrough scaffold. Inert when gate OFF (not constructed), float-equivalent when ON.
- Typed env gate `GNSS_PPP_CLAS_DD_FILTER` (`envExactOne`, default **OFF**) threaded through PPP options; documented in `madoca_port_plan.md`.

### Verification (independent re-run, not the codex report)
| Check | Result |
|---|---|
| Build `gnss_ppp` + `run_tests` | clean |
| CLAS default, gate OFF | **bit-exact** vs baseline (md5 `92479fff…`) |
| MADOCA 1h, gate OFF | **bit-exact** vs baseline (md5 `1c67d641…`) |
| CLAS, gate ON | float passthrough, **0 m** max-3D vs native float, 3599 rows |
| `run_tests` | all green, no failures |

### Not in scope (A1+)
DD measurement update, LAMBDA conditioning, hold/validation, QZSS row-set parity, default flip.

Draft until reviewed. Foundation for A1 (DD measurement update).

🤖 Generated with [Claude Code](https://claude.com/claude-code)