### PR TITLE
[codex] ci: add clas a4b native selfdiff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,6 +335,30 @@ jobs:
           output/clas_zd_component_diff.csv
         if-no-files-found: error
 
+    - name: CLAS A4b native self-diff
+      env:
+        GNSSPP_CLAS_A4B_DATA_ROOT: ${{ vars.GNSSPP_CLAS_A4B_DATA_ROOT }}
+        GNSSPP_CLAS_A4B_AUTO_FETCH: ${{ vars.GNSSPP_CLAS_A4B_AUTO_FETCH }}
+        GNSSPP_CLAS_A4B_CLASLIB_REPO: ${{ vars.GNSSPP_CLAS_A4B_CLASLIB_REPO }}
+        GNSSPP_CLAS_A4B_CLASLIB_REF: ${{ vars.GNSSPP_CLAS_A4B_CLASLIB_REF }}
+        GNSSPP_CLAS_A4B_MAX_EPOCHS: ${{ vars.GNSSPP_CLAS_A4B_MAX_EPOCHS }}
+      run: python3 scripts/ci/run_clas_a4b_native_selfdiff.py
+
+    - name: Upload CLAS A4b native self-diff artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: clas-a4b-native-selfdiff-ubuntu
+        path: |
+          output/ci_clas_a4b_native_selfdiff_summary.json
+          output/ci_clas_a4b_native_selfdiff/*.log
+          output/clas_a4b_native_selfdiff/native.pos
+          output/clas_a4b_native_selfdiff/native_summary.json
+          output/clas_a4b_native_selfdiff/native_code_dump.csv
+          output/clas_a4b_native_selfdiff/selfdiff.json
+          output/clas_a4b_native_selfdiff/selfdiff.csv
+        if-no-files-found: error
+
     - name: Optional MADOCA residual-component diff
       env:
         GNSSPP_MADOCA_RESIDUAL_BASE_CSV: ${{ vars.GNSSPP_MADOCA_RESIDUAL_BASE_CSV }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -342,6 +342,7 @@ jobs:
         GNSSPP_CLAS_A4B_CLASLIB_REPO: ${{ vars.GNSSPP_CLAS_A4B_CLASLIB_REPO }}
         GNSSPP_CLAS_A4B_CLASLIB_REF: ${{ vars.GNSSPP_CLAS_A4B_CLASLIB_REF }}
         GNSSPP_CLAS_A4B_MAX_EPOCHS: ${{ vars.GNSSPP_CLAS_A4B_MAX_EPOCHS }}
+        GNSSPP_CLAS_A4B_FAIL_ON_BLOCKED: ${{ vars.GNSSPP_CLAS_A4B_FAIL_ON_BLOCKED }}
       run: python3 scripts/ci/run_clas_a4b_native_selfdiff.py
 
     - name: Upload CLAS A4b native self-diff artifacts

--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -208,6 +208,14 @@ numeric CLASLIB `sys`/`prn`/RTKLIB `code` fields into the native row-key space
 linking CLASLIB into the production binaries.  Use the normalized CSV as
 `GNSSPP_CLAS_ZD_BASE_CSV` for optional oracle-backed CI.
 
+The native side of the A4b `G14/C2W` slice is generated in CI by
+`scripts/ci/run_clas_a4b_native_selfdiff.py`.  That wrapper sparse-checks out
+the public CLASLIB data fixture, runs the gated native CLAS command with
+`GNSS_PPP_CLAS_CODE_DUMP`, and self-diffs the resulting code dump before any
+oracle comparison.  This is not a replacement for CLASLIB ZD parity; it removes
+the manually staged native CSV from the next oracle-backed PR and guards exact
+observation-code identity and fallback counts on remote CI.
+
 Native RINEX observations now expose exact `pseudorange_rinex_code`,
 `carrier_rinex_code`, RTKLIB code id, and `signal_family` columns in the CLAS
 code/phase diagnostic dumps.  This lets the GPS L2W investigation distinguish

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -223,7 +223,8 @@ the GPS L2W rows preserve exact observation/bias identity, fallback counts are
 zero, and the self-diff has no unmatched rows or component deltas. Set
 `GNSSPP_CLAS_A4B_DATA_ROOT` to use a pre-existing CLASLIB data checkout, or
 `GNSSPP_CLAS_A4B_AUTO_FETCH=0` to record `blocked_infrastructure` instead of
-fetching public data.
+fetching public data. CI treats that blocked state as a failure by default; set
+`GNSSPP_CLAS_A4B_FAIL_ON_BLOCKED=0` only for diagnostic-only local runs.
 
 Build with CLASLIB linked only when you need oracle-backed unit tests:
 

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -206,6 +206,25 @@ component deltas for the same ZD key. Use that field to decide whether the next
 GPS L2W A4b slice is dominated by `receiver_antenna_m`, `prc_m`, atmosphere, or
 another component before changing the gated correction model.
 
+CI can regenerate the native side of this A4b probe without a pre-staged native
+CSV:
+
+```bash
+python3 scripts/ci/run_clas_a4b_native_selfdiff.py
+```
+
+The wrapper sparse-checks out the public CLASLIB `data/` directory at the pinned
+`GNSSPP_CLAS_A4B_CLASLIB_REF`, runs the native command above, and self-diffs the
+`G14/C2W` code rows. It emits
+`ci_clas_a4b_native_selfdiff_summary.json`, `native_code_dump.csv`,
+`native_summary.json`, and `selfdiff.{json,csv}`. The summary uses
+`status: passed` only when the native run reaches the configured epoch count,
+the GPS L2W rows preserve exact observation/bias identity, fallback counts are
+zero, and the self-diff has no unmatched rows or component deltas. Set
+`GNSSPP_CLAS_A4B_DATA_ROOT` to use a pre-existing CLASLIB data checkout, or
+`GNSSPP_CLAS_A4B_AUTO_FETCH=0` to record `blocked_infrastructure` instead of
+fetching public data.
+
 Build with CLASLIB linked only when you need oracle-backed unit tests:
 
 ```bash

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -56,6 +56,10 @@ CI lanes are split as follows:
   next actions when their CSV inputs are unavailable, require a summary/log
   artifact in CI, and fail a passed diff command if the declared JSON/CSV
   artifacts are missing
+- `python3 scripts/ci/run_clas_a4b_native_selfdiff.py` for the public CLAS A4b
+  native-side evidence bundle; it sparse-fetches CLASLIB public data unless
+  `GNSSPP_CLAS_A4B_DATA_ROOT` is supplied, generates the native code dump, and
+  self-diffs the `G14/C2W` rows before any oracle-backed model change
 - `bash scripts/ci/generate_dashboard_artifacts.sh` for the dashboard/manifest artifact path used in CI
 
 Docs-only changes keep CI on the lightweight path: hygiene here, plus the separate Docs workflow.

--- a/scripts/ci/run_clas_a4b_native_selfdiff.py
+++ b/scripts/ci/run_clas_a4b_native_selfdiff.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""Generate the public CLAS A4b native ZD dump and self-diff it in CI."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import time
+from typing import Mapping, Sequence
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from optional_diff_runner import artifact_record, truthy  # noqa: E402
+
+
+SUMMARY_SCHEMA = "ci_clas_a4b_native_selfdiff.v1"
+CONTRACT = "clas_a4b_native_selfdiff.v1"
+DEFAULT_CLASLIB_REPO = "https://github.com/QZSS-Strategy-Office/claslib.git"
+DEFAULT_CLASLIB_REF = "23cfd363a2db6d8d8144e292c82e9d97ca2d3015"
+DEFAULT_MAX_EPOCHS = 300
+DEFAULT_RECEIVER_ANTENNA_TYPE = "TRM59800.80     NONE"
+REQUIRED_DATA_FILES = (
+    "0627239Q.obs",
+    "sept_2019239.nav",
+    "2019239Q.l6",
+    "igs14_L5copy.atx",
+)
+ENV_OVERRIDES = {
+    "GNSS_PPP_CLAS_DD_FILTER": "1",
+    "GNSS_PPP_CLAS_CODE_ROW_PARITY": "bias",
+    "GNSS_PPP_CLAS_RX_ANTENNA": "1",
+}
+
+
+@dataclass(frozen=True)
+class RunPaths:
+    output_dir: Path
+    work_dir: Path
+    log_path: Path
+    summary_json: Path
+    checkout_dir: Path
+    native_pos: Path
+    native_summary_json: Path
+    native_code_dump: Path
+    selfdiff_json: Path
+    selfdiff_csv: Path
+
+
+@dataclass(frozen=True)
+class RunConfig:
+    repo_root: Path
+    output_dir: Path
+    data_root: Path | None
+    auto_fetch: bool
+    claslib_repo: str
+    claslib_ref: str
+    max_epochs: int
+    gps_l2w_rows_min: int
+    receiver_antenna_type: str
+    python_executable: str
+
+
+def repo_root_from_script() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def default_paths(output_dir: Path) -> RunPaths:
+    work_dir = output_dir / "clas_a4b_native_selfdiff"
+    return RunPaths(
+        output_dir=output_dir,
+        work_dir=work_dir,
+        log_path=output_dir / "ci_clas_a4b_native_selfdiff" / "clas_a4b_native_selfdiff.log",
+        summary_json=output_dir / "ci_clas_a4b_native_selfdiff_summary.json",
+        checkout_dir=work_dir / "claslib",
+        native_pos=work_dir / "native.pos",
+        native_summary_json=work_dir / "native_summary.json",
+        native_code_dump=work_dir / "native_code_dump.csv",
+        selfdiff_json=work_dir / "selfdiff.json",
+        selfdiff_csv=work_dir / "selfdiff.csv",
+    )
+
+
+def resolve_optional_path(repo_root: Path, value: str) -> Path | None:
+    text = value.strip()
+    if not text:
+        return None
+    path = Path(text)
+    return path if path.is_absolute() else repo_root / path
+
+
+def env_or(environ: Mapping[str, str], name: str, default: str) -> str:
+    value = environ.get(name, "").strip()
+    return value if value else default
+
+
+def parse_config(args: argparse.Namespace, environ: Mapping[str, str]) -> RunConfig:
+    repo_root = args.repo_root.resolve()
+    output_dir = (args.output_dir if args.output_dir is not None else repo_root / "output").resolve()
+    max_epochs = int(env_or(environ, "GNSSPP_CLAS_A4B_MAX_EPOCHS", str(DEFAULT_MAX_EPOCHS)))
+    return RunConfig(
+        repo_root=repo_root,
+        output_dir=output_dir,
+        data_root=resolve_optional_path(repo_root, environ.get("GNSSPP_CLAS_A4B_DATA_ROOT", "")),
+        auto_fetch=truthy(env_or(environ, "GNSSPP_CLAS_A4B_AUTO_FETCH", "1")),
+        claslib_repo=env_or(environ, "GNSSPP_CLAS_A4B_CLASLIB_REPO", DEFAULT_CLASLIB_REPO),
+        claslib_ref=env_or(environ, "GNSSPP_CLAS_A4B_CLASLIB_REF", DEFAULT_CLASLIB_REF),
+        max_epochs=max_epochs,
+        gps_l2w_rows_min=int(env_or(environ, "GNSSPP_CLAS_A4B_GPS_L2W_ROWS_MIN", str(max_epochs))),
+        receiver_antenna_type=environ.get(
+            "GNSSPP_CLAS_A4B_RECEIVER_ANTENNA_TYPE",
+            DEFAULT_RECEIVER_ANTENNA_TYPE,
+        ).strip()
+        or DEFAULT_RECEIVER_ANTENNA_TYPE,
+        python_executable=sys.executable,
+    )
+
+
+def data_root_failures(data_root: Path) -> list[str]:
+    return [name for name in REQUIRED_DATA_FILES if not (data_root / name).is_file()]
+
+
+def run_logged(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    log_path: Path,
+    env: Mapping[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    display = " ".join(command)
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(f"$ {display}\n")
+    started = time.monotonic()
+    completed = subprocess.run(
+        list(command),
+        cwd=cwd,
+        env=dict(env) if env is not None else None,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    elapsed = time.monotonic() - started
+    combined = completed.stdout
+    if completed.stderr:
+        if combined and not combined.endswith("\n"):
+            combined += "\n"
+        combined += completed.stderr
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(combined)
+        if combined and not combined.endswith("\n"):
+            handle.write("\n")
+        handle.write(f"# exit={completed.returncode} elapsed_s={elapsed:.3f}\n\n")
+    return completed
+
+
+def checkout_claslib_data(config: RunConfig, paths: RunPaths) -> tuple[Path | None, str | None]:
+    if config.data_root is not None:
+        missing = data_root_failures(config.data_root)
+        if not missing:
+            return config.data_root, None
+        return None, f"configured CLAS data root is missing required files: {', '.join(missing)}"
+
+    if not config.auto_fetch:
+        return None, "GNSSPP_CLAS_A4B_DATA_ROOT is unset and auto-fetch is disabled"
+
+    if paths.checkout_dir.exists():
+        shutil.rmtree(paths.checkout_dir)
+    paths.checkout_dir.parent.mkdir(parents=True, exist_ok=True)
+    commands = [
+        ["git", "init", str(paths.checkout_dir)],
+        ["git", "-C", str(paths.checkout_dir), "remote", "add", "origin", config.claslib_repo],
+        ["git", "-C", str(paths.checkout_dir), "sparse-checkout", "init", "--cone"],
+        ["git", "-C", str(paths.checkout_dir), "sparse-checkout", "set", "data"],
+        ["git", "-C", str(paths.checkout_dir), "fetch", "--depth", "1", "origin", config.claslib_ref],
+        ["git", "-C", str(paths.checkout_dir), "checkout", "--detach", "FETCH_HEAD"],
+    ]
+    for command in commands:
+        completed = run_logged(command, cwd=config.repo_root, log_path=paths.log_path)
+        if completed.returncode != 0:
+            return None, f"failed to fetch CLASLIB public data: {' '.join(command)}"
+
+    data_root = paths.checkout_dir / "data"
+    missing = data_root_failures(data_root)
+    if missing:
+        return None, f"fetched CLASLIB data is missing required files: {', '.join(missing)}"
+    return data_root, None
+
+
+def build_native_command(
+    config: RunConfig,
+    paths: RunPaths,
+    data_root: Path,
+) -> tuple[list[str], dict[str, str]]:
+    command = [
+        config.python_executable,
+        str(config.repo_root / "apps" / "gnss.py"),
+        "clas-ppp",
+        "--profile",
+        "clas",
+        "--obs",
+        str(data_root / "0627239Q.obs"),
+        "--nav",
+        str(data_root / "sept_2019239.nav"),
+        "--qzss-l6",
+        str(data_root / "2019239Q.l6"),
+        "--qzss-gps-week",
+        "2068",
+        "--antex",
+        str(data_root / "igs14_L5copy.atx"),
+        "--receiver-antenna-type",
+        config.receiver_antenna_type,
+        "--compact-code-bias-composition-policy",
+        "base-only-if-present",
+        "--compact-code-bias-bank-policy",
+        "latest-preceding-bank",
+        "--compact-bias-row-materialization",
+        "selected-satellite-base-extend",
+        "--out",
+        str(paths.native_pos),
+        "--summary-json",
+        str(paths.native_summary_json),
+        "--max-epochs",
+        str(config.max_epochs),
+    ]
+    env = dict(os.environ)
+    env.update(ENV_OVERRIDES)
+    env["GNSS_PPP_CLAS_CODE_DUMP"] = str(paths.native_code_dump)
+    return command, env
+
+
+def build_selfdiff_command(config: RunConfig, paths: RunPaths) -> list[str]:
+    return [
+        config.python_executable,
+        str(config.repo_root / "scripts" / "analysis" / "clas_zd_component_diff.py"),
+        str(paths.native_code_dump),
+        str(paths.native_code_dump),
+        "--base-label",
+        "native",
+        "--candidate-label",
+        "native",
+        "--row-type",
+        "code",
+        "--sat",
+        "G14",
+        "--freq",
+        "1",
+        "--rinex-code",
+        "C2W",
+        "--duplicate-policy",
+        "mean",
+        "--json-out",
+        str(paths.selfdiff_json),
+        "--details-csv",
+        str(paths.selfdiff_csv),
+        "--fail-on-diff",
+    ]
+
+
+def load_json(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: expected JSON object")
+    return payload
+
+
+def count_csv_data_rows(path: Path) -> int:
+    if not path.is_file():
+        return 0
+    with path.open(encoding="utf-8") as handle:
+        return max(sum(1 for _line in handle) - 1, 0)
+
+
+def max_component_delta(report: Mapping[str, object]) -> float:
+    per_component = report.get("per_component")
+    if not isinstance(per_component, list):
+        return 0.0
+    maximum = 0.0
+    for item in per_component:
+        if isinstance(item, dict):
+            value = item.get("max_abs_delta_m")
+            if isinstance(value, (int, float)):
+                maximum = max(maximum, float(value))
+    return maximum
+
+
+def native_identity(report: Mapping[str, object]) -> dict[str, object]:
+    identity = report.get("identity_provenance")
+    if not isinstance(identity, dict):
+        return {}
+    summary = identity.get("native")
+    return summary if isinstance(summary, dict) else {}
+
+
+def evaluate(config: RunConfig, native_summary: Mapping[str, object], report: Mapping[str, object], dump_rows: int) -> tuple[dict[str, object], dict[str, object], list[str]]:
+    identity = native_identity(report)
+    gps_l2w_rows = int(identity.get("gps_l2w_rows", 0))
+    exact_bias_rows = int(identity.get("gps_l2w_bias_exact_identity_rows", 0))
+    exact_match_rows = int(identity.get("gps_l2w_observation_exact_match_rows", 0))
+    obs_fallback_rows = int(identity.get("gps_l2w_observation_family_fallback_rows", 0))
+    code_fallback_rows = int(identity.get("gps_l2w_code_bias_fallback_rows", 0))
+    max_delta = max_component_delta(report)
+    metrics = {
+        "native_epochs": int(native_summary.get("epochs", 0)),
+        "native_ppp_solution_rate_pct": native_summary.get("ppp_solution_rate_pct"),
+        "native_code_dump_rows": dump_rows,
+        "common_rows": int(report.get("common_rows", 0)),
+        "base_only_rows": int(report.get("base_only_rows", 0)),
+        "candidate_only_rows": int(report.get("candidate_only_rows", 0)),
+        "components_compared": int(report.get("components_compared", 0)),
+        "threshold_exceedances": int(report.get("threshold_exceedances", 0)),
+        "max_abs_delta_m": max_delta,
+        "gps_l2w_rows": gps_l2w_rows,
+        "gps_l2w_bias_exact_identity_rows": exact_bias_rows,
+        "gps_l2w_observation_exact_match_rows": exact_match_rows,
+        "gps_l2w_observation_family_fallback_rows": obs_fallback_rows,
+        "gps_l2w_code_bias_fallback_rows": code_fallback_rows,
+    }
+    thresholds = {
+        "native_epochs_min": config.max_epochs,
+        "gps_l2w_rows_min": config.gps_l2w_rows_min,
+        "base_only_rows_max": 0,
+        "candidate_only_rows_max": 0,
+        "fallback_rows_max": 0,
+        "max_abs_delta_m_max": 0.0,
+    }
+    failures: list[str] = []
+    if metrics["native_epochs"] < config.max_epochs:
+        failures.append(f"native epochs {metrics['native_epochs']} < {config.max_epochs}")
+    if gps_l2w_rows < config.gps_l2w_rows_min:
+        failures.append(f"GPS L2W rows {gps_l2w_rows} < {config.gps_l2w_rows_min}")
+    if exact_bias_rows != gps_l2w_rows:
+        failures.append(f"exact bias rows {exact_bias_rows} != GPS L2W rows {gps_l2w_rows}")
+    if exact_match_rows != gps_l2w_rows:
+        failures.append(f"exact observation-match rows {exact_match_rows} != GPS L2W rows {gps_l2w_rows}")
+    if obs_fallback_rows != 0:
+        failures.append(f"observation-family fallback rows {obs_fallback_rows} != 0")
+    if code_fallback_rows != 0:
+        failures.append(f"code-bias fallback rows {code_fallback_rows} != 0")
+    if metrics["base_only_rows"] != 0 or metrics["candidate_only_rows"] != 0:
+        failures.append(
+            f"self-diff unmatched rows {metrics['base_only_rows']}/{metrics['candidate_only_rows']} != 0/0"
+        )
+    if metrics["threshold_exceedances"] != 0:
+        failures.append(f"threshold exceedances {metrics['threshold_exceedances']} != 0")
+    if max_delta != 0.0:
+        failures.append(f"self-diff max component delta {max_delta} != 0")
+    return metrics, thresholds, failures
+
+
+def summarize_artifacts(paths: RunPaths) -> list[dict[str, object]]:
+    return [
+        artifact_record(paths.log_path, role="log", required=True),
+        artifact_record(paths.native_pos, role="native_solution", required=True),
+        artifact_record(paths.native_summary_json, role="native_summary", required=True),
+        artifact_record(paths.native_code_dump, role="native_zd_component_dump", required=True),
+        artifact_record(paths.selfdiff_json, role="selfdiff_json", required=True),
+        artifact_record(paths.selfdiff_csv, role="selfdiff_csv", required=True),
+    ]
+
+
+def write_summary(paths: RunPaths, payload: dict[str, object]) -> None:
+    paths.summary_json.parent.mkdir(parents=True, exist_ok=True)
+    paths.summary_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def build_payload(
+    *,
+    config: RunConfig,
+    paths: RunPaths,
+    status: str,
+    data_root: Path | None,
+    metrics: dict[str, object] | None = None,
+    thresholds: dict[str, object] | None = None,
+    failures: list[str] | None = None,
+    block_reason: str | None = None,
+) -> dict[str, object]:
+    next_actions: list[str] = []
+    if status == "blocked_infrastructure":
+        next_actions.append("Provide CLAS public data with GNSSPP_CLAS_A4B_DATA_ROOT or allow sparse auto-fetch.")
+        next_actions.append("Treat blocked_infrastructure as missing native A4b evidence, not as a passing sign-off.")
+    elif status == "failed":
+        next_actions.append("Inspect the native run log, self-diff JSON, and component dump before changing CLAS model behavior.")
+    return {
+        "summary_schema": SUMMARY_SCHEMA,
+        "contract": CONTRACT,
+        "status": status,
+        "block_reason": block_reason,
+        "failures": failures or [],
+        "next_actions": next_actions,
+        "input_provenance": {
+            "claslib_repo": config.claslib_repo,
+            "claslib_ref": config.claslib_ref,
+            "data_root": str(data_root) if data_root is not None else None,
+            "required_files": list(REQUIRED_DATA_FILES),
+        },
+        "configuration": {
+            "max_epochs": config.max_epochs,
+            "receiver_antenna_type": config.receiver_antenna_type,
+            "env_overrides": {**ENV_OVERRIDES, "GNSS_PPP_CLAS_CODE_DUMP": str(paths.native_code_dump)},
+            "selfdiff_filter": {"sat": "G14", "freq": 1, "rinex_code": "C2W", "row_type": "code"},
+        },
+        "metrics": metrics or {},
+        "thresholds": thresholds or {},
+        "artifacts": summarize_artifacts(paths),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, default=repo_root_from_script())
+    parser.add_argument("--output-dir", type=Path, default=None)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None, environ: Mapping[str, str] | None = None) -> int:
+    args = parse_args(argv)
+    env = os.environ if environ is None else environ
+    config = parse_config(args, env)
+    paths = default_paths(config.output_dir)
+    paths.work_dir.mkdir(parents=True, exist_ok=True)
+    paths.log_path.parent.mkdir(parents=True, exist_ok=True)
+    paths.log_path.write_text("", encoding="utf-8")
+
+    data_root, block_reason = checkout_claslib_data(config, paths)
+    if data_root is None:
+        payload = build_payload(
+            config=config,
+            paths=paths,
+            status="blocked_infrastructure",
+            data_root=None,
+            block_reason=block_reason,
+        )
+        write_summary(paths, payload)
+        print(f"CLAS A4b native self-diff blocked: {block_reason}")
+        print(f"  summary: {paths.summary_json}")
+        return 0
+
+    native_command, native_env = build_native_command(config, paths, data_root)
+    native_result = run_logged(native_command, cwd=config.repo_root, log_path=paths.log_path, env=native_env)
+    if native_result.returncode != 0:
+        payload = build_payload(
+            config=config,
+            paths=paths,
+            status="failed",
+            data_root=data_root,
+            failures=["native CLAS A4b run failed"],
+        )
+        write_summary(paths, payload)
+        print(f"CLAS A4b native run failed; see {paths.log_path}")
+        return 1
+
+    selfdiff_command = build_selfdiff_command(config, paths)
+    selfdiff_result = run_logged(selfdiff_command, cwd=config.repo_root, log_path=paths.log_path)
+    if selfdiff_result.returncode != 0:
+        payload = build_payload(
+            config=config,
+            paths=paths,
+            status="failed",
+            data_root=data_root,
+            failures=["native CLAS A4b self-diff failed"],
+        )
+        write_summary(paths, payload)
+        print(f"CLAS A4b native self-diff failed; see {paths.log_path}")
+        return 1
+
+    native_summary = load_json(paths.native_summary_json)
+    selfdiff_report = load_json(paths.selfdiff_json)
+    metrics, thresholds, failures = evaluate(
+        config,
+        native_summary,
+        selfdiff_report,
+        count_csv_data_rows(paths.native_code_dump),
+    )
+    status = "failed" if failures else "passed"
+    payload = build_payload(
+        config=config,
+        paths=paths,
+        status=status,
+        data_root=data_root,
+        metrics=metrics,
+        thresholds=thresholds,
+        failures=failures,
+    )
+    write_summary(paths, payload)
+    print("CLAS A4b native self-diff:", status)
+    print(f"  summary: {paths.summary_json}")
+    print(f"  native dump: {paths.native_code_dump}")
+    print(f"  selfdiff: {paths.selfdiff_json}")
+    if failures:
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/run_clas_a4b_native_selfdiff.py
+++ b/scripts/ci/run_clas_a4b_native_selfdiff.py
@@ -59,6 +59,7 @@ class RunConfig:
     output_dir: Path
     data_root: Path | None
     auto_fetch: bool
+    fail_on_blocked: bool
     claslib_repo: str
     claslib_ref: str
     max_epochs: int
@@ -109,6 +110,7 @@ def parse_config(args: argparse.Namespace, environ: Mapping[str, str]) -> RunCon
         output_dir=output_dir,
         data_root=resolve_optional_path(repo_root, environ.get("GNSSPP_CLAS_A4B_DATA_ROOT", "")),
         auto_fetch=truthy(env_or(environ, "GNSSPP_CLAS_A4B_AUTO_FETCH", "1")),
+        fail_on_blocked=truthy(env_or(environ, "GNSSPP_CLAS_A4B_FAIL_ON_BLOCKED", "1")),
         claslib_repo=env_or(environ, "GNSSPP_CLAS_A4B_CLASLIB_REPO", DEFAULT_CLASLIB_REPO),
         claslib_ref=env_or(environ, "GNSSPP_CLAS_A4B_CLASLIB_REF", DEFAULT_CLASLIB_REF),
         max_epochs=max_epochs,
@@ -384,6 +386,8 @@ def build_payload(
     if status == "blocked_infrastructure":
         next_actions.append("Provide CLAS public data with GNSSPP_CLAS_A4B_DATA_ROOT or allow sparse auto-fetch.")
         next_actions.append("Treat blocked_infrastructure as missing native A4b evidence, not as a passing sign-off.")
+        if config.fail_on_blocked:
+            next_actions.append("Set GNSSPP_CLAS_A4B_FAIL_ON_BLOCKED=0 only for diagnostic-only local runs.")
     elif status == "failed":
         next_actions.append("Inspect the native run log, self-diff JSON, and component dump before changing CLAS model behavior.")
     return {
@@ -401,6 +405,7 @@ def build_payload(
         },
         "configuration": {
             "max_epochs": config.max_epochs,
+            "fail_on_blocked": config.fail_on_blocked,
             "receiver_antenna_type": config.receiver_antenna_type,
             "env_overrides": {**ENV_OVERRIDES, "GNSS_PPP_CLAS_CODE_DUMP": str(paths.native_code_dump)},
             "selfdiff_filter": {"sat": "G14", "freq": 1, "rinex_code": "C2W", "row_type": "code"},
@@ -439,7 +444,7 @@ def main(argv: Sequence[str] | None = None, environ: Mapping[str, str] | None = 
         write_summary(paths, payload)
         print(f"CLAS A4b native self-diff blocked: {block_reason}")
         print(f"  summary: {paths.summary_json}")
-        return 0
+        return 1 if config.fail_on_blocked else 0
 
     native_command, native_env = build_native_command(config, paths, data_root)
     native_result = run_logged(native_command, cwd=config.repo_root, log_path=paths.log_path, env=native_env)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -114,6 +114,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_optional_clas_zd_component_diff.py
     )
     add_test(
+        NAME python_clas_a4b_native_selfdiff_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_clas_a4b_native_selfdiff.py
+    )
+    add_test(
         NAME python_madoca_satellite_set_diff_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_madoca_satellite_set_diff.py
     )
@@ -247,6 +251,7 @@ if(GTest_FOUND)
     set(GNSSPP_CORE_TESTS
         run_tests
         python_artifact_manifest_ux_tests
+        python_clas_a4b_native_selfdiff_tests
         python_clas_zd_component_diff_tests
         python_claslib_zd_component_export_tests
         python_cli_ux_tests

--- a/tests/test_clas_a4b_native_selfdiff.py
+++ b/tests/test_clas_a4b_native_selfdiff.py
@@ -1,0 +1,207 @@
+#!/usr/bin/env python3
+"""Tests for the CLAS A4b native self-diff CI wrapper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT_DIR / "scripts" / "ci" / "run_clas_a4b_native_selfdiff.py"
+
+spec = importlib.util.spec_from_file_location("run_clas_a4b_native_selfdiff", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+runner = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = runner
+spec.loader.exec_module(runner)
+
+
+def make_data_root(root: Path) -> Path:
+    data_root = root / "data"
+    data_root.mkdir()
+    for name in runner.REQUIRED_DATA_FILES:
+        (data_root / name).write_text(f"{name}\n", encoding="ascii")
+    return data_root
+
+
+class ClasA4bNativeSelfdiffTest(unittest.TestCase):
+    def test_parse_config_defaults_to_public_claslib_fetch(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_clas_a4b_config_") as temp_dir:
+            config = runner.parse_config(
+                runner.parse_args(["--repo-root", str(ROOT_DIR), "--output-dir", temp_dir]),
+                {},
+            )
+
+            self.assertTrue(config.auto_fetch)
+            self.assertEqual(config.claslib_repo, runner.DEFAULT_CLASLIB_REPO)
+            self.assertEqual(config.claslib_ref, runner.DEFAULT_CLASLIB_REF)
+            self.assertEqual(config.max_epochs, runner.DEFAULT_MAX_EPOCHS)
+            self.assertEqual(config.gps_l2w_rows_min, runner.DEFAULT_MAX_EPOCHS)
+
+    def test_data_root_failures_reports_missing_public_inputs(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_clas_a4b_data_") as temp_dir:
+            data_root = Path(temp_dir)
+            (data_root / "0627239Q.obs").write_text("", encoding="ascii")
+
+            failures = runner.data_root_failures(data_root)
+
+            self.assertEqual(
+                failures,
+                ["sept_2019239.nav", "2019239Q.l6", "igs14_L5copy.atx"],
+            )
+
+    def test_build_native_command_sets_a4b_environment_and_policies(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_clas_a4b_command_") as temp_dir:
+            root = Path(temp_dir)
+            data_root = make_data_root(root)
+            output_dir = root / "output"
+            paths = runner.default_paths(output_dir)
+            config = runner.RunConfig(
+                repo_root=ROOT_DIR,
+                output_dir=output_dir,
+                data_root=data_root,
+                auto_fetch=False,
+                claslib_repo=runner.DEFAULT_CLASLIB_REPO,
+                claslib_ref=runner.DEFAULT_CLASLIB_REF,
+                max_epochs=30,
+                gps_l2w_rows_min=30,
+                receiver_antenna_type="TEST ANT",
+                python_executable=sys.executable,
+            )
+
+            command, env = runner.build_native_command(config, paths, data_root)
+
+            self.assertEqual(env["GNSS_PPP_CLAS_DD_FILTER"], "1")
+            self.assertEqual(env["GNSS_PPP_CLAS_CODE_ROW_PARITY"], "bias")
+            self.assertEqual(env["GNSS_PPP_CLAS_RX_ANTENNA"], "1")
+            self.assertEqual(env["GNSS_PPP_CLAS_CODE_DUMP"], str(paths.native_code_dump))
+            self.assertIn("clas-ppp", command)
+            self.assertIn("--compact-code-bias-composition-policy", command)
+            self.assertIn("base-only-if-present", command)
+            self.assertIn("--compact-code-bias-bank-policy", command)
+            self.assertIn("latest-preceding-bank", command)
+            self.assertIn("--compact-bias-row-materialization", command)
+            self.assertIn("selected-satellite-base-extend", command)
+            self.assertIn("--receiver-antenna-type", command)
+            self.assertIn("TEST ANT", command)
+            self.assertEqual(command[-2:], ["--max-epochs", "30"])
+
+    def test_evaluate_accepts_exact_native_l2w_selfdiff(self) -> None:
+        config = runner.RunConfig(
+            repo_root=ROOT_DIR,
+            output_dir=ROOT_DIR / "output",
+            data_root=None,
+            auto_fetch=True,
+            claslib_repo=runner.DEFAULT_CLASLIB_REPO,
+            claslib_ref=runner.DEFAULT_CLASLIB_REF,
+            max_epochs=30,
+            gps_l2w_rows_min=30,
+            receiver_antenna_type=runner.DEFAULT_RECEIVER_ANTENNA_TYPE,
+            python_executable=sys.executable,
+        )
+        native_summary = {"epochs": 30, "ppp_solution_rate_pct": 100.0}
+        report = {
+            "common_rows": 30,
+            "base_only_rows": 0,
+            "candidate_only_rows": 0,
+            "components_compared": 630,
+            "threshold_exceedances": 0,
+            "per_component": [{"component": "prc_m", "max_abs_delta_m": 0.0}],
+            "identity_provenance": {
+                "native": {
+                    "gps_l2w_rows": 30,
+                    "gps_l2w_bias_exact_identity_rows": 30,
+                    "gps_l2w_observation_exact_match_rows": 30,
+                    "gps_l2w_observation_family_fallback_rows": 0,
+                    "gps_l2w_code_bias_fallback_rows": 0,
+                }
+            },
+        }
+
+        metrics, thresholds, failures = runner.evaluate(config, native_summary, report, 540)
+
+        self.assertEqual(failures, [])
+        self.assertEqual(metrics["gps_l2w_rows"], 30)
+        self.assertEqual(metrics["native_code_dump_rows"], 540)
+        self.assertEqual(thresholds["gps_l2w_rows_min"], 30)
+
+    def test_evaluate_rejects_identity_fallback(self) -> None:
+        config = runner.RunConfig(
+            repo_root=ROOT_DIR,
+            output_dir=ROOT_DIR / "output",
+            data_root=None,
+            auto_fetch=True,
+            claslib_repo=runner.DEFAULT_CLASLIB_REPO,
+            claslib_ref=runner.DEFAULT_CLASLIB_REF,
+            max_epochs=30,
+            gps_l2w_rows_min=30,
+            receiver_antenna_type=runner.DEFAULT_RECEIVER_ANTENNA_TYPE,
+            python_executable=sys.executable,
+        )
+        native_summary = {"epochs": 30, "ppp_solution_rate_pct": 100.0}
+        report = {
+            "common_rows": 30,
+            "base_only_rows": 0,
+            "candidate_only_rows": 0,
+            "components_compared": 630,
+            "threshold_exceedances": 0,
+            "per_component": [{"component": "code_bias_m", "max_abs_delta_m": 0.0}],
+            "identity_provenance": {
+                "native": {
+                    "gps_l2w_rows": 30,
+                    "gps_l2w_bias_exact_identity_rows": 29,
+                    "gps_l2w_observation_exact_match_rows": 30,
+                    "gps_l2w_observation_family_fallback_rows": 1,
+                    "gps_l2w_code_bias_fallback_rows": 0,
+                }
+            },
+        }
+
+        _metrics, _thresholds, failures = runner.evaluate(config, native_summary, report, 540)
+
+        self.assertIn("exact bias rows 29 != GPS L2W rows 30", failures)
+        self.assertIn("observation-family fallback rows 1 != 0", failures)
+
+    def test_blocked_summary_contract_has_next_action(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_clas_a4b_summary_") as temp_dir:
+            output_dir = Path(temp_dir) / "output"
+            paths = runner.default_paths(output_dir)
+            paths.log_path.parent.mkdir(parents=True)
+            paths.log_path.write_text("blocked\n", encoding="ascii")
+            config = runner.RunConfig(
+                repo_root=ROOT_DIR,
+                output_dir=output_dir,
+                data_root=None,
+                auto_fetch=False,
+                claslib_repo=runner.DEFAULT_CLASLIB_REPO,
+                claslib_ref=runner.DEFAULT_CLASLIB_REF,
+                max_epochs=30,
+                gps_l2w_rows_min=30,
+                receiver_antenna_type=runner.DEFAULT_RECEIVER_ANTENNA_TYPE,
+                python_executable=sys.executable,
+            )
+
+            payload = runner.build_payload(
+                config=config,
+                paths=paths,
+                status="blocked_infrastructure",
+                data_root=None,
+                block_reason="no data",
+            )
+            runner.write_summary(paths, payload)
+            written = json.loads(paths.summary_json.read_text(encoding="utf-8"))
+
+        self.assertEqual(written["summary_schema"], runner.SUMMARY_SCHEMA)
+        self.assertEqual(written["contract"], runner.CONTRACT)
+        self.assertEqual(written["status"], "blocked_infrastructure")
+        self.assertIn("missing native A4b evidence", written["next_actions"][1])
+        self.assertEqual(written["configuration"]["selfdiff_filter"]["rinex_code"], "C2W")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_clas_a4b_native_selfdiff.py
+++ b/tests/test_clas_a4b_native_selfdiff.py
@@ -38,6 +38,7 @@ class ClasA4bNativeSelfdiffTest(unittest.TestCase):
             )
 
             self.assertTrue(config.auto_fetch)
+            self.assertTrue(config.fail_on_blocked)
             self.assertEqual(config.claslib_repo, runner.DEFAULT_CLASLIB_REPO)
             self.assertEqual(config.claslib_ref, runner.DEFAULT_CLASLIB_REF)
             self.assertEqual(config.max_epochs, runner.DEFAULT_MAX_EPOCHS)
@@ -66,6 +67,7 @@ class ClasA4bNativeSelfdiffTest(unittest.TestCase):
                 output_dir=output_dir,
                 data_root=data_root,
                 auto_fetch=False,
+                fail_on_blocked=True,
                 claslib_repo=runner.DEFAULT_CLASLIB_REPO,
                 claslib_ref=runner.DEFAULT_CLASLIB_REF,
                 max_epochs=30,
@@ -97,6 +99,7 @@ class ClasA4bNativeSelfdiffTest(unittest.TestCase):
             output_dir=ROOT_DIR / "output",
             data_root=None,
             auto_fetch=True,
+            fail_on_blocked=True,
             claslib_repo=runner.DEFAULT_CLASLIB_REPO,
             claslib_ref=runner.DEFAULT_CLASLIB_REF,
             max_epochs=30,
@@ -136,6 +139,7 @@ class ClasA4bNativeSelfdiffTest(unittest.TestCase):
             output_dir=ROOT_DIR / "output",
             data_root=None,
             auto_fetch=True,
+            fail_on_blocked=True,
             claslib_repo=runner.DEFAULT_CLASLIB_REPO,
             claslib_ref=runner.DEFAULT_CLASLIB_REF,
             max_epochs=30,
@@ -178,6 +182,7 @@ class ClasA4bNativeSelfdiffTest(unittest.TestCase):
                 output_dir=output_dir,
                 data_root=None,
                 auto_fetch=False,
+                fail_on_blocked=False,
                 claslib_repo=runner.DEFAULT_CLASLIB_REPO,
                 claslib_ref=runner.DEFAULT_CLASLIB_REF,
                 max_epochs=30,
@@ -200,6 +205,7 @@ class ClasA4bNativeSelfdiffTest(unittest.TestCase):
         self.assertEqual(written["contract"], runner.CONTRACT)
         self.assertEqual(written["status"], "blocked_infrastructure")
         self.assertIn("missing native A4b evidence", written["next_actions"][1])
+        self.assertFalse(written["configuration"]["fail_on_blocked"])
         self.assertEqual(written["configuration"]["selfdiff_filter"]["rinex_code"], "C2W")
 
 


### PR DESCRIPTION
## Summary

- add a CI wrapper that sparse-fetches the public CLASLIB data fixture, runs the gated CLAS A4b native command, and writes `GNSS_PPP_CLAS_CODE_DUMP`
- self-diff the generated native `G14/C2W` code rows and summarize exact observation/bias identity, fallback counts, row completeness, and artifact evidence
- upload the native solution, summary, code dump, self-diff JSON/CSV, and log from `linux-optional-signoffs`
- document the new native-side evidence bundle in the CLAS A5/A4b docs and contributing guide

## Why

The previous optional CLAS ZD diff could compare CSVs, but the native candidate CSV still had to be staged externally. This PR makes the native side of the A4b GPS L2W probe reproducible on remote CI from the public CLASLIB fixture before we add oracle-backed ZD component closure.

This does not change solver behavior or make the DD filter default-on. It only adds diagnostic/sign-off evidence. Missing public data is recorded as `blocked_infrastructure`; CI fails that state by default so it cannot be mistaken for a passing sign-off.

## Validation

- `python3 -m py_compile scripts/ci/run_clas_a4b_native_selfdiff.py tests/test_clas_a4b_native_selfdiff.py`
- `python3 -m unittest tests.test_clas_a4b_native_selfdiff`
- `GNSSPP_CLAS_A4B_DATA_ROOT=/tmp/gnsspp_claslib_sparse_probe/data GNSSPP_CLAS_A4B_MAX_EPOCHS=30 python3 scripts/ci/run_clas_a4b_native_selfdiff.py --output-dir /tmp/gnsspp_clas_a4b_script_smoke`
- `GNSSPP_CLAS_A4B_AUTO_FETCH=0 GNSSPP_CLAS_A4B_FAIL_ON_BLOCKED=0 python3 scripts/ci/run_clas_a4b_native_selfdiff.py --output-dir /tmp/gnsspp_clas_a4b_blocked`
- `GNSSPP_CLAS_A4B_MAX_EPOCHS=5 python3 scripts/ci/run_clas_a4b_native_selfdiff.py --output-dir /tmp/gnsspp_clas_a4b_autofetch_smoke`
- `GNSSPP_CLAS_A4B_DATA_ROOT=/tmp/gnsspp_claslib_sparse_probe/data python3 scripts/ci/run_clas_a4b_native_selfdiff.py --output-dir /tmp/gnsspp_clas_a4b_script_300`
- `cmake -S . -B build`
- `python3 - <<'PY' ... yaml.safe_load('.github/workflows/ci.yml') ... PY`
- `ctest --test-dir build -R '^python_clas_a4b_native_selfdiff_tests$' --output-on-failure`
- `ctest --test-dir build -L core --output-on-failure`
- `git diff --check`