### PR TITLE
madoca: add materialization dump-only self-diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,6 +382,30 @@ jobs:
           output/madoca_materialization_diff.csv
         if-no-files-found: error
 
+    - name: MADOCA materialization native self-diff
+      env:
+        GNSSPP_MADOCA_MATERIALIZATION_DATA_ROOT: ${{ vars.GNSSPP_MADOCA_MATERIALIZATION_DATA_ROOT }}
+        GNSSPP_MADOCA_MATERIALIZATION_AUTO_FETCH: ${{ vars.GNSSPP_MADOCA_MATERIALIZATION_AUTO_FETCH }}
+        GNSSPP_MADOCA_MATERIALIZATION_MADOCALIB_REPO: ${{ vars.GNSSPP_MADOCA_MATERIALIZATION_MADOCALIB_REPO }}
+        GNSSPP_MADOCA_MATERIALIZATION_MADOCALIB_REF: ${{ vars.GNSSPP_MADOCA_MATERIALIZATION_MADOCALIB_REF }}
+        GNSSPP_MADOCA_MATERIALIZATION_ROWS_MIN: ${{ vars.GNSSPP_MADOCA_MATERIALIZATION_ROWS_MIN }}
+        GNSSPP_MADOCA_MATERIALIZATION_FAIL_ON_BLOCKED: ${{ vars.GNSSPP_MADOCA_MATERIALIZATION_FAIL_ON_BLOCKED }}
+      run: python3 scripts/ci/run_madoca_materialization_selfdiff.py
+
+    - name: Upload MADOCA materialization native self-diff artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: madoca-materialization-selfdiff-ubuntu
+        path: |
+          output/ci_madoca_materialization_selfdiff_summary.json
+          output/ci_madoca_materialization_selfdiff/*.log
+          output/madoca_materialization_selfdiff/native_materialization.csv
+          output/madoca_materialization_selfdiff/native_summary.json
+          output/madoca_materialization_selfdiff/selfdiff.json
+          output/madoca_materialization_selfdiff/selfdiff.csv
+        if-no-files-found: error
+
     - name: Optional MADOCA residual-component diff
       env:
         GNSSPP_MADOCA_RESIDUAL_BASE_CSV: ${{ vars.GNSSPP_MADOCA_RESIDUAL_BASE_CSV }}

--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -26,6 +26,7 @@ struct Options {
     std::string ssr_rtcm_path;
     std::vector<std::string> madoca_l6_paths;
     std::string madoca_materialization_dump_path;
+    bool madoca_materialization_dump_only = false;
     std::string ionex_path;
     std::string dcb_path;
     std::string antex_path;
@@ -94,6 +95,9 @@ void printUsage(const char* program_name) {
         << "  --madoca-materialization-dump <csv>\n"
         << "                          Dump native MADOCA L6E SSRProducts materialization\n"
         << "                          rows before PPP processing\n"
+        << "  --madoca-materialization-dump-only\n"
+        << "                          Exit after writing --madoca-materialization-dump;\n"
+        << "                          useful for correction-materialization sign-off\n"
         << "  --ionex <maps.ionex>     Optional IONEX TEC map product\n"
         << "  --dcb <bias.bsx>         Optional DCB / Bias-SINEX product\n"
         << "  --antex <antennas.atx>   Optional ANTEX file for receiver antenna PCO\n"
@@ -247,6 +251,8 @@ Options parseArguments(int argc, char* argv[]) {
             options.madoca_l6_paths.push_back(argv[++i]);
         } else if (arg == "--madoca-materialization-dump" && i + 1 < argc) {
             options.madoca_materialization_dump_path = argv[++i];
+        } else if (arg == "--madoca-materialization-dump-only") {
+            options.madoca_materialization_dump_only = true;
         } else if (arg == "--ionex" && i + 1 < argc) {
             options.ionex_path = argv[++i];
         } else if (arg == "--dcb" && i + 1 < argc) {
@@ -381,8 +387,14 @@ Options parseArguments(int argc, char* argv[]) {
     if (options.obs_path.empty()) {
         argumentError("--obs is required", argv[0]);
     }
-    if (options.out_path.empty()) {
+    if (options.out_path.empty() && !options.madoca_materialization_dump_only) {
         argumentError("--out is required", argv[0]);
+    }
+    if (options.madoca_materialization_dump_only &&
+        options.madoca_materialization_dump_path.empty()) {
+        argumentError(
+            "--madoca-materialization-dump-only requires --madoca-materialization-dump",
+            argv[0]);
     }
     if (options.nav_path.empty() && options.sp3_path.empty()) {
         argumentError("provide at least one of --nav or --sp3", argv[0]);
@@ -934,6 +946,44 @@ int main(int argc, char* argv[]) {
             if (rows == 0) {
                 std::cerr << "Error: MADOCA materialization dump produced no rows\n";
                 return 1;
+            }
+            if (options.madoca_materialization_dump_only) {
+                if (!options.summary_json_path.empty()) {
+                    const std::filesystem::path summary_path(options.summary_json_path);
+                    if (!summary_path.parent_path().empty()) {
+                        std::filesystem::create_directories(summary_path.parent_path());
+                    }
+                    std::ofstream summary(summary_path);
+                    if (!summary.is_open()) {
+                        std::cerr << "Error: failed to write summary JSON: "
+                                  << options.summary_json_path << "\n";
+                        return 1;
+                    }
+                    summary << "{\n"
+                            << "  \"obs\": \"" << jsonEscape(options.obs_path) << "\",\n"
+                            << "  \"nav\": \"" << jsonEscape(options.nav_path) << "\",\n"
+                            << "  \"madoca_materialization_dump\": \""
+                            << jsonEscape(options.madoca_materialization_dump_path) << "\",\n"
+                            << "  \"madoca_materialization_dump_only\": true,\n"
+                            << "  \"madoca_materialization_rows\": " << rows << ",\n"
+                            << "  \"madoca_l6_inputs\": [";
+                    bool first_l6 = true;
+                    for (const std::string& l6_path : options.madoca_l6_paths) {
+                        if (!first_l6) {
+                            summary << ", ";
+                        }
+                        summary << "\"" << jsonEscape(l6_path) << "\"";
+                        first_l6 = false;
+                    }
+                    summary << "]\n"
+                            << "}\n";
+                }
+                if (!options.quiet) {
+                    std::cout << "MADOCA materialization dump written.\n";
+                    std::cout << "  rows: " << rows << "\n";
+                    std::cout << "  output: " << options.madoca_materialization_dump_path << "\n";
+                }
+                return 0;
             }
         }
         ppp_config.approximate_position = obs_header.approximate_position;

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -61,6 +61,11 @@ CI lanes are split as follows:
   native-side evidence bundle; it sparse-fetches CLASLIB public data unless
   `GNSSPP_CLAS_A4B_DATA_ROOT` is supplied, generates the native code dump, and
   self-diffs the `G14/C2W` rows before any oracle-backed model change
+- `python3 scripts/ci/run_madoca_materialization_selfdiff.py` for the public
+  MADOCA materialization evidence bundle; it sparse-fetches pinned MADOCALIB
+  BRDM/L6 sample files unless `GNSSPP_MADOCA_MATERIALIZATION_DATA_ROOT` is
+  supplied, runs `gnss_ppp --madoca-materialization-dump-only`, and self-diffs
+  the native M3 materialization CSV before residual/state/AR changes
 - `bash scripts/ci/generate_dashboard_artifacts.sh` plus
   `python3 scripts/ci/validate_artifact_manifest_contract.py output/artifact_manifest.json`
   for the dashboard/manifest artifact path used in CI; the validator requires

--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -48,7 +48,10 @@ Open MADOCA levers (measured, none yet a default win): PPP-AR parity
 
 Correction-materialization snapshot: use
 `gnss ppp --madoca-l6 <file> --madoca-materialization-dump <csv>` to record the
-native SSRProducts view before PPP processing.  The CSV schema is
+native SSRProducts view before PPP processing.  Add
+`--madoca-materialization-dump-only` when the sign-off should stop after the
+snapshot instead of requiring a valid PPP solution from the bounded fixture.  The
+CSV schema is
 `madoca_materialization_snapshot.v1` and records satellite key, system/PRN,
 correction epoch, orbit/clock reference epochs, IODE/SSR IOD, RAC orbit,
 clock, code-bias ids/values, phase-bias ids/values, and discontinuity counters.
@@ -78,6 +81,18 @@ materialization snapshots.  It writes
 `GNSSPP_MADOCA_MATERIALIZATION_NUMERIC_THRESHOLD` to set a numeric tolerance and
 `GNSSPP_MADOCA_MATERIALIZATION_FAIL_ON_DIFF=1` when the configured window should
 act as a hard oracle gate.
+
+The public native self-diff runner
+`scripts/ci/run_madoca_materialization_selfdiff.py` sparse-fetches pinned
+MADOCALIB sample BRDM/L6 files unless
+`GNSSPP_MADOCA_MATERIALIZATION_DATA_ROOT` is supplied, generates a native
+materialization dump with `--madoca-materialization-dump-only`, and compares that
+CSV against itself.  It writes
+`ci_madoca_materialization_selfdiff_summary.json`, a log, the native dump,
+native dump-only summary, and `selfdiff.{json,csv}`.  This is not oracle parity;
+it is a remote-CI evidence contract that proves the native M3 dump can be
+regenerated from public data before model-change PRs start consuming oracle
+materialization rows.
 
 Residual-component parity artifact: use
 `scripts/analysis/madoca_residual_component_diff.py` after satellite-set and

--- a/scripts/ci/run_madoca_materialization_selfdiff.py
+++ b/scripts/ci/run_madoca_materialization_selfdiff.py
@@ -1,0 +1,421 @@
+#!/usr/bin/env python3
+"""Generate a public MADOCA materialization dump and self-diff it in CI."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import time
+from typing import Mapping, Sequence
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from optional_diff_runner import artifact_record, truthy  # noqa: E402
+
+
+SUMMARY_SCHEMA = "ci_madoca_materialization_selfdiff.v1"
+CONTRACT = "madoca_materialization_selfdiff.v1"
+DEFAULT_MADOCALIB_REPO = "https://github.com/QZSS-Strategy-Office/madocalib.git"
+DEFAULT_MADOCALIB_REF = "0089f7dc97e8e2ba283a40be2edf4b73a140df6c"
+DEFAULT_MIN_ROWS = 1000
+REQUIRED_DATA_FILES = (
+    "sample_data/data/rinex/BRDM00DLR_S_20250910000_01D_MN.rnx",
+    "sample_data/data/l6/2025/091/2025091A.204.l6",
+)
+TINY_OBS_TEXT = """\
+     3.04           OBSERVATION DATA    M                   RINEX VERSION / TYPE
+GNSSPP              CI                  20250620 000000 UTC PGM / RUN BY / DATE
+  2025     4     1     0     0    0.0000000     GPS         TIME OF FIRST OBS
+                                                            END OF HEADER
+"""
+
+
+@dataclass(frozen=True)
+class RunPaths:
+    output_dir: Path
+    work_dir: Path
+    log_path: Path
+    summary_json: Path
+    checkout_dir: Path
+    tiny_obs: Path
+    native_dump: Path
+    native_summary_json: Path
+    selfdiff_json: Path
+    selfdiff_csv: Path
+
+
+@dataclass(frozen=True)
+class RunConfig:
+    repo_root: Path
+    output_dir: Path
+    data_root: Path | None
+    auto_fetch: bool
+    fail_on_blocked: bool
+    madocalib_repo: str
+    madocalib_ref: str
+    min_rows: int
+    python_executable: str
+
+
+@dataclass(frozen=True)
+class Evaluation:
+    status: str
+    failures: list[str]
+    metrics: dict[str, object]
+
+
+def repo_root_from_script() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def default_paths(output_dir: Path) -> RunPaths:
+    work_dir = output_dir / "madoca_materialization_selfdiff"
+    return RunPaths(
+        output_dir=output_dir,
+        work_dir=work_dir,
+        log_path=output_dir / "ci_madoca_materialization_selfdiff" / "madoca_materialization_selfdiff.log",
+        summary_json=output_dir / "ci_madoca_materialization_selfdiff_summary.json",
+        checkout_dir=work_dir / "madocalib",
+        tiny_obs=work_dir / "tiny.obs",
+        native_dump=work_dir / "native_materialization.csv",
+        native_summary_json=work_dir / "native_summary.json",
+        selfdiff_json=work_dir / "selfdiff.json",
+        selfdiff_csv=work_dir / "selfdiff.csv",
+    )
+
+
+def resolve_optional_path(repo_root: Path, value: str) -> Path | None:
+    text = value.strip()
+    if not text:
+        return None
+    path = Path(text)
+    return path if path.is_absolute() else repo_root / path
+
+
+def env_or(environ: Mapping[str, str], name: str, default: str) -> str:
+    value = environ.get(name, "").strip()
+    return value if value else default
+
+
+def parse_config(args: argparse.Namespace, environ: Mapping[str, str]) -> RunConfig:
+    repo_root = args.repo_root.resolve()
+    output_dir = (args.output_dir if args.output_dir is not None else repo_root / "output").resolve()
+    return RunConfig(
+        repo_root=repo_root,
+        output_dir=output_dir,
+        data_root=resolve_optional_path(
+            repo_root,
+            environ.get("GNSSPP_MADOCA_MATERIALIZATION_DATA_ROOT", ""),
+        ),
+        auto_fetch=truthy(env_or(environ, "GNSSPP_MADOCA_MATERIALIZATION_AUTO_FETCH", "1")),
+        fail_on_blocked=truthy(env_or(environ, "GNSSPP_MADOCA_MATERIALIZATION_FAIL_ON_BLOCKED", "1")),
+        madocalib_repo=env_or(
+            environ,
+            "GNSSPP_MADOCA_MATERIALIZATION_MADOCALIB_REPO",
+            DEFAULT_MADOCALIB_REPO,
+        ),
+        madocalib_ref=env_or(
+            environ,
+            "GNSSPP_MADOCA_MATERIALIZATION_MADOCALIB_REF",
+            DEFAULT_MADOCALIB_REF,
+        ),
+        min_rows=int(env_or(environ, "GNSSPP_MADOCA_MATERIALIZATION_ROWS_MIN", str(DEFAULT_MIN_ROWS))),
+        python_executable=sys.executable,
+    )
+
+
+def data_root_failures(data_root: Path) -> list[str]:
+    return [name for name in REQUIRED_DATA_FILES if not (data_root / name).is_file()]
+
+
+def run_logged(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    log_path: Path,
+    env: Mapping[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    display = " ".join(command)
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(f"$ {display}\n")
+    started = time.monotonic()
+    completed = subprocess.run(
+        list(command),
+        cwd=cwd,
+        env=dict(env) if env is not None else None,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    elapsed = time.monotonic() - started
+    combined = completed.stdout
+    if completed.stderr:
+        if combined and not combined.endswith("\n"):
+            combined += "\n"
+        combined += completed.stderr
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(combined)
+        if combined and not combined.endswith("\n"):
+            handle.write("\n")
+        handle.write(f"# exit={completed.returncode} elapsed_s={elapsed:.3f}\n\n")
+    return completed
+
+
+def checkout_madocalib_data(config: RunConfig, paths: RunPaths) -> tuple[Path | None, str | None]:
+    if config.data_root is not None:
+        missing = data_root_failures(config.data_root)
+        if not missing:
+            return config.data_root, None
+        return None, f"configured MADOCALIB data root is missing required files: {', '.join(missing)}"
+
+    if not config.auto_fetch:
+        return None, "GNSSPP_MADOCA_MATERIALIZATION_DATA_ROOT is unset and auto-fetch is disabled"
+
+    if paths.checkout_dir.exists():
+        shutil.rmtree(paths.checkout_dir)
+    paths.checkout_dir.parent.mkdir(parents=True, exist_ok=True)
+    commands = [
+        ["git", "init", str(paths.checkout_dir)],
+        ["git", "-C", str(paths.checkout_dir), "remote", "add", "origin", config.madocalib_repo],
+        ["git", "-C", str(paths.checkout_dir), "sparse-checkout", "init", "--no-cone"],
+        [
+            "git",
+            "-C",
+            str(paths.checkout_dir),
+            "sparse-checkout",
+            "set",
+            *REQUIRED_DATA_FILES,
+        ],
+        ["git", "-C", str(paths.checkout_dir), "fetch", "--depth", "1", "origin", config.madocalib_ref],
+        ["git", "-C", str(paths.checkout_dir), "checkout", "--detach", "FETCH_HEAD"],
+    ]
+    for command in commands:
+        completed = run_logged(command, cwd=config.repo_root, log_path=paths.log_path)
+        if completed.returncode != 0:
+            return None, f"failed to fetch MADOCALIB public data: {' '.join(command)}"
+
+    missing = data_root_failures(paths.checkout_dir)
+    if missing:
+        return None, f"fetched MADOCALIB data is missing required files: {', '.join(missing)}"
+    return paths.checkout_dir, None
+
+
+def build_dump_command(config: RunConfig, paths: RunPaths, data_root: Path) -> list[str]:
+    binary = config.repo_root / "build" / "apps" / "gnss_ppp"
+    return [
+        str(binary),
+        "--obs",
+        str(paths.tiny_obs),
+        "--nav",
+        str(data_root / REQUIRED_DATA_FILES[0]),
+        "--madoca-l6",
+        str(data_root / REQUIRED_DATA_FILES[1]),
+        "--madoca-materialization-dump",
+        str(paths.native_dump),
+        "--madoca-materialization-dump-only",
+        "--summary-json",
+        str(paths.native_summary_json),
+        "--quiet",
+    ]
+
+
+def build_selfdiff_command(config: RunConfig, paths: RunPaths) -> list[str]:
+    return [
+        config.python_executable,
+        str(config.repo_root / "scripts" / "analysis" / "madoca_materialization_diff.py"),
+        str(paths.native_dump),
+        str(paths.native_dump),
+        "--base-label",
+        "native",
+        "--candidate-label",
+        "native",
+        "--json-out",
+        str(paths.selfdiff_json),
+        "--details-csv",
+        str(paths.selfdiff_csv),
+        "--fail-on-diff",
+    ]
+
+
+def load_json(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: expected JSON object")
+    return payload
+
+
+def count_csv_data_rows(path: Path) -> int:
+    if not path.is_file():
+        return 0
+    with path.open(encoding="utf-8") as handle:
+        return max(sum(1 for _line in handle) - 1, 0)
+
+
+def evaluate(
+    *,
+    config: RunConfig,
+    paths: RunPaths,
+    dump_summary: dict[str, object],
+    selfdiff_report: dict[str, object],
+) -> Evaluation:
+    failures: list[str] = []
+    csv_rows = count_csv_data_rows(paths.native_dump)
+    summary_rows = dump_summary.get("madoca_materialization_rows")
+    if not isinstance(summary_rows, int):
+        failures.append("native summary missing integer madoca_materialization_rows")
+        summary_rows = 0
+    if csv_rows != summary_rows:
+        failures.append(f"CSV rows {csv_rows} != summary rows {summary_rows}")
+    if summary_rows < config.min_rows:
+        failures.append(f"materialization rows {summary_rows} < minimum {config.min_rows}")
+    if selfdiff_report.get("schema") != "madoca_materialization_diff.v1":
+        failures.append("self-diff schema mismatch")
+    for key in ("base_only_rows", "candidate_only_rows", "discrete_mismatches", "numeric_threshold_exceedances"):
+        value = selfdiff_report.get(key)
+        if value != 0:
+            failures.append(f"self-diff {key} {value} != 0")
+    if selfdiff_report.get("row_set_complete") is not True:
+        failures.append("self-diff row_set_complete is not true")
+    max_delta = 0.0
+    for item in selfdiff_report.get("per_numeric_component", []):
+        if isinstance(item, dict) and isinstance(item.get("max_abs_delta"), (float, int)):
+            max_delta = max(max_delta, float(item["max_abs_delta"]))
+    if max_delta != 0.0:
+        failures.append(f"self-diff max numeric delta {max_delta} != 0")
+
+    metrics = {
+        "materialization_rows": summary_rows,
+        "csv_rows": csv_rows,
+        "selfdiff_common_rows": selfdiff_report.get("common_rows"),
+        "selfdiff_numeric_components_compared": selfdiff_report.get("numeric_components_compared"),
+        "selfdiff_max_abs_delta": max_delta,
+    }
+    return Evaluation(status="failed" if failures else "passed", failures=failures, metrics=metrics)
+
+
+def artifact_records(paths: RunPaths, *, blocked: bool = False) -> list[dict[str, object]]:
+    return [
+        artifact_record(paths.log_path, role="log", required=True),
+        artifact_record(paths.native_dump, role="native_materialization_csv", required=not blocked),
+        artifact_record(paths.native_summary_json, role="native_summary_json", required=not blocked),
+        artifact_record(paths.selfdiff_json, role="selfdiff_json", required=not blocked),
+        artifact_record(paths.selfdiff_csv, role="selfdiff_csv", required=not blocked),
+    ]
+
+
+def write_summary(
+    paths: RunPaths,
+    *,
+    config: RunConfig,
+    status: str,
+    block_reason: str | None = None,
+    failures: list[str] | None = None,
+    metrics: dict[str, object] | None = None,
+) -> None:
+    payload = {
+        "summary_schema": SUMMARY_SCHEMA,
+        "contract": CONTRACT,
+        "status": status,
+        "configuration": {
+            "madocalib_repo": config.madocalib_repo,
+            "madocalib_ref": config.madocalib_ref,
+            "min_rows": config.min_rows,
+            "auto_fetch": config.auto_fetch,
+            "data_root": str(config.data_root) if config.data_root is not None else None,
+        },
+        "input_provenance": {
+            "required_data_files": list(REQUIRED_DATA_FILES),
+        },
+        "metrics": metrics or {},
+        "failures": failures or [],
+        "block_reason": block_reason,
+        "artifacts": artifact_records(paths, blocked=status == "blocked_infrastructure"),
+        "next_actions": [],
+    }
+    if status == "blocked_infrastructure":
+        payload["next_actions"] = [
+            "Provide GNSSPP_MADOCA_MATERIALIZATION_DATA_ROOT or allow public MADOCALIB auto-fetch.",
+            "Treat blocked_infrastructure as missing native MADOCA materialization evidence.",
+        ]
+    elif status == "failed":
+        payload["next_actions"] = [
+            "Inspect the native materialization log, summary JSON, and self-diff artifacts before changing solver behavior."
+        ]
+    paths.summary_json.parent.mkdir(parents=True, exist_ok=True)
+    paths.summary_json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, default=repo_root_from_script())
+    parser.add_argument("--output-dir", type=Path, default=None)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    config = parse_config(args, os.environ)
+    paths = default_paths(config.output_dir)
+    paths.log_path.parent.mkdir(parents=True, exist_ok=True)
+    paths.work_dir.mkdir(parents=True, exist_ok=True)
+    if paths.log_path.exists():
+        paths.log_path.unlink()
+    paths.tiny_obs.write_text(TINY_OBS_TEXT, encoding="ascii")
+
+    data_root, block_reason = checkout_madocalib_data(config, paths)
+    if data_root is None:
+        write_summary(paths, config=config, status="blocked_infrastructure", block_reason=block_reason)
+        print(f"MADOCA materialization self-diff blocked: {block_reason}")
+        return 1 if config.fail_on_blocked else 0
+
+    dump_result = run_logged(build_dump_command(config, paths, data_root), cwd=config.repo_root, log_path=paths.log_path)
+    if dump_result.returncode != 0:
+        write_summary(
+            paths,
+            config=config,
+            status="failed",
+            failures=["native MADOCA materialization dump failed"],
+        )
+        print(f"MADOCA materialization dump failed; see {paths.log_path}")
+        return 1
+
+    selfdiff_result = run_logged(build_selfdiff_command(config, paths), cwd=config.repo_root, log_path=paths.log_path)
+    if selfdiff_result.returncode != 0:
+        write_summary(
+            paths,
+            config=config,
+            status="failed",
+            failures=["native MADOCA materialization self-diff failed"],
+        )
+        print(f"MADOCA materialization self-diff failed; see {paths.log_path}")
+        return 1
+
+    evaluation = evaluate(
+        config=config,
+        paths=paths,
+        dump_summary=load_json(paths.native_summary_json),
+        selfdiff_report=load_json(paths.selfdiff_json),
+    )
+    write_summary(
+        paths,
+        config=config,
+        status=evaluation.status,
+        failures=evaluation.failures,
+        metrics=evaluation.metrics,
+    )
+    print("MADOCA materialization self-diff:", evaluation.status)
+    print(f"  rows: {evaluation.metrics.get('materialization_rows')}")
+    print(f"  dump: {paths.native_dump}")
+    print(f"  selfdiff: {paths.selfdiff_json}")
+    return 1 if evaluation.status != "passed" else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -118,6 +118,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_optional_madoca_materialization_diff.py
     )
     add_test(
+        NAME python_madoca_materialization_selfdiff_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_madoca_materialization_selfdiff.py
+    )
+    add_test(
         NAME python_clas_zd_component_diff_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_clas_zd_component_diff.py
     )
@@ -275,6 +279,7 @@ if(GTest_FOUND)
         python_cli_ux_tests
         python_optional_clas_zd_component_diff_tests
         python_madoca_materialization_diff_tests
+        python_madoca_materialization_selfdiff_tests
         python_madoca_residual_component_diff_tests
         python_madoca_solution_diff_tests
         python_madoca_satellite_set_diff_tests

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -4032,6 +4032,28 @@ class CLIToolsTest(unittest.TestCase):
         self.assertIn("--madocalib-l6", result.stdout)
         self.assertIn("--madocalib-mdciono", result.stdout)
         self.assertIn("--madoca-materialization-dump", result.stdout)
+        self.assertIn("--madoca-materialization-dump-only", result.stdout)
+
+    def test_ppp_cli_rejects_madoca_materialization_dump_only_without_dump_path(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ppp_madoca_materialization_dump_only_cli_") as temp_dir:
+            temp_root = Path(temp_dir)
+            obs_path, sp3_path, _, _ = build_synthetic_ppp_inputs(temp_root)
+
+            result = self.run_gnss(
+                "ppp",
+                "--static",
+                "--obs",
+                str(obs_path),
+                "--sp3",
+                str(sp3_path),
+                "--madoca-materialization-dump-only",
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn(
+                "--madoca-materialization-dump-only requires --madoca-materialization-dump",
+                result.stderr,
+            )
 
     def test_public_rtk_benchmarks_cli_lists_matrix(self) -> None:
         result = self.run_gnss("public-rtk-benchmarks", "--format", "json")

--- a/tests/test_madoca_materialization_selfdiff.py
+++ b/tests/test_madoca_materialization_selfdiff.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python3
+"""Tests for the public MADOCA materialization self-diff CI runner."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT_DIR / "scripts" / "ci" / "run_madoca_materialization_selfdiff.py"
+
+spec = importlib.util.spec_from_file_location("run_madoca_materialization_selfdiff", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+selfdiff = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = selfdiff
+spec.loader.exec_module(selfdiff)
+
+
+class MadocaMaterializationSelfdiffTest(unittest.TestCase):
+    def test_parse_config_defaults_to_public_madocalib_fetch(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_materialization_selfdiff_config_") as temp_dir:
+            args = selfdiff.parse_args(["--repo-root", str(ROOT_DIR), "--output-dir", temp_dir])
+
+            config = selfdiff.parse_config(args, {})
+
+            self.assertEqual(config.repo_root, ROOT_DIR)
+            self.assertEqual(config.output_dir, Path(temp_dir).resolve())
+            self.assertTrue(config.auto_fetch)
+            self.assertTrue(config.fail_on_blocked)
+            self.assertEqual(config.madocalib_ref, selfdiff.DEFAULT_MADOCALIB_REF)
+            self.assertEqual(config.min_rows, selfdiff.DEFAULT_MIN_ROWS)
+
+    def test_data_root_failures_require_nav_and_l6(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_materialization_selfdiff_data_") as temp_dir:
+            data_root = Path(temp_dir)
+            for relative in selfdiff.REQUIRED_DATA_FILES:
+                path = data_root / relative
+                path.parent.mkdir(parents=True, exist_ok=True)
+                path.write_text("x", encoding="ascii")
+
+            self.assertEqual(selfdiff.data_root_failures(data_root), [])
+            os.remove(data_root / selfdiff.REQUIRED_DATA_FILES[1])
+            self.assertEqual(
+                selfdiff.data_root_failures(data_root),
+                [selfdiff.REQUIRED_DATA_FILES[1]],
+            )
+
+    def test_build_commands_use_dump_only_and_selfdiff_outputs(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_materialization_selfdiff_command_") as temp_dir:
+            args = selfdiff.parse_args(["--repo-root", str(ROOT_DIR), "--output-dir", temp_dir])
+            config = selfdiff.parse_config(args, {})
+            paths = selfdiff.default_paths(config.output_dir)
+            data_root = Path(temp_dir) / "madocalib"
+
+            dump_command = selfdiff.build_dump_command(config, paths, data_root)
+            selfdiff_command = selfdiff.build_selfdiff_command(config, paths)
+
+            self.assertIn("--madoca-materialization-dump-only", dump_command)
+            self.assertIn("--madoca-materialization-dump", dump_command)
+            self.assertIn(str(paths.native_dump), dump_command)
+            self.assertNotIn("--out", dump_command)
+            self.assertIn(str(ROOT_DIR / "scripts" / "analysis" / "madoca_materialization_diff.py"), selfdiff_command)
+            self.assertIn(str(paths.native_dump), selfdiff_command)
+            self.assertIn(str(paths.selfdiff_json), selfdiff_command)
+            self.assertIn("--fail-on-diff", selfdiff_command)
+
+    def test_evaluate_accepts_exact_selfdiff(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_materialization_selfdiff_eval_") as temp_dir:
+            args = selfdiff.parse_args(["--repo-root", str(ROOT_DIR), "--output-dir", temp_dir])
+            config = selfdiff.parse_config(args, {"GNSSPP_MADOCA_MATERIALIZATION_ROWS_MIN": "2"})
+            paths = selfdiff.default_paths(config.output_dir)
+            paths.work_dir.mkdir(parents=True, exist_ok=True)
+            paths.native_dump.write_text("header\nrow1\nrow2\n", encoding="ascii")
+
+            evaluation = selfdiff.evaluate(
+                config=config,
+                paths=paths,
+                dump_summary={"madoca_materialization_rows": 2},
+                selfdiff_report={
+                    "schema": "madoca_materialization_diff.v1",
+                    "base_only_rows": 0,
+                    "candidate_only_rows": 0,
+                    "row_set_complete": True,
+                    "discrete_mismatches": 0,
+                    "numeric_threshold_exceedances": 0,
+                    "common_rows": 2,
+                    "numeric_components_compared": 12,
+                    "per_numeric_component": [{"component": "clock_m", "max_abs_delta": 0.0}],
+                },
+            )
+
+            self.assertEqual(evaluation.status, "passed")
+            self.assertEqual(evaluation.failures, [])
+            self.assertEqual(evaluation.metrics["materialization_rows"], 2)
+            self.assertEqual(evaluation.metrics["selfdiff_max_abs_delta"], 0.0)
+
+    def test_evaluate_rejects_missing_rows_and_selfdiff_mismatch(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_materialization_selfdiff_bad_") as temp_dir:
+            args = selfdiff.parse_args(["--repo-root", str(ROOT_DIR), "--output-dir", temp_dir])
+            config = selfdiff.parse_config(args, {"GNSSPP_MADOCA_MATERIALIZATION_ROWS_MIN": "10"})
+            paths = selfdiff.default_paths(config.output_dir)
+            paths.work_dir.mkdir(parents=True, exist_ok=True)
+            paths.native_dump.write_text("header\nrow1\n", encoding="ascii")
+
+            evaluation = selfdiff.evaluate(
+                config=config,
+                paths=paths,
+                dump_summary={"madoca_materialization_rows": 1},
+                selfdiff_report={
+                    "schema": "madoca_materialization_diff.v1",
+                    "base_only_rows": 1,
+                    "candidate_only_rows": 0,
+                    "row_set_complete": False,
+                    "discrete_mismatches": 2,
+                    "numeric_threshold_exceedances": 3,
+                    "per_numeric_component": [{"component": "clock_m", "max_abs_delta": 0.5}],
+                },
+            )
+
+            self.assertEqual(evaluation.status, "failed")
+            self.assertGreaterEqual(len(evaluation.failures), 4)
+
+    def test_write_summary_records_blocked_infrastructure(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_materialization_selfdiff_summary_") as temp_dir:
+            args = selfdiff.parse_args(["--repo-root", str(ROOT_DIR), "--output-dir", temp_dir])
+            config = selfdiff.parse_config(args, {})
+            paths = selfdiff.default_paths(config.output_dir)
+            paths.log_path.parent.mkdir(parents=True, exist_ok=True)
+            paths.log_path.write_text("blocked\n", encoding="ascii")
+
+            selfdiff.write_summary(
+                paths,
+                config=config,
+                status="blocked_infrastructure",
+                block_reason="missing data",
+            )
+
+            payload = json.loads(paths.summary_json.read_text(encoding="utf-8"))
+            self.assertEqual(payload["summary_schema"], selfdiff.SUMMARY_SCHEMA)
+            self.assertEqual(payload["contract"], "madoca_materialization_selfdiff.v1")
+            self.assertEqual(payload["status"], "blocked_infrastructure")
+            self.assertEqual(payload["block_reason"], "missing data")
+            self.assertIn("missing native MADOCA materialization evidence", payload["next_actions"][1])
+            self.assertTrue(payload["artifacts"][0]["exists"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `--madoca-materialization-dump-only` so MADOCA materialization evidence can be generated without requiring a PPP solution
- add `scripts/ci/run_madoca_materialization_selfdiff.py` to sparse-fetch pinned public MADOCALIB BRDM/L6 sample data, generate a native M3 dump, and self-diff it
- wire the self-diff runner into optional sign-off CI with required artifacts and document the new lane

## Verification
- `python3 -m py_compile scripts/ci/run_madoca_materialization_selfdiff.py tests/test_madoca_materialization_selfdiff.py`
- `python3 tests/test_madoca_materialization_selfdiff.py`
- `cmake --build build --target gnss_ppp -j4`
- `python3 -m unittest tests.test_cli_tools.CLIToolsTest.test_ppp_help_lists_madocalib_bridge_options tests.test_cli_tools.CLIToolsTest.test_ppp_cli_rejects_madoca_materialization_dump_only_without_dump_path`
- `python3 scripts/ci/run_madoca_materialization_selfdiff.py --output-dir /tmp/gnsspp_madoca_materialization_selfdiff_smoke` (64,693 materialization rows, self-diff passed)
- `ctest --test-dir build -R 'python_madoca_materialization_selfdiff_tests|python_optional_madoca_materialization_diff_tests|python_madoca_materialization_diff_tests' --output-on-failure`
- `bash scripts/ci/run_hygiene.sh`
- `git diff --check`
- `ctest --test-dir build -L core --output-on-failure`

## Not run
- `python3 -m mkdocs build --strict`: local Python environment is missing `mkdocs`