### PR TITLE
ci: summarize optional MADOCA materialization inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,6 +366,7 @@ jobs:
       env:
         GNSSPP_MADOCA_MATERIALIZATION_BASE_CSV: ${{ vars.GNSSPP_MADOCA_MATERIALIZATION_BASE_CSV }}
         GNSSPP_MADOCA_MATERIALIZATION_CANDIDATE_CSV: ${{ vars.GNSSPP_MADOCA_MATERIALIZATION_CANDIDATE_CSV }}
+        GNSSPP_MADOCA_MATERIALIZATION_COMPONENTS: ${{ vars.GNSSPP_MADOCA_MATERIALIZATION_COMPONENTS }}
         GNSSPP_MADOCA_MATERIALIZATION_NUMERIC_THRESHOLD: ${{ vars.GNSSPP_MADOCA_MATERIALIZATION_NUMERIC_THRESHOLD }}
         GNSSPP_MADOCA_MATERIALIZATION_FAIL_ON_DIFF: ${{ vars.GNSSPP_MADOCA_MATERIALIZATION_FAIL_ON_DIFF }}
       run: bash scripts/ci/run_optional_madoca_materialization_diff.sh
@@ -380,6 +381,8 @@ jobs:
           output/ci_optional_madoca_materialization/*.log
           output/madoca_materialization_diff.json
           output/madoca_materialization_diff.csv
+          output/madoca_materialization_diff_madocalib_snapshot_summary.json
+          output/madoca_materialization_diff_native_snapshot_summary.json
         if-no-files-found: error
 
     - name: MADOCA materialization native self-diff

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -56,7 +56,10 @@ CI lanes are split as follows:
   oracle/native diff artifacts; they report `blocked_infrastructure` with
   next actions when their CSV inputs are unavailable, require a summary/log
   artifact in CI, and fail a passed diff command if the declared JSON/CSV
-  artifacts are missing
+  artifacts are missing.  The MADOCA materialization diff additionally emits
+  `madoca_materialization_summary.v1` JSON for both input snapshots and fails
+  before the diff when either snapshot has count, discontinuity, or duplicate-key
+  contract issues.
 - `python3 scripts/ci/run_clas_a4b_native_selfdiff.py` for the public CLAS A4b
   native-side evidence bundle; it sparse-fetches CLASLIB public data unless
   `GNSSPP_CLAS_A4B_DATA_ROOT` is supplied, generates the native code dump, and

--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -75,12 +75,16 @@ The optional CI wrapper
 `GNSSPP_MADOCA_MATERIALIZATION_BASE_CSV` and
 `GNSSPP_MADOCA_MATERIALIZATION_CANDIDATE_CSV` point at generated oracle/native
 materialization snapshots.  It writes
-`ci_optional_madoca_materialization_summary.json`, a log, and
-`madoca_materialization_diff.{json,csv}` artifacts; absent inputs are reported as
+`ci_optional_madoca_materialization_summary.json`, a log,
+`madoca_materialization_diff.{json,csv}`, and one
+`madoca_materialization_summary.v1` JSON for each oracle/native input snapshot;
+absent inputs are reported as
 `status: blocked_infrastructure` rather than a passing sign-off.  Use
 `GNSSPP_MADOCA_MATERIALIZATION_NUMERIC_THRESHOLD` to set a numeric tolerance and
 `GNSSPP_MADOCA_MATERIALIZATION_FAIL_ON_DIFF=1` when the configured window should
-act as a hard oracle gate.
+act as a hard oracle gate.  The wrapper runs the snapshot summaries with
+`--fail-on-issue` before the diff, so count/discontinuity/key problems fail as
+input-contract issues instead of being folded into value deltas.
 
 The public native self-diff runner
 `scripts/ci/run_madoca_materialization_selfdiff.py` sparse-fetches pinned

--- a/scripts/ci/optional_diff_runner.py
+++ b/scripts/ci/optional_diff_runner.py
@@ -44,6 +44,9 @@ class DiffRunnerConfig:
     per_component_max_key: str
     extra_options: tuple[EnvOption, ...] = ()
     component_flag: str | None = "--component"
+    input_summary_script: str | None = None
+    input_summary_schema: str | None = None
+    input_summary_fail_on_issue: bool = False
 
 
 @dataclass(frozen=True)
@@ -54,6 +57,7 @@ class DiffStep:
     outputs: list[str]
     summary_json: str
     skip_reason: str | None = None
+    pre_commands: tuple[tuple[str, ...], ...] = ()
 
 
 @dataclass(frozen=True)
@@ -187,6 +191,7 @@ def make_step(config: DiffRunnerConfig, context: DiffContext) -> DiffStep:
     details_csv = context.output_dir / f"{config.slug}.csv"
     summary_json = context.output_dir / f"{config.slug}_summary.json"
     outputs = [report_json, details_csv]
+    pre_commands: list[tuple[str, ...]] = []
 
     missing = [
         (label, path)
@@ -209,6 +214,25 @@ def make_step(config: DiffRunnerConfig, context: DiffContext) -> DiffStep:
 
     assert context.base_csv is not None
     assert context.candidate_csv is not None
+    if config.input_summary_script is not None:
+        for label, snapshot_csv in (
+            (config.base_label, context.base_csv),
+            (config.candidate_label, context.candidate_csv),
+        ):
+            normalized_label = metric_label(label) or label
+            snapshot_summary = context.output_dir / f"{config.slug}_{normalized_label}_snapshot_summary.json"
+            outputs.append(snapshot_summary)
+            command = [
+                context.python_executable,
+                str(context.repo_root / "scripts" / "analysis" / config.input_summary_script),
+                str(snapshot_csv),
+                "--json-out",
+                str(snapshot_summary),
+            ]
+            if config.input_summary_fail_on_issue:
+                command.append("--fail-on-issue")
+            pre_commands.append(tuple(command))
+
     command = [
         context.python_executable,
         str(context.repo_root / "scripts" / "analysis" / config.analysis_script),
@@ -237,6 +261,7 @@ def make_step(config: DiffRunnerConfig, context: DiffContext) -> DiffStep:
         command=command,
         outputs=[str(path) for path in outputs],
         summary_json=str(summary_json),
+        pre_commands=tuple(pre_commands),
     )
 
 
@@ -325,6 +350,52 @@ def load_diff_metrics(config: DiffRunnerConfig, report_json: Path) -> dict[str, 
     return metrics
 
 
+def load_input_summary_metrics(config: DiffRunnerConfig, outputs: Sequence[str]) -> dict[str, object]:
+    if config.input_summary_schema is None:
+        return {}
+    metrics: dict[str, object] = {}
+    for label in (config.base_label, config.candidate_label):
+        normalized_label = metric_label(label)
+        if not normalized_label:
+            continue
+        suffix = f"{config.slug}_{normalized_label}_snapshot_summary.json"
+        summary_path = next((Path(output) for output in outputs if output.endswith(suffix)), None)
+        if summary_path is None or not summary_path.is_file():
+            continue
+        try:
+            payload = json.loads(summary_path.read_text(encoding="utf-8"))
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(payload, dict):
+            continue
+        metrics[f"{normalized_label}_snapshot_schema"] = payload.get("schema")
+        metrics[f"{normalized_label}_snapshot_status"] = payload.get("status")
+        rows = payload.get("rows")
+        if isinstance(rows, int):
+            metrics[f"{normalized_label}_snapshot_rows"] = rows
+        systems = payload.get("systems")
+        if isinstance(systems, dict):
+            metrics[f"{normalized_label}_snapshot_systems"] = systems
+        row_key = payload.get("row_key")
+        if isinstance(row_key, dict):
+            duplicate_groups = row_key.get("duplicate_groups")
+            if isinstance(duplicate_groups, int):
+                metrics[f"{normalized_label}_snapshot_duplicate_groups"] = duplicate_groups
+            max_duplicate_occurrences = row_key.get("max_duplicate_occurrences")
+            if isinstance(max_duplicate_occurrences, int):
+                metrics[f"{normalized_label}_snapshot_max_duplicate_occurrences"] = max_duplicate_occurrences
+        bias_identity = payload.get("bias_identity")
+        if isinstance(bias_identity, dict):
+            for key in ("rows_with_code_bias", "rows_with_phase_bias"):
+                value = bias_identity.get(key)
+                if isinstance(value, int):
+                    metrics[f"{normalized_label}_snapshot_{key}"] = value
+        issue_counts = payload.get("issue_counts")
+        if isinstance(issue_counts, dict):
+            metrics[f"{normalized_label}_snapshot_issue_counts"] = issue_counts
+    return metrics
+
+
 def run_step(config: DiffRunnerConfig, step: DiffStep, repo_root: Path, log_dir: Path) -> dict[str, object]:
     log_path = log_dir / f"{step.slug}.log"
     summary_json = Path(step.summary_json)
@@ -352,30 +423,50 @@ def run_step(config: DiffRunnerConfig, step: DiffStep, repo_root: Path, log_dir:
         return record
 
     assert step.command is not None
-    command_display = " ".join(step.command)
-    print(f"+ {command_display}")
+    commands = [list(command) for command in step.pre_commands]
+    commands.append(step.command)
+    command_display = " && ".join(" ".join(command) for command in commands)
+    for command in commands:
+        print("+ " + " ".join(command))
     started = time.monotonic()
-    completed = subprocess.run(
-        step.command,
-        cwd=repo_root,
-        text=True,
-        capture_output=True,
-        check=False,
-    )
-    elapsed = time.monotonic() - started
-    combined_log = completed.stdout
-    if completed.stderr:
+    combined_log = ""
+    returncode = 0
+    failed_command: list[str] | None = None
+    for command in commands:
+        single_display = " ".join(command)
+        completed = subprocess.run(
+            command,
+            cwd=repo_root,
+            text=True,
+            capture_output=True,
+            check=False,
+        )
         if combined_log and not combined_log.endswith("\n"):
             combined_log += "\n"
-        combined_log += completed.stderr
-    log_path.write_text(f"$ {command_display}\n\n{combined_log}", encoding="utf-8")
+        combined_log += f"$ {single_display}\n\n"
+        combined_log += completed.stdout
+        if completed.stderr:
+            if combined_log and not combined_log.endswith("\n"):
+                combined_log += "\n"
+            combined_log += completed.stderr
+        if completed.returncode != 0:
+            returncode = completed.returncode
+            failed_command = command
+            break
+    elapsed = time.monotonic() - started
+    log_path.write_text(combined_log, encoding="utf-8")
     record["command"] = step.command
+    if step.pre_commands:
+        record["pre_commands"] = [list(command) for command in step.pre_commands]
     record["elapsed_s"] = elapsed
-    record["returncode"] = completed.returncode
+    record["returncode"] = returncode
+    if failed_command is not None:
+        record["failed_command"] = failed_command
     metrics = load_diff_metrics(config, report_json)
+    metrics.update(load_input_summary_metrics(config, step.outputs))
     if metrics:
         record["metrics"] = metrics
-    if completed.returncode == 0:
+    if returncode == 0:
         missing_outputs = [output for output in step.outputs if not Path(output).exists()]
         record["missing_outputs"] = missing_outputs
         if missing_outputs:
@@ -393,11 +484,12 @@ def run_step(config: DiffRunnerConfig, step: DiffStep, repo_root: Path, log_dir:
         tail = "\n".join(lines[-20:])
         if tail:
             print(tail)
-        print(f"Failed {step.name} in {elapsed:.2f}s; see {log_path}")
+        failed_display = " ".join(failed_command) if failed_command is not None else command_display
+        print(f"Failed {step.name} in {elapsed:.2f}s during `{failed_display}`; see {log_path}")
     record["artifacts"] = [
         artifact_record(log_path, role="log", required=True),
         *[
-            artifact_record(Path(output), role="declared_output", required=completed.returncode == 0)
+            artifact_record(Path(output), role="declared_output", required=returncode == 0)
             for output in step.outputs
         ],
     ]
@@ -453,6 +545,22 @@ def render_result_detail(result: dict[str, object]) -> str:
         candidate_duplicates = metrics.get("candidate_duplicate_keys")
         if base_duplicates is not None or candidate_duplicates is not None:
             detail_parts.append(f"duplicate keys `{base_duplicates}/{candidate_duplicates}`")
+        snapshot_rows = [
+            (str(key).removesuffix("_snapshot_rows"), value)
+            for key, value in metrics.items()
+            if str(key).endswith("_snapshot_rows")
+        ]
+        if snapshot_rows:
+            preferred_order = {"madocalib": 0, "claslib": 0, "native": 1}
+            ordered = sorted(
+                snapshot_rows,
+                key=lambda item: (preferred_order.get(item[0], 10), item[0]),
+            )
+            detail_parts.append(
+                "snapshot rows `"
+                + "/".join(str(value) for _, value in ordered[:2])
+                + "`"
+            )
         native_l2w_rows = metrics.get("identity_native_gps_l2w_rows")
         if native_l2w_rows is not None:
             detail_parts.append(f"native L2W `{native_l2w_rows}`")

--- a/scripts/ci/run_optional_madoca_materialization_diff.py
+++ b/scripts/ci/run_optional_madoca_materialization_diff.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import optional_diff_runner as runner  # noqa: E402
 
 
-SUMMARY_SCHEMA = "ci_optional_madoca_materialization_diff.v1"
+SUMMARY_SCHEMA = "ci_optional_madoca_materialization_diff.v2"
 
 CONFIG = runner.DiffRunnerConfig(
     summary_schema=SUMMARY_SCHEMA,
@@ -48,6 +48,9 @@ CONFIG = runner.DiffRunnerConfig(
             "float",
         ),
     ),
+    input_summary_script="madoca_materialization_summary.py",
+    input_summary_schema="madoca_materialization_summary.v1",
+    input_summary_fail_on_issue=True,
 )
 
 

--- a/tests/test_optional_madoca_materialization_diff.py
+++ b/tests/test_optional_madoca_materialization_diff.py
@@ -53,7 +53,12 @@ FIELDNAMES = [
 ]
 
 
-def materialization_row(*, clock_m: str = "0.200", iode: str = "7") -> dict[str, str]:
+def materialization_row(
+    *,
+    clock_m: str = "0.200",
+    iode: str = "7",
+    code_bias_count: str = "1",
+) -> dict[str, str]:
     return {
         "schema_version": "madoca_materialization_snapshot.v1",
         "sat": "G14",
@@ -77,7 +82,7 @@ def materialization_row(*, clock_m: str = "0.200", iode: str = "7") -> dict[str,
         "orbit_along_m": "-0.300",
         "orbit_cross_m": "0.400",
         "clock_m": clock_m,
-        "code_bias_count": "1",
+        "code_bias_count": code_bias_count,
         "code_biases_m": "3:0.250",
         "phase_bias_count": "1",
         "phase_biases_m": "3:-0.125",
@@ -85,11 +90,23 @@ def materialization_row(*, clock_m: str = "0.200", iode: str = "7") -> dict[str,
     }
 
 
-def write_materialization_csv(path: Path, *, clock_m: str = "0.200", iode: str = "7") -> None:
+def write_materialization_csv(
+    path: Path,
+    *,
+    clock_m: str = "0.200",
+    iode: str = "7",
+    code_bias_count: str = "1",
+) -> None:
     with path.open("w", newline="", encoding="utf-8") as handle:
         writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
         writer.writeheader()
-        writer.writerow(materialization_row(clock_m=clock_m, iode=iode))
+        writer.writerow(
+            materialization_row(
+                clock_m=clock_m,
+                iode=iode,
+                code_bias_count=code_bias_count,
+            )
+        )
 
 
 class OptionalMadocaMaterializationDiffTest(unittest.TestCase):
@@ -152,6 +169,13 @@ class OptionalMadocaMaterializationDiffTest(unittest.TestCase):
             self.assertIn("--fail-on-diff", command)
             self.assertNotIn("--component", command)
             self.assertIn(str(output_dir / "madoca_materialization_diff.json"), command)
+            self.assertEqual(len(steps[0].pre_commands), 2)
+            self.assertIn(
+                str(SCRIPT_PATH.parent.parent / "analysis" / "madoca_materialization_summary.py"),
+                steps[0].pre_commands[0],
+            )
+            self.assertIn(str(output_dir / "madoca_materialization_diff_madocalib_snapshot_summary.json"), steps[0].outputs)
+            self.assertIn(str(output_dir / "madoca_materialization_diff_native_snapshot_summary.json"), steps[0].outputs)
 
     def test_run_step_collects_materialization_metrics(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_materialization_exec_") as temp_dir:
@@ -180,6 +204,43 @@ class OptionalMadocaMaterializationDiffTest(unittest.TestCase):
             self.assertEqual(metrics["threshold_exceedances"], 0)
             self.assertEqual(metrics["discrete_mismatches"], 0)
             self.assertAlmostEqual(metrics["max_abs_delta"], 0.075)
+            self.assertEqual(metrics["madocalib_snapshot_schema"], "madoca_materialization_summary.v1")
+            self.assertEqual(metrics["native_snapshot_schema"], "madoca_materialization_summary.v1")
+            self.assertEqual(metrics["madocalib_snapshot_status"], "passed")
+            self.assertEqual(metrics["native_snapshot_status"], "passed")
+            self.assertEqual(metrics["madocalib_snapshot_rows"], 1)
+            self.assertEqual(metrics["native_snapshot_rows"], 1)
+            self.assertEqual(metrics["madocalib_snapshot_duplicate_groups"], 0)
+            self.assertEqual(metrics["native_snapshot_duplicate_groups"], 0)
+            artifact_paths = {artifact["path"] for artifact in result["artifacts"]}
+            self.assertIn(str(output_dir / "madoca_materialization_diff_madocalib_snapshot_summary.json"), artifact_paths)
+            self.assertIn(str(output_dir / "madoca_materialization_diff_native_snapshot_summary.json"), artifact_paths)
+
+    def test_run_step_fails_when_snapshot_summary_fails(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_materialization_input_summary_") as temp_dir:
+            root = Path(temp_dir)
+            base_csv = root / "madocalib.csv"
+            candidate_csv = root / "native.csv"
+            write_materialization_csv(base_csv)
+            write_materialization_csv(candidate_csv, code_bias_count="2")
+            output_dir = root / "output"
+            log_dir = output_dir / "logs"
+            log_dir.mkdir(parents=True)
+            env = {
+                "GNSSPP_MADOCA_MATERIALIZATION_BASE_CSV": str(base_csv),
+                "GNSSPP_MADOCA_MATERIALIZATION_CANDIDATE_CSV": str(candidate_csv),
+            }
+            step = runner.build_step_plan(ROOT_DIR, output_dir, env)[0]
+
+            result = runner.run_step(step, ROOT_DIR, log_dir)
+
+            self.assertEqual(result["status"], "failed")
+            self.assertNotEqual(result["returncode"], 0)
+            self.assertIn("madoca_materialization_summary.py", " ".join(result["failed_command"]))
+            metrics = result["metrics"]
+            self.assertEqual(metrics["madocalib_snapshot_status"], "passed")
+            self.assertEqual(metrics["native_snapshot_status"], "failed")
+            self.assertEqual(metrics["native_snapshot_rows"], 1)
 
     def test_run_step_reports_discrete_mismatches(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_materialization_discrete_") as temp_dir:
@@ -261,6 +322,20 @@ class OptionalMadocaMaterializationDiffTest(unittest.TestCase):
         self.assertIn("discrete mismatches `4`", markdown)
         self.assertIn("duplicate keys `0/1`", markdown)
 
+        snapshot_markdown = runner.render_markdown_summary(
+            [
+                {
+                    "name": "MADOCA materialization diff",
+                    "status": "passed",
+                    "metrics": {
+                        "madocalib_snapshot_rows": 12,
+                        "native_snapshot_rows": 13,
+                    },
+                }
+            ]
+        )
+        self.assertIn("snapshot rows `12/13`", snapshot_markdown)
+
     def test_write_summary_declares_schema(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_materialization_summary_") as temp_dir:
             summary_path = Path(temp_dir) / "summary.json"
@@ -281,6 +356,7 @@ class OptionalMadocaMaterializationDiffTest(unittest.TestCase):
 
             payload = json.loads(summary_path.read_text(encoding="utf-8"))
             self.assertEqual(payload["summary_schema"], runner.SUMMARY_SCHEMA)
+            self.assertEqual(payload["summary_schema"], "ci_optional_madoca_materialization_diff.v2")
             self.assertEqual(payload["contract"], "optional_diff_artifact_contract.v1")
             self.assertEqual(payload["status"], "blocked_infrastructure")
             self.assertIn("missing evidence", payload["next_actions"][1])


### PR DESCRIPTION
## Summary

- run `madoca_materialization_summary.py` on both optional MADOCA materialization input snapshots before diffing
- include the per-input summary JSON files in the optional diff outputs and uploaded CI artifacts
- surface snapshot row/key/bias summary metrics in the optional diff summary contract

## Validation

- `python3 -m py_compile scripts/ci/optional_diff_runner.py scripts/ci/run_optional_madoca_materialization_diff.py tests/test_optional_madoca_materialization_diff.py`
- `python3 tests/test_optional_madoca_materialization_diff.py`
- `python3 tests/test_optional_clas_zd_component_diff.py && python3 tests/test_optional_madoca_residual_component_diff.py`
- `ctest --test-dir build -R 'python_optional_madoca_materialization_diff_tests|python_optional_clas_zd_component_diff_tests|python_optional_madoca_residual_component_diff_tests|python_madoca_materialization_summary_tests|python_madoca_materialization_diff_tests' --output-on-failure`
- `bash scripts/ci/run_hygiene.sh`
- `git diff --check`
- `ctest --test-dir build -L core --output-on-failure`

Local `python3 -m mkdocs build --strict` was not run because this environment does not have the `mkdocs` module installed.
