### PR TITLE
madoca: add residual component diff artifact

### DIFF
--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -46,6 +46,17 @@ provides no GLONASS phase-bias product, so default GLONASS-phase-off is correct
 Open MADOCA levers (measured, none yet a default win): PPP-AR parity
 (`exec_pppar` window); QZSS atmosphere row-set.
 
+Residual-component parity artifact: use
+`scripts/analysis/madoca_residual_component_diff.py` after satellite-set and
+row-set parity are understood.  It compares only common residual rows, keyed by
+epoch, iteration, row type, satellite, exact observation-code identity,
+frequency slot, ionosphere coefficient, and duplicate occurrence index.  The
+schema is `madoca_residual_component_diff.v1`; unmatched rows remain explicit
+`base_only` / `candidate_only` failures instead of being folded into RMS.  This
+tool is meant for bounded MIZU/ALIC windows and stays analysis-only: it does not
+link MADOCALIB into production targets and does not change native PPP runtime
+behavior.
+
 ### CLAS PPP-RTK native vs CLASLIB (2019-08-27 case, tracker issue #9)
 
 Issues #6 (per-satellite NL datum diagnosis) and #7 (datum alignment

--- a/scripts/analysis/madoca_residual_component_diff.py
+++ b/scripts/analysis/madoca_residual_component_diff.py
@@ -1,0 +1,505 @@
+#!/usr/bin/env python3
+"""Compare MADOCA/MADOCALIB residual component CSV dumps."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from collections import Counter, defaultdict
+from dataclasses import dataclass
+from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
+from pathlib import Path
+from typing import Any, DefaultDict, Iterable, Optional, Sequence
+
+
+SCHEMA = "madoca_residual_component_diff.v1"
+
+KEY_REQUIRED_COLUMNS = ["week", "tow", "iteration", "sat", "row_type"]
+
+COMPONENT_ALIASES: dict[str, tuple[str, ...]] = {
+    "residual_m": ("residual_m", "prefit_residual_m", "postfit_residual_m"),
+    "iono_state_m": ("iono_state_m", "ionosphere_state_m", "dion_m"),
+    "trop_m": ("trop_m", "troposphere_m", "trop_correction_m"),
+    "clock_m": ("clock_m", "receiver_clock_m", "cdtr_m"),
+    "sat_clock_m": ("sat_clock_m", "satellite_clock_m", "satclk_m"),
+    "orbit_clock_m": ("orbit_clock_m", "orbit_clock_correction_m"),
+    "code_bias_m": ("code_bias_m", "code_bias"),
+    "phase_bias_m": ("phase_bias_m", "phase_bias"),
+    "windup_m": ("windup_m", "phase_windup_m"),
+    "antenna_m": ("antenna_m", "receiver_antenna_m", "satellite_antenna_m"),
+    "variance_m2": ("variance_m2", "variance", "measurement_variance_m2"),
+}
+
+DEFAULT_COMPONENTS = ["residual_m"]
+
+
+Row = dict[str, str]
+Group = tuple[int, int, int, str]
+Identity = tuple[str, str, str, str, str, int, str]
+MatchKey = tuple[Group, Identity, int]
+
+
+@dataclass(frozen=True)
+class ResidualRow:
+    key: MatchKey
+    group: Group
+    identity: Identity
+    occurrence: int
+    week: int
+    tow: float
+    iteration: int
+    row_type: str
+    sat: str
+    source_row: int
+    components: dict[str, float]
+
+
+def tow_to_millis(value: str) -> int:
+    try:
+        tow = Decimal(str(value))
+    except InvalidOperation as exc:
+        raise ValueError(f"invalid tow value: {value}") from exc
+    return int((tow * Decimal("1000")).to_integral_value(rounding=ROUND_HALF_UP))
+
+
+def to_int(value: str, default: int = 0) -> int:
+    if value == "":
+        return default
+    try:
+        return int(float(value))
+    except ValueError:
+        return default
+
+
+def to_float(value: str) -> Optional[float]:
+    if value == "":
+        return None
+    try:
+        parsed = float(value)
+    except ValueError:
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def normalize_float_text(value: str, default: str) -> str:
+    if value == "":
+        return default
+    try:
+        parsed = float(value)
+    except ValueError:
+        return value
+    return f"{parsed:.12g}"
+
+
+def first_present(row: Row, names: Iterable[str], default: str = "") -> str:
+    for name in names:
+        if name in row and row[name] != "":
+            return row[name]
+    return default
+
+
+def read_csv_rows(path: Path) -> list[Row]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        if reader.fieldnames is None:
+            raise ValueError(f"{path}: missing CSV header")
+        missing = [column for column in KEY_REQUIRED_COLUMNS if column not in reader.fieldnames]
+        if missing:
+            raise ValueError(f"{path}: missing required columns: {', '.join(missing)}")
+        return [dict(row) for row in reader]
+
+
+def group_from_row(row: Row) -> Group:
+    return (
+        to_int(row["week"]),
+        tow_to_millis(row["tow"]),
+        to_int(row.get("iteration", "0")),
+        row.get("row_type", ""),
+    )
+
+
+def identity_from_row(row: Row) -> Identity:
+    return (
+        row.get("sat", ""),
+        first_present(row, ("primary_signal", "signal", "band"), ""),
+        first_present(row, ("secondary_signal",), ""),
+        first_present(
+            row,
+            (
+                "primary_observation_code",
+                "primary_rinex_code",
+                "pseudorange_rinex_code",
+                "obs_code",
+                "rinex_code",
+                "code",
+            ),
+        ),
+        first_present(
+            row,
+            (
+                "secondary_observation_code",
+                "secondary_rinex_code",
+                "carrier_rinex_code",
+            ),
+        ),
+        to_int(first_present(row, ("frequency_index", "freq", "frequency", "f"), "0")),
+        normalize_float_text(row.get("ionosphere_coefficient", "1"), "1"),
+    )
+
+
+def extract_components(row: Row, component_names: Sequence[str]) -> dict[str, float]:
+    components: dict[str, float] = {}
+    for component in component_names:
+        aliases = COMPONENT_ALIASES.get(component, (component,))
+        value = to_float(first_present(row, aliases))
+        if value is not None:
+            components[component] = value
+    return components
+
+
+def normalize_rows(
+    rows: Sequence[Row],
+    *,
+    component_names: Sequence[str],
+    row_type_filter: Optional[str],
+    iteration_filter: Optional[int],
+) -> list[ResidualRow]:
+    normalized: list[ResidualRow] = []
+    occurrence_counts: Counter[tuple[Group, Identity]] = Counter()
+    for source_row, row in enumerate(rows, start=2):
+        row_type = row.get("row_type", "")
+        if row_type_filter is not None and row_type != row_type_filter:
+            continue
+        iteration = to_int(row.get("iteration", "0"))
+        if iteration_filter is not None and iteration != iteration_filter:
+            continue
+        components = extract_components(row, component_names)
+        if not components:
+            continue
+        group = group_from_row(row)
+        identity = identity_from_row(row)
+        occurrence = occurrence_counts[(group, identity)]
+        occurrence_counts[(group, identity)] += 1
+        week, tow_millis, _, _ = group
+        normalized.append(
+            ResidualRow(
+                key=(group, identity, occurrence),
+                group=group,
+                identity=identity,
+                occurrence=occurrence,
+                week=week,
+                tow=tow_millis / 1000.0,
+                iteration=iteration,
+                row_type=row_type,
+                sat=identity[0],
+                source_row=source_row,
+                components=components,
+            )
+        )
+    return normalized
+
+
+def rows_by_key(rows: Sequence[ResidualRow]) -> tuple[dict[MatchKey, ResidualRow], Counter[MatchKey]]:
+    grouped: dict[MatchKey, ResidualRow] = {}
+    duplicates: Counter[MatchKey] = Counter()
+    for row in rows:
+        if row.key in grouped:
+            duplicates[row.key] += 1
+        grouped[row.key] = row
+    return grouped, duplicates
+
+
+def group_to_dict(group: Group) -> dict[str, Any]:
+    return {
+        "week": group[0],
+        "tow": group[1] / 1000.0,
+        "iteration": group[2],
+        "row_type": group[3],
+    }
+
+
+def identity_to_dict(identity: Identity) -> dict[str, Any]:
+    return {
+        "sat": identity[0],
+        "primary_signal": identity[1],
+        "secondary_signal": identity[2],
+        "primary_observation_code": identity[3],
+        "secondary_observation_code": identity[4],
+        "frequency_index": identity[5],
+        "ionosphere_coefficient": identity[6],
+    }
+
+
+def row_summary(row: ResidualRow) -> dict[str, Any]:
+    return {
+        **group_to_dict(row.group),
+        **identity_to_dict(row.identity),
+        "occurrence": row.occurrence,
+        "source_row": row.source_row,
+        "components": sorted(row.components),
+    }
+
+
+def component_stats(values: Sequence[float]) -> dict[str, Any]:
+    if not values:
+        return {
+            "rows": 0,
+            "mean_abs_delta": 0.0,
+            "rms_delta": 0.0,
+            "max_abs_delta": 0.0,
+        }
+    abs_values = [abs(value) for value in values]
+    return {
+        "rows": len(values),
+        "mean_abs_delta": sum(abs_values) / len(abs_values),
+        "rms_delta": math.sqrt(sum(value * value for value in values) / len(values)),
+        "max_abs_delta": max(abs_values),
+    }
+
+
+def build_report(
+    base_rows: Sequence[ResidualRow],
+    candidate_rows: Sequence[ResidualRow],
+    *,
+    base_label: str,
+    candidate_label: str,
+    threshold: Optional[float],
+    top_deltas: int,
+    top_unmatched: int,
+) -> dict[str, Any]:
+    base_by_key, base_duplicates = rows_by_key(base_rows)
+    candidate_by_key, candidate_duplicates = rows_by_key(candidate_rows)
+    base_keys = set(base_by_key)
+    candidate_keys = set(candidate_by_key)
+    common_keys = sorted(base_keys & candidate_keys)
+    base_only_keys = sorted(base_keys - candidate_keys)
+    candidate_only_keys = sorted(candidate_keys - base_keys)
+
+    component_deltas: DefaultDict[str, list[float]] = defaultdict(list)
+    details: list[dict[str, Any]] = []
+    missing_components: Counter[str] = Counter()
+    threshold_exceedances = 0
+
+    for key in common_keys:
+        base_row = base_by_key[key]
+        candidate_row = candidate_by_key[key]
+        components = sorted(set(base_row.components) | set(candidate_row.components))
+        for component in components:
+            base_value = base_row.components.get(component)
+            candidate_value = candidate_row.components.get(component)
+            if base_value is None or candidate_value is None:
+                missing_components[component] += 1
+                continue
+            delta = candidate_value - base_value
+            abs_delta = abs(delta)
+            component_deltas[component].append(delta)
+            if threshold is not None and abs_delta > threshold:
+                threshold_exceedances += 1
+            details.append(
+                {
+                    **group_to_dict(base_row.group),
+                    **identity_to_dict(base_row.identity),
+                    "occurrence": base_row.occurrence,
+                    "component": component,
+                    "base_value": base_value,
+                    "candidate_value": candidate_value,
+                    "delta": delta,
+                    "abs_delta": abs_delta,
+                    "base_source_row": base_row.source_row,
+                    "candidate_source_row": candidate_row.source_row,
+                }
+            )
+
+    details.sort(
+        key=lambda item: (
+            -item["abs_delta"],
+            item["week"],
+            item["tow"],
+            item["iteration"],
+            item["row_type"],
+            item["sat"],
+            item["frequency_index"],
+            item["component"],
+        )
+    )
+    per_component = [
+        {"component": component, **component_stats(values)}
+        for component, values in sorted(component_deltas.items())
+    ]
+    per_component.sort(key=lambda item: (-item["max_abs_delta"], item["component"]))
+
+    return {
+        "schema": SCHEMA,
+        "base_label": base_label,
+        "candidate_label": candidate_label,
+        "base_rows": len(base_rows),
+        "candidate_rows": len(candidate_rows),
+        "common_rows": len(common_keys),
+        "base_only_rows": len(base_only_keys),
+        "candidate_only_rows": len(candidate_only_keys),
+        "base_duplicate_keys": sum(base_duplicates.values()),
+        "candidate_duplicate_keys": sum(candidate_duplicates.values()),
+        "components_compared": sum(item["rows"] for item in per_component),
+        "component_threshold": threshold,
+        "threshold_exceedances": threshold_exceedances,
+        "row_set_complete": len(base_only_keys) == 0 and len(candidate_only_keys) == 0,
+        "missing_component_counts": [
+            {"component": component, "rows": rows}
+            for component, rows in missing_components.most_common()
+        ],
+        "per_component": per_component,
+        "top_component_deltas": details[:top_deltas],
+        "top_base_only": [row_summary(base_by_key[key]) for key in base_only_keys[:top_unmatched]],
+        "top_candidate_only": [
+            row_summary(candidate_by_key[key]) for key in candidate_only_keys[:top_unmatched]
+        ],
+    }
+
+
+def write_details_csv(path: Path, report: dict[str, Any]) -> None:
+    fieldnames = [
+        "week",
+        "tow",
+        "iteration",
+        "row_type",
+        "sat",
+        "primary_signal",
+        "secondary_signal",
+        "primary_observation_code",
+        "secondary_observation_code",
+        "frequency_index",
+        "ionosphere_coefficient",
+        "occurrence",
+        "component",
+        "base_value",
+        "candidate_value",
+        "delta",
+        "abs_delta",
+        "base_source_row",
+        "candidate_source_row",
+    ]
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        writer.writerows(report.get("top_component_deltas", []))
+
+
+def print_summary(report: dict[str, Any]) -> None:
+    print("madoca_residual_component_diff:")
+    for key in [
+        "schema",
+        "base_label",
+        "candidate_label",
+        "base_rows",
+        "candidate_rows",
+        "common_rows",
+        "base_only_rows",
+        "candidate_only_rows",
+        "components_compared",
+        "threshold_exceedances",
+        "row_set_complete",
+    ]:
+        print(f"  {key}: {report[key]}")
+    print("  per_component:")
+    for item in report["per_component"]:
+        print(
+            "    "
+            f"{item['component']}: rows={item['rows']} "
+            f"mean_abs={item['mean_abs_delta']:.6g} "
+            f"rms={item['rms_delta']:.6g} "
+            f"max_abs={item['max_abs_delta']:.6g}"
+        )
+    if report["top_component_deltas"]:
+        top = report["top_component_deltas"][0]
+        print(
+            "  max_delta: "
+            f"{top['week']}:{top['tow']:.3f} iter={top['iteration']} "
+            f"{top['row_type']} {top['sat']} f{top['frequency_index']} "
+            f"{top['component']} delta={top['delta']:.6g}"
+        )
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Compare common-row residual components between MADOCALIB and native PPP CSV dumps."
+    )
+    parser.add_argument("base_residual_csv", type=Path)
+    parser.add_argument("candidate_residual_csv", type=Path)
+    parser.add_argument("--base-label", default="madocalib")
+    parser.add_argument("--candidate-label", default="native")
+    parser.add_argument("--row-type", help="compare only one row_type, for example phase")
+    parser.add_argument("--iteration", type=int, help="compare only one filter iteration")
+    parser.add_argument(
+        "--component",
+        dest="components",
+        action="append",
+        help="component name to compare; may be repeated. Defaults to residual_m.",
+    )
+    parser.add_argument("--component-threshold", type=float)
+    parser.add_argument("--top-deltas", type=int, default=20)
+    parser.add_argument("--top-unmatched", type=int, default=20)
+    parser.add_argument("--json-out", type=Path)
+    parser.add_argument("--details-csv", type=Path)
+    parser.add_argument(
+        "--fail-on-diff",
+        action="store_true",
+        help="return non-zero when rows are unmatched or a threshold is exceeded",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    component_names = args.components or DEFAULT_COMPONENTS
+    base_rows = normalize_rows(
+        read_csv_rows(args.base_residual_csv),
+        component_names=component_names,
+        row_type_filter=args.row_type,
+        iteration_filter=args.iteration,
+    )
+    candidate_rows = normalize_rows(
+        read_csv_rows(args.candidate_residual_csv),
+        component_names=component_names,
+        row_type_filter=args.row_type,
+        iteration_filter=args.iteration,
+    )
+    report = build_report(
+        base_rows,
+        candidate_rows,
+        base_label=args.base_label,
+        candidate_label=args.candidate_label,
+        threshold=args.component_threshold,
+        top_deltas=args.top_deltas,
+        top_unmatched=args.top_unmatched,
+    )
+    report["base_residual_csv"] = str(args.base_residual_csv)
+    report["candidate_residual_csv"] = str(args.candidate_residual_csv)
+    report["row_type_filter"] = args.row_type
+    report["iteration_filter"] = args.iteration
+    report["component_names"] = component_names
+    print_summary(report)
+    if args.json_out is not None:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(
+            json.dumps(report, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+    if args.details_csv is not None:
+        write_details_csv(args.details_csv, report)
+    if args.fail_on_diff and (
+        report["base_only_rows"] > 0
+        or report["candidate_only_rows"] > 0
+        or report["threshold_exceedances"] > 0
+    ):
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except BrokenPipeError:
+        raise SystemExit(1)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -86,6 +86,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_madoca_solution_diff.py
     )
     add_test(
+        NAME python_madoca_residual_component_diff_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_madoca_residual_component_diff.py
+    )
+    add_test(
         NAME python_clas_zd_component_diff_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_clas_zd_component_diff.py
     )
@@ -219,6 +223,7 @@ if(GTest_FOUND)
     set(GNSSPP_CORE_TESTS
         run_tests
         python_clas_zd_component_diff_tests
+        python_madoca_residual_component_diff_tests
         python_madoca_solution_diff_tests
         python_madoca_satellite_set_diff_tests
         python_mode_compare_tests

--- a/tests/test_madoca_residual_component_diff.py
+++ b/tests/test_madoca_residual_component_diff.py
@@ -1,0 +1,260 @@
+#!/usr/bin/env python3
+"""Tests for MADOCA residual component comparison helpers."""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT_DIR / "scripts" / "analysis" / "madoca_residual_component_diff.py"
+
+spec = importlib.util.spec_from_file_location("madoca_residual_component_diff", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+component_diff = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = component_diff
+spec.loader.exec_module(component_diff)
+
+
+FIELDNAMES = [
+    "week",
+    "tow",
+    "iteration",
+    "row_index",
+    "sat",
+    "row_type",
+    "residual_m",
+    "iono_state_m",
+    "trop_m",
+    "primary_signal",
+    "secondary_signal",
+    "primary_observation_code",
+    "secondary_observation_code",
+    "frequency_index",
+    "ionosphere_coefficient",
+]
+
+
+def residual_row(
+    *,
+    sat: str,
+    row_type: str = "phase",
+    residual_m: str = "0.1",
+    iono_state_m: str = "0.0",
+    trop_m: str = "2.3",
+    tow: str = "172800.000",
+    iteration: str = "1",
+    row_index: str = "0",
+    primary_signal: str = "2",
+    secondary_signal: str = "21",
+    primary_code: str = "C1C",
+    secondary_code: str = "C2W",
+    frequency_index: str = "0",
+    ionosphere_coefficient: str = "1.0",
+) -> dict[str, str]:
+    return {
+        "week": "2360",
+        "tow": tow,
+        "iteration": iteration,
+        "row_index": row_index,
+        "sat": sat,
+        "row_type": row_type,
+        "residual_m": residual_m,
+        "iono_state_m": iono_state_m,
+        "trop_m": trop_m,
+        "primary_signal": primary_signal,
+        "secondary_signal": secondary_signal,
+        "primary_observation_code": primary_code,
+        "secondary_observation_code": secondary_code,
+        "frequency_index": frequency_index,
+        "ionosphere_coefficient": ionosphere_coefficient,
+    }
+
+
+def write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+class MadocaResidualComponentDiffTest(unittest.TestCase):
+    def test_compares_common_row_components_and_reports_unmatched(self) -> None:
+        base_rows = [
+            residual_row(sat="G01", row_type="code", residual_m="0.10", iono_state_m="0.50"),
+            residual_row(
+                sat="G02",
+                row_type="phase",
+                residual_m="-0.20",
+                iono_state_m="0.40",
+                row_index="1",
+                frequency_index="1",
+                primary_code="C2W",
+                secondary_code="",
+                ionosphere_coefficient="1.64694444444444",
+            ),
+            residual_row(sat="E11", row_type="code", residual_m="1.0", row_index="2"),
+        ]
+        candidate_rows = [
+            residual_row(sat="G01", row_type="code", residual_m="0.15", iono_state_m="0.55"),
+            residual_row(
+                sat="G02",
+                row_type="phase",
+                residual_m="-1.00",
+                iono_state_m="0.35",
+                row_index="1",
+                frequency_index="1",
+                primary_code="C2W",
+                secondary_code="",
+                ionosphere_coefficient="1.64694444444444",
+            ),
+            residual_row(sat="R03", row_type="code", residual_m="2.0", row_index="2"),
+        ]
+
+        base = component_diff.normalize_rows(
+            base_rows,
+            component_names=["residual_m", "iono_state_m"],
+            row_type_filter=None,
+            iteration_filter=1,
+        )
+        candidate = component_diff.normalize_rows(
+            candidate_rows,
+            component_names=["residual_m", "iono_state_m"],
+            row_type_filter=None,
+            iteration_filter=1,
+        )
+        report = component_diff.build_report(
+            base,
+            candidate,
+            base_label="madocalib",
+            candidate_label="native",
+            threshold=0.1,
+            top_deltas=10,
+            top_unmatched=10,
+        )
+
+        self.assertEqual(report["schema"], "madoca_residual_component_diff.v1")
+        self.assertEqual(report["base_rows"], 3)
+        self.assertEqual(report["candidate_rows"], 3)
+        self.assertEqual(report["common_rows"], 2)
+        self.assertEqual(report["base_only_rows"], 1)
+        self.assertEqual(report["candidate_only_rows"], 1)
+        self.assertFalse(report["row_set_complete"])
+        self.assertEqual(report["components_compared"], 4)
+        self.assertEqual(report["threshold_exceedances"], 1)
+        self.assertEqual(report["top_base_only"][0]["sat"], "E11")
+        self.assertEqual(report["top_candidate_only"][0]["sat"], "R03")
+        top = report["top_component_deltas"][0]
+        self.assertEqual(top["sat"], "G02")
+        self.assertEqual(top["component"], "residual_m")
+        self.assertAlmostEqual(top["delta"], -0.8)
+        self.assertEqual(top["primary_observation_code"], "C2W")
+        self.assertEqual(top["ionosphere_coefficient"], "1.64694444444")
+
+    def test_exact_observation_identity_separates_same_satellite_aliases(self) -> None:
+        base = component_diff.normalize_rows(
+            [
+                residual_row(
+                    sat="G14",
+                    primary_code="C2W",
+                    secondary_code="",
+                    frequency_index="1",
+                )
+            ],
+            component_names=["residual_m"],
+            row_type_filter=None,
+            iteration_filter=None,
+        )
+        candidate = component_diff.normalize_rows(
+            [
+                residual_row(
+                    sat="G14",
+                    primary_code="C2X",
+                    secondary_code="",
+                    frequency_index="1",
+                )
+            ],
+            component_names=["residual_m"],
+            row_type_filter=None,
+            iteration_filter=None,
+        )
+
+        report = component_diff.build_report(
+            base,
+            candidate,
+            base_label="madocalib",
+            candidate_label="native",
+            threshold=None,
+            top_deltas=10,
+            top_unmatched=10,
+        )
+
+        self.assertEqual(report["common_rows"], 0)
+        self.assertEqual(report["base_only_rows"], 1)
+        self.assertEqual(report["candidate_only_rows"], 1)
+        self.assertEqual(report["top_base_only"][0]["primary_observation_code"], "C2W")
+        self.assertEqual(report["top_candidate_only"][0]["primary_observation_code"], "C2X")
+
+    def test_cli_writes_schema_json_and_details_csv(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="madoca_residual_component_diff_test_") as temp_dir:
+            root = Path(temp_dir)
+            base_path = root / "madocalib.csv"
+            candidate_path = root / "native.csv"
+            report_path = root / "report.json"
+            details_path = root / "details.csv"
+            write_csv(
+                base_path,
+                [residual_row(sat="G01", row_type="code", residual_m="0.10")],
+            )
+            write_csv(
+                candidate_path,
+                [residual_row(sat="G01", row_type="code", residual_m="0.35")],
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    str(base_path),
+                    str(candidate_path),
+                    "--row-type",
+                    "code",
+                    "--iteration",
+                    "1",
+                    "--component",
+                    "residual_m",
+                    "--component-threshold",
+                    "0.1",
+                    "--json-out",
+                    str(report_path),
+                    "--details-csv",
+                    str(details_path),
+                    "--fail-on-diff",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 2, msg=result.stderr)
+            self.assertIn("madoca_residual_component_diff:", result.stdout)
+            report = json.loads(report_path.read_text(encoding="utf-8"))
+            self.assertEqual(report["schema"], "madoca_residual_component_diff.v1")
+            self.assertEqual(report["threshold_exceedances"], 1)
+            self.assertEqual(report["component_names"], ["residual_m"])
+            with details_path.open(newline="", encoding="utf-8") as details_file:
+                rows = list(csv.DictReader(details_file))
+            self.assertEqual(rows[0]["sat"], "G01")
+            self.assertEqual(rows[0]["component"], "residual_m")
+            self.assertAlmostEqual(float(rows[0]["delta"]), 0.25)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `madoca_residual_component_diff.py` for schema-backed common-row residual/component comparisons
- preserve row-set mismatches as explicit base-only/candidate-only failures instead of hiding them in RMS
- register focused Python/CTest coverage and document the MADOCA parity artifact

## Validation
- `python3 -m py_compile scripts/analysis/madoca_residual_component_diff.py tests/test_madoca_residual_component_diff.py`
- `python3 tests/test_madoca_residual_component_diff.py -v`
- `python3 tests/test_ppp_residual_row_set_diff.py -v && python3 tests/test_madoca_satellite_set_diff.py -v && python3 tests/test_clas_zd_component_diff.py -v`
- `cmake -S . -B build-madoca-parity && ctest --test-dir build-madoca-parity -R 'python_(madoca_residual_component_diff|madoca_satellite_set_diff|ppp_residual_row_set_diff|clas_zd_component_diff)_tests' --output-on-failure`\n- `git diff --check`\n