### PR TITLE
[codex] clas: use exact osr observation lookup

### DIFF
--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -203,6 +203,9 @@ differences before component deltas are computed.
 When both `GNSS_PPP_CLAS_DD_FILTER=1` and
 `GNSS_PPP_CLAS_CODE_ROW_PARITY=bias` are set, the CLAS OSR materializer uses
 that exact GPS L2 RINEX identity to choose the code/phase SSR bias signal id.
+The same stored identity now drives CLAS float/DD/SD/WLNL raw observation lookup,
+so a `C2W/L2W` OSR row consumes the matching `C2W/L2W` measurement instead of the
+first collapsed GPS L2 family row.
 Gate-off behavior still uses the existing `SignalType` family id path, and the
 diagnostic dumps include the selected `code_bias_signal_id` /
 `phase_bias_signal_id` for oracle comparison.  They also expose the bias lookup

--- a/include/libgnss++/algorithms/ppp_bias_identity.hpp
+++ b/include/libgnss++/algorithms/ppp_bias_identity.hpp
@@ -62,6 +62,24 @@ inline int rtklibCodeForObservationType(std::string_view observation_type) {
     return madoca_parity::kCodeNone;
 }
 
+inline bool isGpsL2wObservationType(std::string_view observation_type) {
+    return rtklibCodeForObservationType(observation_type) == madoca_parity::kCodeL2W;
+}
+
+inline bool isGpsL2wObservation(GNSSSystem system,
+                                SignalType signal,
+                                std::string_view pseudorange_observation_type,
+                                std::string_view carrier_phase_observation_type) {
+    if (system != GNSSSystem::GPS) {
+        return false;
+    }
+    if (signal != SignalType::GPS_L2C && signal != SignalType::GPS_L2P) {
+        return false;
+    }
+    return isGpsL2wObservationType(pseudorange_observation_type) ||
+           isGpsL2wObservationType(carrier_phase_observation_type);
+}
+
 inline std::uint8_t madocaBiasIdentityIdForObservation(GNSSSystem system,
                                                        SignalType signal,
                                                        std::string_view observation_type,

--- a/include/libgnss++/algorithms/ppp_osr.hpp
+++ b/include/libgnss++/algorithms/ppp_osr.hpp
@@ -69,6 +69,11 @@ std::map<std::string, std::string> selectClasEpochAtmosTokens(
     const Vector3d& receiver_position,
     const ppp_shared::PPPConfig& config);
 
+const Observation* findOsrFrequencyObservation(
+    const ObservationData& obs,
+    const OSRCorrection& osr,
+    int freq_index);
+
 CLASEpochContext prepareClasEpochContext(
     const ObservationData& obs,
     const NavigationData& nav,

--- a/src/algorithms/ppp_clas.cpp
+++ b/src/algorithms/ppp_clas.cpp
@@ -3,6 +3,7 @@
 #include <libgnss++/algorithms/ppp_ar.hpp>
 #include <libgnss++/algorithms/ppp_bias_identity.hpp>
 #include <libgnss++/algorithms/ppp_env_overrides.hpp>
+#include <libgnss++/algorithms/ppp_osr.hpp>
 #include <libgnss++/core/constants.hpp>
 #include <libgnss++/core/coordinates.hpp>
 
@@ -300,7 +301,7 @@ void dumpClasCodeRows(
             have_iono_state ? filter_state.state(iono_state_it->second) : 0.0;
 
         for (int f = 0; f < osr.num_frequencies; ++f) {
-            const Observation* raw = obs.getObservation(osr.satellite, osr.signals[f]);
+            const Observation* raw = findOsrFrequencyObservation(obs, osr, f);
             if (raw == nullptr || !raw->valid || !raw->has_pseudorange ||
                 !std::isfinite(raw->pseudorange)) {
                 continue;
@@ -814,7 +815,7 @@ MeasurementBuildResult buildEpochMeasurements(
             iono_state_index < filter_state.total_states;
         for (int f = 0; f < osr.num_frequencies; ++f) {
             raw_observations[static_cast<size_t>(f)] =
-                obs.getObservation(osr.satellite, osr.signals[f]);
+                findOsrFrequencyObservation(obs, osr, f);
         }
 
         for (int f = 0; f < osr.num_frequencies; ++f) {
@@ -1360,7 +1361,7 @@ FixValidationStats validateFixedSolution(
         std::array<const Observation*, OSR_MAX_FREQ> raw_observations{};
         for (int f = 0; f < osr.num_frequencies; ++f) {
             raw_observations[static_cast<size_t>(f)] =
-                obs.getObservation(osr.satellite, osr.signals[f]);
+                findOsrFrequencyObservation(obs, osr, f);
         }
 
         for (int f = 0; f < osr.num_frequencies; ++f) {

--- a/src/algorithms/ppp_clas_dd.cpp
+++ b/src/algorithms/ppp_clas_dd.cpp
@@ -12,6 +12,7 @@
 #include <utility>
 
 #include <libgnss++/algorithms/lambda.hpp>
+#include <libgnss++/algorithms/ppp_osr.hpp>
 #include <libgnss++/core/constants.hpp>
 #include <libgnss++/core/coordinates.hpp>
 
@@ -600,7 +601,7 @@ DdMeasurementBuildResult buildDdMeasurementSystem(
             if (group < 0) {
                 continue;
             }
-            const Observation* raw = obs.getObservation(osr.satellite, osr.signals[f]);
+            const Observation* raw = findOsrFrequencyObservation(obs, osr, f);
             if (raw == nullptr || !raw->valid) {
                 continue;
             }
@@ -1036,7 +1037,7 @@ void DdFilterScaffold::updateObservedStateBookkeeping(
             if (frequency_index < 0 || frequency_index >= layout.nf()) {
                 continue;
             }
-            const Observation* raw = obs.getObservation(osr.satellite, osr.signals[f]);
+            const Observation* raw = findOsrFrequencyObservation(obs, osr, f);
             if (raw == nullptr || !raw->valid || !raw->has_carrier_phase ||
                 !raw->has_pseudorange || !std::isfinite(raw->carrier_phase) ||
                 !std::isfinite(raw->pseudorange)) {

--- a/src/algorithms/ppp_clas_epoch.cpp
+++ b/src/algorithms/ppp_clas_epoch.cpp
@@ -387,8 +387,8 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         ppp_config_.ar_method == PPPConfig::ARMethod::DD_WLNL) {
         for (const auto& osr : osr_corrections) {
             if (!osr.valid || osr.num_frequencies < 2) continue;
-            const Observation* l1_raw = obs.getObservation(osr.satellite, osr.signals[0]);
-            const Observation* l2_raw = obs.getObservation(osr.satellite, osr.signals[1]);
+            const Observation* l1_raw = findOsrFrequencyObservation(obs, osr, 0);
+            const Observation* l2_raw = findOsrFrequencyObservation(obs, osr, 1);
             if (!l1_raw || !l2_raw || !l1_raw->valid || !l2_raw->valid) continue;
             if (!l1_raw->has_carrier_phase || !l2_raw->has_carrier_phase) continue;
             if (!l1_raw->has_pseudorange || !l2_raw->has_pseudorange) continue;

--- a/src/algorithms/ppp_clas_sd.cpp
+++ b/src/algorithms/ppp_clas_sd.cpp
@@ -10,6 +10,7 @@
 
 #include <libgnss++/algorithms/ppp_clas_sd.hpp>
 #include <libgnss++/algorithms/lambda.hpp>
+#include <libgnss++/algorithms/ppp_osr.hpp>
 #include <libgnss++/algorithms/ppp_shared.hpp>
 #include <libgnss++/core/constants.hpp>
 #include <libgnss++/core/coordinates.hpp>
@@ -69,7 +70,7 @@ SdEpochResult runClockFreeSdEpoch(
         const double sat_clk_m = constants::SPEED_OF_LIGHT * osr.satellite_clock_bias_s;
 
         for (int f = 0; f < std::min(osr.num_frequencies, 2); ++f) {
-            const Observation* raw = obs.getObservation(osr.satellite, osr.signals[f]);
+            const Observation* raw = findOsrFrequencyObservation(obs, osr, f);
             if (!raw || !raw->valid) continue;
             if (raw->has_pseudorange && std::isfinite(raw->pseudorange)) {
                 so.y_code[f] = raw->pseudorange - geo + sat_clk_m - osr.PRC[f];
@@ -295,7 +296,7 @@ std::map<SatelliteId, SdSatObs> buildSdZdres(
         so.los = (osr.satellite_position - position).normalized();
         const double sat_clk_m = constants::SPEED_OF_LIGHT * osr.satellite_clock_bias_s;
         for (int f = 0; f < std::min(osr.num_frequencies, 2); ++f) {
-            const Observation* raw = obs.getObservation(osr.satellite, osr.signals[f]);
+            const Observation* raw = findOsrFrequencyObservation(obs, osr, f);
             if (!raw || !raw->valid) continue;
             if (raw->has_pseudorange && std::isfinite(raw->pseudorange)) {
                 so.y_code[f] = raw->pseudorange - geo + sat_clk_m - osr.PRC[f];
@@ -541,7 +542,7 @@ SdEpochResult solveSingleEpochSdAr(
         const double sat_clk_m = constants::SPEED_OF_LIGHT * osr.satellite_clock_bias_s;
 
         for (int f = 0; f < std::min(osr.num_frequencies, 2); ++f) {
-            const Observation* raw = obs.getObservation(osr.satellite, osr.signals[f]);
+            const Observation* raw = findOsrFrequencyObservation(obs, osr, f);
             if (!raw || !raw->valid) continue;
             if (raw->has_pseudorange && std::isfinite(raw->pseudorange)) {
                 so.y_code[f] = raw->pseudorange - geo + sat_clk_m - osr.PRC[f];
@@ -636,7 +637,7 @@ SdEpochResult solveSingleEpochSdAr(
         so.los = (so.osr->satellite_position - refined_pos).normalized();
         const double sat_clk_m = constants::SPEED_OF_LIGHT * so.osr->satellite_clock_bias_s;
         for (int f = 0; f < std::min(so.osr->num_frequencies, 2); ++f) {
-            const Observation* raw = obs.getObservation(so.osr->satellite, so.osr->signals[f]);
+            const Observation* raw = findOsrFrequencyObservation(obs, *so.osr, f);
             if (!raw || !raw->valid) continue;
             if (raw->has_pseudorange && std::isfinite(raw->pseudorange))
                 so.y_code[f] = raw->pseudorange - geo + sat_clk_m - so.osr->PRC[f];

--- a/src/algorithms/ppp_osr.cpp
+++ b/src/algorithms/ppp_osr.cpp
@@ -62,6 +62,32 @@ bool gpsL2ExactBiasIdentityEnabled(const Observation* observation) {
            pppEnvOverrides().clas_code_row_bias_identity;
 }
 
+bool clasGpsL2wIdentityGateEnabled() {
+    return pppEnvOverrides().clas_dd_filter &&
+           pppEnvOverrides().clas_code_row_bias_identity;
+}
+
+const Observation* findExactGpsL2wObservation(
+    const ObservationData& obs,
+    const SatelliteId& sat) {
+    for (const auto& candidate : obs.observations) {
+        if (!candidate.valid || candidate.satellite != sat) {
+            continue;
+        }
+        if (!candidate.has_carrier_phase || !candidate.has_pseudorange) {
+            continue;
+        }
+        if (algorithms::ppp_bias_identity::isGpsL2wObservation(
+                candidate.satellite.system,
+                candidate.signal,
+                candidate.pseudorange_observation_type,
+                candidate.carrier_phase_observation_type)) {
+            return &candidate;
+        }
+    }
+    return nullptr;
+}
+
 const char* clasAtmosSelectionPolicyName(
     ppp_shared::PPPConfig::ClasAtmosSelectionPolicy policy) {
     switch (policy) {
@@ -508,6 +534,39 @@ int preferredClasNetworkId(const std::map<std::string, std::string>& atmos_token
     return std::max(network_id, 0);
 }
 
+const Observation* findOsrFrequencyObservation(
+    const ObservationData& obs,
+    const OSRCorrection& osr,
+    int freq_index) {
+    if (freq_index < 0 || freq_index >= osr.num_frequencies ||
+        freq_index >= OSR_MAX_FREQ) {
+        return nullptr;
+    }
+    const SignalType signal = osr.signals[freq_index];
+    const Observation* fallback = obs.getObservation(osr.satellite, signal);
+    if (!osr.bias_exact_identity[freq_index]) {
+        return fallback;
+    }
+
+    const auto& pseudorange_code = osr.pseudorange_rinex_codes[freq_index];
+    const auto& carrier_code = osr.carrier_rinex_codes[freq_index];
+    for (const auto& candidate : obs.observations) {
+        if (candidate.satellite != osr.satellite || candidate.signal != signal) {
+            continue;
+        }
+        const bool pseudorange_matches =
+            pseudorange_code.empty() ||
+            candidate.pseudorange_observation_type == pseudorange_code;
+        const bool carrier_matches =
+            carrier_code.empty() ||
+            candidate.carrier_phase_observation_type == carrier_code;
+        if (pseudorange_matches && carrier_matches) {
+            return &candidate;
+        }
+    }
+    return fallback;
+}
+
 std::map<std::string, std::string> selectClasEpochAtmosTokens(
     const SSRProducts& ssr_products,
     const std::vector<SatelliteId>& satellites,
@@ -675,6 +734,12 @@ std::vector<OSRCorrection> computeOSR(
 
         const Observation* l1_obs = findSignal(l1_cands);
         const Observation* l2_obs = findSignal(l2_cands);
+        if (sat.system == GNSSSystem::GPS && clasGpsL2wIdentityGateEnabled()) {
+            if (const Observation* exact_l2w = findExactGpsL2wObservation(obs, sat);
+                exact_l2w != nullptr) {
+                l2_obs = exact_l2w;
+            }
+        }
         if (!l1_obs) {
             if (pppDebugEnabled() && sat.system == GNSSSystem::QZSS) {
                 std::cerr << "[OSR-QZSS-SKIP] " << sat.toString()

--- a/src/algorithms/ppp_wlnl.cpp
+++ b/src/algorithms/ppp_wlnl.cpp
@@ -470,8 +470,8 @@ bool PPPProcessor::buildWlnlNlInfoForSatellite(
     const auto osr_it = osr_by_sat.find(sat);
     if (osr_it != osr_by_sat.end()) {
         const auto& osr = osr_it->second;
-        l1_obs = obs.getObservation(sat, osr.signals[0]);
-        l2_obs = obs.getObservation(sat, osr.signals[1]);
+        l1_obs = findOsrFrequencyObservation(obs, osr, 0);
+        l2_obs = findOsrFrequencyObservation(obs, osr, 1);
         const double f1 = osr.frequencies[0];
         const double f2 = osr.frequencies[1];
         if (l1_obs == nullptr || l2_obs == nullptr ||
@@ -827,8 +827,8 @@ bool PPPProcessor::buildFixedNlObservationForSatellite(
     const auto osr_it = osr_by_sat.find(satellite);
     if (osr_it != osr_by_sat.end()) {
         const auto& osr = osr_it->second;
-        const Observation* l1 = obs.getObservation(satellite, osr.signals[0]);
-        const Observation* l2 = obs.getObservation(satellite, osr.signals[1]);
+        const Observation* l1 = findOsrFrequencyObservation(obs, osr, 0);
+        const Observation* l2 = findOsrFrequencyObservation(obs, osr, 1);
         const double f1 = osr.frequencies[0];
         const double f2 = osr.frequencies[1];
         if (l1 == nullptr || l2 == nullptr ||

--- a/tests/test_ppp_osr.cpp
+++ b/tests/test_ppp_osr.cpp
@@ -49,6 +49,23 @@ Vector3d receiverPositionNearClasNetwork9() {
     return geodetic2ecef(39.98056 * M_PI / 180.0, 141.22509 * M_PI / 180.0, 0.0);
 }
 
+Observation makeGpsL2Observation(
+    const SatelliteId& satellite,
+    const char* pseudorange_code,
+    const char* carrier_code,
+    double pseudorange,
+    double carrier_phase) {
+    Observation obs(satellite, SignalType::GPS_L2C);
+    obs.valid = true;
+    obs.has_pseudorange = true;
+    obs.has_carrier_phase = true;
+    obs.pseudorange_observation_type = pseudorange_code;
+    obs.carrier_phase_observation_type = carrier_code;
+    obs.pseudorange = pseudorange;
+    obs.carrier_phase = carrier_phase;
+    return obs;
+}
+
 }  // namespace
 
 TEST(PPPOSRTest, GridFirstPrefersNearestGridEvenWhenStale) {
@@ -109,6 +126,53 @@ TEST(PPPOSRTest, ExactObservationIdentitySelectsGpsL2wBiasId) {
         static_cast<int>(bias::rtcmSsrSignalIdForObservation(
             GNSSSystem::GPS, SignalType::GPS_L2C, "C2X", true)),
         8);
+    EXPECT_TRUE(
+        bias::isGpsL2wObservation(
+            GNSSSystem::GPS, SignalType::GPS_L2C, "C2W", "L2W"));
+    EXPECT_FALSE(
+        bias::isGpsL2wObservation(
+            GNSSSystem::GPS, SignalType::GPS_L2C, "C2X", "L2X"));
+}
+
+TEST(PPPOSRTest, ExactOsrFrequencyLookupUsesStoredRinexIdentity) {
+    const SatelliteId sat(GNSSSystem::GPS, 14);
+    ObservationData obs(GNSSTime(2068, 230425.0));
+    obs.addObservation(makeGpsL2Observation(sat, "C2X", "L2X", 100.0, 10.0));
+    obs.addObservation(makeGpsL2Observation(sat, "C2W", "L2W", 200.0, 20.0));
+
+    OSRCorrection osr;
+    osr.satellite = sat;
+    osr.num_frequencies = 1;
+    osr.signals[0] = SignalType::GPS_L2C;
+    osr.pseudorange_rinex_codes[0] = "C2W";
+    osr.carrier_rinex_codes[0] = "L2W";
+    osr.bias_exact_identity[0] = true;
+
+    const Observation* selected = findOsrFrequencyObservation(obs, osr, 0);
+    ASSERT_NE(selected, nullptr);
+    EXPECT_EQ(selected->pseudorange_observation_type, "C2W");
+    EXPECT_EQ(selected->carrier_phase_observation_type, "L2W");
+    EXPECT_DOUBLE_EQ(selected->pseudorange, 200.0);
+}
+
+TEST(PPPOSRTest, OsrFrequencyLookupPreservesSignalTypeFallbackWhenExactGateIsOff) {
+    const SatelliteId sat(GNSSSystem::GPS, 14);
+    ObservationData obs(GNSSTime(2068, 230425.0));
+    obs.addObservation(makeGpsL2Observation(sat, "C2X", "L2X", 100.0, 10.0));
+    obs.addObservation(makeGpsL2Observation(sat, "C2W", "L2W", 200.0, 20.0));
+
+    OSRCorrection osr;
+    osr.satellite = sat;
+    osr.num_frequencies = 1;
+    osr.signals[0] = SignalType::GPS_L2C;
+    osr.pseudorange_rinex_codes[0] = "C2W";
+    osr.carrier_rinex_codes[0] = "L2W";
+
+    const Observation* selected = findOsrFrequencyObservation(obs, osr, 0);
+    ASSERT_NE(selected, nullptr);
+    EXPECT_EQ(selected->pseudorange_observation_type, "C2X");
+    EXPECT_EQ(selected->carrier_phase_observation_type, "L2X");
+    EXPECT_DOUBLE_EQ(selected->pseudorange, 100.0);
 }
 
 TEST(PPPOSRTest, BalancedPrefersFreshNetworkWhenNearestGridIsStale) {


### PR DESCRIPTION
## Summary

- add a shared OSR frequency observation lookup that honors stored exact RINEX identity when OSR bias identity is exact
- route CLAS float/DD/SD/WLNL raw observation access through that helper so GPS C2W/L2W rows consume matching measurements under the existing gated path
- document the A5 GPS L2W identity step and add unit coverage for exact-vs-fallback lookup behavior

## Validation

- `cmake --build build-madoca-parity --target run_tests -j2`
- `./build-madoca-parity/tests/run_tests --gtest_filter='PPPOSRTest.*:PPPClasTest.*:PPPClasDdTest.*'`
- `./build-madoca-parity/tests/run_tests`
- `git diff --check`

## Notes

Gate-off behavior still falls back to the existing `SignalType` family lookup. The exact lookup is driven by `OSRCorrection::bias_exact_identity`, which is only populated by the existing CLAS DD/filter plus code-row bias identity gate.
