### PR TITLE
[codex] python: add read-only artifact API

### DIFF
--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -77,6 +77,8 @@ Python bindings expose:
 - `.pos` loading and solution statistics
 - coordinate conversion helpers
 - file-based `SPP`, `PPP`, and `RTK` solve helpers
+- read-only artifact helpers under `libgnsspp.artifacts`:
+  `load_summary()`, `summary_schema()`, `load_pos()`, and `pos_stats()`
 
 ## ROS2
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -2,13 +2,20 @@ set(GNSSPP_PYTHON_PACKAGE_DIR ${CMAKE_BINARY_DIR}/python/libgnsspp)
 set(GNSSPP_PYTHON_INSTALL_DIR
     ${CMAKE_INSTALL_LIBDIR}/python${Python3_VERSION_MAJOR}.${Python3_VERSION_MINOR}/site-packages/libgnsspp
 )
+set(GNSSPP_PYTHON_FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/libgnsspp/__init__.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/libgnsspp/artifacts.py
+)
 
 file(MAKE_DIRECTORY ${GNSSPP_PYTHON_PACKAGE_DIR})
-configure_file(
-    ${CMAKE_CURRENT_SOURCE_DIR}/libgnsspp/__init__.py
-    ${GNSSPP_PYTHON_PACKAGE_DIR}/__init__.py
-    COPYONLY
-)
+foreach(GNSSPP_PYTHON_FILE ${GNSSPP_PYTHON_FILES})
+    get_filename_component(GNSSPP_PYTHON_FILE_NAME ${GNSSPP_PYTHON_FILE} NAME)
+    configure_file(
+        ${GNSSPP_PYTHON_FILE}
+        ${GNSSPP_PYTHON_PACKAGE_DIR}/${GNSSPP_PYTHON_FILE_NAME}
+        COPYONLY
+    )
+endforeach()
 
 pybind11_add_module(_libgnsspp MODULE libgnsspp/bindings.cpp)
 target_link_libraries(_libgnsspp PRIVATE gnss_lib gnss_lib_noopt)
@@ -20,8 +27,8 @@ set_target_properties(_libgnsspp PROPERTIES
 add_custom_command(
     TARGET _libgnsspp POST_BUILD
     COMMAND ${CMAKE_COMMAND} -E copy_if_different
-            ${CMAKE_CURRENT_SOURCE_DIR}/libgnsspp/__init__.py
-            ${GNSSPP_PYTHON_PACKAGE_DIR}/__init__.py
+            ${GNSSPP_PYTHON_FILES}
+            ${GNSSPP_PYTHON_PACKAGE_DIR}
 )
 
 install(
@@ -30,6 +37,6 @@ install(
     RUNTIME DESTINATION ${GNSSPP_PYTHON_INSTALL_DIR}
 )
 install(
-    FILES ${CMAKE_CURRENT_SOURCE_DIR}/libgnsspp/__init__.py
+    FILES ${GNSSPP_PYTHON_FILES}
     DESTINATION ${GNSSPP_PYTHON_INSTALL_DIR}
 )

--- a/python/libgnsspp/__init__.py
+++ b/python/libgnsspp/__init__.py
@@ -8,6 +8,7 @@ import subprocess
 import sys
 import tempfile
 
+from . import artifacts
 from ._libgnsspp import (
     CorrectedMeasurement,
     GNSSTime,
@@ -128,6 +129,7 @@ __all__ = [
     "Solution",
     "SolutionStatistics",
     "SolutionStatus",
+    "artifacts",
     "ecef_to_geodetic_deg",
     "geodetic_deg_to_ecef",
     "load_solution",

--- a/python/libgnsspp/artifacts.py
+++ b/python/libgnsspp/artifacts.py
@@ -1,0 +1,247 @@
+"""Read-only helpers for libgnss++ summary and solution artifacts."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import datetime as dt
+import json
+import math
+from pathlib import Path
+from typing import Any, Iterable, Literal
+
+
+GPS_EPOCH = dt.datetime(1980, 1, 6)
+WGS84_A = 6378137.0
+WGS84_F = 1.0 / 298.257223563
+WGS84_E2 = WGS84_F * (2.0 - WGS84_F)
+
+PosFormat = Literal["auto", "libgnss", "rtklib"]
+
+
+@dataclass(frozen=True)
+class PosRecord:
+    week: int
+    tow: float
+    lat_deg: float
+    lon_deg: float
+    height_m: float
+    ecef_m: tuple[float, float, float]
+    status: int
+    satellites: int
+    ratio: float | None = None
+    source_format: str = "libgnss"
+    line_number: int = 0
+
+
+def load_summary(path: str | Path) -> dict[str, Any]:
+    """Load a summary JSON artifact and require a top-level object."""
+
+    summary_path = Path(path)
+    with summary_path.open(encoding="utf-8") as handle:
+        payload = json.load(handle)
+    if not isinstance(payload, dict):
+        raise ValueError(f"{summary_path}: summary JSON must contain an object")
+    return payload
+
+
+def summary_schema(payload: dict[str, Any]) -> str | None:
+    """Return the declared schema field used by current summary artifacts."""
+
+    value = (
+        payload.get("summary_schema")
+        or payload.get("schema")
+        or payload.get("schema_version")
+    )
+    return str(value) if value is not None else None
+
+
+def geodetic_deg_to_ecef(lat_deg: float, lon_deg: float, height_m: float) -> tuple[float, float, float]:
+    lat = math.radians(lat_deg)
+    lon = math.radians(lon_deg)
+    sin_lat = math.sin(lat)
+    cos_lat = math.cos(lat)
+    sin_lon = math.sin(lon)
+    cos_lon = math.cos(lon)
+    n = WGS84_A / math.sqrt(1.0 - WGS84_E2 * sin_lat * sin_lat)
+    return (
+        (n + height_m) * cos_lat * cos_lon,
+        (n + height_m) * cos_lat * sin_lon,
+        (n * (1.0 - WGS84_E2) + height_m) * sin_lat,
+    )
+
+
+def parse_rtklib_timestamp(token_a: str, token_b: str) -> tuple[int, float]:
+    """Parse RTKLIB date/time or week/TOW timestamp tokens."""
+
+    if "/" not in token_a:
+        return int(float(token_a)), float(token_b)
+
+    year, month, day = map(int, token_a.split("/"))
+    hour, minute, second = token_b.split(":")
+    second_float = float(second)
+    second_int = int(second_float)
+    microsecond = int(round((second_float - second_int) * 1_000_000))
+    stamp = dt.datetime(year, month, day, int(hour), int(minute), second_int, microsecond)
+    total_seconds = (stamp - GPS_EPOCH).total_seconds()
+    week = int(total_seconds // 604800)
+    return week, total_seconds - week * 604800
+
+
+def _data_lines(path: Path) -> Iterable[tuple[int, list[str]]]:
+    with path.open(encoding="utf-8") as handle:
+        for line_number, line in enumerate(handle, start=1):
+            stripped = line.strip()
+            if not stripped or stripped.startswith("%") or stripped.startswith("#"):
+                continue
+            yield line_number, stripped.split()
+
+
+def _detect_pos_format(parts: list[str]) -> Literal["libgnss", "rtklib"]:
+    if "/" in parts[0]:
+        return "rtklib"
+    if len(parts) >= 11:
+        return "libgnss"
+    return "rtklib"
+
+
+def _parse_libgnss_pos_row(parts: list[str], line_number: int) -> PosRecord:
+    if len(parts) < 10:
+        raise ValueError(f"line {line_number}: expected at least 10 libgnss++ .pos columns")
+    ecef = (float(parts[2]), float(parts[3]), float(parts[4]))
+    return PosRecord(
+        week=int(float(parts[0])),
+        tow=float(parts[1]),
+        ecef_m=ecef,
+        lat_deg=float(parts[5]),
+        lon_deg=float(parts[6]),
+        height_m=float(parts[7]),
+        status=int(float(parts[8])),
+        satellites=int(float(parts[9])),
+        ratio=float(parts[11]) if len(parts) > 11 else None,
+        source_format="libgnss",
+        line_number=line_number,
+    )
+
+
+def _parse_rtklib_pos_row(parts: list[str], line_number: int) -> PosRecord:
+    if len(parts) < 7:
+        raise ValueError(f"line {line_number}: expected at least 7 RTKLIB .pos columns")
+    week, tow = parse_rtklib_timestamp(parts[0], parts[1])
+    lat = float(parts[2])
+    lon = float(parts[3])
+    height = float(parts[4])
+    return PosRecord(
+        week=week,
+        tow=tow,
+        lat_deg=lat,
+        lon_deg=lon,
+        height_m=height,
+        ecef_m=geodetic_deg_to_ecef(lat, lon, height),
+        status=int(float(parts[5])),
+        satellites=int(float(parts[6])),
+        ratio=float(parts[14]) if len(parts) > 14 else None,
+        source_format="rtklib",
+        line_number=line_number,
+    )
+
+
+def load_pos(path: str | Path, source_format: PosFormat = "auto") -> list[PosRecord]:
+    """Load libgnss++ or RTKLIB .pos rows without running any solver."""
+
+    pos_path = Path(path)
+    rows: list[PosRecord] = []
+    detected_format: Literal["libgnss", "rtklib"] | None = None
+    for line_number, parts in _data_lines(pos_path):
+        if source_format == "auto":
+            if detected_format is None:
+                detected_format = _detect_pos_format(parts)
+            row_format = detected_format
+        elif source_format in {"libgnss", "rtklib"}:
+            row_format = source_format
+        else:
+            raise ValueError("source_format must be one of: auto, libgnss, rtklib")
+
+        if row_format == "libgnss":
+            rows.append(_parse_libgnss_pos_row(parts, line_number))
+        else:
+            rows.append(_parse_rtklib_pos_row(parts, line_number))
+    return rows
+
+
+def pos_status_name(record: PosRecord) -> str:
+    if record.source_format == "rtklib":
+        return {
+            1: "FIX",
+            2: "FLOAT",
+            4: "DGPS",
+            5: "SINGLE",
+            6: "PPP",
+        }.get(record.status, f"RTKLIB_{record.status}")
+    return {
+        0: "NONE",
+        1: "SPP",
+        2: "DGPS",
+        3: "FLOAT",
+        4: "FIXED",
+        5: "PPP_FLOAT",
+        6: "PPP_FIXED",
+    }.get(record.status, f"STATUS_{record.status}")
+
+
+def pos_stats(records: Iterable[PosRecord]) -> dict[str, Any]:
+    """Return compact counts for loaded .pos records."""
+
+    rows = list(records)
+    status_counts: dict[str, int] = {}
+    for row in rows:
+        name = pos_status_name(row)
+        status_counts[name] = status_counts.get(name, 0) + 1
+
+    valid_rows = [row for row in rows if row.status != 0]
+    fixed_rows = [
+        row
+        for row in rows
+        if pos_status_name(row) in {"FIX", "FIXED", "PPP_FIXED"}
+    ]
+    float_rows = [
+        row
+        for row in rows
+        if pos_status_name(row) in {"FLOAT", "PPP_FLOAT"}
+    ]
+    if rows:
+        first = min(rows, key=lambda row: (row.week, row.tow))
+        last = max(rows, key=lambda row: (row.week, row.tow))
+        solution_span_s = (last.week - first.week) * 604800.0 + (last.tow - first.tow)
+    else:
+        first = last = None
+        solution_span_s = 0.0
+
+    return {
+        "total_epochs": len(rows),
+        "valid_epochs": len(valid_rows),
+        "fixed_epochs": len(fixed_rows),
+        "float_epochs": len(float_rows),
+        "status_counts": status_counts,
+        "source_formats": sorted({row.source_format for row in rows}),
+        "mean_satellites": (
+            sum(row.satellites for row in rows) / len(rows)
+            if rows else 0.0
+        ),
+        "first_week": first.week if first is not None else None,
+        "first_tow": first.tow if first is not None else None,
+        "last_week": last.week if last is not None else None,
+        "last_tow": last.tow if last is not None else None,
+        "solution_span_s": solution_span_s,
+    }
+
+
+__all__ = [
+    "PosRecord",
+    "geodetic_deg_to_ecef",
+    "load_pos",
+    "load_summary",
+    "parse_rtklib_timestamp",
+    "pos_stats",
+    "pos_status_name",
+    "summary_schema",
+]

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -139,6 +139,10 @@ class PackagingSmokeTest(unittest.TestCase):
             python_package_dir = python_packages[0].parent
             extension_modules = list(python_package_dir.glob("_libgnsspp*.so"))
             self.assertTrue(extension_modules, "missing installed Python extension module")
+            self.assertTrue(
+                (python_package_dir / "artifacts.py").exists(),
+                "missing installed Python artifact helpers",
+            )
 
             env = dict(os.environ)
             env["PATH"] = str(prefix / "bin") + os.pathsep + env.get("PATH", "")

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -109,6 +109,55 @@ class PythonBindingsSmokeTest(unittest.TestCase):
             "PPP_FLOAT",
         )
 
+    def test_read_only_artifact_api_loads_summary_and_pos_stats(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_python_artifacts_") as temp_dir:
+            temp_root = Path(temp_dir)
+            summary_path = temp_root / "summary.json"
+            lib_pos_path = temp_root / "lib.pos"
+            rtklib_pos_path = temp_root / "rtklib.pos"
+
+            summary_path.write_text(
+                '{"summary_schema": "ppc_coverage_matrix.v1", "runs": []}\n',
+                encoding="ascii",
+            )
+            lib_pos_path.write_text(
+                "% synthetic libgnss++ solution\n"
+                "1316 518400.0 -3978242.0 3382841.0 3649903.0 35.0 139.0 10.0 4 9 1.0 2.5\n"
+                "1316 518430.0 -3978243.0 3382840.0 3649902.0 35.1 139.1 10.2 3 8 1.0 1.5\n",
+                encoding="ascii",
+            )
+            rtklib_pos_path.write_text(
+                "% synthetic rtklib solution\n"
+                "2024/02/18 00:16:22.000 35.100000000 139.100000000 42.0000 1 10 0 0 0 0\n"
+                "2024/02/18 00:16:22.200 35.100010000 139.100020000 42.2000 2 9 0 0 0 0\n",
+                encoding="ascii",
+            )
+
+            payload = libgnsspp.artifacts.load_summary(summary_path)
+            self.assertEqual(
+                libgnsspp.artifacts.summary_schema(payload),
+                "ppc_coverage_matrix.v1",
+            )
+
+            lib_records = libgnsspp.artifacts.load_pos(lib_pos_path)
+            self.assertEqual(len(lib_records), 2)
+            self.assertEqual(lib_records[0].source_format, "libgnss")
+            self.assertEqual(lib_records[0].status, 4)
+            self.assertAlmostEqual(lib_records[0].ratio or 0.0, 2.5)
+            lib_stats = libgnsspp.artifacts.pos_stats(lib_records)
+            self.assertEqual(lib_stats["fixed_epochs"], 1)
+            self.assertEqual(lib_stats["float_epochs"], 1)
+            self.assertEqual(lib_stats["status_counts"], {"FIXED": 1, "FLOAT": 1})
+            self.assertAlmostEqual(lib_stats["solution_span_s"], 30.0)
+
+            rtklib_records = libgnsspp.artifacts.load_pos(rtklib_pos_path)
+            self.assertEqual(rtklib_records[0].source_format, "rtklib")
+            self.assertEqual(rtklib_records[0].week, 2302)
+            rtklib_stats = libgnsspp.artifacts.pos_stats(rtklib_records)
+            self.assertEqual(rtklib_stats["fixed_epochs"], 1)
+            self.assertEqual(rtklib_stats["float_epochs"], 1)
+            self.assertEqual(rtklib_stats["status_counts"], {"FIX": 1, "FLOAT": 1})
+
     def test_solve_spp_file_returns_valid_solution_records(self) -> None:
         solution = libgnsspp.solve_spp_file(
             str(ROOT_DIR / "data" / "rover_static.obs"),


### PR DESCRIPTION
## Summary

Adds read-only Python helpers for reproducibility artifacts:

- `libgnsspp.artifacts.load_summary()` and `summary_schema()`
- `.pos` loading for libgnss++ and RTKLIB-style outputs
- `.pos` statistics helpers and coordinate utilities
- packaging and Python binding tests

## Validation

- `git diff --check develop..codex/python-artifact-api`
- `PYTHONPATH="$PWD/build-madoca-parity/python:$PWD/python" python3 -m unittest tests.test_python_bindings`
- `GNSSPP_BINARY_DIR="$PWD/build-madoca-parity" python3 -m unittest tests.test_packaging`