### PR TITLE
[codex] clas: guard exact OSR observation lookup

### DIFF
--- a/src/algorithms/ppp_osr.cpp
+++ b/src/algorithms/ppp_osr.cpp
@@ -88,6 +88,14 @@ const Observation* findExactGpsL2wObservation(
     return nullptr;
 }
 
+bool hasUsableCodeAndPhase(const Observation& observation) {
+    return observation.valid &&
+           observation.has_pseudorange &&
+           observation.has_carrier_phase &&
+           std::isfinite(observation.pseudorange) &&
+           std::isfinite(observation.carrier_phase);
+}
+
 const char* clasAtmosSelectionPolicyName(
     ppp_shared::PPPConfig::ClasAtmosSelectionPolicy policy) {
     switch (policy) {
@@ -552,6 +560,9 @@ const Observation* findOsrFrequencyObservation(
     const auto& carrier_code = osr.carrier_rinex_codes[freq_index];
     for (const auto& candidate : obs.observations) {
         if (candidate.satellite != osr.satellite || candidate.signal != signal) {
+            continue;
+        }
+        if (!hasUsableCodeAndPhase(candidate)) {
             continue;
         }
         const bool pseudorange_matches =

--- a/tests/test_ppp_osr.cpp
+++ b/tests/test_ppp_osr.cpp
@@ -155,6 +155,29 @@ TEST(PPPOSRTest, ExactOsrFrequencyLookupUsesStoredRinexIdentity) {
     EXPECT_DOUBLE_EQ(selected->pseudorange, 200.0);
 }
 
+TEST(PPPOSRTest, ExactOsrFrequencyLookupSkipsInvalidStoredRinexIdentity) {
+    const SatelliteId sat(GNSSSystem::GPS, 14);
+    ObservationData obs(GNSSTime(2068, 230425.0));
+    obs.addObservation(makeGpsL2Observation(sat, "C2X", "L2X", 100.0, 10.0));
+    Observation invalid_exact = makeGpsL2Observation(sat, "C2W", "L2W", 200.0, 20.0);
+    invalid_exact.valid = false;
+    obs.addObservation(invalid_exact);
+
+    OSRCorrection osr;
+    osr.satellite = sat;
+    osr.num_frequencies = 1;
+    osr.signals[0] = SignalType::GPS_L2C;
+    osr.pseudorange_rinex_codes[0] = "C2W";
+    osr.carrier_rinex_codes[0] = "L2W";
+    osr.bias_exact_identity[0] = true;
+
+    const Observation* selected = findOsrFrequencyObservation(obs, osr, 0);
+    ASSERT_NE(selected, nullptr);
+    EXPECT_EQ(selected->pseudorange_observation_type, "C2X");
+    EXPECT_EQ(selected->carrier_phase_observation_type, "L2X");
+    EXPECT_DOUBLE_EQ(selected->pseudorange, 100.0);
+}
+
 TEST(PPPOSRTest, OsrFrequencyLookupPreservesSignalTypeFallbackWhenExactGateIsOff) {
     const SatelliteId sat(GNSSSystem::GPS, 14);
     ObservationData obs(GNSSTime(2068, 230425.0));


### PR DESCRIPTION
## Summary

- Require exact OSR observation-code matches to be valid code+phase rows before selecting them.
- Add a PPP OSR unit test covering invalid exact C2W/L2W rows falling back to the existing signal-family selection.

## Why

The exact GPS L2W lookup introduced for CLAS parity scans raw epoch observations directly. Without the same usability guard as OSR materialization, an invalid exact row could be selected and suppress an otherwise usable fallback row in the gated CLAS path.

## Validation

- `cmake --build build-madoca-parity --target run_tests -j2`
- `./build-madoca-parity/tests/run_tests --gtest_filter='PPPOSRTest.*'`
- `./build-madoca-parity/tests/run_tests`
- `git diff --check`