### PR TITLE
[codex] clas: forward ANTEX through wrapper

### DIFF
--- a/apps/gnss_clas_ppp.py
+++ b/apps/gnss_clas_ppp.py
@@ -133,6 +133,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--summary-json", type=Path, default=None, help="Optional summary JSON path.")
     parser.add_argument("--sp3", type=Path, default=None, help="Optional precise SP3 file.")
     parser.add_argument("--clk", type=Path, default=None, help="Optional precise CLK file.")
+    parser.add_argument("--antex", type=Path, default=None, help="Optional ANTEX file forwarded to PPP.")
     parser.add_argument("--kml", type=Path, default=None, help="Optional KML output path.")
     parser.add_argument("--max-epochs", type=int, default=0, help="Stop after N epochs.")
     parser.add_argument(
@@ -588,6 +589,7 @@ def build_summary_payload(
         "nav": str(args.nav),
         "sp3": str(args.sp3) if args.sp3 is not None else None,
         "clk": str(args.clk) if args.clk is not None else None,
+        "antex": str(args.antex) if args.antex is not None else None,
         "ssr_rtcm": args.ssr_rtcm,
         "compact_ssr": args.compact_ssr,
         "qzss_l6": args.qzss_l6,
@@ -700,6 +702,7 @@ def main() -> int:
     ensure_exists(args.nav, "navigation file")
     ensure_exists(args.sp3, "SP3 file")
     ensure_exists(args.clk, "CLK file")
+    ensure_exists(args.antex, "ANTEX file")
     selected_sources = [bool(args.ssr_rtcm), bool(args.compact_ssr), bool(args.qzss_l6)]
     if sum(1 for selected in selected_sources if selected) != 1:
         raise SystemExit("Specify exactly one of --ssr-rtcm, --compact-ssr, or --qzss-l6")
@@ -775,6 +778,8 @@ def main() -> int:
             command.extend(["--sp3", str(args.sp3)])
         if args.clk is not None:
             command.extend(["--clk", str(args.clk)])
+        if args.antex is not None:
+            command.extend(["--antex", str(args.antex)])
         if args.kml is not None:
             command.extend(["--kml", str(args.kml)])
         if args.max_epochs > 0:

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -92,6 +92,12 @@ python3 apps/gnss.py clas-ppp \
   --max-epochs 300
 ```
 
+`gnss clas-ppp` also forwards `--antex <antennas.atx>` to the underlying
+`gnss ppp` run for receiver/satellite antenna parity probes. The public
+`0627239Q.obs` header does not declare a receiver antenna type, so passing the
+CLASLIB ANTEX file alone does not close the `receiver_antenna_m` delta; the
+remaining A4b work still needs explicit receiver antenna identity provenance.
+
 For the A4b GPS L2W identity probe, enable the diagnostic gates and write a
 native zero-difference code component dump:
 

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -264,6 +264,7 @@ For compact-SSR ingestion experiments, the shared decode boundary also exposes:
 - `gnss clas-ppp --compact-phase-bias-source-policy <arrival-order|subtype5-priority|subtype6-priority>`
 - `gnss clas-ppp --compact-code-bias-composition-policy <direct-values|base-plus-network|base-only-if-present>`
 - `gnss clas-ppp --compact-code-bias-bank-policy <pending-epoch|same-30s-bank|close-30s-bank|latest-preceding-bank>`
+- `gnss clas-ppp --antex <antennas.atx>`
 - `gnss clas-ppp --compact-bias-row-materialization <overlap-only|selected-satellite-base-extend|all-base-satellite-extend>`
 - `gnss clas-ppp --compact-phase-bias-composition-policy <direct-values|base-plus-network|base-only-if-present>`
 - `gnss clas-ppp --compact-phase-bias-bank-policy <pending-epoch|same-30s-bank|close-30s-bank|latest-preceding-bank>`

--- a/tests/test_benchmark_scripts.py
+++ b/tests/test_benchmark_scripts.py
@@ -416,6 +416,7 @@ class ClasCompactHelpersTest(unittest.TestCase):
                 "nav": Path("nav.rnx"),
                 "sp3": None,
                 "clk": None,
+                "antex": None,
                 "ssr_rtcm": None,
                 "compact_ssr": "corrections.compact.csv",
                 "qzss_l6": None,
@@ -445,6 +446,73 @@ class ClasCompactHelpersTest(unittest.TestCase):
 
             self.assertTrue(clas_payload["clas_osr_filter_enabled"])
             self.assertFalse(madoca_payload["clas_osr_filter_enabled"])
+            self.assertIsNone(clas_payload["antex"])
+            self.assertIsNone(madoca_payload["antex"])
+
+    def test_main_forwards_antex_to_ppp_and_records_summary(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_clas_antex_forward_") as temp_dir:
+            temp_root = Path(temp_dir)
+            obs_path = temp_root / "rover.obs"
+            nav_path = temp_root / "nav.rnx"
+            compact_path = temp_root / "corrections.compact.csv"
+            antex_path = temp_root / "receiver.atx"
+            output_path = temp_root / "solution.pos"
+            summary_path = temp_root / "summary.json"
+            obs_path.write_text("synthetic obs placeholder\n", encoding="ascii")
+            nav_path.write_text("synthetic nav placeholder\n", encoding="ascii")
+            compact_path.write_text(
+                "\n".join(
+                    [
+                        "# week,tow,system,prn,dx,dy,dz,dclock_m",
+                        "2200,345600.0,G,3,0.0,0.0,0.0,0.0",
+                    ]
+                )
+                + "\n",
+                encoding="ascii",
+            )
+            antex_path.write_text("synthetic antex placeholder\n", encoding="ascii")
+            commands: list[list[str]] = []
+
+            def fake_run_command(command: list[str]) -> mock.Mock:
+                commands.append(command)
+                output_path.write_text(
+                    "% synthetic solution\n"
+                    "2200 345600.000 1.0 2.0 3.0 0.0 0.0 0.0 5 8\n",
+                    encoding="ascii",
+                )
+                return mock.Mock(stdout="PPP summary:\n  valid solutions: 1\n")
+
+            argv = [
+                "gnss_clas_ppp.py",
+                "--profile",
+                "clas",
+                "--obs",
+                str(obs_path),
+                "--nav",
+                str(nav_path),
+                "--compact-ssr",
+                str(compact_path),
+                "--antex",
+                str(antex_path),
+                "--out",
+                str(output_path),
+                "--summary-json",
+                str(summary_path),
+            ]
+            with (
+                mock.patch.object(sys, "argv", argv),
+                mock.patch.object(clas_ppp, "resolve_gnss_command", return_value=["gnss"]),
+                mock.patch.object(clas_ppp, "run_command", side_effect=fake_run_command),
+            ):
+                self.assertEqual(clas_ppp.main(), 0)
+
+            self.assertEqual(len(commands), 1)
+            command = commands[0]
+            self.assertIn("--antex", command)
+            self.assertEqual(command[command.index("--antex") + 1], str(antex_path))
+            self.assertIn("--clas-osr", command)
+            payload = json.loads(summary_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["antex"], str(antex_path))
 
 
 class PPCRTKSignoffHelpersTest(unittest.TestCase):


### PR DESCRIPTION
## Summary

- add `--antex` to `gnss clas-ppp` and forward it to the underlying `gnss ppp` command
- record the ANTEX path in CLAS/MADOCA summary JSON provenance
- document the A4b receiver-antenna parity caveat and cover forwarding with a mock-based unit test

## Why

A4b component diffs show a remaining `receiver_antenna_m` gap, but the CLAS/MADOCA wrapper could not pass an ANTEX file through to PPP. This keeps the change behavior-neutral for default runs while unblocking receiver/satellite antenna parity probes.

## Validation

- `python3 -m py_compile apps/gnss_clas_ppp.py tests/test_benchmark_scripts.py`
- `python3 -m unittest tests.test_benchmark_scripts.ClasCompactHelpersTest.test_main_forwards_antex_to_ppp_and_records_summary tests.test_benchmark_scripts.ClasCompactHelpersTest.test_build_summary_payload_marks_clas_osr_profile`
- `python3 -m unittest tests.test_benchmark_scripts.ClasCompactHelpersTest`
- `python3 apps/gnss.py clas-ppp --help | rg -- '--antex|ANTEX'`
- `git diff --check`
