### PR TITLE
feat(clas): A4 DD row-set parity audit + per-frequency subset fix (#168)

### DIFF
--- a/docs/clas_dd_filter_a4.md
+++ b/docs/clas_dd_filter_a4.md
@@ -1,0 +1,149 @@
+# CLAS DD PPP-RTK Filter A4 Retry
+
+A4 retry starts from the failed A4 attempt 1 and keeps the default CLAS/MADOCA
+paths outside the gated `GNSS_PPP_CLAS_DD_FILTER=1` scaffold.  The retry result
+is a passing partial revert: keep the A4 diagnostics, revert the harmful GPS L2C
+group split and CLASLIB `f2` remap, and do not auto-enable QZSS `S120..S122`
+remapping under the DD filter until QZSS residual parity is fixed.
+
+## CLASLIB Row Audit
+
+The CLASLIB comparison was re-run from the patched disposable build at
+`/tmp/s22_claslib_build`:
+
+```sh
+CLASLIB_S24_DD_DUMP=/tmp/a4_claslib_dd_rows_codes.csv \
+  bash -lc 'cd /tmp/s22_claslib_build/util/rnx2rtkp && \
+  ./rnx2rtkp -k /tmp/a4_static_linux.conf \
+    -ts 2019/08/27 16:00:20 -te 2019/08/27 16:01:40 \
+    -o /tmp/a4_claslib_short_codes.pos \
+    ../../data/0627239Q.obs ../../data/sept_2019239.nav \
+    ../../data/2019239Q.l6'
+```
+
+At GPST 2068/230425 CLASLIB admits:
+
+| Block | Reference | Targets | Rows |
+| --- | --- | --- | ---: |
+| GPS L1 phase/code | G14 | G25 G26 G29 G31 G32 | 10 |
+| GPS L2W phase/code | G14 | G25 G26 G29 G31 G32 | 10 |
+| Galileo E1 phase/code | E27 | E07 | 2 |
+| Galileo E5 phase/code | E27 | E07 | 2 |
+| QZSS L1 phase/code | J02 | J01 J03 | 4 |
+| QZSS L2 phase/code | J02 | J01 J03 | 4 |
+
+Attempt 1's native sample admitted GPS as a separate `m5/f1` L2C group and
+mapped Galileo E5 to `f2`.  The retry found that both are unsafe in the native
+model:
+
+- CLASLIB's GPS f1 row is L2W (`CODE_L2W`), while native RINEX selection keeps
+  GPS `C2X/L2X` under `SignalType::GPS_L2C`.  Splitting that as `m5/f1` was not
+  CLASLIB parity and dominated fixed postfit rejects.
+- The CLASLIB `f2` Galileo remap accepted bad fixed states in the current native
+  ambiguity layout.  Reverting Galileo E5 to the native secondary slot restores
+  the A3-stable ambiguity conditioning.
+- CLASLIB does admit QZSS J01-J03 rows, but the native QZSS residual model is
+  not yet parity-safe.  Enabling the `S120..S122` remap under the DD filter
+  regressed oracle error even when QZSS phase rows were suppressed.
+
+The final A4 retry row sample at GPST 2068/230425 is:
+
+```text
+m0f0C=5;m0f0P=5;m0f1C=5;m0f1P=5;m2f0C=2;m2f0P=2;m2f1C=2;m2f1P=2
+m0f0*=G14, m0f1*=G14, m2f0/f1*=E27
+```
+
+That is intentionally the passing partial-revert surface, not full CLASLIB row
+parity.  The unresolved QZSS and Galileo admission deltas are listed below as A5
+entry points.
+
+## A4 Retry Changes
+
+- Reverted attempt 1's GPS L2C `m5` grouping.  GPS rows stay in CLASLIB/native
+  group `m0`; this removes the worst A4#1 postfit reject source.
+- Reverted attempt 1's Galileo E5 `f2` slot back toward the A3-stable native
+  secondary-frequency layout.  Kept the richer per-frequency subset fallback;
+  after the row-surface revert it improves fixed count and oracle error.
+- Stopped auto-enabling `GNSS_PPP_CLAS_QZSS_S_PRN_FIX` from
+  `GNSS_PPP_CLAS_DD_FILTER=1`.  The explicit QZSS remap knob remains available,
+  and the focused QZSS row-builder unit test remains green, but default A4 retry
+  gate-on does not consume the harmful QZSS rows.
+- Kept the A4 diagnostics: `GNSS_PPP_CLAS_DD_DIAG` records row/ref summaries and
+  the worst fixed-postfit phase row group/frequency/pair.
+
+No ratio gate, postfit gate, static anchor, seed coordinate, or pseudo-measurement
+was added.
+
+## Oracle Result
+
+2019-08-27 CLAS, same-epoch
+`/tmp/s31_ref/claslib_oracle_xyz_full.pos`, `--ar-ratio-threshold 2.0`,
+3599 matched epochs.  Fixed status uses native `FixedAmbiguities` column 13 > 0.
+
+| Path | Fixed epochs | Fixed 3D mean | Fixed Up mean | All-epoch 3D mean |
+| --- | ---: | ---: | ---: | ---: |
+| A3 | 768 | 1.246752 m | 0.378185 m | 1.050019 m |
+| A4#1 | 736 | 2.001001 m | 1.357775 m | 2.025515 m |
+| A4#2 retry | 1067 | 1.122978 m | 0.353088 m | 1.007274 m |
+
+A4#2 beats A3 on fixed count, fixed-only 3D, fixed Up, and all-epoch 3D.  It is
+still about 0.188 m above the native parity target of about 0.935 m fixed-only
+3D.
+
+## Reject Counts
+
+Final gate-on diagnostics from `/tmp/a4b_check_clas_dd_diag.csv`:
+
+| Gate/result | Epochs |
+| --- | ---: |
+| Fixed accepted | 1067 |
+| DD float postfit fallback | 969 |
+| Ratio reject | 932 |
+| Insufficient ambiguities | 553 |
+| Fixed postfit RMS reject | 70 |
+| Fixed postfit max reject | 8 |
+
+Postfit reject split by worst phase row:
+
+| Reason | Group/frequency | Epochs |
+| --- | --- | ---: |
+| postfit_rms | m0 f1 GPS/native L2 | 69 |
+| postfit_max | m0 f1 GPS/native L2 | 8 |
+| postfit_rms | m0 f0 GPS L1 | 1 |
+
+Row participation over 3599 epochs:
+
+| Group/frequency | Rows total | Mean rows/epoch |
+| --- | ---: | ---: |
+| m0 f0 GPS L1 phase/code | 41250 | 11.462 |
+| m0 f1 GPS/native L2 phase/code | 41250 | 11.462 |
+| m2 f0 Galileo E1 phase/code | 15184 | 4.218 |
+| m2 f1 Galileo E5 native slot phase/code | 15184 | 4.218 |
+
+## Verification
+
+- `cmake --build build-madoca-parity --parallel --target gnss_ppp run_tests`
+  passed.
+- CLAS default gate off:
+  `/tmp/a0_ref/clas_default.pos` and `/tmp/a4b_check_clas.pos` matched by
+  `cmp`, md5 `92479fffdeb0010cd940aa997a482358`.
+- MADOCA 1h gate off:
+  `/tmp/a0_ref/madoca_1h.pos` and `/tmp/a4b_check_madoca_1h.pos` matched by
+  `cmp`, md5 `1c67d6415ce92d317a392111a2d78471`.
+- `./build-madoca-parity/tests/run_tests`: 323 passed, 43 skipped.
+
+## A5 Entry Points
+
+- QZSS is the largest unresolved parity blocker.  The CLASLIB row dump admits
+  J01-J03, but native `S120..S122` remap rows worsen oracle error, including in
+  a QZSS-code-only trial.  Compare native QZSS PRC/CPC residuals against
+  CLASLIB `ddres()` before re-enabling automatic remap.
+- GPS L2W parity requires preserving RINEX GPS `C2W/L2W` identity and applying
+  SSR bias id 9.  Native currently collapses GPS band 2 to `GPS_L2C`, so L2W
+  cannot be modeled faithfully inside `ppp_clas_dd.cpp` alone.
+- Galileo exact admission remains open.  A broad broadcast-clock guard removes
+  the extra E30 target at 230425, but it misses the all-epoch A3 bar.  Add a
+  targeted CLASLIB-valid-ZD admission source rather than a broad clock heuristic.
+- After QZSS and L2W identity are fixed, revisit CLASLIB `f2` frequency-slot
+  parity.  The subset fallback is useful on the corrected native row surface,
+  but should be rechecked when true CLASLIB f2 rows are restored.

--- a/include/libgnss++/algorithms/ppp_clas_dd.hpp
+++ b/include/libgnss++/algorithms/ppp_clas_dd.hpp
@@ -132,6 +132,10 @@ struct DdPostfitValidationResult {
     double phase_residual_rms_m = 0.0;
     double phase_residual_max_abs_m = 0.0;
     double chi_square_ratio = 0.0;
+    int worst_phase_system_group = -1;
+    int worst_phase_frequency_index = -1;
+    double worst_phase_residual_m = 0.0;
+    std::string worst_phase_pair;
 };
 
 DdPostfitValidationResult validateDdPostfitResiduals(
@@ -162,6 +166,8 @@ struct DdUpdateDiagnostics {
     bool hold_applied = false;
     int hold_rows = 0;
     std::string hold_reject_reason;
+    std::string row_summary;
+    std::string reference_summary;
     rtk_update::FilterUpdateResult filter_update;
 };
 

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -239,7 +239,7 @@ struct PPPEnvOverrides {
     bool clas_stec_constraint = false;
     // GNSS_PPP_CLAS_QZSS_S_PRN_FIX: map compact CLAS legacy S120..S122
     // correction labels to QZSS J01..J03 when set exactly to "1".
-    // Default false while row-set parity is measured.
+    // Default false while QZSS residual parity is measured.
     bool clas_qzss_s_prn_fix = false;
     // GNSS_PPP_DEBUG: general PPP debug logging. Default false.
     bool debug = false;

--- a/src/algorithms/ppp_clas_dd.cpp
+++ b/src/algorithms/ppp_clas_dd.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <limits>
 #include <set>
+#include <sstream>
 #include <tuple>
 #include <utility>
 
@@ -127,9 +128,11 @@ bool readAtmosphereNetworkId(
     return true;
 }
 
-int systemGroup(const SatelliteId& satellite) {
+int systemGroup(const SatelliteId& satellite, SignalType signal) {
+    (void)signal;
     switch (satellite.system) {
         case GNSSSystem::GPS:
+            return 0;
         case GNSSSystem::SBAS:
             return 0;
         case GNSSSystem::GLONASS:
@@ -143,6 +146,75 @@ int systemGroup(const SatelliteId& satellite) {
         default:
             return -1;
     }
+}
+
+std::string groupFrequencyModeLabel(
+    int system_group,
+    int frequency_index,
+    bool is_phase) {
+    std::ostringstream label;
+    label << 'm' << system_group
+          << 'f' << frequency_index
+          << (is_phase ? 'P' : 'C');
+    return label.str();
+}
+
+std::string summarizeRowsByGroupFrequency(const std::vector<DdRow>& rows) {
+    std::map<std::tuple<int, int, bool>, int> counts;
+    for (const auto& row : rows) {
+        ++counts[{row.system_group, row.frequency_index, row.is_phase}];
+    }
+    std::ostringstream summary;
+    bool first = true;
+    for (const auto& [key, count] : counts) {
+        if (!first) {
+            summary << ';';
+        }
+        first = false;
+        const auto [system_group, frequency_index, is_phase] = key;
+        summary << groupFrequencyModeLabel(system_group, frequency_index, is_phase)
+                << '=' << count;
+    }
+    return summary.str();
+}
+
+std::string summarizeReferenceGroups(
+    const std::vector<DdReferenceGroup>& reference_groups) {
+    std::ostringstream summary;
+    bool first = true;
+    for (const auto& group : reference_groups) {
+        if (!first) {
+            summary << ';';
+        }
+        first = false;
+        summary << groupFrequencyModeLabel(
+                       group.system_group,
+                       group.frequency_index,
+                       group.is_phase)
+                << '=' << group.reference_satellite.toString();
+    }
+    return summary.str();
+}
+
+int claslibFrequencyIndex(
+    const SatelliteId& satellite,
+    SignalType signal,
+    int osr_frequency_index) {
+    (void)satellite;
+    (void)signal;
+    return osr_frequency_index;
+}
+
+double osrWavelengthForClaslibFrequency(
+    const OSRCorrection& osr,
+    int claslib_frequency_index) {
+    for (int f = 0; f < osr.num_frequencies; ++f) {
+        if (claslibFrequencyIndex(osr.satellite, osr.signals[f], f) ==
+            claslib_frequency_index) {
+            return osr.wavelengths[f];
+        }
+    }
+    return 0.0;
 }
 
 double systemErrorFactor(GNSSSystem system) {
@@ -454,6 +526,11 @@ StateLayoutOptions layoutOptionsFromConfig(
     for (const auto& osr : osr_corrections) {
         if (osr.valid) {
             frequencies = std::max(frequencies, osr.num_frequencies);
+            for (int f = 0; f < osr.num_frequencies && f < OSR_MAX_FREQ; ++f) {
+                frequencies = std::max(
+                    frequencies,
+                    claslibFrequencyIndex(osr.satellite, osr.signals[f], f) + 1);
+            }
         }
     }
     options.frequencies = std::max(1, frequencies);
@@ -489,8 +566,7 @@ DdMeasurementBuildResult buildDdMeasurementSystem(
             continue;
         }
         const int satno = claslibSatelliteNumber(osr.satellite);
-        const int group = systemGroup(osr.satellite);
-        if (!layout.validSatelliteNumber(satno) || group < 0) {
+        if (!layout.validSatelliteNumber(satno)) {
             continue;
         }
         const Vector3d range_vector = osr.satellite_position - receiver_position;
@@ -515,20 +591,35 @@ DdMeasurementBuildResult buildDdMeasurementSystem(
             if (osr.wavelengths[f] <= 0.0 || osr.wavelengths[0] <= 0.0) {
                 continue;
             }
+            const int frequency_index =
+                claslibFrequencyIndex(osr.satellite, osr.signals[f], f);
+            if (frequency_index < 0 || frequency_index >= layout.nf()) {
+                continue;
+            }
+            const int group = systemGroup(osr.satellite, osr.signals[f]);
+            if (group < 0) {
+                continue;
+            }
             const Observation* raw = obs.getObservation(osr.satellite, osr.signals[f]);
             if (raw == nullptr || !raw->valid) {
                 continue;
             }
+            const bool phase_observable =
+                raw->has_carrier_phase &&
+                std::isfinite(raw->carrier_phase);
+            const bool code_observable =
+                raw->has_pseudorange &&
+                std::isfinite(raw->pseudorange);
             const double ion_scale =
                 std::pow(osr.wavelengths[f] / osr.wavelengths[0], 2);
 
-            if (raw->has_carrier_phase && std::isfinite(raw->carrier_phase)) {
+            if (phase_observable) {
                 ZeroDiffMeasurement zd;
                 zd.satellite = osr.satellite;
                 zd.satno = satno;
                 zd.system_group = group;
                 zd.is_phase = true;
-                zd.frequency_index = f;
+                zd.frequency_index = frequency_index;
                 zd.residual_m =
                     raw->carrier_phase * osr.wavelengths[f] -
                     (geo - sat_clock_m + osr.CPC[f]);
@@ -539,17 +630,18 @@ DdMeasurementBuildResult buildDdMeasurementSystem(
                 zd.wavelength_m = osr.wavelengths[f];
                 zd.ionosphere_scale = ion_scale;
                 zd.variance_m2 =
-                    claslibVarerr(osr.satellite.system, elevation, true, f);
-                groups[{group, f, true}].push_back(zd);
+                    claslibVarerr(
+                        osr.satellite.system, elevation, true, frequency_index);
+                groups[{group, frequency_index, true}].push_back(zd);
             }
 
-            if (raw->has_pseudorange && std::isfinite(raw->pseudorange)) {
+            if (code_observable) {
                 ZeroDiffMeasurement zd;
                 zd.satellite = osr.satellite;
                 zd.satno = satno;
                 zd.system_group = group;
                 zd.is_phase = false;
-                zd.frequency_index = f;
+                zd.frequency_index = frequency_index;
                 zd.residual_m =
                     raw->pseudorange - (geo - sat_clock_m + osr.PRC[f]);
                 zd.los = los;
@@ -559,8 +651,9 @@ DdMeasurementBuildResult buildDdMeasurementSystem(
                 zd.wavelength_m = osr.wavelengths[f];
                 zd.ionosphere_scale = ion_scale;
                 zd.variance_m2 =
-                    claslibVarerr(osr.satellite.system, elevation, false, f);
-                groups[{group, f, false}].push_back(zd);
+                    claslibVarerr(
+                        osr.satellite.system, elevation, false, frequency_index);
+                groups[{group, frequency_index, false}].push_back(zd);
             }
         }
     }
@@ -680,6 +773,14 @@ DdPostfitValidationResult validateDdPostfitResiduals(
             phase_sum_sq += row.residual_m * row.residual_m;
             validation.phase_residual_max_abs_m =
                 std::max(validation.phase_residual_max_abs_m, abs_residual);
+            if (abs_residual >= std::abs(validation.worst_phase_residual_m)) {
+                validation.worst_phase_residual_m = row.residual_m;
+                validation.worst_phase_system_group = row.system_group;
+                validation.worst_phase_frequency_index = row.frequency_index;
+                validation.worst_phase_pair =
+                    row.reference_satellite.toString() + ">" +
+                    row.target_satellite.toString();
+            }
         }
     }
     validation.residual_rms_m =
@@ -930,20 +1031,25 @@ void DdFilterScaffold::updateObservedStateBookkeeping(
             if (osr.wavelengths[f] <= 0.0) {
                 continue;
             }
+            const int frequency_index =
+                claslibFrequencyIndex(osr.satellite, osr.signals[f], f);
+            if (frequency_index < 0 || frequency_index >= layout.nf()) {
+                continue;
+            }
             const Observation* raw = obs.getObservation(osr.satellite, osr.signals[f]);
             if (raw == nullptr || !raw->valid || !raw->has_carrier_phase ||
                 !raw->has_pseudorange || !std::isfinite(raw->carrier_phase) ||
                 !std::isfinite(raw->pseudorange)) {
                 continue;
             }
-            const auto key = std::make_pair(satno, f);
+            const auto key = std::make_pair(satno, frequency_index);
             ambiguity_outage_by_satno_freq_[key] = 0;
             if (ambiguity_lock_by_satno_freq_.find(key) ==
                 ambiguity_lock_by_satno_freq_.end()) {
                 ambiguity_lock_by_satno_freq_[key] = -kClaslibMinLockCount;
             }
 
-            const int ambiguity_index = layout.ambiguityIndex(satno, f);
+            const int ambiguity_index = layout.ambiguityIndex(satno, frequency_index);
             if (ambiguity_index < 0) {
                 continue;
             }
@@ -959,7 +1065,8 @@ void DdFilterScaffold::updateObservedStateBookkeeping(
             const double bias_m =
                 raw->carrier_phase * osr.wavelengths[f] - raw->pseudorange;
             if (std::isfinite(bias_m)) {
-                ambiguity_biases_m[f].push_back({ambiguity_index, bias_m});
+                ambiguity_biases_m[frequency_index].push_back(
+                    {ambiguity_index, bias_m});
             }
         }
     }
@@ -993,9 +1100,9 @@ void DdFilterScaffold::updateObservedStateBookkeeping(
                 double wavelength = 0.0;
                 for (const auto& osr : osr_corrections) {
                     const int satno = claslibSatelliteNumber(osr.satellite);
-                    if (layout.ambiguityIndex(satno, frequency) == ambiguity_index &&
-                        frequency < osr.num_frequencies) {
-                        wavelength = osr.wavelengths[frequency];
+                    if (layout.ambiguityIndex(satno, frequency) == ambiguity_index) {
+                        wavelength =
+                            osrWavelengthForClaslibFrequency(osr, frequency);
                         break;
                     }
                 }
@@ -1016,9 +1123,9 @@ void DdFilterScaffold::updateObservedStateBookkeeping(
             double wavelength = 0.0;
             for (const auto& osr : osr_corrections) {
                 const int satno = claslibSatelliteNumber(osr.satellite);
-                if (layout.ambiguityIndex(satno, frequency) == ambiguity_index &&
-                    frequency < osr.num_frequencies) {
-                    wavelength = osr.wavelengths[frequency];
+                if (layout.ambiguityIndex(satno, frequency) == ambiguity_index) {
+                    wavelength =
+                        osrWavelengthForClaslibFrequency(osr, frequency);
                     break;
                 }
             }
@@ -1306,12 +1413,17 @@ void DdFilterScaffold::appendDiagnosticsCsv(
             << "lambda_ambiguities,lambda_ratio,reject_reason,postfit_rms_m,"
             << "postfit_max_m,postfit_phase_rms_m,postfit_phase_max_m,"
             << "postfit_chi_ratio,ar_pdop,hold_pdop,reference_change_groups,"
-            << "consecutive_fix_count,hold_applied,hold_rows,hold_reject_reason\n";
+            << "consecutive_fix_count,hold_applied,hold_rows,hold_reject_reason,"
+            << "row_summary,reference_summary,postfit_worst_group,"
+            << "postfit_worst_frequency,postfit_worst_pair,"
+            << "postfit_worst_phase_residual_m\n";
     }
     const std::string reject_reason =
         !last_diagnostics_.fixed_reject_reason.empty()
             ? last_diagnostics_.fixed_reject_reason
-            : last_diagnostics_.lambda_reject_reason;
+            : (!last_diagnostics_.lambda_reject_reason.empty()
+                   ? last_diagnostics_.lambda_reject_reason
+                   : last_diagnostics_.fallback_reason);
     output << time.week << ',' << time.tow << ','
            << (last_diagnostics_.updated ? 1 : 0) << ','
            << (fixed ? 1 : 0) << ','
@@ -1331,7 +1443,13 @@ void DdFilterScaffold::appendDiagnosticsCsv(
            << last_diagnostics_.consecutive_fix_count << ','
            << (last_diagnostics_.hold_applied ? 1 : 0) << ','
            << last_diagnostics_.hold_rows << ','
-           << last_diagnostics_.hold_reject_reason << '\n';
+           << last_diagnostics_.hold_reject_reason << ','
+           << last_diagnostics_.row_summary << ','
+           << last_diagnostics_.reference_summary << ','
+           << last_diagnostics_.fixed_postfit.worst_phase_system_group << ','
+           << last_diagnostics_.fixed_postfit.worst_phase_frequency_index << ','
+           << last_diagnostics_.fixed_postfit.worst_phase_pair << ','
+           << last_diagnostics_.fixed_postfit.worst_phase_residual_m << '\n';
 }
 
 bool DdFilterScaffold::conditionFixedSnapshot(
@@ -1477,7 +1595,9 @@ bool DdFilterScaffold::conditionFixedSnapshot(
 
     remember(evaluate(full_indices));
     if (!best_attempt.accepted && !indices_by_frequency.empty()) {
-        remember(evaluate(indices_by_frequency.rbegin()->second));
+        for (const auto& [_, indices] : indices_by_frequency) {
+            remember(evaluate(indices));
+        }
     }
 
     last_diagnostics_.lambda_attempted = best_attempt.attempted;
@@ -1702,6 +1822,10 @@ PositionSolution DdFilterScaffold::processFloatUpdate(
     last_diagnostics_.phase_rows = measurement_build.phase_rows;
     last_diagnostics_.code_rows = measurement_build.code_rows;
     last_diagnostics_.reference_groups = measurement_build.reference_groups;
+    last_diagnostics_.row_summary =
+        summarizeRowsByGroupFrequency(measurement_build.rows);
+    last_diagnostics_.reference_summary =
+        summarizeReferenceGroups(measurement_build.reference_groups_detail);
 
     rtk_measurement::MeasurementDiagnostics measurement_diagnostics;
     measurement_diagnostics.observation_count =
@@ -1791,6 +1915,10 @@ PositionSolution DdFilterScaffold::processFloatUpdate(
         last_diagnostics_.phase_rows = retry_build.phase_rows;
         last_diagnostics_.code_rows = retry_build.code_rows;
         last_diagnostics_.reference_groups = retry_build.reference_groups;
+        last_diagnostics_.row_summary =
+            summarizeRowsByGroupFrequency(retry_build.rows);
+        last_diagnostics_.reference_summary =
+            summarizeReferenceGroups(retry_build.reference_groups_detail);
         if (retry_build.rows.size() < 4 || !apply_update(retry_build)) {
             PositionSolution solution = fallbackSolution(
                 native_float_solution,

--- a/tests/test_ppp_clas.cpp
+++ b/tests/test_ppp_clas.cpp
@@ -7,6 +7,8 @@
 #include <libgnss++/core/coordinates.hpp>
 
 #include <cmath>
+#include <set>
+#include <tuple>
 
 using namespace libgnss;
 
@@ -168,6 +170,136 @@ TEST(PPPClasDdTest, RowBuilderSelectsHighestElevationReferenceAndFormsResidual) 
             EXPECT_NEAR(row.residual_m, 2.5, 1e-6);
             EXPECT_TRUE(row.state_coefficients.empty());
         }
+    }
+}
+
+TEST(PPPClasDdTest, RowBuilderAdmitsQzssRowsWithDedicatedReferenceGroup) {
+    ObservationData obs(GNSSTime(2068, 230602.0));
+    const Vector3d receiver(constants::WGS84_A, 0.0, 0.0);
+    const double l1_wavelength = constants::GPS_L1_WAVELENGTH;
+    const double l2_wavelength = constants::GPS_L2_WAVELENGTH;
+
+    auto make_qzss_osr = [&](uint8_t prn,
+                             const Vector3d& satellite_position,
+                             double code_l1_residual,
+                             double phase_l1_residual,
+                             double code_l2_residual,
+                             double phase_l2_residual) {
+        OSRCorrection osr;
+        osr.satellite = SatelliteId(GNSSSystem::QZSS, prn);
+        osr.valid = true;
+        osr.num_frequencies = 2;
+        osr.signals[0] = SignalType::QZS_L1CA;
+        osr.signals[1] = SignalType::QZS_L2C;
+        osr.frequencies[0] = constants::GPS_L1_FREQ;
+        osr.frequencies[1] = constants::GPS_L2_FREQ;
+        osr.wavelengths[0] = l1_wavelength;
+        osr.wavelengths[1] = l2_wavelength;
+        osr.satellite_position = satellite_position;
+        osr.PRC[0] = 0.2 + 0.1 * prn;
+        osr.PRC[1] = 0.4 + 0.1 * prn;
+        osr.CPC[0] = -0.3 + 0.1 * prn;
+        osr.CPC[1] = -0.5 + 0.1 * prn;
+
+        double lat = 0.0;
+        double lon = 0.0;
+        double h = 0.0;
+        ecef2geodetic(receiver, lat, lon, h);
+        const Vector3d enu = ecef2enu(satellite_position - receiver, lat, lon);
+        osr.elevation = std::atan2(enu.z(), std::hypot(enu.x(), enu.y()));
+
+        const double geo = geodist(satellite_position, receiver);
+        auto add_observation = [&](SignalType signal,
+                                   int frequency_index,
+                                   double wavelength,
+                                   double code_residual,
+                                   double phase_residual) {
+            Observation raw(osr.satellite, signal);
+            raw.valid = true;
+            raw.has_pseudorange = true;
+            raw.has_carrier_phase = true;
+            raw.pseudorange = geo + osr.PRC[frequency_index] + code_residual;
+            raw.carrier_phase =
+                (geo + osr.CPC[frequency_index] + phase_residual) /
+                wavelength;
+            obs.addObservation(raw);
+        };
+        add_observation(
+            SignalType::QZS_L1CA, 0, l1_wavelength, code_l1_residual,
+            phase_l1_residual);
+        add_observation(
+            SignalType::QZS_L2C, 1, l2_wavelength, code_l2_residual,
+            phase_l2_residual);
+        return osr;
+    };
+
+    const OSRCorrection j01 = make_qzss_osr(
+        1,
+        receiver + Vector3d(16000000.0, 15000000.0, 0.0),
+        1.0,
+        0.10,
+        1.5,
+        0.15);
+    const OSRCorrection j02 = make_qzss_osr(
+        2,
+        receiver + Vector3d(22000000.0, 1000000.0, 0.0),
+        4.0,
+        0.40,
+        4.5,
+        0.45);
+    const OSRCorrection j03 = make_qzss_osr(
+        3,
+        receiver + Vector3d(17000000.0, -10000000.0, 1000000.0),
+        2.0,
+        0.20,
+        2.5,
+        0.25);
+
+    ppp_clas_dd::StateLayoutOptions options;
+    options.frequencies = 2;
+    options.ionosphere_mode = ppp_clas_dd::IonosphereMode::Off;
+    options.troposphere_mode = ppp_clas_dd::TroposphereMode::Off;
+    const ppp_clas_dd::StateLayout layout{options};
+    VectorXd state = VectorXd::Zero(layout.nx());
+    state.segment(0, 3) = receiver;
+
+    ppp_shared::PPPConfig config;
+    config.estimate_ionosphere = false;
+    config.estimate_troposphere = false;
+    config.use_ionosphere_free = false;
+
+    const auto build = ppp_clas_dd::buildDdMeasurementSystem(
+        obs,
+        {j01, j03, j02},
+        layout,
+        state,
+        config,
+        [](const Vector3d&, double, const GNSSTime&) { return 0.0; });
+
+    ASSERT_EQ(build.rows.size(), 8u);
+    EXPECT_EQ(build.phase_rows, 4);
+    EXPECT_EQ(build.code_rows, 4);
+    EXPECT_EQ(build.reference_groups, 4);
+
+    std::set<std::tuple<int, int, bool>> reference_keys;
+    for (const auto& group : build.reference_groups_detail) {
+        EXPECT_EQ(group.system_group, 4);
+        EXPECT_EQ(group.reference_satellite, j02.satellite);
+        reference_keys.insert(
+            {group.system_group, group.frequency_index, group.is_phase});
+    }
+    EXPECT_EQ(reference_keys.size(), 4u);
+    EXPECT_TRUE(reference_keys.count({4, 0, true}));
+    EXPECT_TRUE(reference_keys.count({4, 0, false}));
+    EXPECT_TRUE(reference_keys.count({4, 1, true}));
+    EXPECT_TRUE(reference_keys.count({4, 1, false}));
+
+    for (const auto& row : build.rows) {
+        EXPECT_EQ(row.system_group, 4);
+        EXPECT_EQ(row.reference_satellite, j02.satellite);
+        EXPECT_NE(row.target_satellite, j02.satellite);
+        EXPECT_TRUE(row.target_satellite == j01.satellite ||
+                    row.target_satellite == j03.satellite);
     }
 }
 


### PR DESCRIPTION
Phase **A4** of Option A — CLAS DD PPP-RTK re-architecture (#168). Builds on A0–A3 (#171–#174).

CLASLIB `ddres()` row-set parity investigation. The **first A4 attempt regressed** gate-ON (A3 fixed 3D 1.247 m → 2.001 m); this is the **retry**: keep what helped, revert what hurt, defer unresolved parity to A5. Gate OFF stays bit-exact; gate-ON only; A2 static-anchor removal preserved.

### Root causes (found via CLASLIB row dumps from `/tmp/s22_claslib_build`)
- **GPS L2C**: attempt 1 split native `C2X/L2X` into group `m5/f1`, but CLASLIB's GPS f1 row is **L2W** — that mismatch dominated postfit rejects. The m5 split is **reverted**.
- **Galileo/QZSS admission**: native lacks a CLASLIB-valid ZD admission source for the Galileo target set, and the auto QZSS `S120..S122` remap worsens oracle error. Auto-remap reverted to explicit-only; full parity **deferred to A5**.

### What ships (the net win over A3)
- **Per-frequency ambiguity subset fallback** — evaluate every per-frequency subset, not only the highest index; recovers more fixable subsets.
- Richer DD diagnostics (row/ref summaries + worst postfit phase row group/freq for constellation/frequency reject splitting).
- A4 QZSS row-builder unit test kept green.

### Oracle table (independently re-verified with `/tmp/oracle_cmp.py`, reproduces exactly)
2019-08-27 CLAS vs same-epoch CLASLIB oracle, `--ar-ratio-threshold 2.0`:

| Path | Fixed | Fixed 3D | Fixed Up | All-epoch 3D |
|---|---:|---:|---:|---:|
| A3 | 768 | 1.247 m | 0.378 m | 1.050 m |
| A4 #1 (bad, dropped) | 736 | 2.001 m | 1.358 m | 2.026 m |
| **A4 (this)** | **1067** | **1.123 m** | **0.353 m** | **1.007 m** |

Beats A3 on every #161 metric; fixed count ≥ native baseline (301); **~0.19 m above native fixed parity (0.935 m)**.

### Remaining gap → A5
QZSS PRC/CPC DD residual parity + GPS **L2W** identity (`C2W/L2W` + SSR bias id 9) + Galileo ZD admission.

### Verification (independent re-run)
- gate OFF: CLAS default bit-exact (`92479fff…`), MADOCA 1h bit-exact (`1c67d641…`)
- anchor refs in source: **0**; gate-ON deterministic `.pos` md5 `f7b2ae1e`
- build clean; run_tests 323 passed, 43 skipped, 0 failed

Draft until reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
