### PR TITLE
[codex] clas: test OSR bias materialization identity

### DIFF
--- a/include/libgnss++/algorithms/ppp_osr.hpp
+++ b/include/libgnss++/algorithms/ppp_osr.hpp
@@ -8,6 +8,7 @@
 #include <libgnss++/algorithms/ppp_atmosphere.hpp>
 #include <map>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace libgnss {
@@ -85,6 +86,30 @@ OsrFrequencyObservationLookup findOsrFrequencyObservationWithProvenance(
     const ObservationData& obs,
     const OSRCorrection& osr,
     int freq_index);
+
+struct ClasOsrBiasMaterialization {
+    std::uint8_t code_signal_id = 0;
+    std::uint8_t phase_signal_id = 0;
+    double code_bias_m = 0.0;
+    double phase_bias_m = 0.0;
+    std::uint8_t code_source_signal_id = 0;
+    std::uint8_t phase_source_signal_id = 0;
+    bool code_present = false;
+    bool phase_present = false;
+    bool code_fallback = false;
+    bool phase_fallback = false;
+    bool exact_identity = false;
+};
+
+ClasOsrBiasMaterialization materializeClasOsrBiases(
+    GNSSSystem system,
+    SignalType signal,
+    std::string_view pseudorange_observation_type,
+    std::string_view carrier_phase_observation_type,
+    const std::map<std::uint8_t, double>& code_biases_m,
+    const std::map<std::uint8_t, double>& phase_biases_m,
+    bool exact_bias_identity,
+    bool enable_l2_class_fallback);
 
 CLASEpochContext prepareClasEpochContext(
     const ObservationData& obs,

--- a/src/algorithms/ppp_osr.cpp
+++ b/src/algorithms/ppp_osr.cpp
@@ -593,6 +593,43 @@ OsrFrequencyObservationLookup findOsrFrequencyObservationWithProvenance(
     return result;
 }
 
+ClasOsrBiasMaterialization materializeClasOsrBiases(
+    GNSSSystem system,
+    SignalType signal,
+    std::string_view pseudorange_observation_type,
+    std::string_view carrier_phase_observation_type,
+    const std::map<std::uint8_t, double>& code_biases_m,
+    const std::map<std::uint8_t, double>& phase_biases_m,
+    bool exact_bias_identity,
+    bool enable_l2_class_fallback) {
+    ClasOsrBiasMaterialization result;
+    result.code_signal_id =
+        algorithms::ppp_bias_identity::rtcmSsrSignalIdForObservation(
+            system, signal, pseudorange_observation_type, exact_bias_identity);
+    result.phase_signal_id =
+        algorithms::ppp_bias_identity::rtcmSsrSignalIdForObservation(
+            system, signal, carrier_phase_observation_type, exact_bias_identity);
+    result.exact_identity = exact_bias_identity;
+
+    const auto code_bias = clasOsrBiasLookup(
+        code_biases_m,
+        system,
+        result.code_signal_id,
+        enable_l2_class_fallback && !exact_bias_identity);
+    result.code_bias_m = code_bias.value_m;
+    result.code_source_signal_id = code_bias.source_signal_id;
+    result.code_present = code_bias.present;
+    result.code_fallback = code_bias.fallback;
+
+    const auto phase_bias = phase_biases_m.find(result.phase_signal_id);
+    if (phase_bias != phase_biases_m.end()) {
+        result.phase_bias_m = phase_bias->second;
+        result.phase_source_signal_id = result.phase_signal_id;
+        result.phase_present = true;
+    }
+    return result;
+}
+
 std::map<std::string, std::string> selectClasEpochAtmosTokens(
     const SSRProducts& ssr_products,
     const std::vector<SatelliteId>& satellites,
@@ -1015,37 +1052,26 @@ std::vector<OSRCorrection> computeOSR(
         for (int f = 0; f < osr.num_frequencies; ++f) {
             const Observation* freq_obs = freq_observations[f];
             const bool exact_bias_identity = gpsL2ExactBiasIdentityEnabled(freq_obs);
-            const uint8_t code_sid =
-                algorithms::ppp_bias_identity::rtcmSsrSignalIdForObservation(
-                    sat.system,
-                    osr.signals[f],
-                    freq_obs != nullptr ? freq_obs->pseudorange_observation_type : "",
-                    exact_bias_identity);
-            const uint8_t phase_sid =
-                algorithms::ppp_bias_identity::rtcmSsrSignalIdForObservation(
-                    sat.system,
-                    osr.signals[f],
-                    freq_obs != nullptr ? freq_obs->carrier_phase_observation_type : "",
-                    exact_bias_identity);
-            osr.code_bias_signal_ids[f] = code_sid;
-            osr.phase_bias_signal_ids[f] = phase_sid;
-            osr.bias_exact_identity[f] = exact_bias_identity;
-            const auto code_bias =
-                clasOsrBiasLookup(
-                    ssr_cbias,
-                    sat.system,
-                    code_sid,
-                    pppEnvOverrides().clas_code_row_bias_identity && !exact_bias_identity);
-            osr.code_bias_m[f] = code_bias.value_m;
-            osr.code_bias_source_signal_ids[f] = code_bias.source_signal_id;
-            osr.code_bias_present[f] = code_bias.present;
-            osr.code_bias_fallback[f] = code_bias.fallback;
-            auto pb_it = ssr_pbias.find(phase_sid);
-            if (pb_it != ssr_pbias.end()) {
-                osr.phase_bias_m[f] = pb_it->second;
-                osr.phase_bias_source_signal_ids[f] = phase_sid;
-                osr.phase_bias_present[f] = true;
-            }
+            const auto bias = materializeClasOsrBiases(
+                sat.system,
+                osr.signals[f],
+                freq_obs != nullptr ? freq_obs->pseudorange_observation_type : "",
+                freq_obs != nullptr ? freq_obs->carrier_phase_observation_type : "",
+                ssr_cbias,
+                ssr_pbias,
+                exact_bias_identity,
+                pppEnvOverrides().clas_code_row_bias_identity && !exact_bias_identity);
+            osr.code_bias_signal_ids[f] = bias.code_signal_id;
+            osr.phase_bias_signal_ids[f] = bias.phase_signal_id;
+            osr.bias_exact_identity[f] = bias.exact_identity;
+            osr.code_bias_m[f] = bias.code_bias_m;
+            osr.phase_bias_m[f] = bias.phase_bias_m;
+            osr.code_bias_source_signal_ids[f] = bias.code_source_signal_id;
+            osr.phase_bias_source_signal_ids[f] = bias.phase_source_signal_id;
+            osr.code_bias_present[f] = bias.code_present;
+            osr.phase_bias_present[f] = bias.phase_present;
+            osr.code_bias_fallback[f] = bias.code_fallback;
+            osr.phase_bias_fallback[f] = bias.phase_fallback;
         }
 
         if (osr.num_frequencies >= 2) {

--- a/tests/test_ppp_osr.cpp
+++ b/tests/test_ppp_osr.cpp
@@ -134,6 +134,99 @@ TEST(PPPOSRTest, ExactObservationIdentitySelectsGpsL2wBiasId) {
             GNSSSystem::GPS, SignalType::GPS_L2C, "C2X", "L2X"));
 }
 
+TEST(PPPOSRTest, ClasOsrBiasMaterializationUsesExactGpsL2wIdentity) {
+    const std::map<std::uint8_t, double> code_biases = {
+        {8U, 0.08},
+        {9U, 0.09},
+    };
+    const std::map<std::uint8_t, double> phase_biases = {
+        {8U, 0.18},
+        {9U, 0.19},
+    };
+
+    const auto bias = materializeClasOsrBiases(
+        GNSSSystem::GPS,
+        SignalType::GPS_L2C,
+        "C2W",
+        "L2W",
+        code_biases,
+        phase_biases,
+        true,
+        false);
+
+    EXPECT_TRUE(bias.exact_identity);
+    EXPECT_EQ(static_cast<int>(bias.code_signal_id), 9);
+    EXPECT_EQ(static_cast<int>(bias.phase_signal_id), 9);
+    EXPECT_EQ(static_cast<int>(bias.code_source_signal_id), 9);
+    EXPECT_EQ(static_cast<int>(bias.phase_source_signal_id), 9);
+    EXPECT_TRUE(bias.code_present);
+    EXPECT_TRUE(bias.phase_present);
+    EXPECT_FALSE(bias.code_fallback);
+    EXPECT_FALSE(bias.phase_fallback);
+    EXPECT_DOUBLE_EQ(bias.code_bias_m, 0.09);
+    EXPECT_DOUBLE_EQ(bias.phase_bias_m, 0.19);
+}
+
+TEST(PPPOSRTest, ClasOsrBiasMaterializationTracksLegacyGpsL2Fallback) {
+    const std::map<std::uint8_t, double> code_biases = {
+        {9U, 0.09},
+    };
+    const std::map<std::uint8_t, double> phase_biases = {
+        {9U, 0.19},
+    };
+
+    const auto bias = materializeClasOsrBiases(
+        GNSSSystem::GPS,
+        SignalType::GPS_L2C,
+        "C2W",
+        "L2W",
+        code_biases,
+        phase_biases,
+        false,
+        true);
+
+    EXPECT_FALSE(bias.exact_identity);
+    EXPECT_EQ(static_cast<int>(bias.code_signal_id), 8);
+    EXPECT_EQ(static_cast<int>(bias.phase_signal_id), 8);
+    EXPECT_EQ(static_cast<int>(bias.code_source_signal_id), 9);
+    EXPECT_EQ(static_cast<int>(bias.phase_source_signal_id), 0);
+    EXPECT_TRUE(bias.code_present);
+    EXPECT_FALSE(bias.phase_present);
+    EXPECT_TRUE(bias.code_fallback);
+    EXPECT_FALSE(bias.phase_fallback);
+    EXPECT_DOUBLE_EQ(bias.code_bias_m, 0.09);
+    EXPECT_DOUBLE_EQ(bias.phase_bias_m, 0.0);
+}
+
+TEST(PPPOSRTest, ClasOsrBiasMaterializationDoesNotFallbackInExactMode) {
+    const std::map<std::uint8_t, double> code_biases = {
+        {8U, 0.08},
+    };
+    const std::map<std::uint8_t, double> phase_biases = {
+        {8U, 0.18},
+    };
+
+    const auto bias = materializeClasOsrBiases(
+        GNSSSystem::GPS,
+        SignalType::GPS_L2C,
+        "C2W",
+        "L2W",
+        code_biases,
+        phase_biases,
+        true,
+        true);
+
+    EXPECT_TRUE(bias.exact_identity);
+    EXPECT_EQ(static_cast<int>(bias.code_signal_id), 9);
+    EXPECT_EQ(static_cast<int>(bias.phase_signal_id), 9);
+    EXPECT_FALSE(bias.code_present);
+    EXPECT_FALSE(bias.phase_present);
+    EXPECT_FALSE(bias.code_fallback);
+    EXPECT_FALSE(bias.phase_fallback);
+    EXPECT_DOUBLE_EQ(bias.code_bias_m, 0.0);
+    EXPECT_DOUBLE_EQ(bias.phase_bias_m, 0.0);
+}
+
 TEST(PPPOSRTest, ExactOsrFrequencyLookupUsesStoredRinexIdentity) {
     const SatelliteId sat(GNSSSystem::GPS, 14);
     ObservationData obs(GNSSTime(2068, 230425.0));


### PR DESCRIPTION
## Summary

- Expose CLAS OSR bias materialization as a small helper with explicit exact-identity and L2-class fallback inputs.
- Route `computeOSR` through the helper without changing the default environment-gated behavior.
- Add unit coverage for GPS C2W/L2W exact RTCM SSR id 9 selection, legacy code-bias fallback provenance, and exact-mode no-fallback behavior.

## Validation

- `cmake --build build-madoca-parity --target run_tests -j2 && ./build-madoca-parity/tests/run_tests --gtest_filter='PPPOSRTest.*'`
- `./build-madoca-parity/tests/run_tests`
- `git diff --check`
