### PR TITLE
[codex] cli: suggest close command names

### DIFF
--- a/apps/gnss.py
+++ b/apps/gnss.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import difflib
 import glob
 import os
 import sys
@@ -575,6 +576,40 @@ def usage() -> str:
     return "\n".join(lines)
 
 
+def suggest_commands(command_name: str, *, limit: int = 3) -> list[str]:
+    suggestions: list[str] = []
+    normalized = command_name.replace("_", "-")
+    if normalized in COMMANDS:
+        suggestions.append(normalized)
+
+    for match in difflib.get_close_matches(
+        normalized,
+        sorted(COMMANDS),
+        n=limit,
+        cutoff=0.55,
+    ):
+        if match not in suggestions:
+            suggestions.append(match)
+        if len(suggestions) >= limit:
+            break
+    return suggestions
+
+
+def unknown_command_message(command_name: str) -> str:
+    lines = [f"Error: unknown command `{command_name}`."]
+    suggestions = suggest_commands(command_name)
+    if suggestions:
+        lines.append("")
+        if len(suggestions) == 1:
+            lines.append(f"Did you mean `{suggestions[0]}`?")
+        else:
+            lines.append("Did you mean one of these?")
+            for name in suggestions:
+                lines.append(f"  {name:<22} {COMMANDS[name]['summary']}")
+    lines.extend(["", usage()])
+    return "\n".join(lines)
+
+
 def find_binary(target_name: str) -> str | None:
     filename = target_name + EXE_SUFFIX
     build_roots = [
@@ -643,8 +678,7 @@ def main() -> int:
     command_name = sys.argv[1]
     command = COMMANDS.get(command_name)
     if command is None:
-        print(f"Error: unknown command `{command_name}`.\n", file=sys.stderr)
-        print(usage(), file=sys.stderr)
+        print(unknown_command_message(command_name), file=sys.stderr)
         return 1
 
     args = sys.argv[2:]

--- a/tests/test_cli_ux.py
+++ b/tests/test_cli_ux.py
@@ -174,6 +174,24 @@ class CliUxTest(unittest.TestCase):
                 for snippet in snippets:
                     self.assertIn(snippet, combined)
 
+    def test_unknown_command_suggests_registered_dispatcher_names(self) -> None:
+        cases = [
+            ("clas_ppp", "clas-ppp"),
+            ("ppc-rtk-signof", "ppc-rtk-signoff"),
+            ("qzss-l6-inf", "qzss-l6-info"),
+        ]
+
+        for typo, expected_command in cases:
+            with self.subTest(typo=typo):
+                result = self.run_gnss(typo)
+                self.assertEqual(result.returncode, 1)
+                self.assert_no_traceback(result)
+                self.assertEqual(result.stdout, "")
+                self.assertIn(f"Error: unknown command `{typo}`.", result.stderr)
+                self.assertIn("Did you mean", result.stderr)
+                self.assertIn(expected_command, result.stderr)
+                self.assertIn("Commands:", result.stderr)
+
     def test_doctor_json_stays_machine_readable_for_setup_tools(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_cli_ux_doctor_") as temp_dir:
             missing_root = Path(temp_dir) / "missing-root"


### PR DESCRIPTION
## Summary
- add close-match suggestions for unknown `gnss` dispatcher commands
- handle common underscore-vs-hyphen typos such as `clas_ppp`
- extend CLI UX tests to cover typo suggestions for CLAS, PPC sign-off, and QZSS L6 commands

## User impact
Mistyped command names now fail with an actionable suggestion before the full command list, instead of only dumping the generic help text.

## Validation
- `python3 -m py_compile apps/gnss.py tests/test_cli_ux.py`
- `python3 -m unittest tests.test_cli_ux`
- `python3 apps/gnss.py ppc-rtk-signof >/tmp/gnss_typo_stdout.txt 2>/tmp/gnss_typo_stderr.txt`
- `git diff --check`
- `ctest --test-dir build -R '^python_cli_ux_tests$' --output-on-failure`
- `ctest --test-dir build -L core --output-on-failure`
