### PR TITLE
ci: summarize optional MADOCA residual inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -431,6 +431,8 @@ jobs:
           output/ci_optional_madoca_residual_component/*.log
           output/madoca_residual_component_diff.json
           output/madoca_residual_component_diff.csv
+          output/madoca_residual_component_diff_madocalib_snapshot_summary.json
+          output/madoca_residual_component_diff_native_snapshot_summary.json
         if-no-files-found: error
 
     - name: Upload PPP products comparison artifacts

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -59,7 +59,10 @@ CI lanes are split as follows:
   artifacts are missing.  The MADOCA materialization diff additionally emits
   `madoca_materialization_summary.v1` JSON for both input snapshots and fails
   before the diff when either snapshot has count, discontinuity, or duplicate-key
-  contract issues.
+  contract issues.  The MADOCA residual-component diff follows the same pattern
+  with `madoca_residual_component_summary.v1` JSON for both input snapshots,
+  failing before residual deltas are compared when row identity or component
+  presence is malformed.
 - `python3 scripts/ci/run_clas_a4b_native_selfdiff.py` for the public CLAS A4b
   native-side evidence bundle; it sparse-fetches CLASLIB public data unless
   `GNSSPP_CLAS_A4B_DATA_ROOT` is supplied, generates the native code dump, and

--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -122,11 +122,15 @@ The optional CI wrapper
 when `GNSSPP_MADOCA_RESIDUAL_BASE_CSV` and
 `GNSSPP_MADOCA_RESIDUAL_CANDIDATE_CSV` point at generated oracle/native CSV
 dumps.  It writes `ci_optional_madoca_residual_component_summary.json`, a log,
-and the `madoca_residual_component_diff.{json,csv}` artifacts; when those inputs
-are absent the CI step records `status: blocked_infrastructure` with next
-actions instead of silently treating the missing oracle/native evidence as a
-passing sign-off.  The workflow upload treats the summary/log bundle as
-required evidence.  Optional filters are
+the `madoca_residual_component_diff.{json,csv}` artifacts, and one
+`madoca_residual_component_summary.v1` JSON for each oracle/native input
+snapshot.  The wrapper runs those snapshot summaries with `--fail-on-issue`
+before the diff, so malformed row keys, missing row identity, or rows without
+numeric residual components fail as input-contract issues.  When inputs are
+absent the CI step records `status: blocked_infrastructure` with next actions
+instead of silently treating the missing oracle/native evidence as a passing
+sign-off.  The workflow upload treats the summary/log bundle as required
+evidence.  Optional filters are
 `GNSSPP_MADOCA_RESIDUAL_COMPONENTS`, `GNSSPP_MADOCA_RESIDUAL_ROW_TYPE`,
 `GNSSPP_MADOCA_RESIDUAL_ITERATION`, `GNSSPP_MADOCA_RESIDUAL_THRESHOLD`, and
 `GNSSPP_MADOCA_RESIDUAL_FAIL_ON_DIFF`.

--- a/scripts/analysis/madoca_residual_component_summary.py
+++ b/scripts/analysis/madoca_residual_component_summary.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""Summarize and validate a MADOCA residual-component CSV dump."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import json
+from pathlib import Path
+import sys
+from typing import Any, Mapping, Sequence
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import madoca_residual_component_diff as residual_diff  # noqa: E402
+
+
+SCHEMA = "madoca_residual_component_summary.v1"
+
+
+def _format_counter(counter: Counter[str]) -> dict[str, int]:
+    return {key: counter[key] for key in sorted(counter)}
+
+
+def _format_top(counter: Counter[str], limit: int) -> list[dict[str, object]]:
+    return [
+        {"key": key, "count": count}
+        for key, count in sorted(counter.items(), key=lambda item: (-item[1], item[0]))[:limit]
+    ]
+
+
+def _sat_system(sat: str) -> str:
+    prefix = sat[:1].upper()
+    return {
+        "G": "GPS",
+        "R": "GLONASS",
+        "E": "Galileo",
+        "J": "QZSS",
+        "Q": "QZSS",
+        "C": "BeiDou",
+        "B": "BeiDou",
+        "I": "IRNSS",
+        "S": "SBAS",
+    }.get(prefix, prefix or "unknown")
+
+
+def _parse_int_text(value: str) -> str:
+    try:
+        return str(int(float(value)))
+    except (TypeError, ValueError):
+        return value
+
+
+def _row_key(row: Mapping[str, str]) -> tuple[residual_diff.Group, residual_diff.Identity]:
+    return (residual_diff.group_from_row(dict(row)), residual_diff.identity_from_row(dict(row)))
+
+
+def summarize_rows(rows: Sequence[dict[str, str]], *, top_limit: int = 20) -> dict[str, object]:
+    systems: Counter[str] = Counter()
+    satellites: Counter[str] = Counter()
+    row_types: Counter[str] = Counter()
+    iterations: Counter[str] = Counter()
+    primary_codes: Counter[str] = Counter()
+    secondary_codes: Counter[str] = Counter()
+    frequency_indices: Counter[str] = Counter()
+    ionosphere_coefficients: Counter[str] = Counter()
+    component_rows: Counter[str] = Counter()
+    key_counts: Counter[tuple[residual_diff.Group, residual_diff.Identity]] = Counter()
+    issue_counts: Counter[str] = Counter()
+    issue_examples: dict[str, list[dict[str, object]]] = {}
+    time_keys: list[tuple[int, int]] = []
+
+    component_names = sorted(residual_diff.COMPONENT_ALIASES)
+
+    def record_issue(kind: str, row_number: int, detail: str) -> None:
+        issue_counts[kind] += 1
+        examples = issue_examples.setdefault(kind, [])
+        if len(examples) < 5:
+            examples.append({"row": row_number, "detail": detail})
+
+    for row_number, row in enumerate(rows, start=2):
+        sat = row.get("sat", "")
+        row_type = row.get("row_type", "")
+        if not sat:
+            record_issue("missing_satellite", row_number, "")
+        if not row_type:
+            record_issue("missing_row_type", row_number, "")
+
+        systems[_sat_system(sat)] += 1
+        satellites[sat] += 1
+        row_types[row_type] += 1
+        iterations[_parse_int_text(row.get("iteration", ""))] += 1
+
+        try:
+            key_group, key_identity = _row_key(row)
+            key_counts[(key_group, key_identity)] += 1
+            time_keys.append((key_group[0], key_group[1]))
+        except (ValueError, TypeError) as exc:
+            record_issue("bad_row_key", row_number, str(exc))
+
+        identity = residual_diff.identity_from_row(dict(row))
+        primary_codes[identity[3]] += 1
+        secondary_codes[identity[4]] += 1
+        frequency_indices[str(identity[5])] += 1
+        ionosphere_coefficients[identity[6]] += 1
+
+        components = residual_diff.extract_components(row, component_names)
+        if not components:
+            record_issue("missing_numeric_component", row_number, "")
+        for component in components:
+            component_rows[component] += 1
+
+    duplicate_groups = [group for group, count in key_counts.items() if count > 1]
+    max_duplicate_occurrences = max(key_counts.values(), default=0)
+    if time_keys:
+        first_week, first_tow_ms = min(time_keys)
+        last_week, last_tow_ms = max(time_keys)
+        time_range: dict[str, object] = {
+            "start_week": first_week,
+            "start_tow": first_tow_ms / 1000.0,
+            "end_week": last_week,
+            "end_tow": last_tow_ms / 1000.0,
+        }
+    else:
+        time_range = {}
+
+    return {
+        "schema": SCHEMA,
+        "status": "failed" if issue_counts else "passed",
+        "rows": len(rows),
+        "unique_satellites": len(satellites),
+        "systems": _format_counter(systems),
+        "top_satellites": _format_top(satellites, top_limit),
+        "time_range": time_range,
+        "row_types": _format_counter(row_types),
+        "iterations": _format_counter(iterations),
+        "observation_identity": {
+            "primary_observation_codes": _format_counter(primary_codes),
+            "secondary_observation_codes": _format_counter(secondary_codes),
+            "frequency_indices": _format_counter(frequency_indices),
+            "ionosphere_coefficients": _format_counter(ionosphere_coefficients),
+        },
+        "component_presence": {
+            "rows_with_component": _format_counter(component_rows),
+            "known_components": component_names,
+        },
+        "row_key": {
+            "groups": len(key_counts),
+            "duplicate_groups": len(duplicate_groups),
+            "max_duplicate_occurrences": max_duplicate_occurrences,
+        },
+        "issue_counts": _format_counter(issue_counts),
+        "issue_examples": issue_examples,
+    }
+
+
+def requirement_failures(summary: Mapping[str, Any], args: argparse.Namespace) -> list[str]:
+    failures: list[str] = []
+    rows = summary.get("rows", 0)
+    if not isinstance(rows, int):
+        failures.append("summary rows is not an integer")
+    elif rows < args.require_rows_min:
+        failures.append(f"rows {rows} < required minimum {args.require_rows_min}")
+
+    row_types = summary.get("row_types", {})
+    if not isinstance(row_types, dict):
+        row_types = {}
+    for row_type in args.require_row_type:
+        if int(row_types.get(str(row_type), 0)) <= 0:
+            failures.append(f"required row type {row_type} is absent")
+
+    iterations = summary.get("iterations", {})
+    if not isinstance(iterations, dict):
+        iterations = {}
+    for iteration in args.require_iteration:
+        if int(iterations.get(str(iteration), 0)) <= 0:
+            failures.append(f"required iteration {iteration} is absent")
+
+    component_presence = summary.get("component_presence", {})
+    if not isinstance(component_presence, dict):
+        component_presence = {}
+    rows_with_component = component_presence.get("rows_with_component", {})
+    if not isinstance(rows_with_component, dict):
+        rows_with_component = {}
+    for component in args.require_component:
+        if int(rows_with_component.get(str(component), 0)) <= 0:
+            failures.append(f"required component {component} is absent")
+
+    row_key = summary.get("row_key", {})
+    if not isinstance(row_key, dict):
+        row_key = {}
+    if args.require_no_duplicate_keys and int(row_key.get("duplicate_groups", 0)) != 0:
+        failures.append(f"duplicate row keys {row_key.get('duplicate_groups')} != 0")
+
+    issue_counts = summary.get("issue_counts", {})
+    if args.fail_on_issue and isinstance(issue_counts, dict) and issue_counts:
+        failures.append(f"snapshot issues present: {issue_counts}")
+    return failures
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("snapshot_csv", type=Path)
+    parser.add_argument("--json-out", type=Path)
+    parser.add_argument("--require-rows-min", type=int, default=0)
+    parser.add_argument("--require-row-type", action="append", default=[])
+    parser.add_argument("--require-iteration", action="append", default=[])
+    parser.add_argument("--require-component", action="append", default=[])
+    parser.add_argument("--require-no-duplicate-keys", action="store_true")
+    parser.add_argument("--fail-on-issue", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        rows = residual_diff.read_csv_rows(args.snapshot_csv)
+        summary = summarize_rows(rows)
+        failures = requirement_failures(summary, args)
+        if failures:
+            summary = {**summary, "status": "failed", "failures": failures}
+        else:
+            summary = {**summary, "failures": []}
+    except Exception as exc:
+        summary = {
+            "schema": SCHEMA,
+            "status": "failed",
+            "failures": [str(exc)],
+        }
+
+    if args.json_out is not None:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    print("madoca_residual_component_summary:")
+    print(f"  status: {summary.get('status')}")
+    if "rows" in summary:
+        print(f"  rows: {summary['rows']}")
+    if summary.get("failures"):
+        print("  failures:")
+        for failure in summary["failures"]:
+            print(f"    - {failure}")
+    return 0 if summary.get("status") == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/run_optional_madoca_residual_component_diff.py
+++ b/scripts/ci/run_optional_madoca_residual_component_diff.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import optional_diff_runner as runner  # noqa: E402
 
 
-SUMMARY_SCHEMA = "ci_optional_madoca_residual_component_diff.v2"
+SUMMARY_SCHEMA = "ci_optional_madoca_residual_component_diff.v3"
 
 CONFIG = runner.DiffRunnerConfig(
     summary_schema=SUMMARY_SCHEMA,
@@ -42,6 +42,9 @@ CONFIG = runner.DiffRunnerConfig(
         runner.EnvOption(("GNSSPP_MADOCA_RESIDUAL_ITERATION",), "--iteration", "int"),
         runner.EnvOption(("GNSSPP_MADOCA_RESIDUAL_THRESHOLD",), "--component-threshold", "float"),
     ),
+    input_summary_script="madoca_residual_component_summary.py",
+    input_summary_schema="madoca_residual_component_summary.v1",
+    input_summary_fail_on_issue=True,
 )
 
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -106,6 +106,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_madoca_residual_component_diff.py
     )
     add_test(
+        NAME python_madoca_residual_component_summary_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_madoca_residual_component_summary.py
+    )
+    add_test(
         NAME python_madoca_materialization_diff_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_madoca_materialization_diff.py
     )
@@ -286,6 +290,7 @@ if(GTest_FOUND)
         python_madoca_materialization_selfdiff_tests
         python_madoca_materialization_summary_tests
         python_madoca_residual_component_diff_tests
+        python_madoca_residual_component_summary_tests
         python_madoca_solution_diff_tests
         python_madoca_satellite_set_diff_tests
         python_mode_compare_tests

--- a/tests/test_madoca_residual_component_summary.py
+++ b/tests/test_madoca_residual_component_summary.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Tests for MADOCA residual-component snapshot summaries."""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT_DIR / "scripts" / "analysis" / "madoca_residual_component_summary.py"
+
+spec = importlib.util.spec_from_file_location("madoca_residual_component_summary", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+summary_script = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = summary_script
+spec.loader.exec_module(summary_script)
+
+
+FIELDNAMES = [
+    "week",
+    "tow",
+    "iteration",
+    "sat",
+    "row_type",
+    "residual_m",
+    "iono_state_m",
+    "trop_m",
+    "primary_observation_code",
+    "secondary_observation_code",
+    "frequency_index",
+    "ionosphere_coefficient",
+]
+
+
+def residual_row(
+    *,
+    sat: str = "G01",
+    tow: str = "172800.000",
+    iteration: str = "1",
+    row_type: str = "code",
+    residual_m: str = "0.1",
+    iono_state_m: str = "0.5",
+    trop_m: str = "2.3",
+    primary_code: str = "C1C",
+    secondary_code: str = "C2W",
+    frequency_index: str = "0",
+    ionosphere_coefficient: str = "1.0",
+) -> dict[str, str]:
+    return {
+        "week": "2360",
+        "tow": tow,
+        "iteration": iteration,
+        "sat": sat,
+        "row_type": row_type,
+        "residual_m": residual_m,
+        "iono_state_m": iono_state_m,
+        "trop_m": trop_m,
+        "primary_observation_code": primary_code,
+        "secondary_observation_code": secondary_code,
+        "frequency_index": frequency_index,
+        "ionosphere_coefficient": ionosphere_coefficient,
+    }
+
+
+def write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+class MadocaResidualComponentSummaryTest(unittest.TestCase):
+    def test_summary_reports_row_identity_and_components(self) -> None:
+        rows = [
+            residual_row(sat="G01", row_type="code", primary_code="C1C"),
+            residual_row(
+                sat="E11",
+                row_type="phase",
+                tow="172830.000",
+                iteration="2",
+                primary_code="C5Q",
+                secondary_code="",
+                frequency_index="1",
+                ionosphere_coefficient="1.64694444444444",
+            ),
+        ]
+
+        summary = summary_script.summarize_rows(rows)
+
+        self.assertEqual(summary["schema"], "madoca_residual_component_summary.v1")
+        self.assertEqual(summary["status"], "passed")
+        self.assertEqual(summary["rows"], 2)
+        self.assertEqual(summary["systems"], {"Galileo": 1, "GPS": 1})
+        self.assertEqual(summary["row_types"], {"code": 1, "phase": 1})
+        self.assertEqual(summary["iterations"], {"1": 1, "2": 1})
+        self.assertEqual(summary["time_range"]["start_tow"], 172800.0)
+        self.assertEqual(summary["time_range"]["end_tow"], 172830.0)
+        observation_identity = summary["observation_identity"]
+        self.assertEqual(observation_identity["primary_observation_codes"]["C1C"], 1)
+        self.assertEqual(observation_identity["primary_observation_codes"]["C5Q"], 1)
+        self.assertEqual(observation_identity["frequency_indices"]["1"], 1)
+        self.assertEqual(summary["component_presence"]["rows_with_component"]["residual_m"], 2)
+        self.assertEqual(summary["component_presence"]["rows_with_component"]["iono_state_m"], 2)
+        self.assertEqual(summary["row_key"]["duplicate_groups"], 0)
+
+    def test_summary_detects_bad_rows_and_duplicate_keys(self) -> None:
+        rows = [
+            residual_row(sat="G01", residual_m=""),
+            residual_row(sat="G01", residual_m=""),
+            residual_row(sat="", row_type="", tow="bad", residual_m="nan", iono_state_m="", trop_m=""),
+        ]
+
+        summary = summary_script.summarize_rows(rows)
+
+        self.assertEqual(summary["status"], "failed")
+        self.assertEqual(summary["row_key"]["duplicate_groups"], 1)
+        self.assertEqual(summary["issue_counts"]["missing_satellite"], 1)
+        self.assertEqual(summary["issue_counts"]["missing_row_type"], 1)
+        self.assertEqual(summary["issue_counts"]["bad_row_key"], 1)
+        self.assertEqual(summary["issue_counts"]["missing_numeric_component"], 1)
+
+    def test_cli_writes_json_and_enforces_requirements(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="madoca_residual_component_summary_cli_") as temp_dir:
+            root = Path(temp_dir)
+            snapshot = root / "residual.csv"
+            summary_json = root / "summary.json"
+            write_csv(snapshot, [residual_row(row_type="code")])
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    str(snapshot),
+                    "--json-out",
+                    str(summary_json),
+                    "--require-rows-min",
+                    "2",
+                    "--require-row-type",
+                    "phase",
+                    "--require-iteration",
+                    "2",
+                    "--require-component",
+                    "residual_m",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            payload = json.loads(summary_json.read_text(encoding="utf-8"))
+            self.assertEqual(payload["schema"], "madoca_residual_component_summary.v1")
+            self.assertEqual(payload["status"], "failed")
+            self.assertIn("rows 1 < required minimum 2", payload["failures"])
+            self.assertIn("required row type phase is absent", payload["failures"])
+            self.assertIn("required iteration 2 is absent", payload["failures"])
+
+    def test_cli_passes_clean_snapshot_with_fail_on_issue(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="madoca_residual_component_summary_pass_") as temp_dir:
+            root = Path(temp_dir)
+            snapshot = root / "residual.csv"
+            summary_json = root / "summary.json"
+            write_csv(snapshot, [residual_row(row_type="code")])
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    str(snapshot),
+                    "--json-out",
+                    str(summary_json),
+                    "--fail-on-issue",
+                    "--require-row-type",
+                    "code",
+                    "--require-component",
+                    "residual_m",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            payload = json.loads(summary_json.read_text(encoding="utf-8"))
+            self.assertEqual(payload["status"], "passed")
+            self.assertEqual(payload["failures"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_optional_madoca_residual_component_diff.py
+++ b/tests/test_optional_madoca_residual_component_diff.py
@@ -37,7 +37,7 @@ FIELDNAMES = [
 ]
 
 
-def write_residual_csv(path: Path, *, residual_m: str = "0.1") -> None:
+def write_residual_csv(path: Path, *, residual_m: str = "0.1", sat: str = "G01") -> None:
     with path.open("w", newline="", encoding="utf-8") as handle:
         writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
         writer.writeheader()
@@ -46,7 +46,7 @@ def write_residual_csv(path: Path, *, residual_m: str = "0.1") -> None:
                 "week": "2360",
                 "tow": "172800.000",
                 "iteration": "1",
-                "sat": "G01",
+                "sat": sat,
                 "row_type": "code",
                 "residual_m": residual_m,
                 "iono_state_m": "0.5",
@@ -126,6 +126,19 @@ class OptionalMadocaResidualComponentDiffTest(unittest.TestCase):
             self.assertIn("0.25", command)
             self.assertIn("--fail-on-diff", command)
             self.assertIn(str(output_dir / "madoca_residual_component_diff.json"), command)
+            self.assertEqual(len(steps[0].pre_commands), 2)
+            self.assertIn(
+                str(SCRIPT_PATH.parent.parent / "analysis" / "madoca_residual_component_summary.py"),
+                steps[0].pre_commands[0],
+            )
+            self.assertIn(
+                str(output_dir / "madoca_residual_component_diff_madocalib_snapshot_summary.json"),
+                steps[0].outputs,
+            )
+            self.assertIn(
+                str(output_dir / "madoca_residual_component_diff_native_snapshot_summary.json"),
+                steps[0].outputs,
+            )
 
     def test_run_step_collects_metrics_from_diff_report(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_residual_exec_") as temp_dir:
@@ -155,6 +168,48 @@ class OptionalMadocaResidualComponentDiffTest(unittest.TestCase):
             self.assertEqual(metrics["common_rows"], 1)
             self.assertEqual(metrics["components_compared"], 1)
             self.assertAlmostEqual(metrics["max_abs_delta"], 0.05)
+            self.assertEqual(metrics["madocalib_snapshot_schema"], "madoca_residual_component_summary.v1")
+            self.assertEqual(metrics["native_snapshot_schema"], "madoca_residual_component_summary.v1")
+            self.assertEqual(metrics["madocalib_snapshot_status"], "passed")
+            self.assertEqual(metrics["native_snapshot_status"], "passed")
+            self.assertEqual(metrics["madocalib_snapshot_rows"], 1)
+            self.assertEqual(metrics["native_snapshot_rows"], 1)
+            artifact_paths = {artifact["path"] for artifact in result["artifacts"]}
+            self.assertIn(
+                str(output_dir / "madoca_residual_component_diff_madocalib_snapshot_summary.json"),
+                artifact_paths,
+            )
+            self.assertIn(
+                str(output_dir / "madoca_residual_component_diff_native_snapshot_summary.json"),
+                artifact_paths,
+            )
+
+    def test_run_step_fails_when_snapshot_summary_fails(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_residual_input_summary_") as temp_dir:
+            root = Path(temp_dir)
+            base_csv = root / "madocalib.csv"
+            candidate_csv = root / "native.csv"
+            write_residual_csv(base_csv, residual_m="0.10")
+            write_residual_csv(candidate_csv, residual_m="0.15", sat="")
+            output_dir = root / "output"
+            log_dir = output_dir / "logs"
+            log_dir.mkdir(parents=True)
+            env = {
+                "GNSSPP_MADOCA_RESIDUAL_BASE_CSV": str(base_csv),
+                "GNSSPP_MADOCA_RESIDUAL_CANDIDATE_CSV": str(candidate_csv),
+                "GNSSPP_MADOCA_RESIDUAL_COMPONENTS": "residual_m",
+            }
+            step = runner.build_step_plan(ROOT_DIR, output_dir, env)[0]
+
+            result = runner.run_step(step, ROOT_DIR, log_dir)
+
+            self.assertEqual(result["status"], "failed")
+            self.assertNotEqual(result["returncode"], 0)
+            self.assertIn("madoca_residual_component_summary.py", " ".join(result["failed_command"]))
+            metrics = result["metrics"]
+            self.assertEqual(metrics["madocalib_snapshot_status"], "passed")
+            self.assertEqual(metrics["native_snapshot_status"], "failed")
+            self.assertEqual(metrics["native_snapshot_rows"], 1)
 
     def test_run_step_fails_when_declared_outputs_are_missing(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_residual_missing_") as temp_dir:
@@ -224,6 +279,20 @@ class OptionalMadocaResidualComponentDiffTest(unittest.TestCase):
         self.assertIn("see `/tmp/madoca.log`", markdown)
         self.assertIn("missing `/tmp/missing.json`", markdown)
 
+        snapshot_markdown = runner.render_markdown_summary(
+            [
+                {
+                    "name": "MADOCA residual-component diff",
+                    "status": "passed",
+                    "metrics": {
+                        "madocalib_snapshot_rows": 12,
+                        "native_snapshot_rows": 13,
+                    },
+                }
+            ]
+        )
+        self.assertIn("snapshot rows `12/13`", snapshot_markdown)
+
     def test_write_summary_declares_schema(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ci_madoca_residual_summary_") as temp_dir:
             summary_path = Path(temp_dir) / "summary.json"
@@ -244,6 +313,7 @@ class OptionalMadocaResidualComponentDiffTest(unittest.TestCase):
 
             payload = json.loads(summary_path.read_text(encoding="utf-8"))
             self.assertEqual(payload["summary_schema"], runner.SUMMARY_SCHEMA)
+            self.assertEqual(payload["summary_schema"], "ci_optional_madoca_residual_component_diff.v3")
             self.assertEqual(payload["contract"], "optional_diff_artifact_contract.v1")
             self.assertEqual(payload["status"], "blocked_infrastructure")
             self.assertIn("missing evidence", payload["next_actions"][1])


### PR DESCRIPTION
## Summary

- add `madoca_residual_component_summary.py` to summarize and validate residual-component CSV snapshots
- run per-input residual summaries before the optional MADOCA residual-component diff
- upload the oracle/native residual snapshot summaries as required CI artifacts

## Validation

- `python3 -m py_compile scripts/analysis/madoca_residual_component_summary.py scripts/ci/run_optional_madoca_residual_component_diff.py tests/test_madoca_residual_component_summary.py tests/test_optional_madoca_residual_component_diff.py`
- `python3 tests/test_madoca_residual_component_summary.py`
- `python3 tests/test_optional_madoca_residual_component_diff.py`
- `python3 tests/test_optional_madoca_materialization_diff.py && python3 tests/test_optional_clas_zd_component_diff.py`
- `cmake --build build --target run_tests -j4`
- `git diff --check`
- `bash scripts/ci/run_hygiene.sh`
- `ctest --test-dir build -R 'python_madoca_residual_component_summary_tests|python_optional_madoca_residual_component_diff_tests|python_madoca_residual_component_diff_tests|python_optional_madoca_materialization_diff_tests|python_optional_clas_zd_component_diff_tests' --output-on-failure`
- `python3 -m mkdocs build --strict`
- `ctest --test-dir build -L core --output-on-failure`
