### PR TITLE
feat(madoca): promote POSTFIT_COMMIT to default, retire #145 boundary guard

### DIFF
--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -22,17 +22,29 @@ PPP-RTK filter.
 
 Delta RMS 3D vs the bridge on the MIZU 2025/04/01 window moved from 69.2 m to
 1.820 m all-epoch / 1.196 m tail over slices #130–#147, then the full-day path
-was unblocked (#143) and 24 h parity reached 1.316 m default / 1.206 m with the
-post-fit commit gate, with a converged-filter guard chain (#144 spike guard,
-#145 boundary guard, #146/#147 commit-on-success + shadow validation).  GLONASS
+was unblocked (#143) and 24 h parity reached 1.206 m once the RTKLIB/MADOCALIB
+post-fit commit-on-success gate (#146/#147) was promoted to the default
+(`GNSS_PPP_MADOCA_POSTFIT_COMMIT` now default-on, `=0` opt-out): 24 h all-epoch
+1.316 → 1.206 m, max 5.26 → 4.46 m, validated across MIZU (1 h/6 h/24 h) and a
+second station (ALIC, neutral) with 1 h/6 h staying byte-exact.  The interim
+#145 boundary guard was retired (commit-on-success subsumes it; guard on/off was
+byte-identical under commit); the #144 spike guard (100 m) is kept as the
+opt-out-path safety net.  GLONASS
 phase, QZSS L5, SSR-replay, bias-identity, and pair-selection hypotheses were
 each measured and closed (default-off knobs kept where they were preview-only).
 The repro harness and per-slice history live in the memory note
 `madoca-ppp-frontier` and in issue #148.
 
-Open MADOCA levers (all measured, none yet a default win): GLONASS phase
-residual is geometry-shaped (windup / antenna phase-center, #149); PPP-AR
-parity (`exec_pppar` window); QZSS atmosphere row-set.
+GLONASS phase was re-diagnosed and closed as a parity lever: the per-satellite
+~1.5 m residual is not an unabsorbed constant but a covariance-collapse plus
+within-pass-varying (elevation-arched) phase error — the float ambiguity
+variance collapses to ~0.03 within ~38 epochs and can no longer track the drift,
+and GLONASS code carries large FDMA inter-frequency biases too.  MADOCA SSR
+provides no GLONASS phase-bias product, so default GLONASS-phase-off is correct
+(matches MADOCALIB excluding GLO from the precise phase/AR solution).
+
+Open MADOCA levers (measured, none yet a default win): PPP-AR parity
+(`exec_pppar` window); QZSS atmosphere row-set.
 
 ### CLAS PPP-RTK native vs CLASLIB (2019-08-27 case, tracker issue #9)
 

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -27,15 +27,16 @@ struct PPPEnvOverrides {
     // parity defaults unless set exactly to "0". Default true.
     bool madoca_early_window = true;
     // GNSS_PPP_MADOCA_SPIKE_GUARD: reject implausible converged static update
-    // jumps in coherent MADOCA unless set exactly to "0". Default true.
+    // jumps in coherent MADOCA unless set exactly to "0". Default true. Retained
+    // as the safety-net backstop after the #145 boundary guard was retired in
+    // favor of default-on POSTFIT_COMMIT.
     bool madoca_spike_guard = true;
-    // GNSS_PPP_MADOCA_BOUNDARY_GUARD: reject smaller coherent-MADOCA
-    // file-boundary update jumps unless set exactly to "0". Default true.
-    bool madoca_boundary_guard = true;
-    // GNSS_PPP_MADOCA_POSTFIT_COMMIT: preview RTKLIB/MADOCALIB-style
-    // postfit validation with commit-on-success semantics for coherent MADOCA
-    // when set exactly to "1". Default false.
-    bool madoca_postfit_commit = false;
+    // GNSS_PPP_MADOCA_POSTFIT_COMMIT: RTKLIB/MADOCALIB-style postfit validation
+    // with commit-on-success semantics for coherent MADOCA. Default true; set
+    // exactly to "0" to opt out (raw accumulate-iterations behavior, retained
+    // for bit-exact debugging — note the retired #145 boundary guard no longer
+    // backstops the opt-out path, only the #144 spike guard remains).
+    bool madoca_postfit_commit = true;
     // GNSS_PPP_MADOCA_POSTFIT_SHADOW: path for native MADOCA postfit
     // residual/statistic shadow dump. Empty disables it.
     std::string madoca_postfit_shadow_path;

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -124,9 +124,8 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
     overrides.static_anchor_blend = envDoubleOr("GNSS_PPP_STATIC_ANCHOR_BLEND", -1.0);
     overrides.madoca_early_window = !envExactZero("GNSS_PPP_MADOCA_EARLY_WINDOW");
     overrides.madoca_spike_guard = !envExactZero("GNSS_PPP_MADOCA_SPIKE_GUARD");
-    overrides.madoca_boundary_guard = !envExactZero("GNSS_PPP_MADOCA_BOUNDARY_GUARD");
     overrides.madoca_postfit_commit =
-        envExactOne("GNSS_PPP_MADOCA_POSTFIT_COMMIT");
+        !envExactZero("GNSS_PPP_MADOCA_POSTFIT_COMMIT");
     overrides.madoca_postfit_shadow_path =
         envStringOrEmpty("GNSS_PPP_MADOCA_POSTFIT_SHADOW");
 

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -23,7 +23,6 @@ using namespace ppp_internal;
 namespace {
 
 constexpr double kMadocaStaticSpikeGuardPositionDeltaM = 100.0;
-constexpr double kMadocaBoundaryGuardPositionJumpM = 10.0;
 constexpr double kMadocaPostfitEpochRejectScore = 0.90;
 constexpr double kRadiansToDegrees = 57.29577951308232;
 
@@ -546,11 +545,6 @@ bool PPPProcessor::updateFilter(const ObservationData& obs, const NavigationData
         env_overrides_.madoca_spike_guard &&
         converged_ &&
         (!ppp_config_.kinematic_mode || ppp_config_.low_dynamics_mode);
-    const bool madoca_boundary_guard =
-        require_coherent_ssr_ && ssr_products_loaded_ &&
-        env_overrides_.madoca_boundary_guard &&
-        converged_ &&
-        (!ppp_config_.kinematic_mode || ppp_config_.low_dynamics_mode);
     const bool madoca_postfit_commit =
         require_coherent_ssr_ && ssr_products_loaded_ &&
         env_overrides_.madoca_postfit_commit;
@@ -715,23 +709,6 @@ bool PPPProcessor::updateFilter(const ObservationData& obs, const NavigationData
             }
             restorePostfitFailedEpoch();
             return false;
-        }
-    }
-
-    if (madoca_boundary_guard) {
-        const double epoch_position_jump_m = epoch_position_update_norm_m;
-        if (std::isfinite(epoch_position_jump_m) &&
-            epoch_position_jump_m > kMadocaBoundaryGuardPositionJumpM) {
-            if (pppDebugEnabled()) {
-                std::cerr << "[PPP] MADOCA boundary guard rejected update at week="
-                          << obs.time.week
-                          << " tow=" << obs.time.tow
-                          << " pos_jump=" << epoch_position_jump_m
-                          << "\n";
-            }
-            filter_state_ = pre_update_state;
-            pre_anchor_covariance_ = filter_state_.covariance;
-            return true;
         }
     }
 


### PR DESCRIPTION
## Summary

Promotes the RTKLIB/MADOCALIB-style post-fit **commit-on-success** gate (#146/#147) from a default-OFF preview to the **default**, and retires the interim #145 boundary guard that it subsumes.

- `GNSS_PPP_MADOCA_POSTFIT_COMMIT` now **default-on**; set `=0` to opt out (raw accumulate-iterations behavior, kept for bit-exact debugging).
- **#145 boundary guard retired** — under commit-on-success it was provably redundant (guard on/off byte-identical on both stations). The #144 spike guard (100 m) remains as the opt-out-path safety net.

## Validation (MIZU 2025/04/01 vs MADOCALIB bridge; ALIC second station, same global L6)

| Window / Station | OFF | ON (new default) | Effect |
|---|---|---|---|
| MIZU 1h | 1.820 | 1.820 | byte-identical |
| MIZU 6h | 1.297 | 1.297 | byte-identical |
| MIZU 24h | 1.316 / max 5.26 | **1.206 / max 4.46** | improves (skips 13 boundary epochs MADOCALIB also drops, n 2855→2842) |
| ALIC 24h | tail RMS 0.843 m | 0.843 m | byte-identical (predicate never fires) |

- gate-OFF (`=0`) preserves the pre-commit default path; the only opt-out-path behavior change is that the removed boundary guard no longer backstops the 23.7 m file-boundary spike (by design — commit-on-success is the proper mechanism).
- Short-window (1h/6h) references stay **bit-exact**.

## Limitation

Local sample data covers a single day (091), so **multi-day** could not be tested. Evidence is **multi-station (MIZU + ALIC) × multi-window (1h/6h/24h)**, all consistent: commit-on-success helps-or-neutral, never regresses.

## Tests

- All **323** gtests pass (incl. `*MadocaParity*`, `*MadocaBridgeConfig*`).
- `madoca` / `qzss_l6` CLI tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)