### PR TITLE
[codex] ci: add lightweight cli ux smoke

### DIFF
--- a/apps/gnss.py
+++ b/apps/gnss.py
@@ -517,7 +517,6 @@ def usage() -> str:
             "  python3 apps/gnss.py ubx-info --input serial:///dev/ttyACM0?baud=115200 --limit 10",
             "  python3 apps/gnss.py ionex-info --input products/codg0020.24i --summary-json output/ionex.json",
             "  python3 apps/gnss.py dcb-info --input products/CAS0MGXRAP_20240020000_01D_01D_DCB.BSX --summary-json output/dcb.json",
-            "  python3 apps/gnss.py nmea-info --input logs/session.nmea --decode-gga --decode-rmc",
             "  python3 apps/gnss.py nmea-info --input serial:///dev/ttyUSB0?baud=9600 --limit 10",
             "  python3 apps/gnss.py novatel-info --input logs/novatel.log --decode-bestpos --decode-bestvel",
             "  python3 apps/gnss.py novatel-info --input serial:///dev/ttyUSB0?baud=115200 --limit 10",

--- a/apps/gnss_doctor.py
+++ b/apps/gnss_doctor.py
@@ -158,6 +158,7 @@ def render_text(checks: list[dict[str, str]]) -> str:
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
+        prog=os.environ.get("GNSS_CLI_NAME"),
         description="Check local libgnss++ setup and print first useful commands."
     )
     parser.add_argument("--root", type=Path, default=ROOT_DIR, help="Repository root to inspect.")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -82,6 +82,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_cli_tools.py
     )
     add_test(
+        NAME python_cli_ux_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_cli_ux.py
+    )
+    add_test(
         NAME python_madoca_solution_diff_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_madoca_solution_diff.py
     )
@@ -236,6 +240,7 @@ if(GTest_FOUND)
         run_tests
         python_clas_zd_component_diff_tests
         python_claslib_zd_component_export_tests
+        python_cli_ux_tests
         python_optional_clas_zd_component_diff_tests
         python_madoca_residual_component_diff_tests
         python_madoca_solution_diff_tests

--- a/tests/test_cli_ux.py
+++ b/tests/test_cli_ux.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Lightweight CLI user-experience smoke tests."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+GNSS_CLI = ROOT_DIR / "apps" / "gnss.py"
+
+
+class CliUxTest(unittest.TestCase):
+    def run_gnss(self, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [sys.executable, str(GNSS_CLI), *args],
+            cwd=ROOT_DIR,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def assert_no_traceback(self, result: subprocess.CompletedProcess[str]) -> None:
+        combined = result.stdout + result.stderr
+        self.assertNotIn("Traceback (most recent call last)", combined)
+        self.assertNotIn("ModuleNotFoundError", combined)
+
+    def test_top_level_help_keeps_primary_workflows_discoverable(self) -> None:
+        result = self.run_gnss("--help")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assert_no_traceback(result)
+        self.assertIn("Usage: gnss <command> [args...]", result.stdout)
+        self.assertIn("Commands:", result.stdout)
+        self.assertIn("Examples:", result.stdout)
+        for command in (
+            "doctor",
+            "solve",
+            "ppp",
+            "clas-ppp",
+            "qzss-l6-info",
+            "ppc-rtk-signoff",
+            "web",
+        ):
+            self.assertIn(f"  {command}", result.stdout)
+
+        examples = [
+            line.strip()
+            for line in result.stdout.splitlines()
+            if line.strip().startswith("python3 apps/gnss.py ")
+        ]
+        duplicates = sorted({line for line in examples if examples.count(line) > 1})
+        self.assertEqual(duplicates, [])
+
+    def test_representative_subcommand_help_uses_dispatcher_names(self) -> None:
+        expectations = {
+            "doctor": ("usage: gnss doctor", "--strict"),
+            "qzss-l6-info": (
+                "usage: gnss qzss-l6-info",
+                "--compact-bias-row-materialization",
+            ),
+            "clas-ppp": (
+                "usage: gnss clas-ppp",
+                "--receiver-antenna-type",
+                "--compact-code-bias-composition-policy",
+            ),
+            "web": ("usage: gnss web", "--artifact-manifest"),
+        }
+
+        for command, snippets in expectations.items():
+            with self.subTest(command=command):
+                result = self.run_gnss(command, "--help")
+                self.assertEqual(result.returncode, 0, msg=result.stderr)
+                self.assert_no_traceback(result)
+                for snippet in snippets:
+                    self.assertIn(snippet, result.stdout)
+
+    def test_user_input_errors_are_actionable_not_tracebacks(self) -> None:
+        cases = [
+            (
+                ("does-not-exist",),
+                1,
+                "Error: unknown command `does-not-exist`.",
+                "Commands:",
+            ),
+            (
+                ("qzss-l6-info",),
+                2,
+                "usage: gnss qzss-l6-info",
+                "the following arguments are required: --input",
+            ),
+            (
+                ("clas-ppp",),
+                2,
+                "usage: gnss clas-ppp",
+                "the following arguments are required: --obs, --nav, --out",
+            ),
+        ]
+
+        for args, expected_code, *snippets in cases:
+            with self.subTest(args=args):
+                result = self.run_gnss(*args)
+                self.assertEqual(result.returncode, expected_code)
+                self.assert_no_traceback(result)
+                combined = result.stdout + result.stderr
+                for snippet in snippets:
+                    self.assertIn(snippet, combined)
+
+    def test_doctor_json_stays_machine_readable_for_setup_tools(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_cli_ux_doctor_") as temp_dir:
+            missing_root = Path(temp_dir) / "missing-root"
+            expected_root = str(missing_root.resolve())
+            result = self.run_gnss("doctor", "--root", str(missing_root), "--json")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assert_no_traceback(result)
+        self.assertEqual(result.stderr, "")
+        payload = json.loads(result.stdout)
+        self.assertIs(payload["ok"], False)
+        self.assertEqual(payload["root"], expected_root)
+        self.assertIsInstance(payload["checks"], list)
+        self.assertGreaterEqual(len(payload["checks"]), 3)
+        self.assertIn("next_commands", payload)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a fast `python_cli_ux_tests` CTest target to the core CI label
- guard the user-facing `gnss` dispatcher help, representative subcommand help, actionable argument errors, and `doctor --json` schema
- make `gnss doctor --help` show the dispatcher-facing program name and remove a duplicate top-level NMEA example

## Why

The existing `python_cli_tests` suite is broad and runs in the optional lane. This PR adds a narrow core-lane UX smoke so common CLI regressions fail early without datasets, external services, browser dependencies, or built solver binaries.

## Validation

- `python3 -m py_compile apps/gnss.py apps/gnss_doctor.py tests/test_cli_ux.py`
- `python3 -m unittest tests.test_cli_ux`
- `cmake -S . -B build`
- `ctest --test-dir build -R ^python_cli_ux_tests$ --output-on-failure`
- `ctest --test-dir build -L core --output-on-failure`
- `git diff --check`