### PR TITLE
[codex] ci: slim ubuntu prepare build deps

### DIFF
--- a/.github/actions/prepare-build/action.yml
+++ b/.github/actions/prepare-build/action.yml
@@ -64,15 +64,14 @@ runs:
           ccache
           python3-dev
           pybind11-dev
-          python3-numpy
-          python3-matplotlib
         )
         if [ "${{ inputs.compiler }}" = "clang" ]; then
           packages+=(clang)
         fi
-        sudo apt-get update
-        sudo apt-get install -y "${packages[@]}"
+        sudo apt-get -o Acquire::Retries=3 update
+        sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends "${packages[@]}"
         python -m pip install --upgrade pip
+        python -m pip install numpy matplotlib
         if [ "${{ inputs.install-docs-deps }}" = "true" ]; then
           python -m pip install --user -r requirements-docs.txt
         fi


### PR DESCRIPTION
## Summary

- Remove apt-installed `python3-numpy` and `python3-matplotlib` from the Ubuntu prepare-build action.
- Install `numpy` and `matplotlib` through the setup-python pip cache instead.
- Add apt retry handling and `--no-install-recommends` for the remaining Ubuntu packages.

## Why

PR #198 exposed a remote CI failure where the Ubuntu gcc job spent the full 60-minute job budget in `Prepare build` before tests started. The logs showed the job timing out during apt package installation, not during compilation or tests. Keeping heavy Python plotting dependencies out of apt reduces that failure surface and lets the existing pip cache handle Python packages.

## Validation

- `python3` YAML parse check for `.github/actions/prepare-build/action.yml`
- `git diff --check`

Remote CI is the validation target for this workflow-only change.