### PR TITLE
madoca: summarize materialization snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,6 +402,7 @@ jobs:
           output/ci_madoca_materialization_selfdiff/*.log
           output/madoca_materialization_selfdiff/native_materialization.csv
           output/madoca_materialization_selfdiff/native_summary.json
+          output/madoca_materialization_selfdiff/native_materialization_summary.json
           output/madoca_materialization_selfdiff/selfdiff.json
           output/madoca_materialization_selfdiff/selfdiff.csv
         if-no-files-found: error

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -65,7 +65,10 @@ CI lanes are split as follows:
   MADOCA materialization evidence bundle; it sparse-fetches pinned MADOCALIB
   BRDM/L6 sample files unless `GNSSPP_MADOCA_MATERIALIZATION_DATA_ROOT` is
   supplied, runs `gnss_ppp --madoca-materialization-dump-only`, and self-diffs
-  the native M3 materialization CSV before residual/state/AR changes
+  the native M3 materialization CSV before residual/state/AR changes; the bundle
+  also includes `madoca_materialization_summary.v1` output so row counts,
+  systems, validity flags, bias ids, and duplicate keys are checked before any
+  oracle/native diff is trusted
 - `bash scripts/ci/generate_dashboard_artifacts.sh` plus
   `python3 scripts/ci/validate_artifact_manifest_contract.py output/artifact_manifest.json`
   for the dashboard/manifest artifact path used in CI; the validator requires

--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -89,10 +89,18 @@ MADOCALIB sample BRDM/L6 files unless
 materialization dump with `--madoca-materialization-dump-only`, and compares that
 CSV against itself.  It writes
 `ci_madoca_materialization_selfdiff_summary.json`, a log, the native dump,
-native dump-only summary, and `selfdiff.{json,csv}`.  This is not oracle parity;
-it is a remote-CI evidence contract that proves the native M3 dump can be
-regenerated from public data before model-change PRs start consuming oracle
-materialization rows.
+native dump-only summary, a `native_materialization_summary.json`, and
+`selfdiff.{json,csv}`.  This is not oracle parity; it is a remote-CI evidence
+contract that proves the native M3 dump can be regenerated from public data
+before model-change PRs start consuming oracle materialization rows.
+
+Materialization summary: use
+`scripts/analysis/madoca_materialization_summary.py <snapshot.csv> --json-out
+<summary.json>` to validate and summarize a single M3 snapshot.  The summary
+schema is `madoca_materialization_summary.v1`; it records rows, systems,
+time range, validity counts, code/phase bias ids, duplicate row-key counts, and
+count/discontinuity consistency issues.  Run it before a materialization diff so
+oracle/native CSVs fail early when they do not satisfy the snapshot contract.
 
 Residual-component parity artifact: use
 `scripts/analysis/madoca_residual_component_diff.py` after satellite-set and

--- a/scripts/analysis/madoca_materialization_summary.py
+++ b/scripts/analysis/madoca_materialization_summary.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Summarize and validate a MADOCA materialization snapshot CSV."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import json
+from pathlib import Path
+import sys
+from typing import Any, Mapping, Sequence
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import madoca_materialization_diff as materialization_diff  # noqa: E402
+
+
+SCHEMA = "madoca_materialization_summary.v1"
+
+
+def _int_value(value: str) -> int | None:
+    try:
+        return int(float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _format_counter(counter: Counter[str]) -> dict[str, int]:
+    return {key: counter[key] for key in sorted(counter)}
+
+
+def _format_top(counter: Counter[str], limit: int) -> list[dict[str, object]]:
+    return [
+        {"key": key, "count": count}
+        for key, count in sorted(counter.items(), key=lambda item: (-item[1], item[0]))[:limit]
+    ]
+
+
+def _row_key(row: Mapping[str, str]) -> tuple[str, int, int]:
+    return (
+        row.get("sat", ""),
+        int(float(row.get("week", "0"))),
+        materialization_diff.tow_to_millis(row.get("tow", "0")),
+    )
+
+
+def summarize_rows(rows: Sequence[dict[str, str]], *, top_limit: int = 20) -> dict[str, object]:
+    systems: Counter[str] = Counter()
+    sats: Counter[str] = Counter()
+    key_counts: Counter[tuple[str, int, int]] = Counter()
+    validity: dict[str, Counter[str]] = {
+        "orbit_valid": Counter(),
+        "clock_valid": Counter(),
+        "code_bias_valid": Counter(),
+        "phase_bias_valid": Counter(),
+    }
+    code_bias_ids: Counter[str] = Counter()
+    phase_bias_ids: Counter[str] = Counter()
+    phase_discnt_ids: Counter[str] = Counter()
+    issue_counts: Counter[str] = Counter()
+    issue_examples: dict[str, list[dict[str, object]]] = {}
+    time_keys: list[tuple[int, int]] = []
+
+    def record_issue(kind: str, row_number: int, detail: str) -> None:
+        issue_counts[kind] += 1
+        examples = issue_examples.setdefault(kind, [])
+        if len(examples) < 5:
+            examples.append({"row": row_number, "detail": detail})
+
+    for row_number, row in enumerate(rows, start=2):
+        systems[row.get("system", "")] += 1
+        sats[row.get("sat", "")] += 1
+        try:
+            key = _row_key(row)
+            key_counts[key] += 1
+            time_keys.append((key[1], key[2]))
+        except (ValueError, TypeError) as exc:
+            record_issue("bad_time_key", row_number, str(exc))
+
+        for field, counter in validity.items():
+            counter[materialization_diff.to_int_text(row.get(field, ""))] += 1
+
+        parsed_code_biases = materialization_diff.parse_numeric_map(row.get("code_biases_m", ""))
+        parsed_phase_biases = materialization_diff.parse_numeric_map(row.get("phase_biases_m", ""))
+        parsed_discnt = materialization_diff.parse_discrete_map(row.get("phase_bias_discnt", ""))
+        code_bias_ids.update(parsed_code_biases.keys())
+        phase_bias_ids.update(parsed_phase_biases.keys())
+        phase_discnt_ids.update(parsed_discnt.keys())
+
+        declared_code_count = _int_value(row.get("code_bias_count", ""))
+        if declared_code_count is None:
+            record_issue("bad_code_bias_count", row_number, row.get("code_bias_count", ""))
+        elif declared_code_count != len(parsed_code_biases):
+            record_issue(
+                "code_bias_count_mismatch",
+                row_number,
+                f"declared={declared_code_count} parsed={len(parsed_code_biases)}",
+            )
+
+        declared_phase_count = _int_value(row.get("phase_bias_count", ""))
+        if declared_phase_count is None:
+            record_issue("bad_phase_bias_count", row_number, row.get("phase_bias_count", ""))
+        elif declared_phase_count != len(parsed_phase_biases):
+            record_issue(
+                "phase_bias_count_mismatch",
+                row_number,
+                f"declared={declared_phase_count} parsed={len(parsed_phase_biases)}",
+            )
+
+        phase_only_discnt_ids = sorted(set(parsed_discnt) - set(parsed_phase_biases), key=int)
+        if phase_only_discnt_ids:
+            record_issue(
+                "phase_discnt_without_phase_bias",
+                row_number,
+                ";".join(phase_only_discnt_ids),
+            )
+
+    duplicate_groups = [group for group, count in key_counts.items() if count > 1]
+    max_duplicate_occurrences = max(key_counts.values(), default=0)
+    if time_keys:
+        first_week, first_tow_ms = min(time_keys)
+        last_week, last_tow_ms = max(time_keys)
+        time_range: dict[str, object] = {
+            "start_week": first_week,
+            "start_tow": first_tow_ms / 1000.0,
+            "end_week": last_week,
+            "end_tow": last_tow_ms / 1000.0,
+        }
+    else:
+        time_range = {}
+
+    return {
+        "schema": SCHEMA,
+        "snapshot_schema": materialization_diff.SNAPSHOT_SCHEMA,
+        "status": "failed" if issue_counts else "passed",
+        "rows": len(rows),
+        "unique_satellites": len(sats),
+        "systems": _format_counter(systems),
+        "top_satellites": _format_top(sats, top_limit),
+        "time_range": time_range,
+        "validity_counts": {
+            field: _format_counter(counter) for field, counter in validity.items()
+        },
+        "bias_identity": {
+            "code_bias_ids": _format_counter(code_bias_ids),
+            "phase_bias_ids": _format_counter(phase_bias_ids),
+            "phase_discontinuity_ids": _format_counter(phase_discnt_ids),
+            "rows_with_code_bias": sum(1 for row in rows if row.get("code_biases_m", "") != ""),
+            "rows_with_phase_bias": sum(1 for row in rows if row.get("phase_biases_m", "") != ""),
+        },
+        "row_key": {
+            "groups": len(key_counts),
+            "duplicate_groups": len(duplicate_groups),
+            "max_duplicate_occurrences": max_duplicate_occurrences,
+        },
+        "issue_counts": _format_counter(issue_counts),
+        "issue_examples": issue_examples,
+    }
+
+
+def requirement_failures(summary: Mapping[str, Any], args: argparse.Namespace) -> list[str]:
+    failures: list[str] = []
+    rows = summary.get("rows", 0)
+    if not isinstance(rows, int):
+        failures.append("summary rows is not an integer")
+    elif rows < args.require_rows_min:
+        failures.append(f"rows {rows} < required minimum {args.require_rows_min}")
+
+    systems = summary.get("systems", {})
+    if not isinstance(systems, dict):
+        systems = {}
+    for system in args.require_system:
+        if int(systems.get(system, 0)) <= 0:
+            failures.append(f"required system {system} is absent")
+
+    bias_identity = summary.get("bias_identity", {})
+    if not isinstance(bias_identity, dict):
+        bias_identity = {}
+    code_bias_ids = bias_identity.get("code_bias_ids", {})
+    if not isinstance(code_bias_ids, dict):
+        code_bias_ids = {}
+    phase_bias_ids = bias_identity.get("phase_bias_ids", {})
+    if not isinstance(phase_bias_ids, dict):
+        phase_bias_ids = {}
+    for signal_id in args.require_code_bias_id:
+        if int(code_bias_ids.get(str(signal_id), 0)) <= 0:
+            failures.append(f"required code bias id {signal_id} is absent")
+    for signal_id in args.require_phase_bias_id:
+        if int(phase_bias_ids.get(str(signal_id), 0)) <= 0:
+            failures.append(f"required phase bias id {signal_id} is absent")
+
+    row_key = summary.get("row_key", {})
+    if not isinstance(row_key, dict):
+        row_key = {}
+    if args.require_no_duplicate_keys and int(row_key.get("duplicate_groups", 0)) != 0:
+        failures.append(f"duplicate row keys {row_key.get('duplicate_groups')} != 0")
+
+    issue_counts = summary.get("issue_counts", {})
+    if args.fail_on_issue and isinstance(issue_counts, dict) and issue_counts:
+        failures.append(f"snapshot issues present: {issue_counts}")
+    return failures
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("snapshot_csv", type=Path)
+    parser.add_argument("--json-out", type=Path)
+    parser.add_argument("--require-rows-min", type=int, default=0)
+    parser.add_argument("--require-system", action="append", default=[])
+    parser.add_argument("--require-code-bias-id", action="append", default=[])
+    parser.add_argument("--require-phase-bias-id", action="append", default=[])
+    parser.add_argument("--require-no-duplicate-keys", action="store_true")
+    parser.add_argument("--fail-on-issue", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        rows = materialization_diff.read_csv_rows(args.snapshot_csv)
+        summary = summarize_rows(rows)
+        failures = requirement_failures(summary, args)
+        if failures:
+            summary = {**summary, "status": "failed", "failures": failures}
+        else:
+            summary = {**summary, "failures": []}
+    except Exception as exc:
+        summary = {
+            "schema": SCHEMA,
+            "snapshot_schema": materialization_diff.SNAPSHOT_SCHEMA,
+            "status": "failed",
+            "failures": [str(exc)],
+        }
+
+    if args.json_out is not None:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    print("madoca_materialization_summary:")
+    print(f"  status: {summary.get('status')}")
+    if "rows" in summary:
+        print(f"  rows: {summary['rows']}")
+    if summary.get("failures"):
+        print("  failures:")
+        for failure in summary["failures"]:
+            print(f"    - {failure}")
+    return 0 if summary.get("status") == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/run_madoca_materialization_selfdiff.py
+++ b/scripts/ci/run_madoca_materialization_selfdiff.py
@@ -47,6 +47,7 @@ class RunPaths:
     tiny_obs: Path
     native_dump: Path
     native_summary_json: Path
+    native_materialization_summary_json: Path
     selfdiff_json: Path
     selfdiff_csv: Path
 
@@ -86,6 +87,7 @@ def default_paths(output_dir: Path) -> RunPaths:
         tiny_obs=work_dir / "tiny.obs",
         native_dump=work_dir / "native_materialization.csv",
         native_summary_json=work_dir / "native_summary.json",
+        native_materialization_summary_json=work_dir / "native_materialization_summary.json",
         selfdiff_json=work_dir / "selfdiff.json",
         selfdiff_csv=work_dir / "selfdiff.csv",
     )
@@ -244,6 +246,19 @@ def build_selfdiff_command(config: RunConfig, paths: RunPaths) -> list[str]:
     ]
 
 
+def build_materialization_summary_command(config: RunConfig, paths: RunPaths) -> list[str]:
+    return [
+        config.python_executable,
+        str(config.repo_root / "scripts" / "analysis" / "madoca_materialization_summary.py"),
+        str(paths.native_dump),
+        "--json-out",
+        str(paths.native_materialization_summary_json),
+        "--require-rows-min",
+        str(config.min_rows),
+        "--fail-on-issue",
+    ]
+
+
 def load_json(path: Path) -> dict[str, object]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
@@ -263,6 +278,7 @@ def evaluate(
     config: RunConfig,
     paths: RunPaths,
     dump_summary: dict[str, object],
+    materialization_summary: dict[str, object],
     selfdiff_report: dict[str, object],
 ) -> Evaluation:
     failures: list[str] = []
@@ -275,6 +291,14 @@ def evaluate(
         failures.append(f"CSV rows {csv_rows} != summary rows {summary_rows}")
     if summary_rows < config.min_rows:
         failures.append(f"materialization rows {summary_rows} < minimum {config.min_rows}")
+    if materialization_summary.get("schema") != "madoca_materialization_summary.v1":
+        failures.append("materialization summary schema mismatch")
+    if materialization_summary.get("status") != "passed":
+        failures.append(f"materialization summary status {materialization_summary.get('status')} != passed")
+    if materialization_summary.get("rows") != summary_rows:
+        failures.append(
+            f"materialization summary rows {materialization_summary.get('rows')} != summary rows {summary_rows}"
+        )
     if selfdiff_report.get("schema") != "madoca_materialization_diff.v1":
         failures.append("self-diff schema mismatch")
     for key in ("base_only_rows", "candidate_only_rows", "discrete_mismatches", "numeric_threshold_exceedances"):
@@ -293,6 +317,9 @@ def evaluate(
     metrics = {
         "materialization_rows": summary_rows,
         "csv_rows": csv_rows,
+        "materialization_systems": materialization_summary.get("systems"),
+        "materialization_row_key": materialization_summary.get("row_key"),
+        "materialization_bias_identity": materialization_summary.get("bias_identity"),
         "selfdiff_common_rows": selfdiff_report.get("common_rows"),
         "selfdiff_numeric_components_compared": selfdiff_report.get("numeric_components_compared"),
         "selfdiff_max_abs_delta": max_delta,
@@ -305,6 +332,11 @@ def artifact_records(paths: RunPaths, *, blocked: bool = False) -> list[dict[str
         artifact_record(paths.log_path, role="log", required=True),
         artifact_record(paths.native_dump, role="native_materialization_csv", required=not blocked),
         artifact_record(paths.native_summary_json, role="native_summary_json", required=not blocked),
+        artifact_record(
+            paths.native_materialization_summary_json,
+            role="native_materialization_summary_json",
+            required=not blocked,
+        ),
         artifact_record(paths.selfdiff_json, role="selfdiff_json", required=not blocked),
         artifact_record(paths.selfdiff_csv, role="selfdiff_csv", required=not blocked),
     ]
@@ -386,6 +418,21 @@ def main(argv: Sequence[str] | None = None) -> int:
         print(f"MADOCA materialization dump failed; see {paths.log_path}")
         return 1
 
+    materialization_summary_result = run_logged(
+        build_materialization_summary_command(config, paths),
+        cwd=config.repo_root,
+        log_path=paths.log_path,
+    )
+    if materialization_summary_result.returncode != 0:
+        write_summary(
+            paths,
+            config=config,
+            status="failed",
+            failures=["native MADOCA materialization summary validation failed"],
+        )
+        print(f"MADOCA materialization summary validation failed; see {paths.log_path}")
+        return 1
+
     selfdiff_result = run_logged(build_selfdiff_command(config, paths), cwd=config.repo_root, log_path=paths.log_path)
     if selfdiff_result.returncode != 0:
         write_summary(
@@ -401,6 +448,7 @@ def main(argv: Sequence[str] | None = None) -> int:
         config=config,
         paths=paths,
         dump_summary=load_json(paths.native_summary_json),
+        materialization_summary=load_json(paths.native_materialization_summary_json),
         selfdiff_report=load_json(paths.selfdiff_json),
     )
     write_summary(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -110,6 +110,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_madoca_materialization_diff.py
     )
     add_test(
+        NAME python_madoca_materialization_summary_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_madoca_materialization_summary.py
+    )
+    add_test(
         NAME python_optional_madoca_residual_component_diff_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_optional_madoca_residual_component_diff.py
     )
@@ -280,6 +284,7 @@ if(GTest_FOUND)
         python_optional_clas_zd_component_diff_tests
         python_madoca_materialization_diff_tests
         python_madoca_materialization_selfdiff_tests
+        python_madoca_materialization_summary_tests
         python_madoca_residual_component_diff_tests
         python_madoca_solution_diff_tests
         python_madoca_satellite_set_diff_tests

--- a/tests/test_madoca_materialization_selfdiff.py
+++ b/tests/test_madoca_materialization_selfdiff.py
@@ -59,12 +59,17 @@ class MadocaMaterializationSelfdiffTest(unittest.TestCase):
             data_root = Path(temp_dir) / "madocalib"
 
             dump_command = selfdiff.build_dump_command(config, paths, data_root)
+            summary_command = selfdiff.build_materialization_summary_command(config, paths)
             selfdiff_command = selfdiff.build_selfdiff_command(config, paths)
 
             self.assertIn("--madoca-materialization-dump-only", dump_command)
             self.assertIn("--madoca-materialization-dump", dump_command)
             self.assertIn(str(paths.native_dump), dump_command)
             self.assertNotIn("--out", dump_command)
+            self.assertIn(str(ROOT_DIR / "scripts" / "analysis" / "madoca_materialization_summary.py"), summary_command)
+            self.assertIn(str(paths.native_dump), summary_command)
+            self.assertIn(str(paths.native_materialization_summary_json), summary_command)
+            self.assertIn("--fail-on-issue", summary_command)
             self.assertIn(str(ROOT_DIR / "scripts" / "analysis" / "madoca_materialization_diff.py"), selfdiff_command)
             self.assertIn(str(paths.native_dump), selfdiff_command)
             self.assertIn(str(paths.selfdiff_json), selfdiff_command)
@@ -82,6 +87,14 @@ class MadocaMaterializationSelfdiffTest(unittest.TestCase):
                 config=config,
                 paths=paths,
                 dump_summary={"madoca_materialization_rows": 2},
+                materialization_summary={
+                    "schema": "madoca_materialization_summary.v1",
+                    "status": "passed",
+                    "rows": 2,
+                    "systems": {"GPS": 2},
+                    "row_key": {"groups": 2, "duplicate_groups": 0, "max_duplicate_occurrences": 1},
+                    "bias_identity": {"code_bias_ids": {"2": 2}},
+                },
                 selfdiff_report={
                     "schema": "madoca_materialization_diff.v1",
                     "base_only_rows": 0,
@@ -112,6 +125,14 @@ class MadocaMaterializationSelfdiffTest(unittest.TestCase):
                 config=config,
                 paths=paths,
                 dump_summary={"madoca_materialization_rows": 1},
+                materialization_summary={
+                    "schema": "madoca_materialization_summary.v1",
+                    "status": "failed",
+                    "rows": 0,
+                    "systems": {},
+                    "row_key": {},
+                    "bias_identity": {},
+                },
                 selfdiff_report={
                     "schema": "madoca_materialization_diff.v1",
                     "base_only_rows": 1,

--- a/tests/test_madoca_materialization_summary.py
+++ b/tests/test_madoca_materialization_summary.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""Tests for MADOCA materialization snapshot summaries."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT_DIR / "scripts" / "analysis" / "madoca_materialization_summary.py"
+
+spec = importlib.util.spec_from_file_location("madoca_materialization_summary", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+summary_script = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = summary_script
+spec.loader.exec_module(summary_script)
+
+
+HEADER = (
+    "schema_version,sat,system,prn,week,tow,orbit_frame,orbit_valid,clock_valid,"
+    "code_bias_valid,phase_bias_valid,orbit_week,orbit_tow,clock_week,clock_tow,"
+    "iode,ssr_orbit_iod,ssr_clock_iod,orbit_radial_m,orbit_along_m,orbit_cross_m,"
+    "clock_m,code_bias_count,code_biases_m,phase_bias_count,phase_biases_m,"
+    "phase_bias_discnt\n"
+)
+
+
+def snapshot_row(
+    *,
+    sat: str,
+    system: str,
+    prn: int,
+    tow: float,
+    code_bias_count: int = 1,
+    code_biases: str = "2:0.1",
+    phase_bias_count: int = 1,
+    phase_biases: str = "8:0.2",
+    discnt: str = "8:3",
+) -> str:
+    return (
+        f"madoca_materialization_snapshot.v1,{sat},{system},{prn},2360,{tow},rac,"
+        f"1,1,{1 if code_bias_count else 0},{1 if phase_bias_count else 0},"
+        "2360,100.0,2360,105.0,33,11,11,0.1,0.2,0.3,0.4,"
+        f"{code_bias_count},{code_biases},{phase_bias_count},{phase_biases},{discnt}\n"
+    )
+
+
+class MadocaMaterializationSummaryTest(unittest.TestCase):
+    def test_summarize_rows_reports_systems_bias_ids_and_time_range(self) -> None:
+        rows = summary_script.materialization_diff.read_csv_rows(
+            self.write_snapshot(
+                snapshot_row(sat="G01", system="GPS", prn=1, tow=100.0),
+                snapshot_row(
+                    sat="J02",
+                    system="QZS",
+                    prn=194,
+                    tow=105.0,
+                    code_bias_count=2,
+                    code_biases="2:0.1;9:-0.2",
+                    phase_bias_count=0,
+                    phase_biases="",
+                    discnt="",
+                ),
+            )
+        )
+
+        payload = summary_script.summarize_rows(rows)
+
+        self.assertEqual(payload["schema"], "madoca_materialization_summary.v1")
+        self.assertEqual(payload["status"], "passed")
+        self.assertEqual(payload["rows"], 2)
+        self.assertEqual(payload["systems"], {"GPS": 1, "QZS": 1})
+        self.assertEqual(payload["bias_identity"]["code_bias_ids"], {"2": 2, "9": 1})
+        self.assertEqual(payload["bias_identity"]["phase_bias_ids"], {"8": 1})
+        self.assertEqual(payload["time_range"]["start_tow"], 100.0)
+        self.assertEqual(payload["time_range"]["end_tow"], 105.0)
+
+    def test_summarize_rows_detects_count_mismatch_and_duplicate_keys(self) -> None:
+        path = self.write_snapshot(
+            snapshot_row(sat="G01", system="GPS", prn=1, tow=100.0, code_bias_count=2, code_biases="2:0.1"),
+            snapshot_row(sat="G01", system="GPS", prn=1, tow=100.0, phase_biases="", discnt="8:3"),
+        )
+        rows = summary_script.materialization_diff.read_csv_rows(path)
+
+        payload = summary_script.summarize_rows(rows)
+
+        self.assertEqual(payload["status"], "failed")
+        self.assertEqual(payload["row_key"]["duplicate_groups"], 1)
+        self.assertEqual(payload["row_key"]["max_duplicate_occurrences"], 2)
+        self.assertEqual(payload["issue_counts"]["code_bias_count_mismatch"], 1)
+        self.assertEqual(payload["issue_counts"]["phase_bias_count_mismatch"], 1)
+        self.assertEqual(payload["issue_counts"]["phase_discnt_without_phase_bias"], 1)
+
+    def test_cli_writes_json_and_enforces_requirements(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="madoca_materialization_summary_cli_") as temp_dir:
+            output = Path(temp_dir) / "summary.json"
+            snapshot = self.write_snapshot(
+                snapshot_row(sat="G01", system="GPS", prn=1, tow=100.0),
+                root=Path(temp_dir),
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    str(snapshot),
+                    "--json-out",
+                    str(output),
+                    "--require-rows-min",
+                    "2",
+                    "--require-system",
+                    "QZS",
+                ],
+                cwd=ROOT_DIR,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertNotEqual(result.returncode, 0)
+            payload = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(payload["status"], "failed")
+            self.assertIn("rows 1 < required minimum 2", payload["failures"])
+            self.assertIn("required system QZS is absent", payload["failures"])
+
+    def test_cli_passes_clean_snapshot_with_fail_on_issue(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="madoca_materialization_summary_pass_") as temp_dir:
+            output = Path(temp_dir) / "summary.json"
+            snapshot = self.write_snapshot(
+                snapshot_row(sat="G01", system="GPS", prn=1, tow=100.0),
+                root=Path(temp_dir),
+            )
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    str(snapshot),
+                    "--json-out",
+                    str(output),
+                    "--require-rows-min",
+                    "1",
+                    "--require-code-bias-id",
+                    "2",
+                    "--fail-on-issue",
+                ],
+                cwd=ROOT_DIR,
+                text=True,
+                capture_output=True,
+                check=False,
+            )
+
+            self.assertEqual(result.returncode, 0, result.stderr)
+            payload = json.loads(output.read_text(encoding="utf-8"))
+            self.assertEqual(payload["status"], "passed")
+            self.assertEqual(payload["failures"], [])
+
+    def write_snapshot(self, *rows: str, root: Path | None = None) -> Path:
+        if root is None:
+            self.addCleanup(lambda: None)
+            temp_dir = tempfile.TemporaryDirectory(prefix="madoca_materialization_summary_")
+            self.addCleanup(temp_dir.cleanup)
+            root = Path(temp_dir.name)
+        path = root / "snapshot.csv"
+        path.write_text(HEADER + "".join(rows), encoding="ascii")
+        return path
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add `scripts/analysis/madoca_materialization_summary.py` for single-snapshot MADOCA M3 validation and metrics
- include the summary in the public-data MADOCA materialization self-diff CI bundle
- document the new snapshot summary contract and register focused CTest coverage

## Verification
- `python3 -m py_compile scripts/analysis/madoca_materialization_summary.py scripts/ci/run_madoca_materialization_selfdiff.py tests/test_madoca_materialization_summary.py tests/test_madoca_materialization_selfdiff.py`
- `python3 tests/test_madoca_materialization_summary.py`
- `python3 tests/test_madoca_materialization_selfdiff.py`
- `python3 scripts/ci/run_madoca_materialization_selfdiff.py --output-dir /tmp/gnsspp_madoca_materialization_summary_smoke` (64,693 rows; summary validation and self-diff passed)
- `cmake --build build --target run_tests -j4`
- `ctest --test-dir build -R 'python_madoca_materialization_summary_tests|python_madoca_materialization_selfdiff_tests|python_madoca_materialization_diff_tests|python_optional_madoca_materialization_diff_tests' --output-on-failure`
- `git diff --check`
- `bash scripts/ci/run_hygiene.sh`
- `ctest --test-dir build -L core --output-on-failure`

## Not run
- `python3 -m mkdocs build --strict`: local Python environment is missing `mkdocs`