### PR TITLE
[codex] clas: add ZD row breakdown diagnostics

### DIFF
--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -158,6 +158,10 @@ python3 scripts/analysis/clas_zd_component_diff.py \
 On the 300-epoch 2019 sample smoke, current `develop` produces 5,400 native code
 rows. The GPS L2W slice has 300 rows, all with exact bias identity and exact
 observation matches, and zero observation-family or code-bias fallback rows.
+The diff JSON also includes `top_row_component_breakdowns`, which groups all
+component deltas for the same ZD key. Use that field to decide whether the next
+GPS L2W A4b slice is dominated by `code_bias_m`, `receiver_antenna_m`, `prc_m`,
+or another component before changing the gated correction model.
 
 Build with CLASLIB linked only when you need oracle-backed unit tests:
 

--- a/scripts/analysis/clas_zd_component_diff.py
+++ b/scripts/analysis/clas_zd_component_diff.py
@@ -379,6 +379,46 @@ def row_summary(row: ComponentRow) -> dict[str, Any]:
     }
 
 
+def row_component_breakdown(
+    key: Key,
+    base_row: ComponentRow,
+    candidate_row: ComponentRow,
+) -> dict[str, Any]:
+    components: list[dict[str, Any]] = []
+    for component in sorted(set(base_row.components) | set(candidate_row.components)):
+        base_value = base_row.components.get(component)
+        candidate_value = candidate_row.components.get(component)
+        if base_value is None or candidate_value is None:
+            continue
+        delta = candidate_value - base_value
+        components.append(
+            {
+                "component": component,
+                "base_value_m": base_value,
+                "candidate_value_m": candidate_value,
+                "delta_m": delta,
+                "abs_delta_m": abs(delta),
+            }
+        )
+    components.sort(key=lambda item: (-item["abs_delta_m"], item["component"]))
+    return {
+        **key_to_dict(key),
+        "base_stage": base_row.stage,
+        "candidate_stage": candidate_row.stage,
+        "base_signal": base_row.signal,
+        "candidate_signal": candidate_row.signal,
+        "base_source_row": base_row.source_row,
+        "candidate_source_row": candidate_row.source_row,
+        "component_count": len(components),
+        "max_abs_delta_m": max(
+            (item["abs_delta_m"] for item in components),
+            default=0.0,
+        ),
+        "sum_abs_delta_m": sum(item["abs_delta_m"] for item in components),
+        "components": components,
+    }
+
+
 def build_report(
     base_rows: Sequence[ComponentRow],
     candidate_rows: Sequence[ComponentRow],
@@ -406,12 +446,16 @@ def build_report(
 
     component_deltas: DefaultDict[str, list[float]] = defaultdict(list)
     details: list[dict[str, Any]] = []
+    row_breakdowns: list[dict[str, Any]] = []
     missing_components: Counter[str] = Counter()
     threshold_exceedances = 0
 
     for key in common_keys:
         base_row = base_by_key[key]
         candidate_row = candidate_by_key[key]
+        row_breakdown = row_component_breakdown(key, base_row, candidate_row)
+        if row_breakdown["component_count"] > 0:
+            row_breakdowns.append(row_breakdown)
         components = sorted(set(base_row.components) | set(candidate_row.components))
         for component in components:
             base_value = base_row.components.get(component)
@@ -451,6 +495,18 @@ def build_report(
             item["component"],
         )
     )
+    row_breakdowns.sort(
+        key=lambda item: (
+            -item["sum_abs_delta_m"],
+            -item["max_abs_delta_m"],
+            item["week"],
+            item["tow"],
+            item["row_type"],
+            item["sat"],
+            item["freq"],
+            item["rinex_code"],
+        )
+    )
     per_component = [
         {"component": component, **component_stats(values)}
         for component, values in sorted(component_deltas.items())
@@ -482,6 +538,7 @@ def build_report(
         },
         "per_component": per_component,
         "top_component_deltas": details[:top_deltas],
+        "top_row_component_breakdowns": row_breakdowns[:top_deltas],
         "top_base_only": [row_summary(base_by_key[key]) for key in base_only_keys[:top_unmatched]],
         "top_candidate_only": [
             row_summary(candidate_by_key[key]) for key in candidate_only_keys[:top_unmatched]
@@ -555,6 +612,19 @@ def print_summary(report: dict[str, Any]) -> None:
             f"{top['week']}:{top['tow']:.3f} {top['row_type']} "
             f"{top['sat']} f{top['freq']} {top['component']} "
             f"delta={top['delta_m']:.6g}"
+        )
+    if report["top_row_component_breakdowns"]:
+        top = report["top_row_component_breakdowns"][0]
+        top_components = ", ".join(
+            f"{item['component']}={item['delta_m']:.6g}"
+            for item in top["components"][:5]
+        )
+        print(
+            "  max_row_delta: "
+            f"{top['week']}:{top['tow']:.3f} {top['row_type']} "
+            f"{top['sat']} f{top['freq']} {top['rinex_code']} "
+            f"sum_abs={top['sum_abs_delta_m']:.6g} "
+            f"components=[{top_components}]"
         )
 
 

--- a/scripts/ci/optional_diff_runner.py
+++ b/scripts/ci/optional_diff_runner.py
@@ -260,6 +260,16 @@ def load_diff_metrics(config: DiffRunnerConfig, report_json: Path) -> dict[str, 
             if isinstance(value, (int, float)):
                 max_abs_delta = max(max_abs_delta, float(value))
         metrics["max_abs_delta"] = max_abs_delta
+    top_row_breakdowns = payload.get("top_row_component_breakdowns")
+    if isinstance(top_row_breakdowns, list) and top_row_breakdowns:
+        first_row = top_row_breakdowns[0]
+        if isinstance(first_row, dict):
+            sum_abs_delta = first_row.get("sum_abs_delta_m")
+            max_abs_delta = first_row.get("max_abs_delta_m")
+            if isinstance(sum_abs_delta, (int, float)):
+                metrics["top_row_sum_abs_delta"] = float(sum_abs_delta)
+            if isinstance(max_abs_delta, (int, float)):
+                metrics["top_row_max_abs_delta"] = float(max_abs_delta)
     identity_provenance = payload.get("identity_provenance")
     if isinstance(identity_provenance, dict):
         for label, summary in identity_provenance.items():
@@ -375,6 +385,9 @@ def render_result_detail(result: dict[str, object]) -> str:
         max_abs_delta = metrics.get("max_abs_delta")
         if max_abs_delta is not None:
             detail_parts.append(f"max |delta| {format_metric(max_abs_delta)}")
+        top_row_sum = metrics.get("top_row_sum_abs_delta")
+        if top_row_sum is not None:
+            detail_parts.append(f"top row sum |delta| {format_metric(top_row_sum)}")
         threshold_exceedances = metrics.get("threshold_exceedances")
         if threshold_exceedances is not None:
             detail_parts.append(f"threshold exceedances `{threshold_exceedances}`")

--- a/tests/test_clas_zd_component_diff.py
+++ b/tests/test_clas_zd_component_diff.py
@@ -454,6 +454,16 @@ class ClasZdComponentDiffTest(unittest.TestCase):
         self.assertEqual(report["top_component_deltas"][0]["component"], "prc_m")
         self.assertAlmostEqual(report["top_component_deltas"][0]["delta_m"], 0.25)
         self.assertEqual(report["top_component_deltas"][0]["candidate_signal"], "C2W")
+        row_breakdown = report["top_row_component_breakdowns"][0]
+        self.assertEqual(row_breakdown["sat"], "G14")
+        self.assertEqual(row_breakdown["rinex_code"], "C2W")
+        self.assertEqual(row_breakdown["component_count"], 3)
+        self.assertAlmostEqual(row_breakdown["sum_abs_delta_m"], 0.27)
+        self.assertEqual(
+            [item["component"] for item in row_breakdown["components"]],
+            ["prc_m", "receiver_antenna_m", "code_bias_m"],
+        )
+        self.assertAlmostEqual(row_breakdown["components"][0]["delta_m"], 0.25)
 
     def test_report_summarizes_gps_l2w_identity_provenance(self) -> None:
         base = component_diff.normalize_rows(
@@ -637,6 +647,7 @@ class ClasZdComponentDiffTest(unittest.TestCase):
 
             self.assertEqual(result.returncode, 2, msg=result.stderr)
             self.assertIn("clas_zd_component_diff:", result.stdout)
+            self.assertIn("max_row_delta:", result.stdout)
             report = json.loads(report_path.read_text(encoding="utf-8"))
             self.assertEqual(report["schema"], "clas_zd_component_diff.v1")
             self.assertEqual(report["threshold_exceedances"], 1)
@@ -645,6 +656,11 @@ class ClasZdComponentDiffTest(unittest.TestCase):
             self.assertEqual(report["freq_filter"], [1])
             self.assertEqual(report["rinex_code_filter"], ["C2W"])
             self.assertEqual(report["duplicate_policy"], "mean")
+            self.assertEqual(report["top_row_component_breakdowns"][0]["sat"], "G14")
+            self.assertEqual(
+                report["top_row_component_breakdowns"][0]["components"][0]["component"],
+                "prc_m",
+            )
             with details_path.open(newline="", encoding="utf-8") as details_file:
                 rows = list(csv.DictReader(details_file))
             self.assertEqual(rows[0]["component"], "prc_m")

--- a/tests/test_optional_clas_zd_component_diff.py
+++ b/tests/test_optional_clas_zd_component_diff.py
@@ -173,6 +173,8 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
             self.assertEqual(metrics["rinex_code_filter"], ["C2W"])
             self.assertEqual(metrics["duplicate_policy"], "mean")
             self.assertAlmostEqual(metrics["max_abs_delta"], 0.05)
+            self.assertAlmostEqual(metrics["top_row_sum_abs_delta"], 0.05)
+            self.assertAlmostEqual(metrics["top_row_max_abs_delta"], 0.05)
 
     def test_run_step_collects_identity_provenance_metrics(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ci_clas_zd_identity_") as temp_dir:
@@ -222,6 +224,7 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
                         "candidate_only_rows": 2,
                         "components_compared": 24,
                         "max_abs_delta": 0.125,
+                        "top_row_sum_abs_delta": 0.375,
                         "threshold_exceedances": 3,
                         "identity_native_gps_l2w_rows": 2,
                         "identity_native_gps_l2w_bias_exact_identity_rows": 1,
@@ -251,6 +254,7 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
         self.assertIn("unmatched `1/2`", markdown)
         self.assertIn("components `24`", markdown)
         self.assertIn("max |delta| 0.125", markdown)
+        self.assertIn("top row sum |delta| 0.375", markdown)
         self.assertIn("threshold exceedances `3`", markdown)
         self.assertIn("native L2W `2`", markdown)
         self.assertIn("native L2W exact bias/match `1/1`", markdown)


### PR DESCRIPTION
## Summary

- add `top_row_component_breakdowns` to the CLAS ZD component diff JSON report
- print a `max_row_delta` summary line showing the largest same-row component bundle
- surface top-row sum/max delta metrics in the optional CLAS ZD sign-off summary
- document using row breakdowns to choose the next GPS L2W A4b correction-model slice

## Why

A4b GPS L2W work needs to distinguish whether the same ZD row is dominated by code bias, receiver antenna, PRC, or another component before changing the gated correction model. The existing report ranked individual component deltas, but did not group all deltas for a row key.

## Validation

- `python3 -m py_compile scripts/analysis/clas_zd_component_diff.py scripts/ci/optional_diff_runner.py tests/test_clas_zd_component_diff.py tests/test_optional_clas_zd_component_diff.py`
- `python3 tests/test_clas_zd_component_diff.py`
- `python3 tests/test_optional_clas_zd_component_diff.py`
- `ctest --test-dir build-madoca-parity -R 'python_(optional_)?clas_zd_component_diff_tests' --output-on-failure`\n- `git diff --check`\n\nAlso smoke-tested `top_row_component_breakdowns` against the local A4b `G14/f1/C2W` CLASLIB/native dumps. The largest row shows code bias and PRC dominating, with receiver antenna around 0.09 m.