### PR TITLE
ci: summarize optional CLAS ZD inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -335,6 +335,8 @@ jobs:
           output/ci_optional_clas_zd_component/*.log
           output/clas_zd_component_diff.json
           output/clas_zd_component_diff.csv
+          output/clas_zd_component_diff_claslib_snapshot_summary.json
+          output/clas_zd_component_diff_native_snapshot_summary.json
         if-no-files-found: error
 
     - name: CLAS A4b native self-diff

--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -187,10 +187,14 @@ The optional CI wrapper `scripts/ci/run_optional_clas_zd_component_diff.py`
 runs that comparison when `GNSSPP_CLAS_ZD_BASE_CSV` and
 `GNSSPP_CLAS_ZD_CANDIDATE_CSV` point at generated CLASLIB/native component
 dumps.  It writes `ci_optional_clas_zd_component_summary.json`, a log, and the
-`clas_zd_component_diff.{json,csv}` artifacts.  When those inputs are absent,
-the CI step records `status: blocked_infrastructure` with next actions instead
-of silently treating the missing oracle/native evidence as a passing sign-off.
-The workflow upload treats the summary/log bundle as required evidence.
+`clas_zd_component_diff.{json,csv}` artifacts, plus
+`clas_zd_component_summary.v1` JSON for both CLASLIB and native input snapshots.
+The input summaries validate row keys, observation identity, duplicate groups,
+and component presence before any deltas are compared.  When those inputs are
+absent, the CI step records `status: blocked_infrastructure` with next actions
+instead of silently treating the missing oracle/native evidence as a passing
+sign-off.  The workflow upload treats the summary/log bundle as required
+evidence.
 Optional filters are `GNSSPP_CLAS_ZD_COMPONENTS`, `GNSSPP_CLAS_ZD_STAGE`,
 `GNSSPP_CLAS_ZD_ROW_TYPE`, `GNSSPP_CLAS_ZD_THRESHOLD_M`, and
 `GNSSPP_CLAS_ZD_FAIL_ON_DIFF`.  GPS L2W A4b probes can also narrow the row set

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -56,7 +56,10 @@ CI lanes are split as follows:
   oracle/native diff artifacts; they report `blocked_infrastructure` with
   next actions when their CSV inputs are unavailable, require a summary/log
   artifact in CI, and fail a passed diff command if the declared JSON/CSV
-  artifacts are missing.  The MADOCA materialization diff additionally emits
+  artifacts are missing.  The CLAS ZD component diff additionally emits
+  `clas_zd_component_summary.v1` JSON for both input snapshots and fails before
+  the component diff when row keys, observation identity, or component presence
+  is malformed.  The MADOCA materialization diff additionally emits
   `madoca_materialization_summary.v1` JSON for both input snapshots and fails
   before the diff when either snapshot has count, discontinuity, or duplicate-key
   contract issues.  The MADOCA residual-component diff follows the same pattern

--- a/scripts/analysis/clas_zd_component_summary.py
+++ b/scripts/analysis/clas_zd_component_summary.py
@@ -1,0 +1,315 @@
+#!/usr/bin/env python3
+"""Summarize and validate a CLAS zero-difference component CSV dump."""
+
+from __future__ import annotations
+
+import argparse
+from collections import Counter
+import json
+from pathlib import Path
+import sys
+from typing import Any, Mapping, Sequence
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+import clas_zd_component_diff as zd_diff  # noqa: E402
+
+
+SCHEMA = "clas_zd_component_summary.v1"
+
+
+def _format_counter(counter: Counter[str]) -> dict[str, int]:
+    return {key: counter[key] for key in sorted(counter)}
+
+
+def _format_top(counter: Counter[str], limit: int) -> list[dict[str, object]]:
+    return [
+        {"key": key, "count": count}
+        for key, count in sorted(counter.items(), key=lambda item: (-item[1], item[0]))[:limit]
+    ]
+
+
+def _sat_system(sat: str) -> str:
+    prefix = sat[:1].upper()
+    return {
+        "G": "GPS",
+        "R": "GLONASS",
+        "E": "Galileo",
+        "J": "QZSS",
+        "Q": "QZSS",
+        "C": "BeiDou",
+        "B": "BeiDou",
+        "I": "IRNSS",
+        "S": "SBAS",
+    }.get(prefix, prefix or "unknown")
+
+
+def _parse_week(value: str) -> int:
+    return int(float(value))
+
+
+def _row_key(row: Mapping[str, str]) -> zd_diff.Key:
+    row_type = zd_diff.detect_row_type(dict(row))
+    return (
+        _parse_week(row.get("week", "")),
+        zd_diff.tow_to_millis(row.get("tow", "")),
+        row_type,
+        row.get("sat", ""),
+        zd_diff.detect_frequency(dict(row)),
+        zd_diff.observation_identity(dict(row), row_type),
+    )
+
+
+def _component_true(row: Mapping[str, str], component: str) -> bool:
+    components = zd_diff.extract_components(dict(row), [component])
+    value = components.get(component)
+    return value is not None and value > 0.5
+
+
+def _has_component(row: Mapping[str, str], component: str) -> bool:
+    return component in zd_diff.extract_components(dict(row), [component])
+
+
+def summarize_rows(rows: Sequence[dict[str, str]], *, top_limit: int = 20) -> dict[str, object]:
+    systems: Counter[str] = Counter()
+    satellites: Counter[str] = Counter()
+    stages: Counter[str] = Counter()
+    row_types: Counter[str] = Counter()
+    frequencies: Counter[str] = Counter()
+    rinex_codes: Counter[str] = Counter()
+    component_rows: Counter[str] = Counter()
+    key_counts: Counter[zd_diff.Key] = Counter()
+    issue_counts: Counter[str] = Counter()
+    issue_examples: dict[str, list[dict[str, object]]] = {}
+    time_keys: list[tuple[int, int]] = []
+
+    identity_counts: dict[str, Counter[str]] = {
+        component: Counter() for component in zd_diff.IDENTITY_PROVENANCE_COMPONENTS
+    }
+    gps_l2w_identity_counts: dict[str, Counter[str]] = {
+        component: Counter() for component in zd_diff.IDENTITY_PROVENANCE_COMPONENTS
+    }
+
+    component_names = sorted(zd_diff.COMPONENT_ALIASES)
+
+    def record_issue(kind: str, row_number: int, detail: str) -> None:
+        issue_counts[kind] += 1
+        examples = issue_examples.setdefault(kind, [])
+        if len(examples) < 5:
+            examples.append({"row": row_number, "detail": detail})
+
+    for row_number, row in enumerate(rows, start=2):
+        sat = row.get("sat", "")
+        stage = row.get("stage", "")
+        row_type = zd_diff.detect_row_type(row)
+        freq = zd_diff.detect_frequency(row)
+        signal = zd_diff.observation_identity(row, row_type)
+
+        if not sat:
+            record_issue("missing_satellite", row_number, "")
+        if not row_type:
+            record_issue("missing_row_type", row_number, "")
+        if not signal:
+            record_issue("missing_observation_identity", row_number, "")
+
+        systems[_sat_system(sat)] += 1
+        satellites[sat] += 1
+        stages[stage] += 1
+        row_types[row_type] += 1
+        frequencies[str(freq)] += 1
+        rinex_codes[signal] += 1
+
+        try:
+            key = _row_key(row)
+            key_counts[key] += 1
+            time_keys.append((key[0], key[1]))
+        except (ValueError, TypeError) as exc:
+            record_issue("bad_row_key", row_number, str(exc))
+
+        components = zd_diff.extract_components(row, component_names)
+        if not components:
+            record_issue("missing_numeric_component", row_number, "")
+        for component in components:
+            component_rows[component] += 1
+
+        gps_l2w = sat.startswith("G") and signal in zd_diff.GPS_L2W_RINEX_CODES
+        for component in zd_diff.IDENTITY_PROVENANCE_COMPONENTS:
+            if _component_true(row, component):
+                identity_counts[component]["true_rows"] += 1
+                if gps_l2w:
+                    gps_l2w_identity_counts[component]["true_rows"] += 1
+
+    duplicate_groups = [group for group, count in key_counts.items() if count > 1]
+    max_duplicate_occurrences = max(key_counts.values(), default=0)
+    if time_keys:
+        first_week, first_tow_ms = min(time_keys)
+        last_week, last_tow_ms = max(time_keys)
+        time_range: dict[str, object] = {
+            "start_week": first_week,
+            "start_tow": first_tow_ms / 1000.0,
+            "end_week": last_week,
+            "end_tow": last_tow_ms / 1000.0,
+        }
+    else:
+        time_range = {}
+
+    gps_l2w_rows = sum(
+        1
+        for row in rows
+        if row.get("sat", "").startswith("G")
+        and zd_diff.observation_identity(row, zd_diff.detect_row_type(row)) in zd_diff.GPS_L2W_RINEX_CODES
+    )
+
+    return {
+        "schema": SCHEMA,
+        "status": "failed" if issue_counts else "passed",
+        "rows": len(rows),
+        "unique_satellites": len(satellites),
+        "systems": _format_counter(systems),
+        "top_satellites": _format_top(satellites, top_limit),
+        "time_range": time_range,
+        "stages": _format_counter(stages),
+        "row_types": _format_counter(row_types),
+        "observation_identity": {
+            "rinex_codes": _format_counter(rinex_codes),
+            "frequency_indices": _format_counter(frequencies),
+        },
+        "component_presence": {
+            "rows_with_component": _format_counter(component_rows),
+            "known_components": component_names,
+        },
+        "bias_identity": {
+            "rows_with_code_bias": sum(1 for row in rows if _has_component(row, "code_bias_m")),
+            "rows_with_phase_bias": sum(1 for row in rows if _has_component(row, "phase_bias_m")),
+        },
+        "identity_provenance": {
+            "gps_l2w_rows": gps_l2w_rows,
+            "components": {
+                component: {
+                    "true_rows": identity_counts[component]["true_rows"],
+                    "gps_l2w_true_rows": gps_l2w_identity_counts[component]["true_rows"],
+                }
+                for component in zd_diff.IDENTITY_PROVENANCE_COMPONENTS
+            },
+        },
+        "row_key": {
+            "groups": len(key_counts),
+            "duplicate_groups": len(duplicate_groups),
+            "max_duplicate_occurrences": max_duplicate_occurrences,
+        },
+        "issue_counts": _format_counter(issue_counts),
+        "issue_examples": issue_examples,
+    }
+
+
+def requirement_failures(summary: Mapping[str, Any], args: argparse.Namespace) -> list[str]:
+    failures: list[str] = []
+    rows = summary.get("rows", 0)
+    if not isinstance(rows, int):
+        failures.append("summary rows is not an integer")
+    elif rows < args.require_rows_min:
+        failures.append(f"rows {rows} < required minimum {args.require_rows_min}")
+
+    systems = summary.get("systems", {})
+    if not isinstance(systems, dict):
+        systems = {}
+    for system in args.require_system:
+        if int(systems.get(str(system), 0)) <= 0:
+            failures.append(f"required system {system} is absent")
+
+    stages = summary.get("stages", {})
+    if not isinstance(stages, dict):
+        stages = {}
+    for stage in args.require_stage:
+        if int(stages.get(str(stage), 0)) <= 0:
+            failures.append(f"required stage {stage} is absent")
+
+    row_types = summary.get("row_types", {})
+    if not isinstance(row_types, dict):
+        row_types = {}
+    for row_type in args.require_row_type:
+        if int(row_types.get(str(row_type), 0)) <= 0:
+            failures.append(f"required row type {row_type} is absent")
+
+    observation_identity = summary.get("observation_identity", {})
+    if not isinstance(observation_identity, dict):
+        observation_identity = {}
+    rinex_codes = observation_identity.get("rinex_codes", {})
+    if not isinstance(rinex_codes, dict):
+        rinex_codes = {}
+    for rinex_code in args.require_rinex_code:
+        if int(rinex_codes.get(str(rinex_code), 0)) <= 0:
+            failures.append(f"required RINEX code {rinex_code} is absent")
+
+    component_presence = summary.get("component_presence", {})
+    if not isinstance(component_presence, dict):
+        component_presence = {}
+    rows_with_component = component_presence.get("rows_with_component", {})
+    if not isinstance(rows_with_component, dict):
+        rows_with_component = {}
+    for component in args.require_component:
+        if int(rows_with_component.get(str(component), 0)) <= 0:
+            failures.append(f"required component {component} is absent")
+
+    row_key = summary.get("row_key", {})
+    if not isinstance(row_key, dict):
+        row_key = {}
+    if args.require_no_duplicate_keys and int(row_key.get("duplicate_groups", 0)) != 0:
+        failures.append(f"duplicate row keys {row_key.get('duplicate_groups')} != 0")
+
+    issue_counts = summary.get("issue_counts", {})
+    if args.fail_on_issue and isinstance(issue_counts, dict) and issue_counts:
+        failures.append(f"snapshot issues present: {issue_counts}")
+    return failures
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("snapshot_csv", type=Path)
+    parser.add_argument("--json-out", type=Path)
+    parser.add_argument("--require-rows-min", type=int, default=0)
+    parser.add_argument("--require-system", action="append", default=[])
+    parser.add_argument("--require-stage", action="append", default=[])
+    parser.add_argument("--require-row-type", action="append", default=[])
+    parser.add_argument("--require-rinex-code", action="append", default=[])
+    parser.add_argument("--require-component", action="append", default=[])
+    parser.add_argument("--require-no-duplicate-keys", action="store_true")
+    parser.add_argument("--fail-on-issue", action="store_true")
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = parse_args(argv)
+    try:
+        rows = zd_diff.read_csv_rows(args.snapshot_csv)
+        summary = summarize_rows(rows)
+        failures = requirement_failures(summary, args)
+        if failures:
+            summary = {**summary, "status": "failed", "failures": failures}
+        else:
+            summary = {**summary, "failures": []}
+    except Exception as exc:
+        summary = {
+            "schema": SCHEMA,
+            "status": "failed",
+            "failures": [str(exc)],
+        }
+
+    if args.json_out is not None:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+    print("clas_zd_component_summary:")
+    print(f"  status: {summary.get('status')}")
+    if "rows" in summary:
+        print(f"  rows: {summary['rows']}")
+    if summary.get("failures"):
+        print("  failures:")
+        for failure in summary["failures"]:
+            print(f"    - {failure}")
+    return 0 if summary.get("status") == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/run_optional_clas_zd_component_diff.py
+++ b/scripts/ci/run_optional_clas_zd_component_diff.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import optional_diff_runner as runner  # noqa: E402
 
 
-SUMMARY_SCHEMA = "ci_optional_clas_zd_component_diff.v2"
+SUMMARY_SCHEMA = "ci_optional_clas_zd_component_diff.v3"
 
 CONFIG = runner.DiffRunnerConfig(
     summary_schema=SUMMARY_SCHEMA,
@@ -37,6 +37,9 @@ CONFIG = runner.DiffRunnerConfig(
     summary_filename="ci_optional_clas_zd_component_summary.json",
     log_dir_name="ci_optional_clas_zd_component",
     per_component_max_key="max_abs_delta_m",
+    input_summary_script="clas_zd_component_summary.py",
+    input_summary_schema="clas_zd_component_summary.v1",
+    input_summary_fail_on_issue=True,
     extra_options=(
         runner.EnvOption(("GNSSPP_CLAS_ZD_STAGE",), "--stage"),
         runner.EnvOption(("GNSSPP_CLAS_ZD_ROW_TYPE",), "--row-type"),

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -134,6 +134,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_clas_zd_component_diff.py
     )
     add_test(
+        NAME python_clas_zd_component_summary_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_clas_zd_component_summary.py
+    )
+    add_test(
         NAME python_claslib_zd_component_export_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_claslib_zd_component_export.py
     )
@@ -282,6 +286,7 @@ if(GTest_FOUND)
         python_artifact_manifest_ux_tests
         python_clas_a4b_native_selfdiff_tests
         python_clas_zd_component_diff_tests
+        python_clas_zd_component_summary_tests
         python_claslib_zd_component_export_tests
         python_cli_json_contract_validator_tests
         python_cli_ux_tests

--- a/tests/test_clas_zd_component_summary.py
+++ b/tests/test_clas_zd_component_summary.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""Tests for CLAS zero-difference component snapshot summaries."""
+
+from __future__ import annotations
+
+import csv
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT_DIR / "scripts" / "analysis" / "clas_zd_component_summary.py"
+
+spec = importlib.util.spec_from_file_location("clas_zd_component_summary", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+summary_script = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = summary_script
+spec.loader.exec_module(summary_script)
+
+
+FIELDNAMES = [
+    "week",
+    "tow",
+    "stage",
+    "sat",
+    "row_type",
+    "freq",
+    "pseudorange_rinex_code",
+    "carrier_rinex_code",
+    "bias_exact_identity",
+    "observation_exact_identity_requested",
+    "observation_exact_match",
+    "observation_family_fallback",
+    "code_bias_fallback",
+    "phase_bias_fallback",
+    "prc_m",
+    "cpc_m",
+    "code_bias_m",
+    "phase_bias_m",
+]
+
+
+def zd_row(
+    *,
+    sat: str = "G14",
+    tow: str = "172800.000",
+    stage: str = "accepted",
+    row_type: str = "code",
+    freq: str = "1",
+    pseudorange_code: str = "C2W",
+    carrier_code: str = "",
+    bias_exact_identity: str = "1",
+    observation_exact_identity_requested: str = "1",
+    observation_exact_match: str = "1",
+    observation_family_fallback: str = "0",
+    code_bias_fallback: str = "0",
+    phase_bias_fallback: str = "0",
+    prc_m: str = "0.100",
+    cpc_m: str = "",
+    code_bias_m: str = "0.020",
+    phase_bias_m: str = "",
+) -> dict[str, str]:
+    return {
+        "week": "2360",
+        "tow": tow,
+        "stage": stage,
+        "sat": sat,
+        "row_type": row_type,
+        "freq": freq,
+        "pseudorange_rinex_code": pseudorange_code,
+        "carrier_rinex_code": carrier_code,
+        "bias_exact_identity": bias_exact_identity,
+        "observation_exact_identity_requested": observation_exact_identity_requested,
+        "observation_exact_match": observation_exact_match,
+        "observation_family_fallback": observation_family_fallback,
+        "code_bias_fallback": code_bias_fallback,
+        "phase_bias_fallback": phase_bias_fallback,
+        "prc_m": prc_m,
+        "cpc_m": cpc_m,
+        "code_bias_m": code_bias_m,
+        "phase_bias_m": phase_bias_m,
+    }
+
+
+def write_csv(path: Path, rows: list[dict[str, str]]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+class ClasZdComponentSummaryTest(unittest.TestCase):
+    def test_summary_reports_identity_and_components(self) -> None:
+        rows = [
+            zd_row(sat="G14", row_type="code", pseudorange_code="C2W"),
+            zd_row(
+                sat="J01",
+                row_type="phase",
+                tow="172830.000",
+                freq="2",
+                pseudorange_code="",
+                carrier_code="L2L",
+                prc_m="",
+                cpc_m="0.200",
+                code_bias_m="",
+                phase_bias_m="-0.050",
+            ),
+        ]
+
+        summary = summary_script.summarize_rows(rows)
+
+        self.assertEqual(summary["schema"], "clas_zd_component_summary.v1")
+        self.assertEqual(summary["status"], "passed")
+        self.assertEqual(summary["rows"], 2)
+        self.assertEqual(summary["systems"], {"GPS": 1, "QZSS": 1})
+        self.assertEqual(summary["row_types"], {"code": 1, "phase": 1})
+        self.assertEqual(summary["stages"], {"accepted": 2})
+        self.assertEqual(summary["time_range"]["start_tow"], 172800.0)
+        self.assertEqual(summary["time_range"]["end_tow"], 172830.0)
+        observation_identity = summary["observation_identity"]
+        self.assertEqual(observation_identity["rinex_codes"]["C2W"], 1)
+        self.assertEqual(observation_identity["rinex_codes"]["L2L"], 1)
+        self.assertEqual(observation_identity["frequency_indices"]["2"], 1)
+        self.assertEqual(summary["component_presence"]["rows_with_component"]["prc_m"], 1)
+        self.assertEqual(summary["component_presence"]["rows_with_component"]["phase_bias_m"], 1)
+        self.assertEqual(summary["bias_identity"]["rows_with_code_bias"], 1)
+        self.assertEqual(summary["bias_identity"]["rows_with_phase_bias"], 1)
+        self.assertEqual(summary["identity_provenance"]["gps_l2w_rows"], 1)
+        self.assertEqual(
+            summary["identity_provenance"]["components"]["observation_exact_match"]["gps_l2w_true_rows"],
+            1,
+        )
+        self.assertEqual(summary["row_key"]["duplicate_groups"], 0)
+
+    def test_summary_detects_bad_rows_and_duplicate_keys(self) -> None:
+        rows = [
+            zd_row(prc_m="", code_bias_m=""),
+            zd_row(prc_m="", code_bias_m=""),
+            zd_row(
+                sat="",
+                row_type="",
+                tow="bad",
+                pseudorange_code="",
+                bias_exact_identity="",
+                observation_exact_identity_requested="",
+                observation_exact_match="",
+                observation_family_fallback="",
+                code_bias_fallback="",
+                phase_bias_fallback="",
+                prc_m="nan",
+                code_bias_m="",
+            ),
+        ]
+
+        summary = summary_script.summarize_rows(rows)
+
+        self.assertEqual(summary["status"], "failed")
+        self.assertEqual(summary["row_key"]["duplicate_groups"], 1)
+        self.assertEqual(summary["issue_counts"]["missing_satellite"], 1)
+        self.assertEqual(summary["issue_counts"]["missing_row_type"], 1)
+        self.assertEqual(summary["issue_counts"]["missing_observation_identity"], 1)
+        self.assertEqual(summary["issue_counts"]["bad_row_key"], 1)
+        self.assertEqual(summary["issue_counts"]["missing_numeric_component"], 1)
+
+    def test_cli_writes_json_and_enforces_requirements(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="clas_zd_component_summary_cli_") as temp_dir:
+            root = Path(temp_dir)
+            snapshot = root / "clas_zd.csv"
+            summary_json = root / "summary.json"
+            write_csv(snapshot, [zd_row(row_type="code")])
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    str(snapshot),
+                    "--json-out",
+                    str(summary_json),
+                    "--require-rows-min",
+                    "2",
+                    "--require-system",
+                    "QZSS",
+                    "--require-stage",
+                    "candidate",
+                    "--require-row-type",
+                    "phase",
+                    "--require-rinex-code",
+                    "L2W",
+                    "--require-component",
+                    "prc_m",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 1)
+            payload = json.loads(summary_json.read_text(encoding="utf-8"))
+            self.assertEqual(payload["schema"], "clas_zd_component_summary.v1")
+            self.assertEqual(payload["status"], "failed")
+            self.assertIn("rows 1 < required minimum 2", payload["failures"])
+            self.assertIn("required system QZSS is absent", payload["failures"])
+            self.assertIn("required row type phase is absent", payload["failures"])
+
+    def test_cli_passes_clean_snapshot_with_fail_on_issue(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="clas_zd_component_summary_pass_") as temp_dir:
+            root = Path(temp_dir)
+            snapshot = root / "clas_zd.csv"
+            summary_json = root / "summary.json"
+            write_csv(snapshot, [zd_row(row_type="code")])
+
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    str(SCRIPT_PATH),
+                    str(snapshot),
+                    "--json-out",
+                    str(summary_json),
+                    "--fail-on-issue",
+                    "--require-row-type",
+                    "code",
+                    "--require-rinex-code",
+                    "C2W",
+                    "--require-component",
+                    "prc_m",
+                ],
+                check=False,
+                capture_output=True,
+                text=True,
+            )
+
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            payload = json.loads(summary_json.read_text(encoding="utf-8"))
+            self.assertEqual(payload["status"], "passed")
+            self.assertEqual(payload["failures"], [])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_optional_clas_zd_component_diff.py
+++ b/tests/test_optional_clas_zd_component_diff.py
@@ -44,6 +44,10 @@ FIELDNAMES = [
 def write_zd_component_csv(
     path: Path,
     *,
+    sat: str = "G01",
+    tow: str = "172800.000",
+    row_type: str = "code",
+    pseudorange_code: str = "C2W",
     prc_m: str = "0.1",
     bias_exact_identity: str = "",
     observation_exact_identity_requested: str = "",
@@ -57,12 +61,12 @@ def write_zd_component_csv(
         writer.writerow(
             {
                 "week": "2360",
-                "tow": "172800.000",
+                "tow": tow,
                 "stage": "accepted",
-                "sat": "G01",
-                "row_type": "code",
+                "sat": sat,
+                "row_type": row_type,
                 "freq": "1",
-                "pseudorange_rinex_code": "C2W",
+                "pseudorange_rinex_code": pseudorange_code,
                 "carrier_rinex_code": "",
                 "bias_exact_identity": bias_exact_identity,
                 "observation_exact_identity_requested": observation_exact_identity_requested,
@@ -155,6 +159,13 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
             self.assertIn("0.25", command)
             self.assertIn("--fail-on-diff", command)
             self.assertIn(str(output_dir / "clas_zd_component_diff.json"), command)
+            self.assertEqual(len(steps[0].pre_commands), 2)
+            self.assertIn(
+                str(SCRIPT_PATH.parent.parent / "analysis" / "clas_zd_component_summary.py"),
+                steps[0].pre_commands[0],
+            )
+            self.assertIn(str(output_dir / "clas_zd_component_diff_claslib_snapshot_summary.json"), steps[0].outputs)
+            self.assertIn(str(output_dir / "clas_zd_component_diff_native_snapshot_summary.json"), steps[0].outputs)
 
     def test_run_step_collects_metrics_from_diff_report(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ci_clas_zd_exec_") as temp_dir:
@@ -194,6 +205,43 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
             self.assertAlmostEqual(metrics["max_abs_delta"], 0.05)
             self.assertAlmostEqual(metrics["top_row_sum_abs_delta"], 0.05)
             self.assertAlmostEqual(metrics["top_row_max_abs_delta"], 0.05)
+            self.assertEqual(metrics["claslib_snapshot_schema"], "clas_zd_component_summary.v1")
+            self.assertEqual(metrics["native_snapshot_schema"], "clas_zd_component_summary.v1")
+            self.assertEqual(metrics["claslib_snapshot_status"], "passed")
+            self.assertEqual(metrics["native_snapshot_status"], "passed")
+            self.assertEqual(metrics["claslib_snapshot_rows"], 1)
+            self.assertEqual(metrics["native_snapshot_rows"], 1)
+            self.assertEqual(metrics["claslib_snapshot_duplicate_groups"], 0)
+            self.assertEqual(metrics["native_snapshot_duplicate_groups"], 0)
+            artifact_paths = {artifact["path"] for artifact in result["artifacts"]}
+            self.assertIn(str(output_dir / "clas_zd_component_diff_claslib_snapshot_summary.json"), artifact_paths)
+            self.assertIn(str(output_dir / "clas_zd_component_diff_native_snapshot_summary.json"), artifact_paths)
+
+    def test_run_step_fails_when_snapshot_summary_fails(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_clas_zd_input_summary_") as temp_dir:
+            root = Path(temp_dir)
+            base_csv = root / "claslib.csv"
+            candidate_csv = root / "native.csv"
+            write_zd_component_csv(base_csv)
+            write_zd_component_csv(candidate_csv, sat="", pseudorange_code="")
+            output_dir = root / "output"
+            log_dir = output_dir / "logs"
+            log_dir.mkdir(parents=True)
+            env = {
+                "GNSSPP_CLAS_ZD_BASE_CSV": str(base_csv),
+                "GNSSPP_CLAS_ZD_CANDIDATE_CSV": str(candidate_csv),
+            }
+            step = runner.build_step_plan(ROOT_DIR, output_dir, env)[0]
+
+            result = runner.run_step(step, ROOT_DIR, log_dir)
+
+            self.assertEqual(result["status"], "failed")
+            self.assertNotEqual(result["returncode"], 0)
+            self.assertIn("clas_zd_component_summary.py", " ".join(result["failed_command"]))
+            metrics = result["metrics"]
+            self.assertEqual(metrics["claslib_snapshot_status"], "passed")
+            self.assertEqual(metrics["native_snapshot_status"], "failed")
+            self.assertEqual(metrics["native_snapshot_issue_counts"]["missing_satellite"], 1)
 
     def test_run_step_collects_identity_provenance_metrics(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ci_clas_zd_identity_") as temp_dir:


### PR DESCRIPTION
## Summary
- add clas_zd_component_summary.py to prevalidate CLAS ZD component snapshot CSVs
- run CLASLIB/native input summaries before the optional CLAS ZD component diff
- publish the snapshot summary JSON artifacts and document the updated contract

## Validation
- python3 -m py_compile scripts/analysis/clas_zd_component_summary.py scripts/ci/run_optional_clas_zd_component_diff.py tests/test_clas_zd_component_summary.py tests/test_optional_clas_zd_component_diff.py
- python3 tests/test_clas_zd_component_summary.py
- python3 tests/test_optional_clas_zd_component_diff.py
- ctest --test-dir build -R 'python_clas_zd_component_summary_tests|python_optional_clas_zd_component_diff_tests|python_clas_zd_component_diff_tests|python_optional_madoca_materialization_diff_tests|python_optional_madoca_residual_component_diff_tests' --output-on-failure
- python3 -m mkdocs build --strict
- git diff --check
- bash scripts/ci/run_hygiene.sh
- ctest --test-dir build -L core --output-on-failure