### PR TITLE
[codex] clas: extend base code bias on phase-only rows

### DIFF
--- a/apps/gnss_qzss_l6_info.py
+++ b/apps/gnss_qzss_l6_info.py
@@ -2205,7 +2205,7 @@ def decode_cssr_code_phase_bias_message(
                         )
                     mapped_phase += 1
 
-    if network_bias_correction and code_bias_exists:
+    if network_bias_correction and (code_bias_exists or phase_bias_exists):
         materialize_missing_code_bias_rows(
             state,
             int(header["tow"]),

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -122,6 +122,7 @@ python3 apps/gnss.py clas-ppp \
   --receiver-antenna-type "TRM59800.80     NONE" \
   --compact-code-bias-composition-policy base-only-if-present \
   --compact-code-bias-bank-policy latest-preceding-bank \
+  --compact-bias-row-materialization selected-satellite-base-extend \
   --out /tmp/gnsspp_clas_a4b_native.pos \
   --summary-json /tmp/gnsspp_clas_a4b_native_summary.json \
   --max-epochs 300
@@ -182,12 +183,23 @@ direct network policy produced periodic G14/C2W `code_bias_m` outliers such as
 `-0.70 m` where CLASLIB reports `+0.76 m`. The A4b policy above restores those
 rows to the base value and reduces the G14/C2W `code_bias_m` diff from
 `mean_abs=0.1795 m, rms=0.4000 m, max_abs=1.4600 m` to
-`mean_abs=0.1319 m, rms=0.3029 m, max_abs=0.7800 m`. The gated receiver-antenna
-materialization keeps the exact GPS L2W row on CLASLIB's receiver-antenna slot;
-on the same G14/C2W slice this reduces `receiver_antenna_m` from
-`mean_abs=0.0249 m` to `mean_abs=0.0021 m`. The remaining top-row deltas are
-then dominated by residual/PRC, code-bias, and atmosphere terms rather than the
-30-second code-bias sign flip or receiver-antenna slot mismatch.
+`mean_abs=0.1319 m, rms=0.3029 m, max_abs=0.7800 m`.
+
+The row materialization option also extends the latest base code-bias bank onto
+phase-only subtype-6 network rows. Without it, the 300-epoch G14/C2W smoke has
+49/300 native rows with `code_bias_present=0` and `code_bias_m=0`; with it, the
+same slice has 0/300 missing code-bias rows. On the short CLASLIB ZD oracle
+window bundled with this probe, that phase-only-row extension reduces the
+G14/C2W `code_bias_m` diff from `mean_abs=0.0764 m, rms=0.2295 m,
+max_abs=0.7600 m` to `mean_abs=0.0091 m, rms=0.0135 m, max_abs=0.0200 m`, and
+the aggregate `PRC` diff from `mean_abs=0.0915 m, rms=0.2369 m,
+max_abs=0.7819 m` to `mean_abs=0.0243 m, rms=0.0266 m, max_abs=0.0419 m`. The
+gated receiver-antenna materialization keeps the exact GPS L2W row on CLASLIB's
+receiver-antenna slot; on the same 300-epoch G14/C2W slice this reduces
+`receiver_antenna_m` from `mean_abs=0.0249 m` to `mean_abs=0.0021 m`. The
+remaining top-row deltas are then dominated by residual and atmosphere terms
+rather than the 30-second code-bias sign flip, phase-only code-bias gaps, or
+receiver-antenna slot mismatch.
 
 The diff JSON also includes `top_row_component_breakdowns`, which groups all
 component deltas for the same ZD key. Use that field to decide whether the next

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -5937,6 +5937,92 @@ class CLIToolsTest(unittest.TestCase):
             self.assertIn("cbias:2=0.040000", extend_row)
             self.assertIn("cbias:3=-0.080000", extend_row)
 
+    def test_qzss_l6_info_compact_bias_row_materialization_extends_phase_only_network_code_bias_rows(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_qzss_l6_phase_only_code_bias_row_extend_") as temp_dir:
+            temp_root = Path(temp_dir)
+            input_path = temp_root / "session_l6_phase_only_code_bias_row_extend.bin"
+            strict_path = temp_root / "strict.csv"
+            extend_path = temp_root / "selected_satellite_extend.csv"
+            input_path.write_bytes(
+                build_qzss_l6_subframe_stream(
+                    [
+                        build_qzss_cssr_mask_message(
+                            tow=518400,
+                            iod=3,
+                            prn=3,
+                            sync=True,
+                            sigmask=0x8000,
+                        ),
+                        build_qzss_cssr_code_bias_message(
+                            tow_delta=0,
+                            iod=3,
+                            bias_m=-0.12,
+                            sync=False,
+                        ),
+                        build_qzss_cssr_mask_message(
+                            tow=518412,
+                            iod=3,
+                            prn=3,
+                            sync=True,
+                            sigmask=0x8000,
+                        ),
+                        build_qzss_cssr_code_phase_bias_message(
+                            tow_delta=0,
+                            iod=3,
+                            sync=False,
+                            network_bias=True,
+                            code_bias_exists=False,
+                            phase_bias_exists=True,
+                            selected_mask=0b1,
+                            phase_bias_m=0.045,
+                            entries_per_selected_satellite=1,
+                        ),
+                    ]
+                )
+            )
+
+            strict_result = self.run_gnss(
+                "qzss-l6-info",
+                "--input",
+                str(input_path),
+                "--extract-compact-corrections",
+                str(strict_path),
+                "--gps-week",
+                "2200",
+                "--compact-code-bias-bank-policy",
+                "same-30s-bank",
+            )
+            self.assertEqual(strict_result.returncode, 0, msg=strict_result.stderr)
+            strict_row = next(
+                line
+                for line in strict_path.read_text(encoding="ascii").splitlines()
+                if line.startswith("2200,518400.000") and "bias_network_id=1" in line
+            )
+            self.assertIn("pbias:2=0.045000", strict_row)
+            self.assertNotIn("cbias:2=", strict_row)
+
+            extend_result = self.run_gnss(
+                "qzss-l6-info",
+                "--input",
+                str(input_path),
+                "--extract-compact-corrections",
+                str(extend_path),
+                "--gps-week",
+                "2200",
+                "--compact-code-bias-bank-policy",
+                "same-30s-bank",
+                "--compact-bias-row-materialization",
+                "selected-satellite-base-extend",
+            )
+            self.assertEqual(extend_result.returncode, 0, msg=extend_result.stderr)
+            extend_row = next(
+                line
+                for line in extend_path.read_text(encoding="ascii").splitlines()
+                if line.startswith("2200,518400.000") and "bias_network_id=1" in line
+            )
+            self.assertIn("pbias:2=0.045000", extend_row)
+            self.assertIn("cbias:2=-0.120000", extend_row)
+
     def test_qzss_l6_info_compact_bias_row_materialization_all_base_satellite_extends_unselected_code_bias_rows(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_qzss_l6_code_bias_mask_extend_") as temp_dir:
             temp_root = Path(temp_dir)


### PR DESCRIPTION
## Summary

- extend compact bias row materialization so phase-only subtype-6 network rows can carry the latest base code-bias rows when `selected-satellite-base-extend` is enabled
- add a focused `qzss-l6-info` regression test covering strict vs opt-in behavior for phase-only network rows
- update the CLAS A4b runbook with the required row-materialization flag and measured G14/C2W validation numbers

## Root Cause

The A4b GPS L2W smoke has subtype-4 base code-bias rows followed by subtype-6 network rows that sometimes carry phase bias only. The existing materialization path ran only when `code_bias_exists=true`, so those phase-only network rows flushed without the base `cbias` entry. In the 300-epoch G14/C2W probe this left 49/300 native rows with `code_bias_present=0` and `code_bias_m=0`.

## Validation

- `python3 -m py_compile apps/gnss_qzss_l6_info.py tests/test_cli_tools.py scripts/analysis/clas_zd_component_diff.py scripts/analysis/claslib_zd_component_export.py`
- `python3 -m unittest tests.test_cli_tools.CLIToolsTest.test_qzss_l6_info_compact_bias_row_materialization_extends_phase_only_network_code_bias_rows`
- `python3 -m unittest tests.test_cli_tools.CLIToolsTest.test_qzss_l6_info_compact_bias_row_materialization_selected_satellite_extends_missing_code_bias_rows tests.test_cli_tools.CLIToolsTest.test_qzss_l6_info_compact_bias_row_materialization_all_base_satellite_extends_unselected_code_bias_rows tests.test_cli_tools.CLIToolsTest.test_qzss_l6_info_compact_bias_row_materialization_selected_satellite_extends_missing_phase_bias_rows tests.test_cli_tools.CLIToolsTest.test_qzss_l6_info_compact_bias_row_materialization_extends_phase_only_network_code_bias_rows`
- 300-epoch CLAS A4b G14/C2W smoke: `code_bias_present` missing rows dropped from 49/300 to 0/300 with `--compact-bias-row-materialization selected-satellite-base-extend`
- short CLASLIB ZD oracle window: G14/C2W `code_bias_m` mean_abs/rms/max improved from `0.0764/0.2295/0.7600 m` to `0.0091/0.0135/0.0200 m`; aggregate `PRC` improved from `0.0915/0.2369/0.7819 m` to `0.0243/0.0266/0.0419 m`
- `git diff --check`

Note: `ctest --test-dir build -R ^python_cli_tests --output-on-failure` was also run locally, but failed in unrelated `test_ros2_bag_doctor_reads_mcap_metadata_without_sqlite` because this environment's MCAP reader attempted to parse the synthetic MCAP file and reported `unpack requires a buffer of 8 bytes` instead of the expected unavailable-reader message.