### PR TITLE
[codex] ci: validate docker cli json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -211,8 +211,7 @@ jobs:
       run: |
         docker build -t libgnsspp-ci .
         docker run --rm libgnsspp-ci --help >/dev/null
-        docker run --rm libgnsspp-ci commands --json >/dev/null
-        docker run --rm libgnsspp-ci commands --query ppp --limit 3 --json >/dev/null
+        python3 scripts/ci/validate_cli_json_contract.py --cli docker run --rm libgnsspp-ci
         docker run --rm libgnsspp-ci help web >/dev/null
         docker run --rm libgnsspp-ci web --help >/dev/null
         docker compose -f compose.yaml config >/dev/null

--- a/scripts/ci/validate_cli_json_contract.py
+++ b/scripts/ci/validate_cli_json_contract.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Validate machine-readable CLI UX contracts for local or Docker commands."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from collections.abc import Sequence
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+LOCAL_CLI = ROOT_DIR / "apps" / "gnss.py"
+VALID_COMMAND_KINDS = {"binary", "builtin", "python"}
+
+
+@dataclass(frozen=True)
+class CliInvocation:
+    command: tuple[str, ...]
+    expected_returncode: int = 0
+
+
+def run_invocation(invocation: CliInvocation) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        list(invocation.command),
+        cwd=ROOT_DIR,
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+
+def load_stdout_json(result: subprocess.CompletedProcess[str], label: str) -> Any:
+    if "Traceback (most recent call last)" in result.stdout + result.stderr:
+        raise AssertionError(f"{label}: command printed a Python traceback")
+    try:
+        return json.loads(result.stdout)
+    except json.JSONDecodeError as exc:
+        raise AssertionError(
+            f"{label}: stdout is not valid JSON: {exc}; stdout={result.stdout!r}; stderr={result.stderr!r}"
+        ) from exc
+
+
+def assert_returncode_and_stderr(
+    result: subprocess.CompletedProcess[str],
+    label: str,
+    *,
+    expected_returncode: int,
+    expect_empty_stderr: bool = True,
+) -> None:
+    if result.returncode != expected_returncode:
+        raise AssertionError(
+            f"{label}: expected return code {expected_returncode}, got {result.returncode}; "
+            f"stdout={result.stdout!r}; stderr={result.stderr!r}"
+        )
+    if expect_empty_stderr and result.stderr:
+        raise AssertionError(f"{label}: expected empty stderr, got {result.stderr!r}")
+
+
+def validate_commands_payload(payload: Any, label: str, *, expected_filters: dict[str, Any]) -> set[str]:
+    if not isinstance(payload, dict):
+        raise AssertionError(f"{label}: payload must be an object")
+    if payload.get("schema_version") != 1:
+        raise AssertionError(f"{label}: expected schema_version=1")
+    if payload.get("filters") != expected_filters:
+        raise AssertionError(f"{label}: unexpected filters: {payload.get('filters')!r}")
+
+    commands = payload.get("commands")
+    if not isinstance(commands, list):
+        raise AssertionError(f"{label}: commands must be a list")
+    if payload.get("count") != len(commands):
+        raise AssertionError(f"{label}: count does not match command list length")
+
+    names: list[str] = []
+    for index, item in enumerate(commands):
+        if not isinstance(item, dict):
+            raise AssertionError(f"{label}: commands[{index}] must be an object")
+        if set(item) != {"kind", "name", "summary"}:
+            raise AssertionError(f"{label}: commands[{index}] has unexpected keys {sorted(item)}")
+        if item["kind"] not in VALID_COMMAND_KINDS:
+            raise AssertionError(f"{label}: commands[{index}] has invalid kind {item['kind']!r}")
+        for field in ("name", "summary"):
+            if not isinstance(item[field], str) or not item[field].strip():
+                raise AssertionError(f"{label}: commands[{index}].{field} must be a non-empty string")
+        names.append(item["name"])
+
+    if names != sorted(names):
+        raise AssertionError(f"{label}: command names must be sorted")
+    if len(names) != len(set(names)):
+        raise AssertionError(f"{label}: command names must be unique")
+    return set(names)
+
+
+def validate_doctor_payload(payload: Any, label: str, *, known_commands: set[str]) -> None:
+    if not isinstance(payload, dict):
+        raise AssertionError(f"{label}: payload must be an object")
+    if set(payload) != {"checks", "next_commands", "ok", "root"}:
+        raise AssertionError(f"{label}: unexpected keys {sorted(payload)}")
+    if not isinstance(payload["ok"], bool):
+        raise AssertionError(f"{label}: ok must be a boolean")
+    if not isinstance(payload["root"], str) or not payload["root"]:
+        raise AssertionError(f"{label}: root must be a non-empty string")
+
+    checks = payload["checks"]
+    if not isinstance(checks, list) or not checks:
+        raise AssertionError(f"{label}: checks must be a non-empty list")
+    for index, check in enumerate(checks):
+        if not isinstance(check, dict):
+            raise AssertionError(f"{label}: checks[{index}] must be an object")
+        for key in ("name", "status", "detail"):
+            if not isinstance(check.get(key), str) or not check[key].strip():
+                raise AssertionError(f"{label}: checks[{index}].{key} must be a non-empty string")
+
+    next_commands = payload["next_commands"]
+    if not isinstance(next_commands, list) or not next_commands:
+        raise AssertionError(f"{label}: next_commands must be a non-empty list")
+    stale_next_commands: list[str] = []
+    for command in next_commands:
+        if not isinstance(command, str) or not command.strip():
+            raise AssertionError(f"{label}: next_commands entries must be non-empty strings")
+        prefix = "python3 apps/gnss.py "
+        if not command.startswith(prefix):
+            continue
+        dispatcher_command = command[len(prefix):].split(None, 1)[0]
+        if dispatcher_command not in known_commands:
+            stale_next_commands.append(command)
+    if stale_next_commands:
+        raise AssertionError(f"{label}: stale next_commands: {stale_next_commands}")
+
+
+def validate_invocation_json(
+    invocation: CliInvocation,
+    label: str,
+    *,
+    expected_filters: dict[str, Any] | None = None,
+    known_commands: set[str] | None = None,
+) -> Any:
+    result = run_invocation(invocation)
+    assert_returncode_and_stderr(
+        result,
+        label,
+        expected_returncode=invocation.expected_returncode,
+    )
+    payload = load_stdout_json(result, label)
+    if expected_filters is not None:
+        return validate_commands_payload(payload, label, expected_filters=expected_filters)
+    if known_commands is not None:
+        validate_doctor_payload(payload, label, known_commands=known_commands)
+    return payload
+
+
+def build_command(prefix: Sequence[str], *args: str) -> tuple[str, ...]:
+    return (*prefix, *args)
+
+
+def validate_contract(prefix: Sequence[str]) -> None:
+    all_commands = validate_invocation_json(
+        CliInvocation(build_command(prefix, "commands", "--json")),
+        "commands --json",
+        expected_filters={"kind": None},
+    )
+    filtered_commands = validate_invocation_json(
+        CliInvocation(build_command(prefix, "commands", "--query", "ppp", "--limit", "3", "--json")),
+        "commands --query ppp --limit 3 --json",
+        expected_filters={"kind": None, "query": "ppp", "limit": 3},
+    )
+    if len(filtered_commands) > 3:
+        raise AssertionError("filtered commands exceeded --limit 3")
+    if not filtered_commands:
+        raise AssertionError("filtered commands should include at least one PPP command")
+
+    validate_doctor = CliInvocation(
+        build_command(prefix, "doctor", "--root", "/tmp/gnsspp-missing-root", "--json", "--strict"),
+        expected_returncode=1,
+    )
+    validate_invocation_json(validate_doctor, "doctor missing-root --json --strict", known_commands=all_commands)
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--cli",
+        nargs=argparse.REMAINDER,
+        default=[sys.executable, str(LOCAL_CLI)],
+        help="CLI prefix to execute, for example: python3 apps/gnss.py",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    validate_contract(tuple(args.cli))
+    print("CLI JSON contract validated.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -86,6 +86,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_cli_ux.py
     )
     add_test(
+        NAME python_cli_json_contract_validator_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_cli_json_contract_validator.py
+    )
+    add_test(
         NAME python_artifact_manifest_ux_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_artifact_manifest_ux.py
     )
@@ -254,6 +258,7 @@ if(GTest_FOUND)
         python_clas_a4b_native_selfdiff_tests
         python_clas_zd_component_diff_tests
         python_claslib_zd_component_export_tests
+        python_cli_json_contract_validator_tests
         python_cli_ux_tests
         python_optional_clas_zd_component_diff_tests
         python_madoca_residual_component_diff_tests

--- a/tests/test_cli_json_contract_validator.py
+++ b/tests/test_cli_json_contract_validator.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Tests for the CLI JSON contract validator used by CI and Docker smoke."""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+VALIDATOR_PATH = ROOT_DIR / "scripts" / "ci" / "validate_cli_json_contract.py"
+
+
+def load_validator_module():
+    spec = importlib.util.spec_from_file_location("validate_cli_json_contract", VALIDATOR_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load validator module from {VALIDATOR_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class CliJsonContractValidatorTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.validator = load_validator_module()
+
+    def test_local_cli_contract_passes(self) -> None:
+        self.validator.validate_contract((sys.executable, str(ROOT_DIR / "apps" / "gnss.py")))
+
+    def test_commands_validator_rejects_stale_shape(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "unexpected keys"):
+            self.validator.validate_commands_payload(
+                {
+                    "schema_version": 1,
+                    "filters": {"kind": None},
+                    "count": 1,
+                    "commands": [
+                        {
+                            "kind": "builtin",
+                            "name": "commands",
+                            "summary": "List commands.",
+                            "extra": "field",
+                        }
+                    ],
+                },
+                "commands --json",
+                expected_filters={"kind": None},
+            )
+
+    def test_doctor_validator_rejects_stale_next_command(self) -> None:
+        with self.assertRaisesRegex(AssertionError, "stale next_commands"):
+            self.validator.validate_doctor_payload(
+                {
+                    "root": str(ROOT_DIR),
+                    "ok": False,
+                    "checks": [
+                        {
+                            "name": "repository root",
+                            "status": "missing",
+                            "detail": "missing",
+                        }
+                    ],
+                    "next_commands": ["python3 apps/gnss.py does-not-exist"],
+                },
+                "doctor --json --strict",
+                known_commands={"commands", "doctor"},
+            )
+
+    def test_json_loader_reports_invalid_stdout(self) -> None:
+        result = subprocess.CompletedProcess(
+            args=["gnss", "commands", "--json"],
+            returncode=0,
+            stdout="not json\n",
+            stderr="",
+        )
+        with self.assertRaisesRegex(AssertionError, "stdout is not valid JSON"):
+            self.validator.load_stdout_json(result, "commands --json")
+
+    def test_contract_runs_expected_cli_invocations(self) -> None:
+        calls: list[tuple[str, ...]] = []
+
+        def fake_validate(invocation, label, *, expected_filters=None, known_commands=None):
+            calls.append(tuple(invocation.command))
+            if label == "commands --json":
+                self.assertEqual(invocation.expected_returncode, 0)
+                return {"commands", "doctor", "ppp", "clas-ppp"}
+            if label == "commands --query ppp --limit 3 --json":
+                self.assertEqual(invocation.expected_returncode, 0)
+                return {"ppp", "clas-ppp"}
+            if label == "doctor missing-root --json --strict":
+                self.assertEqual(invocation.expected_returncode, 1)
+                self.assertEqual(known_commands, {"commands", "doctor", "ppp", "clas-ppp"})
+                return {}
+            raise AssertionError(f"unexpected label: {label}")
+
+        with mock.patch.object(self.validator, "validate_invocation_json", side_effect=fake_validate):
+            self.validator.validate_contract(("docker", "run", "--rm", "libgnsspp-ci"))
+
+        self.assertEqual(
+            calls,
+            [
+                ("docker", "run", "--rm", "libgnsspp-ci", "commands", "--json"),
+                (
+                    "docker",
+                    "run",
+                    "--rm",
+                    "libgnsspp-ci",
+                    "commands",
+                    "--query",
+                    "ppp",
+                    "--limit",
+                    "3",
+                    "--json",
+                ),
+                (
+                    "docker",
+                    "run",
+                    "--rm",
+                    "libgnsspp-ci",
+                    "doctor",
+                    "--root",
+                    "/tmp/gnsspp-missing-root",
+                    "--json",
+                    "--strict",
+                ),
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Add `scripts/ci/validate_cli_json_contract.py` to validate machine-readable CLI JSON for local or Docker command prefixes.
- Replace Docker smoke JSON calls that redirected to `/dev/null` with schema and next-command validation.
- Add focused unit and CTest coverage for the validator.

## Validation
- `python3 tests/test_cli_json_contract_validator.py`
- `python3 scripts/ci/validate_cli_json_contract.py`
- `ctest --test-dir build -R '^python_cli_json_contract_validator_tests$' --output-on-failure`\n- `ctest --test-dir build -L core --output-on-failure`\n- `bash scripts/ci/run_hygiene.sh`\n- `docker build -t libgnsspp-ci .`\n- `python3 scripts/ci/validate_cli_json_contract.py --cli docker run --rm libgnsspp-ci`\n- `docker run --rm libgnsspp-ci --help >/dev/null && docker run --rm libgnsspp-ci help web >/dev/null && docker run --rm libgnsspp-ci web --help >/dev/null && docker compose -f compose.yaml config >/dev/null`\n- YAML parse for `.github/workflows/ci.yml`\n- `git diff --check`