### PR TITLE
[codex] clas: sync receiver antenna aggregate osr terms

### DIFF
--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -100,8 +100,9 @@ the native ANTEX antenna key explicitly, for example
 `--receiver-antenna-type "TRM59800.80     NONE"`. The CLASLIB ANTEX file uses
 CRLF line endings, so the native ANTEX loader trims trailing carriage returns
 before matching labels. Set `GNSS_PPP_CLAS_RX_ANTENNA=1` to materialize those
-receiver terms into the CLAS OSR `receiver_antenna_m` component. The default
-path leaves the component unchanged while A4b parity is measured.
+receiver terms into the CLAS OSR `receiver_antenna_m` component and the
+aggregate `PRC`/`CPC` terms. The default path leaves them unchanged while A4b
+parity is measured.
 
 For the A4b GPS L2W identity probe, enable the diagnostic gates and write a
 native zero-difference code component dump:

--- a/include/libgnss++/algorithms/ppp_osr.hpp
+++ b/include/libgnss++/algorithms/ppp_osr.hpp
@@ -118,6 +118,11 @@ double clasReceiverAntennaCorrectionMeters(
     double azimuth_rad,
     double elevation_rad);
 
+void setClasOsrReceiverAntennaCorrection(
+    OSRCorrection& osr,
+    int freq_index,
+    double receiver_antenna_m);
+
 CLASEpochContext prepareClasEpochContext(
     const ObservationData& obs,
     const NavigationData& nav,

--- a/src/algorithms/ppp_corrections.cpp
+++ b/src/algorithms/ppp_corrections.cpp
@@ -749,11 +749,13 @@ void PPPProcessor::materializeClasReceiverAntennaCorrections(
         }
         const int frequency_count = std::min(osr.num_frequencies, OSR_MAX_FREQ);
         for (int f = 0; f < frequency_count; ++f) {
-            osr.receiver_antenna_m[f] =
+            setClasOsrReceiverAntennaCorrection(
+                osr,
+                f,
                 clasReceiverAntennaRangeCorrectionMeters(
                     osr.signals[f],
                     osr.azimuth,
-                    osr.elevation);
+                    osr.elevation));
         }
     }
 }

--- a/src/algorithms/ppp_osr.cpp
+++ b/src/algorithms/ppp_osr.cpp
@@ -649,6 +649,20 @@ double clasReceiverAntennaCorrectionMeters(
     return -offset_enu.dot(los_enu) + pcv_m;
 }
 
+void setClasOsrReceiverAntennaCorrection(
+    OSRCorrection& osr,
+    int freq_index,
+    double receiver_antenna_m) {
+    if (freq_index < 0 || freq_index >= OSR_MAX_FREQ ||
+        freq_index >= osr.num_frequencies) {
+        return;
+    }
+    const double delta_m = receiver_antenna_m - osr.receiver_antenna_m[freq_index];
+    osr.receiver_antenna_m[freq_index] = receiver_antenna_m;
+    osr.PRC[freq_index] += delta_m;
+    osr.CPC[freq_index] += delta_m;
+}
+
 std::map<std::string, std::string> selectClasEpochAtmosTokens(
     const SSRProducts& ssr_products,
     const std::vector<SatelliteId>& satellites,

--- a/tests/test_ppp_clas.cpp
+++ b/tests/test_ppp_clas.cpp
@@ -109,6 +109,20 @@ TEST(PPPClasOsrTest, ReceiverAntennaCorrectionUsesRtkLibEnuConvention) {
         1e-12);
 }
 
+TEST(PPPClasOsrTest, ReceiverAntennaMaterializationUpdatesAggregateCorrections) {
+    OSRCorrection osr;
+    osr.num_frequencies = 2;
+    osr.receiver_antenna_m[1] = 0.20;
+    osr.PRC[1] = 10.0;
+    osr.CPC[1] = 20.0;
+
+    setClasOsrReceiverAntennaCorrection(osr, 1, 0.45);
+
+    EXPECT_DOUBLE_EQ(osr.receiver_antenna_m[1], 0.45);
+    EXPECT_DOUBLE_EQ(osr.PRC[1], 10.25);
+    EXPECT_DOUBLE_EQ(osr.CPC[1], 20.25);
+}
+
 TEST(PPPClasDdTest, RowBuilderSelectsHighestElevationReferenceAndFormsResidual) {
     ObservationData obs(GNSSTime(2068, 230572.0));
     const Vector3d receiver(constants::WGS84_A, 0.0, 0.0);


### PR DESCRIPTION
## Summary

- add a small OSR helper that updates receiver-antenna materialization and keeps aggregate `PRC`/`CPC` terms in sync by delta
- route `GNSS_PPP_CLAS_RX_ANTENNA=1` materialization through that helper
- document that the diagnostic gate updates both the component dump field and aggregate OSR terms

## Root Cause

PR #212 materialized `receiver_antenna_m` after `computeOSR()` had already aggregated `PRC` and `CPC`. The component dump showed the receiver antenna term, but the aggregate corrections used by downstream OSR consumers stayed stale.

## Validation

- `cmake --build build --target run_tests gnss_ppp -j4`
- `./build/tests/run_tests --gtest_filter='PPPClasOsrTest.*:PPPClasTest.*:PPPClasDdTest.*'`
- `ctest --test-dir build -R '^run_tests$' --output-on-failure`
- `git diff --check`
- CLASLIB 300-epoch G14/C2W component diff with `GNSS_PPP_CLAS_RX_ANTENNA=1`: `prc_m` mean_abs dropped from ~0.1975 m to `0.13425273442741725` m; remaining deltas are dominated by code bias, iono, trop, and the known receiver antenna frequency/PCV details.
