### PR TITLE
madoca: add optional residual component diff signoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,29 @@ jobs:
         GNSSPP_PPP_PRODUCTS_MALIB_CONFIG: ${{ vars.GNSSPP_PPP_PRODUCTS_MALIB_CONFIG }}
       run: bash scripts/ci/run_optional_ppp_products_signoff.sh
 
+    - name: Optional MADOCA residual-component diff
+      env:
+        GNSSPP_MADOCA_RESIDUAL_BASE_CSV: ${{ vars.GNSSPP_MADOCA_RESIDUAL_BASE_CSV }}
+        GNSSPP_MADOCA_RESIDUAL_CANDIDATE_CSV: ${{ vars.GNSSPP_MADOCA_RESIDUAL_CANDIDATE_CSV }}
+        GNSSPP_MADOCA_RESIDUAL_COMPONENTS: ${{ vars.GNSSPP_MADOCA_RESIDUAL_COMPONENTS }}
+        GNSSPP_MADOCA_RESIDUAL_ROW_TYPE: ${{ vars.GNSSPP_MADOCA_RESIDUAL_ROW_TYPE }}
+        GNSSPP_MADOCA_RESIDUAL_ITERATION: ${{ vars.GNSSPP_MADOCA_RESIDUAL_ITERATION }}
+        GNSSPP_MADOCA_RESIDUAL_THRESHOLD: ${{ vars.GNSSPP_MADOCA_RESIDUAL_THRESHOLD }}
+        GNSSPP_MADOCA_RESIDUAL_FAIL_ON_DIFF: ${{ vars.GNSSPP_MADOCA_RESIDUAL_FAIL_ON_DIFF }}
+      run: bash scripts/ci/run_optional_madoca_residual_component_diff.sh
+
+    - name: Upload MADOCA residual-component diff artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: madoca-residual-component-diff-ubuntu
+        path: |
+          output/ci_optional_madoca_residual_component_summary.json
+          output/ci_optional_madoca_residual_component/*.log
+          output/madoca_residual_component_diff.json
+          output/madoca_residual_component_diff.csv
+        if-no-files-found: ignore
+
     - name: Upload PPP products comparison artifacts
       if: always()
       uses: actions/upload-artifact@v4

--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -57,6 +57,18 @@ tool is meant for bounded MIZU/ALIC windows and stays analysis-only: it does not
 link MADOCALIB into production targets and does not change native PPP runtime
 behavior.
 
+The optional CI wrapper
+`scripts/ci/run_optional_madoca_residual_component_diff.py` runs the same diff
+when `GNSSPP_MADOCA_RESIDUAL_BASE_CSV` and
+`GNSSPP_MADOCA_RESIDUAL_CANDIDATE_CSV` point at generated oracle/native CSV
+dumps.  It writes `ci_optional_madoca_residual_component_summary.json`, a log,
+and the `madoca_residual_component_diff.{json,csv}` artifacts; when those inputs
+are absent the CI step records an explicit skip instead of silently omitting the
+artifact.  Optional filters are
+`GNSSPP_MADOCA_RESIDUAL_COMPONENTS`, `GNSSPP_MADOCA_RESIDUAL_ROW_TYPE`,
+`GNSSPP_MADOCA_RESIDUAL_ITERATION`, `GNSSPP_MADOCA_RESIDUAL_THRESHOLD`, and
+`GNSSPP_MADOCA_RESIDUAL_FAIL_ON_DIFF`.
+
 ### CLAS PPP-RTK native vs CLASLIB (2019-08-27 case, tracker issue #9)
 
 Issues #6 (per-satellite NL datum diagnosis) and #7 (datum alignment

--- a/scripts/ci/run_optional_madoca_residual_component_diff.py
+++ b/scripts/ci/run_optional_madoca_residual_component_diff.py
@@ -1,0 +1,391 @@
+#!/usr/bin/env python3
+"""Run optional MADOCA residual-component diff and persist a CI summary."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+from typing import Mapping
+
+
+SUMMARY_SCHEMA = "ci_optional_madoca_residual_component_diff.v1"
+
+
+@dataclass(frozen=True)
+class DiffStep:
+    name: str
+    slug: str
+    command: list[str] | None
+    outputs: list[str]
+    summary_json: str
+    skip_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class DiffContext:
+    repo_root: Path
+    output_dir: Path
+    python_executable: str
+    base_csv: Path | None
+    candidate_csv: Path | None
+    components: list[str]
+    row_type: str | None
+    iteration: int | None
+    threshold: float | None
+    fail_on_diff: bool
+
+
+def repo_root_from_script() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def resolve_optional_path(repo_root: Path, value: str) -> Path | None:
+    text = value.strip()
+    if not text:
+        return None
+    path = Path(text)
+    if path.is_absolute():
+        return path
+    return repo_root / path
+
+
+def parse_components(value: str) -> list[str]:
+    components = [item.strip() for item in value.replace(";", ",").split(",")]
+    return [item for item in components if item]
+
+
+def parse_optional_int(value: str) -> int | None:
+    text = value.strip()
+    if not text:
+        return None
+    return int(text)
+
+
+def parse_optional_float(value: str) -> float | None:
+    text = value.strip()
+    if not text:
+        return None
+    return float(text)
+
+
+def truthy(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def build_context(
+    repo_root: Path,
+    output_dir: Path,
+    environ: Mapping[str, str],
+    *,
+    python_executable: str = sys.executable,
+) -> DiffContext:
+    return DiffContext(
+        repo_root=repo_root,
+        output_dir=output_dir,
+        python_executable=python_executable,
+        base_csv=resolve_optional_path(
+            repo_root,
+            environ.get("GNSSPP_MADOCA_RESIDUAL_BASE_CSV", ""),
+        ),
+        candidate_csv=resolve_optional_path(
+            repo_root,
+            environ.get("GNSSPP_MADOCA_RESIDUAL_CANDIDATE_CSV", "")
+            or environ.get("GNSSPP_MADOCA_RESIDUAL_NATIVE_CSV", ""),
+        ),
+        components=parse_components(
+            environ.get("GNSSPP_MADOCA_RESIDUAL_COMPONENTS", "residual_m")
+        ),
+        row_type=environ.get("GNSSPP_MADOCA_RESIDUAL_ROW_TYPE", "").strip() or None,
+        iteration=parse_optional_int(environ.get("GNSSPP_MADOCA_RESIDUAL_ITERATION", "")),
+        threshold=parse_optional_float(environ.get("GNSSPP_MADOCA_RESIDUAL_THRESHOLD", "")),
+        fail_on_diff=truthy(environ.get("GNSSPP_MADOCA_RESIDUAL_FAIL_ON_DIFF", "")),
+    )
+
+
+def make_step(context: DiffContext) -> DiffStep:
+    name = "MADOCA residual-component diff"
+    slug = "madoca_residual_component_diff"
+    report_json = context.output_dir / f"{slug}.json"
+    details_csv = context.output_dir / f"{slug}.csv"
+    summary_json = context.output_dir / f"{slug}_summary.json"
+    outputs = [report_json, details_csv, summary_json]
+
+    missing = [
+        (label, path)
+        for label, path in (
+            ("base residual CSV", context.base_csv),
+            ("candidate residual CSV", context.candidate_csv),
+        )
+        if path is None or not path.is_file()
+    ]
+    if missing:
+        missing_text = ", ".join(f"{label}: {path}" for label, path in missing)
+        return DiffStep(
+            name=name,
+            slug=slug,
+            command=None,
+            outputs=[str(path) for path in outputs],
+            summary_json=str(summary_json),
+            skip_reason=f"MADOCA residual-component input is unavailable ({missing_text}).",
+        )
+
+    assert context.base_csv is not None
+    assert context.candidate_csv is not None
+    command = [
+        context.python_executable,
+        str(context.repo_root / "scripts" / "analysis" / "madoca_residual_component_diff.py"),
+        str(context.base_csv),
+        str(context.candidate_csv),
+        "--base-label",
+        "madocalib",
+        "--candidate-label",
+        "native",
+        "--json-out",
+        str(report_json),
+        "--details-csv",
+        str(details_csv),
+    ]
+    for component in context.components or ["residual_m"]:
+        command.extend(["--component", component])
+    if context.row_type is not None:
+        command.extend(["--row-type", context.row_type])
+    if context.iteration is not None:
+        command.extend(["--iteration", str(context.iteration)])
+    if context.threshold is not None:
+        command.extend(["--component-threshold", str(context.threshold)])
+    if context.fail_on_diff:
+        command.append("--fail-on-diff")
+
+    return DiffStep(
+        name=name,
+        slug=slug,
+        command=command,
+        outputs=[str(path) for path in outputs],
+        summary_json=str(summary_json),
+    )
+
+
+def build_step_plan(
+    repo_root: Path,
+    output_dir: Path,
+    environ: Mapping[str, str],
+    *,
+    python_executable: str = sys.executable,
+) -> list[DiffStep]:
+    context = build_context(repo_root, output_dir, environ, python_executable=python_executable)
+    return [make_step(context)]
+
+
+def load_diff_metrics(report_json: Path) -> dict[str, object]:
+    if not report_json.is_file():
+        return {}
+    try:
+        payload = json.loads(report_json.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    metrics: dict[str, object] = {}
+    for key in [
+        "schema",
+        "base_rows",
+        "candidate_rows",
+        "common_rows",
+        "base_only_rows",
+        "candidate_only_rows",
+        "components_compared",
+        "threshold_exceedances",
+        "row_set_complete",
+    ]:
+        if key in payload:
+            metrics[key] = payload[key]
+    per_component = payload.get("per_component")
+    if isinstance(per_component, list):
+        max_abs_delta = 0.0
+        for item in per_component:
+            if not isinstance(item, dict):
+                continue
+            value = item.get("max_abs_delta")
+            if isinstance(value, (int, float)):
+                max_abs_delta = max(max_abs_delta, float(value))
+        metrics["max_abs_delta"] = max_abs_delta
+    return metrics
+
+
+def run_step(step: DiffStep, repo_root: Path, log_dir: Path) -> dict[str, object]:
+    log_path = log_dir / f"{step.slug}.log"
+    summary_json = Path(step.summary_json)
+    report_json = summary_json.with_name(f"{step.slug}.json")
+    record: dict[str, object] = {
+        "name": step.name,
+        "slug": step.slug,
+        "outputs": step.outputs,
+        "summary_json": step.summary_json,
+        "log_path": str(log_path),
+    }
+    if step.skip_reason is not None:
+        record["status"] = "skipped"
+        record["skip_reason"] = step.skip_reason
+        log_path.write_text(step.skip_reason + "\n", encoding="utf-8")
+        print(f"Skipping {step.name}: {step.skip_reason}")
+        return record
+
+    assert step.command is not None
+    command_display = " ".join(step.command)
+    print(f"+ {command_display}")
+    started = time.monotonic()
+    completed = subprocess.run(
+        step.command,
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    elapsed = time.monotonic() - started
+    combined_log = completed.stdout
+    if completed.stderr:
+        if combined_log and not combined_log.endswith("\n"):
+            combined_log += "\n"
+        combined_log += completed.stderr
+    log_path.write_text(f"$ {command_display}\n\n{combined_log}", encoding="utf-8")
+    record["command"] = step.command
+    record["elapsed_s"] = elapsed
+    record["returncode"] = completed.returncode
+    metrics = load_diff_metrics(report_json)
+    if metrics:
+        record["metrics"] = metrics
+    if completed.returncode == 0:
+        record["status"] = "passed"
+        print(f"Passed {step.name} in {elapsed:.2f}s")
+    else:
+        record["status"] = "failed"
+        lines = combined_log.splitlines()
+        tail = "\n".join(lines[-20:])
+        if tail:
+            print(tail)
+        print(f"Failed {step.name} in {elapsed:.2f}s; see {log_path}")
+    return record
+
+
+def format_metric(value: object) -> str:
+    if isinstance(value, float):
+        return f"{value:.6g}"
+    return str(value)
+
+
+def render_result_detail(result: dict[str, object]) -> str:
+    status = str(result["status"])
+    if status == "skipped":
+        return str(result.get("skip_reason", ""))
+    if status == "failed":
+        log_path = result.get("log_path")
+        return f"see `{log_path}`" if log_path else "failed"
+
+    detail_parts: list[str] = []
+    elapsed = result.get("elapsed_s")
+    if isinstance(elapsed, (float, int)):
+        detail_parts.append(f"{elapsed:.2f}s")
+    metrics = result.get("metrics")
+    if isinstance(metrics, dict):
+        common_rows = metrics.get("common_rows")
+        if common_rows is not None:
+            detail_parts.append(f"common rows `{common_rows}`")
+        base_only = metrics.get("base_only_rows")
+        candidate_only = metrics.get("candidate_only_rows")
+        if base_only is not None or candidate_only is not None:
+            detail_parts.append(f"unmatched `{base_only}/{candidate_only}`")
+        compared = metrics.get("components_compared")
+        if compared is not None:
+            detail_parts.append(f"components `{compared}`")
+        max_abs_delta = metrics.get("max_abs_delta")
+        if max_abs_delta is not None:
+            detail_parts.append(f"max |delta| {format_metric(max_abs_delta)}")
+        threshold_exceedances = metrics.get("threshold_exceedances")
+        if threshold_exceedances is not None:
+            detail_parts.append(f"threshold exceedances `{threshold_exceedances}`")
+    return ", ".join(detail_parts)
+
+
+def render_markdown_summary(results: list[dict[str, object]]) -> str:
+    passed = sum(1 for result in results if result["status"] == "passed")
+    failed = sum(1 for result in results if result["status"] == "failed")
+    skipped = sum(1 for result in results if result["status"] == "skipped")
+    lines = [
+        "## Optional MADOCA Residual-Component Diff",
+        "",
+        f"- `passed`: `{passed}`",
+        f"- `failed`: `{failed}`",
+        f"- `skipped`: `{skipped}`",
+        "",
+        "| Step | Status | Detail |",
+        "| --- | --- | --- |",
+    ]
+    for result in results:
+        lines.append(f"| {result['name']} | `{result['status']}` | {render_result_detail(result)} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_summary(summary_path: Path, steps: list[DiffStep], results: list[dict[str, object]]) -> None:
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "summary_schema": SUMMARY_SCHEMA,
+        "steps": [asdict(step) for step in steps],
+        "results": results,
+        "counts": {
+            "passed": sum(1 for result in results if result["status"] == "passed"),
+            "failed": sum(1 for result in results if result["status"] == "failed"),
+            "skipped": sum(1 for result in results if result["status"] == "skipped"),
+        },
+    }
+    summary_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def append_github_step_summary(path: Path, results: list[dict[str, object]]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(render_markdown_summary(results))
+        handle.write("\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, default=repo_root_from_script())
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--summary-json", type=Path, default=None)
+    parser.add_argument("--github-step-summary", type=Path, default=None)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    output_dir = (args.output_dir if args.output_dir is not None else repo_root / "output").resolve()
+    summary_json = (
+        args.summary_json
+        if args.summary_json is not None
+        else output_dir / "ci_optional_madoca_residual_component_summary.json"
+    ).resolve()
+    log_dir = output_dir / "ci_optional_madoca_residual_component"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    steps = build_step_plan(repo_root, output_dir, os.environ)
+    results = [run_step(step, repo_root, log_dir) for step in steps]
+    write_summary(summary_json, steps, results)
+    summary_path = args.github_step_summary
+    if summary_path is None:
+        summary_env = os.environ.get("GITHUB_STEP_SUMMARY", "").strip()
+        summary_path = Path(summary_env) if summary_env else None
+    if summary_path is not None:
+        append_github_step_summary(summary_path, results)
+    return 1 if any(result["status"] == "failed" for result in results) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/run_optional_madoca_residual_component_diff.sh
+++ b/scripts/ci/run_optional_madoca_residual_component_diff.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+exec python3 "${repo_root}/scripts/ci/run_optional_madoca_residual_component_diff.py" "$@"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -90,6 +90,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_madoca_residual_component_diff.py
     )
     add_test(
+        NAME python_optional_madoca_residual_component_diff_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_optional_madoca_residual_component_diff.py
+    )
+    add_test(
         NAME python_clas_zd_component_diff_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_clas_zd_component_diff.py
     )
@@ -227,6 +231,7 @@ if(GTest_FOUND)
         python_madoca_solution_diff_tests
         python_madoca_satellite_set_diff_tests
         python_mode_compare_tests
+        python_optional_madoca_residual_component_diff_tests
         python_ppp_residual_row_set_diff_tests
         python_spp_residual_dump_summary_tests
         python_spp_iteration_dump_summary_tests

--- a/tests/test_optional_madoca_residual_component_diff.py
+++ b/tests/test_optional_madoca_residual_component_diff.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Tests for the optional MADOCA residual-component CI runner."""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT_DIR / "scripts" / "ci" / "run_optional_madoca_residual_component_diff.py"
+
+spec = importlib.util.spec_from_file_location("run_optional_madoca_residual_component_diff", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+runner = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = runner
+spec.loader.exec_module(runner)
+
+
+FIELDNAMES = [
+    "week",
+    "tow",
+    "iteration",
+    "sat",
+    "row_type",
+    "residual_m",
+    "iono_state_m",
+    "primary_observation_code",
+    "secondary_observation_code",
+    "frequency_index",
+    "ionosphere_coefficient",
+]
+
+
+def write_residual_csv(path: Path, *, residual_m: str = "0.1") -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
+        writer.writeheader()
+        writer.writerow(
+            {
+                "week": "2360",
+                "tow": "172800.000",
+                "iteration": "1",
+                "sat": "G01",
+                "row_type": "code",
+                "residual_m": residual_m,
+                "iono_state_m": "0.5",
+                "primary_observation_code": "C1C",
+                "secondary_observation_code": "C2W",
+                "frequency_index": "0",
+                "ionosphere_coefficient": "1.0",
+            }
+        )
+
+
+class OptionalMadocaResidualComponentDiffTest(unittest.TestCase):
+    def test_build_step_plan_skips_when_inputs_are_missing(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_residual_skip_") as temp_dir:
+            output_dir = Path(temp_dir) / "output"
+
+            steps = runner.build_step_plan(ROOT_DIR, output_dir, {})
+
+            self.assertEqual([step.slug for step in steps], ["madoca_residual_component_diff"])
+            self.assertIsNone(steps[0].command)
+            self.assertIsNotNone(steps[0].skip_reason)
+            self.assertIn("MADOCA residual-component input is unavailable", steps[0].skip_reason)
+
+    def test_build_step_plan_uses_configured_inputs_and_filters(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_residual_plan_") as temp_dir:
+            root = Path(temp_dir)
+            base_csv = root / "madocalib.csv"
+            candidate_csv = root / "native.csv"
+            write_residual_csv(base_csv)
+            write_residual_csv(candidate_csv)
+            output_dir = root / "output"
+            env = {
+                "GNSSPP_MADOCA_RESIDUAL_BASE_CSV": str(base_csv),
+                "GNSSPP_MADOCA_RESIDUAL_CANDIDATE_CSV": str(candidate_csv),
+                "GNSSPP_MADOCA_RESIDUAL_COMPONENTS": "residual_m,iono_state_m",
+                "GNSSPP_MADOCA_RESIDUAL_ROW_TYPE": "code",
+                "GNSSPP_MADOCA_RESIDUAL_ITERATION": "1",
+                "GNSSPP_MADOCA_RESIDUAL_THRESHOLD": "0.25",
+                "GNSSPP_MADOCA_RESIDUAL_FAIL_ON_DIFF": "1",
+            }
+
+            steps = runner.build_step_plan(ROOT_DIR, output_dir, env)
+
+            command = steps[0].command
+            self.assertIsNotNone(command)
+            assert command is not None
+            self.assertIn(str(SCRIPT_PATH.parent.parent / "analysis" / "madoca_residual_component_diff.py"), command)
+            self.assertIn(str(base_csv), command)
+            self.assertIn(str(candidate_csv), command)
+            self.assertIn("--component", command)
+            self.assertIn("residual_m", command)
+            self.assertIn("iono_state_m", command)
+            self.assertIn("--row-type", command)
+            self.assertIn("code", command)
+            self.assertIn("--iteration", command)
+            self.assertIn("1", command)
+            self.assertIn("--component-threshold", command)
+            self.assertIn("0.25", command)
+            self.assertIn("--fail-on-diff", command)
+            self.assertIn(str(output_dir / "madoca_residual_component_diff.json"), command)
+
+    def test_run_step_collects_metrics_from_diff_report(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_residual_exec_") as temp_dir:
+            root = Path(temp_dir)
+            base_csv = root / "madocalib.csv"
+            candidate_csv = root / "native.csv"
+            write_residual_csv(base_csv, residual_m="0.10")
+            write_residual_csv(candidate_csv, residual_m="0.15")
+            output_dir = root / "output"
+            log_dir = output_dir / "logs"
+            log_dir.mkdir(parents=True)
+            env = {
+                "GNSSPP_MADOCA_RESIDUAL_BASE_CSV": str(base_csv),
+                "GNSSPP_MADOCA_RESIDUAL_CANDIDATE_CSV": str(candidate_csv),
+                "GNSSPP_MADOCA_RESIDUAL_COMPONENTS": "residual_m",
+                "GNSSPP_MADOCA_RESIDUAL_ROW_TYPE": "code",
+                "GNSSPP_MADOCA_RESIDUAL_ITERATION": "1",
+            }
+            step = runner.build_step_plan(ROOT_DIR, output_dir, env)[0]
+
+            result = runner.run_step(step, ROOT_DIR, log_dir)
+
+            self.assertEqual(result["status"], "passed")
+            self.assertEqual(result["returncode"], 0)
+            metrics = result["metrics"]
+            self.assertEqual(metrics["schema"], "madoca_residual_component_diff.v1")
+            self.assertEqual(metrics["common_rows"], 1)
+            self.assertEqual(metrics["components_compared"], 1)
+            self.assertAlmostEqual(metrics["max_abs_delta"], 0.05)
+
+    def test_render_markdown_summary_reports_status_table_and_metrics(self) -> None:
+        markdown = runner.render_markdown_summary(
+            [
+                {
+                    "name": "MADOCA residual-component diff",
+                    "status": "passed",
+                    "elapsed_s": 0.5,
+                    "metrics": {
+                        "common_rows": 12,
+                        "base_only_rows": 1,
+                        "candidate_only_rows": 2,
+                        "components_compared": 24,
+                        "max_abs_delta": 0.125,
+                        "threshold_exceedances": 3,
+                    },
+                },
+                {
+                    "name": "MADOCA residual-component diff",
+                    "status": "skipped",
+                    "skip_reason": "MADOCA residual-component input is unavailable.",
+                },
+                {
+                    "name": "MADOCA residual-component diff",
+                    "status": "failed",
+                    "log_path": "/tmp/madoca.log",
+                },
+            ]
+        )
+
+        self.assertIn("## Optional MADOCA Residual-Component Diff", markdown)
+        self.assertIn("`passed`: `1`", markdown)
+        self.assertIn("`failed`: `1`", markdown)
+        self.assertIn("`skipped`: `1`", markdown)
+        self.assertIn("common rows `12`", markdown)
+        self.assertIn("unmatched `1/2`", markdown)
+        self.assertIn("components `24`", markdown)
+        self.assertIn("max |delta| 0.125", markdown)
+        self.assertIn("threshold exceedances `3`", markdown)
+        self.assertIn("see `/tmp/madoca.log`", markdown)
+
+    def test_write_summary_declares_schema(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_residual_summary_") as temp_dir:
+            summary_path = Path(temp_dir) / "summary.json"
+            steps = runner.build_step_plan(ROOT_DIR, Path(temp_dir) / "output", {})
+            results = [
+                {
+                    "name": steps[0].name,
+                    "slug": steps[0].slug,
+                    "status": "skipped",
+                    "skip_reason": steps[0].skip_reason,
+                    "outputs": steps[0].outputs,
+                    "summary_json": steps[0].summary_json,
+                    "log_path": str(Path(temp_dir) / "madoca_residual_component_diff.log"),
+                }
+            ]
+
+            runner.write_summary(summary_path, steps, results)
+
+            payload = json.loads(summary_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["summary_schema"], runner.SUMMARY_SCHEMA)
+            self.assertEqual(payload["counts"], {"passed": 0, "failed": 0, "skipped": 1})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add an optional CI wrapper for MADOCA residual-component diff artifacts
- upload the optional summary/log/diff artifacts from the optional sign-off lane
- register focused Python tests and document the environment-variable contract

## Validation
- python3 -m py_compile scripts/ci/run_optional_madoca_residual_component_diff.py tests/test_optional_madoca_residual_component_diff.py scripts/analysis/madoca_residual_component_diff.py
- python3 tests/test_optional_madoca_residual_component_diff.py -v
- python3 tests/test_madoca_residual_component_diff.py -v
- bash scripts/ci/run_optional_madoca_residual_component_diff.sh --output-dir /tmp/gnsspp-madoca-residual-skip-test
- ctest --test-dir build-madoca-parity -R 'python_(optional_madoca_residual_component_diff|madoca_residual_component_diff)_tests' --output-on-failure\n- git diff --cached --check