### PR TITLE
[codex] ci: surface CLAS ZD identity metrics

### DIFF
--- a/scripts/ci/optional_diff_runner.py
+++ b/scripts/ci/optional_diff_runner.py
@@ -66,6 +66,15 @@ class DiffContext:
     fail_on_diff: bool
 
 
+IDENTITY_PROVENANCE_METRIC_KEYS = (
+    "gps_l2w_rows",
+    "gps_l2w_bias_exact_identity_rows",
+    "gps_l2w_observation_exact_match_rows",
+    "gps_l2w_observation_family_fallback_rows",
+    "gps_l2w_code_bias_fallback_rows",
+)
+
+
 def repo_root_from_script() -> Path:
     return Path(__file__).resolve().parents[2]
 
@@ -108,6 +117,11 @@ def parse_option_value(option: EnvOption, environ: Mapping[str, str]) -> str | N
 
 def truthy(value: str) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def metric_label(value: object) -> str:
+    text = str(value).strip().lower()
+    return "".join(character if character.isalnum() else "_" for character in text).strip("_")
 
 
 def build_context(
@@ -242,6 +256,18 @@ def load_diff_metrics(config: DiffRunnerConfig, report_json: Path) -> dict[str, 
             if isinstance(value, (int, float)):
                 max_abs_delta = max(max_abs_delta, float(value))
         metrics["max_abs_delta"] = max_abs_delta
+    identity_provenance = payload.get("identity_provenance")
+    if isinstance(identity_provenance, dict):
+        for label, summary in identity_provenance.items():
+            if not isinstance(summary, dict):
+                continue
+            normalized_label = metric_label(label)
+            if not normalized_label:
+                continue
+            for key in IDENTITY_PROVENANCE_METRIC_KEYS:
+                value = summary.get(key)
+                if isinstance(value, (int, float)):
+                    metrics[f"identity_{normalized_label}_{key}"] = int(value)
     return metrics
 
 
@@ -348,6 +374,19 @@ def render_result_detail(result: dict[str, object]) -> str:
         threshold_exceedances = metrics.get("threshold_exceedances")
         if threshold_exceedances is not None:
             detail_parts.append(f"threshold exceedances `{threshold_exceedances}`")
+        native_l2w_rows = metrics.get("identity_native_gps_l2w_rows")
+        if native_l2w_rows is not None:
+            detail_parts.append(f"native L2W `{native_l2w_rows}`")
+            exact_bias = metrics.get("identity_native_gps_l2w_bias_exact_identity_rows")
+            exact_match = metrics.get("identity_native_gps_l2w_observation_exact_match_rows")
+            if exact_bias is not None or exact_match is not None:
+                detail_parts.append(f"native L2W exact bias/match `{exact_bias}/{exact_match}`")
+            obs_fallback = metrics.get(
+                "identity_native_gps_l2w_observation_family_fallback_rows"
+            )
+            code_fallback = metrics.get("identity_native_gps_l2w_code_bias_fallback_rows")
+            if obs_fallback is not None or code_fallback is not None:
+                detail_parts.append(f"native L2W fallback obs/code `{obs_fallback}/{code_fallback}`")
     return ", ".join(detail_parts)
 
 

--- a/tests/test_optional_clas_zd_component_diff.py
+++ b/tests/test_optional_clas_zd_component_diff.py
@@ -31,12 +31,26 @@ FIELDNAMES = [
     "freq",
     "pseudorange_rinex_code",
     "carrier_rinex_code",
+    "bias_exact_identity",
+    "observation_exact_identity_requested",
+    "observation_exact_match",
+    "observation_family_fallback",
+    "code_bias_fallback",
     "prc_m",
     "code_bias_m",
 ]
 
 
-def write_zd_component_csv(path: Path, *, prc_m: str = "0.1") -> None:
+def write_zd_component_csv(
+    path: Path,
+    *,
+    prc_m: str = "0.1",
+    bias_exact_identity: str = "",
+    observation_exact_identity_requested: str = "",
+    observation_exact_match: str = "",
+    observation_family_fallback: str = "",
+    code_bias_fallback: str = "",
+) -> None:
     with path.open("w", newline="", encoding="utf-8") as handle:
         writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
         writer.writeheader()
@@ -50,6 +64,11 @@ def write_zd_component_csv(path: Path, *, prc_m: str = "0.1") -> None:
                 "freq": "1",
                 "pseudorange_rinex_code": "C2W",
                 "carrier_rinex_code": "",
+                "bias_exact_identity": bias_exact_identity,
+                "observation_exact_identity_requested": observation_exact_identity_requested,
+                "observation_exact_match": observation_exact_match,
+                "observation_family_fallback": observation_family_fallback,
+                "code_bias_fallback": code_bias_fallback,
                 "prc_m": prc_m,
                 "code_bias_m": "0.5",
             }
@@ -135,6 +154,41 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
             self.assertEqual(metrics["components_compared"], 1)
             self.assertAlmostEqual(metrics["max_abs_delta"], 0.05)
 
+    def test_run_step_collects_identity_provenance_metrics(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_clas_zd_identity_") as temp_dir:
+            root = Path(temp_dir)
+            base_csv = root / "claslib.csv"
+            candidate_csv = root / "native.csv"
+            write_zd_component_csv(base_csv)
+            write_zd_component_csv(
+                candidate_csv,
+                bias_exact_identity="1",
+                observation_exact_identity_requested="1",
+                observation_exact_match="1",
+                observation_family_fallback="0",
+                code_bias_fallback="0",
+            )
+            output_dir = root / "output"
+            log_dir = output_dir / "logs"
+            log_dir.mkdir(parents=True)
+            env = {
+                "GNSSPP_CLAS_ZD_BASE_CSV": str(base_csv),
+                "GNSSPP_CLAS_ZD_CANDIDATE_CSV": str(candidate_csv),
+                "GNSSPP_CLAS_ZD_STAGE": "accepted",
+                "GNSSPP_CLAS_ZD_ROW_TYPE": "code",
+            }
+            step = runner.build_step_plan(ROOT_DIR, output_dir, env)[0]
+
+            result = runner.run_step(step, ROOT_DIR, log_dir)
+
+            self.assertEqual(result["status"], "passed")
+            metrics = result["metrics"]
+            self.assertEqual(metrics["identity_native_gps_l2w_rows"], 1)
+            self.assertEqual(metrics["identity_native_gps_l2w_bias_exact_identity_rows"], 1)
+            self.assertEqual(metrics["identity_native_gps_l2w_observation_exact_match_rows"], 1)
+            self.assertEqual(metrics["identity_native_gps_l2w_observation_family_fallback_rows"], 0)
+            self.assertEqual(metrics["identity_native_gps_l2w_code_bias_fallback_rows"], 0)
+
     def test_render_markdown_summary_reports_status_table_and_metrics(self) -> None:
         markdown = runner.render_markdown_summary(
             [
@@ -149,6 +203,11 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
                         "components_compared": 24,
                         "max_abs_delta": 0.125,
                         "threshold_exceedances": 3,
+                        "identity_native_gps_l2w_rows": 2,
+                        "identity_native_gps_l2w_bias_exact_identity_rows": 1,
+                        "identity_native_gps_l2w_observation_exact_match_rows": 1,
+                        "identity_native_gps_l2w_observation_family_fallback_rows": 0,
+                        "identity_native_gps_l2w_code_bias_fallback_rows": 1,
                     },
                 },
                 {
@@ -173,6 +232,9 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
         self.assertIn("components `24`", markdown)
         self.assertIn("max |delta| 0.125", markdown)
         self.assertIn("threshold exceedances `3`", markdown)
+        self.assertIn("native L2W `2`", markdown)
+        self.assertIn("native L2W exact bias/match `1/1`", markdown)
+        self.assertIn("native L2W fallback obs/code `0/1`", markdown)
         self.assertIn("see `/tmp/clas.log`", markdown)
 
     def test_write_summary_declares_schema(self) -> None:


### PR DESCRIPTION
## Summary

- Surface CLAS ZD identity provenance counts from diff JSON into optional CI metrics.
- Add native GPS L2W exact-bias, exact-observation-match, observation-fallback, and code-bias-fallback counts to the optional diff markdown summary.
- Keep the shared optional runner compatible with MADOCA residual diffs when identity provenance is absent.

## Validation

- `python3 tests/test_optional_clas_zd_component_diff.py`
- `python3 tests/test_optional_madoca_residual_component_diff.py`
- `python3 -m py_compile scripts/ci/optional_diff_runner.py tests/test_optional_clas_zd_component_diff.py tests/test_optional_madoca_residual_component_diff.py`
- `ctest --test-dir build-madoca-parity -R 'python_optional_(clas_zd|madoca_residual)_component_diff_tests' --output-on-failure`
- `git diff --check`
