### PR TITLE
[codex] clas: align gps l2w receiver antenna slot

### DIFF
--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -182,9 +182,12 @@ direct network policy produced periodic G14/C2W `code_bias_m` outliers such as
 `-0.70 m` where CLASLIB reports `+0.76 m`. The A4b policy above restores those
 rows to the base value and reduces the G14/C2W `code_bias_m` diff from
 `mean_abs=0.1795 m, rms=0.4000 m, max_abs=1.4600 m` to
-`mean_abs=0.1319 m, rms=0.3029 m, max_abs=0.7800 m`. The remaining top-row
-deltas are then dominated by residual/PRC, receiver antenna, and atmosphere
-terms rather than the 30-second code-bias sign flip.
+`mean_abs=0.1319 m, rms=0.3029 m, max_abs=0.7800 m`. The gated receiver-antenna
+materialization keeps the exact GPS L2W row on CLASLIB's receiver-antenna slot;
+on the same G14/C2W slice this reduces `receiver_antenna_m` from
+`mean_abs=0.0249 m` to `mean_abs=0.0021 m`. The remaining top-row deltas are
+then dominated by residual/PRC, code-bias, and atmosphere terms rather than the
+30-second code-bias sign flip or receiver-antenna slot mismatch.
 
 The diff JSON also includes `top_row_component_breakdowns`, which groups all
 component deltas for the same ZD key. Use that field to decide whether the next

--- a/include/libgnss++/algorithms/ppp_osr.hpp
+++ b/include/libgnss++/algorithms/ppp_osr.hpp
@@ -123,6 +123,10 @@ void setClasOsrReceiverAntennaCorrection(
     int freq_index,
     double receiver_antenna_m);
 
+SignalType clasReceiverAntennaLookupSignal(
+    const OSRCorrection& osr,
+    int freq_index);
+
 CLASEpochContext prepareClasEpochContext(
     const ObservationData& obs,
     const NavigationData& nav,

--- a/src/algorithms/ppp_corrections.cpp
+++ b/src/algorithms/ppp_corrections.cpp
@@ -753,7 +753,7 @@ void PPPProcessor::materializeClasReceiverAntennaCorrections(
                 osr,
                 f,
                 clasReceiverAntennaRangeCorrectionMeters(
-                    osr.signals[f],
+                    clasReceiverAntennaLookupSignal(osr, f),
                     osr.azimuth,
                     osr.elevation));
         }

--- a/src/algorithms/ppp_osr.cpp
+++ b/src/algorithms/ppp_osr.cpp
@@ -663,6 +663,25 @@ void setClasOsrReceiverAntennaCorrection(
     osr.CPC[freq_index] += delta_m;
 }
 
+SignalType clasReceiverAntennaLookupSignal(
+    const OSRCorrection& osr,
+    int freq_index) {
+    if (freq_index < 0 || freq_index >= OSR_MAX_FREQ ||
+        freq_index >= osr.num_frequencies) {
+        return SignalType::SIGNAL_TYPE_COUNT;
+    }
+    const SignalType signal = osr.signals[freq_index];
+    if (osr.bias_exact_identity[freq_index] &&
+        algorithms::ppp_bias_identity::isGpsL2wObservation(
+            osr.satellite.system,
+            signal,
+            osr.pseudorange_rinex_codes[freq_index],
+            osr.carrier_rinex_codes[freq_index])) {
+        return SignalType::GPS_L1CA;
+    }
+    return signal;
+}
+
 std::map<std::string, std::string> selectClasEpochAtmosTokens(
     const SSRProducts& ssr_products,
     const std::vector<SatelliteId>& satellites,

--- a/tests/test_ppp_clas.cpp
+++ b/tests/test_ppp_clas.cpp
@@ -123,6 +123,23 @@ TEST(PPPClasOsrTest, ReceiverAntennaMaterializationUpdatesAggregateCorrections) 
     EXPECT_DOUBLE_EQ(osr.CPC[1], 20.25);
 }
 
+TEST(PPPClasOsrTest, ReceiverAntennaLookupUsesL1SlotForExactGpsL2w) {
+    OSRCorrection osr;
+    osr.satellite = SatelliteId(GNSSSystem::GPS, 14);
+    osr.num_frequencies = 2;
+    osr.signals[0] = SignalType::GPS_L2C;
+    osr.pseudorange_rinex_codes[0] = "C2W";
+    osr.carrier_rinex_codes[0] = "L2W";
+    osr.bias_exact_identity[0] = true;
+    osr.signals[1] = SignalType::GPS_L2C;
+    osr.pseudorange_rinex_codes[1] = "C2X";
+    osr.carrier_rinex_codes[1] = "L2X";
+    osr.bias_exact_identity[1] = true;
+
+    EXPECT_EQ(clasReceiverAntennaLookupSignal(osr, 0), SignalType::GPS_L1CA);
+    EXPECT_EQ(clasReceiverAntennaLookupSignal(osr, 1), SignalType::GPS_L2C);
+}
+
 TEST(PPPClasDdTest, RowBuilderSelectsHighestElevationReferenceAndFormsResidual) {
     ObservationData obs(GNSSTime(2068, 230572.0));
     const Vector3d receiver(constants::WGS84_A, 0.0, 0.0);


### PR DESCRIPTION
## Summary

- add a CLAS OSR receiver-antenna lookup helper
- keep exact GPS C2W/L2W rows on the CLASLIB receiver-antenna slot while `GNSS_PPP_CLAS_RX_ANTENNA=1` is enabled
- document the updated A4b G14/C2W receiver-antenna component parity result

## Root Cause

After receiver-antenna materialization was wired into CLAS OSR, the exact GPS L2W A4b row still used the native L2 antenna lookup. The CLASLIB diagnostic rows for G14/C2W line up with the L1 receiver-antenna slot instead: native L1 differs by about 2.1 mm while native L2 differs by about 24.9 mm on the 300-epoch sample.

## Validation

- `cmake --build build --target run_tests gnss_ppp -j4`
- `./build/tests/run_tests --gtest_filter='PPPClasOsrTest.*:PPPClasTest.*:PPPClasDdTest.*'`
- `ctest --test-dir build -R '^run_tests$' --output-on-failure`
- `git diff --check`
- CLASLIB 300-epoch G14/C2W component diff with `GNSS_PPP_CLAS_RX_ANTENNA=1`: `receiver_antenna_m` mean_abs dropped from `0.0249236633 m` to `0.0021253233 m`.
