### PR TITLE
[codex] clas: expose exact RINEX observation identity

### DIFF
--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -182,3 +182,8 @@ plus optional component-delta CSV.  The tool intentionally changes no solver
 model; it is the gate for classifying PRC, CPC, ionosphere, bias, antenna,
 wind-up, and related component deltas before any GPS L2W, QZSS, or Galileo model
 change is attempted.
+
+Native RINEX observations now expose exact `pseudorange_rinex_code` and
+`carrier_rinex_code` columns in the CLAS code/phase diagnostic dumps.  This lets
+the GPS L2W investigation distinguish `C2W/L2W` from other GPS L2 tracking codes
+even though both still use the current `SignalType::GPS_L2C` runtime family.

--- a/include/libgnss++/core/observation.hpp
+++ b/include/libgnss++/core/observation.hpp
@@ -45,6 +45,12 @@ struct Observation {
     Observation() = default;
     Observation(const SatelliteId& sat, SignalType sig) 
         : satellite(sat), signal(sig) {}
+
+    const std::string& exactBiasObservationType() const {
+        return !pseudorange_observation_type.empty()
+                   ? pseudorange_observation_type
+                   : carrier_phase_observation_type;
+    }
 };
 
 /**

--- a/scripts/analysis/clas_zd_component_diff.py
+++ b/scripts/analysis/clas_zd_component_diff.py
@@ -113,6 +113,34 @@ def detect_frequency(row: Row) -> int:
     return to_int(first_present(row, ("freq", "frequency_index", "frequency", "f"), "0"))
 
 
+def observation_identity(row: Row, row_type: str) -> str:
+    if row_type == "code":
+        return first_present(
+            row,
+            (
+                "pseudorange_rinex_code",
+                "pseudorange_observation_type",
+                "obs_code",
+                "rinex_code",
+                "code",
+                "signal",
+            ),
+        )
+    if row_type == "phase":
+        return first_present(
+            row,
+            (
+                "carrier_rinex_code",
+                "carrier_phase_observation_type",
+                "obs_code",
+                "rinex_code",
+                "code",
+                "signal",
+            ),
+        )
+    return first_present(row, ("obs_code", "rinex_code", "code", "signal"), "")
+
+
 def extract_components(row: Row, component_names: Sequence[str]) -> ComponentMap:
     components: ComponentMap = {}
     for component in component_names:
@@ -167,7 +195,7 @@ def normalize_rows(
                 tow=tow_millis / 1000.0,
                 sat=sat,
                 freq=freq,
-                signal=first_present(row, ("signal", "code", "obs_code", "rinex_code"), ""),
+                signal=observation_identity(row, row_type),
                 source_row=index,
                 components=components,
             )

--- a/src/algorithms/ppp_clas.cpp
+++ b/src/algorithms/ppp_clas.cpp
@@ -141,7 +141,7 @@ std::ofstream* ambDatumDumpStream() {
         initialized = true;
         stream.open(path, std::ios::out | std::ios::trunc);
         if (stream) {
-            stream << "record,week,tow,sat,freq,signal,lambda_m,"
+            stream << "record,week,tow,sat,freq,signal,carrier_rinex_code,lambda_m,"
                    << "raw_phase_cycles,raw_phase_m,carrier_correction_m,"
                    << "cpc_m,cpc_minus_trop_m,trop_correction_m,relativity_m,"
                    << "receiver_antenna_m,iono_cpc_m,phase_bias_m,windup_m,"
@@ -190,6 +190,7 @@ std::ofstream* clasCodeDumpStream() {
         stream.open(path, std::ios::out | std::ios::trunc);
         if (stream) {
             stream << "record,stage,week,tow,sat,freq,signal,"
+                   << "pseudorange_rinex_code,carrier_rinex_code,"
                    << "raw_p_m,corrected_p_m,applied_pr_corr_m,prc_m,"
                    << "prc_minus_trop_m,trop_correction_m,iono_l1_m,"
                    << "iono_scaled_m,code_bias_m,receiver_ant_m,relativity_m,"
@@ -316,6 +317,8 @@ void dumpClasCodeRows(
                   << osr.satellite.toString() << ','
                   << f << ','
                   << static_cast<int>(raw->signal) << ','
+                  << raw->pseudorange_observation_type << ','
+                  << raw->carrier_phase_observation_type << ','
                   << raw->pseudorange << ','
                   << corrected_p << ','
                   << applied.pseudorange_correction_m << ','
@@ -982,6 +985,7 @@ MeasurementBuildResult buildEpochMeasurements(
                           << osr.satellite.toString() << ','
                           << f << ','
                           << static_cast<int>(raw->signal) << ','
+                          << raw->carrier_phase_observation_type << ','
                           << osr.wavelengths[f] << ','
                           << raw->carrier_phase << ','
                           << l_m << ','

--- a/src/algorithms/ppp_observations.cpp
+++ b/src/algorithms/ppp_observations.cpp
@@ -13,12 +13,6 @@ using namespace ppp_internal;
 
 namespace {
 
-std::string biasObservationType(const Observation& observation) {
-    return !observation.pseudorange_observation_type.empty()
-               ? observation.pseudorange_observation_type
-               : observation.carrier_phase_observation_type;
-}
-
 std::vector<SignalType> secondarySignalsForObservation(const SatelliteId& sat,
                                                        bool prefer_qzss_l5) {
     if (prefer_qzss_l5 && sat.system == GNSSSystem::QZSS) {
@@ -91,7 +85,7 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
             const double primary_frequency_hz = signalFrequencyHz(primary->signal, eph);
             entry.pseudorange_if = primary->pseudorange;
             entry.primary_signal = primary->signal;
-            entry.primary_observation_type = biasObservationType(*primary);
+            entry.primary_observation_type = primary->exactBiasObservationType();
             entry.primary_code_bias_coeff = 1.0;
             entry.secondary_code_bias_coeff = 0.0;
             if (capture_shadow_metadata) {
@@ -134,7 +128,7 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
         if (!ppp_config_.use_ionosphere_free) {
             if (secondary != nullptr) {
                 entry.secondary_signal = secondary->signal;
-                entry.secondary_observation_type = biasObservationType(*secondary);
+                entry.secondary_observation_type = secondary->exactBiasObservationType();
                 const double f1 = signalFrequencyHz(primary->signal, eph);
                 const double f2 = signalFrequencyHz(secondary->signal, eph);
                 if (capture_shadow_metadata) {
@@ -190,7 +184,7 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
         if (secondary == nullptr) {
             entry.pseudorange_if = primary->pseudorange;
             entry.primary_signal = primary->signal;
-            entry.primary_observation_type = biasObservationType(*primary);
+            entry.primary_observation_type = primary->exactBiasObservationType();
             entry.primary_code_bias_coeff = 1.0;
             entry.secondary_code_bias_coeff = 0.0;
             if (capture_shadow_metadata) {
@@ -224,8 +218,8 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
             coefficients.first * primary->pseudorange + coefficients.second * secondary->pseudorange;
         entry.primary_signal = primary->signal;
         entry.secondary_signal = secondary->signal;
-        entry.primary_observation_type = biasObservationType(*primary);
-        entry.secondary_observation_type = biasObservationType(*secondary);
+        entry.primary_observation_type = primary->exactBiasObservationType();
+        entry.secondary_observation_type = secondary->exactBiasObservationType();
         entry.primary_code_bias_coeff = coefficients.first;
         entry.secondary_code_bias_coeff = coefficients.second;
         if (capture_shadow_metadata) {

--- a/tests/test_clas_zd_component_diff.py
+++ b/tests/test_clas_zd_component_diff.py
@@ -31,6 +31,8 @@ FIELDNAMES = [
     "sat",
     "freq",
     "signal",
+    "pseudorange_rinex_code",
+    "carrier_rinex_code",
     "prc_m",
     "PRC",
     "cpc_m",
@@ -60,6 +62,8 @@ def code_row(
     record: str = "CODE",
     stage: str = "",
     signal: str = "",
+    pseudorange_rinex_code: str = "",
+    carrier_rinex_code: str = "",
 ) -> dict[str, str]:
     return {
         "record": record,
@@ -69,6 +73,8 @@ def code_row(
         "sat": sat,
         "freq": freq,
         "signal": signal,
+        "pseudorange_rinex_code": pseudorange_rinex_code,
+        "carrier_rinex_code": carrier_rinex_code,
         "prc_m": prc,
         "PRC": "",
         "cpc_m": "",
@@ -82,6 +88,32 @@ def code_row(
 
 
 class ClasZdComponentDiffTest(unittest.TestCase):
+    def test_observation_identity_prefers_row_type_specific_rinex_code(self) -> None:
+        self.assertEqual(
+            component_diff.observation_identity(
+                {
+                    "record": "CODE",
+                    "signal": "3",
+                    "pseudorange_rinex_code": "C2W",
+                    "carrier_rinex_code": "L2W",
+                },
+                "code",
+            ),
+            "C2W",
+        )
+        self.assertEqual(
+            component_diff.observation_identity(
+                {
+                    "record": "PHASE",
+                    "signal": "3",
+                    "pseudorange_rinex_code": "C2W",
+                    "carrier_rinex_code": "L2W",
+                },
+                "phase",
+            ),
+            "L2W",
+        )
+
     def test_compares_common_component_rows_and_reports_unmatched(self) -> None:
         base_rows = [
             code_row(sat="G14", freq="1", prc="0.50", code_bias="0.10", receiver_ant="-0.02"),
@@ -96,6 +128,7 @@ class ClasZdComponentDiffTest(unittest.TestCase):
                 receiver_ant="0.00",
                 stage="accepted",
                 signal="3",
+                pseudorange_rinex_code="C2W",
             ),
             code_row(
                 sat="J02",
@@ -141,6 +174,7 @@ class ClasZdComponentDiffTest(unittest.TestCase):
         self.assertEqual(report["top_candidate_only"][0]["sat"], "J02")
         self.assertEqual(report["top_component_deltas"][0]["component"], "prc_m")
         self.assertAlmostEqual(report["top_component_deltas"][0]["delta_m"], 0.25)
+        self.assertEqual(report["top_component_deltas"][0]["candidate_signal"], "C2W")
 
     def test_cli_writes_schema_json_and_details_csv(self) -> None:
         with tempfile.TemporaryDirectory(prefix="clas_zd_component_diff_test_") as temp_dir:
@@ -163,6 +197,7 @@ class ClasZdComponentDiffTest(unittest.TestCase):
                         code_bias="0.10",
                         receiver_ant="0.00",
                         signal="3",
+                        pseudorange_rinex_code="C2W",
                     )
                 ],
             )
@@ -206,6 +241,7 @@ class ClasZdComponentDiffTest(unittest.TestCase):
                 rows = list(csv.DictReader(details_file))
             self.assertEqual(rows[0]["component"], "prc_m")
             self.assertEqual(rows[0]["sat"], "G14")
+            self.assertEqual(rows[0]["candidate_signal"], "C2W")
             self.assertEqual(float(rows[0]["delta_m"]), 0.25)
 
 

--- a/tests/test_observation.cpp
+++ b/tests/test_observation.cpp
@@ -43,6 +43,17 @@ TEST_F(ObservationTest, BasicObservationData) {
     EXPECT_FALSE(obs_data_.isEmpty());
 }
 
+TEST_F(ObservationTest, ExactBiasObservationTypePrefersCodeType) {
+    Observation code_and_phase(SatelliteId(GNSSSystem::GPS, 24), SignalType::GPS_L2C);
+    code_and_phase.pseudorange_observation_type = "C2W";
+    code_and_phase.carrier_phase_observation_type = "L2W";
+    EXPECT_EQ(code_and_phase.exactBiasObservationType(), "C2W");
+
+    Observation phase_only(SatelliteId(GNSSSystem::GPS, 24), SignalType::GPS_L2C);
+    phase_only.carrier_phase_observation_type = "L2W";
+    EXPECT_EQ(phase_only.exactBiasObservationType(), "L2W");
+}
+
 TEST_F(ObservationTest, GetObservationsBySatellite) {
     SatelliteId gps1(GNSSSystem::GPS, 1);
     auto gps1_obs = obs_data_.getObservations(gps1);

--- a/tests/test_rinex_writer.cpp
+++ b/tests/test_rinex_writer.cpp
@@ -448,6 +448,68 @@ TEST(RINEXReaderTest, KeepsRinex3TrackingCodeFieldsTogether) {
     std::filesystem::remove(temp_path);
 }
 
+TEST(RINEXReaderTest, PreservesExactGpsL2RinexObservationIdentity) {
+    auto read_l2_epoch = [](const std::string& label,
+                            const std::string& l2_obs_types,
+                            const std::string& c2_value,
+                            const std::string& l2_value) {
+        const auto temp_path =
+            std::filesystem::temp_directory_path() /
+            ("libgnss_gps_l2_identity_" + label + ".obs");
+        std::filesystem::remove(temp_path);
+
+        std::ofstream output(temp_path);
+        EXPECT_TRUE(output.is_open());
+        output << rinexHeaderLine(
+            "     3.04           OBSERVATION DATA    M",
+            "RINEX VERSION / TYPE");
+        output << rinexHeaderLine(
+            "G    4 C1C L1C " + l2_obs_types,
+            "SYS / # / OBS TYPES");
+        output << rinexHeaderLine("", "END OF HEADER");
+        output << "> 2024 08 03 09 51 20.0000000  0  1\n";
+        output << "G24"
+               << rinexObsField("22011162.552")
+               << rinexObsField("115669443.467")
+               << rinexObsField(c2_value)
+               << rinexObsField(l2_value)
+               << "\n";
+        output.close();
+
+        io::RINEXReader reader;
+        EXPECT_TRUE(reader.open(temp_path.string()));
+        io::RINEXReader::RINEXHeader header;
+        EXPECT_TRUE(reader.readHeader(header));
+        ObservationData epoch;
+        EXPECT_TRUE(reader.readObservationEpoch(epoch));
+        reader.close();
+        std::filesystem::remove(temp_path);
+        return epoch;
+    };
+
+    const SatelliteId gps_24(GNSSSystem::GPS, 24);
+
+    const ObservationData w_epoch =
+        read_l2_epoch("w", "C2W L2W", "22022262.423", "120222443.467");
+    const auto* gps_l2w = w_epoch.getObservation(gps_24, SignalType::GPS_L2C);
+    ASSERT_NE(gps_l2w, nullptr);
+    EXPECT_NEAR(gps_l2w->pseudorange, 22022262.423, 1e-3);
+    EXPECT_NEAR(gps_l2w->carrier_phase, 120222443.467, 1e-3);
+    EXPECT_EQ(gps_l2w->pseudorange_observation_type, "C2W");
+    EXPECT_EQ(gps_l2w->carrier_phase_observation_type, "L2W");
+    EXPECT_EQ(gps_l2w->exactBiasObservationType(), "C2W");
+
+    const ObservationData x_epoch =
+        read_l2_epoch("x", "C2X L2X", "22033362.423", "120333443.467");
+    const auto* gps_l2x = x_epoch.getObservation(gps_24, SignalType::GPS_L2C);
+    ASSERT_NE(gps_l2x, nullptr);
+    EXPECT_NEAR(gps_l2x->pseudorange, 22033362.423, 1e-3);
+    EXPECT_NEAR(gps_l2x->carrier_phase, 120333443.467, 1e-3);
+    EXPECT_EQ(gps_l2x->pseudorange_observation_type, "C2X");
+    EXPECT_EQ(gps_l2x->carrier_phase_observation_type, "L2X");
+    EXPECT_EQ(gps_l2x->exactBiasObservationType(), "C2X");
+}
+
 TEST(RINEXReaderTest, QzssSecondaryL5PreferenceSelectsL5Q) {
     const auto temp_path =
         std::filesystem::temp_directory_path() / "libgnss_qzss_l5_preference_test.obs";


### PR DESCRIPTION
## Summary
- Add an `Observation::exactBiasObservationType()` helper and use it when PPP carries RINEX observation identity into SSR bias lookup metadata.
- Preserve exact GPS L2 RINEX identity in tests, distinguishing `C2W/L2W` from `C2X/L2X` while leaving the runtime family as `SignalType::GPS_L2C`.
- Add exact `pseudorange_rinex_code` / `carrier_rinex_code` columns to CLAS code/phase diagnostic dumps and teach `clas_zd_component_diff.py` to prefer them.

## Validation
- `cmake --build build-madoca-parity --parallel --target run_tests`
- `./build-madoca-parity/tests/run_tests`
- `python3 -m py_compile scripts/analysis/clas_zd_component_diff.py tests/test_clas_zd_component_diff.py`
- `python3 -m unittest tests.test_clas_zd_component_diff`
- `ctest --test-dir build-madoca-parity -R "python_clas_zd_component_diff_tests" --output-on-failure`
- `git diff --check`
