### PR TITLE
[codex] repo: enforce scoped development slices

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,43 @@
+name: Bug report
+description: Report a reproducible regression or unexpected solver/tool behavior.
+title: "[bug] "
+labels: ["bug", "needs-triage"]
+body:
+  - type: textarea
+    id: observed
+    attributes:
+      label: Observed behavior
+      description: What happened, including command output or summary fields.
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What should have happened and which benchmark or sign-off defines it.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Reproduction command
+      description: Include exact command, config TOML, env vars, and dataset paths or skip condition.
+      render: bash
+    validations:
+      required: true
+  - type: textarea
+    id: artifacts
+    attributes:
+      label: Artifacts
+      description: Link or paste paths for summary JSON, .pos, logs, matched CSV, plots, or provenance.
+      placeholder: "output/.../summary.json"
+    validations:
+      required: false
+  - type: textarea
+    id: regression_gate
+    attributes:
+      label: Regression gate
+      description: Which test or sign-off should fail once this is captured?
+      placeholder: "Example: gnss ppc-coverage-matrix --config-toml ... --require-p95-h-delta-max ..."
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Validation and sign-off docs
+    url: https://github.com/rsasaki0109/gnssplusplus-library/blob/develop/docs/validation.md
+    about: Use this to choose the smallest relevant sign-off before opening a slice.

--- a/.github/ISSUE_TEMPLATE/development_slice.yml
+++ b/.github/ISSUE_TEMPLATE/development_slice.yml
@@ -1,0 +1,66 @@
+name: Development slice
+description: Plan one scoped implementation, analysis, or sign-off slice.
+title: "[slice] "
+labels: ["needs-triage"]
+body:
+  - type: dropdown
+    id: slice_type
+    attributes:
+      label: Slice type
+      options:
+        - analysis tool
+        - parser or protocol feature
+        - runtime knob or profile
+        - solver behavior change
+        - sign-off or CI improvement
+        - docs or release readiness
+    validations:
+      required: true
+  - type: textarea
+    id: user_value
+    attributes:
+      label: User-visible value
+      description: State the one value this issue should deliver.
+      placeholder: "Example: Reproduce the PPC sigma-demote runtime profile from a named TOML config."
+    validations:
+      required: true
+  - type: textarea
+    id: validation
+    attributes:
+      label: Regression or sign-off improvement
+      description: Name the one test, sign-off, schema check, or artifact gate this slice will add or tighten.
+      placeholder: "Example: ppc-coverage-matrix schema smoke emits summary.json and table.md."
+    validations:
+      required: true
+  - type: textarea
+    id: scope
+    attributes:
+      label: Scope boundary
+      description: List modules or files expected to change, and what must stay out.
+      placeholder: "Touch configs/, apps/gnss_ppc_coverage_matrix.py, and docs/ppc_reproduction.md. Do not change solver behavior."
+    validations:
+      required: true
+  - type: textarea
+    id: non_goals
+    attributes:
+      label: Non-goals
+      description: Explicitly name related work that should be separate.
+      placeholder: "Do not merge stale mixed branches. Do not make CLAS DD default-on."
+    validations:
+      required: true
+  - type: textarea
+    id: datasets
+    attributes:
+      label: Dataset and credential needs
+      description: State required local datasets, optional CI secrets, and expected skip behavior.
+      placeholder: "Needs PPC-Dataset at GNSSPP_PPC_DATASET_ROOT; CI skips with a clear reason when absent."
+    validations:
+      required: false
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: Concrete merge gate, including metric thresholds or artifact names when applicable.
+      placeholder: "Focused unit test passes; summary_schema remains ppc_coverage_matrix.v1; no runtime default change."
+    validations:
+      required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,15 +5,24 @@
 
 ## Scope
 
-- [ ] Single feature / single user-visible value
+- [ ] Single feature / single operational improvement / single user-visible value
+- [ ] Adds or tightens one regression, sign-off, dogfood, or artifact-schema check
 - [ ] No unrelated refactor mixed in
 - [ ] No docs-only noise mixed into solver/protocol work
+- [ ] Protocol ingest, parser work, runtime knobs, solver behavior, and docs are split unless this PR explicitly needs the boundary crossing
 
 ## External Reference
 
 - Source repo used for comparison, if any:
 - What was adopted here:
 - What was intentionally not adopted:
+
+## Behavior Boundary
+
+- Runtime default changed? yes/no:
+- Env-gated or config-gated? yes/no, name:
+- Artifact/schema changed? yes/no, version or field:
+- Dataset or credentials required? yes/no, skip behavior:
 
 ## Validation
 
@@ -32,11 +41,14 @@ Focused checks run:
 
 ## Sign-off / Benchmark Impact
 
-- Added or updated sign-off:
+- Added or updated regression/sign-off:
 - Affected dataset(s):
 - Expected metric impact:
+- Regression budget or threshold:
+- Artifact(s) produced:
 
 ## Notes
 
 - Risk:
 - Follow-up PRs:
+- Explicit non-goals:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,11 @@ Use this rule when splitting work:
 - 1 PR = 1 feature or 1 operational improvement
 - 1 PR = 1 clear benchmark/sign-off/test story
 - Do not mix protocol ingestion, solver tuning, and docs-only cleanup in the same PR
+- Use the `Development slice` issue template before starting larger work. It
+  should name the one user-visible value, the one regression/sign-off
+  improvement, scope boundaries, and explicit non-goals.
+- Fill the PR template's behavior-boundary fields when runtime defaults,
+  env/config gates, artifact schemas, datasets, or credentials are involved.
 
 Good examples:
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -17,6 +17,11 @@
 - 1 PR = 1 clear benchmark/sign-off/test story
 - Do not mix protocol ingestion, solver tuning, and docs-only cleanup in the
   same PR
+- Use the `Development slice` issue template before starting larger work. It
+  should state the one user-visible value, the one regression/sign-off
+  improvement, scope boundaries, and explicit non-goals.
+- Fill the PR template's behavior-boundary fields when runtime defaults,
+  env/config gates, artifact schemas, datasets, or credentials are involved.
 
 ## Required checks
 

--- a/docs/experiments.md
+++ b/docs/experiments.md
@@ -5,3 +5,70 @@ Experimental workflows and evaluation results.
 ## PPP Ambiguity Resolution
 
 See `experiments/ppp_ar/` for PPP-AR experiment configurations and lane-level results.
+
+Keep PPP-AR, CLAS, and MADOCA strategy sweeps in the experiment lane until the
+behavior is stable enough to promote into a normal CLI or solver default. The
+lane is allowed to try competing policies, broad strategy catalogs, and
+reference-oracle comparisons; the stable solver path is not.
+
+Use `experiments/ppp_ar/run_experiments.py` for CLAS PPP policy sweeps:
+
+```bash
+python3 experiments/ppp_ar/run_experiments.py \
+  --config-toml experiments/ppp_ar/input.example.toml \
+  --output-json output/ppp_ar_experiments/results.json \
+  --markdown-out output/ppp_ar_experiments/results.md
+```
+
+Use `experiments/ppp_ar/suite.example.toml` when a result is being evaluated
+for promotion. A single-case win is a diagnostic result, not a promotion
+candidate.
+
+## Promotion Rules
+
+An experiment result can move toward a stable CLI/profile/default only when the
+PR carries both the behavior change and the regression artifact that protects
+it. At minimum, the PR must show:
+
+- the same input schema across all strategy arms: `obs`, `nav`, one correction
+  source, `reference_ecef`, `max_epochs`, mode, and output directory layout
+- a baseline or stable-control arm in the same run
+- shared output metrics: `wall_time_s`, `ppp_solution_rate_pct`,
+  `ppp_fixed_solutions`, `fallback_solutions`,
+  `clas_hybrid_fallback_epochs`, `mean_3d_error_m`,
+  `median_3d_error_m`, `p95_3d_error_m`, `max_3d_error_m`,
+  `readability_score`, and `extensibility_score`
+- `promotion_gate_checks`, `promotion_gate_pass`, `promotion_stage`, and
+  `promotion_rationale` in the result JSON
+- a suite-level comparison when multiple public or oracle-backed cases exist
+- an explicit regression budget for solution rate, fixed count, P95/max error,
+  runtime, and any oracle delta being claimed
+- a follow-up stable sign-off or schema test before the behavior becomes
+  default-on
+
+Promotion should be staged:
+
+| Stage | Meaning | Allowed next step |
+|---|---|---|
+| `exploratory` | The arm does not repeatedly beat the control or has unclear tradeoffs. | Keep it under `experiments/` or delete it. |
+| `extended_trial` | The arm passes in most cases but not all. | Add cases, diagnostics, or a narrower env/config-gated trial. |
+| `trial_candidate` | The arm passes the shared gates across the suite. | Wire an opt-in CLI/profile flag with a dedicated sign-off. |
+| `promotion_candidate` | The arm passes the suite and improves solver-specific outcomes such as fixed epochs. | Consider default-on only after the stable sign-off passes. |
+| `stable_control` | The comparison baseline. | Keep stable and use as the reference arm. |
+
+Do not promote behavior directly from an experiment result when:
+
+- the result depends on reference truth for a runtime decision
+- the strategy changes protocol decoding, correction expansion, and solver
+  behavior in one PR
+- the decoder lacks subtype-level parity or deterministic unsupported-subtype
+  handling
+- the result improves fixed-only epochs while all-epoch RMS, P95, or max error
+  regress outside the stated budget
+- the experiment needs external credentials but has no local fixture or
+  optional CI skip reason
+- the artifact schema changes without a reader or schema-compatibility test
+
+The experiment lane may keep broad comparison tables. Stable PRs should stay
+small: one user-visible behavior, one sign-off or schema improvement, and one
+documented regression budget.

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ checked benchmark artifacts.
 - [Quick start](quickstart.md)
 - [Validation and sign-off](validation.md)
 - [Interfaces](interfaces.md)
+- [Experiments and promotion rules](experiments.md)
 - [RTK tuning gates](rtk_tuning_gates.md)
 - [PPC reproduction commands](ppc_reproduction.md)
 - [Reference analyses](references/index.md)


### PR DESCRIPTION
## Summary

Adds repository workflow guardrails for scoped development slices:

- expands the PR template with behavior-boundary and regression-budget fields
- adds bug, config, and development-slice issue templates
- documents experiment promotion rules and links them from the docs index

## Validation

- `git diff --check develop..codex/repo-scoped-slices`
- `python3 -m unittest tests.test_experiment_runner`