### PR TITLE
[codex] clas: summarize ZD identity provenance

### DIFF
--- a/scripts/analysis/clas_zd_component_diff.py
+++ b/scripts/analysis/clas_zd_component_diff.py
@@ -55,6 +55,17 @@ COMPONENT_ALIASES: dict[str, tuple[str, ...]] = {
 Row = dict[str, str]
 ComponentMap = dict[str, float]
 Key = tuple[int, int, str, str, int, str]
+GPS_L2W_RINEX_CODES = {"C2W", "L2W"}
+IDENTITY_PROVENANCE_COMPONENTS = (
+    "bias_exact_identity",
+    "observation_exact_identity_requested",
+    "observation_exact_match",
+    "observation_family_fallback",
+    "code_bias_present",
+    "phase_bias_present",
+    "code_bias_fallback",
+    "phase_bias_fallback",
+)
 
 
 @dataclass(frozen=True)
@@ -253,6 +264,31 @@ def component_stats(values: Sequence[float]) -> dict[str, Any]:
     }
 
 
+def is_component_true(row: ComponentRow, component: str) -> bool:
+    value = row.components.get(component)
+    return value is not None and value > 0.5
+
+
+def is_gps_l2w_row(row: ComponentRow) -> bool:
+    return row.sat.startswith("G") and row.signal in GPS_L2W_RINEX_CODES
+
+
+def identity_provenance_summary(rows: Sequence[ComponentRow]) -> dict[str, Any]:
+    gps_l2w_rows = [row for row in rows if is_gps_l2w_row(row)]
+    summary: dict[str, Any] = {
+        "rows": len(rows),
+        "gps_l2w_rows": len(gps_l2w_rows),
+    }
+    for component in IDENTITY_PROVENANCE_COMPONENTS:
+        summary[f"{component}_rows"] = sum(
+            1 for row in rows if is_component_true(row, component)
+        )
+        summary[f"gps_l2w_{component}_rows"] = sum(
+            1 for row in gps_l2w_rows if is_component_true(row, component)
+        )
+    return summary
+
+
 def row_summary(row: ComponentRow) -> dict[str, Any]:
     return {
         **key_to_dict(row.key),
@@ -352,6 +388,10 @@ def build_report(
             {"component": component, "rows": rows}
             for component, rows in missing_components.most_common()
         ],
+        "identity_provenance": {
+            base_label: identity_provenance_summary(base_rows),
+            candidate_label: identity_provenance_summary(candidate_rows),
+        },
         "per_component": per_component,
         "top_component_deltas": details[:top_deltas],
         "top_base_only": [row_summary(base_by_key[key]) for key in base_only_keys[:top_unmatched]],
@@ -409,6 +449,16 @@ def print_summary(report: dict[str, Any]) -> None:
             f"mean_abs={item['mean_abs_delta_m']:.6g} "
             f"rms={item['rms_delta_m']:.6g} "
             f"max_abs={item['max_abs_delta_m']:.6g}"
+        )
+    print("  identity_provenance:")
+    for label, summary in report["identity_provenance"].items():
+        print(
+            f"    {label}: gps_l2w_rows={summary['gps_l2w_rows']} "
+            f"gps_l2w_bias_exact_identity={summary['gps_l2w_bias_exact_identity_rows']} "
+            f"gps_l2w_observation_exact_match={summary['gps_l2w_observation_exact_match_rows']} "
+            f"gps_l2w_observation_family_fallback="
+            f"{summary['gps_l2w_observation_family_fallback_rows']} "
+            f"gps_l2w_code_bias_fallback={summary['gps_l2w_code_bias_fallback_rows']}"
         )
     if report["top_component_deltas"]:
         top = report["top_component_deltas"][0]

--- a/tests/test_clas_zd_component_diff.py
+++ b/tests/test_clas_zd_component_diff.py
@@ -325,6 +325,114 @@ class ClasZdComponentDiffTest(unittest.TestCase):
         self.assertAlmostEqual(report["top_component_deltas"][0]["delta_m"], 0.25)
         self.assertEqual(report["top_component_deltas"][0]["candidate_signal"], "C2W")
 
+    def test_report_summarizes_gps_l2w_identity_provenance(self) -> None:
+        base = component_diff.normalize_rows(
+            [
+                code_row(
+                    sat="G14",
+                    freq="1",
+                    prc="0.50",
+                    code_bias="0.10",
+                    receiver_ant="-0.02",
+                    pseudorange_rinex_code="C2W",
+                )
+            ],
+            component_names=[
+                "bias_exact_identity",
+                "observation_exact_identity_requested",
+                "observation_exact_match",
+                "observation_family_fallback",
+                "code_bias_present",
+                "phase_bias_present",
+                "code_bias_fallback",
+                "phase_bias_fallback",
+            ],
+            stage_filter=None,
+            row_type_filter="code",
+        )
+        candidate = component_diff.normalize_rows(
+            [
+                code_row(
+                    sat="G14",
+                    freq="1",
+                    prc="0.50",
+                    code_bias="0.10",
+                    receiver_ant="-0.02",
+                    pseudorange_rinex_code="C2W",
+                    bias_exact_identity="1",
+                    observation_exact_identity_requested="1",
+                    observation_exact_match="1",
+                    observation_family_fallback="0",
+                    code_bias_present="1",
+                    phase_bias_present="1",
+                    code_bias_fallback="0",
+                    phase_bias_fallback="0",
+                ),
+                code_row(
+                    sat="G25",
+                    freq="1",
+                    prc="0.75",
+                    code_bias="0.09",
+                    receiver_ant="-0.02",
+                    pseudorange_rinex_code="C2W",
+                    bias_exact_identity="0",
+                    observation_exact_identity_requested="1",
+                    observation_exact_match="0",
+                    observation_family_fallback="1",
+                    code_bias_present="1",
+                    phase_bias_present="0",
+                    code_bias_fallback="1",
+                    phase_bias_fallback="0",
+                ),
+                code_row(
+                    sat="J01",
+                    freq="1",
+                    prc="0.30",
+                    code_bias="0.00",
+                    receiver_ant="-0.02",
+                    pseudorange_rinex_code="C2X",
+                    bias_exact_identity="1",
+                    observation_exact_identity_requested="1",
+                    observation_exact_match="1",
+                    code_bias_present="1",
+                ),
+            ],
+            component_names=[
+                "bias_exact_identity",
+                "observation_exact_identity_requested",
+                "observation_exact_match",
+                "observation_family_fallback",
+                "code_bias_present",
+                "phase_bias_present",
+                "code_bias_fallback",
+                "phase_bias_fallback",
+            ],
+            stage_filter=None,
+            row_type_filter="code",
+        )
+
+        report = component_diff.build_report(
+            base,
+            candidate,
+            base_label="claslib",
+            candidate_label="native",
+            threshold_m=None,
+            top_deltas=10,
+            top_unmatched=10,
+        )
+
+        native = report["identity_provenance"]["native"]
+        self.assertEqual(native["rows"], 3)
+        self.assertEqual(native["gps_l2w_rows"], 2)
+        self.assertEqual(native["gps_l2w_bias_exact_identity_rows"], 1)
+        self.assertEqual(native["gps_l2w_observation_exact_identity_requested_rows"], 2)
+        self.assertEqual(native["gps_l2w_observation_exact_match_rows"], 1)
+        self.assertEqual(native["gps_l2w_observation_family_fallback_rows"], 1)
+        self.assertEqual(native["gps_l2w_code_bias_present_rows"], 2)
+        self.assertEqual(native["gps_l2w_phase_bias_present_rows"], 1)
+        self.assertEqual(native["gps_l2w_code_bias_fallback_rows"], 1)
+        self.assertEqual(native["bias_exact_identity_rows"], 2)
+
     def test_cli_writes_schema_json_and_details_csv(self) -> None:
         with tempfile.TemporaryDirectory(prefix="clas_zd_component_diff_test_") as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary

- Add identity provenance counts to `clas_zd_component_diff.v1` reports.
- Count GPS C2W/L2W rows separately for exact bias identity, exact observation match, observation family fallback, and code/phase bias fallback.
- Cover the new summary with Python unit tests so optional CLAS ZD artifacts expose whether A4b gate-on rows are using exact L2W identity or legacy fallback.

## Validation

- `python3 tests/test_clas_zd_component_diff.py`
- `python3 -m py_compile scripts/analysis/clas_zd_component_diff.py tests/test_clas_zd_component_diff.py`
- `ctest --test-dir build-madoca-parity -R python_clas_zd_component_diff_tests --output-on-failure`
- `git diff --check`
