### PR TITLE
ci: fail optional diffs on missing artifacts

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -50,6 +50,11 @@ CI lanes are split as follows:
   with JSON/log artifacts under `output/ci_optional_rtk_signoffs*`; the summary
   uses `summary_schema: ci_optional_rtk_signoffs.v1` and a passed step fails the
   lane if any declared output artifact is missing
+- `bash scripts/ci/run_optional_clas_zd_component_diff.sh` and
+  `bash scripts/ci/run_optional_madoca_residual_component_diff.sh` for
+  oracle/native diff artifacts; both skip explicitly when their CSV inputs are
+  unavailable, and both fail a passed diff command if the declared JSON/CSV
+  artifacts are missing
 - `bash scripts/ci/generate_dashboard_artifacts.sh` for the dashboard/manifest artifact path used in CI
 
 Docs-only changes keep CI on the lightweight path: hygiene here, plus the separate Docs workflow.

--- a/scripts/ci/optional_diff_runner.py
+++ b/scripts/ci/optional_diff_runner.py
@@ -144,7 +144,7 @@ def make_step(config: DiffRunnerConfig, context: DiffContext) -> DiffStep:
     report_json = context.output_dir / f"{config.slug}.json"
     details_csv = context.output_dir / f"{config.slug}.csv"
     summary_json = context.output_dir / f"{config.slug}_summary.json"
-    outputs = [report_json, details_csv, summary_json]
+    outputs = [report_json, details_csv]
 
     missing = [
         (label, path)
@@ -288,8 +288,17 @@ def run_step(config: DiffRunnerConfig, step: DiffStep, repo_root: Path, log_dir:
     if metrics:
         record["metrics"] = metrics
     if completed.returncode == 0:
-        record["status"] = "passed"
-        print(f"Passed {step.name} in {elapsed:.2f}s")
+        missing_outputs = [output for output in step.outputs if not Path(output).exists()]
+        record["missing_outputs"] = missing_outputs
+        if missing_outputs:
+            record["status"] = "failed"
+            print(
+                f"Failed {step.name} in {elapsed:.2f}s; "
+                f"missing expected outputs: {', '.join(missing_outputs)}"
+            )
+        else:
+            record["status"] = "passed"
+            print(f"Passed {step.name} in {elapsed:.2f}s")
     else:
         record["status"] = "failed"
         lines = combined_log.splitlines()
@@ -311,6 +320,9 @@ def render_result_detail(result: dict[str, object]) -> str:
     if status == "skipped":
         return str(result.get("skip_reason", ""))
     if status == "failed":
+        missing_outputs = result.get("missing_outputs")
+        if isinstance(missing_outputs, list) and missing_outputs:
+            return "missing " + ", ".join(f"`{output}`" for output in missing_outputs)
         log_path = result.get("log_path")
         return f"see `{log_path}`" if log_path else "failed"
 

--- a/tests/test_optional_madoca_residual_component_diff.py
+++ b/tests/test_optional_madoca_residual_component_diff.py
@@ -137,6 +137,27 @@ class OptionalMadocaResidualComponentDiffTest(unittest.TestCase):
             self.assertEqual(metrics["components_compared"], 1)
             self.assertAlmostEqual(metrics["max_abs_delta"], 0.05)
 
+    def test_run_step_fails_when_declared_outputs_are_missing(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_residual_missing_") as temp_dir:
+            root = Path(temp_dir)
+            output_dir = root / "output"
+            log_dir = output_dir / "logs"
+            log_dir.mkdir(parents=True)
+            missing_json = output_dir / "madoca_residual_component_diff.json"
+            step = runner.DiffStep(
+                name="MADOCA residual-component diff",
+                slug="madoca_residual_component_diff",
+                command=[sys.executable, "-c", "print('no artifacts')"],
+                outputs=[str(missing_json)],
+                summary_json=str(output_dir / "madoca_residual_component_diff_summary.json"),
+            )
+
+            result = runner.run_step(step, ROOT_DIR, log_dir)
+
+            self.assertEqual(result["status"], "failed")
+            self.assertEqual(result["returncode"], 0)
+            self.assertEqual(result["missing_outputs"], [str(missing_json)])
+
     def test_render_markdown_summary_reports_status_table_and_metrics(self) -> None:
         markdown = runner.render_markdown_summary(
             [
@@ -163,12 +184,18 @@ class OptionalMadocaResidualComponentDiffTest(unittest.TestCase):
                     "status": "failed",
                     "log_path": "/tmp/madoca.log",
                 },
+                {
+                    "name": "MADOCA residual-component diff",
+                    "status": "failed",
+                    "missing_outputs": ["/tmp/missing.json"],
+                    "log_path": "/tmp/ignored.log",
+                },
             ]
         )
 
         self.assertIn("## Optional MADOCA Residual-Component Diff", markdown)
         self.assertIn("`passed`: `1`", markdown)
-        self.assertIn("`failed`: `1`", markdown)
+        self.assertIn("`failed`: `2`", markdown)
         self.assertIn("`skipped`: `1`", markdown)
         self.assertIn("common rows `12`", markdown)
         self.assertIn("unmatched `1/2`", markdown)
@@ -176,6 +203,7 @@ class OptionalMadocaResidualComponentDiffTest(unittest.TestCase):
         self.assertIn("max |delta| 0.125", markdown)
         self.assertIn("threshold exceedances `3`", markdown)
         self.assertIn("see `/tmp/madoca.log`", markdown)
+        self.assertIn("missing `/tmp/missing.json`", markdown)
 
     def test_write_summary_declares_schema(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_residual_summary_") as temp_dir:


### PR DESCRIPTION
## Summary

- fail optional CLAS/MADOCA diff steps when a command exits successfully but declared JSON/CSV artifacts are missing
- stop declaring an unwritten per-step summary file as a diff output
- surface missing artifacts in the GitHub step-summary table and contributing docs

## Validation

- `python3 -m py_compile scripts/ci/optional_diff_runner.py scripts/ci/run_optional_madoca_residual_component_diff.py scripts/ci/run_optional_clas_zd_component_diff.py tests/test_optional_madoca_residual_component_diff.py tests/test_optional_clas_zd_component_diff.py`
- `python3 tests/test_optional_madoca_residual_component_diff.py -v`
- `python3 tests/test_optional_clas_zd_component_diff.py -v`
- `bash scripts/ci/run_optional_madoca_residual_component_diff.sh --output-dir /tmp/gnsspp-madoca-contract-skip-test`
- `bash scripts/ci/run_optional_clas_zd_component_diff.sh --output-dir /tmp/gnsspp-clas-contract-skip-test`
- `ctest --test-dir build-madoca-parity -R 'python_optional_(madoca_residual_component_diff|clas_zd_component_diff)_tests' --output-on-failure`
- `python3 -m compileall -q scripts/ci tests/test_optional_madoca_residual_component_diff.py tests/test_optional_clas_zd_component_diff.py`
- `git diff --check`
