### PR TITLE
ppp: expose exact observation code artifacts

### DIFF
--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -193,10 +193,13 @@ Optional filters are `GNSSPP_CLAS_ZD_COMPONENTS`, `GNSSPP_CLAS_ZD_STAGE`,
 `GNSSPP_CLAS_ZD_ROW_TYPE`, `GNSSPP_CLAS_ZD_THRESHOLD_M`, and
 `GNSSPP_CLAS_ZD_FAIL_ON_DIFF`.
 
-Native RINEX observations now expose exact `pseudorange_rinex_code` and
-`carrier_rinex_code` columns in the CLAS code/phase diagnostic dumps.  This lets
-the GPS L2W investigation distinguish `C2W/L2W` from other GPS L2 tracking codes
-even though both still use the current `SignalType::GPS_L2C` runtime family.
+Native RINEX observations now expose exact `pseudorange_rinex_code`,
+`carrier_rinex_code`, RTKLIB code id, and `signal_family` columns in the CLAS
+code/phase diagnostic dumps.  This lets the GPS L2W investigation distinguish
+`C2W/L2W` from other GPS L2 tracking codes even though both still use the
+current `SignalType::GPS_L2C` runtime family.  The CLAS ZD component diff keys
+rows by the exact row-specific RINEX code so alias mismatches show up as row-set
+differences before component deltas are computed.
 When both `GNSS_PPP_CLAS_DD_FILTER=1` and
 `GNSS_PPP_CLAS_CODE_ROW_PARITY=bias` are set, the CLAS OSR materializer uses
 that exact GPS L2 RINEX identity to choose the code/phase SSR bias signal id.

--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -344,6 +344,14 @@ private:
         SignalType secondary_signal = SignalType::SIGNAL_TYPE_COUNT;
         std::string primary_observation_type;
         std::string secondary_observation_type;
+        std::string primary_pseudorange_observation_type;
+        std::string primary_carrier_phase_observation_type;
+        std::string secondary_pseudorange_observation_type;
+        std::string secondary_carrier_phase_observation_type;
+        int primary_pseudorange_rtklib_code = 0;
+        int primary_carrier_phase_rtklib_code = 0;
+        int secondary_pseudorange_rtklib_code = 0;
+        int secondary_carrier_phase_rtklib_code = 0;
         double primary_code_bias_coeff = 1.0;
         double secondary_code_bias_coeff = 0.0;
         double primary_frequency_hz = 0.0;
@@ -604,6 +612,9 @@ private:
         std::vector<double> row_azimuths;          ///< Azimuth angle in radians
         std::vector<SignalType> row_signals;       ///< Signal identity for each row
         std::vector<std::string> row_signal_bands; ///< IF/L1/L2 label for each row
+        std::vector<std::string> row_rinex_codes;
+        std::vector<int> row_rtklib_codes;
+        std::vector<std::string> row_signal_families;
         std::vector<int> row_glonass_frequency_channels;
         std::vector<double> row_primary_frequencies_hz;
         std::vector<double> row_secondary_frequencies_hz;

--- a/scripts/analysis/clas_zd_component_diff.py
+++ b/scripts/analysis/clas_zd_component_diff.py
@@ -44,7 +44,7 @@ COMPONENT_ALIASES: dict[str, tuple[str, ...]] = {
 
 Row = dict[str, str]
 ComponentMap = dict[str, float]
-Key = tuple[int, int, str, str, int]
+Key = tuple[int, int, str, str, int, str]
 
 
 @dataclass(frozen=True)
@@ -185,7 +185,8 @@ def normalize_rows(
         tow_millis = tow_to_millis(row["tow"])
         sat = row["sat"]
         freq = detect_frequency(row)
-        key = (week, tow_millis, row_type, sat, freq)
+        signal = observation_identity(row, row_type)
+        key = (week, tow_millis, row_type, sat, freq, signal)
         normalized.append(
             ComponentRow(
                 key=key,
@@ -195,7 +196,7 @@ def normalize_rows(
                 tow=tow_millis / 1000.0,
                 sat=sat,
                 freq=freq,
-                signal=observation_identity(row, row_type),
+                signal=signal,
                 source_row=index,
                 components=components,
             )
@@ -214,13 +215,14 @@ def rows_by_key(rows: Sequence[ComponentRow]) -> tuple[dict[Key, ComponentRow], 
 
 
 def key_to_dict(key: Key) -> dict[str, Any]:
-    week, tow_millis, row_type, sat, freq = key
+    week, tow_millis, row_type, sat, freq, signal = key
     return {
         "week": week,
         "tow": tow_millis / 1000.0,
         "row_type": row_type,
         "sat": sat,
         "freq": freq,
+        "rinex_code": signal,
     }
 
 
@@ -312,6 +314,7 @@ def build_report(
             item["row_type"],
             item["sat"],
             item["freq"],
+            item["rinex_code"],
             item["component"],
         )
     )
@@ -355,6 +358,7 @@ def write_details_csv(path: Path, report: dict[str, Any]) -> None:
         "row_type",
         "sat",
         "freq",
+        "rinex_code",
         "component",
         "base_value_m",
         "candidate_value_m",

--- a/scripts/analysis/madoca_residual_component_diff.py
+++ b/scripts/analysis/madoca_residual_component_diff.py
@@ -123,7 +123,7 @@ def group_from_row(row: Row) -> Group:
 def identity_from_row(row: Row) -> Identity:
     return (
         row.get("sat", ""),
-        first_present(row, ("primary_signal", "signal", "band"), ""),
+        first_present(row, ("primary_signal", "signal_family", "signal", "band"), ""),
         first_present(row, ("secondary_signal",), ""),
         first_present(
             row,
@@ -133,6 +133,7 @@ def identity_from_row(row: Row) -> Identity:
                 "pseudorange_rinex_code",
                 "obs_code",
                 "rinex_code",
+                "rtklib_code",
                 "code",
             ),
         ),
@@ -142,6 +143,7 @@ def identity_from_row(row: Row) -> Identity:
                 "secondary_observation_code",
                 "secondary_rinex_code",
                 "carrier_rinex_code",
+                "secondary_rtklib_code",
             ),
         ),
         to_int(first_present(row, ("frequency_index", "freq", "frequency", "f"), "0")),

--- a/src/algorithms/ppp_clas.cpp
+++ b/src/algorithms/ppp_clas.cpp
@@ -1,9 +1,12 @@
 #include <libgnss++/algorithms/ppp_clas.hpp>
 
 #include <libgnss++/algorithms/ppp_ar.hpp>
+#include <libgnss++/algorithms/ppp_bias_identity.hpp>
 #include <libgnss++/algorithms/ppp_env_overrides.hpp>
 #include <libgnss++/core/constants.hpp>
 #include <libgnss++/core/coordinates.hpp>
+
+#include "ppp_internal.hpp"
 
 #include <algorithm>
 #include <array>
@@ -142,6 +145,7 @@ std::ofstream* ambDatumDumpStream() {
         stream.open(path, std::ios::out | std::ios::trunc);
         if (stream) {
             stream << "record,week,tow,sat,freq,signal,carrier_rinex_code,"
+                   << "carrier_rtklib_code,signal_family,"
                    << "phase_bias_signal_id,lambda_m,"
                    << "raw_phase_cycles,raw_phase_m,carrier_correction_m,"
                    << "cpc_m,cpc_minus_trop_m,trop_correction_m,relativity_m,"
@@ -192,6 +196,7 @@ std::ofstream* clasCodeDumpStream() {
         if (stream) {
             stream << "record,stage,week,tow,sat,freq,signal,"
                    << "pseudorange_rinex_code,carrier_rinex_code,"
+                   << "pseudorange_rtklib_code,carrier_rtklib_code,signal_family,"
                    << "code_bias_signal_id,phase_bias_signal_id,"
                    << "raw_p_m,corrected_p_m,applied_pr_corr_m,prc_m,"
                    << "prc_minus_trop_m,trop_correction_m,iono_l1_m,"
@@ -321,6 +326,11 @@ void dumpClasCodeRows(
                   << static_cast<int>(raw->signal) << ','
                   << raw->pseudorange_observation_type << ','
                   << raw->carrier_phase_observation_type << ','
+                  << algorithms::ppp_bias_identity::rtklibCodeForObservationType(
+                         raw->pseudorange_observation_type) << ','
+                  << algorithms::ppp_bias_identity::rtklibCodeForObservationType(
+                         raw->carrier_phase_observation_type) << ','
+                  << ppp_internal::signalFamilyName(raw->signal) << ','
                   << static_cast<int>(osr.code_bias_signal_ids[f]) << ','
                   << static_cast<int>(osr.phase_bias_signal_ids[f]) << ','
                   << raw->pseudorange << ','
@@ -990,6 +1000,9 @@ MeasurementBuildResult buildEpochMeasurements(
                           << f << ','
                           << static_cast<int>(raw->signal) << ','
                           << raw->carrier_phase_observation_type << ','
+                          << algorithms::ppp_bias_identity::rtklibCodeForObservationType(
+                                 raw->carrier_phase_observation_type) << ','
+                          << ppp_internal::signalFamilyName(raw->signal) << ','
                           << static_cast<int>(osr.phase_bias_signal_ids[f]) << ','
                           << osr.wavelengths[f] << ','
                           << raw->carrier_phase << ','

--- a/src/algorithms/ppp_internal.hpp
+++ b/src/algorithms/ppp_internal.hpp
@@ -35,6 +35,34 @@ inline bool pppDebugEnabled() {
     return ppp_shared::pppDebugEnabled();
 }
 
+inline const char* signalFamilyName(SignalType signal) {
+    switch (signal) {
+        case SignalType::GPS_L1CA: return "GPS_L1CA";
+        case SignalType::GPS_L1P: return "GPS_L1P";
+        case SignalType::GPS_L2P: return "GPS_L2P";
+        case SignalType::GPS_L2C: return "GPS_L2C";
+        case SignalType::GPS_L5: return "GPS_L5";
+        case SignalType::GLO_L1CA: return "GLO_L1CA";
+        case SignalType::GLO_L1P: return "GLO_L1P";
+        case SignalType::GLO_L2CA: return "GLO_L2CA";
+        case SignalType::GLO_L2P: return "GLO_L2P";
+        case SignalType::GAL_E1: return "GAL_E1";
+        case SignalType::GAL_E5A: return "GAL_E5A";
+        case SignalType::GAL_E5B: return "GAL_E5B";
+        case SignalType::GAL_E6: return "GAL_E6";
+        case SignalType::BDS_B1I: return "BDS_B1I";
+        case SignalType::BDS_B2I: return "BDS_B2I";
+        case SignalType::BDS_B3I: return "BDS_B3I";
+        case SignalType::BDS_B1C: return "BDS_B1C";
+        case SignalType::BDS_B2A: return "BDS_B2A";
+        case SignalType::QZS_L1CA: return "QZS_L1CA";
+        case SignalType::QZS_L2C: return "QZS_L2C";
+        case SignalType::QZS_L5: return "QZS_L5";
+        case SignalType::SIGNAL_TYPE_COUNT: return "UNKNOWN";
+    }
+    return "UNKNOWN";
+}
+
 inline std::vector<SignalType> primarySignals(GNSSSystem system) {
     switch (system) {
         case GNSSSystem::GPS: return {SignalType::GPS_L1CA};

--- a/src/algorithms/ppp_measurement.cpp
+++ b/src/algorithms/ppp_measurement.cpp
@@ -33,6 +33,9 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
     std::vector<double> row_azimuths;
     std::vector<SignalType> row_signals;
     std::vector<std::string> row_signal_bands;
+    std::vector<std::string> row_rinex_codes;
+    std::vector<int> row_rtklib_codes;
+    std::vector<std::string> row_signal_families;
     std::vector<int> row_glonass_frequency_channels;
     std::vector<double> row_primary_frequencies_hz;
     std::vector<double> row_secondary_frequencies_hz;
@@ -45,10 +48,29 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
     std::vector<int> row_ssr_orbit_iodes;
     const bool capture_shadow_metadata =
         !env_overrides_.madoca_postfit_shadow_path.empty();
-    const auto appendShadowMetadata = [&](const IonosphereFreeObs& observation) {
+    const auto appendShadowMetadata = [&](const IonosphereFreeObs& observation,
+                                          bool secondary,
+                                          bool phase) {
         if (!capture_shadow_metadata) {
             return;
         }
+        const std::string& rinex_code =
+            secondary
+                ? (phase ? observation.secondary_carrier_phase_observation_type
+                         : observation.secondary_pseudorange_observation_type)
+                : (phase ? observation.primary_carrier_phase_observation_type
+                         : observation.primary_pseudorange_observation_type);
+        const int rtklib_code =
+            secondary
+                ? (phase ? observation.secondary_carrier_phase_rtklib_code
+                         : observation.secondary_pseudorange_rtklib_code)
+                : (phase ? observation.primary_carrier_phase_rtklib_code
+                         : observation.primary_pseudorange_rtklib_code);
+        const SignalType signal =
+            secondary ? observation.secondary_signal : observation.primary_signal;
+        row_rinex_codes.push_back(rinex_code);
+        row_rtklib_codes.push_back(rtklib_code);
+        row_signal_families.push_back(signalFamilyName(signal));
         row_azimuths.push_back(observation.azimuth);
         row_glonass_frequency_channels.push_back(observation.glonass_frequency_channel);
         row_primary_frequencies_hz.push_back(observation.primary_frequency_hz);
@@ -217,7 +239,7 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
         row_elevations.push_back(observation.elevation);
         row_signals.push_back(observation.primary_signal);
         row_signal_bands.push_back(ppp_config_.use_ionosphere_free ? "IF" : "L1");
-        appendShadowMetadata(observation);
+        appendShadowMetadata(observation, false, false);
 
         const bool qzss_code_only =
             env_overrides_.qzss_code_only ||
@@ -303,7 +325,7 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
                     row_elevations.push_back(observation.elevation);
                     row_signals.push_back(observation.primary_signal);
                     row_signal_bands.push_back(ppp_config_.use_ionosphere_free ? "IF" : "L1");
-                    appendShadowMetadata(observation);
+                    appendShadowMetadata(observation, false, true);
                 }
             }
         }
@@ -358,7 +380,7 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
                     row_elevations.push_back(observation.elevation);
                     row_signals.push_back(observation.secondary_signal);
                     row_signal_bands.push_back("L2");
-                    appendShadowMetadata(observation);
+                    appendShadowMetadata(observation, true, false);
                 }
             }
 
@@ -407,7 +429,7 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
                     row_elevations.push_back(observation.elevation);
                     row_signals.push_back(observation.secondary_signal);
                     row_signal_bands.push_back("L2");
-                    appendShadowMetadata(observation);
+                    appendShadowMetadata(observation, true, true);
                 }
             }
         }
@@ -435,6 +457,9 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
     equation.row_azimuths = row_azimuths;
     equation.row_signals = row_signals;
     equation.row_signal_bands = row_signal_bands;
+    equation.row_rinex_codes = row_rinex_codes;
+    equation.row_rtklib_codes = row_rtklib_codes;
+    equation.row_signal_families = row_signal_families;
     equation.row_glonass_frequency_channels = row_glonass_frequency_channels;
     equation.row_primary_frequencies_hz = row_primary_frequencies_hz;
     equation.row_secondary_frequencies_hz = row_secondary_frequencies_hz;

--- a/src/algorithms/ppp_observations.cpp
+++ b/src/algorithms/ppp_observations.cpp
@@ -1,5 +1,6 @@
 #include "ppp_internal.hpp"
 
+#include <libgnss++/algorithms/ppp_bias_identity.hpp>
 #include <libgnss++/algorithms/ppp_utils.hpp>
 #include <libgnss++/core/signal_policy.hpp>
 #include <libgnss++/core/signals.hpp>
@@ -30,6 +31,34 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
     combined.reserve(obs.getSatellites().size());
     const bool capture_shadow_metadata =
         !env_overrides_.madoca_postfit_shadow_path.empty();
+    const auto captureObservationIdentity =
+        [](IonosphereFreeObs& entry, const Observation& observation, bool primary) {
+            const int pseudorange_code =
+                algorithms::ppp_bias_identity::rtklibCodeForObservationType(
+                    observation.pseudorange_observation_type);
+            const int carrier_phase_code =
+                algorithms::ppp_bias_identity::rtklibCodeForObservationType(
+                    observation.carrier_phase_observation_type);
+            if (primary) {
+                entry.primary_signal = observation.signal;
+                entry.primary_observation_type = observation.exactBiasObservationType();
+                entry.primary_pseudorange_observation_type =
+                    observation.pseudorange_observation_type;
+                entry.primary_carrier_phase_observation_type =
+                    observation.carrier_phase_observation_type;
+                entry.primary_pseudorange_rtklib_code = pseudorange_code;
+                entry.primary_carrier_phase_rtklib_code = carrier_phase_code;
+            } else {
+                entry.secondary_signal = observation.signal;
+                entry.secondary_observation_type = observation.exactBiasObservationType();
+                entry.secondary_pseudorange_observation_type =
+                    observation.pseudorange_observation_type;
+                entry.secondary_carrier_phase_observation_type =
+                    observation.carrier_phase_observation_type;
+                entry.secondary_pseudorange_rtklib_code = pseudorange_code;
+                entry.secondary_carrier_phase_rtklib_code = carrier_phase_code;
+            }
+        };
 
     for (const auto& sat : obs.getSatellites()) {
         // Keep the native MADOCA parity path on systems whose L6 SSR handling is
@@ -84,8 +113,7 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
         if (!ppp_config_.use_ionosphere_free) {
             const double primary_frequency_hz = signalFrequencyHz(primary->signal, eph);
             entry.pseudorange_if = primary->pseudorange;
-            entry.primary_signal = primary->signal;
-            entry.primary_observation_type = primary->exactBiasObservationType();
+            captureObservationIdentity(entry, *primary, true);
             entry.primary_code_bias_coeff = 1.0;
             entry.secondary_code_bias_coeff = 0.0;
             if (capture_shadow_metadata) {
@@ -127,8 +155,7 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
         // SSR corrections (orbit/clock/bias/iono) still applied below.
         if (!ppp_config_.use_ionosphere_free) {
             if (secondary != nullptr) {
-                entry.secondary_signal = secondary->signal;
-                entry.secondary_observation_type = secondary->exactBiasObservationType();
+                captureObservationIdentity(entry, *secondary, false);
                 const double f1 = signalFrequencyHz(primary->signal, eph);
                 const double f2 = signalFrequencyHz(secondary->signal, eph);
                 if (capture_shadow_metadata) {
@@ -183,8 +210,7 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
 
         if (secondary == nullptr) {
             entry.pseudorange_if = primary->pseudorange;
-            entry.primary_signal = primary->signal;
-            entry.primary_observation_type = primary->exactBiasObservationType();
+            captureObservationIdentity(entry, *primary, true);
             entry.primary_code_bias_coeff = 1.0;
             entry.secondary_code_bias_coeff = 0.0;
             if (capture_shadow_metadata) {
@@ -216,10 +242,8 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
         const auto coefficients = ppp_utils::getIonosphereFreeCoefficients(f1, f2);
         entry.pseudorange_if =
             coefficients.first * primary->pseudorange + coefficients.second * secondary->pseudorange;
-        entry.primary_signal = primary->signal;
-        entry.secondary_signal = secondary->signal;
-        entry.primary_observation_type = primary->exactBiasObservationType();
-        entry.secondary_observation_type = secondary->exactBiasObservationType();
+        captureObservationIdentity(entry, *primary, true);
+        captureObservationIdentity(entry, *secondary, false);
         entry.primary_code_bias_coeff = coefficients.first;
         entry.secondary_code_bias_coeff = coefficients.second;
         if (capture_shadow_metadata) {

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -154,7 +154,7 @@ void writeMadocaPostfitShadow(const std::string& path,
     };
 
     writeCommonPrefix("epoch", -1);
-    constexpr int kRowSpecificShadowColumns = 21;
+    constexpr int kRowSpecificShadowColumns = 24;
     for (int column = 1; column < kRowSpecificShadowColumns; ++column) {
         out << ',';
     }
@@ -169,6 +169,10 @@ void writeMadocaPostfitShadow(const std::string& path,
                            size_t row_index,
                            int fallback) {
         return row_index < values.size() ? values[row_index] : fallback;
+    };
+    const auto rowString = [](const std::vector<std::string>& values,
+                              size_t row_index) -> std::string {
+        return row_index < values.size() ? values[row_index] : std::string();
     };
 
     for (int row = 0; row < postfit_eq.residuals.size(); ++row) {
@@ -211,6 +215,9 @@ void writeMadocaPostfitShadow(const std::string& path,
             << gnssSystemName(sat.system) << ','
             << static_cast<int>(signal) << ','
             << signal_band << ','
+            << rowString(postfit_eq.row_signal_families, row_index) << ','
+            << rowString(postfit_eq.row_rinex_codes, row_index) << ','
+            << rowInt(postfit_eq.row_rtklib_codes, row_index, 0) << ','
             << (is_phase ? "phase" : "code") << ','
             << residual_m << ','
             << variance_m2 << ','

--- a/tests/test_clas_zd_component_diff.py
+++ b/tests/test_clas_zd_component_diff.py
@@ -33,6 +33,9 @@ FIELDNAMES = [
     "signal",
     "pseudorange_rinex_code",
     "carrier_rinex_code",
+    "pseudorange_rtklib_code",
+    "carrier_rtklib_code",
+    "signal_family",
     "prc_m",
     "PRC",
     "cpc_m",
@@ -64,6 +67,9 @@ def code_row(
     signal: str = "",
     pseudorange_rinex_code: str = "",
     carrier_rinex_code: str = "",
+    pseudorange_rtklib_code: str = "",
+    carrier_rtklib_code: str = "",
+    signal_family: str = "",
 ) -> dict[str, str]:
     return {
         "record": record,
@@ -75,6 +81,9 @@ def code_row(
         "signal": signal,
         "pseudorange_rinex_code": pseudorange_rinex_code,
         "carrier_rinex_code": carrier_rinex_code,
+        "pseudorange_rtklib_code": pseudorange_rtklib_code,
+        "carrier_rtklib_code": carrier_rtklib_code,
+        "signal_family": signal_family,
         "prc_m": prc,
         "PRC": "",
         "cpc_m": "",
@@ -114,9 +123,64 @@ class ClasZdComponentDiffTest(unittest.TestCase):
             "L2W",
         )
 
+    def test_exact_observation_code_is_part_of_row_key(self) -> None:
+        base = component_diff.normalize_rows(
+            [
+                code_row(
+                    sat="G14",
+                    freq="1",
+                    prc="0.50",
+                    code_bias="0.10",
+                    receiver_ant="-0.02",
+                    pseudorange_rinex_code="C2W",
+                )
+            ],
+            component_names=["prc_m"],
+            stage_filter=None,
+            row_type_filter="code",
+        )
+        candidate = component_diff.normalize_rows(
+            [
+                code_row(
+                    sat="G14",
+                    freq="1",
+                    prc="0.50",
+                    code_bias="0.10",
+                    receiver_ant="-0.02",
+                    pseudorange_rinex_code="C2X",
+                )
+            ],
+            component_names=["prc_m"],
+            stage_filter=None,
+            row_type_filter="code",
+        )
+
+        report = component_diff.build_report(
+            base,
+            candidate,
+            base_label="claslib",
+            candidate_label="native",
+            threshold_m=None,
+            top_deltas=10,
+            top_unmatched=10,
+        )
+
+        self.assertEqual(report["common_rows"], 0)
+        self.assertEqual(report["base_only_rows"], 1)
+        self.assertEqual(report["candidate_only_rows"], 1)
+        self.assertEqual(report["top_base_only"][0]["rinex_code"], "C2W")
+        self.assertEqual(report["top_candidate_only"][0]["rinex_code"], "C2X")
+
     def test_compares_common_component_rows_and_reports_unmatched(self) -> None:
         base_rows = [
-            code_row(sat="G14", freq="1", prc="0.50", code_bias="0.10", receiver_ant="-0.02"),
+            code_row(
+                sat="G14",
+                freq="1",
+                prc="0.50",
+                code_bias="0.10",
+                receiver_ant="-0.02",
+                pseudorange_rinex_code="C2W",
+            ),
             code_row(sat="J01", freq="0", prc="3.75", code_bias="0.00", receiver_ant="-0.05"),
         ]
         candidate_rows = [
@@ -185,7 +249,16 @@ class ClasZdComponentDiffTest(unittest.TestCase):
             details_path = root / "details.csv"
             write_csv(
                 base_csv,
-                [code_row(sat="G14", freq="1", prc="0.50", code_bias="0.10", receiver_ant="-0.02")],
+                [
+                    code_row(
+                        sat="G14",
+                        freq="1",
+                        prc="0.50",
+                        code_bias="0.10",
+                        receiver_ant="-0.02",
+                        pseudorange_rinex_code="C2W",
+                    )
+                ],
             )
             write_csv(
                 candidate_csv,
@@ -241,6 +314,7 @@ class ClasZdComponentDiffTest(unittest.TestCase):
                 rows = list(csv.DictReader(details_file))
             self.assertEqual(rows[0]["component"], "prc_m")
             self.assertEqual(rows[0]["sat"], "G14")
+            self.assertEqual(rows[0]["rinex_code"], "C2W")
             self.assertEqual(rows[0]["candidate_signal"], "C2W")
             self.assertEqual(float(rows[0]["delta_m"]), 0.25)
 


### PR DESCRIPTION
## Summary
- carry selected PPP code/phase RINEX observation identities plus RTKLIB code ids into row-level diagnostic metadata
- add RTKLIB code id and signal family columns to CLAS code/phase diagnostic dumps
- key CLAS ZD component diffs by exact row-specific RINEX code so C2W/C2X-style alias mismatches surface as row-set differences

## Validation
- `cmake --build build-madoca-parity --target run_tests -j2`
- `./build-madoca-parity/tests/run_tests`
- `ctest --test-dir build-madoca-parity -R '(ppp|rinex|signal|observation|clas_zd_component_diff|madoca_residual_component_diff)' --output-on-failure`
- `python3 tests/test_clas_zd_component_diff.py -v`
- `python3 tests/test_madoca_residual_component_diff.py -v`
- `python3 tests/test_optional_clas_zd_component_diff.py -v`
- `python3 tests/test_optional_madoca_residual_component_diff.py -v`
- `python3 -m compileall -q scripts/analysis tests/test_clas_zd_component_diff.py tests/test_madoca_residual_component_diff.py tests/test_optional_clas_zd_component_diff.py tests/test_optional_madoca_residual_component_diff.py`
- `git diff --check`
