### PR TITLE
[codex] madoca: add core helper parity layer

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,7 @@ set(GNSS_SOURCES
     src/algorithms/ppp_wlnl.cpp
     src/algorithms/ppp_clas_epoch.cpp
     src/algorithms/ppp_env_overrides.cpp
+    src/algorithms/madoca_core.cpp
     src/algorithms/madoca_parity.cpp
     src/algorithms/madocalib_oracle.cpp
     src/algorithms/madocalib_bridge.cpp

--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -561,7 +561,7 @@ PR body checklist:
 
 ## Next Slice Queue
 
-Preferred next low-risk slice:
+Completed low-risk helper slice:
 
 - Add `scripts/analysis/spp_iteration_dump_summary.py`.
 - Add `tests/test_spp_iteration_dump_summary.py`.
@@ -573,7 +573,7 @@ Preferred next low-risk slice:
 - Validate with `python3 -m py_compile`, the direct Python unit test, CMake
   configure, focused CTest, and `git diff --check`.
 
-Next medium-risk slice:
+Completed native core foundation slice:
 
 - Add a native MADOCA core foundation under `madoca_core` or a similarly narrow
   namespace.

--- a/include/libgnss++/algorithms/madoca_core.hpp
+++ b/include/libgnss++/algorithms/madoca_core.hpp
@@ -1,0 +1,57 @@
+#pragma once
+
+#include <libgnss++/core/types.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string_view>
+#include <vector>
+
+namespace libgnss::algorithms::madoca_core {
+
+// MADOCA-PPP Compact SSR GNSS IDs (IS-QZSS-MDC-004 Table 4.2.2-7).
+enum class CompactSsrSystemId : std::uint8_t {
+    GPS = 0,
+    GLONASS = 1,
+    Galileo = 2,
+    BeiDou = 3,
+    QZSS = 4,
+    BeiDou3 = 7,
+};
+
+// Compact SSR subtype ids used by MADOCA L6E.
+enum class CompactSsrSubtype : std::uint8_t {
+    Mask = 1,
+    Orbit = 2,
+    Clock = 3,
+    CodeBias = 4,
+    PhaseBias = 5,
+    Ura = 7,
+};
+
+std::optional<CompactSsrSystemId> compactSsrSystemId(int id);
+GNSSSystem gnssSystemForCompactSsrId(int id);
+std::optional<int> compactSsrIdForGnssSystem(GNSSSystem system, bool beidou3 = false);
+std::string_view compactSsrSystemName(int id);
+
+std::optional<CompactSsrSubtype> compactSsrSubtype(int subtype);
+std::string_view compactSsrSubtypeName(int subtype);
+
+std::optional<double> ssrUpdateIntervalSeconds(int index);
+
+// Return the RTKLIB CODE_* value for a Compact SSR signal-mask slot
+// (0..15). Invalid systems or slots return 0 (CODE_NONE).
+int compactSsrSignalCodeAt(int compact_ssr_system_id, int mask_slot);
+
+// Expand a 16-bit Compact SSR signal mask to RTKLIB CODE_* values in the same
+// MSB-first order used by MADOCALIB's sigmask2list().
+std::vector<int> compactSsrSignalCodes(int compact_ssr_system_id, std::uint16_t mask);
+
+// RTCM/MADOCA SSR URA indicator to one-sigma standard deviation in meters.
+double ssrUraIndicatorToSigmaMeters(int ura_index);
+
+// MADOCA-PPP code/phase-bias code selection. The system argument uses the
+// RTKLIB SYS_* bit constants mirrored in madoca_parity.hpp.
+int selectBiasCode(int rtklib_system, int rtklib_code);
+
+}  // namespace libgnss::algorithms::madoca_core

--- a/src/algorithms/madoca_core.cpp
+++ b/src/algorithms/madoca_core.cpp
@@ -1,0 +1,166 @@
+#include <libgnss++/algorithms/madoca_core.hpp>
+
+#include <libgnss++/algorithms/madoca_parity.hpp>
+
+#include <array>
+#include <cmath>
+
+namespace libgnss::algorithms::madoca_core {
+namespace {
+
+using SignalTable = std::array<int, 16>;
+
+constexpr SignalTable kCssrSigGps = {
+    1, 2, 3, 7, 8, 12, 16, 17, 18, 19, 20, 24, 25, 26, 0, 0,
+};
+constexpr SignalTable kCssrSigGlo = {
+    1, 2, 14, 19, 66, 67, 68, 30, 31, 33, 44, 45, 46, 0, 0, 0,
+};
+constexpr SignalTable kCssrSigGal = {
+    11, 1, 12, 24, 25, 26, 27, 28, 29, 37, 38, 39, 31, 32, 0, 0,
+};
+constexpr SignalTable kCssrSigBd2 = {
+    40, 41, 18, 42, 43, 33, 27, 28, 29, 0, 0, 0, 0, 0, 0, 0,
+};
+constexpr SignalTable kCssrSigBd3 = {
+    40, 41, 0, 42, 43, 0, 61, 62, 63, 56, 2, 12, 57, 58, 26, 0,
+};
+constexpr SignalTable kCssrSigQzs = {
+    1, 7, 8, 12, 16, 17, 18, 24, 25, 26, 35, 36, 60, 9, 0, 0,
+};
+constexpr SignalTable kCssrSigNone = {};
+
+constexpr std::array<double, 16> kSsrUpdateIntervals = {
+    1, 2, 5, 10, 15, 30, 60, 120, 240, 300, 600, 900, 1800, 3600, 7200, 10800,
+};
+
+const SignalTable& signalTableFor(int compact_ssr_system_id) {
+    switch (compact_ssr_system_id) {
+        case 0: return kCssrSigGps;
+        case 1: return kCssrSigGlo;
+        case 2: return kCssrSigGal;
+        case 3: return kCssrSigBd2;
+        case 4: return kCssrSigQzs;
+        case 7: return kCssrSigBd3;
+        default: return kCssrSigNone;
+    }
+}
+
+}  // namespace
+
+std::optional<CompactSsrSystemId> compactSsrSystemId(int id) {
+    switch (id) {
+        case 0: return CompactSsrSystemId::GPS;
+        case 1: return CompactSsrSystemId::GLONASS;
+        case 2: return CompactSsrSystemId::Galileo;
+        case 3: return CompactSsrSystemId::BeiDou;
+        case 4: return CompactSsrSystemId::QZSS;
+        case 7: return CompactSsrSystemId::BeiDou3;
+        default: return std::nullopt;
+    }
+}
+
+GNSSSystem gnssSystemForCompactSsrId(int id) {
+    switch (id) {
+        case 0: return GNSSSystem::GPS;
+        case 1: return GNSSSystem::GLONASS;
+        case 2: return GNSSSystem::Galileo;
+        case 3:
+        case 7: return GNSSSystem::BeiDou;
+        case 4: return GNSSSystem::QZSS;
+        default: return GNSSSystem::UNKNOWN;
+    }
+}
+
+std::optional<int> compactSsrIdForGnssSystem(GNSSSystem system, bool beidou3) {
+    switch (system) {
+        case GNSSSystem::GPS: return 0;
+        case GNSSSystem::GLONASS: return 1;
+        case GNSSSystem::Galileo: return 2;
+        case GNSSSystem::BeiDou: return beidou3 ? 7 : 3;
+        case GNSSSystem::QZSS: return 4;
+        default: return std::nullopt;
+    }
+}
+
+std::string_view compactSsrSystemName(int id) {
+    switch (id) {
+        case 0: return "gps";
+        case 1: return "glonass";
+        case 2: return "galileo";
+        case 3: return "beidou-2";
+        case 4: return "qzss";
+        case 7: return "beidou-3";
+        default: return "unknown";
+    }
+}
+
+std::optional<CompactSsrSubtype> compactSsrSubtype(int subtype) {
+    switch (subtype) {
+        case 1: return CompactSsrSubtype::Mask;
+        case 2: return CompactSsrSubtype::Orbit;
+        case 3: return CompactSsrSubtype::Clock;
+        case 4: return CompactSsrSubtype::CodeBias;
+        case 5: return CompactSsrSubtype::PhaseBias;
+        case 7: return CompactSsrSubtype::Ura;
+        default: return std::nullopt;
+    }
+}
+
+std::string_view compactSsrSubtypeName(int subtype) {
+    switch (subtype) {
+        case 1: return "mask";
+        case 2: return "orbit";
+        case 3: return "clock";
+        case 4: return "code-bias";
+        case 5: return "phase-bias";
+        case 7: return "ura";
+        default: return "unknown";
+    }
+}
+
+std::optional<double> ssrUpdateIntervalSeconds(int index) {
+    if (index < 0 || static_cast<int>(kSsrUpdateIntervals.size()) <= index) {
+        return std::nullopt;
+    }
+    return kSsrUpdateIntervals[static_cast<std::size_t>(index)];
+}
+
+int compactSsrSignalCodeAt(int compact_ssr_system_id, int mask_slot) {
+    if (mask_slot < 0 || 16 <= mask_slot) {
+        return 0;
+    }
+    return signalTableFor(compact_ssr_system_id)[static_cast<std::size_t>(mask_slot)];
+}
+
+std::vector<int> compactSsrSignalCodes(int compact_ssr_system_id, std::uint16_t mask) {
+    const auto& table = signalTableFor(compact_ssr_system_id);
+    std::vector<int> codes;
+    std::uint16_t bit = static_cast<std::uint16_t>(1u << 15);
+    for (int slot = 0; slot < 16; ++slot) {
+        if ((mask & bit) != 0) {
+            codes.push_back(table[static_cast<std::size_t>(slot)]);
+        }
+        bit = static_cast<std::uint16_t>(bit >> 1);
+    }
+    return codes;
+}
+
+double ssrUraIndicatorToSigmaMeters(int ura_index) {
+    if (ura_index == 0) {
+        return 0.15;
+    }
+    if (ura_index < 0 || ura_index >= 63) {
+        return 5.4665;
+    }
+    return (std::pow(3.0, static_cast<double>((ura_index >> 3) & 0x07)) *
+                (1.0 + static_cast<double>(ura_index & 0x07) / 4.0) -
+            1.0) *
+           1e-3;
+}
+
+int selectBiasCode(int rtklib_system, int rtklib_code) {
+    return madoca_parity::mcssrSelBiascode(rtklib_system, rtklib_code);
+}
+
+}  // namespace libgnss::algorithms::madoca_core

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ if(GTest_FOUND)
         test_gnss_live.cpp
         test_ppp.cpp
         test_rinex_writer.cpp
+        test_madoca_core.cpp
         test_madoca_parity.cpp
         test_rtk_legacy.cpp
         test_spp.cpp

--- a/tests/test_madoca_core.cpp
+++ b/tests/test_madoca_core.cpp
@@ -1,0 +1,90 @@
+#include <gtest/gtest.h>
+
+#include <libgnss++/algorithms/madoca_core.hpp>
+#include <libgnss++/algorithms/madoca_parity.hpp>
+
+namespace {
+
+namespace core = libgnss::algorithms::madoca_core;
+namespace mp = libgnss::algorithms::madoca_parity;
+
+TEST(MadocaCore, MapsCompactSsrSystems) {
+    EXPECT_EQ(core::gnssSystemForCompactSsrId(0), libgnss::GNSSSystem::GPS);
+    EXPECT_EQ(core::gnssSystemForCompactSsrId(1), libgnss::GNSSSystem::GLONASS);
+    EXPECT_EQ(core::gnssSystemForCompactSsrId(2), libgnss::GNSSSystem::Galileo);
+    EXPECT_EQ(core::gnssSystemForCompactSsrId(3), libgnss::GNSSSystem::BeiDou);
+    EXPECT_EQ(core::gnssSystemForCompactSsrId(4), libgnss::GNSSSystem::QZSS);
+    EXPECT_EQ(core::gnssSystemForCompactSsrId(7), libgnss::GNSSSystem::BeiDou);
+    EXPECT_EQ(core::gnssSystemForCompactSsrId(15), libgnss::GNSSSystem::UNKNOWN);
+
+    ASSERT_TRUE(core::compactSsrIdForGnssSystem(libgnss::GNSSSystem::BeiDou).has_value());
+    EXPECT_EQ(*core::compactSsrIdForGnssSystem(libgnss::GNSSSystem::BeiDou), 3);
+    EXPECT_EQ(*core::compactSsrIdForGnssSystem(libgnss::GNSSSystem::BeiDou, true), 7);
+    EXPECT_FALSE(core::compactSsrIdForGnssSystem(libgnss::GNSSSystem::SBAS).has_value());
+
+    EXPECT_EQ(core::compactSsrSystemName(4), "qzss");
+    EXPECT_EQ(core::compactSsrSystemName(7), "beidou-3");
+    EXPECT_EQ(core::compactSsrSystemName(99), "unknown");
+}
+
+TEST(MadocaCore, NamesSupportedSubtypes) {
+    EXPECT_TRUE(core::compactSsrSubtype(1).has_value());
+    EXPECT_TRUE(core::compactSsrSubtype(7).has_value());
+    EXPECT_FALSE(core::compactSsrSubtype(6).has_value());
+
+    EXPECT_EQ(core::compactSsrSubtypeName(1), "mask");
+    EXPECT_EQ(core::compactSsrSubtypeName(2), "orbit");
+    EXPECT_EQ(core::compactSsrSubtypeName(3), "clock");
+    EXPECT_EQ(core::compactSsrSubtypeName(4), "code-bias");
+    EXPECT_EQ(core::compactSsrSubtypeName(5), "phase-bias");
+    EXPECT_EQ(core::compactSsrSubtypeName(7), "ura");
+    EXPECT_EQ(core::compactSsrSubtypeName(12), "unknown");
+}
+
+TEST(MadocaCore, ProvidesSsrUpdateIntervals) {
+    ASSERT_TRUE(core::ssrUpdateIntervalSeconds(0).has_value());
+    EXPECT_DOUBLE_EQ(*core::ssrUpdateIntervalSeconds(0), 1.0);
+    EXPECT_DOUBLE_EQ(*core::ssrUpdateIntervalSeconds(5), 30.0);
+    EXPECT_DOUBLE_EQ(*core::ssrUpdateIntervalSeconds(15), 10800.0);
+    EXPECT_FALSE(core::ssrUpdateIntervalSeconds(-1).has_value());
+    EXPECT_FALSE(core::ssrUpdateIntervalSeconds(16).has_value());
+}
+
+TEST(MadocaCore, ExpandsSignalMasksInMadocalibOrder) {
+    EXPECT_EQ(core::compactSsrSignalCodeAt(0, 0), mp::kCodeL1C);
+    EXPECT_EQ(core::compactSsrSignalCodeAt(0, 13), mp::kCodeL5X);
+    EXPECT_EQ(core::compactSsrSignalCodeAt(4, 13), mp::kCodeL1E);
+    EXPECT_EQ(core::compactSsrSignalCodeAt(7, 6), mp::kCodeL7D);
+    EXPECT_EQ(core::compactSsrSignalCodeAt(7, 2), mp::kCodeNone);
+    EXPECT_EQ(core::compactSsrSignalCodeAt(99, 0), mp::kCodeNone);
+    EXPECT_EQ(core::compactSsrSignalCodeAt(0, 16), mp::kCodeNone);
+
+    const auto gps = core::compactSsrSignalCodes(0, 0xE001);
+    ASSERT_EQ(gps.size(), 4U);
+    EXPECT_EQ(gps[0], mp::kCodeL1C);
+    EXPECT_EQ(gps[1], mp::kCodeL1P);
+    EXPECT_EQ(gps[2], mp::kCodeL1W);
+    EXPECT_EQ(gps[3], mp::kCodeNone);
+
+    const auto qzss = core::compactSsrSignalCodes(4, 0x0044);
+    ASSERT_EQ(qzss.size(), 2U);
+    EXPECT_EQ(qzss[0], mp::kCodeL5X);
+    EXPECT_EQ(qzss[1], mp::kCodeL1E);
+}
+
+TEST(MadocaCore, ConvertsSsrUraIndicatorToSigmaMeters) {
+    EXPECT_DOUBLE_EQ(core::ssrUraIndicatorToSigmaMeters(0), 0.15);
+    EXPECT_NEAR(core::ssrUraIndicatorToSigmaMeters(9), 0.00275, 1e-12);
+    EXPECT_DOUBLE_EQ(core::ssrUraIndicatorToSigmaMeters(63), 5.4665);
+    EXPECT_DOUBLE_EQ(core::ssrUraIndicatorToSigmaMeters(-1), 5.4665);
+}
+
+TEST(MadocaCore, SelectsBiasCodesThroughParityHelper) {
+    EXPECT_EQ(core::selectBiasCode(mp::kSysGps, mp::kCodeL1C), mp::kCodeL1C);
+    EXPECT_EQ(core::selectBiasCode(mp::kSysGps, mp::kCodeL1P), mp::kCodeL1W);
+    EXPECT_EQ(core::selectBiasCode(mp::kSysQzs, mp::kCodeL1L), mp::kCodeL1X);
+    EXPECT_EQ(core::selectBiasCode(mp::kSysCmp, mp::kCodeL6X), mp::kCodeL6I);
+    EXPECT_EQ(core::selectBiasCode(mp::kSysSbs, mp::kCodeL1C), mp::kCodeNone);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

Adds a native MADOCA core helper layer for deterministic parity checks:

- compact-SSR system/subtype mapping helpers
- update interval, signal-code, URA, and bias-code helpers
- GoogleTest coverage and CMake wiring
- MADOCA port-plan status update

## Validation

- `git diff --check develop..codex/madoca-core-helper`
- `cmake --build build-madoca-parity --target run_tests -j2`