### PR TITLE
[codex] ci: harden optional RTK signoff contract

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -47,7 +47,9 @@ CI lanes are split as follows:
 - `bash scripts/ci/run_optional_tests.sh` for broader Linux-only integration suites such as the full CLI and benchmark script regressions
 - `bash scripts/ci/run_optional_rtk_signoffs.sh` for dataset-gated RTK,
   PPC coverage-matrix schema smoke, SCORPION, and long PPC taroz FGO sign-offs
-  with JSON/log artifacts under `output/ci_optional_rtk_signoffs*`
+  with JSON/log artifacts under `output/ci_optional_rtk_signoffs*`; the summary
+  uses `summary_schema: ci_optional_rtk_signoffs.v1` and a passed step fails the
+  lane if any declared output artifact is missing
 - `bash scripts/ci/generate_dashboard_artifacts.sh` for the dashboard/manifest artifact path used in CI
 
 Docs-only changes keep CI on the lightweight path: hygiene here, plus the separate Docs workflow.

--- a/scripts/ci/run_optional_rtk_signoffs.py
+++ b/scripts/ci/run_optional_rtk_signoffs.py
@@ -14,6 +14,9 @@ import time
 from typing import Mapping
 
 
+SUMMARY_SCHEMA = "ci_optional_rtk_signoffs.v1"
+
+
 @dataclass(frozen=True)
 class SignoffStep:
     name: str
@@ -308,8 +311,17 @@ def run_step(step: SignoffStep, repo_root: Path, log_dir: Path) -> dict[str, obj
     record["elapsed_s"] = elapsed
     record["returncode"] = completed.returncode
     if completed.returncode == 0:
-        record["status"] = "passed"
-        print(f"Passed {step.name} in {elapsed:.2f}s")
+        missing_outputs = [output for output in step.outputs if not Path(output).exists()]
+        record["missing_outputs"] = missing_outputs
+        if missing_outputs:
+            record["status"] = "failed"
+            print(
+                f"Failed {step.name} in {elapsed:.2f}s; "
+                f"missing expected outputs: {', '.join(missing_outputs)}"
+            )
+        else:
+            record["status"] = "passed"
+            print(f"Passed {step.name} in {elapsed:.2f}s")
     else:
         record["status"] = "failed"
         lines = combined_log.splitlines()
@@ -343,8 +355,12 @@ def render_markdown_summary(results: list[dict[str, object]]) -> str:
             elapsed = result.get("elapsed_s")
             detail = f"{elapsed:.2f}s" if isinstance(elapsed, (float, int)) else ""
         elif status == "failed":
-            log_path = result.get("log_path")
-            detail = f"see `{log_path}`" if log_path else "failed"
+            missing_outputs = result.get("missing_outputs")
+            if isinstance(missing_outputs, list) and missing_outputs:
+                detail = "missing " + ", ".join(f"`{output}`" for output in missing_outputs)
+            else:
+                log_path = result.get("log_path")
+                detail = f"see `{log_path}`" if log_path else "failed"
         lines.append(f"| {result['name']} | `{status}` | {detail} |")
     lines.append("")
     return "\n".join(lines)
@@ -353,6 +369,7 @@ def render_markdown_summary(results: list[dict[str, object]]) -> str:
 def write_summary(summary_path: Path, steps: list[SignoffStep], results: list[dict[str, object]]) -> None:
     summary_path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
+        "summary_schema": SUMMARY_SCHEMA,
         "steps": [asdict(step) for step in steps],
         "results": results,
         "counts": {

--- a/tests/test_benchmark_scripts.py
+++ b/tests/test_benchmark_scripts.py
@@ -3259,7 +3259,53 @@ class OptionalRTKSignoffScriptTest(unittest.TestCase):
             passed_result = ci_rtk_signoffs.run_step(passed, ROOT_DIR, log_dir)
             self.assertEqual(passed_result["status"], "passed")
             self.assertEqual(passed_result["returncode"], 0)
+            self.assertEqual(passed_result["missing_outputs"], [])
             self.assertIn("ok", (log_dir / "pass_example.log").read_text(encoding="utf-8"))
+
+            missing_output = ci_rtk_signoffs.SignoffStep(
+                name="Missing output example",
+                slug="missing_output_example",
+                command=[sys.executable, "-c", "print('ok')"],
+                outputs=[str(temp_root / "missing.json")],
+            )
+            missing_result = ci_rtk_signoffs.run_step(missing_output, ROOT_DIR, log_dir)
+            self.assertEqual(missing_result["status"], "failed")
+            self.assertEqual(missing_result["returncode"], 0)
+            self.assertEqual(
+                missing_result["missing_outputs"],
+                [str(temp_root / "missing.json")],
+            )
+
+    def test_write_summary_records_schema_and_counts(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_rtk_summary_") as temp_dir:
+            temp_root = Path(temp_dir)
+            summary_path = temp_root / "summary.json"
+            steps = [
+                ci_rtk_signoffs.SignoffStep(
+                    name="PPC coverage matrix schema smoke",
+                    slug="ppc_coverage_matrix_schema_smoke",
+                    command=None,
+                    outputs=[],
+                    skip_reason="PPC-Dataset root is unavailable.",
+                )
+            ]
+            results = [
+                {
+                    "name": steps[0].name,
+                    "slug": steps[0].slug,
+                    "status": "skipped",
+                    "skip_reason": steps[0].skip_reason,
+                    "outputs": [],
+                    "log_path": str(temp_root / "ppc_coverage_matrix_schema_smoke.log"),
+                }
+            ]
+
+            ci_rtk_signoffs.write_summary(summary_path, steps, results)
+
+            payload = json.loads(summary_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["summary_schema"], ci_rtk_signoffs.SUMMARY_SCHEMA)
+            self.assertEqual(payload["counts"], {"passed": 0, "failed": 0, "skipped": 1})
+            self.assertEqual(payload["steps"][0]["slug"], "ppc_coverage_matrix_schema_smoke")
 
     def test_render_markdown_summary_reports_status_table(self) -> None:
         markdown = ci_rtk_signoffs.render_markdown_summary(
@@ -3281,16 +3327,23 @@ class OptionalRTKSignoffScriptTest(unittest.TestCase):
                     "status": "failed",
                     "log_path": "/tmp/c.log",
                 },
+                {
+                    "name": "PPC coverage matrix schema smoke",
+                    "status": "failed",
+                    "missing_outputs": ["/tmp/summary.json"],
+                    "log_path": "/tmp/d.log",
+                },
             ]
         )
 
         self.assertIn("## Optional RTK Sign-offs", markdown)
         self.assertIn("`passed`: `1`", markdown)
-        self.assertIn("`failed`: `1`", markdown)
+        self.assertIn("`failed`: `2`", markdown)
         self.assertIn("`skipped`: `1`", markdown)
         self.assertIn("| PPC Nagoya RTK sign-off | `passed` | 1.25s |", markdown)
         self.assertIn("RTKLIB binary is unavailable.", markdown)
         self.assertIn("see `/tmp/c.log`", markdown)
+        self.assertIn("missing `/tmp/summary.json`", markdown)
 
 class OptionalPPPProductsSignoffScriptTest(unittest.TestCase):
     def test_build_step_plan_skips_when_malib_is_missing(self) -> None:


### PR DESCRIPTION
## Summary

- add `summary_schema: ci_optional_rtk_signoffs.v1` to optional RTK signoff summaries
- fail a nominally passed optional RTK signoff step when declared output artifacts are missing
- document the contract and cover the schema/output checks in focused tests

## Validation

- `python3 -m py_compile scripts/ci/run_optional_rtk_signoffs.py`
- `python3 -m unittest tests.test_benchmark_scripts.OptionalRTKSignoffScriptTest`
- dataset-unavailable smoke for `scripts/ci/run_optional_rtk_signoffs.py` confirming 5 skipped steps and the schema value
- `git diff --check`