### PR TITLE
[codex] madoca materialization snapshot dump

### DIFF
--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -12,6 +12,7 @@
 #include <libgnss++/algorithms/ppp_env_overrides.hpp>
 #include <libgnss++/core/solution.hpp>
 #include <libgnss++/external/madocalib_bridge.hpp>
+#include <libgnss++/io/madoca_l6.hpp>
 #include <libgnss++/io/rinex.hpp>
 
 namespace {
@@ -24,6 +25,7 @@ struct Options {
     std::string ssr_path;
     std::string ssr_rtcm_path;
     std::vector<std::string> madoca_l6_paths;
+    std::string madoca_materialization_dump_path;
     std::string ionex_path;
     std::string dcb_path;
     std::string antex_path;
@@ -89,6 +91,9 @@ void printUsage(const char* program_name) {
         << "                          RTCM SSR source converted/read for PPP use\n"
         << "  --madoca-l6 <file>       Native MADOCA L6E SSR channel (repeatable,\n"
         << "                          e.g. PRN 204 and 206); requires --nav\n"
+        << "  --madoca-materialization-dump <csv>\n"
+        << "                          Dump native MADOCA L6E SSRProducts materialization\n"
+        << "                          rows before PPP processing\n"
         << "  --ionex <maps.ionex>     Optional IONEX TEC map product\n"
         << "  --dcb <bias.bsx>         Optional DCB / Bias-SINEX product\n"
         << "  --antex <antennas.atx>   Optional ANTEX file for receiver antenna PCO\n"
@@ -240,6 +245,8 @@ Options parseArguments(int argc, char* argv[]) {
             options.ssr_rtcm_path = argv[++i];
         } else if (arg == "--madoca-l6" && i + 1 < argc) {
             options.madoca_l6_paths.push_back(argv[++i]);
+        } else if (arg == "--madoca-materialization-dump" && i + 1 < argc) {
+            options.madoca_materialization_dump_path = argv[++i];
         } else if (arg == "--ionex" && i + 1 < argc) {
             options.ionex_path = argv[++i];
         } else if (arg == "--dcb" && i + 1 < argc) {
@@ -905,6 +912,30 @@ int main(int argc, char* argv[]) {
         if (obs_header.first_obs.week > 0) {
             ppp_config.l6_gps_week = obs_header.first_obs.week;
         }
+        if (!options.madoca_materialization_dump_path.empty()) {
+            if (options.madoca_l6_paths.empty()) {
+                std::cerr << "Error: --madoca-materialization-dump requires --madoca-l6\n";
+                return 1;
+            }
+            const std::filesystem::path dump_path(options.madoca_materialization_dump_path);
+            if (!dump_path.parent_path().empty()) {
+                std::filesystem::create_directories(dump_path.parent_path());
+            }
+            const int rows = libgnss::io::writeMadocaL6eMaterializationCsv(
+                options.madoca_l6_paths,
+                ppp_config.l6_gps_week,
+                options.madoca_materialization_dump_path,
+                ppp_env_overrides.madoca_ssr_replay);
+            if (rows < 0) {
+                std::cerr << "Error: failed to write MADOCA materialization dump: "
+                          << options.madoca_materialization_dump_path << "\n";
+                return 1;
+            }
+            if (rows == 0) {
+                std::cerr << "Error: MADOCA materialization dump produced no rows\n";
+                return 1;
+            }
+        }
         ppp_config.approximate_position = obs_header.approximate_position;
         ppp_config.receiver_antenna_type =
             options.receiver_antenna_type.empty() ?
@@ -1058,6 +1089,11 @@ int main(int argc, char* argv[]) {
                     << "  \"receiver_antenna_type_source\": \""
                     << (options.receiver_antenna_type.empty() ? "rinex-header" : "cli")
                     << "\",\n"
+                    << "  \"madoca_materialization_dump\": "
+                    << (options.madoca_materialization_dump_path.empty() ?
+                            "null" :
+                            ("\"" + jsonEscape(options.madoca_materialization_dump_path) + "\""))
+                    << ",\n"
                     << "  \"out\": \"" << jsonEscape(options.out_path) << "\",\n"
                     << "  \"mode\": \"" << (options.kinematic_mode ? "kinematic" : "static") << "\",\n"
                     << "  \"low_dynamics\": " << (options.low_dynamics_mode ? "true" : "false") << ",\n"
@@ -1145,6 +1181,10 @@ int main(int argc, char* argv[]) {
                       << ((options.ssr_path.empty() && options.ssr_rtcm_path.empty() &&
                            options.madoca_l6_paths.empty()) ? "off" : "on")
                       << "\n";
+            if (!options.madoca_materialization_dump_path.empty()) {
+                std::cout << "  MADOCA materialization dump: "
+                          << options.madoca_materialization_dump_path << "\n";
+            }
             if (atmospheric_trop_corrections > 0 || atmospheric_iono_corrections > 0) {
                 std::cout << "  atmospheric trop corrections: "
                           << atmospheric_trop_corrections << "\n";

--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -46,6 +46,18 @@ provides no GLONASS phase-bias product, so default GLONASS-phase-off is correct
 Open MADOCA levers (measured, none yet a default win): PPP-AR parity
 (`exec_pppar` window); QZSS atmosphere row-set.
 
+Correction-materialization snapshot: use
+`gnss ppp --madoca-l6 <file> --madoca-materialization-dump <csv>` to record the
+native SSRProducts view before PPP processing.  The CSV schema is
+`madoca_materialization_snapshot.v1` and records satellite key, system/PRN,
+correction epoch, orbit/clock reference epochs, IODE/SSR IOD, RAC orbit,
+clock, code-bias ids/values, phase-bias ids/values, and discontinuity counters.
+This is the M3 boundary between decoded L6E content and solver row construction:
+use it before residual or state/covariance tuning so decoder-vs-materializer
+identity/time/IOD mistakes are visible as artifacts.  The option changes no
+solver behavior when omitted and does not link MADOCALIB into production
+targets.
+
 Residual-component parity artifact: use
 `scripts/analysis/madoca_residual_component_diff.py` after satellite-set and
 row-set parity are understood.  It compares only common residual rows, keyed by

--- a/include/libgnss++/io/madoca_l6.hpp
+++ b/include/libgnss++/io/madoca_l6.hpp
@@ -3,6 +3,7 @@
 #include <libgnss++/algorithms/ppp_env_overrides.hpp>
 
 #include <cstdint>
+#include <iosfwd>
 #include <string>
 #include <vector>
 
@@ -153,5 +154,21 @@ int decodeMadocaL6eFilesToProducts(const std::vector<std::string>& files,
 int decodeMadocaL6eFilesToProductsReplay(const std::vector<std::string>& files,
                                          int gps_week,
                                          libgnss::SSRProducts& products);
+
+// Write the materialized native SSRProducts view used by MADOCA PPP. This is a
+// diagnostic boundary dump: it records the satellite key, correction epoch,
+// component reference times, IODs, orbit/clock values, and code/phase bias
+// identities after decoder output has been converted into native products.
+// Returns the number of correction rows written.
+int writeMadocaMaterializationCsv(const libgnss::SSRProducts& products,
+                                  std::ostream& output);
+
+// Decode MADOCA L6E files through the native converter and write the same
+// materialization CSV without running PPP. Returns the number of rows written;
+// <0 means the output file could not be opened.
+int writeMadocaL6eMaterializationCsv(const std::vector<std::string>& files,
+                                     int gps_week,
+                                     const std::string& output_path,
+                                     bool replay_mode);
 
 }  // namespace libgnss::io

--- a/src/io/madoca_l6.cpp
+++ b/src/io/madoca_l6.cpp
@@ -8,6 +8,10 @@
 #include <cmath>
 #include <cstdint>
 #include <fstream>
+#include <iomanip>
+#include <map>
+#include <ostream>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -927,6 +931,38 @@ bool useMadocaBiasIdentityKey(libgnss::GNSSSystem system,
            system == libgnss::GNSSSystem::QZSS;
 }
 
+const char* gnssSystemName(libgnss::GNSSSystem system) {
+    switch (system) {
+        case libgnss::GNSSSystem::GPS: return "GPS";
+        case libgnss::GNSSSystem::GLONASS: return "GLONASS";
+        case libgnss::GNSSSystem::Galileo: return "Galileo";
+        case libgnss::GNSSSystem::BeiDou: return "BeiDou";
+        case libgnss::GNSSSystem::QZSS: return "QZSS";
+        case libgnss::GNSSSystem::SBAS: return "SBAS";
+        case libgnss::GNSSSystem::NavIC: return "NavIC";
+        default: return "UNKNOWN";
+    }
+}
+
+template <typename Value>
+std::string joinSignalMapValues(const std::map<std::uint8_t, Value>& values) {
+    std::ostringstream out;
+    out << std::setprecision(17);
+    bool first = true;
+    for (const auto& [id, value] : values) {
+        if (!first) {
+            out << ';';
+        }
+        out << static_cast<unsigned>(id) << ':' << value;
+        first = false;
+    }
+    return out.str();
+}
+
+std::string csvBool(bool value) {
+    return value ? "1" : "0";
+}
+
 int madocaL6eSnapshotToProducts(const MadocaL6eDecoder& decoder,
                                 libgnss::SSRProducts& products) {
     products.setOrbitCorrectionsAreRac(true);
@@ -1049,6 +1085,74 @@ int decodeMadocaL6eFilesToProductsReplay(const std::vector<std::string>& files,
     }
     products.addCorrections(corrections);
     return added;
+}
+
+int writeMadocaMaterializationCsv(const libgnss::SSRProducts& products,
+                                  std::ostream& output) {
+    output
+        << "schema_version,sat,system,prn,week,tow,orbit_frame,"
+        << "orbit_valid,clock_valid,code_bias_valid,phase_bias_valid,"
+        << "orbit_week,orbit_tow,clock_week,clock_tow,"
+        << "iode,ssr_orbit_iod,ssr_clock_iod,"
+        << "orbit_radial_m,orbit_along_m,orbit_cross_m,clock_m,"
+        << "code_bias_count,code_biases_m,"
+        << "phase_bias_count,phase_biases_m,phase_bias_discnt\n";
+
+    output << std::setprecision(17);
+    int rows = 0;
+    const char* orbit_frame = products.orbitCorrectionsAreRac() ? "rac" : "ecef";
+    for (const auto& [satellite, corrections] : products.orbit_clock_corrections) {
+        for (const auto& correction : corrections) {
+            output
+                << "madoca_materialization_snapshot.v1,"
+                << satellite.toString() << ','
+                << gnssSystemName(satellite.system) << ','
+                << static_cast<unsigned>(satellite.prn) << ','
+                << correction.time.week << ','
+                << correction.time.tow << ','
+                << orbit_frame << ','
+                << csvBool(correction.orbit_valid) << ','
+                << csvBool(correction.clock_valid) << ','
+                << csvBool(correction.code_bias_valid) << ','
+                << csvBool(correction.phase_bias_valid) << ','
+                << correction.orbit_reference_time.week << ','
+                << correction.orbit_reference_time.tow << ','
+                << correction.clock_reference_time.week << ','
+                << correction.clock_reference_time.tow << ','
+                << correction.iode << ','
+                << correction.ssr_orbit_iod << ','
+                << correction.ssr_clock_iod << ','
+                << correction.orbit_correction_ecef.x() << ','
+                << correction.orbit_correction_ecef.y() << ','
+                << correction.orbit_correction_ecef.z() << ','
+                << correction.clock_correction_m << ','
+                << correction.code_bias_m.size() << ','
+                << joinSignalMapValues(correction.code_bias_m) << ','
+                << correction.phase_bias_m.size() << ','
+                << joinSignalMapValues(correction.phase_bias_m) << ','
+                << joinSignalMapValues(correction.phase_bias_discnt) << '\n';
+            ++rows;
+        }
+    }
+    return rows;
+}
+
+int writeMadocaL6eMaterializationCsv(const std::vector<std::string>& files,
+                                     int gps_week,
+                                     const std::string& output_path,
+                                     bool replay_mode) {
+    libgnss::SSRProducts products;
+    if (replay_mode) {
+        decodeMadocaL6eFilesToProductsReplay(files, gps_week, products);
+    } else {
+        decodeMadocaL6eFilesToProducts(files, gps_week, products);
+    }
+
+    std::ofstream output(output_path);
+    if (!output.is_open()) {
+        return -1;
+    }
+    return writeMadocaMaterializationCsv(products, output);
 }
 
 }  // namespace libgnss::io

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -4031,6 +4031,7 @@ class CLIToolsTest(unittest.TestCase):
         self.assertIn("--madocalib-bridge", result.stdout)
         self.assertIn("--madocalib-l6", result.stdout)
         self.assertIn("--madocalib-mdciono", result.stdout)
+        self.assertIn("--madoca-materialization-dump", result.stdout)
 
     def test_public_rtk_benchmarks_cli_lists_matrix(self) -> None:
         result = self.run_gnss("public-rtk-benchmarks", "--format", "json")
@@ -10489,6 +10490,32 @@ class CLIToolsTest(unittest.TestCase):
             self.assertTrue(output_path.exists())
             self.assertIn("SSR corrections: on", result.stdout)
             self.assertIn("valid solutions: 3", result.stdout)
+
+    def test_ppp_cli_rejects_madoca_materialization_dump_without_l6(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ppp_madoca_materialization_cli_") as temp_dir:
+            temp_root = Path(temp_dir)
+            obs_path, sp3_path, _, _ = build_synthetic_ppp_inputs(temp_root)
+            output_path = temp_root / "ppp.pos"
+            dump_path = temp_root / "madoca_materialization.csv"
+
+            result = self.run_gnss(
+                "ppp",
+                "--static",
+                "--obs",
+                str(obs_path),
+                "--sp3",
+                str(sp3_path),
+                "--madoca-materialization-dump",
+                str(dump_path),
+                "--out",
+                str(output_path),
+                "--max-epochs",
+                "1",
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("--madoca-materialization-dump requires --madoca-l6", result.stderr)
+            self.assertFalse(dump_path.exists())
 
     def test_ppp_cli_reports_applied_atmospheric_corrections_from_sampled_ssr(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ppp_ssr_atmos_cli_") as temp_dir:

--- a/tests/test_madoca_parity.cpp
+++ b/tests/test_madoca_parity.cpp
@@ -15,6 +15,7 @@
 #include <fstream>
 #include <map>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -108,6 +109,44 @@ TEST(MadocaBridgeConfig, AvailabilityMatchesBuildFlag) {
     EXPECT_EQ(libgnss::external::madocalib::runPostpos({}, &error_message), -1);
     EXPECT_NE(error_message.find("MADOCALIB bridge is not linked"), std::string::npos);
 #endif
+}
+
+TEST(MadocaMaterializationDump, WritesStableCsvContract) {
+    libgnss::SSRProducts products;
+    products.setOrbitCorrectionsAreRac(true);
+
+    libgnss::SSROrbitClockCorrection correction;
+    correction.satellite = libgnss::SatelliteId(libgnss::GNSSSystem::GPS, 14);
+    correction.time = libgnss::GNSSTime(2299, 123.5);
+    correction.orbit_reference_time = libgnss::GNSSTime(2299, 120.0);
+    correction.clock_reference_time = libgnss::GNSSTime(2299, 121.0);
+    correction.orbit_valid = true;
+    correction.clock_valid = true;
+    correction.code_bias_valid = true;
+    correction.phase_bias_valid = true;
+    correction.iode = 7;
+    correction.ssr_orbit_iod = 8;
+    correction.ssr_clock_iod = 9;
+    correction.orbit_correction_ecef = libgnss::Vector3d(1.0, 2.0, 3.0);
+    correction.clock_correction_m = 0.25;
+    correction.code_bias_m[9] = 0.125;
+    correction.phase_bias_m[9] = -0.5;
+    correction.phase_bias_discnt[9] = 4;
+    products.addCorrection(correction);
+
+    std::ostringstream csv;
+    const int rows = libgnss::io::writeMadocaMaterializationCsv(products, csv);
+
+    EXPECT_EQ(rows, 1);
+    const std::string text = csv.str();
+    EXPECT_NE(text.find(
+        "schema_version,sat,system,prn,week,tow,orbit_frame,"
+        "orbit_valid,clock_valid,code_bias_valid,phase_bias_valid"),
+        std::string::npos);
+    EXPECT_NE(text.find(
+        "madoca_materialization_snapshot.v1,G14,GPS,14,2299,123.5,rac,"
+        "1,1,1,1,2299,120,2299,121,7,8,9,1,2,3,0.25,1,9:0.125,1,9:-0.5,9:4"),
+        std::string::npos);
 }
 
 #if GNSSPP_HAS_MADOCALIB_ORACLE
@@ -493,6 +532,11 @@ TEST_F(MadocaParity, L6eSnapshotConvertsToSsrProducts) {
     const int added = libgnss::io::madocaL6eSnapshotToProducts(decoder, products);
     EXPECT_GT(added, 0) << "no satellites converted";
     EXPECT_TRUE(products.orbitCorrectionsAreRac());
+    std::ostringstream materialization_csv;
+    EXPECT_GT(libgnss::io::writeMadocaMaterializationCsv(products, materialization_csv), 0);
+    EXPECT_NE(materialization_csv.str().find("madoca_materialization_snapshot.v1"),
+              std::string::npos);
+    EXPECT_NE(materialization_csv.str().find(",rac,"), std::string::npos);
 
     auto sysmap = [](int s) {
         switch (s) {


### PR DESCRIPTION
## Summary

Adds a solver-neutral MADOCA L6E materialization snapshot boundary before PPP processing.

- Adds `gnss ppp --madoca-materialization-dump <csv>` alongside `--madoca-l6`.
- Dumps the native `SSRProducts` view after L6E decoder conversion and before PPP row/state processing.
- Records schema `madoca_materialization_snapshot.v1` with satellite identity, correction/reference epochs, IODs, RAC orbit, clock, code/phase bias ids and values, and phase-bias discontinuity counters.
- Leaves solver behavior unchanged when the option is omitted and keeps MADOCALIB out of production targets.

## Why

MADOCA migration needs a stable M3 boundary between decoded L6E content and solver row construction. This artifact makes materialization identity/time/IOD mistakes visible before residual, state/covariance, or AR tuning.

## Validation

- `python3 -m py_compile tests/test_cli_tools.py tests/test_cli_ux.py`
- `python3 tests/test_cli_ux.py`
- `python3 tests/test_cli_tools.py -k madoca_materialization`
- `cmake --build build --target run_tests -j4`
- `ctest --test-dir build -R '^run_tests$' --output-on-failure`
- `ctest --test-dir build -L core --output-on-failure`
- `bash scripts/ci/run_hygiene.sh`
- `git diff --check`
