### PR TITLE
[codex] ci: harden optional diff artifact contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -333,7 +333,7 @@ jobs:
           output/ci_optional_clas_zd_component/*.log
           output/clas_zd_component_diff.json
           output/clas_zd_component_diff.csv
-        if-no-files-found: ignore
+        if-no-files-found: error
 
     - name: Optional MADOCA residual-component diff
       env:
@@ -356,7 +356,7 @@ jobs:
           output/ci_optional_madoca_residual_component/*.log
           output/madoca_residual_component_diff.json
           output/madoca_residual_component_diff.csv
-        if-no-files-found: ignore
+        if-no-files-found: error
 
     - name: Upload PPP products comparison artifacts
       if: always()

--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -188,7 +188,9 @@ runs that comparison when `GNSSPP_CLAS_ZD_BASE_CSV` and
 `GNSSPP_CLAS_ZD_CANDIDATE_CSV` point at generated CLASLIB/native component
 dumps.  It writes `ci_optional_clas_zd_component_summary.json`, a log, and the
 `clas_zd_component_diff.{json,csv}` artifacts.  When those inputs are absent,
-the CI step records an explicit skip instead of silently omitting the artifact.
+the CI step records `status: blocked_infrastructure` with next actions instead
+of silently treating the missing oracle/native evidence as a passing sign-off.
+The workflow upload treats the summary/log bundle as required evidence.
 Optional filters are `GNSSPP_CLAS_ZD_COMPONENTS`, `GNSSPP_CLAS_ZD_STAGE`,
 `GNSSPP_CLAS_ZD_ROW_TYPE`, `GNSSPP_CLAS_ZD_THRESHOLD_M`, and
 `GNSSPP_CLAS_ZD_FAIL_ON_DIFF`.  GPS L2W A4b probes can also narrow the row set

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -52,8 +52,9 @@ CI lanes are split as follows:
   lane if any declared output artifact is missing
 - `bash scripts/ci/run_optional_clas_zd_component_diff.sh` and
   `bash scripts/ci/run_optional_madoca_residual_component_diff.sh` for
-  oracle/native diff artifacts; both skip explicitly when their CSV inputs are
-  unavailable, and both fail a passed diff command if the declared JSON/CSV
+  oracle/native diff artifacts; both report `blocked_infrastructure` with
+  next actions when their CSV inputs are unavailable, require a summary/log
+  artifact in CI, and fail a passed diff command if the declared JSON/CSV
   artifacts are missing
 - `bash scripts/ci/generate_dashboard_artifacts.sh` for the dashboard/manifest artifact path used in CI
 

--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -63,8 +63,10 @@ when `GNSSPP_MADOCA_RESIDUAL_BASE_CSV` and
 `GNSSPP_MADOCA_RESIDUAL_CANDIDATE_CSV` point at generated oracle/native CSV
 dumps.  It writes `ci_optional_madoca_residual_component_summary.json`, a log,
 and the `madoca_residual_component_diff.{json,csv}` artifacts; when those inputs
-are absent the CI step records an explicit skip instead of silently omitting the
-artifact.  Optional filters are
+are absent the CI step records `status: blocked_infrastructure` with next
+actions instead of silently treating the missing oracle/native evidence as a
+passing sign-off.  The workflow upload treats the summary/log bundle as
+required evidence.  Optional filters are
 `GNSSPP_MADOCA_RESIDUAL_COMPONENTS`, `GNSSPP_MADOCA_RESIDUAL_ROW_TYPE`,
 `GNSSPP_MADOCA_RESIDUAL_ITERATION`, `GNSSPP_MADOCA_RESIDUAL_THRESHOLD`, and
 `GNSSPP_MADOCA_RESIDUAL_FAIL_ON_DIFF`.

--- a/scripts/ci/optional_diff_runner.py
+++ b/scripts/ci/optional_diff_runner.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import argparse
 from dataclasses import asdict, dataclass
+import hashlib
 import json
 import os
 from pathlib import Path
@@ -74,6 +75,8 @@ IDENTITY_PROVENANCE_METRIC_KEYS = (
     "gps_l2w_code_bias_fallback_rows",
 )
 
+STATUS_ORDER = ("passed", "failed", "blocked_infrastructure", "not_applicable", "skipped")
+
 
 def repo_root_from_script() -> Path:
     return Path(__file__).resolve().parents[2]
@@ -117,6 +120,30 @@ def parse_option_value(option: EnvOption, environ: Mapping[str, str]) -> str | N
 
 def truthy(value: str) -> bool:
     return value.strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def file_sha256(path: Path) -> str | None:
+    if not path.is_file():
+        return None
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def artifact_record(path: Path, *, role: str, required: bool) -> dict[str, object]:
+    exists = path.is_file()
+    record: dict[str, object] = {
+        "role": role,
+        "path": str(path),
+        "required": required,
+        "exists": exists,
+    }
+    if exists:
+        record["bytes"] = path.stat().st_size
+        record["sha256"] = file_sha256(path)
+    return record
 
 
 def metric_label(value: object) -> str:
@@ -297,10 +324,18 @@ def run_step(config: DiffRunnerConfig, step: DiffStep, repo_root: Path, log_dir:
         "log_path": str(log_path),
     }
     if step.skip_reason is not None:
-        record["status"] = "skipped"
+        record["status"] = "blocked_infrastructure"
+        record["block_reason"] = step.skip_reason
         record["skip_reason"] = step.skip_reason
         log_path.write_text(step.skip_reason + "\n", encoding="utf-8")
-        print(f"Skipping {step.name}: {step.skip_reason}")
+        record["artifacts"] = [
+            artifact_record(log_path, role="log", required=True),
+            *[
+                artifact_record(Path(output), role="declared_output", required=False)
+                for output in step.outputs
+            ],
+        ]
+        print(f"Blocked {step.name}: {step.skip_reason}")
         return record
 
     assert step.command is not None
@@ -346,6 +381,13 @@ def run_step(config: DiffRunnerConfig, step: DiffStep, repo_root: Path, log_dir:
         if tail:
             print(tail)
         print(f"Failed {step.name} in {elapsed:.2f}s; see {log_path}")
+    record["artifacts"] = [
+        artifact_record(log_path, role="log", required=True),
+        *[
+            artifact_record(Path(output), role="declared_output", required=completed.returncode == 0)
+            for output in step.outputs
+        ],
+    ]
     return record
 
 
@@ -357,8 +399,8 @@ def format_metric(value: object) -> str:
 
 def render_result_detail(result: dict[str, object]) -> str:
     status = str(result["status"])
-    if status == "skipped":
-        return str(result.get("skip_reason", ""))
+    if status in {"blocked_infrastructure", "not_applicable", "skipped"}:
+        return str(result.get("block_reason") or result.get("skip_reason", ""))
     if status == "failed":
         missing_outputs = result.get("missing_outputs")
         if isinstance(missing_outputs, list) and missing_outputs:
@@ -408,15 +450,11 @@ def render_result_detail(result: dict[str, object]) -> str:
 
 
 def render_markdown_summary(config: DiffRunnerConfig, results: list[dict[str, object]]) -> str:
-    passed = sum(1 for result in results if result["status"] == "passed")
-    failed = sum(1 for result in results if result["status"] == "failed")
-    skipped = sum(1 for result in results if result["status"] == "skipped")
+    counts = status_counts(results)
     lines = [
         f"## {config.markdown_title}",
         "",
-        f"- `passed`: `{passed}`",
-        f"- `failed`: `{failed}`",
-        f"- `skipped`: `{skipped}`",
+        *[f"- `{status}`: `{count}`" for status, count in counts.items()],
         "",
         "| Step | Status | Detail |",
         "| --- | --- | --- |",
@@ -425,6 +463,36 @@ def render_markdown_summary(config: DiffRunnerConfig, results: list[dict[str, ob
         lines.append(f"| {result['name']} | `{result['status']}` | {render_result_detail(result)} |")
     lines.append("")
     return "\n".join(lines)
+
+
+def status_counts(results: list[dict[str, object]]) -> dict[str, int]:
+    counts = {status: 0 for status in STATUS_ORDER}
+    for result in results:
+        status = str(result["status"])
+        counts.setdefault(status, 0)
+        counts[status] += 1
+    return counts
+
+
+def aggregate_status(results: list[dict[str, object]]) -> str:
+    if any(result["status"] == "failed" for result in results):
+        return "failed"
+    if any(result["status"] == "blocked_infrastructure" for result in results):
+        return "blocked_infrastructure"
+    if any(result["status"] == "passed" for result in results):
+        return "passed"
+    return "not_applicable"
+
+
+def next_actions(results: list[dict[str, object]]) -> list[str]:
+    if any(result["status"] == "blocked_infrastructure" for result in results):
+        return [
+            "Provide the configured base and candidate CSV inputs, then rerun the optional diff.",
+            "Treat blocked_infrastructure as missing evidence, not as a passing oracle sign-off.",
+        ]
+    if any(result["status"] == "failed" for result in results):
+        return ["Inspect the per-step log and declared output artifacts before changing solver behavior."]
+    return []
 
 
 def write_summary(
@@ -436,13 +504,12 @@ def write_summary(
     summary_path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "summary_schema": config.summary_schema,
+        "contract": "optional_diff_artifact_contract.v1",
+        "status": aggregate_status(results),
+        "next_actions": next_actions(results),
         "steps": [asdict(step) for step in steps],
         "results": results,
-        "counts": {
-            "passed": sum(1 for result in results if result["status"] == "passed"),
-            "failed": sum(1 for result in results if result["status"] == "failed"),
-            "skipped": sum(1 for result in results if result["status"] == "skipped"),
-        },
+        "counts": status_counts(results),
     }
     summary_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
 

--- a/scripts/ci/run_optional_clas_zd_component_diff.py
+++ b/scripts/ci/run_optional_clas_zd_component_diff.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import optional_diff_runner as runner  # noqa: E402
 
 
-SUMMARY_SCHEMA = "ci_optional_clas_zd_component_diff.v1"
+SUMMARY_SCHEMA = "ci_optional_clas_zd_component_diff.v2"
 
 CONFIG = runner.DiffRunnerConfig(
     summary_schema=SUMMARY_SCHEMA,

--- a/scripts/ci/run_optional_madoca_residual_component_diff.py
+++ b/scripts/ci/run_optional_madoca_residual_component_diff.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import optional_diff_runner as runner  # noqa: E402
 
 
-SUMMARY_SCHEMA = "ci_optional_madoca_residual_component_diff.v1"
+SUMMARY_SCHEMA = "ci_optional_madoca_residual_component_diff.v2"
 
 CONFIG = runner.DiffRunnerConfig(
     summary_schema=SUMMARY_SCHEMA,

--- a/tests/test_optional_clas_zd_component_diff.py
+++ b/tests/test_optional_clas_zd_component_diff.py
@@ -76,7 +76,7 @@ def write_zd_component_csv(
 
 
 class OptionalClasZdComponentDiffTest(unittest.TestCase):
-    def test_build_step_plan_skips_when_inputs_are_missing(self) -> None:
+    def test_build_step_plan_blocks_when_inputs_are_missing(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ci_clas_zd_skip_") as temp_dir:
             output_dir = Path(temp_dir) / "output"
 
@@ -86,6 +86,25 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
             self.assertIsNone(steps[0].command)
             self.assertIsNotNone(steps[0].skip_reason)
             self.assertIn("CLAS ZD component input is unavailable", steps[0].skip_reason)
+
+    def test_run_step_records_blocked_infrastructure_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_clas_zd_blocked_") as temp_dir:
+            output_dir = Path(temp_dir) / "output"
+            log_dir = output_dir / "logs"
+            log_dir.mkdir(parents=True)
+            step = runner.build_step_plan(ROOT_DIR, output_dir, {})[0]
+
+            result = runner.run_step(step, ROOT_DIR, log_dir)
+
+            self.assertEqual(result["status"], "blocked_infrastructure")
+            self.assertIn("CLAS ZD component input is unavailable", result["block_reason"])
+            artifacts = result["artifacts"]
+            log_artifact = artifacts[0]
+            self.assertEqual(log_artifact["role"], "log")
+            self.assertTrue(log_artifact["required"])
+            self.assertTrue(log_artifact["exists"])
+            self.assertGreater(log_artifact["bytes"], 0)
+            self.assertTrue(str(log_artifact["sha256"]))
 
     def test_build_step_plan_uses_configured_inputs_and_filters(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ci_clas_zd_plan_") as temp_dir:
@@ -235,8 +254,8 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
                 },
                 {
                     "name": "CLAS ZD component diff",
-                    "status": "skipped",
-                    "skip_reason": "CLAS ZD component input is unavailable.",
+                    "status": "blocked_infrastructure",
+                    "block_reason": "CLAS ZD component input is unavailable.",
                 },
                 {
                     "name": "CLAS ZD component diff",
@@ -249,7 +268,7 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
         self.assertIn("## Optional CLAS ZD Component Diff", markdown)
         self.assertIn("`passed`: `1`", markdown)
         self.assertIn("`failed`: `1`", markdown)
-        self.assertIn("`skipped`: `1`", markdown)
+        self.assertIn("`blocked_infrastructure`: `1`", markdown)
         self.assertIn("common rows `12`", markdown)
         self.assertIn("unmatched `1/2`", markdown)
         self.assertIn("components `24`", markdown)
@@ -269,8 +288,8 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
                 {
                     "name": steps[0].name,
                     "slug": steps[0].slug,
-                    "status": "skipped",
-                    "skip_reason": steps[0].skip_reason,
+                    "status": "blocked_infrastructure",
+                    "block_reason": steps[0].skip_reason,
                     "outputs": steps[0].outputs,
                     "summary_json": steps[0].summary_json,
                     "log_path": str(Path(temp_dir) / "clas_zd_component_diff.log"),
@@ -281,7 +300,13 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
 
             payload = json.loads(summary_path.read_text(encoding="utf-8"))
             self.assertEqual(payload["summary_schema"], runner.SUMMARY_SCHEMA)
-            self.assertEqual(payload["counts"], {"passed": 0, "failed": 0, "skipped": 1})
+            self.assertEqual(payload["contract"], "optional_diff_artifact_contract.v1")
+            self.assertEqual(payload["status"], "blocked_infrastructure")
+            self.assertIn("missing evidence", payload["next_actions"][1])
+            self.assertEqual(payload["counts"]["passed"], 0)
+            self.assertEqual(payload["counts"]["failed"], 0)
+            self.assertEqual(payload["counts"]["blocked_infrastructure"], 1)
+            self.assertEqual(payload["counts"]["skipped"], 0)
 
 
 if __name__ == "__main__":

--- a/tests/test_optional_madoca_residual_component_diff.py
+++ b/tests/test_optional_madoca_residual_component_diff.py
@@ -59,7 +59,7 @@ def write_residual_csv(path: Path, *, residual_m: str = "0.1") -> None:
 
 
 class OptionalMadocaResidualComponentDiffTest(unittest.TestCase):
-    def test_build_step_plan_skips_when_inputs_are_missing(self) -> None:
+    def test_build_step_plan_blocks_when_inputs_are_missing(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_residual_skip_") as temp_dir:
             output_dir = Path(temp_dir) / "output"
 
@@ -69,6 +69,25 @@ class OptionalMadocaResidualComponentDiffTest(unittest.TestCase):
             self.assertIsNone(steps[0].command)
             self.assertIsNotNone(steps[0].skip_reason)
             self.assertIn("MADOCA residual-component input is unavailable", steps[0].skip_reason)
+
+    def test_run_step_records_blocked_infrastructure_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_residual_blocked_") as temp_dir:
+            output_dir = Path(temp_dir) / "output"
+            log_dir = output_dir / "logs"
+            log_dir.mkdir(parents=True)
+            step = runner.build_step_plan(ROOT_DIR, output_dir, {})[0]
+
+            result = runner.run_step(step, ROOT_DIR, log_dir)
+
+            self.assertEqual(result["status"], "blocked_infrastructure")
+            self.assertIn("MADOCA residual-component input is unavailable", result["block_reason"])
+            artifacts = result["artifacts"]
+            log_artifact = artifacts[0]
+            self.assertEqual(log_artifact["role"], "log")
+            self.assertTrue(log_artifact["required"])
+            self.assertTrue(log_artifact["exists"])
+            self.assertGreater(log_artifact["bytes"], 0)
+            self.assertTrue(str(log_artifact["sha256"]))
 
     def test_build_step_plan_uses_configured_inputs_and_filters(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_residual_plan_") as temp_dir:
@@ -176,8 +195,8 @@ class OptionalMadocaResidualComponentDiffTest(unittest.TestCase):
                 },
                 {
                     "name": "MADOCA residual-component diff",
-                    "status": "skipped",
-                    "skip_reason": "MADOCA residual-component input is unavailable.",
+                    "status": "blocked_infrastructure",
+                    "block_reason": "MADOCA residual-component input is unavailable.",
                 },
                 {
                     "name": "MADOCA residual-component diff",
@@ -196,7 +215,7 @@ class OptionalMadocaResidualComponentDiffTest(unittest.TestCase):
         self.assertIn("## Optional MADOCA Residual-Component Diff", markdown)
         self.assertIn("`passed`: `1`", markdown)
         self.assertIn("`failed`: `2`", markdown)
-        self.assertIn("`skipped`: `1`", markdown)
+        self.assertIn("`blocked_infrastructure`: `1`", markdown)
         self.assertIn("common rows `12`", markdown)
         self.assertIn("unmatched `1/2`", markdown)
         self.assertIn("components `24`", markdown)
@@ -213,8 +232,8 @@ class OptionalMadocaResidualComponentDiffTest(unittest.TestCase):
                 {
                     "name": steps[0].name,
                     "slug": steps[0].slug,
-                    "status": "skipped",
-                    "skip_reason": steps[0].skip_reason,
+                    "status": "blocked_infrastructure",
+                    "block_reason": steps[0].skip_reason,
                     "outputs": steps[0].outputs,
                     "summary_json": steps[0].summary_json,
                     "log_path": str(Path(temp_dir) / "madoca_residual_component_diff.log"),
@@ -225,7 +244,13 @@ class OptionalMadocaResidualComponentDiffTest(unittest.TestCase):
 
             payload = json.loads(summary_path.read_text(encoding="utf-8"))
             self.assertEqual(payload["summary_schema"], runner.SUMMARY_SCHEMA)
-            self.assertEqual(payload["counts"], {"passed": 0, "failed": 0, "skipped": 1})
+            self.assertEqual(payload["contract"], "optional_diff_artifact_contract.v1")
+            self.assertEqual(payload["status"], "blocked_infrastructure")
+            self.assertIn("missing evidence", payload["next_actions"][1])
+            self.assertEqual(payload["counts"]["passed"], 0)
+            self.assertEqual(payload["counts"]["failed"], 0)
+            self.assertEqual(payload["counts"]["blocked_infrastructure"], 1)
+            self.assertEqual(payload["counts"]["skipped"], 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- promote optional CLAS/MADOCA oracle diff input gaps from `skipped` to `blocked_infrastructure` in the machine-readable summaries
- add optional diff summary status, next actions, and per-artifact evidence records with hashes/sizes
- require CLAS/MADOCA optional diff artifact uploads to find at least the summary/log evidence bundle
- document the updated contract for CLAS A5 and MADOCA residual-component parity work

## Why

The next CLAS/MADOCA work needs remote CI evidence that distinguishes missing oracle/native inputs from a passing sign-off. This keeps optional jobs green when inputs are unavailable, but the resulting summary now makes that state explicit and upload misconfiguration can no longer silently drop every artifact.

## Validation

- `python3 -m py_compile scripts/ci/optional_diff_runner.py scripts/ci/run_optional_clas_zd_component_diff.py scripts/ci/run_optional_madoca_residual_component_diff.py tests/test_optional_clas_zd_component_diff.py tests/test_optional_madoca_residual_component_diff.py`
- `python3 -m unittest tests.test_optional_clas_zd_component_diff tests.test_optional_madoca_residual_component_diff`
- `python3 scripts/ci/run_optional_clas_zd_component_diff.py --output-dir /tmp/gnsspp_optional_diff_contract/clas`
- `python3 scripts/ci/run_optional_madoca_residual_component_diff.py --output-dir /tmp/gnsspp_optional_diff_contract/madoca`
- `ctest --test-dir build -R 'python_optional_(clas_zd_component_diff|madoca_residual_component_diff)_tests' --output-on-failure`
- `ctest --test-dir build -L core --output-on-failure`
- `git diff --check`
