### PR TITLE
[codex] ci madoca materialization diff signoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -362,6 +362,26 @@ jobs:
           output/clas_a4b_native_selfdiff/selfdiff.csv
         if-no-files-found: error
 
+    - name: Optional MADOCA materialization diff
+      env:
+        GNSSPP_MADOCA_MATERIALIZATION_BASE_CSV: ${{ vars.GNSSPP_MADOCA_MATERIALIZATION_BASE_CSV }}
+        GNSSPP_MADOCA_MATERIALIZATION_CANDIDATE_CSV: ${{ vars.GNSSPP_MADOCA_MATERIALIZATION_CANDIDATE_CSV }}
+        GNSSPP_MADOCA_MATERIALIZATION_NUMERIC_THRESHOLD: ${{ vars.GNSSPP_MADOCA_MATERIALIZATION_NUMERIC_THRESHOLD }}
+        GNSSPP_MADOCA_MATERIALIZATION_FAIL_ON_DIFF: ${{ vars.GNSSPP_MADOCA_MATERIALIZATION_FAIL_ON_DIFF }}
+      run: bash scripts/ci/run_optional_madoca_materialization_diff.sh
+
+    - name: Upload MADOCA materialization diff artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: madoca-materialization-diff-ubuntu
+        path: |
+          output/ci_optional_madoca_materialization_summary.json
+          output/ci_optional_madoca_materialization/*.log
+          output/madoca_materialization_diff.json
+          output/madoca_materialization_diff.csv
+        if-no-files-found: error
+
     - name: Optional MADOCA residual-component diff
       env:
         GNSSPP_MADOCA_RESIDUAL_BASE_CSV: ${{ vars.GNSSPP_MADOCA_RESIDUAL_BASE_CSV }}

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -50,9 +50,10 @@ CI lanes are split as follows:
   with JSON/log artifacts under `output/ci_optional_rtk_signoffs*`; the summary
   uses `summary_schema: ci_optional_rtk_signoffs.v1` and a passed step fails the
   lane if any declared output artifact is missing
-- `bash scripts/ci/run_optional_clas_zd_component_diff.sh` and
+- `bash scripts/ci/run_optional_clas_zd_component_diff.sh`,
+  `bash scripts/ci/run_optional_madoca_materialization_diff.sh`, and
   `bash scripts/ci/run_optional_madoca_residual_component_diff.sh` for
-  oracle/native diff artifacts; both report `blocked_infrastructure` with
+  oracle/native diff artifacts; they report `blocked_infrastructure` with
   next actions when their CSV inputs are unavailable, require a summary/log
   artifact in CI, and fail a passed diff command if the declared JSON/CSV
   artifacts are missing

--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -67,6 +67,18 @@ row key, reports reference-time/IOD/bias-identity differences as discrete
 mismatches, and reports orbit/clock/code-bias/phase-bias value differences as
 numeric deltas.
 
+The optional CI wrapper
+`scripts/ci/run_optional_madoca_materialization_diff.py` runs that diff when
+`GNSSPP_MADOCA_MATERIALIZATION_BASE_CSV` and
+`GNSSPP_MADOCA_MATERIALIZATION_CANDIDATE_CSV` point at generated oracle/native
+materialization snapshots.  It writes
+`ci_optional_madoca_materialization_summary.json`, a log, and
+`madoca_materialization_diff.{json,csv}` artifacts; absent inputs are reported as
+`status: blocked_infrastructure` rather than a passing sign-off.  Use
+`GNSSPP_MADOCA_MATERIALIZATION_NUMERIC_THRESHOLD` to set a numeric tolerance and
+`GNSSPP_MADOCA_MATERIALIZATION_FAIL_ON_DIFF=1` when the configured window should
+act as a hard oracle gate.
+
 Residual-component parity artifact: use
 `scripts/analysis/madoca_residual_component_diff.py` after satellite-set and
 row-set parity are understood.  It compares only common residual rows, keyed by

--- a/scripts/ci/optional_diff_runner.py
+++ b/scripts/ci/optional_diff_runner.py
@@ -43,6 +43,7 @@ class DiffRunnerConfig:
     log_dir_name: str
     per_component_max_key: str
     extra_options: tuple[EnvOption, ...] = ()
+    component_flag: str | None = "--component"
 
 
 @dataclass(frozen=True)
@@ -222,8 +223,9 @@ def make_step(config: DiffRunnerConfig, context: DiffContext) -> DiffStep:
         "--details-csv",
         str(details_csv),
     ]
-    for component in context.components:
-        command.extend(["--component", component])
+    if config.component_flag is not None:
+        for component in context.components:
+            command.extend([config.component_flag, component])
     for flag, value in context.option_values.items():
         command.extend([flag, value])
     if context.fail_on_diff:
@@ -267,8 +269,13 @@ def load_diff_metrics(config: DiffRunnerConfig, report_json: Path) -> dict[str, 
         "common_rows",
         "base_only_rows",
         "candidate_only_rows",
+        "base_duplicate_keys",
+        "candidate_duplicate_keys",
         "components_compared",
+        "numeric_components_compared",
+        "discrete_mismatches",
         "threshold_exceedances",
+        "numeric_threshold_exceedances",
         "row_set_complete",
         "sat_filter",
         "freq_filter",
@@ -277,7 +284,13 @@ def load_diff_metrics(config: DiffRunnerConfig, report_json: Path) -> dict[str, 
     ]:
         if key in payload:
             metrics[key] = payload[key]
+    if "components_compared" not in metrics and "numeric_components_compared" in payload:
+        metrics["components_compared"] = payload["numeric_components_compared"]
+    if "threshold_exceedances" not in metrics and "numeric_threshold_exceedances" in payload:
+        metrics["threshold_exceedances"] = payload["numeric_threshold_exceedances"]
     per_component = payload.get("per_component")
+    if not isinstance(per_component, list):
+        per_component = payload.get("per_numeric_component")
     if isinstance(per_component, list):
         max_abs_delta = 0.0
         for item in per_component:
@@ -433,6 +446,13 @@ def render_result_detail(result: dict[str, object]) -> str:
         threshold_exceedances = metrics.get("threshold_exceedances")
         if threshold_exceedances is not None:
             detail_parts.append(f"threshold exceedances `{threshold_exceedances}`")
+        discrete_mismatches = metrics.get("discrete_mismatches")
+        if discrete_mismatches is not None:
+            detail_parts.append(f"discrete mismatches `{discrete_mismatches}`")
+        base_duplicates = metrics.get("base_duplicate_keys")
+        candidate_duplicates = metrics.get("candidate_duplicate_keys")
+        if base_duplicates is not None or candidate_duplicates is not None:
+            detail_parts.append(f"duplicate keys `{base_duplicates}/{candidate_duplicates}`")
         native_l2w_rows = metrics.get("identity_native_gps_l2w_rows")
         if native_l2w_rows is not None:
             detail_parts.append(f"native L2W `{native_l2w_rows}`")

--- a/scripts/ci/run_optional_madoca_materialization_diff.py
+++ b/scripts/ci/run_optional_madoca_materialization_diff.py
@@ -1,0 +1,88 @@
+#!/usr/bin/env python3
+"""Run optional MADOCA materialization diff and persist a CI summary."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import sys
+from typing import Mapping
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import optional_diff_runner as runner  # noqa: E402
+
+
+SUMMARY_SCHEMA = "ci_optional_madoca_materialization_diff.v1"
+
+CONFIG = runner.DiffRunnerConfig(
+    summary_schema=SUMMARY_SCHEMA,
+    name="MADOCA materialization diff",
+    markdown_title="Optional MADOCA Materialization Diff",
+    slug="madoca_materialization_diff",
+    analysis_script="madoca_materialization_diff.py",
+    base_label="madocalib",
+    candidate_label="native",
+    base_env="GNSSPP_MADOCA_MATERIALIZATION_BASE_CSV",
+    candidate_envs=(
+        "GNSSPP_MADOCA_MATERIALIZATION_CANDIDATE_CSV",
+        "GNSSPP_MADOCA_MATERIALIZATION_NATIVE_CSV",
+    ),
+    components_env="GNSSPP_MADOCA_MATERIALIZATION_COMPONENTS",
+    fail_on_diff_env="GNSSPP_MADOCA_MATERIALIZATION_FAIL_ON_DIFF",
+    default_components=(),
+    skip_subject="MADOCA materialization",
+    base_missing_label="base materialization CSV",
+    candidate_missing_label="candidate materialization CSV",
+    summary_filename="ci_optional_madoca_materialization_summary.json",
+    log_dir_name="ci_optional_madoca_materialization",
+    per_component_max_key="max_abs_delta",
+    component_flag=None,
+    extra_options=(
+        runner.EnvOption(
+            (
+                "GNSSPP_MADOCA_MATERIALIZATION_NUMERIC_THRESHOLD",
+                "GNSSPP_MADOCA_MATERIALIZATION_THRESHOLD",
+            ),
+            "--numeric-threshold",
+            "float",
+        ),
+    ),
+)
+
+
+DiffStep = runner.DiffStep
+
+
+def repo_root_from_script() -> Path:
+    return runner.repo_root_from_script()
+
+
+def build_step_plan(
+    repo_root: Path,
+    output_dir: Path,
+    environ: Mapping[str, str],
+    *,
+    python_executable: str = sys.executable,
+) -> list[DiffStep]:
+    return runner.build_step_plan(CONFIG, repo_root, output_dir, environ, python_executable=python_executable)
+
+
+def run_step(step: DiffStep, repo_root: Path, log_dir: Path) -> dict[str, object]:
+    return runner.run_step(CONFIG, step, repo_root, log_dir)
+
+
+def render_markdown_summary(results: list[dict[str, object]]) -> str:
+    return runner.render_markdown_summary(CONFIG, results)
+
+
+def write_summary(summary_path: Path, steps: list[DiffStep], results: list[dict[str, object]]) -> None:
+    runner.write_summary(CONFIG, summary_path, steps, results)
+
+
+def main() -> int:
+    return runner.main(CONFIG)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/run_optional_madoca_materialization_diff.sh
+++ b/scripts/ci/run_optional_madoca_materialization_diff.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+exec python3 "${repo_root}/scripts/ci/run_optional_madoca_materialization_diff.py" "$@"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -114,6 +114,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_optional_madoca_residual_component_diff.py
     )
     add_test(
+        NAME python_optional_madoca_materialization_diff_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_optional_madoca_materialization_diff.py
+    )
+    add_test(
         NAME python_clas_zd_component_diff_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_clas_zd_component_diff.py
     )
@@ -275,6 +279,7 @@ if(GTest_FOUND)
         python_madoca_solution_diff_tests
         python_madoca_satellite_set_diff_tests
         python_mode_compare_tests
+        python_optional_madoca_materialization_diff_tests
         python_optional_madoca_residual_component_diff_tests
         python_ppp_residual_row_set_diff_tests
         python_spp_residual_dump_summary_tests

--- a/tests/test_optional_madoca_materialization_diff.py
+++ b/tests/test_optional_madoca_materialization_diff.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Tests for the optional MADOCA materialization CI runner."""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT_DIR / "scripts" / "ci" / "run_optional_madoca_materialization_diff.py"
+
+spec = importlib.util.spec_from_file_location("run_optional_madoca_materialization_diff", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+runner = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = runner
+spec.loader.exec_module(runner)
+
+
+FIELDNAMES = [
+    "schema_version",
+    "sat",
+    "system",
+    "prn",
+    "week",
+    "tow",
+    "orbit_frame",
+    "orbit_valid",
+    "clock_valid",
+    "code_bias_valid",
+    "phase_bias_valid",
+    "orbit_week",
+    "orbit_tow",
+    "clock_week",
+    "clock_tow",
+    "iode",
+    "ssr_orbit_iod",
+    "ssr_clock_iod",
+    "orbit_radial_m",
+    "orbit_along_m",
+    "orbit_cross_m",
+    "clock_m",
+    "code_bias_count",
+    "code_biases_m",
+    "phase_bias_count",
+    "phase_biases_m",
+    "phase_bias_discnt",
+]
+
+
+def materialization_row(*, clock_m: str = "0.200", iode: str = "7") -> dict[str, str]:
+    return {
+        "schema_version": "madoca_materialization_snapshot.v1",
+        "sat": "G14",
+        "system": "GPS",
+        "prn": "14",
+        "week": "2299",
+        "tow": "123.500",
+        "orbit_frame": "rac",
+        "orbit_valid": "1",
+        "clock_valid": "1",
+        "code_bias_valid": "1",
+        "phase_bias_valid": "1",
+        "orbit_week": "2299",
+        "orbit_tow": "120.000",
+        "clock_week": "2299",
+        "clock_tow": "123.000",
+        "iode": iode,
+        "ssr_orbit_iod": "11",
+        "ssr_clock_iod": "12",
+        "orbit_radial_m": "0.100",
+        "orbit_along_m": "-0.300",
+        "orbit_cross_m": "0.400",
+        "clock_m": clock_m,
+        "code_bias_count": "1",
+        "code_biases_m": "3:0.250",
+        "phase_bias_count": "1",
+        "phase_biases_m": "3:-0.125",
+        "phase_bias_discnt": "3:0",
+    }
+
+
+def write_materialization_csv(path: Path, *, clock_m: str = "0.200", iode: str = "7") -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
+        writer.writeheader()
+        writer.writerow(materialization_row(clock_m=clock_m, iode=iode))
+
+
+class OptionalMadocaMaterializationDiffTest(unittest.TestCase):
+    def test_build_step_plan_blocks_when_inputs_are_missing(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_materialization_skip_") as temp_dir:
+            output_dir = Path(temp_dir) / "output"
+
+            steps = runner.build_step_plan(ROOT_DIR, output_dir, {})
+
+            self.assertEqual([step.slug for step in steps], ["madoca_materialization_diff"])
+            self.assertIsNone(steps[0].command)
+            self.assertIsNotNone(steps[0].skip_reason)
+            self.assertIn("MADOCA materialization input is unavailable", steps[0].skip_reason)
+
+    def test_run_step_records_blocked_infrastructure_artifacts(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_materialization_blocked_") as temp_dir:
+            output_dir = Path(temp_dir) / "output"
+            log_dir = output_dir / "logs"
+            log_dir.mkdir(parents=True)
+            step = runner.build_step_plan(ROOT_DIR, output_dir, {})[0]
+
+            result = runner.run_step(step, ROOT_DIR, log_dir)
+
+            self.assertEqual(result["status"], "blocked_infrastructure")
+            self.assertIn("MADOCA materialization input is unavailable", result["block_reason"])
+            artifacts = result["artifacts"]
+            log_artifact = artifacts[0]
+            self.assertEqual(log_artifact["role"], "log")
+            self.assertTrue(log_artifact["required"])
+            self.assertTrue(log_artifact["exists"])
+            self.assertGreater(log_artifact["bytes"], 0)
+            self.assertTrue(str(log_artifact["sha256"]))
+
+    def test_build_step_plan_uses_configured_inputs_and_threshold(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_materialization_plan_") as temp_dir:
+            root = Path(temp_dir)
+            base_csv = root / "madocalib.csv"
+            candidate_csv = root / "native.csv"
+            write_materialization_csv(base_csv)
+            write_materialization_csv(candidate_csv)
+            output_dir = root / "output"
+            env = {
+                "GNSSPP_MADOCA_MATERIALIZATION_BASE_CSV": str(base_csv),
+                "GNSSPP_MADOCA_MATERIALIZATION_CANDIDATE_CSV": str(candidate_csv),
+                "GNSSPP_MADOCA_MATERIALIZATION_COMPONENTS": "clock_m",
+                "GNSSPP_MADOCA_MATERIALIZATION_THRESHOLD": "0.25",
+                "GNSSPP_MADOCA_MATERIALIZATION_FAIL_ON_DIFF": "1",
+            }
+
+            steps = runner.build_step_plan(ROOT_DIR, output_dir, env)
+
+            command = steps[0].command
+            self.assertIsNotNone(command)
+            assert command is not None
+            self.assertIn(str(SCRIPT_PATH.parent.parent / "analysis" / "madoca_materialization_diff.py"), command)
+            self.assertIn(str(base_csv), command)
+            self.assertIn(str(candidate_csv), command)
+            self.assertIn("--numeric-threshold", command)
+            self.assertIn("0.25", command)
+            self.assertIn("--fail-on-diff", command)
+            self.assertNotIn("--component", command)
+            self.assertIn(str(output_dir / "madoca_materialization_diff.json"), command)
+
+    def test_run_step_collects_materialization_metrics(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_materialization_exec_") as temp_dir:
+            root = Path(temp_dir)
+            base_csv = root / "madocalib.csv"
+            candidate_csv = root / "native.csv"
+            write_materialization_csv(base_csv, clock_m="0.200")
+            write_materialization_csv(candidate_csv, clock_m="0.275")
+            output_dir = root / "output"
+            log_dir = output_dir / "logs"
+            log_dir.mkdir(parents=True)
+            env = {
+                "GNSSPP_MADOCA_MATERIALIZATION_BASE_CSV": str(base_csv),
+                "GNSSPP_MADOCA_MATERIALIZATION_CANDIDATE_CSV": str(candidate_csv),
+            }
+            step = runner.build_step_plan(ROOT_DIR, output_dir, env)[0]
+
+            result = runner.run_step(step, ROOT_DIR, log_dir)
+
+            self.assertEqual(result["status"], "passed")
+            self.assertEqual(result["returncode"], 0)
+            metrics = result["metrics"]
+            self.assertEqual(metrics["schema"], "madoca_materialization_diff.v1")
+            self.assertEqual(metrics["common_rows"], 1)
+            self.assertEqual(metrics["components_compared"], 6)
+            self.assertEqual(metrics["threshold_exceedances"], 0)
+            self.assertEqual(metrics["discrete_mismatches"], 0)
+            self.assertAlmostEqual(metrics["max_abs_delta"], 0.075)
+
+    def test_run_step_reports_discrete_mismatches(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_materialization_discrete_") as temp_dir:
+            root = Path(temp_dir)
+            base_csv = root / "madocalib.csv"
+            candidate_csv = root / "native.csv"
+            write_materialization_csv(base_csv, iode="7")
+            write_materialization_csv(candidate_csv, iode="8")
+            output_dir = root / "output"
+            log_dir = output_dir / "logs"
+            log_dir.mkdir(parents=True)
+            env = {
+                "GNSSPP_MADOCA_MATERIALIZATION_BASE_CSV": str(base_csv),
+                "GNSSPP_MADOCA_MATERIALIZATION_CANDIDATE_CSV": str(candidate_csv),
+            }
+            step = runner.build_step_plan(ROOT_DIR, output_dir, env)[0]
+
+            result = runner.run_step(step, ROOT_DIR, log_dir)
+
+            self.assertEqual(result["status"], "passed")
+            self.assertEqual(result["metrics"]["discrete_mismatches"], 1)
+
+    def test_run_step_fails_when_declared_outputs_are_missing(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_materialization_missing_") as temp_dir:
+            root = Path(temp_dir)
+            output_dir = root / "output"
+            log_dir = output_dir / "logs"
+            log_dir.mkdir(parents=True)
+            missing_json = output_dir / "madoca_materialization_diff.json"
+            step = runner.DiffStep(
+                name="MADOCA materialization diff",
+                slug="madoca_materialization_diff",
+                command=[sys.executable, "-c", "print('no artifacts')"],
+                outputs=[str(missing_json)],
+                summary_json=str(output_dir / "madoca_materialization_diff_summary.json"),
+            )
+
+            result = runner.run_step(step, ROOT_DIR, log_dir)
+
+            self.assertEqual(result["status"], "failed")
+            self.assertEqual(result["returncode"], 0)
+            self.assertEqual(result["missing_outputs"], [str(missing_json)])
+
+    def test_render_markdown_summary_reports_materialization_metrics(self) -> None:
+        markdown = runner.render_markdown_summary(
+            [
+                {
+                    "name": "MADOCA materialization diff",
+                    "status": "passed",
+                    "elapsed_s": 0.5,
+                    "metrics": {
+                        "common_rows": 12,
+                        "base_only_rows": 1,
+                        "candidate_only_rows": 2,
+                        "components_compared": 72,
+                        "max_abs_delta": 0.125,
+                        "threshold_exceedances": 3,
+                        "discrete_mismatches": 4,
+                        "base_duplicate_keys": 0,
+                        "candidate_duplicate_keys": 1,
+                    },
+                },
+                {
+                    "name": "MADOCA materialization diff",
+                    "status": "blocked_infrastructure",
+                    "block_reason": "MADOCA materialization input is unavailable.",
+                },
+            ]
+        )
+
+        self.assertIn("## Optional MADOCA Materialization Diff", markdown)
+        self.assertIn("`passed`: `1`", markdown)
+        self.assertIn("`blocked_infrastructure`: `1`", markdown)
+        self.assertIn("common rows `12`", markdown)
+        self.assertIn("unmatched `1/2`", markdown)
+        self.assertIn("components `72`", markdown)
+        self.assertIn("max |delta| 0.125", markdown)
+        self.assertIn("threshold exceedances `3`", markdown)
+        self.assertIn("discrete mismatches `4`", markdown)
+        self.assertIn("duplicate keys `0/1`", markdown)
+
+    def test_write_summary_declares_schema(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_materialization_summary_") as temp_dir:
+            summary_path = Path(temp_dir) / "summary.json"
+            steps = runner.build_step_plan(ROOT_DIR, Path(temp_dir) / "output", {})
+            results = [
+                {
+                    "name": steps[0].name,
+                    "slug": steps[0].slug,
+                    "status": "blocked_infrastructure",
+                    "block_reason": steps[0].skip_reason,
+                    "outputs": steps[0].outputs,
+                    "summary_json": steps[0].summary_json,
+                    "log_path": str(Path(temp_dir) / "madoca_materialization_diff.log"),
+                }
+            ]
+
+            runner.write_summary(summary_path, steps, results)
+
+            payload = json.loads(summary_path.read_text(encoding="utf-8"))
+            self.assertEqual(payload["summary_schema"], runner.SUMMARY_SCHEMA)
+            self.assertEqual(payload["contract"], "optional_diff_artifact_contract.v1")
+            self.assertEqual(payload["status"], "blocked_infrastructure")
+            self.assertIn("missing evidence", payload["next_actions"][1])
+            self.assertEqual(payload["counts"]["blocked_infrastructure"], 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds an optional CI/sign-off wrapper for the MADOCA materialization diff introduced in #236.

- Adds `scripts/ci/run_optional_madoca_materialization_diff.py` and shell entrypoint.
- Uploads required summary/log/JSON/CSV artifacts from the optional sign-off lane.
- Reuses the optional diff artifact contract with `blocked_infrastructure` when oracle/native materialization CSV inputs are absent.
- Extends optional diff metrics to summarize materialization-specific numeric/discrete mismatch counts.
- Registers focused CTest coverage and documents the new MADOCA M3 sign-off hook.

## Why

This connects the native MADOCA materialization dump and diff tool to the remote artifact contract, so M3 correction-materialization parity can be collected before row-set, residual, state/covariance, or AR changes.

## Validation

- `python3 -m py_compile scripts/ci/optional_diff_runner.py scripts/ci/run_optional_madoca_materialization_diff.py tests/test_optional_madoca_materialization_diff.py`
- `python3 tests/test_optional_madoca_materialization_diff.py`
- `python3 tests/test_optional_madoca_residual_component_diff.py && python3 tests/test_optional_clas_zd_component_diff.py`
- `cmake --build build --target run_tests -j4`
- `git diff --check`
- `ctest --test-dir build -R 'python_optional_madoca_materialization_diff_tests|python_optional_madoca_residual_component_diff_tests|python_optional_clas_zd_component_diff_tests' --output-on-failure`
- `bash scripts/ci/run_optional_madoca_materialization_diff.sh --output-dir /tmp/gnsspp_madoca_materialization_optional_smoke --summary-json /tmp/gnsspp_madoca_materialization_optional_smoke/summary.json`
- `bash scripts/ci/run_hygiene.sh`
- `ctest --test-dir build -L core --output-on-failure`

Note: `bash scripts/ci/run_optional_tests.sh` reaches the pre-existing `python_cli_tests` ROS2/MCAP assertion locally because this environment has an MCAP reader and reports an MCAP read warning instead of `mcap reader unavailable`. That path is unrelated to this PR; remote CI remains the merge gate.
