### PR TITLE
[codex] ppc: add sigma-demote coverage profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -274,6 +274,9 @@ jobs:
         path: |
           output/ci_optional_rtk_signoffs_summary.json
           output/ci_optional_rtk_signoffs/*.log
+          output/ppc_coverage_matrix_schema_smoke/summary.json
+          output/ppc_coverage_matrix_schema_smoke/table.md
+          output/ppc_coverage_matrix_schema_smoke/*_summary.json
           output/ppc_nagoya_run1_rtk_summary.json
           output/ppc_nagoya_run1_rtk.pos
           output/ppc_nagoya_run1_rtk_events.csv

--- a/apps/gnss_ppc_coverage_matrix.py
+++ b/apps/gnss_ppc_coverage_matrix.py
@@ -11,6 +11,7 @@ import re
 import subprocess
 import time
 
+from gnss_toml_config import parse_args_with_toml
 from gnss_runtime import ensure_input_exists, resolve_gnss_command
 
 
@@ -22,6 +23,56 @@ PPC_RUNS: tuple[tuple[str, str], ...] = (
     ("nagoya", "run1"),
     ("nagoya", "run2"),
     ("nagoya", "run3"),
+)
+SUMMARY_SCHEMA = "ppc_coverage_matrix.v1"
+RUN_METRIC_FIELDS = (
+    "positioning_rate_pct",
+    "fix_rate_pct",
+    "ppc_official_score_pct",
+    "ppc_official_score_distance_m",
+    "ppc_official_total_distance_m",
+    "ppc_score_3d_50cm_ref_pct",
+    "p95_h_m",
+    "max_h_m",
+    "solver_wall_time_s",
+    "realtime_factor",
+    "effective_epoch_rate_hz",
+)
+DELTA_METRIC_FIELDS = (
+    "positioning_rate_pct",
+    "fix_rate_pct",
+    "ppc_official_score_pct",
+    "ppc_score_3d_50cm_ref_pct",
+    "p95_h_m",
+)
+AGGREGATE_FIELDS = (
+    "run_count",
+    "rtklib_comparison_run_count",
+    "weighted_official_score_pct",
+    "weighted_rtklib_official_score_pct",
+    "weighted_official_score_delta_pct",
+    "avg_positioning_delta_pct",
+    "avg_fix_delta_pct",
+    "avg_official_score_delta_pct",
+    "avg_score_3d_50cm_ref_delta_pct",
+    "avg_p95_h_delta_m",
+    "min_positioning_delta_pct",
+    "min_official_score_delta_pct",
+    "max_p95_h_delta_m",
+    "avg_solver_wall_time_s",
+    "max_solver_wall_time_s",
+    "avg_realtime_factor",
+    "min_realtime_factor",
+    "avg_effective_epoch_rate_hz",
+    "min_effective_epoch_rate_hz",
+    "float_bridge_tail_rejected_epochs",
+    "fixed_bridge_burst_rejected_epochs",
+)
+GUARD_FIELDS = (
+    "nonfix_drift_guard",
+    "spp_height_step_guard",
+    "float_bridge_tail_guard",
+    "fixed_bridge_burst_guard",
 )
 GUARD_PATTERNS = {
     "nonfix_drift_guard": re.compile(
@@ -51,6 +102,12 @@ GUARD_PATTERNS = {
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(prog=os.environ.get("GNSS_CLI_NAME"))
+    parser.add_argument(
+        "--config-toml",
+        type=Path,
+        default=None,
+        help="Optional TOML config. Uses [ppc_coverage_matrix] or top-level keys.",
+    )
     parser.add_argument("--dataset-root", type=Path, required=True)
     parser.add_argument(
         "--output-dir",
@@ -301,7 +358,7 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Require each PPC run effective solved epoch rate to be at or above this Hz value.",
     )
-    return parser.parse_args()
+    return parse_args_with_toml(parser, "ppc_coverage_matrix")
 
 
 def run_key(city: str, run_name: str) -> str:
@@ -828,6 +885,7 @@ def aggregate_runs(runs: list[dict[str, object]]) -> dict[str, object]:
 
 def build_matrix_payload(args: argparse.Namespace, runs: list[dict[str, object]]) -> dict[str, object]:
     return {
+        "summary_schema": SUMMARY_SCHEMA,
         "dataset_root": str(args.dataset_root),
         "output_dir": str(args.output_dir),
         "max_epochs": args.max_epochs,
@@ -945,6 +1003,199 @@ def build_matrix_payload(args: argparse.Namespace, runs: list[dict[str, object]]
         "runs": runs,
         "aggregates": aggregate_runs(runs),
     }
+
+
+def is_number(value: object) -> bool:
+    return isinstance(value, (int, float)) and not isinstance(value, bool)
+
+
+def require_keys(
+    section: dict[str, object],
+    keys: tuple[str, ...],
+    label: str,
+    failures: list[str],
+) -> None:
+    for key in keys:
+        if key not in section:
+            failures.append(f"{label}: missing `{key}`")
+
+
+def require_nullable_number_fields(
+    section: dict[str, object],
+    keys: tuple[str, ...],
+    label: str,
+    failures: list[str],
+) -> None:
+    require_keys(section, keys, label, failures)
+    for key in keys:
+        value = section.get(key)
+        if value is not None and not is_number(value):
+            failures.append(f"{label}.{key}: expected number or null")
+
+
+def validate_matrix_payload_schema(payload: dict[str, object]) -> None:
+    """Keep the PPC matrix summary stable for CI, docs, Python, and web readers."""
+    failures: list[str] = []
+    require_keys(
+        payload,
+        (
+            "summary_schema",
+            "dataset_root",
+            "output_dir",
+            "max_epochs",
+            "match_tolerance_s",
+            "preset",
+            "coverage_profile",
+            "runtime_requirements",
+            "runs",
+            "aggregates",
+        ),
+        "summary",
+        failures,
+    )
+    if payload.get("summary_schema") != SUMMARY_SCHEMA:
+        failures.append(
+            f"summary.summary_schema: expected {SUMMARY_SCHEMA!r}, got {payload.get('summary_schema')!r}"
+        )
+    for key in ("dataset_root", "output_dir", "preset"):
+        if not isinstance(payload.get(key), str):
+            failures.append(f"summary.{key}: expected string")
+    if not isinstance(payload.get("max_epochs"), int):
+        failures.append("summary.max_epochs: expected integer")
+    if not is_number(payload.get("match_tolerance_s")):
+        failures.append("summary.match_tolerance_s: expected number")
+
+    coverage_profile = payload.get("coverage_profile")
+    if not isinstance(coverage_profile, dict):
+        failures.append("summary.coverage_profile: expected object")
+    else:
+        require_keys(
+            coverage_profile,
+            ("no_arfilter", "no_kinematic_post_filter", "float_bridge_tail_guard_enabled"),
+            "summary.coverage_profile",
+            failures,
+        )
+        for key in ("no_arfilter", "no_kinematic_post_filter", "float_bridge_tail_guard_enabled"):
+            if not isinstance(coverage_profile.get(key), bool):
+                failures.append(f"summary.coverage_profile.{key}: expected bool")
+
+    runtime_requirements = payload.get("runtime_requirements")
+    if not isinstance(runtime_requirements, dict):
+        failures.append("summary.runtime_requirements: expected object")
+    else:
+        require_nullable_number_fields(
+            runtime_requirements,
+            (
+                "solver_wall_time_max_s",
+                "realtime_factor_min",
+                "effective_epoch_rate_min_hz",
+            ),
+            "summary.runtime_requirements",
+            failures,
+        )
+
+    aggregates = payload.get("aggregates")
+    if not isinstance(aggregates, dict):
+        failures.append("summary.aggregates: expected object")
+    else:
+        require_nullable_number_fields(aggregates, AGGREGATE_FIELDS, "summary.aggregates", failures)
+        for key in ("run_count", "rtklib_comparison_run_count"):
+            value = aggregates.get(key)
+            if not isinstance(value, int) or isinstance(value, bool):
+                failures.append(f"summary.aggregates.{key}: expected integer")
+
+    runs = payload.get("runs")
+    if not isinstance(runs, list):
+        failures.append("summary.runs: expected array")
+    else:
+        for index, run in enumerate(runs):
+            label = f"summary.runs[{index}]"
+            if not isinstance(run, dict):
+                failures.append(f"{label}: expected object")
+                continue
+            require_keys(
+                run,
+                (
+                    "city",
+                    "run",
+                    "key",
+                    "command",
+                    "solution_pos",
+                    "summary_json",
+                    "log_path",
+                    "elapsed_s",
+                    "metrics",
+                    "rtklib",
+                    "delta_vs_rtklib",
+                    "guards",
+                ),
+                label,
+                failures,
+            )
+            for key in ("city", "run", "key", "solution_pos", "summary_json", "log_path"):
+                if not isinstance(run.get(key), str):
+                    failures.append(f"{label}.{key}: expected string")
+            command = run.get("command")
+            if not isinstance(command, list) or not all(isinstance(item, str) for item in command):
+                failures.append(f"{label}.command: expected string array")
+            if not is_number(run.get("elapsed_s")):
+                failures.append(f"{label}.elapsed_s: expected number")
+
+            metrics = run.get("metrics")
+            if not isinstance(metrics, dict):
+                failures.append(f"{label}.metrics: expected object")
+            else:
+                require_nullable_number_fields(metrics, RUN_METRIC_FIELDS, f"{label}.metrics", failures)
+
+            rtklib = run.get("rtklib")
+            if rtklib is not None:
+                if not isinstance(rtklib, dict):
+                    failures.append(f"{label}.rtklib: expected object or null")
+                else:
+                    require_nullable_number_fields(rtklib, RUN_METRIC_FIELDS, f"{label}.rtklib", failures)
+
+            delta = run.get("delta_vs_rtklib")
+            if delta is not None:
+                if not isinstance(delta, dict):
+                    failures.append(f"{label}.delta_vs_rtklib: expected object or null")
+                else:
+                    require_nullable_number_fields(
+                        delta,
+                        DELTA_METRIC_FIELDS,
+                        f"{label}.delta_vs_rtklib",
+                        failures,
+                    )
+
+            guards = run.get("guards")
+            if not isinstance(guards, dict):
+                failures.append(f"{label}.guards: expected object")
+            else:
+                require_keys(guards, GUARD_FIELDS, f"{label}.guards", failures)
+                for guard_name in GUARD_FIELDS:
+                    guard = guards.get(guard_name)
+                    guard_label = f"{label}.guards.{guard_name}"
+                    if guard is None:
+                        continue
+                    if not isinstance(guard, dict):
+                        failures.append(f"{guard_label}: expected object or null")
+                        continue
+                    require_keys(
+                        guard,
+                        ("enabled", "inspected_segments", "rejected_segments", "rejected_epochs"),
+                        guard_label,
+                        failures,
+                    )
+                    if not isinstance(guard.get("enabled"), bool):
+                        failures.append(f"{guard_label}.enabled: expected bool")
+                    for key in ("inspected_segments", "rejected_segments", "rejected_epochs"):
+                        value = guard.get(key)
+                        if not isinstance(value, int) or isinstance(value, bool):
+                            failures.append(f"{guard_label}.{key}: expected integer")
+
+    if failures:
+        raise SystemExit(
+            "PPC coverage matrix summary schema failed:\n" + "\n".join(failures)
+        )
 
 
 def metric(metrics: dict[str, object] | None, name: str) -> float | None:
@@ -1140,6 +1391,7 @@ def main() -> int:
 
     payload = build_matrix_payload(args, runs)
     enforce_requirements(payload, args)
+    validate_matrix_payload_schema(payload)
     summary_json.parent.mkdir(parents=True, exist_ok=True)
     summary_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
     markdown = render_markdown(payload)

--- a/configs/ppc_sigma_demote_nis2_ratio4.toml
+++ b/configs/ppc_sigma_demote_nis2_ratio4.toml
@@ -1,0 +1,30 @@
+[ppc_coverage_matrix]
+dataset_root = "data/PPC-Dataset"
+max_epochs = -1
+match_tolerance_s = 0.25
+
+# Deployable PPC six-run runtime profile. This is the long
+# sigma-demote/nis2-ratio4 command from docs/ppc_reproduction.md pinned as data.
+preset = "low-cost"
+ratio = 2.8
+carrier_phase_sigma = 0.001
+max_postfix_rms = 0.20
+max_consec_float_reset = 10
+max_subset_ar_drop_steps = 18
+adaptive_dynamic_slip_thresholds = true
+adaptive_dynamic_slip_nonfix_count = 25
+max_pos_jump = 5.0
+max_pos_jump_min = 5.0
+max_pos_jump_rate = 25.0
+demote_fixed_status_nis_per_obs = 2.0
+demote_fixed_status_max_ratio = 4.0
+
+output_dir = "output/ppc_sigma_profile_runtime_demote_nis2_ratio4"
+summary_json = "output/ppc_sigma_profile_runtime_demote_nis2_ratio4/summary.json"
+markdown_output = "output/ppc_sigma_profile_runtime_demote_nis2_ratio4/table.md"
+
+# Uncomment when comparing against prepared RTKLIB demo5 outputs:
+# rtklib_root = "output/benchmark"
+# require_positioning_delta_min = 0.0
+# require_official_score_delta_min = 0.0
+# require_p95_h_delta_max = 0.0

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -41,8 +41,8 @@ CI lanes are split as follows:
 - `bash scripts/ci/run_extended_tests.sh` for Linux-only heavy checks such as web, packaging, and ROS2 surfaces
 - `bash scripts/ci/run_optional_tests.sh` for broader Linux-only integration suites such as the full CLI and benchmark script regressions
 - `bash scripts/ci/run_optional_rtk_signoffs.sh` for dataset-gated RTK,
-  SCORPION, and long PPC taroz FGO sign-offs with JSON/log artifacts under
-  `output/ci_optional_rtk_signoffs*`
+  PPC coverage-matrix schema smoke, SCORPION, and long PPC taroz FGO sign-offs
+  with JSON/log artifacts under `output/ci_optional_rtk_signoffs*`
 - `bash scripts/ci/generate_dashboard_artifacts.sh` for the dashboard/manifest artifact path used in CI
 
 Docs-only changes keep CI on the lightweight path: hygiene here, plus the separate Docs workflow.

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -34,7 +34,8 @@ Examples:
 
 For longer workflows, `gnss web`, `gnss live-signoff`,
 `gnss moving-base-signoff`, `gnss scorpion-moving-base-signoff`,
-`gnss ppc-rtk-signoff`, and `gnss ppp-products-signoff`
+`gnss ppc-rtk-signoff`, `gnss ppc-coverage-matrix`, and
+`gnss ppp-products-signoff`
 also accept `--config-toml <file>`. Example templates live in `configs/`.
 
 For CLAS-oriented PPP experiments, `gnss ppp` also exposes the boundary and

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -65,8 +65,10 @@ python3 apps/gnss.py ppp-products-signoff \
 For the `ppc` profile with `--malib-pos` or `--malib-bin`, the command also emits paired comparison artifacts (`comparison_csv`, `comparison_png`) and `common_epoch_pairs`, so `gnss web` and CI artifact bundles can show the same side-by-side error slices.
 
 `gnss live-signoff`, `gnss ppp-products-signoff`, `gnss moving-base-signoff`,
-`gnss scorpion-moving-base-signoff`, and `gnss ppc-rtk-signoff`
-also accept `--config-toml`, so you can pin long threshold sets and artifact paths in a file instead of repeating them on the command line.
+`gnss scorpion-moving-base-signoff`, `gnss ppc-rtk-signoff`, and
+`gnss ppc-coverage-matrix`
+also accept `--config-toml`, so you can pin long threshold sets and artifact
+paths in a file instead of repeating them on the command line.
 
 For public benchmark rows that can be expressed as rover/base/nav plus an
 independent `reference.csv`, `gnss ppc-demo` and `gnss ppc-rtk-signoff` also
@@ -114,14 +116,22 @@ Use `--nonfix-drift-max-residual 4 --nonfix-drift-min-horizontal-residual 6`
 only for an explicit P95-cleanup profile: combined with the fixed-burst guard it
 rejects 226 non-FIX drift epochs on Tokyo run1, improves P95H from 34.53 m to
 30.61 m, and keeps PPC official nearly flat, but costs 1.47 pp Positioning rate.
-`ppc-coverage-matrix` accepts these non-FIX, SPP height-step, FLOAT bridge-tail,
-and fixed-burst tuning flags so the same profile can be swept across all six PPC
-runs. The full six-run sweep keeps a +15.7 pp average Positioning lead over
+`ppc-coverage-matrix` also accepts `--config-toml`; the deployable
+`sigma-demote nis2-ratio4` profile is pinned in
+`configs/ppc_sigma_demote_nis2_ratio4.toml`. It accepts these non-FIX, SPP
+height-step, FLOAT bridge-tail, and fixed-burst tuning flags so the same profile
+can be swept across all six PPC runs. The full six-run sweep keeps a +15.7 pp
+average Positioning lead over
 RTKLIB and a +28.1 pp PPC official lead, but costs 1.33 pp average Positioning
 versus the coverage profile and only improves P95H on 3/6 runs; the horizontal
 residual floor reduces Nagoya run3 over-pruning from 13.90 pp to 3.48 pp
 Positioning cost. Treat the profile as a tail-diagnostic lens, not as the
 Positioning-rate sign-off.
+The matrix summary declares `summary_schema: ppc_coverage_matrix.v1` and is
+validated before writing. Each run must carry the KPI fields used by CI, docs,
+Python, and web artifact readers, including `positioning_rate_pct`,
+`fix_rate_pct`, `ppc_official_score_pct`, `p95_h_m`, `solver_wall_time_s`,
+`realtime_factor`, and `effective_epoch_rate_hz`.
 Use `scripts/analyze_ppc_coverage_quality.py` with the PPC solution, RTKLIB
 solution, and `reference.csv` when a coverage run improves Positioning rate but
 regresses P95 horizontal error; the report separates FIXED/FLOAT/SPP quality and
@@ -205,8 +215,8 @@ python3 apps/gnss.py ppc-taroz-amb-pdc-smoke \
 ```
 
 The dataset-gated optional CI sign-off runner also includes the
-`nagoya/run3` 1000-epoch generated-seed check when `GNSSPP_PPC_DATASET_ROOT`
-is configured.
+`ppc-coverage-matrix --max-epochs 2` schema smoke and the `nagoya/run3`
+1000-epoch generated-seed check when `GNSSPP_PPC_DATASET_ROOT` is configured.
 
 The `taroz-amb-pdc` preset enables two truth-free FLOAT output guards by
 default: `--max-float-seed-divergence 100` and

--- a/scripts/ci/run_optional_rtk_signoffs.py
+++ b/scripts/ci/run_optional_rtk_signoffs.py
@@ -125,6 +125,45 @@ def make_ppc_rtk_step(context: SignoffContext, city: str, *, require_rtklib: boo
     return make_step(step_name, slug, command, outputs)
 
 
+def make_ppc_coverage_matrix_smoke_step(context: SignoffContext) -> SignoffStep:
+    slug = "ppc_coverage_matrix_schema_smoke"
+    name = "PPC coverage matrix schema smoke"
+    out_dir = context.output_dir / slug
+    outputs = [
+        out_dir / "summary.json",
+        out_dir / "table.md",
+        *(out_dir / f"{city}_{run_name}_summary.json" for city, run_name in (
+            ("tokyo", "run1"),
+            ("tokyo", "run2"),
+            ("tokyo", "run3"),
+            ("nagoya", "run1"),
+            ("nagoya", "run2"),
+            ("nagoya", "run3"),
+        )),
+    ]
+
+    if context.dataset_root is None or not context.dataset_root.is_dir():
+        return skip_step(name, slug, outputs, "PPC-Dataset root is unavailable.")
+
+    command = [
+        *context.gnss_command,
+        "ppc-coverage-matrix",
+        "--config-toml",
+        str(context.repo_root / "configs" / "ppc_sigma_demote_nis2_ratio4.toml"),
+        "--dataset-root",
+        str(context.dataset_root),
+        "--max-epochs",
+        "2",
+        "--output-dir",
+        str(out_dir),
+        "--summary-json",
+        str(out_dir / "summary.json"),
+        "--markdown-output",
+        str(out_dir / "table.md"),
+    ]
+    return make_step(name, slug, command, outputs)
+
+
 def make_ppc_taroz_amb_pdc_long_step(context: SignoffContext) -> SignoffStep:
     slug = "ppc_taroz_amb_pdc_nagoya_run3_1000_seed"
     name = "PPC taroz ambiguity PDC long generated-seed sign-off"
@@ -224,6 +263,7 @@ def build_step_plan(
         python_executable=python_executable,
     )
     return [
+        make_ppc_coverage_matrix_smoke_step(context),
         make_ppc_rtk_step(context, "nagoya", require_rtklib=False),
         make_ppc_rtk_step(context, "tokyo", require_rtklib=True),
         make_ppc_taroz_amb_pdc_long_step(context),

--- a/tests/test_benchmark_scripts.py
+++ b/tests/test_benchmark_scripts.py
@@ -763,6 +763,104 @@ class PPCRTKSignoffHelpersTest(unittest.TestCase):
 
 
 class PPCCoverageMatrixTest(unittest.TestCase):
+    def test_parse_args_loads_config_toml_profile_and_allows_cli_overrides(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ppc_coverage_config_") as temp_dir:
+            temp_root = Path(temp_dir)
+            dataset_root = temp_root / "PPC-Dataset"
+            config_toml = temp_root / "coverage.toml"
+            config_toml.write_text(
+                "\n".join(
+                    [
+                        "[ppc_coverage_matrix]",
+                        f'dataset_root = "{dataset_root}"',
+                        'output_dir = "output/ppc_sigma_profile_runtime_demote_nis2_ratio4"',
+                        'summary_json = "output/ppc_sigma_profile_runtime_demote_nis2_ratio4/summary.json"',
+                        'markdown_output = "output/ppc_sigma_profile_runtime_demote_nis2_ratio4/table.md"',
+                        "max_epochs = -1",
+                        'preset = "low-cost"',
+                        "ratio = 2.8",
+                        "carrier_phase_sigma = 0.001",
+                        "max_postfix_rms = 0.20",
+                        "max_consec_float_reset = 10",
+                        "max_subset_ar_drop_steps = 18",
+                        "adaptive_dynamic_slip_thresholds = true",
+                        "adaptive_dynamic_slip_nonfix_count = 25",
+                        "max_pos_jump = 5.0",
+                        "max_pos_jump_min = 5.0",
+                        "max_pos_jump_rate = 25.0",
+                        "demote_fixed_status_nis_per_obs = 2.0",
+                        "demote_fixed_status_max_ratio = 4.0",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+
+            with mock.patch.object(
+                sys,
+                "argv",
+                [
+                    "gnss_ppc_coverage_matrix.py",
+                    "--config-toml",
+                    str(config_toml),
+                    "--max-epochs",
+                    "20",
+                ],
+            ):
+                args = ppc_coverage_matrix.parse_args()
+
+            self.assertEqual(args.dataset_root, dataset_root)
+            self.assertEqual(
+                args.output_dir,
+                Path("output/ppc_sigma_profile_runtime_demote_nis2_ratio4"),
+            )
+            self.assertEqual(
+                args.summary_json,
+                Path("output/ppc_sigma_profile_runtime_demote_nis2_ratio4/summary.json"),
+            )
+            self.assertEqual(
+                args.markdown_output,
+                Path("output/ppc_sigma_profile_runtime_demote_nis2_ratio4/table.md"),
+            )
+            self.assertEqual(args.max_epochs, 20)
+            self.assertEqual(args.preset, "low-cost")
+            self.assertEqual(args.ratio, 2.8)
+            self.assertEqual(args.carrier_phase_sigma, 0.001)
+            self.assertEqual(args.max_postfix_rms, 0.20)
+            self.assertEqual(args.max_consec_float_reset, 10)
+            self.assertEqual(args.max_subset_ar_drop_steps, 18)
+            self.assertTrue(args.adaptive_dynamic_slip_thresholds)
+            self.assertEqual(args.adaptive_dynamic_slip_nonfix_count, 25)
+            self.assertEqual(args.max_pos_jump, 5.0)
+            self.assertEqual(args.max_pos_jump_min, 5.0)
+            self.assertEqual(args.max_pos_jump_rate, 25.0)
+            self.assertEqual(args.demote_fixed_status_nis_per_obs, 2.0)
+            self.assertEqual(args.demote_fixed_status_max_ratio, 4.0)
+
+    def test_tracked_sigma_demote_profile_config_parses(self) -> None:
+        config_toml = ROOT_DIR / "configs" / "ppc_sigma_demote_nis2_ratio4.toml"
+
+        with mock.patch.object(
+            sys,
+            "argv",
+            [
+                "gnss_ppc_coverage_matrix.py",
+                "--config-toml",
+                str(config_toml),
+            ],
+        ):
+            args = ppc_coverage_matrix.parse_args()
+
+        self.assertEqual(args.dataset_root, Path("data/PPC-Dataset"))
+        self.assertEqual(args.ratio, 2.8)
+        self.assertEqual(args.carrier_phase_sigma, 0.001)
+        self.assertEqual(args.demote_fixed_status_nis_per_obs, 2.0)
+        self.assertEqual(args.demote_fixed_status_max_ratio, 4.0)
+        self.assertEqual(
+            args.summary_json,
+            Path("output/ppc_sigma_profile_runtime_demote_nis2_ratio4/summary.json"),
+        )
+
     def test_validate_inputs_rejects_invalid_epoch_limit(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ppc_coverage_validate_") as temp_dir:
             dataset_root = Path(temp_dir) / "PPC-Dataset"
@@ -1025,6 +1123,12 @@ class PPCCoverageMatrixTest(unittest.TestCase):
                             "ppc_official_score_pct": 21.0,
                             "ppc_official_score_distance_m": 210.0,
                             "ppc_official_total_distance_m": 1000.0,
+                            "ppc_score_3d_50cm_ref_pct": 0.0,
+                            "p95_h_m": 31.13,
+                            "max_h_m": 52.0,
+                            "solver_wall_time_s": 0.5,
+                            "realtime_factor": 20.0,
+                            "effective_epoch_rate_hz": 100.0,
                         },
                         "delta_vs_rtklib": {
                             "positioning_rate_pct": 19.9,
@@ -1056,6 +1160,8 @@ class PPCCoverageMatrixTest(unittest.TestCase):
             payload = ppc_coverage_matrix.build_matrix_payload(args, [run])
             markdown = ppc_coverage_matrix.render_markdown(payload)
 
+            self.assertEqual(payload["summary_schema"], ppc_coverage_matrix.SUMMARY_SCHEMA)
+            ppc_coverage_matrix.validate_matrix_payload_schema(payload)
             self.assertEqual(payload["aggregates"]["avg_positioning_delta_pct"], 19.9)
             self.assertEqual(payload["aggregates"]["avg_official_score_delta_pct"], 21.0)
             self.assertEqual(payload["aggregates"]["weighted_official_score_pct"], 42.0)
@@ -1141,6 +1247,12 @@ class PPCCoverageMatrixTest(unittest.TestCase):
             self.assertIn("solver_wall_time_s", runtime_message)
             self.assertIn("realtime_factor", runtime_message)
             self.assertIn("effective_epoch_rate_hz", runtime_message)
+
+            invalid_payload = json.loads(json.dumps(payload))
+            del invalid_payload["runs"][0]["metrics"]["p95_h_m"]
+            with self.assertRaises(SystemExit) as schema_context:
+                ppc_coverage_matrix.validate_matrix_payload_schema(invalid_payload)
+            self.assertIn("metrics: missing `p95_h_m`", str(schema_context.exception))
 
 
 class PPCResidualResetSweepAnalysisTest(unittest.TestCase):
@@ -3040,6 +3152,7 @@ class OptionalRTKSignoffScriptTest(unittest.TestCase):
             self.assertEqual(
                 [step.slug for step in steps],
                 [
+                    "ppc_coverage_matrix_schema_smoke",
                     "ppc_nagoya_run1_rtk",
                     "ppc_tokyo_run1_rtk",
                     "ppc_taroz_amb_pdc_nagoya_run3_1000_seed",
@@ -3050,7 +3163,8 @@ class OptionalRTKSignoffScriptTest(unittest.TestCase):
             self.assertEqual(steps[0].skip_reason, "PPC-Dataset root is unavailable.")
             self.assertEqual(steps[1].skip_reason, "PPC-Dataset root is unavailable.")
             self.assertEqual(steps[2].skip_reason, "PPC-Dataset root is unavailable.")
-            self.assertEqual(steps[3].skip_reason, "SCORPION moving-base input is unavailable.")
+            self.assertEqual(steps[3].skip_reason, "PPC-Dataset root is unavailable.")
+            self.assertEqual(steps[4].skip_reason, "SCORPION moving-base input is unavailable.")
 
     def test_build_step_plan_uses_dataset_rtklib_and_scorpion_url(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ci_rtk_plan_") as temp_dir:
@@ -3069,7 +3183,14 @@ class OptionalRTKSignoffScriptTest(unittest.TestCase):
 
             steps = ci_rtk_signoffs.build_step_plan(ROOT_DIR, output_dir, env)
 
-            nagoya, tokyo, taroz_long, scorpion = steps
+            coverage, nagoya, tokyo, taroz_long, scorpion = steps
+            self.assertIsNotNone(coverage.command)
+            self.assertIn("ppc-coverage-matrix", coverage.command)
+            self.assertIn("--config-toml", coverage.command)
+            self.assertIn("--max-epochs", coverage.command)
+            self.assertIn("2", coverage.command)
+            self.assertIn("--summary-json", coverage.command)
+            self.assertIn(str(output_dir / "ppc_coverage_matrix_schema_smoke" / "summary.json"), coverage.command)
             self.assertIsNotNone(nagoya.command)
             self.assertIn("--dataset-root", nagoya.command)
             self.assertIn(str(dataset_root), nagoya.command)
@@ -3105,7 +3226,8 @@ class OptionalRTKSignoffScriptTest(unittest.TestCase):
                 {"GNSSPP_PPC_DATASET_ROOT": str(dataset_root)},
             )
 
-            nagoya, tokyo, taroz_long, _ = steps
+            coverage, nagoya, tokyo, taroz_long, _ = steps
+            self.assertIsNotNone(coverage.command)
             self.assertIsNotNone(nagoya.command)
             self.assertIsNone(tokyo.command)
             self.assertEqual(tokyo.skip_reason, "RTKLIB binary is unavailable.")


### PR DESCRIPTION
## Summary

Pins the PPC sigma-demote runtime profile and makes its coverage-matrix artifacts schema-checked:

- adds `configs/ppc_sigma_demote_nis2_ratio4.toml`
- adds `--config-toml` support and `ppc_coverage_matrix.v1` validation
- adds optional CI schema smoke and artifact upload paths
- updates validation and reproduction docs

## Validation

- `git diff --check develop..codex/ppc-sigma-demote-profile`
- `python3 -m unittest tests.test_benchmark_scripts tests.test_experiment_runner`