### PR TITLE
[codex] ppc: add MADOCALIB RTKLIB smoke config

### DIFF
--- a/apps/gnss_ppc_demo.py
+++ b/apps/gnss_ppc_demo.py
@@ -1098,7 +1098,7 @@ def run_rtklib_solver(
         temp_dir_path = Path(temp_dir)
         config_path = temp_dir_path / "ppc_rtklib.conf"
         config_path.write_text(rtklib_config_text(Path(args.rtklib_config), args.solver), encoding="utf-8")
-        command.extend(["-k", str(config_path), "-o", str(rtklib_pos)])
+        command.extend(["-k", str(config_path), "-p", "2", "-o", str(rtklib_pos)])
         window_reference = reference
         if args.max_epochs > 0:
             window_reference = reference[:args.max_epochs]

--- a/docs/ppc_reproduction.md
+++ b/docs/ppc_reproduction.md
@@ -30,24 +30,34 @@ profile:
 
 ```bash
 python3 apps/gnss.py ppc-coverage-matrix \
-  --dataset-root /datasets/PPC-Dataset \
-  --preset low-cost \
-  --ratio 2.8 \
-  --carrier-phase-sigma 0.001 \
-  --max-postfix-rms 0.2 \
-  --max-consec-float-reset 10 \
-  --max-subset-ar-drop-steps 18 \
-  --adaptive-dynamic-slip-thresholds \
-  --adaptive-dynamic-slip-nonfix-count 25 \
-  --max-pos-jump 5.0 \
-  --max-pos-jump-min 5.0 \
-  --max-pos-jump-rate 25.0 \
-  --demote-fixed-status-nis-per-obs 2 \
-  --demote-fixed-status-max-ratio 4 \
-  --output-dir output/ppc_sigma_profile_runtime_demote_nis2_ratio4 \
-  --summary-json output/ppc_sigma_profile_runtime_demote_nis2_ratio4/summary.json \
-  --markdown-output output/ppc_sigma_profile_runtime_demote_nis2_ratio4/table.md
+  --config-toml configs/ppc_sigma_demote_nis2_ratio4.toml
 ```
+
+Override `--dataset-root` after `--config-toml` when your PPC checkout is not
+under `data/PPC-Dataset`.
+
+## Local MADOCALIB RTKLIB Smoke
+
+If a standard RTKLIB `rnx2rtkp` is not installed but `external/madocalib` is
+available locally, build its console app and use the PPC RTK config for the
+fork-specific option enum:
+
+```bash
+make -C external/madocalib/app/consapp/rnx2rtkp/gcc
+
+python3 apps/gnss.py ppc-coverage-matrix \
+  --config-toml configs/ppc_sigma_demote_nis2_ratio4.toml \
+  --max-epochs 20 \
+  --rtklib-bin external/madocalib/app/consapp/rnx2rtkp/gcc/rnx2rtkp \
+  --rtklib-config scripts/madocalib_ppc_rtk.conf \
+  --output-dir output/ppc_rtklib_baseline_smoke \
+  --summary-json output/ppc_rtklib_baseline_smoke/summary.json \
+  --markdown-output output/ppc_rtklib_baseline_smoke/table.md
+```
+
+`ppc-demo` passes `-p 2` to `rnx2rtkp` for RTK comparisons. The MADOCALIB
+config intentionally omits `pos1-posmode` because that fork's config enum does
+not accept relative `kinematic`, while the CLI option does.
 
 ## Coverage Matrix
 

--- a/scripts/madocalib_ppc_rtk.conf
+++ b/scripts/madocalib_ppc_rtk.conf
@@ -1,0 +1,47 @@
+# MADOCALIB rnx2rtkp config for PPC relative RTK comparison.
+#
+# Do not set pos1-posmode here. MADOCALIB's config enum only accepts single
+# and PPP modes, while the rnx2rtkp CLI default is relative kinematic.
+pos1-frequency     =l1+2
+pos1-soltype       =forward
+pos1-elmask        =15
+pos1-dynamics      =off
+pos1-ionoopt       =brdc
+pos1-tropopt       =saas
+pos1-sateph        =brdc
+pos1-navsys        =61
+pos2-armode        =continuous
+pos2-gloarmode     =off
+pos2-arthres       =3
+pos2-arlockcnt     =5
+pos2-arelmask      =0
+pos2-aroutcnt      =5
+pos2-arminfix      =10
+pos2-slipthres     =0.05
+pos2-maxage        =30
+pos2-rejionno      =30
+pos2-rejgdop       =30
+pos2-niter         =1
+out-solformat      =llh
+out-outhead        =on
+out-outopt         =on
+out-timesys        =gpst
+out-timeform       =hms
+out-timendec       =3
+out-height         =ellipsoidal
+out-solstatic      =all
+out-outstat        =off
+stats-eratio1      =100
+stats-eratio2      =100
+stats-errphase     =0.003
+stats-errphaseel   =0.003
+stats-errphasebl   =0
+stats-prnaccelh    =1
+stats-prnaccelv    =0.1
+stats-prnbias      =0.0001
+stats-prniono      =0.001
+stats-prntrop      =0.0001
+stats-clkstab      =5e-12
+ant1-postype       =rinexhead
+ant2-postype       =rinexhead
+misc-timeinterp    =on

--- a/tests/test_benchmark_scripts.py
+++ b/tests/test_benchmark_scripts.py
@@ -5500,6 +5500,7 @@ from pathlib import Path
 
 args = sys.argv[1:]
 out = Path(args[args.index("-o") + 1])
+out.with_suffix(".args").write_text(" ".join(args), encoding="ascii")
 out.write_text(
     "% synthetic rtklib solution\\n"
     "2024/02/18 00:16:22.000 35.100000000 139.100000000 42.0000 1 0 0 0 0 0 0\\n"
@@ -5531,6 +5532,21 @@ out.write_text(
             self.assertTrue(rtklib_pos.exists())
             contents = rtklib_pos.read_text(encoding="ascii")
             self.assertIn("synthetic rtklib solution", contents)
+            args_text = rtklib_pos.with_suffix(".args").read_text(encoding="ascii")
+            self.assertIn("-p 2", args_text)
+
+    def test_madocalib_ppc_rtk_config_omits_unsupported_posmode(self) -> None:
+        config_path = ROOT_DIR / "scripts" / "madocalib_ppc_rtk.conf"
+
+        text = ppc_demo.rtklib_config_text(config_path, "rtk")
+        config_lines = [
+            line.strip()
+            for line in text.splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ]
+
+        self.assertIn("pos1-frequency     =l1+2", text)
+        self.assertFalse(any(line.startswith("pos1-posmode") for line in config_lines))
 
 
 class PPCMultiCandidateSelectorTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

Adds a local MADOCALIB `rnx2rtkp` smoke path for PPC RTKLIB comparisons:

- adds `scripts/madocalib_ppc_rtk.conf`
- passes `-p 2` to `rnx2rtkp` for RTK comparisons
- documents the local MADOCALIB smoke command
- tests the fork-specific config behavior

## Validation

- `git diff --check develop..codex/ppc-madocalib-smoke`
- `python3 -m unittest tests.test_benchmark_scripts tests.test_experiment_runner`