### PR TITLE
feat(clas): A2 DD-native LAMBDA conditioning + remove static anchor (#168)

### DIFF
--- a/docs/clas_dd_filter_a2.md
+++ b/docs/clas_dd_filter_a2.md
@@ -1,0 +1,62 @@
+# CLAS DD PPP-RTK Filter A2
+
+A2 adds gated DD-native LAMBDA conditioning to the A1 double-differenced
+CLAS scaffold and removes the A1 static position anchor pseudo-measurement.
+The path remains behind `GNSS_PPP_CLAS_DD_FILTER=1`; the default CLAS and
+MADOCA paths do not call this code.
+
+## Implemented
+
+- `DdFilterScaffold::processFloatUpdate()` now attempts integer fixing after a
+  successful DD float update.
+- The ambiguity vector is built from the same phase rows selected by
+  `buildDdMeasurementSystem()`, using `StateLayout::ambiguityIndex()` for the
+  reference and target satellites in each DD group.
+- DD ambiguity covariance and ambiguity-vs-head covariance are extracted through
+  `rtk_measurement::buildAmbiguityTransform()` on the DD scaffold state and
+  covariance.  The old PPP ambiguity maps in `ppp_ar.cpp` and `ppp_wlnl.cpp`
+  are not used.
+- The full DD candidate vector is attempted first.  If the full vector does not
+  pass the ratio gate, A2 attempts the highest available per-frequency DD
+  subset from the same row builder groups.  This is a minimal PAR bridge for
+  CLASLIB's `posopt7=on` oracle configuration; post-fit fixed validation and
+  hold policy remain A3.
+- On acceptance, the DD head state is conditioned with
+  `xa = x - Qab * Qb^-1 * (b_float - b_fixed)`, the head covariance is
+  downdated with `Pa = Paa - Qab * Qb^-1 * Qab'`, and compatible
+  single-satellite ambiguity values are restored into the fixed snapshot.
+- Accepted fixed snapshots are fed back into the DD scaffold so subsequent
+  epochs carry the accepted ambiguity datum.  No hold pseudo-measurements are
+  added in A2.
+- The A1 anchor row was removed: no `appendStaticPositionAnchor()`, no
+  anchor variance constant, and no static distance fallback guard remain.  The
+  only stabilization retained is the initial DD position covariance
+  (`0.003 m^2`) used when seeding the DD state from the first native float.
+
+## Anchor Removal Measurement
+
+2019-08-27 CLAS, same-epoch `/tmp/s31_ref/claslib_oracle_xyz_full.pos` oracle,
+`--ar-ratio-threshold 2.0`, 3599 matched epochs.
+
+| Path | Fixed epochs | Fixed 3D mean / p95 | Fixed Up mean / p95 | All 3D mean / p95 | LAMBDA accepted / rejected | Mean attempted ratio |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| A1 anchor, no A2 LAMBDA | 0 | n/a | n/a | 1.721532 / 3.335225 m | 0 / 0 | n/a |
+| A2 with A1 anchor still present | 169 | 2.138678 / 3.870272 m | 1.785294 / 2.749376 m | 1.721540 / 3.335829 m | 169 / 2420 | 1.450616 |
+| A2 final, anchor removed | 1073 | 1.342069 / 2.868478 m | 0.709820 / 1.918809 m | 1.161354 / 2.914994 m | 1073 / 1576 | 84.636654 |
+
+The final no-anchor path fixes more epochs than the native baseline fixed count
+(301) and improves the A1 float oracle mean/p95 3D and Up errors, but it does
+not yet reach CLASLIB/native fixed accuracy.  That remaining gap is the A3
+hold/validation target.
+
+## A3 Entry Points
+
+- `DdFilterScaffold::conditionFixedSnapshot()`: add CLASLIB-style post-fix
+  residual validation around the accepted `fixed_snapshot_` before feedback.
+- `DdFilterScaffold::processFloatUpdate()`: add holdamb-style pseudo-row
+  feedback only after min-fix, ratio, PDOP, and postfit gates pass.
+- `buildDdMeasurementSystem()`: preserve reference-satellite continuity and
+  expose reference changes so A3 can reset or withhold ambiguity feedback on
+  unstable groups.
+- `DdUpdateDiagnostics`: surface accepted/rejected reasons and subset type if
+  A3 needs per-epoch validation telemetry.

--- a/include/libgnss++/algorithms/ppp_clas_dd.hpp
+++ b/include/libgnss++/algorithms/ppp_clas_dd.hpp
@@ -116,6 +116,12 @@ struct DdUpdateDiagnostics {
     int phase_rows = 0;
     int code_rows = 0;
     int reference_groups = 0;
+    bool lambda_attempted = false;
+    bool lambda_accepted = false;
+    int lambda_ambiguities = 0;
+    double lambda_ratio = 0.0;
+    double lambda_required_ratio = 0.0;
+    std::string lambda_reject_reason;
     rtk_update::FilterUpdateResult filter_update;
 };
 
@@ -138,10 +144,19 @@ public:
         const std::map<std::string, std::string>& epoch_atmos);
 
     const StateSnapshot& snapshot() const { return snapshot_; }
+    const StateSnapshot& fixedSnapshot() const { return fixed_snapshot_; }
     bool hasSnapshot() const { return has_snapshot_; }
+    bool hasFixedSnapshot() const { return has_fixed_snapshot_; }
     const DdUpdateDiagnostics& lastDiagnostics() const { return last_diagnostics_; }
     int totalUpdatedEpochs() const { return total_updated_epochs_; }
     int totalFallbackEpochs() const { return total_fallback_epochs_; }
+    int totalLambdaAcceptedEpochs() const { return total_lambda_accepted_epochs_; }
+    int totalLambdaRejectedEpochs() const { return total_lambda_rejected_epochs_; }
+    double meanLambdaRatio() const {
+        return lambda_ratio_count_ > 0
+            ? lambda_ratio_sum_ / static_cast<double>(lambda_ratio_count_)
+            : 0.0;
+    }
     void reset();
 
 private:
@@ -172,18 +187,27 @@ private:
     PositionSolution publishSolution(
         const PositionSolution& native_float_solution,
         const rtk_measurement::MeasurementDiagnostics& measurement_diagnostics,
-        int observed_satellites) const;
+        int observed_satellites,
+        const StateSnapshot& source_snapshot,
+        bool fixed) const;
+    bool conditionFixedSnapshot(
+        const std::vector<DdRow>& rows,
+        const ppp_shared::PPPConfig& config);
 
     StateSnapshot snapshot_;
+    StateSnapshot fixed_snapshot_;
     std::map<int, int> ionosphere_outage_by_satno_;
     std::map<int, double> ionosphere_process_noise_by_satno_;
     std::map<std::pair<int, int>, int> ambiguity_outage_by_satno_freq_;
     DdUpdateDiagnostics last_diagnostics_;
-    Vector3d static_anchor_position_ = Vector3d::Zero();
     int total_updated_epochs_ = 0;
     int total_fallback_epochs_ = 0;
+    int total_lambda_accepted_epochs_ = 0;
+    int total_lambda_rejected_epochs_ = 0;
+    double lambda_ratio_sum_ = 0.0;
+    int lambda_ratio_count_ = 0;
     bool has_snapshot_ = false;
-    bool has_static_anchor_ = false;
+    bool has_fixed_snapshot_ = false;
 };
 
 }  // namespace libgnss::ppp_clas_dd

--- a/src/algorithms/ppp_clas_dd.cpp
+++ b/src/algorithms/ppp_clas_dd.cpp
@@ -9,6 +9,7 @@
 #include <tuple>
 #include <utility>
 
+#include <libgnss++/algorithms/lambda.hpp>
 #include <libgnss++/core/constants.hpp>
 #include <libgnss++/core/coordinates.hpp>
 
@@ -39,7 +40,7 @@ constexpr int kMinPrnSbas = 120;
 constexpr int kMaxPrnSbas = 158;
 constexpr int kNsatNavic = 14;
 
-constexpr double kDdStaticInitialPositionVariance = 1.0;
+constexpr double kDdInitialPositionVarianceM2 = 0.003;
 constexpr double kClaslibInitialZwdM = 0.001;
 constexpr double kClaslibStdBiasCycles = 100.0;
 constexpr double kClaslibStdIonoM = 0.01;
@@ -52,8 +53,6 @@ constexpr double kClaslibForgetIono = 0.5;
 constexpr double kClaslibAfGainIono = 1.0;
 constexpr int kClaslibMaxOutage = 5;
 constexpr double kGpsL2VarianceScale = (2.55 / 1.55) * (2.55 / 1.55);
-constexpr double kDdStaticAnchorVarianceM2 = 0.003;
-constexpr double kDdStaticPositionCovarianceFloorM2 = 1.0;
 constexpr double kDdPostfitResidualRmsLimitM = 5.0;
 constexpr double kDdPostfitResidualMaxLimitM = 20.0;
 
@@ -82,6 +81,11 @@ struct DdGroupKey {
         return std::tie(system_group, frequency_index, is_phase) <
                std::tie(rhs.system_group, rhs.frequency_index, rhs.is_phase);
     }
+};
+
+struct DdAmbiguityCandidate {
+    rtk_measurement::AmbiguityDifference difference;
+    int frequency_index = 0;
 };
 
 int qzssPrnForClaslib(int prn) {
@@ -254,33 +258,45 @@ bool postfitRowsAccepted(const DdMeasurementBuildResult& postfit_build) {
            rowResidualMaxAbs(postfit_build.rows) <= kDdPostfitResidualMaxLimitM;
 }
 
-void appendStaticPositionAnchor(rtk_measurement::MeasurementSystem& system,
-                                const Vector3d& state_position,
-                                const Vector3d& anchor_position) {
-    const int old_rows = static_cast<int>(system.residuals.size());
-    const int n_states = static_cast<int>(system.design_matrix.cols());
-    if (n_states < 3 || system.design_matrix.rows() != old_rows ||
-        system.covariance.rows() != old_rows ||
-        system.covariance.cols() != old_rows) {
-        return;
+std::vector<DdAmbiguityCandidate> collectDdAmbiguityCandidates(
+    const std::vector<DdRow>& rows,
+    const StateLayout& layout,
+    const VectorXd& state,
+    const MatrixXd& covariance) {
+    std::vector<DdAmbiguityCandidate> candidates;
+    std::set<std::tuple<int, int, int>> seen;
+    for (const auto& row : rows) {
+        if (!row.is_phase) {
+            continue;
+        }
+        const int ref_satno = claslibSatelliteNumber(row.reference_satellite);
+        const int target_satno = claslibSatelliteNumber(row.target_satellite);
+        const int ref_index =
+            layout.ambiguityIndex(ref_satno, row.frequency_index);
+        const int target_index =
+            layout.ambiguityIndex(target_satno, row.frequency_index);
+        if (ref_index < 0 || target_index < 0 ||
+            ref_index >= state.size() || target_index >= state.size() ||
+            ref_index >= covariance.rows() || target_index >= covariance.rows() ||
+            ref_index >= covariance.cols() || target_index >= covariance.cols()) {
+            continue;
+        }
+        if (!std::isfinite(state(ref_index)) || !std::isfinite(state(target_index)) ||
+            !std::isfinite(covariance(ref_index, ref_index)) ||
+            !std::isfinite(covariance(target_index, target_index)) ||
+            covariance(ref_index, ref_index) <= 0.0 ||
+            covariance(target_index, target_index) <= 0.0) {
+            continue;
+        }
+        const auto key = std::make_tuple(
+            row.frequency_index, ref_index, target_index);
+        if (!seen.insert(key).second) {
+            continue;
+        }
+        candidates.push_back(
+            {{ref_index, target_index}, row.frequency_index});
     }
-
-    MatrixXd design = MatrixXd::Zero(old_rows + 3, n_states);
-    VectorXd residuals = VectorXd::Zero(old_rows + 3);
-    MatrixXd covariance = MatrixXd::Zero(old_rows + 3, old_rows + 3);
-    if (old_rows > 0) {
-        design.topRows(old_rows) = system.design_matrix;
-        residuals.head(old_rows) = system.residuals;
-        covariance.topLeftCorner(old_rows, old_rows) = system.covariance;
-    }
-    for (int axis = 0; axis < 3; ++axis) {
-        design(old_rows + axis, axis) = 1.0;
-        residuals(old_rows + axis) = anchor_position(axis) - state_position(axis);
-        covariance(old_rows + axis, old_rows + axis) = kDdStaticAnchorVarianceM2;
-    }
-    system.design_matrix = std::move(design);
-    system.residuals = std::move(residuals);
-    system.covariance = std::move(covariance);
+    return candidates;
 }
 
 }  // namespace
@@ -649,12 +665,8 @@ void DdFilterScaffold::initializeFromNativeFloat(
         native_float_solution.position_ecef.allFinite()
             ? native_float_solution.position_ecef
             : native_state.state.segment(native_state.pos_index, 3);
-    if (!has_static_anchor_) {
-        static_anchor_position_ = seed_position;
-        has_static_anchor_ = true;
-    }
     for (int axis = 0; axis < 3 && axis < layout.np(); ++axis) {
-        resetStateElement(axis, seed_position(axis), kDdStaticInitialPositionVariance);
+        resetStateElement(axis, seed_position(axis), kDdInitialPositionVarianceM2);
     }
 
     if (layout.options.dynamics && native_state.state.size() >= native_state.pos_index + 9) {
@@ -900,15 +912,20 @@ PositionSolution DdFilterScaffold::fallbackSolution(
 PositionSolution DdFilterScaffold::publishSolution(
     const PositionSolution& native_float_solution,
     const rtk_measurement::MeasurementDiagnostics& measurement_diagnostics,
-    int observed_satellites) const {
+    int observed_satellites,
+    const StateSnapshot& source_snapshot,
+    bool fixed) const {
     PositionSolution solution = native_float_solution;
-    solution.position_ecef = snapshot_.state.segment(0, 3);
-    if (snapshot_.covariance.rows() >= 3 && snapshot_.covariance.cols() >= 3) {
-        solution.position_covariance = snapshot_.covariance.block<3, 3>(0, 0);
+    solution.position_ecef = source_snapshot.state.segment(0, 3);
+    if (source_snapshot.covariance.rows() >= 3 &&
+        source_snapshot.covariance.cols() >= 3) {
+        solution.position_covariance =
+            source_snapshot.covariance.block<3, 3>(0, 0);
     }
-    solution.status = SolutionStatus::PPP_FLOAT;
-    solution.ratio = 0.0;
-    solution.num_fixed_ambiguities = 0;
+    solution.status = fixed ? SolutionStatus::PPP_FIXED : SolutionStatus::PPP_FLOAT;
+    solution.ratio = last_diagnostics_.lambda_ratio;
+    solution.num_fixed_ambiguities =
+        fixed ? last_diagnostics_.lambda_ambiguities : 0;
     solution.num_satellites = observed_satellites;
     solution.iterations = 1;
     solution.residual_rms = measurement_diagnostics.residual_rms_m;
@@ -934,6 +951,210 @@ PositionSolution DdFilterScaffold::publishSolution(
     solution.rtk_update_rejected_by_innovation_gate =
         last_diagnostics_.filter_update.rejected_by_innovation_gate ? 1 : 0;
     return solution;
+}
+
+bool DdFilterScaffold::conditionFixedSnapshot(
+    const std::vector<DdRow>& rows,
+    const ppp_shared::PPPConfig& config) {
+    struct LambdaAttempt {
+        bool attempted = false;
+        bool lambda_success = false;
+        bool accepted = false;
+        int nb = 0;
+        double ratio = 0.0;
+        std::string reject_reason;
+        std::vector<rtk_measurement::AmbiguityDifference> differences;
+        rtk_measurement::AmbiguityTransform transform;
+        MatrixXd q_amb;
+        VectorXd fixed_ambiguities;
+    };
+
+    has_fixed_snapshot_ = false;
+    last_diagnostics_.lambda_attempted = false;
+    last_diagnostics_.lambda_accepted = false;
+    last_diagnostics_.lambda_ambiguities = 0;
+    last_diagnostics_.lambda_ratio = 0.0;
+    last_diagnostics_.lambda_required_ratio = config.ar_ratio_threshold;
+    last_diagnostics_.lambda_reject_reason.clear();
+
+    const StateLayout& layout = snapshot_.layout;
+    const int na = layout.nr();
+    if (!config.enable_ambiguity_resolution) {
+        last_diagnostics_.lambda_reject_reason = "ar_disabled";
+        return false;
+    }
+    if (snapshot_.state.size() != layout.nx() ||
+        snapshot_.covariance.rows() != layout.nx() ||
+        snapshot_.covariance.cols() != layout.nx() ||
+        na <= 0 || na > layout.nx()) {
+        last_diagnostics_.lambda_reject_reason = "invalid_snapshot";
+        return false;
+    }
+
+    const auto candidates = collectDdAmbiguityCandidates(
+        rows, layout, snapshot_.state, snapshot_.covariance);
+    last_diagnostics_.lambda_ambiguities = static_cast<int>(candidates.size());
+    const int min_ambiguities = std::max(2, config.min_satellites_for_ar);
+
+    auto evaluate = [&](const std::vector<int>& indices) {
+        LambdaAttempt attempt;
+        attempt.nb = static_cast<int>(indices.size());
+        if (attempt.nb < min_ambiguities) {
+            attempt.reject_reason = "insufficient_ambiguities";
+            return attempt;
+        }
+
+        attempt.differences.reserve(indices.size());
+        for (const int index : indices) {
+            if (index < 0 || index >= static_cast<int>(candidates.size())) {
+                continue;
+            }
+            attempt.differences.push_back(
+                candidates[static_cast<size_t>(index)].difference);
+        }
+        attempt.nb = static_cast<int>(attempt.differences.size());
+        if (attempt.nb < min_ambiguities) {
+            attempt.reject_reason = "insufficient_ambiguities";
+            return attempt;
+        }
+
+        attempt.transform = rtk_measurement::buildAmbiguityTransform(
+            snapshot_.state, snapshot_.covariance, na, attempt.differences);
+        attempt.q_amb = 0.5 *
+            (attempt.transform.ambiguity_covariance +
+             attempt.transform.ambiguity_covariance.transpose());
+        if (!attempt.transform.dd_float.allFinite() ||
+            !attempt.q_amb.allFinite()) {
+            attempt.reject_reason = "nonfinite_ambiguity_system";
+            return attempt;
+        }
+
+        attempt.attempted = true;
+        if (!lambdaSearch(
+                attempt.transform.dd_float,
+                attempt.q_amb,
+                attempt.fixed_ambiguities,
+                attempt.ratio)) {
+            attempt.reject_reason = "lambda_search";
+            return attempt;
+        }
+        attempt.lambda_success = true;
+        if (std::isfinite(attempt.ratio)) {
+            attempt.ratio = std::min(attempt.ratio, 999.9);
+        } else {
+            attempt.ratio = 0.0;
+        }
+        if (attempt.ratio < config.ar_ratio_threshold) {
+            attempt.reject_reason = "ratio";
+            return attempt;
+        }
+        attempt.accepted = true;
+        return attempt;
+    };
+
+    std::vector<int> full_indices;
+    full_indices.reserve(candidates.size());
+    std::map<int, std::vector<int>> indices_by_frequency;
+    for (int i = 0; i < static_cast<int>(candidates.size()); ++i) {
+        full_indices.push_back(i);
+        indices_by_frequency[candidates[static_cast<size_t>(i)].frequency_index]
+            .push_back(i);
+    }
+
+    LambdaAttempt best_attempt;
+    auto remember = [&](LambdaAttempt&& attempt) {
+        if (!attempt.attempted) {
+            if (best_attempt.reject_reason.empty()) {
+                best_attempt.reject_reason = attempt.reject_reason;
+                best_attempt.nb = std::max(best_attempt.nb, attempt.nb);
+            }
+            return;
+        }
+        if (!best_attempt.attempted ||
+            (attempt.accepted && !best_attempt.accepted) ||
+            (attempt.accepted && best_attempt.accepted &&
+             std::tie(attempt.nb, attempt.ratio) >
+                 std::tie(best_attempt.nb, best_attempt.ratio)) ||
+            (!attempt.accepted && !best_attempt.accepted &&
+             attempt.ratio > best_attempt.ratio)) {
+            best_attempt = std::move(attempt);
+        }
+    };
+
+    remember(evaluate(full_indices));
+    if (!best_attempt.accepted && !indices_by_frequency.empty()) {
+        remember(evaluate(indices_by_frequency.rbegin()->second));
+    }
+
+    last_diagnostics_.lambda_attempted = best_attempt.attempted;
+    last_diagnostics_.lambda_ambiguities = best_attempt.nb;
+    last_diagnostics_.lambda_ratio = best_attempt.ratio;
+    last_diagnostics_.lambda_reject_reason = best_attempt.reject_reason;
+
+    if (!best_attempt.attempted) {
+        last_diagnostics_.lambda_reject_reason = "insufficient_ambiguities";
+        return false;
+    }
+    lambda_ratio_sum_ += best_attempt.ratio;
+    ++lambda_ratio_count_;
+    if (!best_attempt.accepted) {
+        ++total_lambda_rejected_epochs_;
+        return false;
+    }
+
+    Eigen::LDLT<MatrixXd> ldlt(best_attempt.q_amb);
+    if (ldlt.info() != Eigen::Success) {
+        ++total_lambda_rejected_epochs_;
+        last_diagnostics_.lambda_reject_reason = "q_amb_ldlt";
+        return false;
+    }
+
+    const VectorXd dd_residual =
+        best_attempt.transform.dd_float - best_attempt.fixed_ambiguities;
+    const VectorXd db = ldlt.solve(dd_residual);
+    if (!db.allFinite()) {
+        ++total_lambda_rejected_epochs_;
+        last_diagnostics_.lambda_reject_reason = "q_amb_solve";
+        return false;
+    }
+
+    fixed_snapshot_ = snapshot_;
+    fixed_snapshot_.state.head(na) -=
+        best_attempt.transform.head_ambiguity_covariance * db;
+
+    const MatrixXd q_ab_solved =
+        ldlt.solve(
+            best_attempt.transform.head_ambiguity_covariance.transpose());
+    MatrixXd fixed_head_cov =
+        snapshot_.covariance.topLeftCorner(na, na) -
+        best_attempt.transform.head_ambiguity_covariance * q_ab_solved;
+    fixed_head_cov = 0.5 * (fixed_head_cov + fixed_head_cov.transpose());
+    fixed_snapshot_.covariance.topLeftCorner(na, na) = fixed_head_cov;
+    fixed_snapshot_.covariance.topRightCorner(na, layout.nx() - na).setZero();
+    fixed_snapshot_.covariance.bottomLeftCorner(layout.nx() - na, na).setZero();
+
+    for (int k = 0; k < best_attempt.nb; ++k) {
+        const int ref_index =
+            best_attempt.differences[static_cast<size_t>(k)].reference_state_index;
+        const int target_index =
+            best_attempt.differences[static_cast<size_t>(k)].satellite_state_index;
+        if (ref_index < 0 || target_index < 0 ||
+            ref_index >= fixed_snapshot_.state.size() ||
+            target_index >= fixed_snapshot_.state.size()) {
+            continue;
+        }
+        fixed_snapshot_.state(target_index) =
+            fixed_snapshot_.state(ref_index) - best_attempt.fixed_ambiguities(k);
+        fixed_snapshot_.covariance.row(target_index).setZero();
+        fixed_snapshot_.covariance.col(target_index).setZero();
+        fixed_snapshot_.covariance(target_index, target_index) = 1e-6;
+    }
+
+    has_fixed_snapshot_ = true;
+    last_diagnostics_.lambda_accepted = true;
+    last_diagnostics_.lambda_reject_reason.clear();
+    ++total_lambda_accepted_epochs_;
+    return true;
 }
 
 PositionSolution DdFilterScaffold::processFloatUpdate(
@@ -1047,19 +1268,9 @@ PositionSolution DdFilterScaffold::processFloatUpdate(
         return solution;
     }
 
+    std::vector<DdRow> accepted_rows;
     auto apply_update = [&](DdMeasurementBuildResult& build) {
         auto measurement_system = build.measurement_system;
-        if (!snapshot_.layout.options.dynamics && has_static_anchor_) {
-            for (int axis = 0; axis < 3; ++axis) {
-                snapshot_.covariance(axis, axis) = std::max(
-                    snapshot_.covariance(axis, axis),
-                    kDdStaticPositionCovarianceFloorM2);
-            }
-            appendStaticPositionAnchor(
-                measurement_system,
-                snapshot_.state.segment(0, 3),
-                static_anchor_position_);
-        }
         last_diagnostics_.filter_update = rtk_update::applyMeasurementUpdate(
             snapshot_.state,
             snapshot_.covariance,
@@ -1079,10 +1290,7 @@ PositionSolution DdFilterScaffold::processFloatUpdate(
         if (!postfitRowsAccepted(postfit_build)) {
             return false;
         }
-        if (!snapshot_.layout.options.dynamics && has_static_anchor_ &&
-            (snapshot_.state.segment(0, 3) - static_anchor_position_).norm() > 8.0) {
-            return false;
-        }
+        accepted_rows = build.rows;
         return true;
     };
 
@@ -1149,8 +1357,16 @@ PositionSolution DdFilterScaffold::processFloatUpdate(
 
     ++total_updated_epochs_;
     last_diagnostics_.updated = true;
+    const bool fixed = conditionFixedSnapshot(accepted_rows, config);
+    if (fixed) {
+        snapshot_ = fixed_snapshot_;
+    }
     PositionSolution solution = publishSolution(
-        native_float_solution, measurement_diagnostics, observed_satellites);
+        native_float_solution,
+        measurement_diagnostics,
+        observed_satellites,
+        fixed ? fixed_snapshot_ : snapshot_,
+        fixed);
     solution.time = obs.time;
     return solution;
 }
@@ -1227,15 +1443,19 @@ PositionSolution DdFilterScaffold::processFloatPassthrough(
 
 void DdFilterScaffold::reset() {
     snapshot_ = StateSnapshot{};
+    fixed_snapshot_ = StateSnapshot{};
     ionosphere_outage_by_satno_.clear();
     ionosphere_process_noise_by_satno_.clear();
     ambiguity_outage_by_satno_freq_.clear();
     last_diagnostics_ = DdUpdateDiagnostics{};
-    static_anchor_position_ = Vector3d::Zero();
     total_updated_epochs_ = 0;
     total_fallback_epochs_ = 0;
+    total_lambda_accepted_epochs_ = 0;
+    total_lambda_rejected_epochs_ = 0;
+    lambda_ratio_sum_ = 0.0;
+    lambda_ratio_count_ = 0;
     has_snapshot_ = false;
-    has_static_anchor_ = false;
+    has_fixed_snapshot_ = false;
 }
 
 }  // namespace libgnss::ppp_clas_dd

--- a/tests/test_ppp_clas.cpp
+++ b/tests/test_ppp_clas.cpp
@@ -2,6 +2,7 @@
 
 #include <libgnss++/algorithms/ppp_clas.hpp>
 #include <libgnss++/algorithms/ppp_clas_dd.hpp>
+#include <libgnss++/algorithms/lambda.hpp>
 #include <libgnss++/core/constants.hpp>
 #include <libgnss++/core/coordinates.hpp>
 
@@ -168,4 +169,54 @@ TEST(PPPClasDdTest, RowBuilderSelectsHighestElevationReferenceAndFormsResidual) 
             EXPECT_TRUE(row.state_coefficients.empty());
         }
     }
+}
+
+TEST(PPPClasDdTest, LambdaConditioningFixesDdNativeAmbiguities) {
+    VectorXd state(5);
+    state << 10.0, -3.0, 5.02, 4.00, 7.01;
+
+    MatrixXd covariance = MatrixXd::Zero(5, 5);
+    covariance.diagonal() << 0.5, 0.4, 0.0004, 0.0004, 0.0004;
+    covariance(0, 2) = covariance(2, 0) = 0.020;
+    covariance(0, 3) = covariance(3, 0) = 0.006;
+    covariance(0, 4) = covariance(4, 0) = -0.004;
+    covariance(1, 2) = covariance(2, 1) = -0.010;
+    covariance(1, 3) = covariance(3, 1) = 0.003;
+    covariance(1, 4) = covariance(4, 1) = 0.002;
+
+    const std::vector<rtk_measurement::AmbiguityDifference> differences = {
+        {2, 3},
+        {2, 4},
+    };
+    const auto transform =
+        rtk_measurement::buildAmbiguityTransform(state, covariance, 2, differences);
+
+    VectorXd fixed_ambiguities;
+    double ratio = 0.0;
+    ASSERT_TRUE(lambdaSearch(
+        transform.dd_float,
+        transform.ambiguity_covariance,
+        fixed_ambiguities,
+        ratio));
+    ASSERT_GT(ratio, 2.0);
+    ASSERT_EQ(fixed_ambiguities.size(), 2);
+    EXPECT_NEAR(fixed_ambiguities(0), 1.0, 1e-12);
+    EXPECT_NEAR(fixed_ambiguities(1), -2.0, 1e-12);
+
+    Eigen::LDLT<MatrixXd> ldlt(transform.ambiguity_covariance);
+    ASSERT_EQ(ldlt.info(), Eigen::Success);
+    const VectorXd dd_residual = transform.dd_float - fixed_ambiguities;
+    const VectorXd conditioned_head =
+        transform.head_state -
+        transform.head_ambiguity_covariance * ldlt.solve(dd_residual);
+    const MatrixXd conditioned_covariance =
+        covariance.topLeftCorner(2, 2) -
+        transform.head_ambiguity_covariance *
+            ldlt.solve(transform.head_ambiguity_covariance.transpose());
+
+    EXPECT_LT((conditioned_head - transform.head_state).norm(), 1.0);
+    EXPECT_TRUE(conditioned_covariance.isApprox(
+        conditioned_covariance.transpose(), 1e-14));
+    EXPECT_LT(conditioned_covariance(0, 0), covariance(0, 0));
+    EXPECT_LT(conditioned_covariance(1, 1), covariance(1, 1));
 }


### PR DESCRIPTION
Phase **A2** of Option A — CLAS DD PPP-RTK re-architecture (#168). Builds on A0 (#171) + A1 (#172).

DD-native ambiguity resolution (LAMBDA) on the A1 DD scaffold, **and removal of the A1 static position anchor** (the #161 retired-static-anchor requirement). Gate OFF stays the exact native pipeline (bit-exact); all A2 behavior is gate-ON only.

### What's here
- `ppp_clas_dd.{hpp,cpp}`: DD-native ambiguity vector from `StateLayout::ambiguityIndex()` for the `buildDdMeasurementSystem()` ref-sat groups → `Qb/Qab` via `rtk_measurement::buildAmbiguityTransform()` → `lambdaSearch()` ratio gate → on accept condition head state (`xa = x − Qab Qb⁻¹ (b_float − b_fixed)`, `Pa = Paa − Qab Qb⁻¹ Qabᵀ`) and feed the accepted datum forward. Full-vector first, then highest per-frequency subset (minimal PAR bridge). `ppp_ar.cpp`/`ppp_wlnl.cpp`/`lambda.cpp` untouched.
- **Removed the A1 static anchor**: no `appendStaticPositionAnchor()`, no anchor variance constant, no static fallback. Only the initial DD seed covariance (0.003 m²) remains.
- `PPPClasDdTest.LambdaConditioningFixesDdNativeAmbiguities`; `docs/clas_dd_filter_a2.md`.

### Anchor removal is a clear win (2019-08-27 CLAS vs same-epoch CLASLIB oracle)
| Path | Fixed | Fixed 3D mean/p95 | All 3D mean/p95 | LAMBDA acc/rej | Mean ratio |
|---|---:|---:|---:|---:|---:|
| A1 anchor, no LAMBDA | 0 | n/a | 1.72 / 3.34 m | 0 / 0 | n/a |
| A2 **with** A1 anchor | 169 | 2.14 / 3.87 m | 1.72 / 3.34 m | 169 / 2420 | 1.45 |
| A2 **anchor removed** | **1073** | **1.34 / 2.87 m** | **1.16 / 2.91 m** | 1073 / 1576 | 84.6 |

Fixed count 1073 > native baseline (301); all-epoch oracle 3D improves to 1.16 m (A1 float was 1.72 m).

### ⚠️ Honest caveat
Per-fix accuracy (1.34 m) does **not** yet reach native fixed parity (0.935 m). A2 fixes *more* epochs but not yet *as accurately* — pruning bad fixes is the **A3 hold/validation** target, not A2. This is a mid-architecture milestone, gated OFF by default.

### Verification (independent re-run)
- gate OFF: CLAS default bit-exact (`92479fff…`), MADOCA 1h bit-exact (`1c67d641…`)
- anchor refs in source: **0**; gate-ON deterministic `.pos` md5 `7f9151b3`
- build clean; run_tests 321 passed, 43 skipped, 0 failed

### A3 next steps
Post-fix residual validation before feedback; holdamb-style pseudo-rows after min-fix/ratio/PDOP/postfit gates; ref-sat continuity tracking; per-epoch rejection telemetry.

Draft until reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)