### PR TITLE
[codex] clas: route profile wrapper through OSR path

### DIFF
--- a/apps/gnss_clas_ppp.py
+++ b/apps/gnss_clas_ppp.py
@@ -600,6 +600,7 @@ def build_summary_payload(
         "mean_satellites": rounded(mean_satellites),
         "ambiguity_resolution_enabled": bool(args.enable_ar),
         "ar_ratio_threshold": rounded(args.ar_ratio_threshold),
+        "clas_osr_filter_enabled": args.profile == "clas",
         "mode": "kinematic" if args.kinematic else "static",
         "compact_atmos_merge_policy": args.compact_atmos_merge_policy,
         "compact_atmos_subtype_merge_policy": args.compact_atmos_subtype_merge_policy,
@@ -768,6 +769,8 @@ def main() -> int:
         # enable per-satellite ionosphere estimation with STEC constraints.
         command.append("--no-ionosphere-free")
         command.append("--estimate-ionosphere")
+        if args.profile == "clas":
+            command.append("--clas-osr")
         if args.sp3 is not None:
             command.extend(["--sp3", str(args.sp3)])
         if args.clk is not None:

--- a/docs/clas_port_architecture.md
+++ b/docs/clas_port_architecture.md
@@ -1,15 +1,15 @@
 # CLAS Port Architecture
 
-> **Implementation status on `develop`**: the README describes the native CLASNAT
-> path, which is fully implemented on branch
-> [`codex/ship-of-theseus-20260418`](https://github.com/rsasaki0109/gnssplusplus-library/tree/codex/ship-of-theseus-20260418).
-> That branch has no common ancestor with `develop` (local re-init history), so
-> merging it requires either a web-UI "Allow unrelated histories" merge or an
-> incremental re-port on top of `develop`.  The README reference tables, plots,
-> and this document were ported as docs-only PRs so the plan is visible here
-> even before the implementation lands on `develop`.
+> **Current `develop` status (2026-06-19)**: this page is a historical iter55
+> port-architecture note. The current binary no longer exposes
+> `--claslib-parity`, `--ported-clasnat`, or `--legacy-strict-parity`; current
+> native CLAS runs use `gnss ppp --clas-osr`, or
+> `gnss clas-ppp --profile clas`, which forwards `--clas-osr`. The active
+> default-flip status is the A5 STOP in
+> [clas_dd_filter_a5.md](clas_dd_filter_a5.md), so do not treat the historical
+> CLI names below as current runbook commands.
 
-Status: iter55 public-validation and helper-parity note.
+Status: historical iter55 public-validation and helper-parity note.
 
 This note records the CLASLIB port structure after the native CLASNAT path
 became the default `--claslib-parity` behavior and after the iter55 cleanup that

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -1,10 +1,12 @@
 # CLAS Public Validation Datasets
 
-> **Implementation status on `develop`**: the native CLASNAT path that produced
-> these numbers is fully implemented on branch
-> [`codex/ship-of-theseus-20260418`](https://github.com/rsasaki0109/gnssplusplus-library/tree/codex/ship-of-theseus-20260418).
-> That branch has no common ancestor with `develop` and needs an
-> "Allow unrelated histories" merge or an incremental re-port.
+> **Current `develop` status (2026-06-19)**: the current CLI no longer exposes
+> the historical `--claslib-parity` entry point. Native CLAS runs use
+> `gnss ppp --clas-osr` directly, or `gnss clas-ppp --profile clas`, which
+> forwards `--clas-osr` after expanding QZSS L6/Compact SSR inputs. The iter55
+> millimetre-level table below is retained as historical reference; the active
+> default-flip decision remains the A5 STOP described in
+> [clas_dd_filter_a5.md](clas_dd_filter_a5.md).
 
 This page records the public CLAS datasets used for the native CLASNAT parity
 checks.  It separates accepted regression gates from public exploratory runs
@@ -36,10 +38,10 @@ The files below are from that repository's `data/` directory.
 
 | Case | Public files | Window | Native mode | Acceptance status |
 | --- | --- | --- | --- | --- |
-| 2019-08-27, QZSS CLAS sample | `0627239Q.obs`, `sept_2019239.nav`, `2019239Q.l6` | 2019-08-27, 16:00 GPST window | `gnss_ppp --claslib-parity` default native CLASNAT path | Accepted gate. Iter55 measured `0.00556 m` RMS 3D against the CLASLIB trajectory over the last 100 epochs of a 2000-epoch run, and `0.01014 m` RMS 3D over the last 100 epochs of a 300-epoch smoke window. |
+| 2019-08-27, QZSS CLAS sample | `0627239Q.obs`, `sept_2019239.nav`, `2019239Q.l6` | 2019-08-27, 16:00 GPST window | Historical iter55 `--claslib-parity` native CLASNAT path | Historical accepted gate. Iter55 measured `0.00556 m` RMS 3D against the CLASLIB trajectory over the last 100 epochs of a 2000-epoch run, and `0.01014 m` RMS 3D over the last 100 epochs of a 300-epoch smoke window. |
 
-This is the dataset behind the current `--claslib-parity` mm-level regression.
-It is public because the input files are shipped in the public
+This is the dataset behind the historical `--claslib-parity` mm-level
+regression. It is public because the input files are shipped in the public
 `QZSS-Strategy-Office/claslib` repository, not because they are private local
 capture files.
 
@@ -59,7 +61,7 @@ in iter55.  Those probes are still useful because they confirm that the
 additional samples are public and reproducible, and they expose the next
 robustness gaps without weakening the accepted 2019-08-27 gate.
 
-## Reproduce The Main Public Gate
+## Reproduce The Current Native CLAS Run
 
 Clone CLASLIB and point the commands at its public `data/` directory:
 
@@ -68,38 +70,83 @@ git clone https://github.com/QZSS-Strategy-Office/claslib.git /tmp/claslib
 DATA=/tmp/claslib/data
 ```
 
-Build with CLASLIB linked when you want the oracle-backed unit tests and bridge
-available:
+Build the current native PPP binary:
 
 ```bash
-cmake -S . -B build \
-  -DCLASLIB_PARITY_LINK=ON \
-  -DCLASLIB_ROOT_DIR=/tmp/claslib
+cmake -S . -B build
 cmake --build build --target gnss_ppp -j4
-cmake --build build --target run_tests -j4
 ```
 
-Run the native CLASNAT parity path:
+Run the current CLAS wrapper. `--profile clas` expands the raw QZSS L6 file and
+forwards the resulting sampled corrections to `gnss ppp --clas-osr`:
 
 ```bash
-./build/apps/gnss_ppp \
-  --claslib-parity \
+python3 apps/gnss.py clas-ppp \
+  --profile clas \
   --obs "$DATA/0627239Q.obs" \
   --nav "$DATA/sept_2019239.nav" \
-  --ssr "$DATA/2019239Q.l6" \
+  --qzss-l6 "$DATA/2019239Q.l6" \
+  --qzss-gps-week 2068 \
   --out /tmp/gnsspp_2019239.pos \
   --summary-json /tmp/gnsspp_2019239_summary.json \
-  --ref-x -3957235.3717 \
-  --ref-y 3310368.2257 \
-  --ref-z 3737529.7179 \
-  --max-epochs 300 \
-  --quiet
+  --max-epochs 300
 ```
 
-Run the oracle helper parity tests:
+For the A4b GPS L2W identity probe, enable the diagnostic gates and write a
+native zero-difference code component dump:
 
 ```bash
-./build/tests/run_tests --gtest_filter='*ClasnatParity*'
+GNSS_PPP_CLAS_DD_FILTER=1 \
+GNSS_PPP_CLAS_CODE_ROW_PARITY=bias \
+GNSS_PPP_CLAS_CODE_DUMP=/tmp/clas_a4b_native_code_dump.csv \
+python3 apps/gnss.py clas-ppp \
+  --profile clas \
+  --obs "$DATA/0627239Q.obs" \
+  --nav "$DATA/sept_2019239.nav" \
+  --qzss-l6 "$DATA/2019239Q.l6" \
+  --qzss-gps-week 2068 \
+  --out /tmp/gnsspp_clas_a4b_native.pos \
+  --summary-json /tmp/gnsspp_clas_a4b_native_summary.json \
+  --max-epochs 300
+```
+
+Self-diff the dump to inspect identity provenance before comparing against a
+CLASLIB-side component dump:
+
+```bash
+python3 scripts/analysis/clas_zd_component_diff.py \
+  /tmp/clas_a4b_native_code_dump.csv \
+  /tmp/clas_a4b_native_code_dump.csv \
+  --base-label native \
+  --candidate-label native \
+  --row-type code \
+  --json-out /tmp/clas_a4b_native_code_selfdiff.json \
+  --details-csv /tmp/clas_a4b_native_code_selfdiff.csv
+
+python3 - <<'PY'
+import json
+payload = json.load(open("/tmp/clas_a4b_native_code_selfdiff.json"))
+print(json.dumps(payload["identity_provenance"], indent=2, sort_keys=True))
+PY
+```
+
+On the 300-epoch 2019 sample smoke, current `develop` produces 5,400 native code
+rows. The GPS L2W slice has 300 rows, all with exact bias identity and exact
+observation matches, and zero observation-family or code-bias fallback rows.
+
+Build with CLASLIB linked only when you need oracle-backed unit tests:
+
+```bash
+cmake -S . -B build-claslib \
+  -DCLASLIB_PARITY_LINK=ON \
+  -DCLASLIB_ROOT_DIR=/tmp/claslib
+cmake --build build-claslib --target run_tests -j4
+```
+
+Run the oracle helper parity tests when that optional build is available:
+
+```bash
+./build-claslib/tests/run_tests --gtest_filter='*ClasnatParity*'
 ```
 
 Expected helper coverage after iter55 is 17 tests, including `filter`,

--- a/tests/test_benchmark_scripts.py
+++ b/tests/test_benchmark_scripts.py
@@ -395,6 +395,57 @@ class ClasCompactHelpersTest(unittest.TestCase):
         self.assertAlmostEqual(float(parsed["ppp_atmospheric_trop_meters"]), 5.5)
         self.assertAlmostEqual(float(parsed["ppp_atmospheric_ionosphere_meters"]), 3.25)
 
+    def test_build_summary_payload_marks_clas_osr_profile(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_clas_summary_") as temp_dir:
+            temp_root = Path(temp_dir)
+            pos_path = temp_root / "solution.pos"
+            pos_path.write_text(
+                "\n".join(
+                    [
+                        "% synthetic solution",
+                        "2200 345600.000 1.0 2.0 3.0 0.0 0.0 0.0 5 8",
+                        "2200 345630.000 1.0 2.0 3.0 0.0 0.0 0.0 6 9",
+                    ]
+                )
+                + "\n",
+                encoding="ascii",
+            )
+
+            common_args = {
+                "obs": Path("rover.obs"),
+                "nav": Path("nav.rnx"),
+                "sp3": None,
+                "clk": None,
+                "ssr_rtcm": None,
+                "compact_ssr": "corrections.compact.csv",
+                "qzss_l6": None,
+                "out": pos_path,
+                "summary_json": None,
+                "enable_ar": False,
+                "ar_ratio_threshold": 3.0,
+                "kinematic": False,
+                "compact_atmos_merge_policy": "stec-coeff-carry",
+                "compact_atmos_subtype_merge_policy": "union",
+                "compact_phase_bias_merge_policy": "latest-union",
+                "compact_phase_bias_source_policy": "arrival-order",
+                "compact_code_bias_composition_policy": "direct-values",
+                "compact_code_bias_bank_policy": "pending-epoch",
+                "compact_phase_bias_composition_policy": "direct-values",
+                "compact_phase_bias_bank_policy": "pending-epoch",
+                "compact_bias_row_materialization": "overlap-only",
+                "compact_row_construction_policy": "independent",
+            }
+
+            clas_payload = clas_ppp.build_summary_payload(
+                argparse.Namespace(profile="clas", **common_args)
+            )
+            madoca_payload = clas_ppp.build_summary_payload(
+                argparse.Namespace(profile="madoca", **common_args)
+            )
+
+            self.assertTrue(clas_payload["clas_osr_filter_enabled"])
+            self.assertFalse(madoca_payload["clas_osr_filter_enabled"])
+
 
 class PPCRTKSignoffHelpersTest(unittest.TestCase):
     def test_selected_thresholds_keep_rtklib_gates_only_when_enabled(self) -> None:

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -10808,6 +10808,8 @@ class CLIToolsTest(unittest.TestCase):
             self.assertEqual(payload["ssr_transport"], "file")
             self.assertEqual(payload["epochs"], 3)
             self.assertEqual(payload["ppp_solution_rate_pct"], 100.0)
+            self.assertFalse(payload["clas_osr_filter_enabled"])
+            self.assertNotIn("--clas-osr", result.stdout)
 
     def test_clas_ppp_cli_accepts_compact_sampled_corrections(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_clas_ppp_compact_cli_") as temp_dir:
@@ -10864,6 +10866,8 @@ class CLIToolsTest(unittest.TestCase):
             self.assertEqual(payload["correction_encoding"], "compact")
             self.assertEqual(payload["epochs"], 3)
             self.assertEqual(payload["ppp_solution_rate_pct"], 100.0)
+            self.assertTrue(payload["clas_osr_filter_enabled"])
+            self.assertIn("--clas-osr", result.stdout)
 
     def test_clas_ppp_cli_accepts_direct_qzss_l6_corrections(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_clas_ppp_qzss_l6_cli_") as temp_dir:
@@ -10934,6 +10938,8 @@ class CLIToolsTest(unittest.TestCase):
             self.assertEqual(payload["correction_encoding"], "qzss_l6")
             self.assertEqual(payload["epochs"], 3)
             self.assertEqual(payload["ppp_solution_rate_pct"], 100.0)
+            self.assertTrue(payload["clas_osr_filter_enabled"])
+            self.assertIn("--clas-osr", result.stdout)
 
     def test_clas_ppp_cli_accepts_direct_qzss_l6_orbit_clock_corrections(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_clas_ppp_qzss_l6_oc_cli_") as temp_dir:


### PR DESCRIPTION
## Summary
- forward `gnss clas-ppp --profile clas` runs through the native `gnss ppp --clas-osr` path
- add `clas_osr_filter_enabled` to CLAS/MADOCA wrapper summaries
- refresh CLAS public sample docs with the current `--clas-osr` runbook and A4b GPS L2W identity probe

## Validation
- `python3 -m unittest tests.test_benchmark_scripts.ClasCompactHelpersTest`
- `python3 -m unittest -v tests.test_cli_tools.CLIToolsTest.test_clas_ppp_cli_writes_summary_for_named_profile tests.test_cli_tools.CLIToolsTest.test_clas_ppp_cli_accepts_compact_sampled_corrections tests.test_cli_tools.CLIToolsTest.test_clas_ppp_cli_accepts_direct_qzss_l6_corrections` (skipped locally: repo static test data unavailable)
- `python3 -m py_compile apps/gnss_clas_ppp.py tests/test_cli_tools.py tests/test_benchmark_scripts.py`
- `git diff --check`
- Public CLASLIB 2019 sample wrapper smoke, 300 epochs: `clas_osr_filter_enabled=True`, 5,400 code rows, GPS L2W 300/300 exact bias identity and observation match, fallback rows 0
