### PR TITLE
[codex] cli: expose command registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,6 +211,8 @@ jobs:
       run: |
         docker build -t libgnsspp-ci .
         docker run --rm libgnsspp-ci --help >/dev/null
+        docker run --rm libgnsspp-ci commands --json >/dev/null
+        docker run --rm libgnsspp-ci help web >/dev/null
         docker run --rm libgnsspp-ci web --help >/dev/null
         docker compose -f compose.yaml config >/dev/null
 

--- a/README.md
+++ b/README.md
@@ -131,7 +131,8 @@ Then open `http://127.0.0.1:8085`.
 List commands:
 
 ```bash
-python3 apps/gnss.py --help
+python3 apps/gnss.py commands
+python3 apps/gnss.py commands --json
 ```
 
 ## Docker

--- a/apps/gnss.py
+++ b/apps/gnss.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import difflib
 import glob
+import json
 import os
 import sys
 
@@ -15,6 +16,14 @@ EXE_SUFFIX = ".exe" if os.name == "nt" else ""
 BUILD_CONFIGS = ("Release", "RelWithDebInfo", "Debug", "MinSizeRel")
 
 COMMANDS = {
+    "commands": {
+        "kind": "builtin",
+        "summary": "List registered dispatcher commands as text or JSON for users, docs, and tooling.",
+    },
+    "help": {
+        "kind": "builtin",
+        "summary": "Show top-level help or dispatch to a command's own --help output.",
+    },
     "doctor": {
         "kind": "python",
         "target": os.path.join(APPS_DIR, "gnss_doctor.py"),
@@ -468,18 +477,48 @@ COMMANDS = {
 }
 
 
+def command_kinds() -> list[str]:
+    return sorted({metadata["kind"] for metadata in COMMANDS.values()})
+
+
+def command_records(kind_filter: str | None = None) -> list[dict[str, str]]:
+    records: list[dict[str, str]] = []
+    for name, metadata in sorted(COMMANDS.items()):
+        kind = metadata["kind"]
+        if kind_filter is not None and kind != kind_filter:
+            continue
+        records.append(
+            {
+                "name": name,
+                "kind": kind,
+                "summary": metadata["summary"],
+            }
+        )
+    return records
+
+
+def format_command_records(records: list[dict[str, str]]) -> str:
+    width = max((len(record["name"]) for record in records), default=7)
+    lines = ["Commands:"]
+    for record in records:
+        lines.append(f"  {record['name']:<{width}}  {record['summary']}")
+    lines.extend(["", "Run `gnss help <command>` for command-specific options."])
+    return "\n".join(lines)
+
+
 def usage() -> str:
     lines = [
         "Usage: gnss <command> [args...]",
         "",
-        "Commands:",
+        format_command_records(command_records()),
     ]
-    for name in sorted(COMMANDS):
-        lines.append(f"  {name:<10} {COMMANDS[name]['summary']}")
     lines.extend(
         [
             "",
             "Examples:",
+            "  python3 apps/gnss.py commands",
+            "  python3 apps/gnss.py commands --json",
+            "  python3 apps/gnss.py help doctor",
             "  python3 apps/gnss.py doctor",
             "  python3 apps/gnss.py robotics-smoke --profile realtime",
             "  python3 apps/gnss.py ros2-doctor --device /dev/ttyUSB0",
@@ -610,6 +649,135 @@ def unknown_command_message(command_name: str) -> str:
     return "\n".join(lines)
 
 
+def help_usage() -> str:
+    return "\n".join(
+        [
+            "Usage: gnss help [command]",
+            "",
+            "Show top-level help, or show the named command's own --help output.",
+            "",
+            "Examples:",
+            "  python3 apps/gnss.py help",
+            "  python3 apps/gnss.py help doctor",
+            "  python3 apps/gnss.py help clas-ppp",
+        ]
+    )
+
+
+def commands_usage() -> str:
+    return "\n".join(
+        [
+            "Usage: gnss commands [--json] [--kind KIND]",
+            "",
+            "List registered dispatcher commands without invoking solver binaries.",
+            "",
+            "Options:",
+            "  --json       Emit a machine-readable command registry.",
+            f"  --kind KIND  Filter by command kind: {', '.join(command_kinds())}.",
+            "",
+            "Examples:",
+            "  python3 apps/gnss.py commands",
+            "  python3 apps/gnss.py commands --json",
+            "  python3 apps/gnss.py commands --kind python",
+        ]
+    )
+
+
+def run_help(args: list[str]) -> int:
+    if not args:
+        print(usage())
+        return 0
+    if args == ["-h"] or args == ["--help"]:
+        print(help_usage())
+        return 0
+    if len(args) > 1:
+        print(
+            f"Error: gnss help accepts at most one command, got {len(args)}.",
+            "",
+            help_usage(),
+            sep="\n",
+            file=sys.stderr,
+        )
+        return 2
+    return dispatch_command(args[0], ["--help"])
+
+
+def run_commands(args: list[str]) -> int:
+    emit_json = False
+    kind_filter: str | None = None
+    index = 0
+    valid_kinds = set(command_kinds())
+
+    while index < len(args):
+        arg = args[index]
+        if arg in ("-h", "--help"):
+            print(commands_usage())
+            return 0
+        if arg == "--json":
+            emit_json = True
+            index += 1
+            continue
+        if arg == "--kind":
+            if index + 1 >= len(args):
+                print(
+                    "Error: --kind requires one of: "
+                    + ", ".join(sorted(valid_kinds))
+                    + ".",
+                    "",
+                    commands_usage(),
+                    sep="\n",
+                    file=sys.stderr,
+                )
+                return 2
+            kind_filter = args[index + 1]
+            index += 2
+        elif arg.startswith("--kind="):
+            kind_filter = arg.split("=", 1)[1]
+            index += 1
+        else:
+            print(
+                f"Error: unknown option for gnss commands: `{arg}`.",
+                "",
+                commands_usage(),
+                sep="\n",
+                file=sys.stderr,
+            )
+            return 2
+
+        if kind_filter is not None and kind_filter not in valid_kinds:
+            print(
+                f"Error: unknown command kind `{kind_filter}`. "
+                f"Expected one of: {', '.join(sorted(valid_kinds))}.",
+                "",
+                commands_usage(),
+                sep="\n",
+                file=sys.stderr,
+            )
+            return 2
+
+    records = command_records(kind_filter)
+    if emit_json:
+        payload = {
+            "schema_version": 1,
+            "filters": {"kind": kind_filter},
+            "count": len(records),
+            "commands": records,
+        }
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(format_command_records(records))
+    return 0
+
+
+def run_builtin(command_name: str, args: list[str]) -> int:
+    if command_name == "help":
+        return run_help(args)
+    if command_name == "commands":
+        return run_commands(args)
+    print(f"Error: unsupported builtin command `{command_name}`.", file=sys.stderr)
+    return 1
+
+
 def find_binary(target_name: str) -> str | None:
     filename = target_name + EXE_SUFFIX
     build_roots = [
@@ -676,6 +844,8 @@ def dispatch_command(command_name: str, args: list[str]) -> int:
         print(unknown_command_message(command_name), file=sys.stderr)
         return 1
 
+    if command["kind"] == "builtin":
+        return run_builtin(command_name, args)
     if command["kind"] == "python":
         return run_python(command["target"], command_name, args)
     return run_binary(command["target"], args)
@@ -690,14 +860,7 @@ def main() -> int:
         print(usage())
         return 0
 
-    command_name = sys.argv[1]
-    if command_name == "help":
-        if len(sys.argv) < 3:
-            print(usage())
-            return 0
-        return dispatch_command(sys.argv[2], ["--help"])
-
-    return dispatch_command(command_name, sys.argv[2:])
+    return dispatch_command(sys.argv[1], sys.argv[2:])
 
 
 if __name__ == "__main__":

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -60,6 +60,8 @@ python3 apps/gnss.py replay \
 
 | Command | Purpose |
 |---|---|
+| `gnss commands` | List registered dispatcher commands as text or JSON |
+| `gnss help <command>` | Show focused help for one command |
 | `gnss doctor` | Check local setup, built tools, dataset/docs readiness, Docker, and ROS2 hints |
 | `gnss ros2-doctor` | Check ROS2 receiver readiness, serial permissions, launch/record commands, and topic debug commands |
 | `gnss ros2-bag-doctor` | Inspect a ROS2 GNSS bag for required topics, message rates, timestamp gaps, raw-binary replayability, and MCAP reader/metadata fallback |

--- a/docs/research_quickstart.md
+++ b/docs/research_quickstart.md
@@ -20,7 +20,8 @@ cmake --build build -j
 Confirm the dispatcher can see the command set:
 
 ```bash
-python3 apps/gnss.py --help
+python3 apps/gnss.py commands
+python3 apps/gnss.py commands --json
 ```
 
 ## Reproduce a bounded RTK run

--- a/tests/test_cli_ux.py
+++ b/tests/test_cli_ux.py
@@ -145,6 +145,7 @@ class CliUxTest(unittest.TestCase):
 
     def test_help_command_dispatches_to_subcommand_help(self) -> None:
         expectations = {
+            "commands": ("Usage: gnss commands", "--json"),
             "doctor": ("usage: gnss doctor", "--strict"),
             "qzss-l6-info": (
                 "usage: gnss qzss-l6-info",
@@ -162,6 +163,62 @@ class CliUxTest(unittest.TestCase):
                 self.assertNotIn("Usage: gnss <command> [args...]", result.stdout)
                 for snippet in snippets:
                     self.assertIn(snippet, result.stdout)
+
+    def test_commands_text_output_lists_dispatcher_registry(self) -> None:
+        result = self.run_gnss("commands")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assert_no_traceback(result)
+        self.assertEqual(result.stderr, "")
+        self.assertIn("Commands:", result.stdout)
+        self.assertIn("  commands", result.stdout)
+        self.assertIn("  doctor", result.stdout)
+        self.assertIn("  clas-ppp", result.stdout)
+        self.assertIn("Run `gnss help <command>`", result.stdout)
+        self.assertNotIn("Examples:", result.stdout)
+
+    def test_commands_json_output_is_stable_for_tooling(self) -> None:
+        result = self.run_gnss("commands", "--json")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assert_no_traceback(result)
+        self.assertEqual(result.stderr, "")
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["filters"], {"kind": None})
+        self.assertEqual(payload["count"], len(payload["commands"]))
+
+        names = [item["name"] for item in payload["commands"]]
+        self.assertEqual(names, sorted(names))
+        self.assertIn("commands", names)
+        self.assertIn("help", names)
+        self.assertIn("doctor", names)
+
+        for item in payload["commands"]:
+            self.assertEqual(set(item), {"kind", "name", "summary"})
+            self.assertIn(item["kind"], {"binary", "builtin", "python"})
+            self.assertIsInstance(item["summary"], str)
+            self.assertTrue(item["summary"].strip())
+
+    def test_commands_kind_filter_and_errors_are_actionable(self) -> None:
+        builtin_result = self.run_gnss("commands", "--kind", "builtin", "--json")
+
+        self.assertEqual(builtin_result.returncode, 0, msg=builtin_result.stderr)
+        self.assert_no_traceback(builtin_result)
+        self.assertEqual(builtin_result.stderr, "")
+        payload = json.loads(builtin_result.stdout)
+        self.assertEqual(payload["filters"], {"kind": "builtin"})
+        self.assertEqual(
+            [item["name"] for item in payload["commands"]],
+            ["commands", "help"],
+        )
+
+        invalid_result = self.run_gnss("commands", "--kind", "solver")
+        self.assertEqual(invalid_result.returncode, 2)
+        self.assert_no_traceback(invalid_result)
+        self.assertEqual(invalid_result.stdout, "")
+        self.assertIn("Error: unknown command kind `solver`.", invalid_result.stderr)
+        self.assertIn("Usage: gnss commands", invalid_result.stderr)
 
     def test_user_input_errors_are_actionable_not_tracebacks(self) -> None:
         cases = [
@@ -294,13 +351,19 @@ class CliUxTest(unittest.TestCase):
             target = metadata.get("target")
             summary = metadata.get("summary")
 
-            if kind not in {"python", "binary"}:
+            if kind not in {"python", "binary", "builtin"}:
                 failures.append(f"{command}: unsupported kind {kind!r}")
+            if not isinstance(summary, str) or not summary.strip():
+                failures.append(f"{command}: missing summary")
+
+            if kind == "builtin":
+                if target:
+                    failures.append(f"{command}: builtin should not declare target")
+                continue
+
             if not isinstance(target, str) or not target:
                 failures.append(f"{command}: missing target")
                 continue
-            if not isinstance(summary, str) or not summary.strip():
-                failures.append(f"{command}: missing summary")
 
             if kind != "python":
                 continue


### PR DESCRIPTION
## Summary
- Add built-in `gnss commands` with text and JSON registry output.
- Make `help` a registered built-in command so `gnss help commands` has focused help.
- Update docs and Docker smoke coverage so command-list UX stays checked in CI.

## Validation
- `python3 -m py_compile apps/gnss.py tests/test_cli_ux.py`
- `python3 -m unittest tests.test_cli_ux`
- `ctest --test-dir build -R '^python_cli_ux_tests$' --output-on-failure`
- `ctest --test-dir build -L core --output-on-failure`
