### PR TITLE
[codex] clas: normalize CLASLIB ZD dumps

### DIFF
--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -193,6 +193,13 @@ Optional filters are `GNSSPP_CLAS_ZD_COMPONENTS`, `GNSSPP_CLAS_ZD_STAGE`,
 `GNSSPP_CLAS_ZD_ROW_TYPE`, `GNSSPP_CLAS_ZD_THRESHOLD_M`, and
 `GNSSPP_CLAS_ZD_FAIL_ON_DIFF`.
 
+CLASLIB-side disposable dumps must first be normalized with
+`scripts/analysis/claslib_zd_component_export.py`.  That export step converts
+numeric CLASLIB `sys`/`prn`/RTKLIB `code` fields into the native row-key space
+(`G14`, `J01`, `E07`, `C2W`, `L2W`, and related exact RINEX identities) without
+linking CLASLIB into the production binaries.  Use the normalized CSV as
+`GNSSPP_CLAS_ZD_BASE_CSV` for optional oracle-backed CI.
+
 Native RINEX observations now expose exact `pseudorange_rinex_code`,
 `carrier_rinex_code`, RTKLIB code id, and `signal_family` columns in the CLAS
 code/phase diagnostic dumps.  This lets the GPS L2W investigation distinguish

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -130,6 +130,27 @@ print(json.dumps(payload["identity_provenance"], indent=2, sort_keys=True))
 PY
 ```
 
+Disposable CLASLIB dumps usually use numeric `sys`/`prn`/RTKLIB `code` fields
+instead of native `G14`/`C2W`-style row keys. Normalize those dumps before using
+them as the oracle side of the component diff:
+
+```bash
+python3 scripts/analysis/claslib_zd_component_export.py \
+  /tmp/claslib_zd_dump.csv \
+  --output /tmp/claslib_zd_dump.normalized.csv \
+  --stage-label post
+
+python3 scripts/analysis/clas_zd_component_diff.py \
+  /tmp/claslib_zd_dump.normalized.csv \
+  /tmp/clas_a4b_native_code_dump.csv \
+  --base-label claslib \
+  --candidate-label native \
+  --stage post \
+  --row-type code \
+  --json-out /tmp/clas_a4b_native_vs_claslib_code.json \
+  --details-csv /tmp/clas_a4b_native_vs_claslib_code.csv
+```
+
 On the 300-epoch 2019 sample smoke, current `develop` produces 5,400 native code
 rows. The GPS L2W slice has 300 rows, all with exact bias identity and exact
 observation matches, and zero observation-family or code-bias fallback rows.

--- a/scripts/analysis/claslib_zd_component_export.py
+++ b/scripts/analysis/claslib_zd_component_export.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Normalize disposable CLASLIB component dumps for native CLAS ZD diffing."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import sys
+from pathlib import Path
+from typing import Iterable, Optional
+
+
+SYS_PREFIX_BY_ID = {
+    1: "G",  # GPS
+    2: "S",  # SBAS
+    4: "R",  # GLONASS
+    8: "E",  # Galileo
+    16: "J",  # QZSS
+    32: "C",  # BeiDou
+    64: "I",  # NavIC/IRNSS
+}
+
+RTKLIB_CODE_TO_SUFFIX = {
+    1: "1C",
+    2: "1P",
+    3: "1W",
+    4: "1Y",
+    5: "1M",
+    6: "1N",
+    7: "1S",
+    8: "1L",
+    9: "1E",
+    10: "1A",
+    11: "1B",
+    12: "1X",
+    13: "1Z",
+    14: "2C",
+    15: "2D",
+    16: "2S",
+    17: "2L",
+    18: "2X",
+    19: "2P",
+    20: "2W",
+    21: "2Y",
+    22: "2M",
+    23: "2N",
+    24: "5I",
+    25: "5Q",
+    26: "5X",
+    27: "7I",
+    28: "7Q",
+    29: "7X",
+    30: "6A",
+    31: "6B",
+    32: "6C",
+    33: "6X",
+    34: "6Z",
+    35: "6S",
+    36: "6L",
+    37: "8I",
+    38: "8Q",
+    39: "8X",
+    40: "2I",
+    41: "2Q",
+    42: "6I",
+    43: "6Q",
+    44: "3I",
+    45: "3Q",
+    46: "3X",
+    47: "1I",
+    48: "1Q",
+}
+
+FIELDNAMES = [
+    "record",
+    "stage",
+    "week",
+    "tow",
+    "sat",
+    "row_type",
+    "freq",
+    "signal",
+    "pseudorange_rinex_code",
+    "carrier_rinex_code",
+    "pseudorange_rtklib_code",
+    "carrier_rtklib_code",
+    "source_sys",
+    "source_prn",
+    "source_satno",
+    "source_rtklib_code",
+    "raw_p_m",
+    "corrected_p_m",
+    "raw_l_m",
+    "corrected_l_m",
+    "applied_pr_corr_m",
+    "carrier_correction_m",
+    "prc_m",
+    "cpc_m",
+    "trop_correction_m",
+    "iono_l1_m",
+    "iono_scaled_m",
+    "code_bias_m",
+    "phase_bias_m",
+    "receiver_antenna_m",
+    "relativity_m",
+    "windup_m",
+    "orbit_projection_m",
+    "clock_correction_m",
+    "residual_m",
+    "geo_m",
+    "sat_clk_m",
+    "model_m",
+    "az_rad",
+    "el_rad",
+    "rx_x_m",
+    "rx_y_m",
+    "rx_z_m",
+]
+
+
+class ExportError(ValueError):
+    """Raised for unsupported CLASLIB dump content."""
+
+
+def first_present(row: dict[str, str], names: Iterable[str], default: str = "") -> str:
+    for name in names:
+        value = row.get(name, "")
+        if value != "":
+            return value
+    return default
+
+
+def parse_int(value: str, *, field: str) -> int:
+    try:
+        return int(float(value))
+    except ValueError as exc:
+        raise ExportError(f"invalid {field}: {value!r}") from exc
+
+
+def normalize_qzss_prn(prn: int) -> int:
+    return prn - 192 if prn >= 193 else prn
+
+
+def sat_label(sys_id: int, prn: int) -> str:
+    prefix = SYS_PREFIX_BY_ID.get(sys_id)
+    if prefix is None:
+        raise ExportError(f"unsupported CLASLIB system id: {sys_id}")
+    if prefix == "J":
+        prn = normalize_qzss_prn(prn)
+    return f"{prefix}{prn:02d}"
+
+
+def rinex_pair(rtklib_code: int) -> tuple[str, str]:
+    suffix = RTKLIB_CODE_TO_SUFFIX.get(rtklib_code)
+    if suffix is None:
+        raise ExportError(f"unsupported RTKLIB observation code: {rtklib_code}")
+    return f"C{suffix}", f"L{suffix}"
+
+
+def detect_row_type(row: dict[str, str]) -> str:
+    value = first_present(row, ("row_type", "record", "type", "kind"), "").strip().lower()
+    if value in {"code", "pseudorange", "pr"} or value.startswith("code"):
+        return "code"
+    if value in {"phase", "carrier", "carrier_phase"} or value.startswith("phase"):
+        return "phase"
+    raise ExportError(f"unsupported row type: {value!r}")
+
+
+def normalized_record(row_type: str) -> str:
+    return "CODE" if row_type == "code" else "PHASE"
+
+
+def normalize_row(
+    row: dict[str, str],
+    *,
+    row_number: int,
+    stage_label: Optional[str],
+) -> dict[str, str]:
+    sys_id = parse_int(first_present(row, ("sys", "system")), field=f"row {row_number} sys")
+    prn = parse_int(first_present(row, ("prn",)), field=f"row {row_number} prn")
+    rtklib_code = parse_int(first_present(row, ("code", "rtklib_code")), field=f"row {row_number} code")
+    row_type = detect_row_type(row)
+    pseudorange_code, carrier_code = rinex_pair(rtklib_code)
+    row_signal = pseudorange_code if row_type == "code" else carrier_code
+    stage = row.get("stage", "") or (stage_label or "")
+
+    output = {field: "" for field in FIELDNAMES}
+    output.update(
+        {
+            "record": first_present(row, ("record",), normalized_record(row_type)).upper(),
+            "stage": stage,
+            "week": first_present(row, ("week",)),
+            "tow": first_present(row, ("tow",)),
+            "sat": sat_label(sys_id, prn),
+            "row_type": row_type,
+            "freq": first_present(row, ("freq", "f"), "0"),
+            "signal": row_signal,
+            "pseudorange_rinex_code": pseudorange_code,
+            "carrier_rinex_code": carrier_code,
+            "pseudorange_rtklib_code": str(rtklib_code),
+            "carrier_rtklib_code": str(rtklib_code),
+            "source_sys": str(sys_id),
+            "source_prn": str(prn),
+            "source_satno": first_present(row, ("sat", "satno")),
+            "source_rtklib_code": str(rtklib_code),
+            "raw_p_m": first_present(row, ("raw_p_m", "raw_m")),
+            "corrected_p_m": first_present(row, ("corrected_p_m", "corr_meas_m")),
+            "raw_l_m": first_present(row, ("raw_l_m",)),
+            "corrected_l_m": first_present(row, ("corrected_l_m",)),
+            "applied_pr_corr_m": first_present(row, ("applied_pr_corr_m",)),
+            "carrier_correction_m": first_present(row, ("carrier_correction_m",)),
+            "prc_m": first_present(row, ("prc_m", "PRC", "PRC_m")),
+            "cpc_m": first_present(row, ("cpc_m", "CPC", "CPC_m")),
+            "trop_correction_m": first_present(row, ("trop_correction_m", "trop_m")),
+            "iono_l1_m": first_present(row, ("iono_l1_m", "l1_iono_m")),
+            "iono_scaled_m": first_present(row, ("iono_scaled_m",)),
+            "code_bias_m": first_present(row, ("code_bias_m", "code_bias", "cbias_m")),
+            "phase_bias_m": first_present(row, ("phase_bias_m", "phase_bias", "pbias_m", "comp_m")),
+            "receiver_antenna_m": first_present(row, ("receiver_antenna_m", "receiver_ant_m", "receiver_ant")),
+            "relativity_m": first_present(row, ("relativity_m", "relativity_correction_m")),
+            "windup_m": first_present(row, ("windup_m",)),
+            "orbit_projection_m": first_present(row, ("orbit_projection_m", "orb_m")),
+            "clock_correction_m": first_present(row, ("clock_correction_m", "clk_m")),
+            "residual_m": first_present(row, ("residual_m", "zd_residual_m")),
+            "geo_m": first_present(row, ("geo_m",)),
+            "sat_clk_m": first_present(row, ("sat_clk_m",)),
+            "model_m": first_present(row, ("model_m",)),
+            "az_rad": first_present(row, ("az_rad",)),
+            "el_rad": first_present(row, ("el_rad",)),
+            "rx_x_m": first_present(row, ("rx_x_m",)),
+            "rx_y_m": first_present(row, ("rx_y_m",)),
+            "rx_z_m": first_present(row, ("rx_z_m",)),
+        }
+    )
+    return output
+
+
+def export_csv(input_path: Path, output_path: Path, *, stage_label: Optional[str]) -> int:
+    with input_path.open(newline="", encoding="utf-8") as input_handle:
+        reader = csv.DictReader(input_handle)
+        if reader.fieldnames is None:
+            raise ExportError(f"{input_path}: missing CSV header")
+        rows = [
+            normalize_row(row, row_number=index, stage_label=stage_label)
+            for index, row in enumerate(reader, start=2)
+        ]
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", newline="", encoding="utf-8") as output_handle:
+        writer = csv.DictWriter(output_handle, fieldnames=FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(rows)
+    return len(rows)
+
+
+def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Normalize disposable CLASLIB ZD/code component dumps into the "
+            "CSV schema consumed by clas_zd_component_diff.py."
+        )
+    )
+    parser.add_argument("input_csv", type=Path, help="Raw CLASLIB component dump CSV")
+    parser.add_argument("--output", type=Path, required=True, help="Normalized output CSV")
+    parser.add_argument(
+        "--stage-label",
+        default=None,
+        help="Stage label to use only for input rows that do not already have a stage column",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    args = parse_args(argv)
+    try:
+        rows_written = export_csv(args.input_csv, args.output, stage_label=args.stage_label)
+    except ExportError as exc:
+        print(f"claslib_zd_component_export: {exc}", file=sys.stderr)
+        return 2
+    print(f"claslib_zd_component_export: wrote {rows_written} rows to {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -98,6 +98,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_clas_zd_component_diff.py
     )
     add_test(
+        NAME python_claslib_zd_component_export_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_claslib_zd_component_export.py
+    )
+    add_test(
         NAME python_optional_clas_zd_component_diff_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_optional_clas_zd_component_diff.py
     )
@@ -231,6 +235,7 @@ if(GTest_FOUND)
     set(GNSSPP_CORE_TESTS
         run_tests
         python_clas_zd_component_diff_tests
+        python_claslib_zd_component_export_tests
         python_optional_clas_zd_component_diff_tests
         python_madoca_residual_component_diff_tests
         python_madoca_solution_diff_tests

--- a/tests/test_claslib_zd_component_export.py
+++ b/tests/test_claslib_zd_component_export.py
@@ -1,0 +1,294 @@
+#!/usr/bin/env python3
+"""Tests for CLASLIB ZD component dump normalization."""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+EXPORT_SCRIPT = ROOT_DIR / "scripts" / "analysis" / "claslib_zd_component_export.py"
+DIFF_SCRIPT = ROOT_DIR / "scripts" / "analysis" / "clas_zd_component_diff.py"
+
+export_spec = importlib.util.spec_from_file_location("claslib_zd_component_export", EXPORT_SCRIPT)
+assert export_spec is not None and export_spec.loader is not None
+export = importlib.util.module_from_spec(export_spec)
+sys.modules[export_spec.name] = export
+export_spec.loader.exec_module(export)
+
+diff_spec = importlib.util.spec_from_file_location("clas_zd_component_diff", DIFF_SCRIPT)
+assert diff_spec is not None and diff_spec.loader is not None
+component_diff = importlib.util.module_from_spec(diff_spec)
+sys.modules[diff_spec.name] = component_diff
+diff_spec.loader.exec_module(component_diff)
+
+
+RAW_FIELDNAMES = [
+    "record",
+    "stage",
+    "week",
+    "tow",
+    "row_type",
+    "sat",
+    "sys",
+    "prn",
+    "freq",
+    "code",
+    "raw_m",
+    "corr_meas_m",
+    "raw_p_m",
+    "corrected_p_m",
+    "prc_m",
+    "cpc_m",
+    "trop_m",
+    "iono_l1_m",
+    "iono_scaled_m",
+    "cbias_m",
+    "pbias_m",
+    "receiver_ant_m",
+    "relativity_m",
+    "windup_m",
+    "orb_m",
+    "clk_m",
+    "zd_residual_m",
+    "residual_m",
+    "geo_m",
+    "sat_clk_m",
+    "model_m",
+    "az_rad",
+    "el_rad",
+    "rx_x_m",
+    "rx_y_m",
+    "rx_z_m",
+]
+
+
+def write_csv(path: Path, rows: list[dict[str, str]], fieldnames: list[str]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=fieldnames)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({field: row.get(field, "") for field in fieldnames})
+
+
+def read_csv(path: Path) -> list[dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        return list(csv.DictReader(handle))
+
+
+class ClaslibZdComponentExportTest(unittest.TestCase):
+    def test_normalizes_gps_l2w_code_row(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="claslib_zd_export_test_") as temp_dir:
+            input_path = Path(temp_dir) / "claslib_raw.csv"
+            output_path = Path(temp_dir) / "normalized.csv"
+            write_csv(
+                input_path,
+                [
+                    {
+                        "record": "ZD",
+                        "week": "2068",
+                        "tow": "230420.000",
+                        "row_type": "code",
+                        "sat": "14",
+                        "sys": "1",
+                        "prn": "14",
+                        "freq": "1",
+                        "code": "20",
+                        "raw_m": "20486467.0",
+                        "corr_meas_m": "20486468.0",
+                        "prc_m": "1.25",
+                        "cbias_m": "0.125",
+                        "receiver_ant_m": "-0.02",
+                        "trop_m": "2.4",
+                        "zd_residual_m": "-0.5",
+                    }
+                ],
+                RAW_FIELDNAMES,
+            )
+
+            rows_written = export.export_csv(input_path, output_path, stage_label="post")
+            self.assertEqual(rows_written, 1)
+            row = read_csv(output_path)[0]
+            self.assertEqual(row["stage"], "post")
+            self.assertEqual(row["sat"], "G14")
+            self.assertEqual(row["row_type"], "code")
+            self.assertEqual(row["freq"], "1")
+            self.assertEqual(row["signal"], "C2W")
+            self.assertEqual(row["pseudorange_rinex_code"], "C2W")
+            self.assertEqual(row["carrier_rinex_code"], "L2W")
+            self.assertEqual(row["pseudorange_rtklib_code"], "20")
+            self.assertEqual(row["carrier_rtklib_code"], "20")
+            self.assertEqual(row["code_bias_m"], "0.125")
+            self.assertEqual(row["receiver_antenna_m"], "-0.02")
+            self.assertEqual(row["trop_correction_m"], "2.4")
+            self.assertEqual(row["residual_m"], "-0.5")
+
+    def test_normalizes_qzss_phase_and_galileo_code_rows(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="claslib_zd_export_test_") as temp_dir:
+            input_path = Path(temp_dir) / "claslib_raw.csv"
+            output_path = Path(temp_dir) / "normalized.csv"
+            write_csv(
+                input_path,
+                [
+                    {
+                        "record": "ZD",
+                        "week": "2068",
+                        "tow": "230420.000",
+                        "row_type": "phase",
+                        "sat": "194",
+                        "sys": "16",
+                        "prn": "193",
+                        "freq": "1",
+                        "code": "18",
+                        "cpc_m": "-1.5",
+                        "pbias_m": "0.75",
+                    },
+                    {
+                        "record": "CODE",
+                        "stage": "pre",
+                        "week": "2068",
+                        "tow": "230420.000",
+                        "sat": "7",
+                        "sys": "8",
+                        "prn": "7",
+                        "freq": "2",
+                        "code": "26",
+                        "raw_p_m": "23000000.0",
+                        "corrected_p_m": "23000001.0",
+                        "cbias_m": "-0.25",
+                    },
+                ],
+                RAW_FIELDNAMES,
+            )
+
+            export.export_csv(input_path, output_path, stage_label="post")
+            rows = read_csv(output_path)
+            self.assertEqual(rows[0]["stage"], "post")
+            self.assertEqual(rows[0]["sat"], "J01")
+            self.assertEqual(rows[0]["row_type"], "phase")
+            self.assertEqual(rows[0]["signal"], "L2X")
+            self.assertEqual(rows[0]["pseudorange_rinex_code"], "C2X")
+            self.assertEqual(rows[0]["carrier_rinex_code"], "L2X")
+            self.assertEqual(rows[0]["phase_bias_m"], "0.75")
+            self.assertEqual(rows[1]["stage"], "pre")
+            self.assertEqual(rows[1]["sat"], "E07")
+            self.assertEqual(rows[1]["row_type"], "code")
+            self.assertEqual(rows[1]["freq"], "2")
+            self.assertEqual(rows[1]["signal"], "C5X")
+            self.assertEqual(rows[1]["pseudorange_rinex_code"], "C5X")
+            self.assertEqual(rows[1]["carrier_rinex_code"], "L5X")
+
+    def test_exported_csv_uses_native_diff_key_space(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="claslib_zd_export_test_") as temp_dir:
+            base_input = Path(temp_dir) / "claslib_raw.csv"
+            base_csv = Path(temp_dir) / "base_normalized.csv"
+            candidate_csv = Path(temp_dir) / "native.csv"
+            write_csv(
+                base_input,
+                [
+                    {
+                        "record": "ZD",
+                        "week": "2068",
+                        "tow": "230420.000",
+                        "row_type": "code",
+                        "sat": "14",
+                        "sys": "1",
+                        "prn": "14",
+                        "freq": "1",
+                        "code": "20",
+                        "prc_m": "1.25",
+                        "cbias_m": "0.125",
+                    }
+                ],
+                RAW_FIELDNAMES,
+            )
+            export.export_csv(base_input, base_csv, stage_label="post")
+            write_csv(
+                candidate_csv,
+                [
+                    {
+                        "record": "CODE",
+                        "stage": "post",
+                        "week": "2068",
+                        "tow": "230420.000",
+                        "sat": "G14",
+                        "row_type": "code",
+                        "freq": "1",
+                        "signal": "C2W",
+                        "pseudorange_rinex_code": "C2W",
+                        "carrier_rinex_code": "L2W",
+                        "pseudorange_rtklib_code": "20",
+                        "carrier_rtklib_code": "20",
+                        "prc_m": "1.50",
+                        "code_bias_m": "0.125",
+                    }
+                ],
+                export.FIELDNAMES,
+            )
+
+            base_rows = component_diff.normalize_rows(
+                component_diff.read_csv_rows(base_csv),
+                component_names=("prc_m", "code_bias_m"),
+                stage_filter="post",
+                row_type_filter="code",
+            )
+            candidate_rows = component_diff.normalize_rows(
+                component_diff.read_csv_rows(candidate_csv),
+                component_names=("prc_m", "code_bias_m"),
+                stage_filter="post",
+                row_type_filter="code",
+            )
+            report = component_diff.build_report(
+                base_rows,
+                candidate_rows,
+                base_label="claslib",
+                candidate_label="native",
+                threshold_m=None,
+                top_deltas=10,
+                top_unmatched=10,
+            )
+            self.assertEqual(report["common_rows"], 1)
+            self.assertEqual(report["base_only_rows"], 0)
+            self.assertEqual(report["candidate_only_rows"], 0)
+            prc_stats = next(item for item in report["per_component"] if item["component"] == "prc_m")
+            self.assertAlmostEqual(prc_stats["max_abs_delta_m"], 0.25)
+
+    def test_cli_rejects_unknown_observation_code(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="claslib_zd_export_test_") as temp_dir:
+            input_path = Path(temp_dir) / "claslib_raw.csv"
+            output_path = Path(temp_dir) / "normalized.csv"
+            write_csv(
+                input_path,
+                [
+                    {
+                        "record": "ZD",
+                        "week": "2068",
+                        "tow": "230420.000",
+                        "row_type": "code",
+                        "sat": "14",
+                        "sys": "1",
+                        "prn": "14",
+                        "freq": "1",
+                        "code": "99",
+                    }
+                ],
+                RAW_FIELDNAMES,
+            )
+            result = subprocess.run(
+                [sys.executable, str(EXPORT_SCRIPT), str(input_path), "--output", str(output_path)],
+                check=False,
+                text=True,
+                capture_output=True,
+            )
+            self.assertEqual(result.returncode, 2)
+            self.assertIn("unsupported RTKLIB observation code", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `claslib_zd_component_export.py` to normalize disposable CLASLIB ZD/code component dumps into the native CLAS ZD diff CSV key space
- map CLASLIB numeric system/PRN/RTKLIB observation code fields to exact native identities such as `G14`, `J01`, `E07`, `C2W`, and `L2W`
- add focused Python coverage, CTest registration, and CLAS runbook notes for optional oracle-backed ZD component diffing

## Why
CLASLIB dump rows currently use numeric `sys`/`prn`/`code` values, while `clas_zd_component_diff.py` keys native rows by exact satellite and RINEX observation identity. Normalizing the oracle CSV first makes row-set mismatches meaningful and avoids linking CLASLIB into production binaries.

## Validation
- `python3 -m py_compile scripts/analysis/claslib_zd_component_export.py tests/test_claslib_zd_component_export.py`
- `python3 tests/test_claslib_zd_component_export.py`
- `python3 tests/test_clas_zd_component_diff.py`
- `cmake -S . -B build-clas-zd-export`
- `ctest --test-dir build-clas-zd-export -R 'python_clas(lib)?_zd_component_(export|diff)_tests' --output-on-failure`
- normalized `/tmp/s35_ref/claslib_code_dump.csv` and `/tmp/s24_ref/claslib_zd_dump.csv` successfully