### PR TITLE
feat(rtk): motion-aware kinematic fixed-jump gate + subset-AR full-ratio floor (low-cost)

### DIFF
--- a/apps/gnss_ppc_demo.py
+++ b/apps/gnss_ppc_demo.py
@@ -1197,6 +1197,12 @@ def run_solver(
             "kinematic",
             "--no-kml",
         ]
+        _dbg_log = os.environ.get("PPC_DEBUG_EPOCH_LOG")
+        if _dbg_log:
+            command.extend(["--debug-epoch-log", _dbg_log])
+        _extra = os.environ.get("PPC_EXTRA_SOLVER_ARGS")
+        if _extra:
+            command.extend(_extra.split())
         if args.preset is not None:
             command.extend(["--preset", args.preset])
         if getattr(args, "iono", None) is not None:

--- a/apps/gnss_solve.cpp
+++ b/apps/gnss_solve.cpp
@@ -163,6 +163,9 @@ struct SolveConfig {
     bool min_subset_dual_frequency_sats_for_ar_set = false;
     bool min_hold_count_set = false;
     bool hold_ratio_threshold_set = false;
+    bool max_position_jump_min_m_set = false;
+    bool max_position_jump_rate_mps_set = false;
+    bool min_full_ratio_for_subset_ar_set = false;
     libgnss::RTKProcessor::RTKConfig::ARPolicy ar_policy =
         libgnss::RTKProcessor::RTKConfig::ARPolicy::EXTENDED;
     double max_hold_divergence_m = 0.0;
@@ -934,6 +937,21 @@ void applyRTKTuningPreset(SolveConfig& config) {
             if (!config.min_satellites_for_ar_set) config.min_satellites_for_ar = 6;
             if (!config.min_hold_count_set) config.min_hold_count = 8;
             if (!config.hold_ratio_threshold_set) config.hold_ratio_threshold = 2.5;
+            // Motion-aware fixed-position jump gate for kinematic rovers. The
+            // static 5 m jump-from-last-fix limit starves fixes once the rover
+            // drives away from the last accepted fix (the limit never grows, so
+            // every correct fix past ~5 m of travel is rejected and the
+            // last-fixed anchor freezes). Use a velocity-scaled limit instead.
+            if (!config.max_position_jump_rate_mps_set)
+                config.max_position_jump_rate_mps = 30.0;
+            if (!config.max_position_jump_min_m_set)
+                config.max_position_jump_min_m = 5.0;
+            // Require the full-constellation LAMBDA ratio to be non-degenerate
+            // before admitting a subset-AR fix; subset blunders show full_ratio
+            // ~1 (the rest of the constellation disagrees) yet pass the subset
+            // ratio locally.
+            if (!config.min_full_ratio_for_subset_ar_set)
+                config.min_full_ratio_for_subset_ar = 1.5;
             return;
         case RTKTuningPreset::MOVING_BASE:
             if (!config.ratio_threshold_set) config.ratio_threshold = 2.8;
@@ -1032,6 +1050,7 @@ SolveConfig parseArguments(int argc, char* argv[]) {
             config.min_subset_dual_frequency_sats_for_ar_set = true;
         } else if (arg == "--min-full-ratio-for-subset-ar" && i + 1 < argc) {
             config.min_full_ratio_for_subset_ar = std::stod(argv[++i]);
+            config.min_full_ratio_for_subset_ar_set = true;
         } else if (arg == "--min-hold-count" && i + 1 < argc) {
             config.min_hold_count = std::stoi(argv[++i]);
             config.min_hold_count_set = true;
@@ -1099,8 +1118,10 @@ SolveConfig parseArguments(int argc, char* argv[]) {
             config.max_position_jump_m = std::stod(argv[++i]);
         } else if (arg == "--max-pos-jump-min" && i + 1 < argc) {
             config.max_position_jump_min_m = std::stod(argv[++i]);
+            config.max_position_jump_min_m_set = true;
         } else if (arg == "--max-pos-jump-rate" && i + 1 < argc) {
             config.max_position_jump_rate_mps = std::stod(argv[++i]);
+            config.max_position_jump_rate_mps_set = true;
         } else if (arg == "--max-float-spp-div" && i + 1 < argc) {
             config.max_float_spp_divergence_m = std::stod(argv[++i]);
         } else if (arg == "--max-float-prefit-rms" && i + 1 < argc) {


### PR DESCRIPTION
## Summary

The `low-cost` preset starved RTK fixes on **moving** rovers. `validateFixedSolution()` compares each new fix against the last **accepted** fixed position with a **static 5 m** limit (`max_position_jump_rate_mps=0` ⇒ adaptive path disabled). Once the rover drives >5 m past the last fix, every correct fix is rejected as `max_position_jump`, the last-fixed anchor **freezes**, and fix rate collapses.

This is the **inverse of a false-fix problem**: AR was high quality (full-set fixes ~0.13 m) but structurally unreachable. On `nagoya/run3` the baseline produced **12 fixes / 4460 epochs (0.27%)**; the only fixes that survived were a 3-second burst where the rover was nearly stationary.

## Root cause (from per-epoch AR telemetry)

In the good window (1051 epochs, ~20 sats, sub-metre float): AR attempted 1047×, LAMBDA selected a fix 661×, but **645 were rejected by `max_position_jump`** and only 12 applied. The rejecting gate measures distance from a stale last-fixed anchor with a fixed 5 m bound — nonsensical for a vehicle.

The residual blunder tail (after loosening the gate) was cleanly separated by the **full-set LAMBDA ratio**: good fixes p50 = 8.4, subset blunders p50 = 1.2.

## Fix (low-cost preset defaults; CLI still overrides via `_set` guards)

- `max_position_jump_rate_mps = 30`, `max_position_jump_min_m = 5` — velocity-scaled jump limit so a moving rover can re-fix after legitimate travel.
- `min_full_ratio_for_subset_ar = 1.5` — require a non-degenerate full-constellation ratio before admitting a subset-AR fix.

Other presets (`survey`/`moving-base`/`odaiba`) and the no-preset default are **unchanged**.

## Validation — all 6 PPC-Dataset runs (PPC official 0.5 m score)

| run | baseline | this PR | Δ | fixed-epoch <0.5 m |
|---|---|---|---|---|
| nagoya/run1 | 17.78% | **55.24%** | +37.5 | 99% |
| nagoya/run2 | 13.22% | **33.89%** | +20.7 | 99% |
| nagoya/run3 |  5.93% | **29.27%** | +23.3 | 90% |
| tokyo/run1  |  5.77% | **30.09%** | +24.3 | 93% |
| tokyo/run2  | 21.11% | **81.82%** | +60.7 | 99% |
| tokyo/run3  | 42.26% | **70.67%** | +28.4 | 98% |

Mean ~17.7% → ~50.2% (~3×). No regression on any run; Tokyo good-reacquisition preserved. The built-in preset default reproduces the flag-tuned result byte-for-byte.

Relates to the RTK kinematic cluster (#10 false-fix / #11 float-drift): the dominant error on this dataset was **fix starvation**, not false-fixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
