### PR TITLE
[codex] clas: add ZD diff slice filters

### DIFF
--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -191,7 +191,10 @@ dumps.  It writes `ci_optional_clas_zd_component_summary.json`, a log, and the
 the CI step records an explicit skip instead of silently omitting the artifact.
 Optional filters are `GNSSPP_CLAS_ZD_COMPONENTS`, `GNSSPP_CLAS_ZD_STAGE`,
 `GNSSPP_CLAS_ZD_ROW_TYPE`, `GNSSPP_CLAS_ZD_THRESHOLD_M`, and
-`GNSSPP_CLAS_ZD_FAIL_ON_DIFF`.
+`GNSSPP_CLAS_ZD_FAIL_ON_DIFF`.  GPS L2W A4b probes can also narrow the row set
+with `GNSSPP_CLAS_ZD_SAT`, `GNSSPP_CLAS_ZD_FREQ`, and
+`GNSSPP_CLAS_ZD_RINEX_CODE`, matching the analysis script's `--sat`, `--freq`,
+and `--rinex-code` filters.
 
 CLASLIB-side disposable dumps must first be normalized with
 `scripts/analysis/claslib_zd_component_export.py`.  That export step converts

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -147,6 +147,9 @@ python3 scripts/analysis/clas_zd_component_diff.py \
   --candidate-label native \
   --stage post \
   --row-type code \
+  --sat G14 \
+  --freq 1 \
+  --rinex-code C2W \
   --json-out /tmp/clas_a4b_native_vs_claslib_code.json \
   --details-csv /tmp/clas_a4b_native_vs_claslib_code.csv
 ```

--- a/scripts/analysis/clas_zd_component_diff.py
+++ b/scripts/analysis/clas_zd_component_diff.py
@@ -190,6 +190,9 @@ def normalize_rows(
     component_names: Sequence[str],
     stage_filter: Optional[str],
     row_type_filter: Optional[str],
+    sat_filter: Optional[set[str]] = None,
+    freq_filter: Optional[set[int]] = None,
+    rinex_code_filter: Optional[set[str]] = None,
 ) -> list[ComponentRow]:
     normalized: list[ComponentRow] = []
     for index, row in enumerate(rows, start=2):
@@ -199,14 +202,20 @@ def normalize_rows(
         row_type = detect_row_type(row)
         if row_type_filter is not None and row_type != row_type_filter:
             continue
-        components = extract_components(row, component_names)
-        if not components:
-            continue
         week = to_int(row["week"])
         tow_millis = tow_to_millis(row["tow"])
         sat = row["sat"]
         freq = detect_frequency(row)
         signal = observation_identity(row, row_type)
+        if sat_filter is not None and sat not in sat_filter:
+            continue
+        if freq_filter is not None and freq not in freq_filter:
+            continue
+        if rinex_code_filter is not None and signal not in rinex_code_filter:
+            continue
+        components = extract_components(row, component_names)
+        if not components:
+            continue
         key = (week, tow_millis, row_type, sat, freq, signal)
         normalized.append(
             ComponentRow(
@@ -223,6 +232,25 @@ def normalize_rows(
             )
         )
     return normalized
+
+
+def normalize_filter_values(values: Optional[Sequence[str]]) -> Optional[set[str]]:
+    if not values:
+        return None
+    normalized: set[str] = set()
+    for value in values:
+        for item in value.replace(";", ",").split(","):
+            text = item.strip()
+            if text:
+                normalized.add(text)
+    return normalized or None
+
+
+def normalize_freq_filter(values: Optional[Sequence[str]]) -> Optional[set[int]]:
+    text_values = normalize_filter_values(values)
+    if text_values is None:
+        return None
+    return {to_int(value) for value in text_values}
 
 
 def rows_by_key(rows: Sequence[ComponentRow]) -> tuple[dict[Key, ComponentRow], Counter[Key]]:
@@ -481,6 +509,21 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
     parser.add_argument("--stage", help="compare only rows with this native/bridge stage")
     parser.add_argument("--row-type", choices=["code", "phase"], help="compare only one row type")
     parser.add_argument(
+        "--sat",
+        action="append",
+        help="compare only one satellite label, such as G14; may be repeated or comma-separated",
+    )
+    parser.add_argument(
+        "--freq",
+        action="append",
+        help="compare only one frequency index; may be repeated or comma-separated",
+    )
+    parser.add_argument(
+        "--rinex-code",
+        action="append",
+        help="compare only one row-specific RINEX observation code, such as C2W or L2W",
+    )
+    parser.add_argument(
         "--component",
         dest="components",
         action="append",
@@ -502,17 +545,26 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
 def main(argv: Optional[Sequence[str]] = None) -> int:
     args = parse_args(argv)
     component_names = args.components or sorted(COMPONENT_ALIASES)
+    sat_filter = normalize_filter_values(args.sat)
+    freq_filter = normalize_freq_filter(args.freq)
+    rinex_code_filter = normalize_filter_values(args.rinex_code)
     base_rows = normalize_rows(
         read_csv_rows(args.base_csv),
         component_names=component_names,
         stage_filter=args.stage,
         row_type_filter=args.row_type,
+        sat_filter=sat_filter,
+        freq_filter=freq_filter,
+        rinex_code_filter=rinex_code_filter,
     )
     candidate_rows = normalize_rows(
         read_csv_rows(args.candidate_csv),
         component_names=component_names,
         stage_filter=args.stage,
         row_type_filter=args.row_type,
+        sat_filter=sat_filter,
+        freq_filter=freq_filter,
+        rinex_code_filter=rinex_code_filter,
     )
     report = build_report(
         base_rows,
@@ -527,6 +579,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     report["candidate_csv"] = str(args.candidate_csv)
     report["stage_filter"] = args.stage
     report["row_type_filter"] = args.row_type
+    report["sat_filter"] = sorted(sat_filter) if sat_filter is not None else None
+    report["freq_filter"] = sorted(freq_filter) if freq_filter is not None else None
+    report["rinex_code_filter"] = (
+        sorted(rinex_code_filter) if rinex_code_filter is not None else None
+    )
     report["component_names"] = component_names
     print_summary(report)
     if args.json_out is not None:

--- a/scripts/ci/optional_diff_runner.py
+++ b/scripts/ci/optional_diff_runner.py
@@ -243,6 +243,9 @@ def load_diff_metrics(config: DiffRunnerConfig, report_json: Path) -> dict[str, 
         "components_compared",
         "threshold_exceedances",
         "row_set_complete",
+        "sat_filter",
+        "freq_filter",
+        "rinex_code_filter",
     ]:
         if key in payload:
             metrics[key] = payload[key]

--- a/scripts/ci/run_optional_clas_zd_component_diff.py
+++ b/scripts/ci/run_optional_clas_zd_component_diff.py
@@ -40,6 +40,9 @@ CONFIG = runner.DiffRunnerConfig(
     extra_options=(
         runner.EnvOption(("GNSSPP_CLAS_ZD_STAGE",), "--stage"),
         runner.EnvOption(("GNSSPP_CLAS_ZD_ROW_TYPE",), "--row-type"),
+        runner.EnvOption(("GNSSPP_CLAS_ZD_SAT",), "--sat"),
+        runner.EnvOption(("GNSSPP_CLAS_ZD_FREQ",), "--freq"),
+        runner.EnvOption(("GNSSPP_CLAS_ZD_RINEX_CODE",), "--rinex-code"),
         runner.EnvOption(
             ("GNSSPP_CLAS_ZD_THRESHOLD_M", "GNSSPP_CLAS_ZD_THRESHOLD"),
             "--component-threshold-m",

--- a/tests/test_clas_zd_component_diff.py
+++ b/tests/test_clas_zd_component_diff.py
@@ -256,6 +256,57 @@ class ClasZdComponentDiffTest(unittest.TestCase):
         self.assertEqual(report["top_base_only"][0]["rinex_code"], "C2W")
         self.assertEqual(report["top_candidate_only"][0]["rinex_code"], "C2X")
 
+    def test_slice_filters_apply_after_row_identity_normalization(self) -> None:
+        rows = [
+            code_row(
+                sat="G14",
+                freq="1",
+                prc="0.50",
+                code_bias="0.10",
+                receiver_ant="-0.02",
+                pseudorange_rinex_code="C2W",
+            ),
+            code_row(
+                sat="G14",
+                freq="1",
+                prc="0.60",
+                code_bias="0.10",
+                receiver_ant="-0.02",
+                pseudorange_rinex_code="C2X",
+            ),
+            code_row(
+                sat="G25",
+                freq="1",
+                prc="0.70",
+                code_bias="0.10",
+                receiver_ant="-0.02",
+                pseudorange_rinex_code="C2W",
+            ),
+            code_row(
+                sat="G14",
+                freq="0",
+                prc="0.80",
+                code_bias="0.10",
+                receiver_ant="-0.02",
+                pseudorange_rinex_code="C1C",
+            ),
+        ]
+
+        filtered = component_diff.normalize_rows(
+            rows,
+            component_names=["prc_m"],
+            stage_filter=None,
+            row_type_filter="code",
+            sat_filter={"G14"},
+            freq_filter={1},
+            rinex_code_filter={"C2W"},
+        )
+
+        self.assertEqual(len(filtered), 1)
+        self.assertEqual(filtered[0].sat, "G14")
+        self.assertEqual(filtered[0].freq, 1)
+        self.assertEqual(filtered[0].signal, "C2W")
+
     def test_compares_common_component_rows_and_reports_unmatched(self) -> None:
         base_rows = [
             code_row(
@@ -480,6 +531,12 @@ class ClasZdComponentDiffTest(unittest.TestCase):
                     "native",
                     "--row-type",
                     "code",
+                    "--sat",
+                    "G14",
+                    "--freq",
+                    "1",
+                    "--rinex-code",
+                    "C2W",
                     "--component",
                     "prc_m",
                     "--component",
@@ -503,6 +560,9 @@ class ClasZdComponentDiffTest(unittest.TestCase):
             self.assertEqual(report["schema"], "clas_zd_component_diff.v1")
             self.assertEqual(report["threshold_exceedances"], 1)
             self.assertEqual(report["component_names"], ["prc_m", "receiver_antenna_m"])
+            self.assertEqual(report["sat_filter"], ["G14"])
+            self.assertEqual(report["freq_filter"], [1])
+            self.assertEqual(report["rinex_code_filter"], ["C2W"])
             with details_path.open(newline="", encoding="utf-8") as details_file:
                 rows = list(csv.DictReader(details_file))
             self.assertEqual(rows[0]["component"], "prc_m")

--- a/tests/test_optional_clas_zd_component_diff.py
+++ b/tests/test_optional_clas_zd_component_diff.py
@@ -101,6 +101,9 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
                 "GNSSPP_CLAS_ZD_COMPONENTS": "prc_m,code_bias_m",
                 "GNSSPP_CLAS_ZD_STAGE": "accepted",
                 "GNSSPP_CLAS_ZD_ROW_TYPE": "code",
+                "GNSSPP_CLAS_ZD_SAT": "G01",
+                "GNSSPP_CLAS_ZD_FREQ": "1",
+                "GNSSPP_CLAS_ZD_RINEX_CODE": "C2W",
                 "GNSSPP_CLAS_ZD_THRESHOLD_M": "0.25",
                 "GNSSPP_CLAS_ZD_FAIL_ON_DIFF": "1",
             }
@@ -120,6 +123,12 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
             self.assertIn("accepted", command)
             self.assertIn("--row-type", command)
             self.assertIn("code", command)
+            self.assertIn("--sat", command)
+            self.assertIn("G01", command)
+            self.assertIn("--freq", command)
+            self.assertIn("1", command)
+            self.assertIn("--rinex-code", command)
+            self.assertIn("C2W", command)
             self.assertIn("--component-threshold-m", command)
             self.assertIn("0.25", command)
             self.assertIn("--fail-on-diff", command)
@@ -141,6 +150,9 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
                 "GNSSPP_CLAS_ZD_COMPONENTS": "prc_m",
                 "GNSSPP_CLAS_ZD_STAGE": "accepted",
                 "GNSSPP_CLAS_ZD_ROW_TYPE": "code",
+                "GNSSPP_CLAS_ZD_SAT": "G01",
+                "GNSSPP_CLAS_ZD_FREQ": "1",
+                "GNSSPP_CLAS_ZD_RINEX_CODE": "C2W",
             }
             step = runner.build_step_plan(ROOT_DIR, output_dir, env)[0]
 
@@ -152,6 +164,9 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
             self.assertEqual(metrics["schema"], "clas_zd_component_diff.v1")
             self.assertEqual(metrics["common_rows"], 1)
             self.assertEqual(metrics["components_compared"], 1)
+            self.assertEqual(metrics["sat_filter"], ["G01"])
+            self.assertEqual(metrics["freq_filter"], [1])
+            self.assertEqual(metrics["rinex_code_filter"], ["C2W"])
             self.assertAlmostEqual(metrics["max_abs_delta"], 0.05)
 
     def test_run_step_collects_identity_provenance_metrics(self) -> None:


### PR DESCRIPTION
## Summary
- add `--sat`, `--freq`, and `--rinex-code` filters to `clas_zd_component_diff.py`
- expose the same slice controls through optional CI env vars for CLAS ZD component diffs
- record filter selections in JSON/CI metrics and document the A4b `G14 f1 C2W` probe

## Why
After normalizing CLASLIB dumps, the next A4b debugging step is comparing exact slices such as `G14 f1 C2W`. Previously that required ad hoc local Python filtering. The diff artifact and optional CI wrapper can now produce the same focused report directly.

## Validation
- `python3 -m py_compile scripts/analysis/clas_zd_component_diff.py scripts/ci/run_optional_clas_zd_component_diff.py scripts/ci/optional_diff_runner.py tests/test_clas_zd_component_diff.py tests/test_optional_clas_zd_component_diff.py`
- `python3 tests/test_clas_zd_component_diff.py`
- `python3 tests/test_optional_clas_zd_component_diff.py`
- `GNSSPP_CLAS_ZD_BASE_CSV=/tmp/s35_ref/claslib_code_dump.normalized.csv GNSSPP_CLAS_ZD_CANDIDATE_CSV=/tmp/clas_a4b_wrapper_code_dump.csv GNSSPP_CLAS_ZD_COMPONENTS=prc_m,iono_scaled_m GNSSPP_CLAS_ZD_STAGE=post GNSSPP_CLAS_ZD_ROW_TYPE=code GNSSPP_CLAS_ZD_SAT=G14 GNSSPP_CLAS_ZD_FREQ=1 GNSSPP_CLAS_ZD_RINEX_CODE=C2W python3 scripts/ci/run_optional_clas_zd_component_diff.py --output-dir /tmp/clas_zd_optional_filter_smoke`
- `cmake -S . -B build-clas-zd-filter`
- `ctest --test-dir build-clas-zd-filter -R 'python_(optional_)?clas_zd_component_diff_tests' --output-on-failure`