### PR TITLE
[codex] clas: gate GPS L2W bias identity parity

### DIFF
--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -187,3 +187,9 @@ Native RINEX observations now expose exact `pseudorange_rinex_code` and
 `carrier_rinex_code` columns in the CLAS code/phase diagnostic dumps.  This lets
 the GPS L2W investigation distinguish `C2W/L2W` from other GPS L2 tracking codes
 even though both still use the current `SignalType::GPS_L2C` runtime family.
+When both `GNSS_PPP_CLAS_DD_FILTER=1` and
+`GNSS_PPP_CLAS_CODE_ROW_PARITY=bias` are set, the CLAS OSR materializer uses
+that exact GPS L2 RINEX identity to choose the code/phase SSR bias signal id.
+Gate-off behavior still uses the existing `SignalType` family id path, and the
+diagnostic dumps include the selected `code_bias_signal_id` /
+`phase_bias_signal_id` for oracle comparison.

--- a/include/libgnss++/algorithms/ppp_bias_identity.hpp
+++ b/include/libgnss++/algorithms/ppp_bias_identity.hpp
@@ -1,0 +1,168 @@
+#pragma once
+
+#include <libgnss++/algorithms/madoca_parity.hpp>
+#include <libgnss++/core/signals.hpp>
+
+#include <cstdint>
+#include <string_view>
+
+namespace libgnss::algorithms::ppp_bias_identity {
+
+struct ObservationCodeMapEntry {
+    std::string_view observation_type;
+    int rtklib_code;
+};
+
+inline constexpr ObservationCodeMapEntry kObservationCodeMap[] = {
+    {"C1C", madoca_parity::kCodeL1C}, {"L1C", madoca_parity::kCodeL1C},
+    {"C1P", madoca_parity::kCodeL1P}, {"L1P", madoca_parity::kCodeL1P},
+    {"C1W", madoca_parity::kCodeL1W}, {"L1W", madoca_parity::kCodeL1W},
+    {"C1S", madoca_parity::kCodeL1S}, {"L1S", madoca_parity::kCodeL1S},
+    {"C1L", madoca_parity::kCodeL1L}, {"L1L", madoca_parity::kCodeL1L},
+    {"C1E", madoca_parity::kCodeL1E}, {"L1E", madoca_parity::kCodeL1E},
+    {"C1B", madoca_parity::kCodeL1B}, {"L1B", madoca_parity::kCodeL1B},
+    {"C1X", madoca_parity::kCodeL1X}, {"L1X", madoca_parity::kCodeL1X},
+    {"C2C", madoca_parity::kCodeL2C}, {"L2C", madoca_parity::kCodeL2C},
+    {"C2S", madoca_parity::kCodeL2S}, {"L2S", madoca_parity::kCodeL2S},
+    {"C2L", madoca_parity::kCodeL2L}, {"L2L", madoca_parity::kCodeL2L},
+    {"C2X", madoca_parity::kCodeL2X}, {"L2X", madoca_parity::kCodeL2X},
+    {"C2P", madoca_parity::kCodeL2P}, {"L2P", madoca_parity::kCodeL2P},
+    {"C2W", madoca_parity::kCodeL2W}, {"L2W", madoca_parity::kCodeL2W},
+    {"C5I", madoca_parity::kCodeL5I}, {"L5I", madoca_parity::kCodeL5I},
+    {"C5Q", madoca_parity::kCodeL5Q}, {"L5Q", madoca_parity::kCodeL5Q},
+    {"C5X", madoca_parity::kCodeL5X}, {"L5X", madoca_parity::kCodeL5X},
+    {"C5D", madoca_parity::kCodeL5D}, {"L5D", madoca_parity::kCodeL5D},
+    {"C5P", madoca_parity::kCodeL5P}, {"L5P", madoca_parity::kCodeL5P},
+    {"C6B", madoca_parity::kCodeL6B}, {"L6B", madoca_parity::kCodeL6B},
+    {"C6C", madoca_parity::kCodeL6C}, {"L6C", madoca_parity::kCodeL6C},
+    {"C6X", madoca_parity::kCodeL6X}, {"L6X", madoca_parity::kCodeL6X},
+    {"C6I", madoca_parity::kCodeL6I}, {"L6I", madoca_parity::kCodeL6I},
+    {"C6Q", madoca_parity::kCodeL6Q}, {"L6Q", madoca_parity::kCodeL6Q},
+    {"C7I", madoca_parity::kCodeL7I}, {"L7I", madoca_parity::kCodeL7I},
+    {"C7Q", madoca_parity::kCodeL7Q}, {"L7Q", madoca_parity::kCodeL7Q},
+    {"C7X", madoca_parity::kCodeL7X}, {"L7X", madoca_parity::kCodeL7X},
+    {"C7D", madoca_parity::kCodeL7D}, {"L7D", madoca_parity::kCodeL7D},
+};
+
+inline int rtklibSystemForGnss(GNSSSystem system) {
+    switch (system) {
+        case GNSSSystem::GPS: return madoca_parity::kSysGps;
+        case GNSSSystem::Galileo: return madoca_parity::kSysGal;
+        case GNSSSystem::QZSS: return madoca_parity::kSysQzs;
+        default: return madoca_parity::kSysNone;
+    }
+}
+
+inline int rtklibCodeForObservationType(std::string_view observation_type) {
+    for (const auto& entry : kObservationCodeMap) {
+        if (observation_type == entry.observation_type) {
+            return entry.rtklib_code;
+        }
+    }
+    return madoca_parity::kCodeNone;
+}
+
+inline std::uint8_t madocaBiasIdentityIdForObservation(GNSSSystem system,
+                                                       SignalType signal,
+                                                       std::string_view observation_type,
+                                                       bool exact_bias_identity) {
+    if (!exact_bias_identity) {
+        return rtcmSsrSignalId(system, signal);
+    }
+    const int rtklib_system = rtklibSystemForGnss(system);
+    if (rtklib_system == madoca_parity::kSysNone) {
+        return rtcmSsrSignalId(system, signal);
+    }
+    const int rtklib_code = rtklibCodeForObservationType(observation_type);
+    const int bias_code = madoca_parity::mcssrSelBiascode(rtklib_system, rtklib_code);
+    if (bias_code <= 0 || bias_code > 255) {
+        return 0U;
+    }
+    return static_cast<std::uint8_t>(bias_code);
+}
+
+inline std::uint8_t rtcmSsrSignalIdForRtklibCode(GNSSSystem system, int code) {
+    switch (system) {
+        case GNSSSystem::GPS:
+            switch (code) {
+                case madoca_parity::kCodeL1C: return 2;
+                case madoca_parity::kCodeL1P:
+                case madoca_parity::kCodeL1W: return 3;
+                case madoca_parity::kCodeL2S:
+                case madoca_parity::kCodeL2L:
+                case madoca_parity::kCodeL2X: return 8;
+                case madoca_parity::kCodeL2P:
+                case madoca_parity::kCodeL2W: return 9;
+                case madoca_parity::kCodeL5I:
+                case madoca_parity::kCodeL5Q:
+                case madoca_parity::kCodeL5X: return 22;
+            }
+            break;
+        case GNSSSystem::GLONASS:
+            switch (code) {
+                case madoca_parity::kCodeL1C: return 2;
+                case madoca_parity::kCodeL1P: return 3;
+                case madoca_parity::kCodeL2C: return 8;
+                case madoca_parity::kCodeL2P: return 9;
+            }
+            break;
+        case GNSSSystem::Galileo:
+            switch (code) {
+                case madoca_parity::kCodeL1C:
+                case madoca_parity::kCodeL1X: return 2;
+                case madoca_parity::kCodeL6B:
+                case madoca_parity::kCodeL6C:
+                case madoca_parity::kCodeL6X: return 8;
+                case madoca_parity::kCodeL7I:
+                case madoca_parity::kCodeL7Q:
+                case madoca_parity::kCodeL7X: return 14;
+                case madoca_parity::kCodeL5I:
+                case madoca_parity::kCodeL5Q:
+                case madoca_parity::kCodeL5X: return 22;
+            }
+            break;
+        case GNSSSystem::BeiDou:
+            switch (code) {
+                case madoca_parity::kCodeL2I:
+                case madoca_parity::kCodeL2Q: return 2;
+                case madoca_parity::kCodeL6I:
+                case madoca_parity::kCodeL6Q: return 8;
+                case madoca_parity::kCodeL7I:
+                case madoca_parity::kCodeL7Q:
+                case madoca_parity::kCodeL7X: return 14;
+            }
+            break;
+        case GNSSSystem::QZSS:
+            switch (code) {
+                case madoca_parity::kCodeL1C:
+                case madoca_parity::kCodeL1L:
+                case madoca_parity::kCodeL1X: return 2;
+                case madoca_parity::kCodeL2X: return 8;
+                case madoca_parity::kCodeL5I:
+                case madoca_parity::kCodeL5Q:
+                case madoca_parity::kCodeL5X: return 22;
+            }
+            break;
+        default:
+            break;
+    }
+    return 0U;
+}
+
+inline std::uint8_t rtcmSsrSignalIdForObservation(GNSSSystem system,
+                                                  SignalType signal,
+                                                  std::string_view observation_type,
+                                                  bool exact_bias_identity) {
+    if (!exact_bias_identity) {
+        return rtcmSsrSignalId(system, signal);
+    }
+    const int rtklib_system = rtklibSystemForGnss(system);
+    if (rtklib_system == madoca_parity::kSysNone) {
+        return rtcmSsrSignalId(system, signal);
+    }
+    const int rtklib_code = rtklibCodeForObservationType(observation_type);
+    const int bias_code = madoca_parity::mcssrSelBiascode(rtklib_system, rtklib_code);
+    return rtcmSsrSignalIdForRtklibCode(system, bias_code);
+}
+
+}  // namespace libgnss::algorithms::ppp_bias_identity

--- a/include/libgnss++/algorithms/ppp_osr_types.hpp
+++ b/include/libgnss++/algorithms/ppp_osr_types.hpp
@@ -3,6 +3,7 @@
 #include <libgnss++/core/types.hpp>
 
 #include <array>
+#include <cstdint>
 #include <map>
 #include <string>
 #include <vector>
@@ -37,6 +38,10 @@ struct OSRCorrection {
     double azimuth = 0.0;
 
     SignalType signals[OSR_MAX_FREQ] = {};
+    std::string pseudorange_rinex_codes[OSR_MAX_FREQ];
+    std::string carrier_rinex_codes[OSR_MAX_FREQ];
+    std::uint8_t code_bias_signal_ids[OSR_MAX_FREQ] = {};
+    std::uint8_t phase_bias_signal_ids[OSR_MAX_FREQ] = {};
     double wavelengths[OSR_MAX_FREQ] = {};
     double frequencies[OSR_MAX_FREQ] = {};
     int num_frequencies = 0;

--- a/src/algorithms/ppp_clas.cpp
+++ b/src/algorithms/ppp_clas.cpp
@@ -141,7 +141,8 @@ std::ofstream* ambDatumDumpStream() {
         initialized = true;
         stream.open(path, std::ios::out | std::ios::trunc);
         if (stream) {
-            stream << "record,week,tow,sat,freq,signal,carrier_rinex_code,lambda_m,"
+            stream << "record,week,tow,sat,freq,signal,carrier_rinex_code,"
+                   << "phase_bias_signal_id,lambda_m,"
                    << "raw_phase_cycles,raw_phase_m,carrier_correction_m,"
                    << "cpc_m,cpc_minus_trop_m,trop_correction_m,relativity_m,"
                    << "receiver_antenna_m,iono_cpc_m,phase_bias_m,windup_m,"
@@ -191,6 +192,7 @@ std::ofstream* clasCodeDumpStream() {
         if (stream) {
             stream << "record,stage,week,tow,sat,freq,signal,"
                    << "pseudorange_rinex_code,carrier_rinex_code,"
+                   << "code_bias_signal_id,phase_bias_signal_id,"
                    << "raw_p_m,corrected_p_m,applied_pr_corr_m,prc_m,"
                    << "prc_minus_trop_m,trop_correction_m,iono_l1_m,"
                    << "iono_scaled_m,code_bias_m,receiver_ant_m,relativity_m,"
@@ -319,6 +321,8 @@ void dumpClasCodeRows(
                   << static_cast<int>(raw->signal) << ','
                   << raw->pseudorange_observation_type << ','
                   << raw->carrier_phase_observation_type << ','
+                  << static_cast<int>(osr.code_bias_signal_ids[f]) << ','
+                  << static_cast<int>(osr.phase_bias_signal_ids[f]) << ','
                   << raw->pseudorange << ','
                   << corrected_p << ','
                   << applied.pseudorange_correction_m << ','
@@ -986,6 +990,7 @@ MeasurementBuildResult buildEpochMeasurements(
                           << f << ','
                           << static_cast<int>(raw->signal) << ','
                           << raw->carrier_phase_observation_type << ','
+                          << static_cast<int>(osr.phase_bias_signal_ids[f]) << ','
                           << osr.wavelengths[f] << ','
                           << raw->carrier_phase << ','
                           << l_m << ','

--- a/src/algorithms/ppp_corrections.cpp
+++ b/src/algorithms/ppp_corrections.cpp
@@ -1,6 +1,6 @@
 #include "ppp_internal.hpp"
 
-#include <libgnss++/algorithms/madoca_parity.hpp>
+#include <libgnss++/algorithms/ppp_bias_identity.hpp>
 #include <libgnss++/algorithms/ppp_atmosphere.hpp>
 #include <libgnss++/algorithms/ppp_osr.hpp>
 #include <libgnss++/algorithms/ppp_utils.hpp>
@@ -52,81 +52,6 @@ constexpr std::array<double, 11> kOceanLoadingPeriodsSeconds = {
     661.3111655 * 3600.0,  // Mm
     4382.905 * 3600.0      // Ssa
 };
-
-namespace mp = libgnss::algorithms::madoca_parity;
-
-struct MadocaObservationCodeMapEntry {
-    const char* observation_type;
-    int rtklib_code;
-};
-
-constexpr MadocaObservationCodeMapEntry kMadocaObservationCodeMap[] = {
-    {"C1C", mp::kCodeL1C}, {"L1C", mp::kCodeL1C},
-    {"C1P", mp::kCodeL1P}, {"L1P", mp::kCodeL1P},
-    {"C1W", mp::kCodeL1W}, {"L1W", mp::kCodeL1W},
-    {"C1S", mp::kCodeL1S}, {"L1S", mp::kCodeL1S},
-    {"C1L", mp::kCodeL1L}, {"L1L", mp::kCodeL1L},
-    {"C1E", mp::kCodeL1E}, {"L1E", mp::kCodeL1E},
-    {"C1B", mp::kCodeL1B}, {"L1B", mp::kCodeL1B},
-    {"C1X", mp::kCodeL1X}, {"L1X", mp::kCodeL1X},
-    {"C2C", mp::kCodeL2C}, {"L2C", mp::kCodeL2C},
-    {"C2S", mp::kCodeL2S}, {"L2S", mp::kCodeL2S},
-    {"C2L", mp::kCodeL2L}, {"L2L", mp::kCodeL2L},
-    {"C2X", mp::kCodeL2X}, {"L2X", mp::kCodeL2X},
-    {"C2P", mp::kCodeL2P}, {"L2P", mp::kCodeL2P},
-    {"C2W", mp::kCodeL2W}, {"L2W", mp::kCodeL2W},
-    {"C5I", mp::kCodeL5I}, {"L5I", mp::kCodeL5I},
-    {"C5Q", mp::kCodeL5Q}, {"L5Q", mp::kCodeL5Q},
-    {"C5X", mp::kCodeL5X}, {"L5X", mp::kCodeL5X},
-    {"C5D", mp::kCodeL5D}, {"L5D", mp::kCodeL5D},
-    {"C5P", mp::kCodeL5P}, {"L5P", mp::kCodeL5P},
-    {"C6B", mp::kCodeL6B}, {"L6B", mp::kCodeL6B},
-    {"C6C", mp::kCodeL6C}, {"L6C", mp::kCodeL6C},
-    {"C6X", mp::kCodeL6X}, {"L6X", mp::kCodeL6X},
-    {"C6I", mp::kCodeL6I}, {"L6I", mp::kCodeL6I},
-    {"C6Q", mp::kCodeL6Q}, {"L6Q", mp::kCodeL6Q},
-    {"C7I", mp::kCodeL7I}, {"L7I", mp::kCodeL7I},
-    {"C7Q", mp::kCodeL7Q}, {"L7Q", mp::kCodeL7Q},
-    {"C7X", mp::kCodeL7X}, {"L7X", mp::kCodeL7X},
-    {"C7D", mp::kCodeL7D}, {"L7D", mp::kCodeL7D},
-};
-
-int madocaSystemId(GNSSSystem system) {
-    switch (system) {
-        case GNSSSystem::GPS: return mp::kSysGps;
-        case GNSSSystem::Galileo: return mp::kSysGal;
-        case GNSSSystem::QZSS: return mp::kSysQzs;
-        default: return mp::kSysNone;
-    }
-}
-
-int madocaRtklibCodeForObservationType(const std::string& observation_type) {
-    for (const auto& entry : kMadocaObservationCodeMap) {
-        if (observation_type == entry.observation_type) {
-            return entry.rtklib_code;
-        }
-    }
-    return mp::kCodeNone;
-}
-
-uint8_t ssrBiasIdentityId(GNSSSystem system,
-                          SignalType signal,
-                          const std::string& observation_type,
-                          bool madoca_bias_identity) {
-    if (!madoca_bias_identity) {
-        return rtcmSsrSignalId(system, signal);
-    }
-    const int madoca_sys = madocaSystemId(system);
-    if (madoca_sys == mp::kSysNone) {
-        return rtcmSsrSignalId(system, signal);
-    }
-    const int rtklib_code = madocaRtklibCodeForObservationType(observation_type);
-    const int bias_code = mp::mcssrSelBiascode(madoca_sys, rtklib_code);
-    if (bias_code <= 0 || bias_code > 255) {
-        return 0U;
-    }
-    return static_cast<uint8_t>(bias_code);
-}
 
 bool madocaSsrReferenceIsCurrent(const GNSSTime& epoch, const GNSSTime& reference) {
     if (reference.week == 0) {
@@ -360,7 +285,7 @@ double observationCodeBiasMeters(GNSSSystem system,
                                  const std::string& primary_observation_type,
                                  const std::string& secondary_observation_type,
                                  bool madoca_bias_identity) {
-    const uint8_t primary_id = ssrBiasIdentityId(
+    const uint8_t primary_id = algorithms::ppp_bias_identity::madocaBiasIdentityIdForObservation(
         system, primary_signal, primary_observation_type, madoca_bias_identity);
     if (primary_id == 0U) {
         return 0.0;
@@ -371,7 +296,7 @@ double observationCodeBiasMeters(GNSSSystem system,
         return primary_bias;
     }
 
-    const uint8_t secondary_id = ssrBiasIdentityId(
+    const uint8_t secondary_id = algorithms::ppp_bias_identity::madocaBiasIdentityIdForObservation(
         system, secondary_signal, secondary_observation_type, madoca_bias_identity);
     if (secondary_id == 0U) {
         return coeff_primary * primary_bias;
@@ -391,7 +316,7 @@ double observationPhaseBiasMeters(GNSSSystem system,
                                   const std::string& primary_observation_type,
                                   const std::string& secondary_observation_type,
                                   bool madoca_bias_identity) {
-    const uint8_t primary_id = ssrBiasIdentityId(
+    const uint8_t primary_id = algorithms::ppp_bias_identity::madocaBiasIdentityIdForObservation(
         system, primary_signal, primary_observation_type, madoca_bias_identity);
     if (primary_id == 0U) {
         return 0.0;
@@ -402,7 +327,7 @@ double observationPhaseBiasMeters(GNSSSystem system,
         return primary_bias;
     }
 
-    const uint8_t secondary_id = ssrBiasIdentityId(
+    const uint8_t secondary_id = algorithms::ppp_bias_identity::madocaBiasIdentityIdForObservation(
         system, secondary_signal, secondary_observation_type, madoca_bias_identity);
     if (secondary_id == 0U) {
         return coeff_primary * primary_bias;
@@ -417,7 +342,8 @@ bool ssrBiasPresent(const std::map<uint8_t, double>& bias_m,
                     SignalType signal,
                     const std::string& observation_type,
                     bool madoca_bias_identity) {
-    const uint8_t id = ssrBiasIdentityId(system, signal, observation_type, madoca_bias_identity);
+    const uint8_t id = algorithms::ppp_bias_identity::madocaBiasIdentityIdForObservation(
+        system, signal, observation_type, madoca_bias_identity);
     if (id == 0U) {
         return false;
     }

--- a/src/algorithms/ppp_osr.cpp
+++ b/src/algorithms/ppp_osr.cpp
@@ -1,4 +1,5 @@
 #include <libgnss++/algorithms/ppp_osr.hpp>
+#include <libgnss++/algorithms/ppp_bias_identity.hpp>
 #include <libgnss++/algorithms/ppp_env_overrides.hpp>
 #include <libgnss++/core/coordinates.hpp>
 #include <libgnss++/core/signals.hpp>
@@ -19,12 +20,12 @@ bool pppDebugEnabled() {
 double clasOsrCodeBiasLookup(const std::map<uint8_t, double>& bias_m,
                              GNSSSystem system,
                              uint8_t signal_id,
-                             bool l2_class_fallback) {
+                             bool enable_l2_class_fallback) {
     const auto it = bias_m.find(signal_id);
     if (it != bias_m.end()) {
         return it->second;
     }
-    if (l2_class_fallback && system == GNSSSystem::GPS &&
+    if (enable_l2_class_fallback && system == GNSSSystem::GPS &&
         (signal_id == 8U || signal_id == 9U)) {
         const auto sibling = bias_m.find(signal_id == 8U ? 9U : 8U);
         if (sibling != bias_m.end()) {
@@ -32,6 +33,18 @@ double clasOsrCodeBiasLookup(const std::map<uint8_t, double>& bias_m,
         }
     }
     return 0.0;
+}
+
+bool gpsL2ExactBiasIdentityEnabled(const Observation* observation) {
+    if (observation == nullptr || observation->satellite.system != GNSSSystem::GPS) {
+        return false;
+    }
+    if (observation->signal != SignalType::GPS_L2C &&
+        observation->signal != SignalType::GPS_L2P) {
+        return false;
+    }
+    return pppEnvOverrides().clas_dd_filter &&
+           pppEnvOverrides().clas_code_row_bias_identity;
 }
 
 const char* clasAtmosSelectionPolicyName(
@@ -830,11 +843,15 @@ std::vector<OSRCorrection> computeOSR(
 
         const Ephemeris* eph = nav.getEphemeris(sat, obs.time);
         osr.signals[0] = l1_obs->signal;
+        osr.pseudorange_rinex_codes[0] = l1_obs->pseudorange_observation_type;
+        osr.carrier_rinex_codes[0] = l1_obs->carrier_phase_observation_type;
         osr.frequencies[0] = signalFrequencyHz(l1_obs->signal, eph);
         osr.wavelengths[0] = constants::SPEED_OF_LIGHT / osr.frequencies[0];
         osr.num_frequencies = 1;
         if (l2_obs) {
             osr.signals[1] = l2_obs->signal;
+            osr.pseudorange_rinex_codes[1] = l2_obs->pseudorange_observation_type;
+            osr.carrier_rinex_codes[1] = l2_obs->carrier_phase_observation_type;
             osr.frequencies[1] = signalFrequencyHz(l2_obs->signal, eph);
             osr.wavelengths[1] = constants::SPEED_OF_LIGHT / osr.frequencies[1];
             osr.num_frequencies = 2;
@@ -888,14 +905,31 @@ std::vector<OSRCorrection> computeOSR(
         }
 
         // --- 7. Code/Phase bias ---
-        const bool code_bias_l2_class =
-            pppEnvOverrides().clas_code_row_bias_identity;
+        const Observation* freq_observations[2] = {l1_obs, l2_obs};
         for (int f = 0; f < osr.num_frequencies; ++f) {
-            const uint8_t sid = rtcmSsrSignalId(sat.system, osr.signals[f]);
+            const Observation* freq_obs = freq_observations[f];
+            const bool exact_bias_identity = gpsL2ExactBiasIdentityEnabled(freq_obs);
+            const uint8_t code_sid =
+                algorithms::ppp_bias_identity::rtcmSsrSignalIdForObservation(
+                    sat.system,
+                    osr.signals[f],
+                    freq_obs != nullptr ? freq_obs->pseudorange_observation_type : "",
+                    exact_bias_identity);
+            const uint8_t phase_sid =
+                algorithms::ppp_bias_identity::rtcmSsrSignalIdForObservation(
+                    sat.system,
+                    osr.signals[f],
+                    freq_obs != nullptr ? freq_obs->carrier_phase_observation_type : "",
+                    exact_bias_identity);
+            osr.code_bias_signal_ids[f] = code_sid;
+            osr.phase_bias_signal_ids[f] = phase_sid;
             osr.code_bias_m[f] =
                 clasOsrCodeBiasLookup(
-                    ssr_cbias, sat.system, sid, code_bias_l2_class);
-            auto pb_it = ssr_pbias.find(sid);
+                    ssr_cbias,
+                    sat.system,
+                    code_sid,
+                    pppEnvOverrides().clas_code_row_bias_identity && !exact_bias_identity);
+            auto pb_it = ssr_pbias.find(phase_sid);
             osr.phase_bias_m[f] = (pb_it != ssr_pbias.end()) ? pb_it->second : 0.0;
         }
 

--- a/tests/test_ppp_osr.cpp
+++ b/tests/test_ppp_osr.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <libgnss++/algorithms/madoca_parity.hpp>
+#include <libgnss++/algorithms/ppp_bias_identity.hpp>
 #include <libgnss++/algorithms/ppp_osr.hpp>
 #include <libgnss++/core/coordinates.hpp>
 
@@ -69,6 +71,44 @@ TEST(PPPOSRTest, GridFirstPrefersNearestGridEvenWhenStale) {
         receiverPositionNearClasNetwork9(),
         config);
     EXPECT_EQ(preferredClasNetworkId(selected), 9);
+}
+
+TEST(PPPOSRTest, ExactObservationIdentitySelectsGpsL2wBiasId) {
+    namespace bias = libgnss::algorithms::ppp_bias_identity;
+    namespace mp = libgnss::algorithms::madoca_parity;
+
+    EXPECT_EQ(bias::rtklibCodeForObservationType("C2W"), mp::kCodeL2W);
+    EXPECT_EQ(bias::rtklibCodeForObservationType("L2W"), mp::kCodeL2W);
+    EXPECT_EQ(bias::rtklibCodeForObservationType("C2X"), mp::kCodeL2X);
+
+    EXPECT_EQ(
+        static_cast<int>(bias::madocaBiasIdentityIdForObservation(
+            GNSSSystem::GPS, SignalType::GPS_L2C, "C2W", true)),
+        mp::kCodeL2W);
+    EXPECT_EQ(
+        static_cast<int>(bias::madocaBiasIdentityIdForObservation(
+            GNSSSystem::GPS, SignalType::GPS_L2C, "L2W", true)),
+        mp::kCodeL2W);
+    EXPECT_EQ(
+        static_cast<int>(bias::madocaBiasIdentityIdForObservation(
+            GNSSSystem::GPS, SignalType::GPS_L2C, "C2X", true)),
+        mp::kCodeL2X);
+    EXPECT_EQ(
+        static_cast<int>(bias::madocaBiasIdentityIdForObservation(
+            GNSSSystem::GPS, SignalType::GPS_L2C, "C2W", false)),
+        8);
+    EXPECT_EQ(
+        static_cast<int>(bias::rtcmSsrSignalIdForObservation(
+            GNSSSystem::GPS, SignalType::GPS_L2C, "C2W", true)),
+        9);
+    EXPECT_EQ(
+        static_cast<int>(bias::rtcmSsrSignalIdForObservation(
+            GNSSSystem::GPS, SignalType::GPS_L2C, "L2W", true)),
+        9);
+    EXPECT_EQ(
+        static_cast<int>(bias::rtcmSsrSignalIdForObservation(
+            GNSSSystem::GPS, SignalType::GPS_L2C, "C2X", true)),
+        8);
 }
 
 TEST(PPPOSRTest, BalancedPrefersFreshNetworkWhenNearestGridIsStale) {


### PR DESCRIPTION
## Summary
- Add a reusable PPP bias-identity helper so exact RINEX observation codes can be mapped separately to MADOCA identity ids and RTCM SSR signal ids.
- Gate CLAS OSR GPS L2 exact-code bias selection behind `GNSS_PPP_CLAS_DD_FILTER=1` plus `GNSS_PPP_CLAS_CODE_ROW_PARITY=bias`, preserving legacy gate-off behavior.
- Carry selected code/phase bias signal ids into CLAS diagnostics for ZD oracle comparison.

## Validation
- `cmake --build build-madoca-parity --parallel --target run_tests`
- `./build-madoca-parity/tests/run_tests --gtest_filter='PPPOSRTest.*:PPPClasTest.*:PPPClasDdTest.*:MadocaCore.*:MadocaSsrConvert.*:ObservationTest.*:RINEXReaderTest.PreservesExactGpsL2RinexObservationIdentity'`
- `./build-madoca-parity/tests/run_tests`
- `git diff --check`
