### PR TITLE
ci: validate dashboard artifact manifest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,9 @@ jobs:
     - name: Generate dashboard artifacts
       run: bash scripts/ci/generate_dashboard_artifacts.sh
 
+    - name: Validate dashboard artifact contract
+      run: python3 scripts/ci/validate_artifact_manifest_contract.py output/artifact_manifest.json
+
     - name: Upload dashboard artifacts
       if: always()
       uses: actions/upload-artifact@v4
@@ -229,7 +232,7 @@ jobs:
           output/visibility_static_summary.json
           output/visibility_static.csv
           output/visibility_static.png
-        if-no-files-found: ignore
+        if-no-files-found: error
 
   linux-optional-signoffs:
     needs: [changes, linux-extended-tests]

--- a/apps/gnss_artifact_manifest.py
+++ b/apps/gnss_artifact_manifest.py
@@ -592,6 +592,8 @@ def main() -> int:
     bundles.extend(build_ppc_spp_policy_suite_entries(root_dir, args.ppc_spp_policy_suite_glob))
 
     payload = {
+        "schema_version": 1,
+        "contract": "artifact_manifest.v1",
         "root": str(root_dir),
         "generated_at_utc": datetime.now(timezone.utc).isoformat(),
         "bundle_count": len(bundles),

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -60,7 +60,11 @@ CI lanes are split as follows:
   native-side evidence bundle; it sparse-fetches CLASLIB public data unless
   `GNSSPP_CLAS_A4B_DATA_ROOT` is supplied, generates the native code dump, and
   self-diffs the `G14/C2W` rows before any oracle-backed model change
-- `bash scripts/ci/generate_dashboard_artifacts.sh` for the dashboard/manifest artifact path used in CI
+- `bash scripts/ci/generate_dashboard_artifacts.sh` plus
+  `python3 scripts/ci/validate_artifact_manifest_contract.py output/artifact_manifest.json`
+  for the dashboard/manifest artifact path used in CI; the validator requires
+  schema version `artifact_manifest.v1`, matching bundle counts, root-confined
+  artifact links, non-empty local files, and parseable JSON/CSV/PNG payloads
 
 Docs-only changes keep CI on the lightweight path: hygiene here, plus the separate Docs workflow.
 

--- a/scripts/ci/validate_artifact_manifest_contract.py
+++ b/scripts/ci/validate_artifact_manifest_contract.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Validate dashboard artifact manifest files before CI upload."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+from collections.abc import Iterator, Sequence
+from pathlib import Path
+from typing import Any
+from urllib.parse import urlparse
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+PNG_SIGNATURE = b"\x89PNG\r\n\x1a\n"
+
+
+def load_json_file(path: Path, label: str) -> Any:
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except OSError as exc:
+        raise AssertionError(f"{label}: failed to read {path}: {exc}") from exc
+    except json.JSONDecodeError as exc:
+        raise AssertionError(f"{label}: invalid JSON in {path}: {exc}") from exc
+
+
+def is_url(value: str) -> bool:
+    parsed = urlparse(value)
+    return parsed.scheme in {"http", "https"} and bool(parsed.netloc)
+
+
+def resolve_manifest_path(root_dir: Path, value: str, label: str) -> Path:
+    candidate = Path(value)
+    if candidate.is_absolute():
+        resolved = candidate.resolve()
+    else:
+        resolved = (root_dir / candidate).resolve()
+    try:
+        resolved.relative_to(root_dir)
+    except ValueError as exc:
+        raise AssertionError(f"{label}: artifact path escapes manifest root: {value!r}") from exc
+    return resolved
+
+
+def assert_regular_nonempty_file(path: Path, label: str) -> None:
+    if not path.is_file():
+        raise AssertionError(f"{label}: missing artifact file: {path}")
+    size = path.stat().st_size
+    if size <= 0:
+        raise AssertionError(f"{label}: artifact is empty: {path}")
+
+
+def assert_parseable_file(path: Path, label: str) -> None:
+    suffix = path.suffix.lower()
+    if suffix == ".json":
+        load_json_file(path, label)
+        return
+    if suffix == ".csv":
+        try:
+            with path.open(newline="", encoding="utf-8") as handle:
+                first_row = next(csv.reader(handle), None)
+        except UnicodeDecodeError as exc:
+            raise AssertionError(f"{label}: CSV is not UTF-8 text: {path}") from exc
+        except csv.Error as exc:
+            raise AssertionError(f"{label}: CSV parse failed: {path}: {exc}") from exc
+        if not first_row or not any(cell.strip() for cell in first_row):
+            raise AssertionError(f"{label}: CSV header is empty: {path}")
+        return
+    if suffix == ".png":
+        signature = path.read_bytes()[: len(PNG_SIGNATURE)]
+        if signature != PNG_SIGNATURE:
+            raise AssertionError(f"{label}: PNG signature is invalid: {path}")
+
+
+def iter_artifact_paths(value: Any, label: str) -> Iterator[tuple[str, str]]:
+    if isinstance(value, str) and value:
+        yield label, value
+        return
+    if isinstance(value, dict):
+        for key, item in value.items():
+            child_label = f"{label}.{key}" if label else str(key)
+            yield from iter_artifact_paths(item, child_label)
+        return
+    if isinstance(value, list):
+        for index, item in enumerate(value):
+            child_label = f"{label}[{index}]"
+            yield from iter_artifact_paths(item, child_label)
+
+
+def validate_artifact_value(root_dir: Path, label: str, value: str) -> None:
+    if is_url(value):
+        return
+    path = resolve_manifest_path(root_dir, value, label)
+    assert_regular_nonempty_file(path, label)
+    assert_parseable_file(path, label)
+
+
+def validate_bundle(root_dir: Path, bundle: Any, index: int) -> None:
+    label = f"bundles[{index}]"
+    if not isinstance(bundle, dict):
+        raise AssertionError(f"{label}: bundle must be an object")
+    required_fields = {"category", "label", "summary_json", "status", "headline", "artifacts", "metrics"}
+    missing = sorted(required_fields - set(bundle))
+    if missing:
+        raise AssertionError(f"{label}: missing required fields: {missing}")
+    for key in ("category", "label", "summary_json", "status", "headline"):
+        if not isinstance(bundle.get(key), str) or not bundle[key].strip():
+            raise AssertionError(f"{label}.{key}: must be a non-empty string")
+    if not isinstance(bundle.get("artifacts"), dict):
+        raise AssertionError(f"{label}.artifacts: must be an object")
+    if not isinstance(bundle.get("metrics"), dict):
+        raise AssertionError(f"{label}.metrics: must be an object")
+
+    validate_artifact_value(root_dir, f"{label}.summary_json", bundle["summary_json"])
+    for artifact_label, artifact_path in iter_artifact_paths(bundle["artifacts"], f"{label}.artifacts"):
+        validate_artifact_value(root_dir, artifact_label, artifact_path)
+
+
+def validate_manifest(payload: Any) -> None:
+    if not isinstance(payload, dict):
+        raise AssertionError("manifest payload must be an object")
+    expected_top_level = {
+        "schema_version",
+        "contract",
+        "root",
+        "generated_at_utc",
+        "bundle_count",
+        "bundles",
+    }
+    if set(payload) != expected_top_level:
+        raise AssertionError(f"manifest has unexpected top-level keys: {sorted(payload)}")
+    if payload.get("schema_version") != 1:
+        raise AssertionError("manifest schema_version must be 1")
+    if payload.get("contract") != "artifact_manifest.v1":
+        raise AssertionError("manifest contract must be artifact_manifest.v1")
+    if not isinstance(payload.get("root"), str) or not payload["root"].strip():
+        raise AssertionError("manifest root must be a non-empty string")
+    root_dir = Path(payload["root"]).resolve()
+    if not root_dir.is_dir():
+        raise AssertionError(f"manifest root is not a directory: {root_dir}")
+    if not isinstance(payload.get("generated_at_utc"), str) or not payload["generated_at_utc"].strip():
+        raise AssertionError("generated_at_utc must be a non-empty string")
+    bundles = payload.get("bundles")
+    if not isinstance(bundles, list):
+        raise AssertionError("bundles must be a list")
+    if payload.get("bundle_count") != len(bundles):
+        raise AssertionError("bundle_count does not match bundles length")
+    for index, bundle in enumerate(bundles):
+        validate_bundle(root_dir, bundle, index)
+
+
+def parse_args(argv: Sequence[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "manifest",
+        nargs="?",
+        type=Path,
+        default=ROOT_DIR / "output" / "artifact_manifest.json",
+        help="Artifact manifest JSON path.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(sys.argv[1:] if argv is None else argv)
+    manifest_path = args.manifest.resolve()
+    assert_regular_nonempty_file(manifest_path, "manifest")
+    validate_manifest(load_json_file(manifest_path, "manifest"))
+    print("Artifact manifest contract validated.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,6 +94,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_artifact_manifest_ux.py
     )
     add_test(
+        NAME python_artifact_manifest_contract_validator_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_artifact_manifest_contract_validator.py
+    )
+    add_test(
         NAME python_madoca_solution_diff_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_madoca_solution_diff.py
     )
@@ -254,6 +258,7 @@ if(GTest_FOUND)
 
     set(GNSSPP_CORE_TESTS
         run_tests
+        python_artifact_manifest_contract_validator_tests
         python_artifact_manifest_ux_tests
         python_clas_a4b_native_selfdiff_tests
         python_clas_zd_component_diff_tests

--- a/tests/test_artifact_manifest_contract_validator.py
+++ b/tests/test_artifact_manifest_contract_validator.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Tests for the dashboard artifact manifest CI contract validator."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+VALIDATOR_PATH = ROOT_DIR / "scripts" / "ci" / "validate_artifact_manifest_contract.py"
+PNG_BYTES = b"\x89PNG\r\n\x1a\nsynthetic\n"
+
+
+def load_validator_module():
+    spec = importlib.util.spec_from_file_location("validate_artifact_manifest_contract", VALIDATOR_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load {VALIDATOR_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+validator = load_validator_module()
+
+
+class ArtifactManifestContractValidatorTest(unittest.TestCase):
+    def make_fixture(self, root: Path) -> Path:
+        output = root / "output"
+        output.mkdir()
+        summary = output / "visibility_static_summary.json"
+        csv_path = output / "visibility_static.csv"
+        png_path = output / "visibility_static.png"
+        manifest = output / "artifact_manifest.json"
+        summary.write_text(
+            json.dumps(
+                {
+                    "epochs_processed": 1,
+                    "rows_written": 1,
+                    "csv": "output/visibility_static.csv",
+                    "png": "output/visibility_static.png",
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        csv_path.write_text("satellite,system\nG01,GPS\n", encoding="utf-8")
+        png_path.write_bytes(PNG_BYTES)
+        manifest.write_text(
+            json.dumps(
+                {
+                    "schema_version": 1,
+                    "contract": "artifact_manifest.v1",
+                    "root": str(root.resolve()),
+                    "generated_at_utc": "2026-06-20T00:00:00+00:00",
+                    "bundle_count": 1,
+                    "bundles": [
+                        {
+                            "category": "visibility",
+                            "label": "visibility_static_summary.json",
+                            "summary_json": "output/visibility_static_summary.json",
+                            "status": "available",
+                            "headline": "1 rows / 1 sats",
+                            "artifacts": {
+                                "summary": "output/visibility_static_summary.json",
+                                "csv": "output/visibility_static.csv",
+                                "png": "output/visibility_static.png",
+                                "external": "https://example.com/report",
+                                "runs": [{"csv": "output/visibility_static.csv"}],
+                            },
+                            "metrics": {"rows_written": 1},
+                        }
+                    ],
+                },
+                indent=2,
+                sort_keys=True,
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        return manifest
+
+    def load_payload(self, manifest: Path) -> dict[str, object]:
+        return json.loads(manifest.read_text(encoding="utf-8"))
+
+    def test_valid_manifest_passes(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_artifact_contract_") as temp_dir:
+            manifest = self.make_fixture(Path(temp_dir))
+            validator.validate_manifest(self.load_payload(manifest))
+
+    def test_missing_linked_artifact_fails(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_artifact_contract_") as temp_dir:
+            root = Path(temp_dir)
+            manifest = self.make_fixture(root)
+            (root / "output" / "visibility_static.csv").unlink()
+
+            with self.assertRaisesRegex(AssertionError, "missing artifact file"):
+                validator.validate_manifest(self.load_payload(manifest))
+
+    def test_path_escape_fails(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_artifact_contract_") as temp_dir:
+            manifest = self.make_fixture(Path(temp_dir))
+            payload = self.load_payload(manifest)
+            bundle = payload["bundles"][0]
+            bundle["artifacts"]["csv"] = "../outside.csv"
+
+            with self.assertRaisesRegex(AssertionError, "escapes manifest root"):
+                validator.validate_manifest(payload)
+
+    def test_invalid_png_signature_fails(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_artifact_contract_") as temp_dir:
+            root = Path(temp_dir)
+            manifest = self.make_fixture(root)
+            (root / "output" / "visibility_static.png").write_bytes(b"not-a-png")
+
+            with self.assertRaisesRegex(AssertionError, "PNG signature is invalid"):
+                validator.validate_manifest(self.load_payload(manifest))
+
+    def test_bundle_count_mismatch_fails(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_artifact_contract_") as temp_dir:
+            manifest = self.make_fixture(Path(temp_dir))
+            payload = self.load_payload(manifest)
+            payload["bundle_count"] = 2
+
+            with self.assertRaisesRegex(AssertionError, "bundle_count"):
+                validator.validate_manifest(payload)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_artifact_manifest_ux.py
+++ b/tests/test_artifact_manifest_ux.py
@@ -102,6 +102,8 @@ class ArtifactManifestUxTest(unittest.TestCase):
             self.assertEqual(result.stderr, "")
             payload = json.loads(manifest_path.read_text(encoding="utf-8"))
 
+        self.assertEqual(payload["schema_version"], 1)
+        self.assertEqual(payload["contract"], "artifact_manifest.v1")
         self.assertEqual(payload["bundle_count"], 2)
         self.assertEqual(payload["root"], str(root.resolve()))
         bundles = {bundle["category"]: bundle for bundle in payload["bundles"]}


### PR DESCRIPTION
## Summary
- add `artifact_manifest.v1` metadata to generated dashboard manifests
- validate dashboard manifest bundles, local artifact links, file sizes, and JSON/CSV/PNG parseability before upload
- make dashboard artifact upload fail when no files are available and document the CI contract

## Validation
- `python3 -m py_compile scripts/ci/validate_artifact_manifest_contract.py tests/test_artifact_manifest_contract_validator.py apps/gnss_artifact_manifest.py tests/test_artifact_manifest_ux.py`
- `python3 tests/test_artifact_manifest_contract_validator.py`
- `python3 tests/test_artifact_manifest_ux.py`
- `bash scripts/ci/generate_dashboard_artifacts.sh && python3 scripts/ci/validate_artifact_manifest_contract.py output/artifact_manifest.json`
- `cmake -S . -B build && ctest --test-dir build -R 'python_artifact_manifest_(ux|contract_validator)_tests' --output-on-failure`\n- `ctest --test-dir build -L core --output-on-failure`\n- `bash scripts/ci/run_hygiene.sh`\n- `git diff --check`\n- YAML parse for `.github/workflows/ci.yml`