### PR TITLE
[codex] cli: search command registry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -212,6 +212,7 @@ jobs:
         docker build -t libgnsspp-ci .
         docker run --rm libgnsspp-ci --help >/dev/null
         docker run --rm libgnsspp-ci commands --json >/dev/null
+        docker run --rm libgnsspp-ci commands --query ppp --limit 3 --json >/dev/null
         docker run --rm libgnsspp-ci help web >/dev/null
         docker run --rm libgnsspp-ci web --help >/dev/null
         docker compose -f compose.yaml config >/dev/null

--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ List commands:
 ```bash
 python3 apps/gnss.py commands
 python3 apps/gnss.py commands --json
+python3 apps/gnss.py commands --query ppp --limit 10
 ```
 
 ## Docker

--- a/apps/gnss.py
+++ b/apps/gnss.py
@@ -481,25 +481,52 @@ def command_kinds() -> list[str]:
     return sorted({metadata["kind"] for metadata in COMMANDS.values()})
 
 
-def command_records(kind_filter: str | None = None) -> list[dict[str, str]]:
+def command_matches_query(record: dict[str, str], query: str) -> bool:
+    query_words = query.lower().replace("_", "-").split()
+    haystack = " ".join(
+        [
+            record["name"],
+            record["kind"],
+            record["summary"],
+        ]
+    ).lower()
+    return all(word in haystack for word in query_words)
+
+
+def command_records(
+    kind_filter: str | None = None,
+    query: str | None = None,
+    limit: int | None = None,
+) -> list[dict[str, str]]:
     records: list[dict[str, str]] = []
     for name, metadata in sorted(COMMANDS.items()):
         kind = metadata["kind"]
         if kind_filter is not None and kind != kind_filter:
             continue
-        records.append(
-            {
-                "name": name,
-                "kind": kind,
-                "summary": metadata["summary"],
-            }
-        )
+        record = {
+            "name": name,
+            "kind": kind,
+            "summary": metadata["summary"],
+        }
+        if query is not None and not command_matches_query(record, query):
+            continue
+        records.append(record)
+        if limit is not None and len(records) >= limit:
+            break
     return records
 
 
-def format_command_records(records: list[dict[str, str]]) -> str:
+def format_command_records(
+    records: list[dict[str, str]],
+    *,
+    query: str | None = None,
+) -> str:
     width = max((len(record["name"]) for record in records), default=7)
-    lines = ["Commands:"]
+    lines = [f"Commands matching `{query}`:" if query is not None else "Commands:"]
+    if not records:
+        lines.append("  (none)")
+        lines.extend(["", "Run `gnss commands` to list all registered commands."])
+        return "\n".join(lines)
     for record in records:
         lines.append(f"  {record['name']:<{width}}  {record['summary']}")
     lines.extend(["", "Run `gnss help <command>` for command-specific options."])
@@ -667,18 +694,21 @@ def help_usage() -> str:
 def commands_usage() -> str:
     return "\n".join(
         [
-            "Usage: gnss commands [--json] [--kind KIND]",
+            "Usage: gnss commands [--json] [--kind KIND] [--query TEXT] [--limit N]",
             "",
             "List registered dispatcher commands without invoking solver binaries.",
             "",
             "Options:",
             "  --json       Emit a machine-readable command registry.",
             f"  --kind KIND  Filter by command kind: {', '.join(command_kinds())}.",
+            "  --query TEXT Search command names, kinds, and summaries.",
+            "  --limit N    Return at most N commands after filtering.",
             "",
             "Examples:",
             "  python3 apps/gnss.py commands",
             "  python3 apps/gnss.py commands --json",
             "  python3 apps/gnss.py commands --kind python",
+            "  python3 apps/gnss.py commands --query ppp --limit 10",
         ]
     )
 
@@ -705,6 +735,8 @@ def run_help(args: list[str]) -> int:
 def run_commands(args: list[str]) -> int:
     emit_json = False
     kind_filter: str | None = None
+    query: str | None = None
+    limit: int | None = None
     index = 0
     valid_kinds = set(command_kinds())
 
@@ -716,6 +748,81 @@ def run_commands(args: list[str]) -> int:
         if arg == "--json":
             emit_json = True
             index += 1
+            continue
+        if arg == "--query":
+            if index + 1 >= len(args):
+                print(
+                    "Error: --query requires a non-empty search string.",
+                    "",
+                    commands_usage(),
+                    sep="\n",
+                    file=sys.stderr,
+                )
+                return 2
+            query = args[index + 1].strip()
+            if not query:
+                print(
+                    "Error: --query requires a non-empty search string.",
+                    "",
+                    commands_usage(),
+                    sep="\n",
+                    file=sys.stderr,
+                )
+                return 2
+            index += 2
+            continue
+        if arg.startswith("--query="):
+            query = arg.split("=", 1)[1].strip()
+            if not query:
+                print(
+                    "Error: --query requires a non-empty search string.",
+                    "",
+                    commands_usage(),
+                    sep="\n",
+                    file=sys.stderr,
+                )
+                return 2
+            index += 1
+            continue
+        if arg == "--limit":
+            if index + 1 >= len(args):
+                print(
+                    "Error: --limit requires a positive integer.",
+                    "",
+                    commands_usage(),
+                    sep="\n",
+                    file=sys.stderr,
+                )
+                return 2
+            raw_limit = args[index + 1]
+            index += 2
+        elif arg.startswith("--limit="):
+            raw_limit = arg.split("=", 1)[1]
+            index += 1
+        else:
+            raw_limit = None
+
+        if raw_limit is not None:
+            try:
+                limit = int(raw_limit)
+            except ValueError:
+                print(
+                    f"Error: invalid --limit value `{raw_limit}`; expected a positive integer.",
+                    "",
+                    commands_usage(),
+                    sep="\n",
+                    file=sys.stderr,
+                )
+                return 2
+            if limit < 1:
+                print(
+                    f"Error: invalid --limit value `{raw_limit}`; expected a positive integer.",
+                    "",
+                    commands_usage(),
+                    sep="\n",
+                    file=sys.stderr,
+                )
+                return 2
             continue
         if arg == "--kind":
             if index + 1 >= len(args):
@@ -755,17 +862,22 @@ def run_commands(args: list[str]) -> int:
             )
             return 2
 
-    records = command_records(kind_filter)
+    records = command_records(kind_filter, query, limit)
     if emit_json:
+        filters = {"kind": kind_filter}
+        if query is not None:
+            filters["query"] = query
+        if limit is not None:
+            filters["limit"] = limit
         payload = {
             "schema_version": 1,
-            "filters": {"kind": kind_filter},
+            "filters": filters,
             "count": len(records),
             "commands": records,
         }
         print(json.dumps(payload, indent=2, sort_keys=True))
     else:
-        print(format_command_records(records))
+        print(format_command_records(records, query=query))
     return 0
 
 

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -60,7 +60,7 @@ python3 apps/gnss.py replay \
 
 | Command | Purpose |
 |---|---|
-| `gnss commands` | List registered dispatcher commands as text or JSON |
+| `gnss commands` | List or search registered dispatcher commands as text or JSON |
 | `gnss help <command>` | Show focused help for one command |
 | `gnss doctor` | Check local setup, built tools, dataset/docs readiness, Docker, and ROS2 hints |
 | `gnss ros2-doctor` | Check ROS2 receiver readiness, serial permissions, launch/record commands, and topic debug commands |

--- a/docs/research_quickstart.md
+++ b/docs/research_quickstart.md
@@ -22,6 +22,7 @@ Confirm the dispatcher can see the command set:
 ```bash
 python3 apps/gnss.py commands
 python3 apps/gnss.py commands --json
+python3 apps/gnss.py commands --query ppc --limit 10
 ```
 
 ## Reproduce a bounded RTK run

--- a/tests/test_cli_ux.py
+++ b/tests/test_cli_ux.py
@@ -145,7 +145,7 @@ class CliUxTest(unittest.TestCase):
 
     def test_help_command_dispatches_to_subcommand_help(self) -> None:
         expectations = {
-            "commands": ("Usage: gnss commands", "--json"),
+            "commands": ("Usage: gnss commands", "--json", "--query"),
             "doctor": ("usage: gnss doctor", "--strict"),
             "qzss-l6-info": (
                 "usage: gnss qzss-l6-info",
@@ -177,6 +177,23 @@ class CliUxTest(unittest.TestCase):
         self.assertIn("Run `gnss help <command>`", result.stdout)
         self.assertNotIn("Examples:", result.stdout)
 
+    def test_commands_query_text_output_filters_registry(self) -> None:
+        result = self.run_gnss("commands", "--query", "clas")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assert_no_traceback(result)
+        self.assertEqual(result.stderr, "")
+        self.assertIn("Commands matching `clas`:", result.stdout)
+        self.assertIn("  clas-ppp", result.stdout)
+        self.assertNotIn("  doctor", result.stdout)
+
+        no_match = self.run_gnss("commands", "--query", "definitely-not-a-command")
+        self.assertEqual(no_match.returncode, 0, msg=no_match.stderr)
+        self.assert_no_traceback(no_match)
+        self.assertIn("Commands matching `definitely-not-a-command`:", no_match.stdout)
+        self.assertIn("  (none)", no_match.stdout)
+        self.assertIn("Run `gnss commands`", no_match.stdout)
+
     def test_commands_json_output_is_stable_for_tooling(self) -> None:
         result = self.run_gnss("commands", "--json")
 
@@ -200,6 +217,36 @@ class CliUxTest(unittest.TestCase):
             self.assertIsInstance(item["summary"], str)
             self.assertTrue(item["summary"].strip())
 
+    def test_commands_query_json_output_is_stable_for_tooling(self) -> None:
+        result = self.run_gnss(
+            "commands",
+            "--kind",
+            "python",
+            "--query",
+            "ppp",
+            "--limit",
+            "3",
+            "--json",
+        )
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assert_no_traceback(result)
+        self.assertEqual(result.stderr, "")
+        payload = json.loads(result.stdout)
+        self.assertEqual(
+            payload["filters"],
+            {"kind": "python", "query": "ppp", "limit": 3},
+        )
+        self.assertLessEqual(payload["count"], 3)
+        self.assertEqual(payload["count"], len(payload["commands"]))
+        self.assertGreater(payload["count"], 0)
+        for item in payload["commands"]:
+            self.assertEqual(item["kind"], "python")
+            self.assertIn(
+                "ppp",
+                f"{item['name']} {item['summary']}".lower(),
+            )
+
     def test_commands_kind_filter_and_errors_are_actionable(self) -> None:
         builtin_result = self.run_gnss("commands", "--kind", "builtin", "--json")
 
@@ -219,6 +266,18 @@ class CliUxTest(unittest.TestCase):
         self.assertEqual(invalid_result.stdout, "")
         self.assertIn("Error: unknown command kind `solver`.", invalid_result.stderr)
         self.assertIn("Usage: gnss commands", invalid_result.stderr)
+
+        bad_limit = self.run_gnss("commands", "--limit", "0")
+        self.assertEqual(bad_limit.returncode, 2)
+        self.assert_no_traceback(bad_limit)
+        self.assertEqual(bad_limit.stdout, "")
+        self.assertIn("Error: invalid --limit value `0`", bad_limit.stderr)
+
+        missing_query = self.run_gnss("commands", "--query")
+        self.assertEqual(missing_query.returncode, 2)
+        self.assert_no_traceback(missing_query)
+        self.assertEqual(missing_query.stdout, "")
+        self.assertIn("Error: --query requires a non-empty search string.", missing_query.stderr)
 
     def test_user_input_errors_are_actionable_not_tracebacks(self) -> None:
         cases = [


### PR DESCRIPTION
## Summary
- Add `gnss commands --query TEXT` and `--limit N` for searchable command discovery.
- Preserve `commands --json` while adding query/limit filters when requested.
- Update quickstart docs and Docker smoke so installed CLI search stays covered.

## Validation
- `python3 -m py_compile apps/gnss.py tests/test_cli_ux.py`
- `python3 -m unittest tests.test_cli_ux`
- `ctest --test-dir build -R '^python_cli_ux_tests$' --output-on-failure`
- `ctest --test-dir build -L core --output-on-failure`
