### PR TITLE
[codex] ppp: add receiver antenna type override

### DIFF
--- a/apps/gnss.py
+++ b/apps/gnss.py
@@ -503,7 +503,7 @@ def usage() -> str:
             "  python3 apps/gnss.py visibility --obs data/rover_static.obs --nav data/navigation_static.nav --csv output/visibility.csv --summary-json output/visibility.json --max-epochs 60",
             "  python3 apps/gnss.py visibility-plot output/visibility.csv output/visibility.png",
             "  python3 apps/gnss.py solve --rover data/rover_kinematic.obs --base data/base_kinematic.obs --nav data/navigation_kinematic.nav --iono est --max-epochs 5",
-            "  python3 apps/gnss.py ppp --static --obs data/rover_static.obs --nav data/navigation_static.nav --sp3 precise.sp3 --clk precise.clk --antex igs20.atx --blq station.blq --out output/ppp_solution.pos",
+            "  python3 apps/gnss.py ppp --static --obs data/rover_static.obs --nav data/navigation_static.nav --sp3 precise.sp3 --clk precise.clk --antex igs20.atx --receiver-antenna-type \"TRM59800.80     NONE\" --blq station.blq --out output/ppp_solution.pos",
             "  python3 apps/gnss.py ppp --kinematic --enable-ar --convergence-min-epochs 4 --ar-ratio-threshold 2.0 --obs rover.obs --sp3 precise.sp3 --clk precise.clk --out output/ppp_ar.pos",
             "  python3 apps/gnss.py nav-products --obs data/rover_static.obs --nav data/navigation_static.nav --sp3-out output/static_products.sp3 --clk-out output/static_products.clk --max-epochs 60",
             "  python3 apps/gnss.py fetch-products --date 2024-01-02 --product sp3=https://example.net/{yyyy}{doy}.sp3.gz --product clk=file:///data/{yyyy}{doy}.clk.gz --summary-json output/products.json",

--- a/apps/gnss_clas_ppp.py
+++ b/apps/gnss_clas_ppp.py
@@ -134,6 +134,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--sp3", type=Path, default=None, help="Optional precise SP3 file.")
     parser.add_argument("--clk", type=Path, default=None, help="Optional precise CLK file.")
     parser.add_argument("--antex", type=Path, default=None, help="Optional ANTEX file forwarded to PPP.")
+    parser.add_argument(
+        "--receiver-antenna-type",
+        default=None,
+        help="Optional receiver antenna type override forwarded to PPP with --antex.",
+    )
     parser.add_argument("--kml", type=Path, default=None, help="Optional KML output path.")
     parser.add_argument("--max-epochs", type=int, default=0, help="Stop after N epochs.")
     parser.add_argument(
@@ -590,6 +595,7 @@ def build_summary_payload(
         "sp3": str(args.sp3) if args.sp3 is not None else None,
         "clk": str(args.clk) if args.clk is not None else None,
         "antex": str(args.antex) if args.antex is not None else None,
+        "receiver_antenna_type": args.receiver_antenna_type,
         "ssr_rtcm": args.ssr_rtcm,
         "compact_ssr": args.compact_ssr,
         "qzss_l6": args.qzss_l6,
@@ -780,6 +786,8 @@ def main() -> int:
             command.extend(["--clk", str(args.clk)])
         if args.antex is not None:
             command.extend(["--antex", str(args.antex)])
+        if args.receiver_antenna_type is not None:
+            command.extend(["--receiver-antenna-type", args.receiver_antenna_type])
         if args.kml is not None:
             command.extend(["--kml", str(args.kml)])
         if args.max_epochs > 0:

--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -27,6 +27,7 @@ struct Options {
     std::string ionex_path;
     std::string dcb_path;
     std::string antex_path;
+    std::string receiver_antenna_type;
     std::string blq_path;
     std::string ocean_loading_station_name;
     std::string out_path;
@@ -91,6 +92,8 @@ void printUsage(const char* program_name) {
         << "  --ionex <maps.ionex>     Optional IONEX TEC map product\n"
         << "  --dcb <bias.bsx>         Optional DCB / Bias-SINEX product\n"
         << "  --antex <antennas.atx>   Optional ANTEX file for receiver antenna PCO\n"
+        << "  --receiver-antenna-type <type>\n"
+        << "                          Override the RINEX receiver antenna type used with --antex\n"
         << "  --blq <station.blq>      Optional BLQ ocean loading coefficient file\n"
         << "  --ocean-loading-station <name>\n"
         << "                          Station name to select from the BLQ file\n"
@@ -243,6 +246,8 @@ Options parseArguments(int argc, char* argv[]) {
             options.dcb_path = argv[++i];
         } else if (arg == "--antex" && i + 1 < argc) {
             options.antex_path = argv[++i];
+        } else if (arg == "--receiver-antenna-type" && i + 1 < argc) {
+            options.receiver_antenna_type = argv[++i];
         } else if (arg == "--blq" && i + 1 < argc) {
             options.blq_path = argv[++i];
         } else if (arg == "--ocean-loading-station" && i + 1 < argc) {
@@ -901,7 +906,10 @@ int main(int argc, char* argv[]) {
             ppp_config.l6_gps_week = obs_header.first_obs.week;
         }
         ppp_config.approximate_position = obs_header.approximate_position;
-        ppp_config.receiver_antenna_type = obs_header.antenna_type;
+        ppp_config.receiver_antenna_type =
+            options.receiver_antenna_type.empty() ?
+                obs_header.antenna_type :
+                options.receiver_antenna_type;
         ppp_config.receiver_antenna_delta_enu = obs_header.antenna_delta;
         ppp_config.ocean_loading_station_name =
             options.ocean_loading_station_name.empty() ?
@@ -1039,6 +1047,17 @@ int main(int argc, char* argv[]) {
                     << "  \"dcb\": "
                     << (options.dcb_path.empty() ? "null" : ("\"" + jsonEscape(options.dcb_path) + "\""))
                     << ",\n"
+                    << "  \"antex\": "
+                    << (options.antex_path.empty() ? "null" : ("\"" + jsonEscape(options.antex_path) + "\""))
+                    << ",\n"
+                    << "  \"receiver_antenna_type\": "
+                    << (ppp_config.receiver_antenna_type.empty() ?
+                            "null" :
+                            ("\"" + jsonEscape(ppp_config.receiver_antenna_type) + "\""))
+                    << ",\n"
+                    << "  \"receiver_antenna_type_source\": \""
+                    << (options.receiver_antenna_type.empty() ? "rinex-header" : "cli")
+                    << "\",\n"
                     << "  \"out\": \"" << jsonEscape(options.out_path) << "\",\n"
                     << "  \"mode\": \"" << (options.kinematic_mode ? "kinematic" : "static") << "\",\n"
                     << "  \"low_dynamics\": " << (options.low_dynamics_mode ? "true" : "false") << ",\n"

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -92,11 +92,16 @@ python3 apps/gnss.py clas-ppp \
   --max-epochs 300
 ```
 
-`gnss clas-ppp` also forwards `--antex <antennas.atx>` to the underlying
-`gnss ppp` run for receiver/satellite antenna parity probes. The public
-`0627239Q.obs` header does not declare a receiver antenna type, so passing the
-CLASLIB ANTEX file alone does not close the `receiver_antenna_m` delta; the
-remaining A4b work still needs explicit receiver antenna identity provenance.
+`gnss clas-ppp` also forwards `--antex <antennas.atx>` and
+`--receiver-antenna-type <type>` to the underlying `gnss ppp` run for
+receiver/satellite antenna parity probes. The public `0627239Q.obs` header does
+not declare a receiver antenna type, so A4b receiver-antenna probes should pass
+the native ANTEX antenna key explicitly, for example
+`--receiver-antenna-type "TRM59800.80     NONE"`. The CLASLIB ANTEX file uses
+CRLF line endings, so the native ANTEX loader trims trailing carriage returns
+before matching labels. This fixes ANTEX file/type provenance; wiring those
+receiver terms into the CLAS OSR `receiver_antenna_m` component remains a
+separate A4b materialization step.
 
 For the A4b GPS L2W identity probe, enable the diagnostic gates and write a
 native zero-difference code component dump:
@@ -111,6 +116,8 @@ python3 apps/gnss.py clas-ppp \
   --nav "$DATA/sept_2019239.nav" \
   --qzss-l6 "$DATA/2019239Q.l6" \
   --qzss-gps-week 2068 \
+  --antex "$DATA/igs14_L5copy.atx" \
+  --receiver-antenna-type "TRM59800.80     NONE" \
   --compact-code-bias-composition-policy base-only-if-present \
   --compact-code-bias-bank-policy latest-preceding-bank \
   --out /tmp/gnsspp_clas_a4b_native.pos \

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -258,6 +258,7 @@ For compact-SSR ingestion experiments, the shared decode boundary also exposes:
 - `gnss qzss-l6-info --compact-bias-row-materialization <overlap-only|selected-satellite-base-extend|all-base-satellite-extend>`
 - `gnss qzss-l6-info --compact-phase-bias-composition-policy <direct-values|base-plus-network|base-only-if-present>`
 - `gnss qzss-l6-info --compact-phase-bias-bank-policy <pending-epoch|same-30s-bank|close-30s-bank|latest-preceding-bank>`
+- `gnss ppp --receiver-antenna-type <type>`
 - `gnss clas-ppp --compact-atmos-merge-policy <stec-coeff-carry|no-carry|network-locked-stec-coeff-carry>`
 - `gnss clas-ppp --compact-atmos-subtype-merge-policy <union|gridded-priority|combined-priority>`
 - `gnss clas-ppp --compact-phase-bias-merge-policy <latest-union|message-reset|selected-mask-prune>`
@@ -265,6 +266,7 @@ For compact-SSR ingestion experiments, the shared decode boundary also exposes:
 - `gnss clas-ppp --compact-code-bias-composition-policy <direct-values|base-plus-network|base-only-if-present>`
 - `gnss clas-ppp --compact-code-bias-bank-policy <pending-epoch|same-30s-bank|close-30s-bank|latest-preceding-bank>`
 - `gnss clas-ppp --antex <antennas.atx>`
+- `gnss clas-ppp --receiver-antenna-type <type>`
 - `gnss clas-ppp --compact-bias-row-materialization <overlap-only|selected-satellite-base-extend|all-base-satellite-extend>`
 - `gnss clas-ppp --compact-phase-bias-composition-policy <direct-values|base-plus-network|base-only-if-present>`
 - `gnss clas-ppp --compact-phase-bias-bank-policy <pending-epoch|same-30s-bank|close-30s-bank|latest-preceding-bank>`

--- a/src/algorithms/ppp_internal.hpp
+++ b/src/algorithms/ppp_internal.hpp
@@ -15,12 +15,15 @@ namespace libgnss::ppp_internal {
 inline constexpr double kDefaultZenithDelayMeters = 2.3;
 
 inline std::string trimCopy(const std::string& text) {
-    const size_t first = text.find_first_not_of(' ');
-    if (first == std::string::npos) {
+    const auto is_not_space = [](unsigned char ch) {
+        return !std::isspace(ch);
+    };
+    const auto first_it = std::find_if(text.begin(), text.end(), is_not_space);
+    if (first_it == text.end()) {
         return "";
     }
-    const size_t last = text.find_last_not_of(' ');
-    return text.substr(first, last - first + 1);
+    const auto last_it = std::find_if(text.rbegin(), text.rend(), is_not_space).base();
+    return std::string(first_it, last_it);
 }
 
 inline std::string normalizeAntennaType(const std::string& antenna_type) {

--- a/tests/test_benchmark_scripts.py
+++ b/tests/test_benchmark_scripts.py
@@ -417,6 +417,7 @@ class ClasCompactHelpersTest(unittest.TestCase):
                 "sp3": None,
                 "clk": None,
                 "antex": None,
+                "receiver_antenna_type": None,
                 "ssr_rtcm": None,
                 "compact_ssr": "corrections.compact.csv",
                 "qzss_l6": None,
@@ -448,6 +449,8 @@ class ClasCompactHelpersTest(unittest.TestCase):
             self.assertFalse(madoca_payload["clas_osr_filter_enabled"])
             self.assertIsNone(clas_payload["antex"])
             self.assertIsNone(madoca_payload["antex"])
+            self.assertIsNone(clas_payload["receiver_antenna_type"])
+            self.assertIsNone(madoca_payload["receiver_antenna_type"])
 
     def test_main_forwards_antex_to_ppp_and_records_summary(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_clas_antex_forward_") as temp_dir:
@@ -494,6 +497,8 @@ class ClasCompactHelpersTest(unittest.TestCase):
                 str(compact_path),
                 "--antex",
                 str(antex_path),
+                "--receiver-antenna-type",
+                "TEST-ANT",
                 "--out",
                 str(output_path),
                 "--summary-json",
@@ -510,9 +515,12 @@ class ClasCompactHelpersTest(unittest.TestCase):
             command = commands[0]
             self.assertIn("--antex", command)
             self.assertEqual(command[command.index("--antex") + 1], str(antex_path))
+            self.assertIn("--receiver-antenna-type", command)
+            self.assertEqual(command[command.index("--receiver-antenna-type") + 1], "TEST-ANT")
             self.assertIn("--clas-osr", command)
             payload = json.loads(summary_path.read_text(encoding="utf-8"))
             self.assertEqual(payload["antex"], str(antex_path))
+            self.assertEqual(payload["receiver_antenna_type"], "TEST-ANT")
 
 
 class PPCRTKSignoffHelpersTest(unittest.TestCase):

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -4480,6 +4480,85 @@ class CLIToolsTest(unittest.TestCase):
             self.assertGreater(solution_delta, 1e-4)
             self.assertLess(solution_delta, 1.0)
 
+    def test_ppp_cli_supports_receiver_antex_type_override(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ppp_antex_override_test_") as temp_dir:
+            temp_root = Path(temp_dir)
+            obs_path, sp3_path, clk_path, true_position = build_synthetic_ppp_inputs(temp_root)
+            antex_path = temp_root / "receiver.atx"
+            antex_path.write_text(
+                build_synthetic_receiver_antex_text().replace("\n", "\r\n"),
+                encoding="ascii",
+            )
+            base_out_path = temp_root / "ppp_base.pos"
+            antex_out_path = temp_root / "ppp_antex_override.pos"
+            summary_path = temp_root / "ppp_antex_override_summary.json"
+
+            base_result = self.run_gnss(
+                "ppp",
+                "--static",
+                "--obs",
+                str(obs_path),
+                "--sp3",
+                str(sp3_path),
+                "--clk",
+                str(clk_path),
+                "--no-estimate-troposphere",
+                "--out",
+                str(base_out_path),
+                "--max-epochs",
+                "8",
+            )
+            antex_result = self.run_gnss(
+                "ppp",
+                "--static",
+                "--obs",
+                str(obs_path),
+                "--sp3",
+                str(sp3_path),
+                "--clk",
+                str(clk_path),
+                "--antex",
+                str(antex_path),
+                "--receiver-antenna-type",
+                "TEST-ANT",
+                "--no-estimate-troposphere",
+                "--out",
+                str(antex_out_path),
+                "--summary-json",
+                str(summary_path),
+                "--max-epochs",
+                "8",
+            )
+
+            self.assertEqual(base_result.returncode, 0, msg=base_result.stderr)
+            self.assertEqual(antex_result.returncode, 0, msg=antex_result.stderr)
+            self.assertIn("PPP float solutions: 8", antex_result.stdout)
+
+            base_records = self.read_pos_records(base_out_path)
+            antex_records = self.read_pos_records(antex_out_path)
+            self.assertEqual(len(base_records), 8)
+            self.assertEqual(len(antex_records), 8)
+            base_last = base_records[-1]
+            antex_last = antex_records[-1]
+            antex_error = math.sqrt(
+                (antex_last["x"] - true_position[0]) ** 2
+                + (antex_last["y"] - true_position[1]) ** 2
+                + (antex_last["z"] - true_position[2]) ** 2
+            )
+            solution_delta = math.sqrt(
+                (antex_last["x"] - base_last["x"]) ** 2
+                + (antex_last["y"] - base_last["y"]) ** 2
+                + (antex_last["z"] - base_last["z"]) ** 2
+            )
+            payload = json.loads(summary_path.read_text(encoding="utf-8"))
+
+            self.assertLess(antex_error, 1.7)
+            self.assertGreater(solution_delta, 1e-4)
+            self.assertLess(solution_delta, 1.0)
+            self.assertEqual(payload["receiver_antenna_type"], "TEST-ANT")
+            self.assertEqual(payload["receiver_antenna_type_source"], "cli")
+            self.assertEqual(payload["antex"], str(antex_path))
+
     def test_ppp_cli_supports_ocean_loading_coefficients(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ppp_blq_test_") as temp_dir:
             temp_root = Path(temp_dir)


### PR DESCRIPTION
## Summary

- add `--receiver-antenna-type` to `gnss ppp` and forward it through `gnss clas-ppp`
- record ANTEX and receiver antenna type provenance in PPP/CLAS summaries
- make PPP ANTEX label trimming tolerate CRLF files such as CLASLIB's `igs14_L5copy.atx`
- document the A4b receiver antenna provenance command and remaining CLAS OSR materialization gap

## Why

The public 2019 CLAS sample has an empty RINEX antenna type, while CLASLIB config supplies `TRM59800.80     NONE`. Without an explicit override, native PPP cannot reproduce the receiver antenna provenance used by the oracle. The CLASLIB ANTEX file also uses CRLF line endings, which left native ANTEX labels unmatched before this change.

This does not default-enable CLAS OSR receiver antenna materialization; it unblocks file/type provenance and keeps the remaining `receiver_antenna_m` wiring as a separate A4b step.

## Validation

- `cmake --build build --target gnss_ppp -j4`
- `python3 -m py_compile apps/gnss_clas_ppp.py tests/test_benchmark_scripts.py`
- `python3 -m unittest tests.test_cli_tools.CLIToolsTest.test_ppp_cli_supports_receiver_antex_type_override tests.test_cli_tools.CLIToolsTest.test_ppp_cli_supports_receiver_antex_offsets`
- `python3 -m unittest tests.test_benchmark_scripts.ClasCompactHelpersTest`
- `python3 apps/gnss.py ppp --help | rg -- '--receiver-antenna-type|--antex'`
- `python3 apps/gnss.py clas-ppp --help | rg -- '--receiver-antenna-type|--antex'`
- CLASLIB 20-epoch smoke with `--antex /tmp/claslib/data/igs14_L5copy.atx --receiver-antenna-type "TRM59800.80     NONE"`
- `git diff --check`
