### PR TITLE
feat(clas): A1 DD measurement update (gated, #168)

### DIFF
--- a/docs/clas_dd_filter_a1.md
+++ b/docs/clas_dd_filter_a1.md
@@ -1,0 +1,53 @@
+# CLAS DD PPP-RTK Filter A1
+
+A1 replaces the `GNSS_PPP_CLAS_DD_FILTER=1` passthrough scaffold with a
+persistent double-differenced float filter.  The gate remains off by default;
+the native CLAS and MADOCA paths do not call this code unless the environment
+override is exactly `1`.
+
+## Implemented
+
+- `DdFilterScaffold::processFloatUpdate()` now carries a persistent DD state
+  across epochs, seeded from the native CLAS float position on first use.
+- The active state layout follows the A0 CLASLIB audit: position/dynamics,
+  per-satellite ionosphere `II`, ZTD, optional GLONASS bias slots, and
+  cycle-valued per-satellite/per-frequency ambiguity `IB` states. Receiver
+  clocks remain outside the active DD update because phase and code rows are
+  double-differenced before filtering.
+- The time update mirrors the CLASLIB `udstate_ppp()` split for the A1 static
+  CLAS path: position process noise, ZTD process noise, adaptive ionosphere
+  process noise, ambiguity random walk, outage resets, LLI resets, atmosphere
+  network ionosphere reset, and phase-code ambiguity initialization.
+- `buildDdMeasurementSystem()` builds CLASLIB-style `ddres()` rows from the
+  existing lifecycle atmosphere and OSR products: highest-elevation reference
+  selection per system/frequency/kind, full `PRC/CPC` zero-difference residuals,
+  `ref - sat` phase and code rows, ionosphere/troposphere/ambiguity columns,
+  and DD covariance blocks.
+- The DD measurement update uses the shared RTK measurement/update helpers and
+  publishes the DD float position and covariance. Integer fixing remains out of
+  scope for A1.
+- For the static CLAS A1 gate, the first native float position is retained as a
+  tight static anchor pseudo-measurement inside the gated DD update. This keeps
+  the incomplete A1 float datum from drifting while phase/code DD rows, iono,
+  trop, and ambiguity states are still estimated by the DD filter.
+- Candidate DD updates are postfit-checked before commit. If the DD postfit rows
+  exceed the residual gate, or the static candidate moves more than 8 m from the
+  seeded anchor, the scaffold reseeds once from the same-epoch native float and
+  retries the DD update. A failed retry publishes the native float for that
+  epoch with `iterations=0`; successful DD updates publish with `iterations=1`.
+
+## A2 Entry Points
+
+- Use `DdFilterScaffold::snapshot()` after a successful A1 update as the source
+  of the float DD state/covariance for LAMBDA.
+- Build the ambiguity candidate vector from `StateLayout::ambiguityIndex()` for
+  the same reference-satellite groups selected by `buildDdMeasurementSystem()`.
+- Reuse `rtk_measurement::buildAmbiguityTransform()` or an equivalent
+  DD-native transform to extract `Qb` and `Qab` from the DD covariance; do not
+  consume the old native PPP ambiguity map.
+- Publish the conditioned `xa/Pa` through the DD scaffold, then let
+  `ppp_clas_epoch.cpp` choose the fixed DD snapshot under
+  `GNSS_PPP_CLAS_DD_FILTER=1`.
+- Revisit or remove the A1 static anchor once LAMBDA conditioning and hold
+  feedback stabilize the DD ambiguity datum; A2 should measure fixed-state
+  performance both with and without the anchor before tightening the default.

--- a/include/libgnss++/algorithms/ppp_clas_dd.hpp
+++ b/include/libgnss++/algorithms/ppp_clas_dd.hpp
@@ -1,9 +1,13 @@
 #pragma once
 
 #include <libgnss++/algorithms/ppp_osr_types.hpp>
+#include <libgnss++/algorithms/rtk_measurement.hpp>
+#include <libgnss++/algorithms/rtk_update.hpp>
+#include <libgnss++/core/observation.hpp>
 #include <libgnss++/algorithms/ppp_shared.hpp>
 #include <libgnss++/core/solution.hpp>
 
+#include <functional>
 #include <map>
 #include <string>
 #include <vector>
@@ -74,8 +78,57 @@ struct StateSnapshot {
     bool has_atmosphere_network_id = false;
 };
 
+using TropMappingFunction =
+    std::function<double(const Vector3d&, double, const GNSSTime&)>;
+
+struct DdRow {
+    SatelliteId reference_satellite;
+    SatelliteId target_satellite;
+    bool is_phase = false;
+    int frequency_index = 0;
+    double residual_m = 0.0;
+    Vector3d position_coefficients = Vector3d::Zero();
+    std::vector<rtk_measurement::StateCoefficient> state_coefficients;
+    double reference_variance_m2 = 0.0;
+    double target_variance_m2 = 0.0;
+};
+
+struct DdMeasurementBuildResult {
+    std::vector<DdRow> rows;
+    rtk_measurement::MeasurementSystem measurement_system;
+    int phase_rows = 0;
+    int code_rows = 0;
+    int reference_groups = 0;
+};
+
+DdMeasurementBuildResult buildDdMeasurementSystem(
+    const ObservationData& obs,
+    const std::vector<OSRCorrection>& osr_corrections,
+    const StateLayout& layout,
+    const VectorXd& state,
+    const ppp_shared::PPPConfig& config,
+    const TropMappingFunction& trop_mapping_function);
+
+struct DdUpdateDiagnostics {
+    bool updated = false;
+    std::string fallback_reason;
+    int measurement_rows = 0;
+    int phase_rows = 0;
+    int code_rows = 0;
+    int reference_groups = 0;
+    rtk_update::FilterUpdateResult filter_update;
+};
+
 class DdFilterScaffold {
 public:
+    PositionSolution processFloatUpdate(
+        const ObservationData& obs,
+        const CLASEpochContext& epoch_context,
+        const ppp_shared::PPPState& native_state,
+        const PositionSolution& native_float_solution,
+        const ppp_shared::PPPConfig& config,
+        const TropMappingFunction& trop_mapping_function);
+
     PositionSolution processFloatPassthrough(
         const GNSSTime& time,
         const ppp_shared::PPPState& native_state,
@@ -86,13 +139,51 @@ public:
 
     const StateSnapshot& snapshot() const { return snapshot_; }
     bool hasSnapshot() const { return has_snapshot_; }
+    const DdUpdateDiagnostics& lastDiagnostics() const { return last_diagnostics_; }
+    int totalUpdatedEpochs() const { return total_updated_epochs_; }
+    int totalFallbackEpochs() const { return total_fallback_epochs_; }
     void reset();
 
 private:
-    void ensureSnapshotStorage(const StateLayout& layout);
+    void ensureSnapshotStorage(const StateLayout& layout, bool preserve_existing);
+    void initializeFromNativeFloat(
+        const GNSSTime& time,
+        const StateLayout& layout,
+        const ppp_shared::PPPState& native_state,
+        const PositionSolution& native_float_solution,
+        const ppp_shared::PPPConfig& config,
+        const std::vector<OSRCorrection>& osr_corrections,
+        const std::map<std::string, std::string>& epoch_atmos);
+    void predictState(
+        const ObservationData& obs,
+        const std::vector<OSRCorrection>& osr_corrections,
+        const ppp_shared::PPPConfig& config,
+        double dt);
+    void updateObservedStateBookkeeping(
+        const ObservationData& obs,
+        const std::vector<OSRCorrection>& osr_corrections,
+        const ppp_shared::PPPConfig& config,
+        double dt);
+    void resetStateElement(int index, double value, double variance);
+    PositionSolution fallbackSolution(
+        const PositionSolution& native_float_solution,
+        const std::string& reason,
+        int observed_satellites);
+    PositionSolution publishSolution(
+        const PositionSolution& native_float_solution,
+        const rtk_measurement::MeasurementDiagnostics& measurement_diagnostics,
+        int observed_satellites) const;
 
     StateSnapshot snapshot_;
+    std::map<int, int> ionosphere_outage_by_satno_;
+    std::map<int, double> ionosphere_process_noise_by_satno_;
+    std::map<std::pair<int, int>, int> ambiguity_outage_by_satno_freq_;
+    DdUpdateDiagnostics last_diagnostics_;
+    Vector3d static_anchor_position_ = Vector3d::Zero();
+    int total_updated_epochs_ = 0;
+    int total_fallback_epochs_ = 0;
     bool has_snapshot_ = false;
+    bool has_static_anchor_ = false;
 };
 
 }  // namespace libgnss::ppp_clas_dd

--- a/src/algorithms/ppp_clas_dd.cpp
+++ b/src/algorithms/ppp_clas_dd.cpp
@@ -1,7 +1,16 @@
 #include <libgnss++/algorithms/ppp_clas_dd.hpp>
 
 #include <algorithm>
+#include <array>
+#include <cmath>
 #include <cstdlib>
+#include <limits>
+#include <set>
+#include <tuple>
+#include <utility>
+
+#include <libgnss++/core/constants.hpp>
+#include <libgnss++/core/coordinates.hpp>
 
 namespace libgnss::ppp_clas_dd {
 namespace {
@@ -30,6 +39,51 @@ constexpr int kMinPrnSbas = 120;
 constexpr int kMaxPrnSbas = 158;
 constexpr int kNsatNavic = 14;
 
+constexpr double kDdStaticInitialPositionVariance = 1.0;
+constexpr double kClaslibInitialZwdM = 0.001;
+constexpr double kClaslibStdBiasCycles = 100.0;
+constexpr double kClaslibStdIonoM = 0.01;
+constexpr double kClaslibStdTropM = 0.005;
+constexpr double kClaslibPrnBiasCycles = 1e-3;
+constexpr double kClaslibPrnIonoM = 1e-3;
+constexpr double kClaslibPrnIonoMaxM = 0.05;
+constexpr double kClaslibPrnTropM = 1e-3;
+constexpr double kClaslibForgetIono = 0.5;
+constexpr double kClaslibAfGainIono = 1.0;
+constexpr int kClaslibMaxOutage = 5;
+constexpr double kGpsL2VarianceScale = (2.55 / 1.55) * (2.55 / 1.55);
+constexpr double kDdStaticAnchorVarianceM2 = 0.003;
+constexpr double kDdStaticPositionCovarianceFloorM2 = 1.0;
+constexpr double kDdPostfitResidualRmsLimitM = 5.0;
+constexpr double kDdPostfitResidualMaxLimitM = 20.0;
+
+struct ZeroDiffMeasurement {
+    SatelliteId satellite;
+    int satno = 0;
+    int system_group = 0;
+    bool is_phase = false;
+    int frequency_index = 0;
+    double residual_m = 0.0;
+    Vector3d los = Vector3d::Zero();
+    double elevation_rad = 0.0;
+    double ionosphere_map = 1.0;
+    double trop_mapping = 0.0;
+    double wavelength_m = 0.0;
+    double ionosphere_scale = 1.0;
+    double variance_m2 = 0.0;
+};
+
+struct DdGroupKey {
+    int system_group = 0;
+    int frequency_index = 0;
+    bool is_phase = false;
+
+    bool operator<(const DdGroupKey& rhs) const {
+        return std::tie(system_group, frequency_index, is_phase) <
+               std::tie(rhs.system_group, rhs.frequency_index, rhs.is_phase);
+    }
+};
+
 int qzssPrnForClaslib(int prn) {
     if (prn >= kMinPrnQzsClaslib && prn <= kMaxPrnQzsClaslib) {
         return prn;
@@ -54,6 +108,179 @@ bool readAtmosphereNetworkId(
     }
     network_id = static_cast<int>(parsed);
     return true;
+}
+
+int systemGroup(const SatelliteId& satellite) {
+    switch (satellite.system) {
+        case GNSSSystem::GPS:
+        case GNSSSystem::SBAS:
+            return 0;
+        case GNSSSystem::GLONASS:
+            return 1;
+        case GNSSSystem::Galileo:
+            return 2;
+        case GNSSSystem::BeiDou:
+            return 3;
+        case GNSSSystem::QZSS:
+            return 4;
+        default:
+            return -1;
+    }
+}
+
+double systemErrorFactor(GNSSSystem system) {
+    if (system == GNSSSystem::GLONASS) {
+        return 1.5;
+    }
+    if (system == GNSSSystem::SBAS) {
+        return 3.0;
+    }
+    return 1.0;
+}
+
+double ionosphereMapFactor(const Vector3d& receiver_position, double elevation_rad) {
+    double lat = 0.0;
+    double lon = 0.0;
+    double height = 0.0;
+    ecef2geodetic(receiver_position, lat, lon, height);
+    constexpr double kIonosphereHeightM = 350000.0;
+    if (height >= kIonosphereHeightM) {
+        return 1.0;
+    }
+    const double sin_z =
+        (constants::WGS84_A + height) / (constants::WGS84_A + kIonosphereHeightM) *
+        std::cos(elevation_rad);
+    const double clamped = std::clamp(sin_z, -0.999999, 0.999999);
+    return 1.0 / std::cos(std::asin(clamped));
+}
+
+double claslibVarerr(
+    GNSSSystem system,
+    double elevation_rad,
+    bool is_phase,
+    int frequency_index) {
+    const double sin_el = std::max(std::abs(std::sin(elevation_rad)), 1e-3);
+    double factor = systemErrorFactor(system);
+    if (!is_phase) {
+        factor *= 50.0;
+    }
+    const double a = factor * 0.010;
+    const double b = factor * 0.005;
+    double variance = a * a + b * b / (sin_el * sin_el);
+    if (is_phase && frequency_index == 1) {
+        variance *= kGpsL2VarianceScale;
+    }
+    return std::max(variance, 1e-12);
+}
+
+void addStateCoefficient(
+    std::vector<rtk_measurement::StateCoefficient>& coefficients,
+    int state_index,
+    double coefficient) {
+    if (state_index < 0 || coefficient == 0.0) {
+        return;
+    }
+    for (auto& existing : coefficients) {
+        if (existing.state_index == state_index) {
+            existing.coefficient += coefficient;
+            return;
+        }
+    }
+    coefficients.push_back({state_index, coefficient});
+}
+
+std::vector<rtk_measurement::MeasurementBlock> rowsToBlocks(
+    const std::map<DdGroupKey, std::vector<DdRow>>& rows_by_group) {
+    std::vector<rtk_measurement::MeasurementBlock> blocks;
+    blocks.reserve(rows_by_group.size());
+    for (const auto& [key, rows] : rows_by_group) {
+        if (rows.empty()) {
+            continue;
+        }
+        rtk_measurement::MeasurementBlock block;
+        block.kind = key.is_phase
+            ? rtk_measurement::MeasurementKind::PHASE
+            : rtk_measurement::MeasurementKind::CODE;
+        block.frequency_index = key.frequency_index;
+        block.rows.reserve(rows.size());
+        for (const auto& row : rows) {
+            rtk_measurement::MeasurementRow measurement_row;
+            measurement_row.residual = row.residual_m;
+            measurement_row.baseline_coefficients = row.position_coefficients;
+            measurement_row.state_coefficients = row.state_coefficients;
+            measurement_row.reference_variance = row.reference_variance_m2;
+            measurement_row.satellite_variance = row.target_variance_m2;
+            block.rows.push_back(std::move(measurement_row));
+        }
+        blocks.push_back(std::move(block));
+    }
+    return blocks;
+}
+
+int countObservedSatellites(const std::vector<OSRCorrection>& osr_corrections) {
+    int count = 0;
+    for (const auto& osr : osr_corrections) {
+        if (osr.valid) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+double rowResidualRms(const std::vector<DdRow>& rows) {
+    if (rows.empty()) {
+        return 0.0;
+    }
+    double sum_sq = 0.0;
+    for (const auto& row : rows) {
+        sum_sq += row.residual_m * row.residual_m;
+    }
+    return std::sqrt(sum_sq / static_cast<double>(rows.size()));
+}
+
+double rowResidualMaxAbs(const std::vector<DdRow>& rows) {
+    double max_abs = 0.0;
+    for (const auto& row : rows) {
+        max_abs = std::max(max_abs, std::abs(row.residual_m));
+    }
+    return max_abs;
+}
+
+bool postfitRowsAccepted(const DdMeasurementBuildResult& postfit_build) {
+    if (postfit_build.rows.size() < 4) {
+        return false;
+    }
+    return rowResidualRms(postfit_build.rows) <= kDdPostfitResidualRmsLimitM &&
+           rowResidualMaxAbs(postfit_build.rows) <= kDdPostfitResidualMaxLimitM;
+}
+
+void appendStaticPositionAnchor(rtk_measurement::MeasurementSystem& system,
+                                const Vector3d& state_position,
+                                const Vector3d& anchor_position) {
+    const int old_rows = static_cast<int>(system.residuals.size());
+    const int n_states = static_cast<int>(system.design_matrix.cols());
+    if (n_states < 3 || system.design_matrix.rows() != old_rows ||
+        system.covariance.rows() != old_rows ||
+        system.covariance.cols() != old_rows) {
+        return;
+    }
+
+    MatrixXd design = MatrixXd::Zero(old_rows + 3, n_states);
+    VectorXd residuals = VectorXd::Zero(old_rows + 3);
+    MatrixXd covariance = MatrixXd::Zero(old_rows + 3, old_rows + 3);
+    if (old_rows > 0) {
+        design.topRows(old_rows) = system.design_matrix;
+        residuals.head(old_rows) = system.residuals;
+        covariance.topLeftCorner(old_rows, old_rows) = system.covariance;
+    }
+    for (int axis = 0; axis < 3; ++axis) {
+        design(old_rows + axis, axis) = 1.0;
+        residuals(old_rows + axis) = anchor_position(axis) - state_position(axis);
+        covariance(old_rows + axis, old_rows + axis) = kDdStaticAnchorVarianceM2;
+    }
+    system.design_matrix = std::move(design);
+    system.residuals = std::move(residuals);
+    system.covariance = std::move(covariance);
 }
 
 }  // namespace
@@ -187,17 +414,745 @@ StateLayoutOptions layoutOptionsFromConfig(
     return options;
 }
 
-void DdFilterScaffold::ensureSnapshotStorage(const StateLayout& layout) {
+DdMeasurementBuildResult buildDdMeasurementSystem(
+    const ObservationData& obs,
+    const std::vector<OSRCorrection>& osr_corrections,
+    const StateLayout& layout,
+    const VectorXd& state,
+    const ppp_shared::PPPConfig& config,
+    const TropMappingFunction& trop_mapping_function) {
+    DdMeasurementBuildResult result;
+    const int nx = layout.nx();
+    if (state.size() < nx || nx < 3 || trop_mapping_function == nullptr) {
+        return result;
+    }
+
+    const Vector3d receiver_position = state.segment(0, 3);
+    if (!receiver_position.allFinite() || receiver_position.norm() <= 0.0) {
+        return result;
+    }
+
+    double rx_lat = 0.0;
+    double rx_lon = 0.0;
+    double rx_height = 0.0;
+    ecef2geodetic(receiver_position, rx_lat, rx_lon, rx_height);
+
+    std::map<DdGroupKey, std::vector<ZeroDiffMeasurement>> groups;
+    for (const auto& osr : osr_corrections) {
+        if (!osr.valid || osr.num_frequencies <= 0) {
+            continue;
+        }
+        const int satno = claslibSatelliteNumber(osr.satellite);
+        const int group = systemGroup(osr.satellite);
+        if (!layout.validSatelliteNumber(satno) || group < 0) {
+            continue;
+        }
+        const Vector3d range_vector = osr.satellite_position - receiver_position;
+        const double range_norm = range_vector.norm();
+        const double geo = geodist(osr.satellite_position, receiver_position);
+        if (!std::isfinite(geo) || range_norm <= 0.0) {
+            continue;
+        }
+        const Vector3d los = range_vector / range_norm;
+        const Vector3d los_enu = ecef2enu(range_vector, rx_lat, rx_lon);
+        const double elevation =
+            std::atan2(los_enu.z(), std::hypot(los_enu.x(), los_enu.y()));
+        const double sat_clock_m =
+            constants::SPEED_OF_LIGHT * osr.satellite_clock_bias_s;
+        const double ion_map = ionosphereMapFactor(receiver_position, elevation);
+        const double trop_mapping =
+            config.estimate_troposphere
+                ? trop_mapping_function(receiver_position, elevation, obs.time)
+                : 0.0;
+
+        for (int f = 0; f < osr.num_frequencies && f < layout.nf(); ++f) {
+            if (osr.wavelengths[f] <= 0.0 || osr.wavelengths[0] <= 0.0) {
+                continue;
+            }
+            const Observation* raw = obs.getObservation(osr.satellite, osr.signals[f]);
+            if (raw == nullptr || !raw->valid) {
+                continue;
+            }
+            const double ion_scale =
+                std::pow(osr.wavelengths[f] / osr.wavelengths[0], 2);
+
+            if (raw->has_carrier_phase && std::isfinite(raw->carrier_phase)) {
+                ZeroDiffMeasurement zd;
+                zd.satellite = osr.satellite;
+                zd.satno = satno;
+                zd.system_group = group;
+                zd.is_phase = true;
+                zd.frequency_index = f;
+                zd.residual_m =
+                    raw->carrier_phase * osr.wavelengths[f] -
+                    (geo - sat_clock_m + osr.CPC[f]);
+                zd.los = los;
+                zd.elevation_rad = elevation;
+                zd.ionosphere_map = ion_map;
+                zd.trop_mapping = trop_mapping;
+                zd.wavelength_m = osr.wavelengths[f];
+                zd.ionosphere_scale = ion_scale;
+                zd.variance_m2 =
+                    claslibVarerr(osr.satellite.system, elevation, true, f);
+                groups[{group, f, true}].push_back(zd);
+            }
+
+            if (raw->has_pseudorange && std::isfinite(raw->pseudorange)) {
+                ZeroDiffMeasurement zd;
+                zd.satellite = osr.satellite;
+                zd.satno = satno;
+                zd.system_group = group;
+                zd.is_phase = false;
+                zd.frequency_index = f;
+                zd.residual_m =
+                    raw->pseudorange - (geo - sat_clock_m + osr.PRC[f]);
+                zd.los = los;
+                zd.elevation_rad = elevation;
+                zd.ionosphere_map = ion_map;
+                zd.trop_mapping = trop_mapping;
+                zd.wavelength_m = osr.wavelengths[f];
+                zd.ionosphere_scale = ion_scale;
+                zd.variance_m2 =
+                    claslibVarerr(osr.satellite.system, elevation, false, f);
+                groups[{group, f, false}].push_back(zd);
+            }
+        }
+    }
+
+    std::map<DdGroupKey, std::vector<DdRow>> rows_by_group;
+    for (const auto& [key, measurements] : groups) {
+        if (measurements.size() < 2) {
+            continue;
+        }
+
+        const auto ref_it = std::max_element(
+            measurements.begin(),
+            measurements.end(),
+            [](const ZeroDiffMeasurement& lhs, const ZeroDiffMeasurement& rhs) {
+                return lhs.elevation_rad < rhs.elevation_rad;
+            });
+        if (ref_it == measurements.end()) {
+            continue;
+        }
+        ++result.reference_groups;
+        const ZeroDiffMeasurement& ref = *ref_it;
+
+        for (const auto& sat : measurements) {
+            if (sat.satellite == ref.satellite) {
+                continue;
+            }
+
+            DdRow row;
+            row.reference_satellite = ref.satellite;
+            row.target_satellite = sat.satellite;
+            row.is_phase = key.is_phase;
+            row.frequency_index = key.frequency_index;
+            row.residual_m = ref.residual_m - sat.residual_m;
+            row.position_coefficients = -ref.los + sat.los;
+            row.reference_variance_m2 = ref.variance_m2;
+            row.target_variance_m2 = sat.variance_m2;
+
+            if (config.estimate_ionosphere &&
+                layout.options.ionosphere_mode != IonosphereMode::Off) {
+                const double sign = row.is_phase ? -1.0 : 1.0;
+                const double ref_coeff =
+                    sign * ref.ionosphere_scale * ref.ionosphere_map;
+                const double sat_coeff =
+                    sign * sat.ionosphere_scale * sat.ionosphere_map;
+                const int ref_iono = layout.ionosphereIndex(ref.satno);
+                const int sat_iono = layout.ionosphereIndex(sat.satno);
+                row.residual_m -=
+                    ref_coeff * state(ref_iono) - sat_coeff * state(sat_iono);
+                addStateCoefficient(row.state_coefficients, ref_iono, ref_coeff);
+                addStateCoefficient(row.state_coefficients, sat_iono, -sat_coeff);
+            }
+
+            const int trop_index = layout.troposphereIndex();
+            if (trop_index >= 0 && config.estimate_troposphere) {
+                const double trop_coeff = ref.trop_mapping - sat.trop_mapping;
+                row.residual_m -= trop_coeff * state(trop_index);
+                addStateCoefficient(row.state_coefficients, trop_index, trop_coeff);
+            }
+
+            if (row.is_phase) {
+                const int ref_ambiguity =
+                    layout.ambiguityIndex(ref.satno, key.frequency_index);
+                const int sat_ambiguity =
+                    layout.ambiguityIndex(sat.satno, key.frequency_index);
+                row.residual_m -=
+                    ref.wavelength_m * state(ref_ambiguity) -
+                    sat.wavelength_m * state(sat_ambiguity);
+                addStateCoefficient(
+                    row.state_coefficients, ref_ambiguity, ref.wavelength_m);
+                addStateCoefficient(
+                    row.state_coefficients, sat_ambiguity, -sat.wavelength_m);
+                ++result.phase_rows;
+            } else {
+                ++result.code_rows;
+            }
+
+            rows_by_group[key].push_back(row);
+            result.rows.push_back(std::move(row));
+        }
+    }
+
+    const auto blocks = rowsToBlocks(rows_by_group);
+    result.measurement_system =
+        rtk_measurement::assembleMeasurementSystem(blocks, nx);
+    return result;
+}
+
+void DdFilterScaffold::ensureSnapshotStorage(
+    const StateLayout& layout,
+    bool preserve_existing) {
     const int nx = layout.nx();
     if (!has_snapshot_ || snapshot_.state.size() != nx) {
         snapshot_.state = VectorXd::Zero(nx);
         snapshot_.covariance = MatrixXd::Zero(nx, nx);
-    } else {
+    } else if (!preserve_existing) {
         snapshot_.state.setZero();
         snapshot_.covariance.setZero();
     }
     snapshot_.layout = layout;
     has_snapshot_ = true;
+}
+
+void DdFilterScaffold::resetStateElement(
+    int index,
+    double value,
+    double variance) {
+    if (index < 0 || index >= snapshot_.state.size()) {
+        return;
+    }
+    snapshot_.state(index) = value;
+    snapshot_.covariance.row(index).setZero();
+    snapshot_.covariance.col(index).setZero();
+    snapshot_.covariance(index, index) = variance;
+}
+
+void DdFilterScaffold::initializeFromNativeFloat(
+    const GNSSTime& time,
+    const StateLayout& layout,
+    const ppp_shared::PPPState& native_state,
+    const PositionSolution& native_float_solution,
+    const ppp_shared::PPPConfig& config,
+    const std::vector<OSRCorrection>& osr_corrections,
+    const std::map<std::string, std::string>& epoch_atmos) {
+    ensureSnapshotStorage(layout, false);
+    snapshot_.time = time;
+    snapshot_.seeded_from_native_float = true;
+    snapshot_.native_total_states = native_state.total_states;
+    snapshot_.has_atmosphere_network_id =
+        readAtmosphereNetworkId(epoch_atmos, snapshot_.atmosphere_network_id);
+
+    const Vector3d seed_position =
+        native_float_solution.position_ecef.allFinite()
+            ? native_float_solution.position_ecef
+            : native_state.state.segment(native_state.pos_index, 3);
+    if (!has_static_anchor_) {
+        static_anchor_position_ = seed_position;
+        has_static_anchor_ = true;
+    }
+    for (int axis = 0; axis < 3 && axis < layout.np(); ++axis) {
+        resetStateElement(axis, seed_position(axis), kDdStaticInitialPositionVariance);
+    }
+
+    if (layout.options.dynamics && native_state.state.size() >= native_state.pos_index + 9) {
+        for (int axis = 3; axis < 9; ++axis) {
+            const double variance = axis < 6 ? 1.0 : 1.0;
+            resetStateElement(axis, native_state.state(native_state.pos_index + axis), variance);
+        }
+    }
+
+    const int trop_index = layout.troposphereIndex();
+    if (trop_index >= 0 && config.estimate_troposphere) {
+        resetStateElement(
+            trop_index,
+            kClaslibInitialZwdM,
+            kClaslibStdTropM * kClaslibStdTropM);
+    }
+
+    updateObservedStateBookkeeping(
+        ObservationData(time), osr_corrections, config, 0.0);
+}
+
+void DdFilterScaffold::predictState(
+    const ObservationData& obs,
+    const std::vector<OSRCorrection>& osr_corrections,
+    const ppp_shared::PPPConfig& config,
+    double dt) {
+    if (!has_snapshot_) {
+        return;
+    }
+    const double abs_dt = std::abs(dt);
+    const StateLayout& layout = snapshot_.layout;
+    if (layout.options.dynamics && layout.np() >= 9) {
+        for (int axis = 0; axis < 3; ++axis) {
+            snapshot_.state(axis) +=
+                snapshot_.state(axis + 3) * dt +
+                0.5 * snapshot_.state(axis + 6) * dt * dt;
+            snapshot_.state(axis + 3) += snapshot_.state(axis + 6) * dt;
+        }
+    }
+
+    const double position_q = std::max(0.0, config.process_noise_position) * abs_dt;
+    if (position_q > 0.0) {
+        for (int axis = 0; axis < 3; ++axis) {
+            snapshot_.covariance(axis, axis) += position_q;
+        }
+    }
+
+    const int trop_index = layout.troposphereIndex();
+    if (trop_index >= 0 && snapshot_.state(trop_index) == 0.0) {
+        resetStateElement(
+            trop_index,
+            kClaslibInitialZwdM,
+            kClaslibStdTropM * kClaslibStdTropM);
+    } else if (trop_index >= 0) {
+        snapshot_.covariance(trop_index, trop_index) +=
+            kClaslibPrnTropM * kClaslibPrnTropM * abs_dt;
+    }
+
+    updateObservedStateBookkeeping(obs, osr_corrections, config, abs_dt);
+}
+
+void DdFilterScaffold::updateObservedStateBookkeeping(
+    const ObservationData& obs,
+    const std::vector<OSRCorrection>& osr_corrections,
+    const ppp_shared::PPPConfig& config,
+    double dt) {
+    if (!has_snapshot_) {
+        return;
+    }
+
+    const StateLayout& layout = snapshot_.layout;
+    std::map<int, std::vector<std::pair<int, double>>> ambiguity_biases_m;
+
+    for (auto& [_, outage] : ionosphere_outage_by_satno_) {
+        ++outage;
+    }
+    for (auto& [_, outage] : ambiguity_outage_by_satno_freq_) {
+        ++outage;
+    }
+
+    for (const auto& osr : osr_corrections) {
+        if (!osr.valid) {
+            continue;
+        }
+        const int satno = claslibSatelliteNumber(osr.satellite);
+        if (!layout.validSatelliteNumber(satno)) {
+            continue;
+        }
+        ionosphere_outage_by_satno_[satno] = 0;
+
+        const int iono_index = layout.ionosphereIndex(satno);
+        if (config.estimate_ionosphere && iono_index >= 0) {
+            if (snapshot_.state(iono_index) == 0.0 ||
+                snapshot_.covariance(iono_index, iono_index) <= 0.0) {
+                resetStateElement(
+                    iono_index,
+                    1e-6,
+                    kClaslibStdIonoM * kClaslibStdIonoM);
+                ionosphere_process_noise_by_satno_[satno] = 0.0;
+            } else if (dt > 0.0) {
+                const double elevation = osr.elevation;
+                double qi = ionosphere_process_noise_by_satno_[satno];
+                if (layout.options.ionosphere_mode == IonosphereMode::EstimateAdaptive) {
+                    if (qi == 0.0) {
+                        const double fact = std::cos(elevation);
+                        qi = kClaslibPrnIonoM * kClaslibPrnIonoM * fact * fact;
+                    } else {
+                        qi = std::clamp(
+                            qi,
+                            kClaslibPrnIonoM * kClaslibPrnIonoM,
+                            kClaslibPrnIonoMaxM * kClaslibPrnIonoMaxM);
+                    }
+                } else {
+                    const double fact = std::cos(elevation);
+                    qi = kClaslibPrnIonoM * kClaslibPrnIonoM * fact * fact;
+                }
+                ionosphere_process_noise_by_satno_[satno] = qi;
+                snapshot_.covariance(iono_index, iono_index) += qi * dt;
+            }
+        }
+
+        for (int f = 0; f < osr.num_frequencies && f < layout.nf(); ++f) {
+            if (osr.wavelengths[f] <= 0.0) {
+                continue;
+            }
+            const Observation* raw = obs.getObservation(osr.satellite, osr.signals[f]);
+            if (raw == nullptr || !raw->valid || !raw->has_carrier_phase ||
+                !raw->has_pseudorange || !std::isfinite(raw->carrier_phase) ||
+                !std::isfinite(raw->pseudorange)) {
+                continue;
+            }
+            const auto key = std::make_pair(satno, f);
+            ambiguity_outage_by_satno_freq_[key] = 0;
+
+            const int ambiguity_index = layout.ambiguityIndex(satno, f);
+            if (ambiguity_index < 0) {
+                continue;
+            }
+            if (raw->loss_of_lock) {
+                resetStateElement(ambiguity_index, 0.0, 0.0);
+            } else if (snapshot_.covariance(ambiguity_index, ambiguity_index) > 0.0 &&
+                       dt > 0.0) {
+                snapshot_.covariance(ambiguity_index, ambiguity_index) +=
+                    kClaslibPrnBiasCycles * kClaslibPrnBiasCycles * dt;
+            }
+
+            const double bias_m =
+                raw->carrier_phase * osr.wavelengths[f] - raw->pseudorange;
+            if (std::isfinite(bias_m)) {
+                ambiguity_biases_m[f].push_back({ambiguity_index, bias_m});
+            }
+        }
+    }
+
+    for (const auto& [satno, outage] : ionosphere_outage_by_satno_) {
+        if (outage <= kClaslibMaxOutage) {
+            continue;
+        }
+        const int iono_index = layout.ionosphereIndex(satno);
+        if (iono_index >= 0) {
+            resetStateElement(iono_index, 0.0, 0.0);
+        }
+    }
+    for (const auto& [key, outage] : ambiguity_outage_by_satno_freq_) {
+        if (outage <= kClaslibMaxOutage) {
+            continue;
+        }
+        const int ambiguity_index = layout.ambiguityIndex(key.first, key.second);
+        if (ambiguity_index >= 0) {
+            resetStateElement(ambiguity_index, 0.0, 0.0);
+        }
+    }
+
+    for (const auto& [frequency, biases] : ambiguity_biases_m) {
+        double common_bias_m = 0.0;
+        int common_count = 0;
+        for (const auto& [ambiguity_index, bias_m] : biases) {
+            if (snapshot_.covariance(ambiguity_index, ambiguity_index) > 0.0 &&
+                snapshot_.state(ambiguity_index) != 0.0) {
+                double wavelength = 0.0;
+                for (const auto& osr : osr_corrections) {
+                    const int satno = claslibSatelliteNumber(osr.satellite);
+                    if (layout.ambiguityIndex(satno, frequency) == ambiguity_index &&
+                        frequency < osr.num_frequencies) {
+                        wavelength = osr.wavelengths[frequency];
+                        break;
+                    }
+                }
+                if (wavelength > 0.0) {
+                    common_bias_m += bias_m - snapshot_.state(ambiguity_index) * wavelength;
+                    ++common_count;
+                }
+            }
+        }
+        if (common_count > 0) {
+            common_bias_m /= static_cast<double>(common_count);
+        }
+        for (const auto& [ambiguity_index, bias_m] : biases) {
+            if (snapshot_.state(ambiguity_index) != 0.0 &&
+                snapshot_.covariance(ambiguity_index, ambiguity_index) > 0.0) {
+                continue;
+            }
+            double wavelength = 0.0;
+            for (const auto& osr : osr_corrections) {
+                const int satno = claslibSatelliteNumber(osr.satellite);
+                if (layout.ambiguityIndex(satno, frequency) == ambiguity_index &&
+                    frequency < osr.num_frequencies) {
+                    wavelength = osr.wavelengths[frequency];
+                    break;
+                }
+            }
+            if (wavelength <= 0.0) {
+                continue;
+            }
+            double cycles = (bias_m - common_bias_m) / wavelength;
+            if (cycles == 0.0) {
+                cycles = 1e-6;
+            }
+            resetStateElement(
+                ambiguity_index,
+                cycles,
+                kClaslibStdBiasCycles * kClaslibStdBiasCycles);
+        }
+    }
+}
+
+PositionSolution DdFilterScaffold::fallbackSolution(
+    const PositionSolution& native_float_solution,
+    const std::string& reason,
+    int observed_satellites) {
+    ++total_fallback_epochs_;
+    last_diagnostics_.updated = false;
+    last_diagnostics_.fallback_reason = reason;
+    PositionSolution solution = native_float_solution;
+    solution.status = SolutionStatus::PPP_FLOAT;
+    solution.ratio = 0.0;
+    solution.num_fixed_ambiguities = 0;
+    solution.num_satellites = observed_satellites;
+    solution.iterations = 0;
+    return solution;
+}
+
+PositionSolution DdFilterScaffold::publishSolution(
+    const PositionSolution& native_float_solution,
+    const rtk_measurement::MeasurementDiagnostics& measurement_diagnostics,
+    int observed_satellites) const {
+    PositionSolution solution = native_float_solution;
+    solution.position_ecef = snapshot_.state.segment(0, 3);
+    if (snapshot_.covariance.rows() >= 3 && snapshot_.covariance.cols() >= 3) {
+        solution.position_covariance = snapshot_.covariance.block<3, 3>(0, 0);
+    }
+    solution.status = SolutionStatus::PPP_FLOAT;
+    solution.ratio = 0.0;
+    solution.num_fixed_ambiguities = 0;
+    solution.num_satellites = observed_satellites;
+    solution.iterations = 1;
+    solution.residual_rms = measurement_diagnostics.residual_rms_m;
+    solution.rtk_update_observations = measurement_diagnostics.observation_count;
+    solution.rtk_update_phase_observations =
+        measurement_diagnostics.phase_observation_count;
+    solution.rtk_update_code_observations =
+        measurement_diagnostics.code_observation_count;
+    solution.rtk_update_suppressed_outliers =
+        last_diagnostics_.filter_update.suppressed_outliers;
+    solution.rtk_update_prefit_residual_rms_m =
+        last_diagnostics_.filter_update.prefit_residual_rms_m;
+    solution.rtk_update_prefit_residual_max_m =
+        last_diagnostics_.filter_update.prefit_residual_max_abs_m;
+    solution.rtk_update_post_suppression_residual_rms_m =
+        last_diagnostics_.filter_update.post_suppression_residual_rms_m;
+    solution.rtk_update_post_suppression_residual_max_m =
+        last_diagnostics_.filter_update.post_suppression_residual_max_abs_m;
+    solution.rtk_update_normalized_innovation_squared =
+        last_diagnostics_.filter_update.normalized_innovation_squared;
+    solution.rtk_update_normalized_innovation_squared_per_observation =
+        last_diagnostics_.filter_update.normalized_innovation_squared_per_observation;
+    solution.rtk_update_rejected_by_innovation_gate =
+        last_diagnostics_.filter_update.rejected_by_innovation_gate ? 1 : 0;
+    return solution;
+}
+
+PositionSolution DdFilterScaffold::processFloatUpdate(
+    const ObservationData& obs,
+    const CLASEpochContext& epoch_context,
+    const ppp_shared::PPPState& native_state,
+    const PositionSolution& native_float_solution,
+    const ppp_shared::PPPConfig& config,
+    const TropMappingFunction& trop_mapping_function) {
+    last_diagnostics_ = DdUpdateDiagnostics{};
+    const auto& osr_corrections = epoch_context.osr_corrections;
+    const auto& epoch_atmos = epoch_context.epoch_atmos_tokens;
+    const StateLayout layout{layoutOptionsFromConfig(config, osr_corrections)};
+    const int observed_satellites = countObservedSatellites(osr_corrections);
+
+    const bool needs_seed =
+        !has_snapshot_ || snapshot_.state.size() != layout.nx() ||
+        snapshot_.layout.nx() != layout.nx();
+    if (needs_seed) {
+        initializeFromNativeFloat(
+            obs.time,
+            layout,
+            native_state,
+            native_float_solution,
+            config,
+            osr_corrections,
+            epoch_atmos);
+    } else {
+        snapshot_.layout = layout;
+    }
+
+    snapshot_.observed_satellites.clear();
+    snapshot_.observed_satellites.reserve(osr_corrections.size());
+    for (const auto& osr : osr_corrections) {
+        if (osr.valid) {
+            snapshot_.observed_satellites.push_back(osr.satellite);
+        }
+    }
+    snapshot_.native_total_states = native_state.total_states;
+
+    int network_id = -1;
+    const bool has_network_id = readAtmosphereNetworkId(epoch_atmos, network_id);
+    if (has_network_id) {
+        if (snapshot_.has_atmosphere_network_id &&
+            snapshot_.atmosphere_network_id != network_id) {
+            for (int satno = 1; satno <= layout.options.max_satellites; ++satno) {
+                const int iono_index = layout.ionosphereIndex(satno);
+                if (iono_index >= 0) {
+                    resetStateElement(iono_index, 0.0, 0.0);
+                }
+            }
+            ionosphere_process_noise_by_satno_.clear();
+            ionosphere_outage_by_satno_.clear();
+        }
+        snapshot_.atmosphere_network_id = network_id;
+        snapshot_.has_atmosphere_network_id = true;
+    } else {
+        snapshot_.has_atmosphere_network_id = false;
+    }
+
+    const double dt = needs_seed ? 1.0 : std::max(obs.time - snapshot_.time, 0.001);
+    if (std::abs(dt) > 30.0) {
+        initializeFromNativeFloat(
+            obs.time,
+            layout,
+            native_state,
+            native_float_solution,
+            config,
+            osr_corrections,
+            epoch_atmos);
+        updateObservedStateBookkeeping(obs, osr_corrections, config, 0.0);
+    } else {
+        predictState(obs, osr_corrections, config, dt);
+    }
+    snapshot_.time = obs.time;
+
+    const auto measurement_build = buildDdMeasurementSystem(
+        obs,
+        osr_corrections,
+        snapshot_.layout,
+        snapshot_.state,
+        config,
+        trop_mapping_function);
+    last_diagnostics_.measurement_rows =
+        static_cast<int>(measurement_build.rows.size());
+    last_diagnostics_.phase_rows = measurement_build.phase_rows;
+    last_diagnostics_.code_rows = measurement_build.code_rows;
+    last_diagnostics_.reference_groups = measurement_build.reference_groups;
+
+    rtk_measurement::MeasurementDiagnostics measurement_diagnostics;
+    measurement_diagnostics.observation_count =
+        static_cast<int>(measurement_build.rows.size());
+    measurement_diagnostics.phase_observation_count = measurement_build.phase_rows;
+    measurement_diagnostics.code_observation_count = measurement_build.code_rows;
+    double residual_sum_sq = 0.0;
+    for (const auto& row : measurement_build.rows) {
+        residual_sum_sq += row.residual_m * row.residual_m;
+        measurement_diagnostics.residual_max_abs_m =
+            std::max(measurement_diagnostics.residual_max_abs_m, std::abs(row.residual_m));
+    }
+    if (measurement_diagnostics.observation_count > 0) {
+        measurement_diagnostics.residual_rms_m =
+            std::sqrt(residual_sum_sq /
+                      static_cast<double>(measurement_diagnostics.observation_count));
+    }
+
+    if (measurement_build.rows.size() < 4) {
+        PositionSolution solution = fallbackSolution(
+            native_float_solution, "insufficient_dd_rows", observed_satellites);
+        solution.time = obs.time;
+        return solution;
+    }
+
+    auto apply_update = [&](DdMeasurementBuildResult& build) {
+        auto measurement_system = build.measurement_system;
+        if (!snapshot_.layout.options.dynamics && has_static_anchor_) {
+            for (int axis = 0; axis < 3; ++axis) {
+                snapshot_.covariance(axis, axis) = std::max(
+                    snapshot_.covariance(axis, axis),
+                    kDdStaticPositionCovarianceFloorM2);
+            }
+            appendStaticPositionAnchor(
+                measurement_system,
+                snapshot_.state.segment(0, 3),
+                static_anchor_position_);
+        }
+        last_diagnostics_.filter_update = rtk_update::applyMeasurementUpdate(
+            snapshot_.state,
+            snapshot_.covariance,
+            measurement_system,
+            std::numeric_limits<double>::infinity(),
+            4);
+        if (!last_diagnostics_.filter_update.ok) {
+            return false;
+        }
+        const auto postfit_build = buildDdMeasurementSystem(
+            obs,
+            osr_corrections,
+            snapshot_.layout,
+            snapshot_.state,
+            config,
+            trop_mapping_function);
+        if (!postfitRowsAccepted(postfit_build)) {
+            return false;
+        }
+        if (!snapshot_.layout.options.dynamics && has_static_anchor_ &&
+            (snapshot_.state.segment(0, 3) - static_anchor_position_).norm() > 8.0) {
+            return false;
+        }
+        return true;
+    };
+
+    const VectorXd predicted_state = snapshot_.state;
+    const MatrixXd predicted_covariance = snapshot_.covariance;
+    auto update_build = measurement_build;
+    bool update_accepted = apply_update(update_build);
+    if (!update_accepted) {
+        snapshot_.state = predicted_state;
+        snapshot_.covariance = predicted_covariance;
+
+        initializeFromNativeFloat(
+            obs.time,
+            layout,
+            native_state,
+            native_float_solution,
+            config,
+            osr_corrections,
+            epoch_atmos);
+        updateObservedStateBookkeeping(obs, osr_corrections, config, 0.0);
+        auto retry_build = buildDdMeasurementSystem(
+            obs,
+            osr_corrections,
+            snapshot_.layout,
+            snapshot_.state,
+            config,
+            trop_mapping_function);
+        last_diagnostics_.measurement_rows =
+            static_cast<int>(retry_build.rows.size());
+        last_diagnostics_.phase_rows = retry_build.phase_rows;
+        last_diagnostics_.code_rows = retry_build.code_rows;
+        last_diagnostics_.reference_groups = retry_build.reference_groups;
+        if (retry_build.rows.size() < 4 || !apply_update(retry_build)) {
+            PositionSolution solution = fallbackSolution(
+                native_float_solution,
+                last_diagnostics_.filter_update.ok
+                    ? "postfit_dd_residual"
+                    : "kalman_update",
+                observed_satellites);
+            solution.time = obs.time;
+            return solution;
+        }
+    }
+
+    if (snapshot_.layout.options.ionosphere_mode == IonosphereMode::EstimateAdaptive) {
+        for (const auto& osr : osr_corrections) {
+            if (!osr.valid) {
+                continue;
+            }
+            const int satno = claslibSatelliteNumber(osr.satellite);
+            const int iono_index = snapshot_.layout.ionosphereIndex(satno);
+            if (iono_index < 0 ||
+                iono_index >= snapshot_.covariance.rows()) {
+                continue;
+            }
+            const double old_q = ionosphere_process_noise_by_satno_[satno];
+            ionosphere_process_noise_by_satno_[satno] =
+                kClaslibForgetIono * old_q +
+                (1.0 - kClaslibForgetIono) *
+                    kClaslibAfGainIono * kClaslibAfGainIono *
+                    snapshot_.covariance(iono_index, iono_index);
+        }
+    }
+
+    ++total_updated_epochs_;
+    last_diagnostics_.updated = true;
+    PositionSolution solution = publishSolution(
+        native_float_solution, measurement_diagnostics, observed_satellites);
+    solution.time = obs.time;
+    return solution;
 }
 
 PositionSolution DdFilterScaffold::processFloatPassthrough(
@@ -208,7 +1163,7 @@ PositionSolution DdFilterScaffold::processFloatPassthrough(
     const std::vector<OSRCorrection>& osr_corrections,
     const std::map<std::string, std::string>& epoch_atmos) {
     const StateLayout layout{layoutOptionsFromConfig(config, osr_corrections)};
-    ensureSnapshotStorage(layout);
+    ensureSnapshotStorage(layout, false);
 
     snapshot_.time = time;
     snapshot_.observed_satellites.clear();
@@ -272,7 +1227,15 @@ PositionSolution DdFilterScaffold::processFloatPassthrough(
 
 void DdFilterScaffold::reset() {
     snapshot_ = StateSnapshot{};
+    ionosphere_outage_by_satno_.clear();
+    ionosphere_process_noise_by_satno_.clear();
+    ambiguity_outage_by_satno_freq_.clear();
+    last_diagnostics_ = DdUpdateDiagnostics{};
+    static_anchor_position_ = Vector3d::Zero();
+    total_updated_epochs_ = 0;
+    total_fallback_epochs_ = 0;
     has_snapshot_ = false;
+    has_static_anchor_ = false;
 }
 
 }  // namespace libgnss::ppp_clas_dd

--- a/src/algorithms/ppp_clas_epoch.cpp
+++ b/src/algorithms/ppp_clas_epoch.cpp
@@ -367,13 +367,15 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
             0.0,
             0,
             static_cast<int>(osr_corrections.size()));
-        solution = clas_dd_filter_->processFloatPassthrough(
-            obs.time,
+        solution = clas_dd_filter_->processFloatUpdate(
+            obs,
+            epoch_context,
             filter_state_,
             native_float_solution,
             ppp_config_,
-            osr_corrections,
-            epoch_atmos);
+            [&](const Vector3d& receiver_pos, double elevation, const GNSSTime& time) {
+                return calculateMappingFunction(receiver_pos, elevation, time);
+            });
         has_last_processed_time_ = true;
         last_processed_time_ = obs.time;
         ++total_epochs_processed_;

--- a/tests/test_ppp_clas.cpp
+++ b/tests/test_ppp_clas.cpp
@@ -1,6 +1,11 @@
 #include <gtest/gtest.h>
 
 #include <libgnss++/algorithms/ppp_clas.hpp>
+#include <libgnss++/algorithms/ppp_clas_dd.hpp>
+#include <libgnss++/core/constants.hpp>
+#include <libgnss++/core/coordinates.hpp>
+
+#include <cmath>
 
 using namespace libgnss;
 
@@ -69,4 +74,98 @@ TEST(PPPClasTest, OrbitClockOnlyModeDropsBiasAndPhaseCompensationTerms) {
     EXPECT_DOUBLE_EQ(applied.carrier_phase_correction_m, 1.15);
     EXPECT_FALSE(ppp_clas::usesClasTropospherePrior(
         ppp_shared::PPPConfig::ClasCorrectionApplicationPolicy::ORBIT_CLOCK_ONLY));
+}
+
+TEST(PPPClasDdTest, RowBuilderSelectsHighestElevationReferenceAndFormsResidual) {
+    ObservationData obs(GNSSTime(2068, 230572.0));
+    const Vector3d receiver(constants::WGS84_A, 0.0, 0.0);
+    const double wavelength = constants::GPS_L1_WAVELENGTH;
+
+    auto make_osr = [&](uint8_t prn,
+                        const Vector3d& satellite_position,
+                        double code_residual,
+                        double phase_residual) {
+        OSRCorrection osr;
+        osr.satellite = SatelliteId(GNSSSystem::GPS, prn);
+        osr.valid = true;
+        osr.num_frequencies = 1;
+        osr.signals[0] = SignalType::GPS_L1CA;
+        osr.frequencies[0] = constants::GPS_L1_FREQ;
+        osr.wavelengths[0] = wavelength;
+        osr.satellite_position = satellite_position;
+        osr.satellite_clock_bias_s = 0.0;
+        osr.PRC[0] = 1.25 + prn;
+        osr.CPC[0] = -0.75 + prn;
+
+        double lat = 0.0;
+        double lon = 0.0;
+        double h = 0.0;
+        ecef2geodetic(receiver, lat, lon, h);
+        const Vector3d enu = ecef2enu(satellite_position - receiver, lat, lon);
+        osr.elevation = std::atan2(enu.z(), std::hypot(enu.x(), enu.y()));
+
+        const double geo = geodist(satellite_position, receiver);
+        Observation raw(osr.satellite, SignalType::GPS_L1CA);
+        raw.valid = true;
+        raw.has_pseudorange = true;
+        raw.has_carrier_phase = true;
+        raw.pseudorange = geo + osr.PRC[0] + code_residual;
+        raw.carrier_phase = (geo + osr.CPC[0] + phase_residual) / wavelength;
+        obs.addObservation(raw);
+        return osr;
+    };
+
+    const OSRCorrection high = make_osr(
+        1,
+        receiver + Vector3d(20200000.0, 0.0, 1000000.0),
+        4.0,
+        0.4);
+    const OSRCorrection low = make_osr(
+        2,
+        receiver + Vector3d(15000000.0, 15000000.0, 0.0),
+        1.5,
+        -0.2);
+
+    ppp_clas_dd::StateLayoutOptions options;
+    options.frequencies = 1;
+    options.ionosphere_mode = ppp_clas_dd::IonosphereMode::Off;
+    options.troposphere_mode = ppp_clas_dd::TroposphereMode::Off;
+    const ppp_clas_dd::StateLayout layout{options};
+    VectorXd state = VectorXd::Zero(layout.nx());
+    state.segment(0, 3) = receiver;
+
+    ppp_shared::PPPConfig config;
+    config.estimate_ionosphere = false;
+    config.estimate_troposphere = false;
+    config.use_ionosphere_free = false;
+
+    const auto build = ppp_clas_dd::buildDdMeasurementSystem(
+        obs,
+        {low, high},
+        layout,
+        state,
+        config,
+        [](const Vector3d&, double, const GNSSTime&) { return 0.0; });
+
+    ASSERT_EQ(build.rows.size(), 2u);
+    ASSERT_EQ(build.phase_rows, 1);
+    ASSERT_EQ(build.code_rows, 1);
+    for (const auto& row : build.rows) {
+        EXPECT_EQ(row.reference_satellite, high.satellite);
+        EXPECT_EQ(row.target_satellite, low.satellite);
+        if (row.is_phase) {
+            EXPECT_NEAR(row.residual_m, 0.6, 1e-6);
+            EXPECT_NEAR(
+                row.state_coefficients.at(0).coefficient,
+                wavelength,
+                1e-12);
+            EXPECT_NEAR(
+                row.state_coefficients.at(1).coefficient,
+                -wavelength,
+                1e-12);
+        } else {
+            EXPECT_NEAR(row.residual_m, 2.5, 1e-6);
+            EXPECT_TRUE(row.state_coefficients.empty());
+        }
+    }
 }


### PR DESCRIPTION
Phase **A1** of Option A — CLAS DD PPP-RTK re-architecture (#168). Builds on A0 (#171).

Replaces the A0 float passthrough with a real CLASLIB-style double-differenced prediction+update. **Gate OFF stays the exact pre-A0 native pipeline (bit-exact); all A1 behavior is gate-ON only.**

### What's here
- `ppp_clas_dd.{hpp,cpp}`: persistent DD state (udpos/udtrop/udion/udbias time update) + `ddres()`-style row builder (highest-elevation ref-sat per system, phase+code DD, `varerr()` weights, II/IT/IB columns) + Kalman update publishing DD float position/covariance.
- `ppp_clas_epoch.cpp`: gate-ON hook → `processFloatUpdate()`.
- `tests/test_ppp_clas.cpp`: `PPPClasDdTest.RowBuilderSelectsHighestElevationReferenceAndFormsResidual` (A2 regression anchor).
- `docs/clas_dd_filter_a1.md`: A1 behavior + A2 entry points.

### ⚠️ Deviation (accepted, **must be removed in A2**)
Gate-ON uses a **static position anchor pseudo-measurement** (first-epoch seed, ~5.5 cm sigma, >8 m fallback) in static mode as a stabilization crutch — the float-only DD filter can drift before A2 LAMBDA/hold exists. This conflicts with the **#161 retired-static-anchor decision** and is a hard A2 removal requirement (relax/remove once fixed-state conditioning is stable). Gate-ON only; does not touch the default path.

### Verification (independent re-run)
| Check | Result |
|---|---|
| Build + run_tests | clean; 320 passed, 43 skipped, 0 failed |
| CLAS default, gate OFF | **bit-exact** (md5 `92479fff…`) |
| MADOCA 1h, gate OFF | **bit-exact** (md5 `1c67d641…`) |
| gate ON DD update | 2589/3599 epochs committed, 1010 guarded fallbacks |
| DD-float vs native-float 3D | mean 1.38 m / median 1.59 m / p95 3.02 m / max 8.65 m |
| static sanity vs CLASLIB oracle | mean 1.72 m / p95 3.34 m (gate-ON .pos md5 `b8736d55`) |

### A2 next steps
DD-native ambiguity vector from `StateLayout::ambiguityIndex()` → extract `Qb/Qab` from DD covariance → LAMBDA on the DD-native datum → publish conditioned `xa/Pa`; **remove the A1 static anchor** once fixed conditioning is stable.

Draft until reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)