### PR TITLE
ci: share optional diff artifact runner

### DIFF
--- a/scripts/ci/optional_diff_runner.py
+++ b/scripts/ci/optional_diff_runner.py
@@ -1,0 +1,419 @@
+#!/usr/bin/env python3
+"""Shared runner for optional CI diff artifacts."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import asdict, dataclass
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import time
+from typing import Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class EnvOption:
+    env_names: tuple[str, ...]
+    flag: str
+    value_type: str = "str"
+
+
+@dataclass(frozen=True)
+class DiffRunnerConfig:
+    summary_schema: str
+    name: str
+    markdown_title: str
+    slug: str
+    analysis_script: str
+    base_label: str
+    candidate_label: str
+    base_env: str
+    candidate_envs: tuple[str, ...]
+    components_env: str
+    fail_on_diff_env: str
+    default_components: tuple[str, ...]
+    skip_subject: str
+    base_missing_label: str
+    candidate_missing_label: str
+    summary_filename: str
+    log_dir_name: str
+    per_component_max_key: str
+    extra_options: tuple[EnvOption, ...] = ()
+
+
+@dataclass(frozen=True)
+class DiffStep:
+    name: str
+    slug: str
+    command: list[str] | None
+    outputs: list[str]
+    summary_json: str
+    skip_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class DiffContext:
+    repo_root: Path
+    output_dir: Path
+    python_executable: str
+    base_csv: Path | None
+    candidate_csv: Path | None
+    components: list[str]
+    option_values: dict[str, str]
+    fail_on_diff: bool
+
+
+def repo_root_from_script() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def resolve_optional_path(repo_root: Path, value: str) -> Path | None:
+    text = value.strip()
+    if not text:
+        return None
+    path = Path(text)
+    if path.is_absolute():
+        return path
+    return repo_root / path
+
+
+def parse_components(value: str) -> list[str]:
+    components = [item.strip() for item in value.replace(";", ",").split(",")]
+    return [item for item in components if item]
+
+
+def optional_env(environ: Mapping[str, str], names: Sequence[str]) -> str:
+    for name in names:
+        value = environ.get(name, "").strip()
+        if value:
+            return value
+    return ""
+
+
+def parse_option_value(option: EnvOption, environ: Mapping[str, str]) -> str | None:
+    value = optional_env(environ, option.env_names)
+    if not value:
+        return None
+    if option.value_type == "int":
+        return str(int(value))
+    if option.value_type == "float":
+        return str(float(value))
+    if option.value_type != "str":
+        raise ValueError(f"unsupported option value type: {option.value_type}")
+    return value
+
+
+def truthy(value: str) -> bool:
+    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def build_context(
+    config: DiffRunnerConfig,
+    repo_root: Path,
+    output_dir: Path,
+    environ: Mapping[str, str],
+    *,
+    python_executable: str = sys.executable,
+) -> DiffContext:
+    components = parse_components(environ.get(config.components_env, ""))
+    if not components:
+        components = list(config.default_components)
+    return DiffContext(
+        repo_root=repo_root,
+        output_dir=output_dir,
+        python_executable=python_executable,
+        base_csv=resolve_optional_path(repo_root, environ.get(config.base_env, "")),
+        candidate_csv=resolve_optional_path(
+            repo_root,
+            optional_env(environ, config.candidate_envs),
+        ),
+        components=components,
+        option_values={
+            option.flag: value
+            for option in config.extra_options
+            if (value := parse_option_value(option, environ)) is not None
+        },
+        fail_on_diff=truthy(environ.get(config.fail_on_diff_env, "")),
+    )
+
+
+def make_step(config: DiffRunnerConfig, context: DiffContext) -> DiffStep:
+    report_json = context.output_dir / f"{config.slug}.json"
+    details_csv = context.output_dir / f"{config.slug}.csv"
+    summary_json = context.output_dir / f"{config.slug}_summary.json"
+    outputs = [report_json, details_csv, summary_json]
+
+    missing = [
+        (label, path)
+        for label, path in (
+            (config.base_missing_label, context.base_csv),
+            (config.candidate_missing_label, context.candidate_csv),
+        )
+        if path is None or not path.is_file()
+    ]
+    if missing:
+        missing_text = ", ".join(f"{label}: {path}" for label, path in missing)
+        return DiffStep(
+            name=config.name,
+            slug=config.slug,
+            command=None,
+            outputs=[str(path) for path in outputs],
+            summary_json=str(summary_json),
+            skip_reason=f"{config.skip_subject} input is unavailable ({missing_text}).",
+        )
+
+    assert context.base_csv is not None
+    assert context.candidate_csv is not None
+    command = [
+        context.python_executable,
+        str(context.repo_root / "scripts" / "analysis" / config.analysis_script),
+        str(context.base_csv),
+        str(context.candidate_csv),
+        "--base-label",
+        config.base_label,
+        "--candidate-label",
+        config.candidate_label,
+        "--json-out",
+        str(report_json),
+        "--details-csv",
+        str(details_csv),
+    ]
+    for component in context.components:
+        command.extend(["--component", component])
+    for flag, value in context.option_values.items():
+        command.extend([flag, value])
+    if context.fail_on_diff:
+        command.append("--fail-on-diff")
+
+    return DiffStep(
+        name=config.name,
+        slug=config.slug,
+        command=command,
+        outputs=[str(path) for path in outputs],
+        summary_json=str(summary_json),
+    )
+
+
+def build_step_plan(
+    config: DiffRunnerConfig,
+    repo_root: Path,
+    output_dir: Path,
+    environ: Mapping[str, str],
+    *,
+    python_executable: str = sys.executable,
+) -> list[DiffStep]:
+    context = build_context(config, repo_root, output_dir, environ, python_executable=python_executable)
+    return [make_step(config, context)]
+
+
+def load_diff_metrics(config: DiffRunnerConfig, report_json: Path) -> dict[str, object]:
+    if not report_json.is_file():
+        return {}
+    try:
+        payload = json.loads(report_json.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        return {}
+    if not isinstance(payload, dict):
+        return {}
+    metrics: dict[str, object] = {}
+    for key in [
+        "schema",
+        "base_rows",
+        "candidate_rows",
+        "common_rows",
+        "base_only_rows",
+        "candidate_only_rows",
+        "components_compared",
+        "threshold_exceedances",
+        "row_set_complete",
+    ]:
+        if key in payload:
+            metrics[key] = payload[key]
+    per_component = payload.get("per_component")
+    if isinstance(per_component, list):
+        max_abs_delta = 0.0
+        for item in per_component:
+            if not isinstance(item, dict):
+                continue
+            value = item.get(config.per_component_max_key)
+            if isinstance(value, (int, float)):
+                max_abs_delta = max(max_abs_delta, float(value))
+        metrics["max_abs_delta"] = max_abs_delta
+    return metrics
+
+
+def run_step(config: DiffRunnerConfig, step: DiffStep, repo_root: Path, log_dir: Path) -> dict[str, object]:
+    log_path = log_dir / f"{step.slug}.log"
+    summary_json = Path(step.summary_json)
+    report_json = summary_json.with_name(f"{step.slug}.json")
+    record: dict[str, object] = {
+        "name": step.name,
+        "slug": step.slug,
+        "outputs": step.outputs,
+        "summary_json": step.summary_json,
+        "log_path": str(log_path),
+    }
+    if step.skip_reason is not None:
+        record["status"] = "skipped"
+        record["skip_reason"] = step.skip_reason
+        log_path.write_text(step.skip_reason + "\n", encoding="utf-8")
+        print(f"Skipping {step.name}: {step.skip_reason}")
+        return record
+
+    assert step.command is not None
+    command_display = " ".join(step.command)
+    print(f"+ {command_display}")
+    started = time.monotonic()
+    completed = subprocess.run(
+        step.command,
+        cwd=repo_root,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    elapsed = time.monotonic() - started
+    combined_log = completed.stdout
+    if completed.stderr:
+        if combined_log and not combined_log.endswith("\n"):
+            combined_log += "\n"
+        combined_log += completed.stderr
+    log_path.write_text(f"$ {command_display}\n\n{combined_log}", encoding="utf-8")
+    record["command"] = step.command
+    record["elapsed_s"] = elapsed
+    record["returncode"] = completed.returncode
+    metrics = load_diff_metrics(config, report_json)
+    if metrics:
+        record["metrics"] = metrics
+    if completed.returncode == 0:
+        record["status"] = "passed"
+        print(f"Passed {step.name} in {elapsed:.2f}s")
+    else:
+        record["status"] = "failed"
+        lines = combined_log.splitlines()
+        tail = "\n".join(lines[-20:])
+        if tail:
+            print(tail)
+        print(f"Failed {step.name} in {elapsed:.2f}s; see {log_path}")
+    return record
+
+
+def format_metric(value: object) -> str:
+    if isinstance(value, float):
+        return f"{value:.6g}"
+    return str(value)
+
+
+def render_result_detail(result: dict[str, object]) -> str:
+    status = str(result["status"])
+    if status == "skipped":
+        return str(result.get("skip_reason", ""))
+    if status == "failed":
+        log_path = result.get("log_path")
+        return f"see `{log_path}`" if log_path else "failed"
+
+    detail_parts: list[str] = []
+    elapsed = result.get("elapsed_s")
+    if isinstance(elapsed, (float, int)):
+        detail_parts.append(f"{elapsed:.2f}s")
+    metrics = result.get("metrics")
+    if isinstance(metrics, dict):
+        common_rows = metrics.get("common_rows")
+        if common_rows is not None:
+            detail_parts.append(f"common rows `{common_rows}`")
+        base_only = metrics.get("base_only_rows")
+        candidate_only = metrics.get("candidate_only_rows")
+        if base_only is not None or candidate_only is not None:
+            detail_parts.append(f"unmatched `{base_only}/{candidate_only}`")
+        compared = metrics.get("components_compared")
+        if compared is not None:
+            detail_parts.append(f"components `{compared}`")
+        max_abs_delta = metrics.get("max_abs_delta")
+        if max_abs_delta is not None:
+            detail_parts.append(f"max |delta| {format_metric(max_abs_delta)}")
+        threshold_exceedances = metrics.get("threshold_exceedances")
+        if threshold_exceedances is not None:
+            detail_parts.append(f"threshold exceedances `{threshold_exceedances}`")
+    return ", ".join(detail_parts)
+
+
+def render_markdown_summary(config: DiffRunnerConfig, results: list[dict[str, object]]) -> str:
+    passed = sum(1 for result in results if result["status"] == "passed")
+    failed = sum(1 for result in results if result["status"] == "failed")
+    skipped = sum(1 for result in results if result["status"] == "skipped")
+    lines = [
+        f"## {config.markdown_title}",
+        "",
+        f"- `passed`: `{passed}`",
+        f"- `failed`: `{failed}`",
+        f"- `skipped`: `{skipped}`",
+        "",
+        "| Step | Status | Detail |",
+        "| --- | --- | --- |",
+    ]
+    for result in results:
+        lines.append(f"| {result['name']} | `{result['status']}` | {render_result_detail(result)} |")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def write_summary(
+    config: DiffRunnerConfig,
+    summary_path: Path,
+    steps: list[DiffStep],
+    results: list[dict[str, object]],
+) -> None:
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "summary_schema": config.summary_schema,
+        "steps": [asdict(step) for step in steps],
+        "results": results,
+        "counts": {
+            "passed": sum(1 for result in results if result["status"] == "passed"),
+            "failed": sum(1 for result in results if result["status"] == "failed"),
+            "skipped": sum(1 for result in results if result["status"] == "skipped"),
+        },
+    }
+    summary_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def append_github_step_summary(config: DiffRunnerConfig, path: Path, results: list[dict[str, object]]) -> None:
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(render_markdown_summary(config, results))
+        handle.write("\n")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, default=repo_root_from_script())
+    parser.add_argument("--output-dir", type=Path, default=None)
+    parser.add_argument("--summary-json", type=Path, default=None)
+    parser.add_argument("--github-step-summary", type=Path, default=None)
+    return parser.parse_args()
+
+
+def main(config: DiffRunnerConfig) -> int:
+    args = parse_args()
+    repo_root = args.repo_root.resolve()
+    output_dir = (args.output_dir if args.output_dir is not None else repo_root / "output").resolve()
+    summary_json = (
+        args.summary_json
+        if args.summary_json is not None
+        else output_dir / config.summary_filename
+    ).resolve()
+    log_dir = output_dir / config.log_dir_name
+    output_dir.mkdir(parents=True, exist_ok=True)
+    log_dir.mkdir(parents=True, exist_ok=True)
+
+    steps = build_step_plan(config, repo_root, output_dir, os.environ)
+    results = [run_step(config, step, repo_root, log_dir) for step in steps]
+    write_summary(config, summary_json, steps, results)
+    summary_path = args.github_step_summary
+    if summary_path is None:
+        summary_env = os.environ.get("GITHUB_STEP_SUMMARY", "").strip()
+        summary_path = Path(summary_env) if summary_env else None
+    if summary_path is not None:
+        append_github_step_summary(config, summary_path, results)
+    return 1 if any(result["status"] == "failed" for result in results) else 0

--- a/scripts/ci/run_optional_clas_zd_component_diff.py
+++ b/scripts/ci/run_optional_clas_zd_component_diff.py
@@ -3,166 +3,57 @@
 
 from __future__ import annotations
 
-import argparse
-from dataclasses import asdict, dataclass
-import json
-import os
 from pathlib import Path
-import subprocess
 import sys
-import time
 from typing import Mapping
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import optional_diff_runner as runner  # noqa: E402
 
 
 SUMMARY_SCHEMA = "ci_optional_clas_zd_component_diff.v1"
 
+CONFIG = runner.DiffRunnerConfig(
+    summary_schema=SUMMARY_SCHEMA,
+    name="CLAS ZD component diff",
+    markdown_title="Optional CLAS ZD Component Diff",
+    slug="clas_zd_component_diff",
+    analysis_script="clas_zd_component_diff.py",
+    base_label="claslib",
+    candidate_label="native",
+    base_env="GNSSPP_CLAS_ZD_BASE_CSV",
+    candidate_envs=(
+        "GNSSPP_CLAS_ZD_CANDIDATE_CSV",
+        "GNSSPP_CLAS_ZD_NATIVE_CSV",
+    ),
+    components_env="GNSSPP_CLAS_ZD_COMPONENTS",
+    fail_on_diff_env="GNSSPP_CLAS_ZD_FAIL_ON_DIFF",
+    default_components=(),
+    skip_subject="CLAS ZD component",
+    base_missing_label="base ZD component CSV",
+    candidate_missing_label="candidate ZD component CSV",
+    summary_filename="ci_optional_clas_zd_component_summary.json",
+    log_dir_name="ci_optional_clas_zd_component",
+    per_component_max_key="max_abs_delta_m",
+    extra_options=(
+        runner.EnvOption(("GNSSPP_CLAS_ZD_STAGE",), "--stage"),
+        runner.EnvOption(("GNSSPP_CLAS_ZD_ROW_TYPE",), "--row-type"),
+        runner.EnvOption(
+            ("GNSSPP_CLAS_ZD_THRESHOLD_M", "GNSSPP_CLAS_ZD_THRESHOLD"),
+            "--component-threshold-m",
+            "float",
+        ),
+    ),
+)
 
-@dataclass(frozen=True)
-class DiffStep:
-    name: str
-    slug: str
-    command: list[str] | None
-    outputs: list[str]
-    summary_json: str
-    skip_reason: str | None = None
 
-
-@dataclass(frozen=True)
-class DiffContext:
-    repo_root: Path
-    output_dir: Path
-    python_executable: str
-    base_csv: Path | None
-    candidate_csv: Path | None
-    components: list[str]
-    stage: str | None
-    row_type: str | None
-    threshold: float | None
-    fail_on_diff: bool
+DiffStep = runner.DiffStep
 
 
 def repo_root_from_script() -> Path:
-    return Path(__file__).resolve().parents[2]
-
-
-def resolve_optional_path(repo_root: Path, value: str) -> Path | None:
-    text = value.strip()
-    if not text:
-        return None
-    path = Path(text)
-    if path.is_absolute():
-        return path
-    return repo_root / path
-
-
-def parse_components(value: str) -> list[str]:
-    components = [item.strip() for item in value.replace(";", ",").split(",")]
-    return [item for item in components if item]
-
-
-def parse_optional_float(value: str) -> float | None:
-    text = value.strip()
-    if not text:
-        return None
-    return float(text)
-
-
-def truthy(value: str) -> bool:
-    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
-
-
-def build_context(
-    repo_root: Path,
-    output_dir: Path,
-    environ: Mapping[str, str],
-    *,
-    python_executable: str = sys.executable,
-) -> DiffContext:
-    return DiffContext(
-        repo_root=repo_root,
-        output_dir=output_dir,
-        python_executable=python_executable,
-        base_csv=resolve_optional_path(
-            repo_root,
-            environ.get("GNSSPP_CLAS_ZD_BASE_CSV", ""),
-        ),
-        candidate_csv=resolve_optional_path(
-            repo_root,
-            environ.get("GNSSPP_CLAS_ZD_CANDIDATE_CSV", "")
-            or environ.get("GNSSPP_CLAS_ZD_NATIVE_CSV", ""),
-        ),
-        components=parse_components(environ.get("GNSSPP_CLAS_ZD_COMPONENTS", "")),
-        stage=environ.get("GNSSPP_CLAS_ZD_STAGE", "").strip() or None,
-        row_type=environ.get("GNSSPP_CLAS_ZD_ROW_TYPE", "").strip() or None,
-        threshold=parse_optional_float(
-            environ.get("GNSSPP_CLAS_ZD_THRESHOLD_M", "")
-            or environ.get("GNSSPP_CLAS_ZD_THRESHOLD", "")
-        ),
-        fail_on_diff=truthy(environ.get("GNSSPP_CLAS_ZD_FAIL_ON_DIFF", "")),
-    )
-
-
-def make_step(context: DiffContext) -> DiffStep:
-    name = "CLAS ZD component diff"
-    slug = "clas_zd_component_diff"
-    report_json = context.output_dir / f"{slug}.json"
-    details_csv = context.output_dir / f"{slug}.csv"
-    summary_json = context.output_dir / f"{slug}_summary.json"
-    outputs = [report_json, details_csv, summary_json]
-
-    missing = [
-        (label, path)
-        for label, path in (
-            ("base ZD component CSV", context.base_csv),
-            ("candidate ZD component CSV", context.candidate_csv),
-        )
-        if path is None or not path.is_file()
-    ]
-    if missing:
-        missing_text = ", ".join(f"{label}: {path}" for label, path in missing)
-        return DiffStep(
-            name=name,
-            slug=slug,
-            command=None,
-            outputs=[str(path) for path in outputs],
-            summary_json=str(summary_json),
-            skip_reason=f"CLAS ZD component input is unavailable ({missing_text}).",
-        )
-
-    assert context.base_csv is not None
-    assert context.candidate_csv is not None
-    command = [
-        context.python_executable,
-        str(context.repo_root / "scripts" / "analysis" / "clas_zd_component_diff.py"),
-        str(context.base_csv),
-        str(context.candidate_csv),
-        "--base-label",
-        "claslib",
-        "--candidate-label",
-        "native",
-        "--json-out",
-        str(report_json),
-        "--details-csv",
-        str(details_csv),
-    ]
-    for component in context.components:
-        command.extend(["--component", component])
-    if context.stage is not None:
-        command.extend(["--stage", context.stage])
-    if context.row_type is not None:
-        command.extend(["--row-type", context.row_type])
-    if context.threshold is not None:
-        command.extend(["--component-threshold-m", str(context.threshold)])
-    if context.fail_on_diff:
-        command.append("--fail-on-diff")
-
-    return DiffStep(
-        name=name,
-        slug=slug,
-        command=command,
-        outputs=[str(path) for path in outputs],
-        summary_json=str(summary_json),
-    )
+    return runner.repo_root_from_script()
 
 
 def build_step_plan(
@@ -172,213 +63,23 @@ def build_step_plan(
     *,
     python_executable: str = sys.executable,
 ) -> list[DiffStep]:
-    context = build_context(repo_root, output_dir, environ, python_executable=python_executable)
-    return [make_step(context)]
-
-
-def load_diff_metrics(report_json: Path) -> dict[str, object]:
-    if not report_json.is_file():
-        return {}
-    try:
-        payload = json.loads(report_json.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
-        return {}
-    if not isinstance(payload, dict):
-        return {}
-    metrics: dict[str, object] = {}
-    for key in [
-        "schema",
-        "base_rows",
-        "candidate_rows",
-        "common_rows",
-        "base_only_rows",
-        "candidate_only_rows",
-        "components_compared",
-        "threshold_exceedances",
-        "row_set_complete",
-    ]:
-        if key in payload:
-            metrics[key] = payload[key]
-    per_component = payload.get("per_component")
-    if isinstance(per_component, list):
-        max_abs_delta = 0.0
-        for item in per_component:
-            if not isinstance(item, dict):
-                continue
-            value = item.get("max_abs_delta_m")
-            if isinstance(value, (int, float)):
-                max_abs_delta = max(max_abs_delta, float(value))
-        metrics["max_abs_delta"] = max_abs_delta
-    return metrics
+    return runner.build_step_plan(CONFIG, repo_root, output_dir, environ, python_executable=python_executable)
 
 
 def run_step(step: DiffStep, repo_root: Path, log_dir: Path) -> dict[str, object]:
-    log_path = log_dir / f"{step.slug}.log"
-    summary_json = Path(step.summary_json)
-    report_json = summary_json.with_name(f"{step.slug}.json")
-    record: dict[str, object] = {
-        "name": step.name,
-        "slug": step.slug,
-        "outputs": step.outputs,
-        "summary_json": step.summary_json,
-        "log_path": str(log_path),
-    }
-    if step.skip_reason is not None:
-        record["status"] = "skipped"
-        record["skip_reason"] = step.skip_reason
-        log_path.write_text(step.skip_reason + "\n", encoding="utf-8")
-        print(f"Skipping {step.name}: {step.skip_reason}")
-        return record
-
-    assert step.command is not None
-    command_display = " ".join(step.command)
-    print(f"+ {command_display}")
-    started = time.monotonic()
-    completed = subprocess.run(
-        step.command,
-        cwd=repo_root,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-    elapsed = time.monotonic() - started
-    combined_log = completed.stdout
-    if completed.stderr:
-        if combined_log and not combined_log.endswith("\n"):
-            combined_log += "\n"
-        combined_log += completed.stderr
-    log_path.write_text(f"$ {command_display}\n\n{combined_log}", encoding="utf-8")
-    record["command"] = step.command
-    record["elapsed_s"] = elapsed
-    record["returncode"] = completed.returncode
-    metrics = load_diff_metrics(report_json)
-    if metrics:
-        record["metrics"] = metrics
-    if completed.returncode == 0:
-        record["status"] = "passed"
-        print(f"Passed {step.name} in {elapsed:.2f}s")
-    else:
-        record["status"] = "failed"
-        lines = combined_log.splitlines()
-        tail = "\n".join(lines[-20:])
-        if tail:
-            print(tail)
-        print(f"Failed {step.name} in {elapsed:.2f}s; see {log_path}")
-    return record
-
-
-def format_metric(value: object) -> str:
-    if isinstance(value, float):
-        return f"{value:.6g}"
-    return str(value)
-
-
-def render_result_detail(result: dict[str, object]) -> str:
-    status = str(result["status"])
-    if status == "skipped":
-        return str(result.get("skip_reason", ""))
-    if status == "failed":
-        log_path = result.get("log_path")
-        return f"see `{log_path}`" if log_path else "failed"
-
-    detail_parts: list[str] = []
-    elapsed = result.get("elapsed_s")
-    if isinstance(elapsed, (float, int)):
-        detail_parts.append(f"{elapsed:.2f}s")
-    metrics = result.get("metrics")
-    if isinstance(metrics, dict):
-        common_rows = metrics.get("common_rows")
-        if common_rows is not None:
-            detail_parts.append(f"common rows `{common_rows}`")
-        base_only = metrics.get("base_only_rows")
-        candidate_only = metrics.get("candidate_only_rows")
-        if base_only is not None or candidate_only is not None:
-            detail_parts.append(f"unmatched `{base_only}/{candidate_only}`")
-        compared = metrics.get("components_compared")
-        if compared is not None:
-            detail_parts.append(f"components `{compared}`")
-        max_abs_delta = metrics.get("max_abs_delta")
-        if max_abs_delta is not None:
-            detail_parts.append(f"max |delta| {format_metric(max_abs_delta)}")
-        threshold_exceedances = metrics.get("threshold_exceedances")
-        if threshold_exceedances is not None:
-            detail_parts.append(f"threshold exceedances `{threshold_exceedances}`")
-    return ", ".join(detail_parts)
+    return runner.run_step(CONFIG, step, repo_root, log_dir)
 
 
 def render_markdown_summary(results: list[dict[str, object]]) -> str:
-    passed = sum(1 for result in results if result["status"] == "passed")
-    failed = sum(1 for result in results if result["status"] == "failed")
-    skipped = sum(1 for result in results if result["status"] == "skipped")
-    lines = [
-        "## Optional CLAS ZD Component Diff",
-        "",
-        f"- `passed`: `{passed}`",
-        f"- `failed`: `{failed}`",
-        f"- `skipped`: `{skipped}`",
-        "",
-        "| Step | Status | Detail |",
-        "| --- | --- | --- |",
-    ]
-    for result in results:
-        lines.append(f"| {result['name']} | `{result['status']}` | {render_result_detail(result)} |")
-    lines.append("")
-    return "\n".join(lines)
+    return runner.render_markdown_summary(CONFIG, results)
 
 
 def write_summary(summary_path: Path, steps: list[DiffStep], results: list[dict[str, object]]) -> None:
-    summary_path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {
-        "summary_schema": SUMMARY_SCHEMA,
-        "steps": [asdict(step) for step in steps],
-        "results": results,
-        "counts": {
-            "passed": sum(1 for result in results if result["status"] == "passed"),
-            "failed": sum(1 for result in results if result["status"] == "failed"),
-            "skipped": sum(1 for result in results if result["status"] == "skipped"),
-        },
-    }
-    summary_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-
-
-def append_github_step_summary(path: Path, results: list[dict[str, object]]) -> None:
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(render_markdown_summary(results))
-        handle.write("\n")
-
-
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--repo-root", type=Path, default=repo_root_from_script())
-    parser.add_argument("--output-dir", type=Path, default=None)
-    parser.add_argument("--summary-json", type=Path, default=None)
-    parser.add_argument("--github-step-summary", type=Path, default=None)
-    return parser.parse_args()
+    runner.write_summary(CONFIG, summary_path, steps, results)
 
 
 def main() -> int:
-    args = parse_args()
-    repo_root = args.repo_root.resolve()
-    output_dir = (args.output_dir if args.output_dir is not None else repo_root / "output").resolve()
-    summary_json = (
-        args.summary_json
-        if args.summary_json is not None
-        else output_dir / "ci_optional_clas_zd_component_summary.json"
-    ).resolve()
-    log_dir = output_dir / "ci_optional_clas_zd_component"
-    output_dir.mkdir(parents=True, exist_ok=True)
-    log_dir.mkdir(parents=True, exist_ok=True)
-
-    steps = build_step_plan(repo_root, output_dir, os.environ)
-    results = [run_step(step, repo_root, log_dir) for step in steps]
-    write_summary(summary_json, steps, results)
-    summary_path = args.github_step_summary
-    if summary_path is None:
-        summary_env = os.environ.get("GITHUB_STEP_SUMMARY", "").strip()
-        summary_path = Path(summary_env) if summary_env else None
-    if summary_path is not None:
-        append_github_step_summary(summary_path, results)
-    return 1 if any(result["status"] == "failed" for result in results) else 0
+    return runner.main(CONFIG)
 
 
 if __name__ == "__main__":

--- a/scripts/ci/run_optional_madoca_residual_component_diff.py
+++ b/scripts/ci/run_optional_madoca_residual_component_diff.py
@@ -3,172 +3,53 @@
 
 from __future__ import annotations
 
-import argparse
-from dataclasses import asdict, dataclass
-import json
-import os
 from pathlib import Path
-import subprocess
 import sys
-import time
 from typing import Mapping
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import optional_diff_runner as runner  # noqa: E402
 
 
 SUMMARY_SCHEMA = "ci_optional_madoca_residual_component_diff.v1"
 
+CONFIG = runner.DiffRunnerConfig(
+    summary_schema=SUMMARY_SCHEMA,
+    name="MADOCA residual-component diff",
+    markdown_title="Optional MADOCA Residual-Component Diff",
+    slug="madoca_residual_component_diff",
+    analysis_script="madoca_residual_component_diff.py",
+    base_label="madocalib",
+    candidate_label="native",
+    base_env="GNSSPP_MADOCA_RESIDUAL_BASE_CSV",
+    candidate_envs=(
+        "GNSSPP_MADOCA_RESIDUAL_CANDIDATE_CSV",
+        "GNSSPP_MADOCA_RESIDUAL_NATIVE_CSV",
+    ),
+    components_env="GNSSPP_MADOCA_RESIDUAL_COMPONENTS",
+    fail_on_diff_env="GNSSPP_MADOCA_RESIDUAL_FAIL_ON_DIFF",
+    default_components=("residual_m",),
+    skip_subject="MADOCA residual-component",
+    base_missing_label="base residual CSV",
+    candidate_missing_label="candidate residual CSV",
+    summary_filename="ci_optional_madoca_residual_component_summary.json",
+    log_dir_name="ci_optional_madoca_residual_component",
+    per_component_max_key="max_abs_delta",
+    extra_options=(
+        runner.EnvOption(("GNSSPP_MADOCA_RESIDUAL_ROW_TYPE",), "--row-type"),
+        runner.EnvOption(("GNSSPP_MADOCA_RESIDUAL_ITERATION",), "--iteration", "int"),
+        runner.EnvOption(("GNSSPP_MADOCA_RESIDUAL_THRESHOLD",), "--component-threshold", "float"),
+    ),
+)
 
-@dataclass(frozen=True)
-class DiffStep:
-    name: str
-    slug: str
-    command: list[str] | None
-    outputs: list[str]
-    summary_json: str
-    skip_reason: str | None = None
 
-
-@dataclass(frozen=True)
-class DiffContext:
-    repo_root: Path
-    output_dir: Path
-    python_executable: str
-    base_csv: Path | None
-    candidate_csv: Path | None
-    components: list[str]
-    row_type: str | None
-    iteration: int | None
-    threshold: float | None
-    fail_on_diff: bool
+DiffStep = runner.DiffStep
 
 
 def repo_root_from_script() -> Path:
-    return Path(__file__).resolve().parents[2]
-
-
-def resolve_optional_path(repo_root: Path, value: str) -> Path | None:
-    text = value.strip()
-    if not text:
-        return None
-    path = Path(text)
-    if path.is_absolute():
-        return path
-    return repo_root / path
-
-
-def parse_components(value: str) -> list[str]:
-    components = [item.strip() for item in value.replace(";", ",").split(",")]
-    return [item for item in components if item]
-
-
-def parse_optional_int(value: str) -> int | None:
-    text = value.strip()
-    if not text:
-        return None
-    return int(text)
-
-
-def parse_optional_float(value: str) -> float | None:
-    text = value.strip()
-    if not text:
-        return None
-    return float(text)
-
-
-def truthy(value: str) -> bool:
-    return value.strip().lower() in {"1", "true", "yes", "y", "on"}
-
-
-def build_context(
-    repo_root: Path,
-    output_dir: Path,
-    environ: Mapping[str, str],
-    *,
-    python_executable: str = sys.executable,
-) -> DiffContext:
-    return DiffContext(
-        repo_root=repo_root,
-        output_dir=output_dir,
-        python_executable=python_executable,
-        base_csv=resolve_optional_path(
-            repo_root,
-            environ.get("GNSSPP_MADOCA_RESIDUAL_BASE_CSV", ""),
-        ),
-        candidate_csv=resolve_optional_path(
-            repo_root,
-            environ.get("GNSSPP_MADOCA_RESIDUAL_CANDIDATE_CSV", "")
-            or environ.get("GNSSPP_MADOCA_RESIDUAL_NATIVE_CSV", ""),
-        ),
-        components=parse_components(
-            environ.get("GNSSPP_MADOCA_RESIDUAL_COMPONENTS", "residual_m")
-        ),
-        row_type=environ.get("GNSSPP_MADOCA_RESIDUAL_ROW_TYPE", "").strip() or None,
-        iteration=parse_optional_int(environ.get("GNSSPP_MADOCA_RESIDUAL_ITERATION", "")),
-        threshold=parse_optional_float(environ.get("GNSSPP_MADOCA_RESIDUAL_THRESHOLD", "")),
-        fail_on_diff=truthy(environ.get("GNSSPP_MADOCA_RESIDUAL_FAIL_ON_DIFF", "")),
-    )
-
-
-def make_step(context: DiffContext) -> DiffStep:
-    name = "MADOCA residual-component diff"
-    slug = "madoca_residual_component_diff"
-    report_json = context.output_dir / f"{slug}.json"
-    details_csv = context.output_dir / f"{slug}.csv"
-    summary_json = context.output_dir / f"{slug}_summary.json"
-    outputs = [report_json, details_csv, summary_json]
-
-    missing = [
-        (label, path)
-        for label, path in (
-            ("base residual CSV", context.base_csv),
-            ("candidate residual CSV", context.candidate_csv),
-        )
-        if path is None or not path.is_file()
-    ]
-    if missing:
-        missing_text = ", ".join(f"{label}: {path}" for label, path in missing)
-        return DiffStep(
-            name=name,
-            slug=slug,
-            command=None,
-            outputs=[str(path) for path in outputs],
-            summary_json=str(summary_json),
-            skip_reason=f"MADOCA residual-component input is unavailable ({missing_text}).",
-        )
-
-    assert context.base_csv is not None
-    assert context.candidate_csv is not None
-    command = [
-        context.python_executable,
-        str(context.repo_root / "scripts" / "analysis" / "madoca_residual_component_diff.py"),
-        str(context.base_csv),
-        str(context.candidate_csv),
-        "--base-label",
-        "madocalib",
-        "--candidate-label",
-        "native",
-        "--json-out",
-        str(report_json),
-        "--details-csv",
-        str(details_csv),
-    ]
-    for component in context.components or ["residual_m"]:
-        command.extend(["--component", component])
-    if context.row_type is not None:
-        command.extend(["--row-type", context.row_type])
-    if context.iteration is not None:
-        command.extend(["--iteration", str(context.iteration)])
-    if context.threshold is not None:
-        command.extend(["--component-threshold", str(context.threshold)])
-    if context.fail_on_diff:
-        command.append("--fail-on-diff")
-
-    return DiffStep(
-        name=name,
-        slug=slug,
-        command=command,
-        outputs=[str(path) for path in outputs],
-        summary_json=str(summary_json),
-    )
+    return runner.repo_root_from_script()
 
 
 def build_step_plan(
@@ -178,213 +59,23 @@ def build_step_plan(
     *,
     python_executable: str = sys.executable,
 ) -> list[DiffStep]:
-    context = build_context(repo_root, output_dir, environ, python_executable=python_executable)
-    return [make_step(context)]
-
-
-def load_diff_metrics(report_json: Path) -> dict[str, object]:
-    if not report_json.is_file():
-        return {}
-    try:
-        payload = json.loads(report_json.read_text(encoding="utf-8"))
-    except json.JSONDecodeError:
-        return {}
-    if not isinstance(payload, dict):
-        return {}
-    metrics: dict[str, object] = {}
-    for key in [
-        "schema",
-        "base_rows",
-        "candidate_rows",
-        "common_rows",
-        "base_only_rows",
-        "candidate_only_rows",
-        "components_compared",
-        "threshold_exceedances",
-        "row_set_complete",
-    ]:
-        if key in payload:
-            metrics[key] = payload[key]
-    per_component = payload.get("per_component")
-    if isinstance(per_component, list):
-        max_abs_delta = 0.0
-        for item in per_component:
-            if not isinstance(item, dict):
-                continue
-            value = item.get("max_abs_delta")
-            if isinstance(value, (int, float)):
-                max_abs_delta = max(max_abs_delta, float(value))
-        metrics["max_abs_delta"] = max_abs_delta
-    return metrics
+    return runner.build_step_plan(CONFIG, repo_root, output_dir, environ, python_executable=python_executable)
 
 
 def run_step(step: DiffStep, repo_root: Path, log_dir: Path) -> dict[str, object]:
-    log_path = log_dir / f"{step.slug}.log"
-    summary_json = Path(step.summary_json)
-    report_json = summary_json.with_name(f"{step.slug}.json")
-    record: dict[str, object] = {
-        "name": step.name,
-        "slug": step.slug,
-        "outputs": step.outputs,
-        "summary_json": step.summary_json,
-        "log_path": str(log_path),
-    }
-    if step.skip_reason is not None:
-        record["status"] = "skipped"
-        record["skip_reason"] = step.skip_reason
-        log_path.write_text(step.skip_reason + "\n", encoding="utf-8")
-        print(f"Skipping {step.name}: {step.skip_reason}")
-        return record
-
-    assert step.command is not None
-    command_display = " ".join(step.command)
-    print(f"+ {command_display}")
-    started = time.monotonic()
-    completed = subprocess.run(
-        step.command,
-        cwd=repo_root,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-    elapsed = time.monotonic() - started
-    combined_log = completed.stdout
-    if completed.stderr:
-        if combined_log and not combined_log.endswith("\n"):
-            combined_log += "\n"
-        combined_log += completed.stderr
-    log_path.write_text(f"$ {command_display}\n\n{combined_log}", encoding="utf-8")
-    record["command"] = step.command
-    record["elapsed_s"] = elapsed
-    record["returncode"] = completed.returncode
-    metrics = load_diff_metrics(report_json)
-    if metrics:
-        record["metrics"] = metrics
-    if completed.returncode == 0:
-        record["status"] = "passed"
-        print(f"Passed {step.name} in {elapsed:.2f}s")
-    else:
-        record["status"] = "failed"
-        lines = combined_log.splitlines()
-        tail = "\n".join(lines[-20:])
-        if tail:
-            print(tail)
-        print(f"Failed {step.name} in {elapsed:.2f}s; see {log_path}")
-    return record
-
-
-def format_metric(value: object) -> str:
-    if isinstance(value, float):
-        return f"{value:.6g}"
-    return str(value)
-
-
-def render_result_detail(result: dict[str, object]) -> str:
-    status = str(result["status"])
-    if status == "skipped":
-        return str(result.get("skip_reason", ""))
-    if status == "failed":
-        log_path = result.get("log_path")
-        return f"see `{log_path}`" if log_path else "failed"
-
-    detail_parts: list[str] = []
-    elapsed = result.get("elapsed_s")
-    if isinstance(elapsed, (float, int)):
-        detail_parts.append(f"{elapsed:.2f}s")
-    metrics = result.get("metrics")
-    if isinstance(metrics, dict):
-        common_rows = metrics.get("common_rows")
-        if common_rows is not None:
-            detail_parts.append(f"common rows `{common_rows}`")
-        base_only = metrics.get("base_only_rows")
-        candidate_only = metrics.get("candidate_only_rows")
-        if base_only is not None or candidate_only is not None:
-            detail_parts.append(f"unmatched `{base_only}/{candidate_only}`")
-        compared = metrics.get("components_compared")
-        if compared is not None:
-            detail_parts.append(f"components `{compared}`")
-        max_abs_delta = metrics.get("max_abs_delta")
-        if max_abs_delta is not None:
-            detail_parts.append(f"max |delta| {format_metric(max_abs_delta)}")
-        threshold_exceedances = metrics.get("threshold_exceedances")
-        if threshold_exceedances is not None:
-            detail_parts.append(f"threshold exceedances `{threshold_exceedances}`")
-    return ", ".join(detail_parts)
+    return runner.run_step(CONFIG, step, repo_root, log_dir)
 
 
 def render_markdown_summary(results: list[dict[str, object]]) -> str:
-    passed = sum(1 for result in results if result["status"] == "passed")
-    failed = sum(1 for result in results if result["status"] == "failed")
-    skipped = sum(1 for result in results if result["status"] == "skipped")
-    lines = [
-        "## Optional MADOCA Residual-Component Diff",
-        "",
-        f"- `passed`: `{passed}`",
-        f"- `failed`: `{failed}`",
-        f"- `skipped`: `{skipped}`",
-        "",
-        "| Step | Status | Detail |",
-        "| --- | --- | --- |",
-    ]
-    for result in results:
-        lines.append(f"| {result['name']} | `{result['status']}` | {render_result_detail(result)} |")
-    lines.append("")
-    return "\n".join(lines)
+    return runner.render_markdown_summary(CONFIG, results)
 
 
 def write_summary(summary_path: Path, steps: list[DiffStep], results: list[dict[str, object]]) -> None:
-    summary_path.parent.mkdir(parents=True, exist_ok=True)
-    payload = {
-        "summary_schema": SUMMARY_SCHEMA,
-        "steps": [asdict(step) for step in steps],
-        "results": results,
-        "counts": {
-            "passed": sum(1 for result in results if result["status"] == "passed"),
-            "failed": sum(1 for result in results if result["status"] == "failed"),
-            "skipped": sum(1 for result in results if result["status"] == "skipped"),
-        },
-    }
-    summary_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
-
-
-def append_github_step_summary(path: Path, results: list[dict[str, object]]) -> None:
-    with path.open("a", encoding="utf-8") as handle:
-        handle.write(render_markdown_summary(results))
-        handle.write("\n")
-
-
-def parse_args() -> argparse.Namespace:
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--repo-root", type=Path, default=repo_root_from_script())
-    parser.add_argument("--output-dir", type=Path, default=None)
-    parser.add_argument("--summary-json", type=Path, default=None)
-    parser.add_argument("--github-step-summary", type=Path, default=None)
-    return parser.parse_args()
+    runner.write_summary(CONFIG, summary_path, steps, results)
 
 
 def main() -> int:
-    args = parse_args()
-    repo_root = args.repo_root.resolve()
-    output_dir = (args.output_dir if args.output_dir is not None else repo_root / "output").resolve()
-    summary_json = (
-        args.summary_json
-        if args.summary_json is not None
-        else output_dir / "ci_optional_madoca_residual_component_summary.json"
-    ).resolve()
-    log_dir = output_dir / "ci_optional_madoca_residual_component"
-    output_dir.mkdir(parents=True, exist_ok=True)
-    log_dir.mkdir(parents=True, exist_ok=True)
-
-    steps = build_step_plan(repo_root, output_dir, os.environ)
-    results = [run_step(step, repo_root, log_dir) for step in steps]
-    write_summary(summary_json, steps, results)
-    summary_path = args.github_step_summary
-    if summary_path is None:
-        summary_env = os.environ.get("GITHUB_STEP_SUMMARY", "").strip()
-        summary_path = Path(summary_env) if summary_env else None
-    if summary_path is not None:
-        append_github_step_summary(summary_path, results)
-    return 1 if any(result["status"] == "failed" for result in results) else 0
+    return runner.main(CONFIG)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- factor the CLAS ZD and MADOCA residual optional CI diff wrappers through a shared `optional_diff_runner`
- preserve existing env names, summary schemas, skip behavior, artifact names, and command construction
- keep the individual wrapper modules as thin adapters so existing tests and CI entrypoints remain stable

## Validation

- `python3 -m py_compile scripts/ci/optional_diff_runner.py scripts/ci/run_optional_madoca_residual_component_diff.py scripts/ci/run_optional_clas_zd_component_diff.py tests/test_optional_madoca_residual_component_diff.py tests/test_optional_clas_zd_component_diff.py`
- `python3 tests/test_optional_madoca_residual_component_diff.py -v`
- `python3 tests/test_optional_clas_zd_component_diff.py -v`
- `bash scripts/ci/run_optional_madoca_residual_component_diff.sh --output-dir /tmp/gnsspp-madoca-shared-skip-test`
- `bash scripts/ci/run_optional_clas_zd_component_diff.sh --output-dir /tmp/gnsspp-clas-shared-skip-test`
- `ctest --test-dir build-madoca-parity -R 'python_optional_(madoca_residual_component_diff|clas_zd_component_diff)_tests' --output-on-failure`
- `python3 -m compileall -q scripts/ci tests/test_optional_madoca_residual_component_diff.py tests/test_optional_clas_zd_component_diff.py`
- `git diff --check`
