### PR TITLE
ci: surface CLAS ZD dominant component

### DIFF
--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -194,7 +194,10 @@ and component presence before any deltas are compared.  When those inputs are
 absent, the CI step records `status: blocked_infrastructure` with next actions
 instead of silently treating the missing oracle/native evidence as a passing
 sign-off.  The workflow upload treats the summary/log bundle as required
-evidence.
+evidence.  The `ci_optional_clas_zd_component_diff.v4` summary also surfaces the
+top ZD row's dominant component and its absolute delta, so the next A4b model
+PR can be scoped to one correction component instead of tuning final solution
+RMS.
 Optional filters are `GNSSPP_CLAS_ZD_COMPONENTS`, `GNSSPP_CLAS_ZD_STAGE`,
 `GNSSPP_CLAS_ZD_ROW_TYPE`, `GNSSPP_CLAS_ZD_THRESHOLD_M`, and
 `GNSSPP_CLAS_ZD_FAIL_ON_DIFF`.  GPS L2W A4b probes can also narrow the row set

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -204,7 +204,10 @@ receiver-antenna slot mismatch.
 The diff JSON also includes `top_row_component_breakdowns`, which groups all
 component deltas for the same ZD key. Use that field to decide whether the next
 GPS L2W A4b slice is dominated by `receiver_antenna_m`, `prc_m`, atmosphere, or
-another component before changing the gated correction model.
+another component before changing the gated correction model. The optional CI
+summary schema `ci_optional_clas_zd_component_diff.v4` lifts the leading
+breakdown component into summary metrics so release artifacts show the next
+single-component target without manually opening the full diff JSON.
 
 CI can regenerate the native side of this A4b probe without a pre-staged native
 CSV:

--- a/scripts/ci/optional_diff_runner.py
+++ b/scripts/ci/optional_diff_runner.py
@@ -354,6 +354,27 @@ def load_diff_metrics(config: DiffRunnerConfig, report_json: Path) -> dict[str, 
                 metrics["top_row_sum_abs_delta"] = float(sum_abs_delta)
             if isinstance(max_abs_delta, (int, float)):
                 metrics["top_row_max_abs_delta"] = float(max_abs_delta)
+            key_parts = []
+            for key in ("week", "tow", "row_type", "sat", "freq", "rinex_code"):
+                value = first_row.get(key)
+                if value is not None:
+                    metrics[f"top_row_{key}"] = value
+                    key_parts.append(str(value))
+            if key_parts:
+                metrics["top_row_key"] = "/".join(key_parts)
+            components = first_row.get("components")
+            if isinstance(components, list) and components:
+                first_component = components[0]
+                if isinstance(first_component, dict):
+                    component = first_component.get("component")
+                    delta = first_component.get("delta_m")
+                    abs_delta = first_component.get("abs_delta_m")
+                    if isinstance(component, str) and component:
+                        metrics["top_row_dominant_component"] = component
+                    if isinstance(delta, (int, float)):
+                        metrics["top_row_dominant_delta"] = float(delta)
+                    if isinstance(abs_delta, (int, float)):
+                        metrics["top_row_dominant_abs_delta"] = float(abs_delta)
     identity_provenance = payload.get("identity_provenance")
     if isinstance(identity_provenance, dict):
         for label, summary in identity_provenance.items():
@@ -554,6 +575,16 @@ def render_result_detail(result: dict[str, object]) -> str:
         top_row_sum = metrics.get("top_row_sum_abs_delta")
         if top_row_sum is not None:
             detail_parts.append(f"top row sum |delta| {format_metric(top_row_sum)}")
+        top_row_component = metrics.get("top_row_dominant_component")
+        top_row_component_abs = metrics.get("top_row_dominant_abs_delta")
+        if top_row_component is not None:
+            if top_row_component_abs is not None:
+                detail_parts.append(
+                    "top component "
+                    f"`{top_row_component}` |delta| {format_metric(top_row_component_abs)}"
+                )
+            else:
+                detail_parts.append(f"top component `{top_row_component}`")
         threshold_exceedances = metrics.get("threshold_exceedances")
         if threshold_exceedances is not None:
             detail_parts.append(f"threshold exceedances `{threshold_exceedances}`")

--- a/scripts/ci/run_optional_clas_zd_component_diff.py
+++ b/scripts/ci/run_optional_clas_zd_component_diff.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import optional_diff_runner as runner  # noqa: E402
 
 
-SUMMARY_SCHEMA = "ci_optional_clas_zd_component_diff.v3"
+SUMMARY_SCHEMA = "ci_optional_clas_zd_component_diff.v4"
 
 CONFIG = runner.DiffRunnerConfig(
     summary_schema=SUMMARY_SCHEMA,

--- a/tests/test_optional_clas_zd_component_diff.py
+++ b/tests/test_optional_clas_zd_component_diff.py
@@ -205,6 +205,11 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
             self.assertAlmostEqual(metrics["max_abs_delta"], 0.05)
             self.assertAlmostEqual(metrics["top_row_sum_abs_delta"], 0.05)
             self.assertAlmostEqual(metrics["top_row_max_abs_delta"], 0.05)
+            self.assertEqual(metrics["top_row_sat"], "G01")
+            self.assertEqual(metrics["top_row_rinex_code"], "C2W")
+            self.assertEqual(metrics["top_row_dominant_component"], "prc_m")
+            self.assertAlmostEqual(metrics["top_row_dominant_delta"], 0.05)
+            self.assertAlmostEqual(metrics["top_row_dominant_abs_delta"], 0.05)
             self.assertEqual(metrics["claslib_snapshot_schema"], "clas_zd_component_summary.v2")
             self.assertEqual(metrics["native_snapshot_schema"], "clas_zd_component_summary.v2")
             self.assertEqual(metrics["claslib_snapshot_status"], "passed")
@@ -292,6 +297,8 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
                         "components_compared": 24,
                         "max_abs_delta": 0.125,
                         "top_row_sum_abs_delta": 0.375,
+                        "top_row_dominant_component": "prc_m",
+                        "top_row_dominant_abs_delta": 0.25,
                         "threshold_exceedances": 3,
                         "identity_native_gps_l2w_rows": 2,
                         "identity_native_gps_l2w_bias_exact_identity_rows": 1,
@@ -322,6 +329,7 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
         self.assertIn("components `24`", markdown)
         self.assertIn("max |delta| 0.125", markdown)
         self.assertIn("top row sum |delta| 0.375", markdown)
+        self.assertIn("top component `prc_m` |delta| 0.25", markdown)
         self.assertIn("threshold exceedances `3`", markdown)
         self.assertIn("native L2W `2`", markdown)
         self.assertIn("native L2W exact bias/match `1/1`", markdown)
@@ -348,6 +356,7 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
 
             payload = json.loads(summary_path.read_text(encoding="utf-8"))
             self.assertEqual(payload["summary_schema"], runner.SUMMARY_SCHEMA)
+            self.assertEqual(payload["summary_schema"], "ci_optional_clas_zd_component_diff.v4")
             self.assertEqual(payload["contract"], "optional_diff_artifact_contract.v1")
             self.assertEqual(payload["status"], "blocked_infrastructure")
             self.assertIn("missing evidence", payload["next_actions"][1])


### PR DESCRIPTION
## Summary

- surface the dominant component from the top CLAS ZD row breakdown in optional diff metrics
- bump the optional CLAS ZD component summary schema to `ci_optional_clas_zd_component_diff.v4`
- document that the summary now points model work at one correction component before solver changes

## Validation

- `python3 -m py_compile scripts/ci/optional_diff_runner.py scripts/ci/run_optional_clas_zd_component_diff.py tests/test_optional_clas_zd_component_diff.py`
- `python3 tests/test_optional_clas_zd_component_diff.py`
- `ctest --test-dir build -R 'python_optional_clas_zd_component_diff_tests' --output-on-failure`\n- `python3 -m mkdocs build --strict`\n- `git diff --check`\n- `bash scripts/ci/run_hygiene.sh`\n- `python3 tests/test_optional_madoca_materialization_diff.py && python3 tests/test_optional_madoca_residual_component_diff.py`\n- `ctest --test-dir build -R 'python_optional_.*diff_tests' --output-on-failure`