### PR TITLE
ci: summarize CLAS A4b native dump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -360,6 +360,7 @@ jobs:
           output/clas_a4b_native_selfdiff/native.pos
           output/clas_a4b_native_selfdiff/native_summary.json
           output/clas_a4b_native_selfdiff/native_code_dump.csv
+          output/clas_a4b_native_selfdiff/native_code_dump_summary.json
           output/clas_a4b_native_selfdiff/selfdiff.json
           output/clas_a4b_native_selfdiff/selfdiff.csv
         if-no-files-found: error

--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -215,10 +215,13 @@ linking CLASLIB into the production binaries.  Use the normalized CSV as
 The native side of the A4b `G14/C2W` slice is generated in CI by
 `scripts/ci/run_clas_a4b_native_selfdiff.py`.  That wrapper sparse-checks out
 the public CLASLIB data fixture, runs the gated native CLAS command with
-`GNSS_PPP_CLAS_CODE_DUMP`, and self-diffs the resulting code dump before any
-oracle comparison.  This is not a replacement for CLASLIB ZD parity; it removes
-the manually staged native CSV from the next oracle-backed PR and guards exact
-observation-code identity and fallback counts on remote CI.
+`GNSS_PPP_CLAS_CODE_DUMP`, writes `clas_zd_component_summary.v1` for the
+resulting native dump, and self-diffs it before any oracle comparison.  The
+summary step catches malformed row keys, missing observation identity, and
+missing component values before the self-diff can pass.  This is not a
+replacement for CLASLIB ZD parity; it removes the manually staged native CSV
+from the next oracle-backed PR and guards exact observation-code identity and
+fallback counts on remote CI.
 
 Native RINEX observations now expose exact `pseudorange_rinex_code`,
 `carrier_rinex_code`, RTKLIB code id, and `signal_family` columns in the CLAS

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -217,10 +217,14 @@ The wrapper sparse-checks out the public CLASLIB `data/` directory at the pinned
 `GNSSPP_CLAS_A4B_CLASLIB_REF`, runs the native command above, and self-diffs the
 `G14/C2W` code rows. It emits
 `ci_clas_a4b_native_selfdiff_summary.json`, `native_code_dump.csv`,
-`native_summary.json`, and `selfdiff.{json,csv}`. The summary uses
-`status: passed` only when the native run reaches the configured epoch count,
-the GPS L2W rows preserve exact observation/bias identity, fallback counts are
-zero, and the self-diff has no unmatched rows or component deltas. Set
+`native_code_dump_summary.json`, `native_summary.json`, and
+`selfdiff.{json,csv}`. The wrapper first validates the native dump with
+`clas_zd_component_summary.v1`; the CI summary schema is
+`ci_clas_a4b_native_selfdiff.v2`. The summary uses `status: passed` only when
+the native run reaches the configured epoch count, the native dump summary
+passes and covers the dump rows, the GPS L2W rows preserve exact
+observation/bias identity, fallback counts are zero, and the self-diff has no
+unmatched rows or component deltas. Set
 `GNSSPP_CLAS_A4B_DATA_ROOT` to use a pre-existing CLASLIB data checkout, or
 `GNSSPP_CLAS_A4B_AUTO_FETCH=0` to record `blocked_infrastructure` instead of
 fetching public data. CI treats that blocked state as a failure by default; set

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -69,7 +69,9 @@ CI lanes are split as follows:
 - `python3 scripts/ci/run_clas_a4b_native_selfdiff.py` for the public CLAS A4b
   native-side evidence bundle; it sparse-fetches CLASLIB public data unless
   `GNSSPP_CLAS_A4B_DATA_ROOT` is supplied, generates the native code dump, and
-  self-diffs the `G14/C2W` rows before any oracle-backed model change
+  writes `clas_zd_component_summary.v1` for that dump before self-diffing the
+  `G14/C2W` rows; this native-side evidence must pass before any oracle-backed
+  model change
 - `python3 scripts/ci/run_madoca_materialization_selfdiff.py` for the public
   MADOCA materialization evidence bundle; it sparse-fetches pinned MADOCALIB
   BRDM/L6 sample files unless `GNSSPP_MADOCA_MATERIALIZATION_DATA_ROOT` is

--- a/scripts/ci/run_clas_a4b_native_selfdiff.py
+++ b/scripts/ci/run_clas_a4b_native_selfdiff.py
@@ -20,7 +20,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 from optional_diff_runner import artifact_record, truthy  # noqa: E402
 
 
-SUMMARY_SCHEMA = "ci_clas_a4b_native_selfdiff.v1"
+SUMMARY_SCHEMA = "ci_clas_a4b_native_selfdiff.v2"
 CONTRACT = "clas_a4b_native_selfdiff.v1"
 DEFAULT_CLASLIB_REPO = "https://github.com/QZSS-Strategy-Office/claslib.git"
 DEFAULT_CLASLIB_REF = "23cfd363a2db6d8d8144e292c82e9d97ca2d3015"
@@ -49,6 +49,7 @@ class RunPaths:
     native_pos: Path
     native_summary_json: Path
     native_code_dump: Path
+    native_code_dump_summary_json: Path
     selfdiff_json: Path
     selfdiff_csv: Path
 
@@ -83,6 +84,7 @@ def default_paths(output_dir: Path) -> RunPaths:
         native_pos=work_dir / "native.pos",
         native_summary_json=work_dir / "native_summary.json",
         native_code_dump=work_dir / "native_code_dump.csv",
+        native_code_dump_summary_json=work_dir / "native_code_dump_summary.json",
         selfdiff_json=work_dir / "selfdiff.json",
         selfdiff_csv=work_dir / "selfdiff.csv",
     )
@@ -264,6 +266,23 @@ def build_selfdiff_command(config: RunConfig, paths: RunPaths) -> list[str]:
     ]
 
 
+def build_code_dump_summary_command(config: RunConfig, paths: RunPaths) -> list[str]:
+    return [
+        config.python_executable,
+        str(config.repo_root / "scripts" / "analysis" / "clas_zd_component_summary.py"),
+        str(paths.native_code_dump),
+        "--json-out",
+        str(paths.native_code_dump_summary_json),
+        "--fail-on-issue",
+        "--require-row-type",
+        "code",
+        "--require-rinex-code",
+        "C2W",
+        "--require-component",
+        "prc_m",
+    ]
+
+
 def load_json(path: Path) -> dict[str, object]:
     payload = json.loads(path.read_text(encoding="utf-8"))
     if not isinstance(payload, dict):
@@ -299,7 +318,13 @@ def native_identity(report: Mapping[str, object]) -> dict[str, object]:
     return summary if isinstance(summary, dict) else {}
 
 
-def evaluate(config: RunConfig, native_summary: Mapping[str, object], report: Mapping[str, object], dump_rows: int) -> tuple[dict[str, object], dict[str, object], list[str]]:
+def evaluate(
+    config: RunConfig,
+    native_summary: Mapping[str, object],
+    code_dump_summary: Mapping[str, object],
+    report: Mapping[str, object],
+    dump_rows: int,
+) -> tuple[dict[str, object], dict[str, object], list[str]]:
     identity = native_identity(report)
     gps_l2w_rows = int(identity.get("gps_l2w_rows", 0))
     exact_bias_rows = int(identity.get("gps_l2w_bias_exact_identity_rows", 0))
@@ -311,6 +336,14 @@ def evaluate(config: RunConfig, native_summary: Mapping[str, object], report: Ma
         "native_epochs": int(native_summary.get("epochs", 0)),
         "native_ppp_solution_rate_pct": native_summary.get("ppp_solution_rate_pct"),
         "native_code_dump_rows": dump_rows,
+        "native_code_dump_summary_schema": code_dump_summary.get("schema"),
+        "native_code_dump_summary_status": code_dump_summary.get("status"),
+        "native_code_dump_summary_rows": code_dump_summary.get("rows"),
+        "native_code_dump_summary_duplicate_groups": (
+            code_dump_summary.get("row_key", {}).get("duplicate_groups")
+            if isinstance(code_dump_summary.get("row_key"), dict)
+            else None
+        ),
         "common_rows": int(report.get("common_rows", 0)),
         "base_only_rows": int(report.get("base_only_rows", 0)),
         "candidate_only_rows": int(report.get("candidate_only_rows", 0)),
@@ -334,6 +367,19 @@ def evaluate(config: RunConfig, native_summary: Mapping[str, object], report: Ma
     failures: list[str] = []
     if metrics["native_epochs"] < config.max_epochs:
         failures.append(f"native epochs {metrics['native_epochs']} < {config.max_epochs}")
+    if metrics["native_code_dump_summary_schema"] != "clas_zd_component_summary.v1":
+        failures.append(
+            f"native code dump summary schema {metrics['native_code_dump_summary_schema']} "
+            "!= clas_zd_component_summary.v1"
+        )
+    if metrics["native_code_dump_summary_status"] != "passed":
+        failures.append(
+            f"native code dump summary status {metrics['native_code_dump_summary_status']} != passed"
+        )
+    if metrics["native_code_dump_summary_rows"] != dump_rows:
+        failures.append(
+            f"native code dump summary rows {metrics['native_code_dump_summary_rows']} != dump rows {dump_rows}"
+        )
     if gps_l2w_rows < config.gps_l2w_rows_min:
         failures.append(f"GPS L2W rows {gps_l2w_rows} < {config.gps_l2w_rows_min}")
     if exact_bias_rows != gps_l2w_rows:
@@ -361,6 +407,7 @@ def summarize_artifacts(paths: RunPaths) -> list[dict[str, object]]:
         artifact_record(paths.native_pos, role="native_solution", required=True),
         artifact_record(paths.native_summary_json, role="native_summary", required=True),
         artifact_record(paths.native_code_dump, role="native_zd_component_dump", required=True),
+        artifact_record(paths.native_code_dump_summary_json, role="native_zd_component_summary", required=True),
         artifact_record(paths.selfdiff_json, role="selfdiff_json", required=True),
         artifact_record(paths.selfdiff_csv, role="selfdiff_csv", required=True),
     ]
@@ -460,6 +507,24 @@ def main(argv: Sequence[str] | None = None, environ: Mapping[str, str] | None = 
         print(f"CLAS A4b native run failed; see {paths.log_path}")
         return 1
 
+    code_dump_summary_command = build_code_dump_summary_command(config, paths)
+    code_dump_summary_result = run_logged(
+        code_dump_summary_command,
+        cwd=config.repo_root,
+        log_path=paths.log_path,
+    )
+    if code_dump_summary_result.returncode != 0:
+        payload = build_payload(
+            config=config,
+            paths=paths,
+            status="failed",
+            data_root=data_root,
+            failures=["native CLAS A4b code dump summary failed"],
+        )
+        write_summary(paths, payload)
+        print(f"CLAS A4b native code dump summary failed; see {paths.log_path}")
+        return 1
+
     selfdiff_command = build_selfdiff_command(config, paths)
     selfdiff_result = run_logged(selfdiff_command, cwd=config.repo_root, log_path=paths.log_path)
     if selfdiff_result.returncode != 0:
@@ -475,10 +540,12 @@ def main(argv: Sequence[str] | None = None, environ: Mapping[str, str] | None = 
         return 1
 
     native_summary = load_json(paths.native_summary_json)
+    code_dump_summary = load_json(paths.native_code_dump_summary_json)
     selfdiff_report = load_json(paths.selfdiff_json)
     metrics, thresholds, failures = evaluate(
         config,
         native_summary,
+        code_dump_summary,
         selfdiff_report,
         count_csv_data_rows(paths.native_code_dump),
     )

--- a/tests/test_clas_a4b_native_selfdiff.py
+++ b/tests/test_clas_a4b_native_selfdiff.py
@@ -93,6 +93,35 @@ class ClasA4bNativeSelfdiffTest(unittest.TestCase):
             self.assertIn("TEST ANT", command)
             self.assertEqual(command[-2:], ["--max-epochs", "30"])
 
+    def test_build_code_dump_summary_command_validates_native_dump(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_clas_a4b_summary_command_") as temp_dir:
+            output_dir = Path(temp_dir) / "output"
+            paths = runner.default_paths(output_dir)
+            config = runner.RunConfig(
+                repo_root=ROOT_DIR,
+                output_dir=output_dir,
+                data_root=None,
+                auto_fetch=True,
+                fail_on_blocked=True,
+                claslib_repo=runner.DEFAULT_CLASLIB_REPO,
+                claslib_ref=runner.DEFAULT_CLASLIB_REF,
+                max_epochs=30,
+                gps_l2w_rows_min=30,
+                receiver_antenna_type=runner.DEFAULT_RECEIVER_ANTENNA_TYPE,
+                python_executable=sys.executable,
+            )
+
+            command = runner.build_code_dump_summary_command(config, paths)
+
+            self.assertIn(str(ROOT_DIR / "scripts" / "analysis" / "clas_zd_component_summary.py"), command)
+            self.assertIn(str(paths.native_code_dump), command)
+            self.assertIn(str(paths.native_code_dump_summary_json), command)
+            self.assertIn("--fail-on-issue", command)
+            self.assertIn("--require-row-type", command)
+            self.assertIn("code", command)
+            self.assertIn("--require-rinex-code", command)
+            self.assertIn("C2W", command)
+
     def test_evaluate_accepts_exact_native_l2w_selfdiff(self) -> None:
         config = runner.RunConfig(
             repo_root=ROOT_DIR,
@@ -108,6 +137,12 @@ class ClasA4bNativeSelfdiffTest(unittest.TestCase):
             python_executable=sys.executable,
         )
         native_summary = {"epochs": 30, "ppp_solution_rate_pct": 100.0}
+        code_dump_summary = {
+            "schema": "clas_zd_component_summary.v1",
+            "status": "passed",
+            "rows": 540,
+            "row_key": {"duplicate_groups": 0},
+        }
         report = {
             "common_rows": 30,
             "base_only_rows": 0,
@@ -126,11 +161,21 @@ class ClasA4bNativeSelfdiffTest(unittest.TestCase):
             },
         }
 
-        metrics, thresholds, failures = runner.evaluate(config, native_summary, report, 540)
+        metrics, thresholds, failures = runner.evaluate(
+            config,
+            native_summary,
+            code_dump_summary,
+            report,
+            540,
+        )
 
         self.assertEqual(failures, [])
         self.assertEqual(metrics["gps_l2w_rows"], 30)
         self.assertEqual(metrics["native_code_dump_rows"], 540)
+        self.assertEqual(metrics["native_code_dump_summary_schema"], "clas_zd_component_summary.v1")
+        self.assertEqual(metrics["native_code_dump_summary_status"], "passed")
+        self.assertEqual(metrics["native_code_dump_summary_rows"], 540)
+        self.assertEqual(metrics["native_code_dump_summary_duplicate_groups"], 0)
         self.assertEqual(thresholds["gps_l2w_rows_min"], 30)
 
     def test_evaluate_rejects_identity_fallback(self) -> None:
@@ -148,6 +193,12 @@ class ClasA4bNativeSelfdiffTest(unittest.TestCase):
             python_executable=sys.executable,
         )
         native_summary = {"epochs": 30, "ppp_solution_rate_pct": 100.0}
+        code_dump_summary = {
+            "schema": "clas_zd_component_summary.v1",
+            "status": "passed",
+            "rows": 540,
+            "row_key": {"duplicate_groups": 0},
+        }
         report = {
             "common_rows": 30,
             "base_only_rows": 0,
@@ -166,10 +217,66 @@ class ClasA4bNativeSelfdiffTest(unittest.TestCase):
             },
         }
 
-        _metrics, _thresholds, failures = runner.evaluate(config, native_summary, report, 540)
+        _metrics, _thresholds, failures = runner.evaluate(
+            config,
+            native_summary,
+            code_dump_summary,
+            report,
+            540,
+        )
 
         self.assertIn("exact bias rows 29 != GPS L2W rows 30", failures)
         self.assertIn("observation-family fallback rows 1 != 0", failures)
+
+    def test_evaluate_rejects_bad_code_dump_summary(self) -> None:
+        config = runner.RunConfig(
+            repo_root=ROOT_DIR,
+            output_dir=ROOT_DIR / "output",
+            data_root=None,
+            auto_fetch=True,
+            fail_on_blocked=True,
+            claslib_repo=runner.DEFAULT_CLASLIB_REPO,
+            claslib_ref=runner.DEFAULT_CLASLIB_REF,
+            max_epochs=30,
+            gps_l2w_rows_min=30,
+            receiver_antenna_type=runner.DEFAULT_RECEIVER_ANTENNA_TYPE,
+            python_executable=sys.executable,
+        )
+        native_summary = {"epochs": 30, "ppp_solution_rate_pct": 100.0}
+        code_dump_summary = {
+            "schema": "clas_zd_component_summary.v1",
+            "status": "failed",
+            "rows": 539,
+            "row_key": {"duplicate_groups": 1},
+        }
+        report = {
+            "common_rows": 30,
+            "base_only_rows": 0,
+            "candidate_only_rows": 0,
+            "components_compared": 630,
+            "threshold_exceedances": 0,
+            "per_component": [{"component": "prc_m", "max_abs_delta_m": 0.0}],
+            "identity_provenance": {
+                "native": {
+                    "gps_l2w_rows": 30,
+                    "gps_l2w_bias_exact_identity_rows": 30,
+                    "gps_l2w_observation_exact_match_rows": 30,
+                    "gps_l2w_observation_family_fallback_rows": 0,
+                    "gps_l2w_code_bias_fallback_rows": 0,
+                }
+            },
+        }
+
+        _metrics, _thresholds, failures = runner.evaluate(
+            config,
+            native_summary,
+            code_dump_summary,
+            report,
+            540,
+        )
+
+        self.assertIn("native code dump summary status failed != passed", failures)
+        self.assertIn("native code dump summary rows 539 != dump rows 540", failures)
 
     def test_blocked_summary_contract_has_next_action(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_clas_a4b_summary_") as temp_dir:
@@ -207,6 +314,17 @@ class ClasA4bNativeSelfdiffTest(unittest.TestCase):
         self.assertIn("missing native A4b evidence", written["next_actions"][1])
         self.assertFalse(written["configuration"]["fail_on_blocked"])
         self.assertEqual(written["configuration"]["selfdiff_filter"]["rinex_code"], "C2W")
+
+    def test_artifacts_include_code_dump_summary(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_clas_a4b_artifacts_") as temp_dir:
+            paths = runner.default_paths(Path(temp_dir) / "output")
+            artifacts = runner.summarize_artifacts(paths)
+
+        roles = {artifact["role"]: artifact["path"] for artifact in artifacts}
+        self.assertEqual(
+            roles["native_zd_component_summary"],
+            str(paths.native_code_dump_summary_json),
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- run clas_zd_component_summary.py on the CLAS A4b native code dump before self-diffing it
- publish native_code_dump_summary.json in the CLAS A4b CI artifact bundle
- include the dump-summary schema/status/row-count checks in ci_clas_a4b_native_selfdiff.v2

## Validation
- python3 -m py_compile scripts/ci/run_clas_a4b_native_selfdiff.py tests/test_clas_a4b_native_selfdiff.py
- python3 tests/test_clas_a4b_native_selfdiff.py
- ctest --test-dir build -R 'python_clas_a4b_native_selfdiff_tests|python_clas_zd_component_summary_tests' --output-on-failure
- python3 -m mkdocs build --strict
- git diff --check
- bash scripts/ci/run_hygiene.sh
- ctest --test-dir build -L core --output-on-failure