### PR TITLE
[codex] clas: document A4b base-only code bias policy

### DIFF
--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -228,3 +228,11 @@ from exact `C2W/L2W` matches.  The native dumps also carry the requested
 `C2W/L2W` identity plus `observation_exact_match` and
 `observation_family_fallback` flags, separating a bias lookup fallback from a raw
 observation lookup fallback before the A4b GPS L2W correction model changes.
+For the GPS L2W A4b correction-materialization probe, run the raw CLAS L6
+expansion with `--compact-code-bias-composition-policy base-only-if-present` and
+`--compact-code-bias-bank-policy latest-preceding-bank`. The 2019 G14/C2W
+network code-bias rows behave as subtype-4 base-value replacements: using direct
+subtype-6 values leaves periodic `-0.70 m` native rows against `+0.76 m`
+CLASLIB rows, while adding base plus network leaves the same rows near
+`+0.06 m`. The base-only policy removes that 30-second sign flip without
+changing default CLAS behavior.

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -105,6 +105,8 @@ python3 apps/gnss.py clas-ppp \
   --nav "$DATA/sept_2019239.nav" \
   --qzss-l6 "$DATA/2019239Q.l6" \
   --qzss-gps-week 2068 \
+  --compact-code-bias-composition-policy base-only-if-present \
+  --compact-code-bias-bank-policy latest-preceding-bank \
   --out /tmp/gnsspp_clas_a4b_native.pos \
   --summary-json /tmp/gnsspp_clas_a4b_native_summary.json \
   --max-epochs 300
@@ -158,10 +160,21 @@ python3 scripts/analysis/clas_zd_component_diff.py \
 On the 300-epoch 2019 sample smoke, current `develop` produces 5,400 native code
 rows. The GPS L2W slice has 300 rows, all with exact bias identity and exact
 observation matches, and zero observation-family or code-bias fallback rows.
+Use `base-only-if-present` with the latest preceding base bank for this A4b
+probe: the subtype-6 network code-bias rows are replacement rows for the
+subtype-4 base values, not additive deltas. On the same 300-epoch window, the
+direct network policy produced periodic G14/C2W `code_bias_m` outliers such as
+`-0.70 m` where CLASLIB reports `+0.76 m`. The A4b policy above restores those
+rows to the base value and reduces the G14/C2W `code_bias_m` diff from
+`mean_abs=0.1795 m, rms=0.4000 m, max_abs=1.4600 m` to
+`mean_abs=0.1319 m, rms=0.3029 m, max_abs=0.7800 m`. The remaining top-row
+deltas are then dominated by residual/PRC, receiver antenna, and atmosphere
+terms rather than the 30-second code-bias sign flip.
+
 The diff JSON also includes `top_row_component_breakdowns`, which groups all
 component deltas for the same ZD key. Use that field to decide whether the next
-GPS L2W A4b slice is dominated by `code_bias_m`, `receiver_antenna_m`, `prc_m`,
-or another component before changing the gated correction model.
+GPS L2W A4b slice is dominated by `receiver_antenna_m`, `prc_m`, atmosphere, or
+another component before changing the gated correction model.
 
 Build with CLASLIB linked only when you need oracle-backed unit tests:
 

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -5631,6 +5631,81 @@ class CLIToolsTest(unittest.TestCase):
             self.assertEqual(preceding_result.returncode, 0, msg=preceding_result.stderr)
             self.assertIn("cbias:2=-0.080000", preceding_path.read_text(encoding="ascii"))
 
+    def test_qzss_l6_info_compact_code_bias_base_only_uses_prior_anchor(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_qzss_l6_code_bias_base_only_prev_") as temp_dir:
+            temp_root = Path(temp_dir)
+            input_path = temp_root / "session_l6_code_bias_base_only_prev.bin"
+            direct_path = temp_root / "direct.csv"
+            base_only_path = temp_root / "base_only.csv"
+            input_path.write_bytes(
+                build_qzss_l6_subframe_stream(
+                    [
+                        build_qzss_cssr_mask_message(tow=518370, iod=3, prn=3, sync=True),
+                        build_qzss_cssr_code_bias_message(
+                            tow_delta=0,
+                            iod=3,
+                            bias_m=-0.12,
+                            sync=False,
+                        ),
+                        build_qzss_cssr_mask_message(tow=518400, iod=3, prn=3, sync=True),
+                        build_qzss_cssr_code_phase_bias_message(
+                            tow_delta=0,
+                            iod=3,
+                            sync=False,
+                            network_bias=True,
+                            code_bias_exists=True,
+                            phase_bias_exists=False,
+                            selected_mask=0b1,
+                            code_bias_m=0.04,
+                        ),
+                    ]
+                )
+            )
+
+            direct_result = self.run_gnss(
+                "qzss-l6-info",
+                "--input",
+                str(input_path),
+                "--extract-compact-corrections",
+                str(direct_path),
+                "--gps-week",
+                "2200",
+            )
+            self.assertEqual(direct_result.returncode, 0, msg=direct_result.stderr)
+            direct_csv = direct_path.read_text(encoding="ascii")
+            direct_network_rows = [
+                line
+                for line in direct_csv.splitlines()
+                if line.startswith("2200,518400.000,G,3")
+            ]
+            self.assertEqual(len(direct_network_rows), 1)
+            self.assertIn("cbias:2=0.040000", direct_network_rows[0])
+            self.assertNotIn("cbias:2=-0.120000", direct_network_rows[0])
+
+            base_only_result = self.run_gnss(
+                "qzss-l6-info",
+                "--input",
+                str(input_path),
+                "--extract-compact-corrections",
+                str(base_only_path),
+                "--gps-week",
+                "2200",
+                "--compact-code-bias-composition-policy",
+                "base-only-if-present",
+                "--compact-code-bias-bank-policy",
+                "latest-preceding-bank",
+            )
+            self.assertEqual(base_only_result.returncode, 0, msg=base_only_result.stderr)
+            base_only_csv = base_only_path.read_text(encoding="ascii")
+            base_only_network_rows = [
+                line
+                for line in base_only_csv.splitlines()
+                if line.startswith("2200,518400.000,G,3")
+            ]
+            self.assertEqual(len(base_only_network_rows), 1)
+            self.assertIn("cbias:2=-0.120000", base_only_network_rows[0])
+            self.assertNotIn("cbias:2=0.040000", base_only_network_rows[0])
+
     def test_qzss_l6_info_compact_code_bias_bank_policy_close_30s_bank_rejects_older_anchor(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_qzss_l6_code_bias_bank_close30_") as temp_dir:
             temp_root = Path(temp_dir)


### PR DESCRIPTION
## Summary
- Document the GPS L2W A4b CLAS runbook policy as `base-only-if-present` with `latest-preceding-bank`.
- Add a synthetic QZSS L6 regression test proving base-only composition uses a prior subtype-4 base value for later subtype-6 network rows.
- Record the observed 2019 G14/C2W improvement from the local 300-epoch component diff.

## Root Cause
The A4b GPS L2W outliers were not an exact-observation identity problem anymore. Subtype-6 network code-bias rows were being interpreted as direct replacement values in the default diagnostic run, producing periodic negative native rows such as `-0.70 m` where CLASLIB reports about `+0.76 m`. For this probe, the network rows should preserve the latest subtype-4 base value when present.

## Validation
- `python3 -m unittest tests.test_cli_tools.CLIToolsTest.test_qzss_l6_info_compact_code_bias_base_only_uses_prior_anchor`
- `python3 -m unittest tests.test_cli_tools.CLIToolsTest.test_qzss_l6_info_compact_code_bias_composition_policy_base_plus_network_adds_base_row tests.test_cli_tools.CLIToolsTest.test_qzss_l6_info_compact_code_bias_composition_policy_base_only_if_present_keeps_base_row tests.test_cli_tools.CLIToolsTest.test_qzss_l6_info_compact_code_bias_bank_policy_same_30s_bank_uses_prior_base_bank tests.test_cli_tools.CLIToolsTest.test_qzss_l6_info_compact_code_bias_bank_policy_latest_preceding_bank_uses_prior_anchor tests.test_cli_tools.CLIToolsTest.test_qzss_l6_info_compact_code_bias_base_only_uses_prior_anchor tests.test_cli_tools.CLIToolsTest.test_qzss_l6_info_compact_code_bias_bank_policy_close_30s_bank_rejects_older_anchor`
- `python3 -m py_compile apps/gnss_qzss_l6_info.py apps/gnss_clas_ppp.py tests/test_cli_tools.py`
- `git diff --check`
- Local optional CLAS 300-epoch A4b run against `/tmp/claslib/data`, followed by `clas_zd_component_diff.py` for G14/C2W.