### PR TITLE
[codex] cli: dispatch help to subcommands

### DIFF
--- a/apps/gnss.py
+++ b/apps/gnss.py
@@ -670,21 +670,34 @@ def run_binary(target_name: str, args: list[str]) -> int:
         return 1
 
 
-def main() -> int:
-    if len(sys.argv) < 2 or sys.argv[1] in ("-h", "--help", "help"):
-        print(usage())
-        return 0 if len(sys.argv) >= 2 else 1
-
-    command_name = sys.argv[1]
+def dispatch_command(command_name: str, args: list[str]) -> int:
     command = COMMANDS.get(command_name)
     if command is None:
         print(unknown_command_message(command_name), file=sys.stderr)
         return 1
 
-    args = sys.argv[2:]
     if command["kind"] == "python":
         return run_python(command["target"], command_name, args)
     return run_binary(command["target"], args)
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(usage())
+        return 1
+
+    if sys.argv[1] in ("-h", "--help"):
+        print(usage())
+        return 0
+
+    command_name = sys.argv[1]
+    if command_name == "help":
+        if len(sys.argv) < 3:
+            print(usage())
+            return 0
+        return dispatch_command(sys.argv[2], ["--help"])
+
+    return dispatch_command(command_name, sys.argv[2:])
 
 
 if __name__ == "__main__":

--- a/tests/test_cli_ux.py
+++ b/tests/test_cli_ux.py
@@ -143,6 +143,26 @@ class CliUxTest(unittest.TestCase):
                 for snippet in snippets:
                     self.assertIn(snippet, result.stdout)
 
+    def test_help_command_dispatches_to_subcommand_help(self) -> None:
+        expectations = {
+            "doctor": ("usage: gnss doctor", "--strict"),
+            "qzss-l6-info": (
+                "usage: gnss qzss-l6-info",
+                "--compact-bias-row-materialization",
+            ),
+            "web": ("usage: gnss web", "--artifact-manifest"),
+        }
+
+        for command, snippets in expectations.items():
+            with self.subTest(command=command):
+                result = self.run_gnss("help", command)
+                self.assertEqual(result.returncode, 0, msg=result.stderr)
+                self.assert_no_traceback(result)
+                self.assertEqual(result.stderr, "")
+                self.assertNotIn("Usage: gnss <command> [args...]", result.stdout)
+                for snippet in snippets:
+                    self.assertIn(snippet, result.stdout)
+
     def test_user_input_errors_are_actionable_not_tracebacks(self) -> None:
         cases = [
             (
@@ -191,6 +211,16 @@ class CliUxTest(unittest.TestCase):
                 self.assertIn("Did you mean", result.stderr)
                 self.assertIn(expected_command, result.stderr)
                 self.assertIn("Commands:", result.stderr)
+
+    def test_help_command_unknown_target_uses_command_suggestions(self) -> None:
+        result = self.run_gnss("help", "clas_ppp")
+
+        self.assertEqual(result.returncode, 1)
+        self.assert_no_traceback(result)
+        self.assertEqual(result.stdout, "")
+        self.assertIn("Error: unknown command `clas_ppp`.", result.stderr)
+        self.assertIn("Did you mean `clas-ppp`?", result.stderr)
+        self.assertIn("Commands:", result.stderr)
 
     def test_doctor_json_stays_machine_readable_for_setup_tools(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_cli_ux_doctor_") as temp_dir:


### PR DESCRIPTION
## Summary
- make `gnss help <command>` dispatch to the target command's own `--help`
- reuse the dispatcher path for normal command execution and help dispatch
- keep typo handling on `gnss help <typo>` wired to the close-command suggestions from the previous CLI UX improvement

## User impact
Users can now type `python3 apps/gnss.py help doctor` or `python3 apps/gnss.py help qzss-l6-info` and get the focused subcommand help instead of the long top-level command list.

## Validation
- `python3 -m py_compile apps/gnss.py tests/test_cli_ux.py`
- `python3 -m unittest tests.test_cli_ux`
- `python3 apps/gnss.py help doctor`
- `python3 apps/gnss.py help clas_ppp`
- `ctest --test-dir build -R '^python_cli_ux_tests$' --output-on-failure`
- `ctest --test-dir build -L core --output-on-failure`
- `git diff --check`
