### PR TITLE
[codex] docs: guard clas maturity claims

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,7 @@ on:
       - "mkdocs.yml"
       - "requirements-docs.txt"
       - "scripts/generate_architecture_diagram.py"
+      - "tests/test_cli_ux.py"
   pull_request:
     branches: [ main, develop ]
     paths:
@@ -19,6 +20,7 @@ on:
       - "mkdocs.yml"
       - "requirements-docs.txt"
       - "scripts/generate_architecture_diagram.py"
+      - "tests/test_cli_ux.py"
   workflow_dispatch:
 
 permissions:
@@ -44,6 +46,8 @@ jobs:
           cache-dependency-path: requirements-docs.txt
       - name: Install docs dependencies
         run: python -m pip install --upgrade pip && python -m pip install -r requirements-docs.txt
+      - name: Run docs CLI UX contract
+        run: python tests/test_cli_ux.py
       - name: Generate docs visuals
         env:
           MPLBACKEND: Agg

--- a/README.md
+++ b/README.md
@@ -16,12 +16,12 @@ handling without an external RTKLIB runtime.
 
 ![Feature overview](docs/libgnsspp_feature_overview.png)
 
-## Results
+## Results And Validation Status
 
-| Area | Public comparison | Current result |
+| Area | Public comparison | Evidence / status |
 |---|---|---|
 | RTK | PPC Tokyo/Nagoya vs RTKLIB `demo5` | +17.0 pp positioning, +28.1 pp official score, -11.96 m P95 H delta |
-| CLAS PPP | QZSS CLAS vs CLASLIB | 3.57 mm vs 7.29 mm RMS 3D |
+| CLAS PPP | QZSS CLAS vs CLASLIB | Historical `--claslib-parity` result: 3.57 mm vs 7.29 mm RMS 3D. Current native DD filter remains default-off at A5 STOP. |
 | Urban RTK | UrbanNav Tokyo Odaiba vs RTKLIB `demo5` | More fixes, lower Hp95/Vp95; `--preset odaiba` closes Hmed |
 | SPP | PPC SPP adaptive robust + policy gate | No P95 regression with <=1 pp positioning drop |
 
@@ -47,12 +47,19 @@ Positioning-rate lead, **+28.1 pp** PPC official-score lead, and
 
 ![PPC RTK coverage scorecard](docs/ppc_rtk_demo5_scorecard.png)
 
-### CLAS PPP vs CLASLIB
+### Historical CLAS PPP vs CLASLIB
+
+This is the historical iter55 `--claslib-parity` result, not the current default
+CLAS capability. Current `develop` no longer exposes `--claslib-parity`; active
+native CLAS work is gated by A4b component-diff evidence, and the DD filter
+default flip remains stopped at A5. See
+[CLAS validation datasets](docs/clas_validated_datasets.md) and
+[A5 closure](docs/clas_dd_filter_a5.md).
 
 QZSS CLAS PPP from raw L6 binary, 2019-08-27 static dataset, 1 hour
 (`3599` epochs):
 
-| Metric | libgnss++ `--claslib-parity` | CLASLIB |
+| Metric | libgnss++ historical `--claslib-parity` | CLASLIB |
 |---|---:|---:|
 | Matched fixed epochs | **3594 / 3599 (99.86%)** | 3594 / 3599 (99.86%) |
 | RMS 3D fixed-only | **3.57 mm** | 7.29 mm |

--- a/tests/test_cli_ux.py
+++ b/tests/test_cli_ux.py
@@ -444,6 +444,40 @@ class CliUxTest(unittest.TestCase):
         self.assertGreaterEqual(seen_examples, 20)
         self.assertEqual(stale_examples, [])
 
+    def test_readme_clas_maturity_claim_is_explicit(self) -> None:
+        readme = (ROOT_DIR / "README.md").read_text(encoding="utf-8")
+
+        self.assertNotIn("| Area | Public comparison | Current result |", readme)
+        self.assertIn("| Area | Public comparison | Evidence / status |", readme)
+
+        clas_rows = [
+            line for line in readme.splitlines()
+            if line.startswith("| CLAS PPP |")
+        ]
+        self.assertEqual(len(clas_rows), 1)
+        clas_row = clas_rows[0]
+        for snippet in (
+            "Historical `--claslib-parity` result",
+            "Current native DD filter",
+            "default-off",
+            "A5 STOP",
+        ):
+            self.assertIn(snippet, clas_row)
+
+        section_heading = "### Historical CLAS PPP vs CLASLIB"
+        self.assertIn(section_heading, readme)
+        section_start = readme.index(section_heading)
+        section_end = readme.find("\n### ", section_start + len(section_heading))
+        clas_section = readme[section_start:] if section_end == -1 else readme[section_start:section_end]
+        normalized_section = re.sub(r"\s+", " ", clas_section)
+        for snippet in (
+            "not the current default CLAS capability",
+            "no longer exposes `--claslib-parity`",
+            "A4b component-diff evidence",
+            "DD filter default flip remains stopped at A5",
+        ):
+            self.assertIn(snippet, normalized_section)
+
     def test_app_generated_gnss_examples_use_registered_dispatcher_commands(self) -> None:
         app_files = sorted((ROOT_DIR / "apps").glob("*.py"))
         seen_examples, stale_examples = self.stale_gnss_example_commands_in_files(app_files)


### PR DESCRIPTION
## Summary
- Reword the README results table so the CLAS mm-level table is clearly historical evidence rather than current default capability.
- Add a CLI/docs UX test that guards the README CLAS maturity wording and keeps the A5 STOP/default-off caveat visible.
- Run the same Python UX contract in the docs workflow so README/docs-only PRs still catch stale CLI examples and maturity wording regressions.

## Validation
- `python3 tests/test_cli_ux.py`
- `ctest --test-dir build -R ^python_cli_ux_tests --output-on-failure`
- `python3 -m py_compile tests/test_cli_ux.py`
- YAML parse for `.github/workflows/docs.yml`
- `/tmp` docs venv: `python scripts/generate_architecture_diagram.py --output docs/libgnsspp_architecture.png && python -m mkdocs build --strict`
- `git diff --check`