### PR TITLE
[codex] clas: materialize receiver antenna osr terms

### DIFF
--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -99,9 +99,9 @@ not declare a receiver antenna type, so A4b receiver-antenna probes should pass
 the native ANTEX antenna key explicitly, for example
 `--receiver-antenna-type "TRM59800.80     NONE"`. The CLASLIB ANTEX file uses
 CRLF line endings, so the native ANTEX loader trims trailing carriage returns
-before matching labels. This fixes ANTEX file/type provenance; wiring those
-receiver terms into the CLAS OSR `receiver_antenna_m` component remains a
-separate A4b materialization step.
+before matching labels. Set `GNSS_PPP_CLAS_RX_ANTENNA=1` to materialize those
+receiver terms into the CLAS OSR `receiver_antenna_m` component. The default
+path leaves the component unchanged while A4b parity is measured.
 
 For the A4b GPS L2W identity probe, enable the diagnostic gates and write a
 native zero-difference code component dump:
@@ -109,6 +109,7 @@ native zero-difference code component dump:
 ```bash
 GNSS_PPP_CLAS_DD_FILTER=1 \
 GNSS_PPP_CLAS_CODE_ROW_PARITY=bias \
+GNSS_PPP_CLAS_RX_ANTENNA=1 \
 GNSS_PPP_CLAS_CODE_DUMP=/tmp/clas_a4b_native_code_dump.csv \
 python3 apps/gnss.py clas-ppp \
   --profile clas \

--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -443,6 +443,12 @@ private:
     // available. Sign matches RTKLIB antmodel(): the value is added to the
     // modeled range (equivalently subtracted from the observable).
     double receiverAntennaPcvMeters(SignalType signal, double elevation_rad) const;
+    double clasReceiverAntennaRangeCorrectionMeters(
+        SignalType signal,
+        double azimuth_rad,
+        double elevation_rad) const;
+    void materializeClasReceiverAntennaCorrections(
+        std::vector<OSRCorrection>& osr_corrections) const;
 
     /**
      * @brief Detect cycle slips

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -202,6 +202,10 @@ struct PPPEnvOverrides {
     // "1" to enable. The default and exact "0" preserve legacy bit-exact
     // behavior because the S28 rollout rule rejected this term as default-on.
     bool clas_tx_time_sign_fix = false;
+    // GNSS_PPP_CLAS_RX_ANTENNA: materialize CLAS OSR receiver antenna terms
+    // from the loaded ANTEX receiver entry when set exactly to "1". Default
+    // false while GPS L2W ZD parity is measured.
+    bool clas_rx_antenna = false;
     // GNSS_PPP_CLAS_GEOM_DUMP: path for CLAS geometry-row forensic dump.
     // Empty disables it.
     std::string clas_geom_dump_path;

--- a/include/libgnss++/algorithms/ppp_osr.hpp
+++ b/include/libgnss++/algorithms/ppp_osr.hpp
@@ -111,6 +111,13 @@ ClasOsrBiasMaterialization materializeClasOsrBiases(
     bool exact_bias_identity,
     bool enable_l2_class_fallback);
 
+double clasReceiverAntennaCorrectionMeters(
+    const Vector3d& receiver_delta_enu,
+    const Vector3d& antenna_offset_neu,
+    double pcv_m,
+    double azimuth_rad,
+    double elevation_rad);
+
 CLASEpochContext prepareClasEpochContext(
     const ObservationData& obs,
     const NavigationData& nav,

--- a/src/algorithms/ppp_clas_epoch.cpp
+++ b/src/algorithms/ppp_clas_epoch.cpp
@@ -279,7 +279,7 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         return solution;
     }
 
-    const auto epoch_context = prepareClasEpochContext(
+    auto epoch_context = prepareClasEpochContext(
         obs,
         nav,
         ssr_products_,
@@ -291,6 +291,7 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         clas_dispersion_compensation_,
         clas_sis_continuity_,
         clas_phase_bias_repair_);
+    materializeClasReceiverAntennaCorrections(epoch_context.osr_corrections);
     const auto& epoch_atmos = epoch_context.epoch_atmos_tokens;
     const auto& osr_corrections = epoch_context.osr_corrections;
 

--- a/src/algorithms/ppp_corrections.cpp
+++ b/src/algorithms/ppp_corrections.cpp
@@ -711,6 +711,53 @@ double PPPProcessor::receiverAntennaPcvMeters(SignalType signal,
     return grid.noazi_m[i0] * (1.0 - frac) + grid.noazi_m[i0 + 1] * frac;
 }
 
+double PPPProcessor::clasReceiverAntennaRangeCorrectionMeters(
+    SignalType signal,
+    double azimuth_rad,
+    double elevation_rad) const {
+    if (!receiver_antex_loaded_ || ppp_config_.receiver_antenna_type.empty() ||
+        signal == SignalType::SIGNAL_TYPE_COUNT) {
+        return 0.0;
+    }
+    const auto ant_it =
+        receiver_antex_offsets_.find(normalizeAntennaType(ppp_config_.receiver_antenna_type));
+    if (ant_it == receiver_antex_offsets_.end()) {
+        return 0.0;
+    }
+    Vector3d antenna_offset_neu = Vector3d::Zero();
+    const auto sig_it = ant_it->second.find(signal);
+    if (sig_it != ant_it->second.end()) {
+        antenna_offset_neu = sig_it->second;
+    }
+    return clasReceiverAntennaCorrectionMeters(
+        ppp_config_.receiver_antenna_delta_enu,
+        antenna_offset_neu,
+        receiverAntennaPcvMeters(signal, elevation_rad),
+        azimuth_rad,
+        elevation_rad);
+}
+
+void PPPProcessor::materializeClasReceiverAntennaCorrections(
+    std::vector<OSRCorrection>& osr_corrections) const {
+    if (!env_overrides_.clas_rx_antenna || !receiver_antex_loaded_ ||
+        ppp_config_.receiver_antenna_type.empty()) {
+        return;
+    }
+    for (auto& osr : osr_corrections) {
+        if (!osr.valid) {
+            continue;
+        }
+        const int frequency_count = std::min(osr.num_frequencies, OSR_MAX_FREQ);
+        for (int f = 0; f < frequency_count; ++f) {
+            osr.receiver_antenna_m[f] =
+                clasReceiverAntennaRangeCorrectionMeters(
+                    osr.signals[f],
+                    osr.azimuth,
+                    osr.elevation);
+        }
+    }
+}
+
 void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& observations,
                                            const NavigationData& nav,
                                            const GNSSTime& time) {

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -209,6 +209,8 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
         envDoubleOr("GNSS_PPP_CLAS_TROP_PROCESS_NOISE", 0.0);
     overrides.clas_tx_time_sign_fix =
         envExactOne("GNSS_PPP_CLAS_TX_TIME_SIGN_FIX");
+    overrides.clas_rx_antenna =
+        envExactOne("GNSS_PPP_CLAS_RX_ANTENNA");
     overrides.clas_geom_dump_path =
         envStringOrEmpty("GNSS_PPP_CLAS_GEOM_DUMP");
     overrides.clas_geom_dump_rx_xyz =

--- a/src/algorithms/ppp_osr.cpp
+++ b/src/algorithms/ppp_osr.cpp
@@ -630,6 +630,25 @@ ClasOsrBiasMaterialization materializeClasOsrBiases(
     return result;
 }
 
+double clasReceiverAntennaCorrectionMeters(
+    const Vector3d& receiver_delta_enu,
+    const Vector3d& antenna_offset_neu,
+    double pcv_m,
+    double azimuth_rad,
+    double elevation_rad) {
+    const Vector3d antenna_offset_enu(
+        antenna_offset_neu.y(),
+        antenna_offset_neu.x(),
+        antenna_offset_neu.z());
+    const Vector3d offset_enu = receiver_delta_enu + antenna_offset_enu;
+    const double cosel = std::cos(elevation_rad);
+    const Vector3d los_enu(
+        std::sin(azimuth_rad) * cosel,
+        std::cos(azimuth_rad) * cosel,
+        std::sin(elevation_rad));
+    return -offset_enu.dot(los_enu) + pcv_m;
+}
+
 std::map<std::string, std::string> selectClasEpochAtmosTokens(
     const SSRProducts& ssr_products,
     const std::vector<SatelliteId>& satellites,

--- a/src/algorithms/ppp_wlnl.cpp
+++ b/src/algorithms/ppp_wlnl.cpp
@@ -404,11 +404,13 @@ std::map<SatelliteId, OSRCorrection> PPPProcessor::computeWlnlOsrCorrections(
     auto phase_bias_repair = clas_phase_bias_repair_;
     const auto epoch_atmos = selectClasEpochAtmosTokens(
         ssr_products_, obs.getSatellites(), obs.time, receiver_position, ppp_config_);
-    for (const auto& osr : computeOSR(obs, nav, ssr_products_, epoch_atmos,
+    auto osr_corrections = computeOSR(obs, nav, ssr_products_, epoch_atmos,
                                       receiver_position, clock_bias_m, trop_zenith,
                                       ppp_config_,
                                       windup_cache, dispersion_compensation,
-                                      sis_continuity, phase_bias_repair)) {
+                                      sis_continuity, phase_bias_repair);
+    materializeClasReceiverAntennaCorrections(osr_corrections);
+    for (const auto& osr : osr_corrections) {
         if (osr.valid && osr.num_frequencies >= 2) {
             osr_by_sat[osr.satellite] = osr;
         }

--- a/tests/test_ppp_clas.cpp
+++ b/tests/test_ppp_clas.cpp
@@ -2,6 +2,7 @@
 
 #include <libgnss++/algorithms/ppp_clas.hpp>
 #include <libgnss++/algorithms/ppp_clas_dd.hpp>
+#include <libgnss++/algorithms/ppp_osr.hpp>
 #include <libgnss++/algorithms/lambda.hpp>
 #include <libgnss++/core/constants.hpp>
 #include <libgnss++/core/coordinates.hpp>
@@ -77,6 +78,35 @@ TEST(PPPClasTest, OrbitClockOnlyModeDropsBiasAndPhaseCompensationTerms) {
     EXPECT_DOUBLE_EQ(applied.carrier_phase_correction_m, 1.15);
     EXPECT_FALSE(ppp_clas::usesClasTropospherePrior(
         ppp_shared::PPPConfig::ClasCorrectionApplicationPolicy::ORBIT_CLOCK_ONLY));
+}
+
+TEST(PPPClasOsrTest, ReceiverAntennaCorrectionUsesRtkLibEnuConvention) {
+    const Vector3d receiver_delta_enu(0.10, -0.20, 1.00);
+    const Vector3d antenna_offset_neu(0.02, -0.03, 0.12);
+    const double pcv_m = 0.004;
+    const double azimuth_rad = 35.0 * M_PI / 180.0;
+    const double elevation_rad = 40.0 * M_PI / 180.0;
+
+    const double cosel = std::cos(elevation_rad);
+    const Vector3d los_enu(
+        std::sin(azimuth_rad) * cosel,
+        std::cos(azimuth_rad) * cosel,
+        std::sin(elevation_rad));
+    const Vector3d expected_offset_enu(
+        receiver_delta_enu.x() + antenna_offset_neu.y(),
+        receiver_delta_enu.y() + antenna_offset_neu.x(),
+        receiver_delta_enu.z() + antenna_offset_neu.z());
+    const double expected = -expected_offset_enu.dot(los_enu) + pcv_m;
+
+    EXPECT_NEAR(
+        clasReceiverAntennaCorrectionMeters(
+            receiver_delta_enu,
+            antenna_offset_neu,
+            pcv_m,
+            azimuth_rad,
+            elevation_rad),
+        expected,
+        1e-12);
 }
 
 TEST(PPPClasDdTest, RowBuilderSelectsHighestElevationReferenceAndFormsResidual) {


### PR DESCRIPTION
## Summary

- Add `GNSS_PPP_CLAS_RX_ANTENNA=1` to materialize CLAS OSR `receiver_antenna_m` from the loaded receiver ANTEX entry.
- Wire the materialized OSR terms through the CLAS epoch path and WL/NL OSR lookup while preserving the default-off path.
- Add a focused RTKLIB/CLASLIB ENU convention test and update the A4b validated dataset notes.

## Why

The CLAS wrapper can now forward `--antex` and `--receiver-antenna-type`, but the native CLAS OSR correction still left `receiver_antenna_m` at zero. That blocked the GPS L2W ZD component parity ladder from separating receiver antenna residuals from PRC/atmosphere differences.

## Validation

- `cmake --build build --target run_tests gnss_ppp -j4`
- `./build/tests/run_tests --gtest_filter='PPPClasOsrTest.*:PPPClasTest.*:PPPClasDdTest.*'`
- `python3 -m py_compile apps/gnss_clas_ppp.py tests/test_benchmark_scripts.py`
- `python3 -m unittest tests.test_benchmark_scripts.ClasCompactHelpersTest`
- `git diff --check`
- `ctest --test-dir build -R ^'^run_tests$'$' --output-on-failure`
- Local CLASLIB 20-epoch smoke with `GNSS_PPP_CLAS_RX_ANTENNA=1`: `receiver_ant_m` nonzero rows = 320, range `[-0.11520130933776616, -0.060219887453580978]`
- Same smoke with `GNSS_PPP_CLAS_RX_ANTENNA` unset: `receiver_ant_m` nonzero rows = 0
