### PR TITLE
[codex] clas: add ZD diff duplicate policy

### DIFF
--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -194,7 +194,10 @@ Optional filters are `GNSSPP_CLAS_ZD_COMPONENTS`, `GNSSPP_CLAS_ZD_STAGE`,
 `GNSSPP_CLAS_ZD_FAIL_ON_DIFF`.  GPS L2W A4b probes can also narrow the row set
 with `GNSSPP_CLAS_ZD_SAT`, `GNSSPP_CLAS_ZD_FREQ`, and
 `GNSSPP_CLAS_ZD_RINEX_CODE`, matching the analysis script's `--sat`, `--freq`,
-and `--rinex-code` filters.
+and `--rinex-code` filters.  CLASLIB dumps can contain repeated rows for the
+same ZD key, so `GNSSPP_CLAS_ZD_DUPLICATE_POLICY` maps to
+`--duplicate-policy`; use `mean` for A4b slice summaries and `fail` when a
+sign-off must reject ambiguous row keys.
 
 CLASLIB-side disposable dumps must first be normalized with
 `scripts/analysis/claslib_zd_component_export.py`.  That export step converts

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -150,6 +150,7 @@ python3 scripts/analysis/clas_zd_component_diff.py \
   --sat G14 \
   --freq 1 \
   --rinex-code C2W \
+  --duplicate-policy mean \
   --json-out /tmp/clas_a4b_native_vs_claslib_code.json \
   --details-csv /tmp/clas_a4b_native_vs_claslib_code.csv
 ```

--- a/scripts/analysis/clas_zd_component_diff.py
+++ b/scripts/analysis/clas_zd_component_diff.py
@@ -7,6 +7,7 @@ import argparse
 import csv
 import json
 import math
+import sys
 from collections import Counter, defaultdict
 from dataclasses import dataclass
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
@@ -55,6 +56,7 @@ COMPONENT_ALIASES: dict[str, tuple[str, ...]] = {
 Row = dict[str, str]
 ComponentMap = dict[str, float]
 Key = tuple[int, int, str, str, int, str]
+DuplicatePolicy = str
 GPS_L2W_RINEX_CODES = {"C2W", "L2W"}
 IDENTITY_PROVENANCE_COMPONENTS = (
     "bias_exact_identity",
@@ -253,13 +255,63 @@ def normalize_freq_filter(values: Optional[Sequence[str]]) -> Optional[set[int]]
     return {to_int(value) for value in text_values}
 
 
-def rows_by_key(rows: Sequence[ComponentRow]) -> tuple[dict[Key, ComponentRow], Counter[Key]]:
+def merge_duplicate_rows(rows: Sequence[ComponentRow]) -> ComponentRow:
+    if not rows:
+        raise ValueError("cannot merge an empty duplicate group")
+    template = rows[0]
+    component_values: DefaultDict[str, list[float]] = defaultdict(list)
+    for row in rows:
+        for component, value in row.components.items():
+            component_values[component].append(value)
+    return ComponentRow(
+        key=template.key,
+        stage=template.stage,
+        row_type=template.row_type,
+        week=template.week,
+        tow=template.tow,
+        sat=template.sat,
+        freq=template.freq,
+        signal=template.signal,
+        source_row=template.source_row,
+        components={
+            component: sum(values) / len(values)
+            for component, values in component_values.items()
+        },
+    )
+
+
+def rows_by_key(
+    rows: Sequence[ComponentRow],
+    *,
+    duplicate_policy: DuplicatePolicy = "last",
+) -> tuple[dict[Key, ComponentRow], Counter[Key]]:
+    if duplicate_policy not in {"first", "last", "mean", "fail"}:
+        raise ValueError(f"unsupported duplicate policy: {duplicate_policy}")
     grouped: dict[Key, ComponentRow] = {}
     duplicate_counts: Counter[Key] = Counter()
+    if duplicate_policy == "mean":
+        duplicates: DefaultDict[Key, list[ComponentRow]] = defaultdict(list)
+        for row in rows:
+            duplicates[row.key].append(row)
+        for key, group in duplicates.items():
+            if len(group) > 1:
+                duplicate_counts[key] = len(group) - 1
+            grouped[key] = merge_duplicate_rows(group)
+        return grouped, duplicate_counts
+
     for row in rows:
         if row.key in grouped:
             duplicate_counts[row.key] += 1
+            if duplicate_policy == "first":
+                continue
         grouped[row.key] = row
+    if duplicate_policy == "fail" and duplicate_counts:
+        first_key, count = duplicate_counts.most_common(1)[0]
+        raise ValueError(
+            "duplicate row keys are present "
+            f"(first duplicate {key_to_dict(first_key)}, extra_rows={count}); "
+            "choose --duplicate-policy first, last, or mean to continue"
+        )
     return grouped, duplicate_counts
 
 
@@ -336,9 +388,16 @@ def build_report(
     threshold_m: Optional[float],
     top_deltas: int,
     top_unmatched: int,
+    duplicate_policy: DuplicatePolicy = "last",
 ) -> dict[str, Any]:
-    base_by_key, base_duplicates = rows_by_key(base_rows)
-    candidate_by_key, candidate_duplicates = rows_by_key(candidate_rows)
+    base_by_key, base_duplicates = rows_by_key(
+        base_rows,
+        duplicate_policy=duplicate_policy,
+    )
+    candidate_by_key, candidate_duplicates = rows_by_key(
+        candidate_rows,
+        duplicate_policy=duplicate_policy,
+    )
     base_keys = set(base_by_key)
     candidate_keys = set(candidate_by_key)
     common_keys = sorted(base_keys & candidate_keys)
@@ -409,6 +468,7 @@ def build_report(
         "candidate_only_rows": len(candidate_only_keys),
         "base_duplicate_keys": sum(base_duplicates.values()),
         "candidate_duplicate_keys": sum(candidate_duplicates.values()),
+        "duplicate_policy": duplicate_policy,
         "components_compared": sum(item["rows"] for item in per_component),
         "component_threshold_m": threshold_m,
         "threshold_exceedances": threshold_exceedances,
@@ -524,6 +584,15 @@ def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
         help="compare only one row-specific RINEX observation code, such as C2W or L2W",
     )
     parser.add_argument(
+        "--duplicate-policy",
+        choices=["first", "last", "mean", "fail"],
+        default="last",
+        help=(
+            "how to handle multiple rows with the same comparison key. "
+            "Default last preserves the historical behavior."
+        ),
+    )
+    parser.add_argument(
         "--component",
         dest="components",
         action="append",
@@ -566,15 +635,20 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         freq_filter=freq_filter,
         rinex_code_filter=rinex_code_filter,
     )
-    report = build_report(
-        base_rows,
-        candidate_rows,
-        base_label=args.base_label,
-        candidate_label=args.candidate_label,
-        threshold_m=args.component_threshold_m,
-        top_deltas=args.top_deltas,
-        top_unmatched=args.top_unmatched,
-    )
+    try:
+        report = build_report(
+            base_rows,
+            candidate_rows,
+            base_label=args.base_label,
+            candidate_label=args.candidate_label,
+            threshold_m=args.component_threshold_m,
+            top_deltas=args.top_deltas,
+            top_unmatched=args.top_unmatched,
+            duplicate_policy=args.duplicate_policy,
+        )
+    except ValueError as exc:
+        print(f"clas_zd_component_diff: {exc}", file=sys.stderr)
+        return 2
     report["base_csv"] = str(args.base_csv)
     report["candidate_csv"] = str(args.candidate_csv)
     report["stage_filter"] = args.stage

--- a/scripts/ci/optional_diff_runner.py
+++ b/scripts/ci/optional_diff_runner.py
@@ -246,6 +246,7 @@ def load_diff_metrics(config: DiffRunnerConfig, report_json: Path) -> dict[str, 
         "sat_filter",
         "freq_filter",
         "rinex_code_filter",
+        "duplicate_policy",
     ]:
         if key in payload:
             metrics[key] = payload[key]

--- a/scripts/ci/run_optional_clas_zd_component_diff.py
+++ b/scripts/ci/run_optional_clas_zd_component_diff.py
@@ -43,6 +43,7 @@ CONFIG = runner.DiffRunnerConfig(
         runner.EnvOption(("GNSSPP_CLAS_ZD_SAT",), "--sat"),
         runner.EnvOption(("GNSSPP_CLAS_ZD_FREQ",), "--freq"),
         runner.EnvOption(("GNSSPP_CLAS_ZD_RINEX_CODE",), "--rinex-code"),
+        runner.EnvOption(("GNSSPP_CLAS_ZD_DUPLICATE_POLICY",), "--duplicate-policy"),
         runner.EnvOption(
             ("GNSSPP_CLAS_ZD_THRESHOLD_M", "GNSSPP_CLAS_ZD_THRESHOLD"),
             "--component-threshold-m",

--- a/tests/test_clas_zd_component_diff.py
+++ b/tests/test_clas_zd_component_diff.py
@@ -307,6 +307,85 @@ class ClasZdComponentDiffTest(unittest.TestCase):
         self.assertEqual(filtered[0].freq, 1)
         self.assertEqual(filtered[0].signal, "C2W")
 
+    def test_duplicate_policy_controls_repeated_row_keys(self) -> None:
+        base = component_diff.normalize_rows(
+            [
+                code_row(
+                    sat="G14",
+                    freq="1",
+                    prc="0.50",
+                    code_bias="0.10",
+                    receiver_ant="-0.02",
+                    pseudorange_rinex_code="C2W",
+                ),
+                code_row(
+                    sat="G14",
+                    freq="1",
+                    prc="0.70",
+                    code_bias="0.10",
+                    receiver_ant="-0.02",
+                    pseudorange_rinex_code="C2W",
+                ),
+            ],
+            component_names=["prc_m"],
+            stage_filter=None,
+            row_type_filter="code",
+        )
+        candidate = component_diff.normalize_rows(
+            [
+                code_row(
+                    sat="G14",
+                    freq="1",
+                    prc="1.00",
+                    code_bias="0.10",
+                    receiver_ant="-0.02",
+                    pseudorange_rinex_code="C2W",
+                )
+            ],
+            component_names=["prc_m"],
+            stage_filter=None,
+            row_type_filter="code",
+        )
+
+        last_report = component_diff.build_report(
+            base,
+            candidate,
+            base_label="claslib",
+            candidate_label="native",
+            threshold_m=None,
+            top_deltas=10,
+            top_unmatched=10,
+        )
+        self.assertEqual(last_report["duplicate_policy"], "last")
+        self.assertEqual(last_report["base_duplicate_keys"], 1)
+        self.assertAlmostEqual(last_report["top_component_deltas"][0]["delta_m"], 0.30)
+
+        mean_report = component_diff.build_report(
+            base,
+            candidate,
+            base_label="claslib",
+            candidate_label="native",
+            threshold_m=None,
+            top_deltas=10,
+            top_unmatched=10,
+            duplicate_policy="mean",
+        )
+        self.assertEqual(mean_report["duplicate_policy"], "mean")
+        self.assertEqual(mean_report["base_duplicate_keys"], 1)
+        self.assertAlmostEqual(mean_report["top_component_deltas"][0]["delta_m"], 0.40)
+
+        with self.assertRaisesRegex(ValueError, "duplicate row keys are present"):
+            component_diff.build_report(
+                base,
+                candidate,
+                base_label="claslib",
+                candidate_label="native",
+                threshold_m=None,
+                top_deltas=10,
+                top_unmatched=10,
+                duplicate_policy="fail",
+            )
+
     def test_compares_common_component_rows_and_reports_unmatched(self) -> None:
         base_rows = [
             code_row(
@@ -537,6 +616,8 @@ class ClasZdComponentDiffTest(unittest.TestCase):
                     "1",
                     "--rinex-code",
                     "C2W",
+                    "--duplicate-policy",
+                    "mean",
                     "--component",
                     "prc_m",
                     "--component",
@@ -563,6 +644,7 @@ class ClasZdComponentDiffTest(unittest.TestCase):
             self.assertEqual(report["sat_filter"], ["G14"])
             self.assertEqual(report["freq_filter"], [1])
             self.assertEqual(report["rinex_code_filter"], ["C2W"])
+            self.assertEqual(report["duplicate_policy"], "mean")
             with details_path.open(newline="", encoding="utf-8") as details_file:
                 rows = list(csv.DictReader(details_file))
             self.assertEqual(rows[0]["component"], "prc_m")

--- a/tests/test_optional_clas_zd_component_diff.py
+++ b/tests/test_optional_clas_zd_component_diff.py
@@ -104,6 +104,7 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
                 "GNSSPP_CLAS_ZD_SAT": "G01",
                 "GNSSPP_CLAS_ZD_FREQ": "1",
                 "GNSSPP_CLAS_ZD_RINEX_CODE": "C2W",
+                "GNSSPP_CLAS_ZD_DUPLICATE_POLICY": "mean",
                 "GNSSPP_CLAS_ZD_THRESHOLD_M": "0.25",
                 "GNSSPP_CLAS_ZD_FAIL_ON_DIFF": "1",
             }
@@ -129,6 +130,8 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
             self.assertIn("1", command)
             self.assertIn("--rinex-code", command)
             self.assertIn("C2W", command)
+            self.assertIn("--duplicate-policy", command)
+            self.assertIn("mean", command)
             self.assertIn("--component-threshold-m", command)
             self.assertIn("0.25", command)
             self.assertIn("--fail-on-diff", command)
@@ -153,6 +156,7 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
                 "GNSSPP_CLAS_ZD_SAT": "G01",
                 "GNSSPP_CLAS_ZD_FREQ": "1",
                 "GNSSPP_CLAS_ZD_RINEX_CODE": "C2W",
+                "GNSSPP_CLAS_ZD_DUPLICATE_POLICY": "mean",
             }
             step = runner.build_step_plan(ROOT_DIR, output_dir, env)[0]
 
@@ -167,6 +171,7 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
             self.assertEqual(metrics["sat_filter"], ["G01"])
             self.assertEqual(metrics["freq_filter"], [1])
             self.assertEqual(metrics["rinex_code_filter"], ["C2W"])
+            self.assertEqual(metrics["duplicate_policy"], "mean")
             self.assertAlmostEqual(metrics["max_abs_delta"], 0.05)
 
     def test_run_step_collects_identity_provenance_metrics(self) -> None:


### PR DESCRIPTION
## Summary

- add `--duplicate-policy first|last|mean|fail` to `clas_zd_component_diff.py`, with `last` preserving the historical behavior
- pass `GNSSPP_CLAS_ZD_DUPLICATE_POLICY` through the optional CLAS ZD diff runner and expose the selected policy in CI metrics
- document `mean` for A4b slice summaries and `fail` for strict sign-off jobs that should reject ambiguous row keys

## Why

CLASLIB ZD component dumps can contain repeated rows for the same comparison key. The diff tool previously overwrote duplicates implicitly, which made GPS L2W A4b slice summaries depend on row ordering. This makes the policy explicit while keeping the default behavior unchanged.

## Validation

- `python3 -m py_compile scripts/analysis/clas_zd_component_diff.py scripts/ci/run_optional_clas_zd_component_diff.py scripts/ci/optional_diff_runner.py tests/test_clas_zd_component_diff.py tests/test_optional_clas_zd_component_diff.py`
- `python3 tests/test_clas_zd_component_diff.py`
- `python3 tests/test_optional_clas_zd_component_diff.py`
- `git diff --check`

Also smoke-tested `--duplicate-policy mean` against the local A4b `G14/f1/C2W` CLASLIB/native component dumps before publishing.