### PR TITLE
ci: reuse CLAS A4b native dump for ZD diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -314,31 +314,6 @@ jobs:
         GNSSPP_PPP_PRODUCTS_MALIB_CONFIG: ${{ vars.GNSSPP_PPP_PRODUCTS_MALIB_CONFIG }}
       run: bash scripts/ci/run_optional_ppp_products_signoff.sh
 
-    - name: Optional CLAS ZD component diff
-      env:
-        GNSSPP_CLAS_ZD_BASE_CSV: ${{ vars.GNSSPP_CLAS_ZD_BASE_CSV }}
-        GNSSPP_CLAS_ZD_CANDIDATE_CSV: ${{ vars.GNSSPP_CLAS_ZD_CANDIDATE_CSV }}
-        GNSSPP_CLAS_ZD_COMPONENTS: ${{ vars.GNSSPP_CLAS_ZD_COMPONENTS }}
-        GNSSPP_CLAS_ZD_STAGE: ${{ vars.GNSSPP_CLAS_ZD_STAGE }}
-        GNSSPP_CLAS_ZD_ROW_TYPE: ${{ vars.GNSSPP_CLAS_ZD_ROW_TYPE }}
-        GNSSPP_CLAS_ZD_THRESHOLD_M: ${{ vars.GNSSPP_CLAS_ZD_THRESHOLD_M }}
-        GNSSPP_CLAS_ZD_FAIL_ON_DIFF: ${{ vars.GNSSPP_CLAS_ZD_FAIL_ON_DIFF }}
-      run: bash scripts/ci/run_optional_clas_zd_component_diff.sh
-
-    - name: Upload CLAS ZD component diff artifacts
-      if: always()
-      uses: actions/upload-artifact@v4
-      with:
-        name: clas-zd-component-diff-ubuntu
-        path: |
-          output/ci_optional_clas_zd_component_summary.json
-          output/ci_optional_clas_zd_component/*.log
-          output/clas_zd_component_diff.json
-          output/clas_zd_component_diff.csv
-          output/clas_zd_component_diff_claslib_snapshot_summary.json
-          output/clas_zd_component_diff_native_snapshot_summary.json
-        if-no-files-found: error
-
     - name: CLAS A4b native self-diff
       env:
         GNSSPP_CLAS_A4B_DATA_ROOT: ${{ vars.GNSSPP_CLAS_A4B_DATA_ROOT }}
@@ -363,6 +338,36 @@ jobs:
           output/clas_a4b_native_selfdiff/native_code_dump_summary.json
           output/clas_a4b_native_selfdiff/selfdiff.json
           output/clas_a4b_native_selfdiff/selfdiff.csv
+        if-no-files-found: error
+
+    - name: Optional CLAS ZD component diff
+      env:
+        GNSSPP_CLAS_ZD_BASE_CSV: ${{ vars.GNSSPP_CLAS_ZD_BASE_CSV }}
+        GNSSPP_CLAS_ZD_CANDIDATE_CSV: ${{ vars.GNSSPP_CLAS_ZD_CANDIDATE_CSV }}
+        GNSSPP_CLAS_ZD_NATIVE_CSV: output/clas_a4b_native_selfdiff/native_code_dump.csv
+        GNSSPP_CLAS_ZD_COMPONENTS: ${{ vars.GNSSPP_CLAS_ZD_COMPONENTS }}
+        GNSSPP_CLAS_ZD_STAGE: ${{ vars.GNSSPP_CLAS_ZD_STAGE }}
+        GNSSPP_CLAS_ZD_ROW_TYPE: ${{ vars.GNSSPP_CLAS_ZD_ROW_TYPE }}
+        GNSSPP_CLAS_ZD_SAT: ${{ vars.GNSSPP_CLAS_ZD_SAT }}
+        GNSSPP_CLAS_ZD_FREQ: ${{ vars.GNSSPP_CLAS_ZD_FREQ }}
+        GNSSPP_CLAS_ZD_RINEX_CODE: ${{ vars.GNSSPP_CLAS_ZD_RINEX_CODE }}
+        GNSSPP_CLAS_ZD_DUPLICATE_POLICY: ${{ vars.GNSSPP_CLAS_ZD_DUPLICATE_POLICY }}
+        GNSSPP_CLAS_ZD_THRESHOLD_M: ${{ vars.GNSSPP_CLAS_ZD_THRESHOLD_M }}
+        GNSSPP_CLAS_ZD_FAIL_ON_DIFF: ${{ vars.GNSSPP_CLAS_ZD_FAIL_ON_DIFF }}
+      run: bash scripts/ci/run_optional_clas_zd_component_diff.sh
+
+    - name: Upload CLAS ZD component diff artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: clas-zd-component-diff-ubuntu
+        path: |
+          output/ci_optional_clas_zd_component_summary.json
+          output/ci_optional_clas_zd_component/*.log
+          output/clas_zd_component_diff.json
+          output/clas_zd_component_diff.csv
+          output/clas_zd_component_diff_claslib_snapshot_summary.json
+          output/clas_zd_component_diff_native_snapshot_summary.json
         if-no-files-found: error
 
     - name: Optional MADOCA materialization diff

--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -189,6 +189,11 @@ runs that comparison when `GNSSPP_CLAS_ZD_BASE_CSV` and
 dumps.  It writes `ci_optional_clas_zd_component_summary.json`, a log, and the
 `clas_zd_component_diff.{json,csv}` artifacts, plus
 `clas_zd_component_summary.v2` JSON for both CLASLIB and native input snapshots.
+In GitHub Actions, the CLAS A4b native self-diff step runs first and exposes its
+public-data `native_code_dump.csv` as `GNSSPP_CLAS_ZD_NATIVE_CSV`; if
+`GNSSPP_CLAS_ZD_CANDIDATE_CSV` is unset, the optional ZD diff uses that generated
+native dump as the candidate side.  The CLASLIB-side normalized base CSV remains
+an explicit input until the CLASLIB oracle dump itself is generated in CI.
 The input summaries validate row keys, observation identity, duplicate groups,
 and component presence before any deltas are compared.  When those inputs are
 absent, the CI step records `status: blocked_infrastructure` with next actions

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -233,6 +233,14 @@ unmatched rows or component deltas. Set
 fetching public data. CI treats that blocked state as a failure by default; set
 `GNSSPP_CLAS_A4B_FAIL_ON_BLOCKED=0` only for diagnostic-only local runs.
 
+The optional CLAS ZD oracle/native diff runs after this native self-diff in CI.
+When `GNSSPP_CLAS_ZD_CANDIDATE_CSV` is unset, the workflow sets
+`GNSSPP_CLAS_ZD_NATIVE_CSV=output/clas_a4b_native_selfdiff/native_code_dump.csv`
+so the generated public-data native dump becomes the candidate side. That still
+leaves `GNSSPP_CLAS_ZD_BASE_CSV` as an explicit normalized CLASLIB dump input;
+until CLASLIB-side dump generation is also automated, a missing base CSV is
+reported as `blocked_infrastructure`, not as a passing sign-off.
+
 Build with CLASLIB linked only when you need oracle-backed unit tests:
 
 ```bash

--- a/scripts/ci/optional_diff_runner.py
+++ b/scripts/ci/optional_diff_runner.py
@@ -665,7 +665,7 @@ def aggregate_status(results: list[dict[str, object]]) -> str:
 def next_actions(results: list[dict[str, object]]) -> list[str]:
     if any(result["status"] == "blocked_infrastructure" for result in results):
         return [
-            "Provide the configured base and candidate CSV inputs, then rerun the optional diff.",
+            "Provide the missing configured CSV inputs, then rerun the optional diff.",
             "Treat blocked_infrastructure as missing evidence, not as a passing oracle sign-off.",
         ]
     if any(result["status"] == "failed" for result in results):

--- a/tests/test_optional_clas_zd_component_diff.py
+++ b/tests/test_optional_clas_zd_component_diff.py
@@ -167,6 +167,29 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
             self.assertIn(str(output_dir / "clas_zd_component_diff_claslib_snapshot_summary.json"), steps[0].outputs)
             self.assertIn(str(output_dir / "clas_zd_component_diff_native_snapshot_summary.json"), steps[0].outputs)
 
+    def test_build_step_plan_falls_back_to_a4b_native_candidate(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_clas_zd_native_fallback_") as temp_dir:
+            root = Path(temp_dir)
+            base_csv = root / "claslib.csv"
+            native_csv = root / "output" / "clas_a4b_native_selfdiff" / "native_code_dump.csv"
+            write_zd_component_csv(base_csv)
+            native_csv.parent.mkdir(parents=True)
+            write_zd_component_csv(native_csv)
+            output_dir = root / "output"
+            env = {
+                "GNSSPP_CLAS_ZD_BASE_CSV": str(base_csv),
+                "GNSSPP_CLAS_ZD_NATIVE_CSV": str(native_csv),
+            }
+
+            steps = runner.build_step_plan(ROOT_DIR, output_dir, env)
+
+            command = steps[0].command
+            self.assertIsNotNone(command)
+            assert command is not None
+            self.assertIn(str(base_csv), command)
+            self.assertIn(str(native_csv), command)
+            self.assertNotIn("CLAS ZD component input is unavailable", steps[0].skip_reason or "")
+
     def test_run_step_collects_metrics_from_diff_report(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ci_clas_zd_exec_") as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary

- Run the CLAS A4b native self-diff before the optional CLAS ZD component diff in CI.
- Pass the generated public-data `native_code_dump.csv` as `GNSSPP_CLAS_ZD_NATIVE_CSV` so optional ZD diff candidate input no longer needs a pre-staged native CSV.
- Expose the documented SAT/FREQ/RINEX/duplicate-policy filters in the workflow and document the remaining CLASLIB base CSV boundary.

## Validation

- `python3 -m py_compile tests/test_optional_clas_zd_component_diff.py scripts/ci/run_optional_clas_zd_component_diff.py scripts/ci/optional_diff_runner.py`
- `python3 tests/test_optional_clas_zd_component_diff.py`
- `python3 tests/test_clas_a4b_native_selfdiff.py`
- `ctest --test-dir build -R 'python_(optional_clas_zd_component_diff|clas_a4b_native_selfdiff)_tests' --output-on-failure`
- `python3 -m mkdocs build --strict`
- `git diff --check`
- `bash scripts/ci/run_hygiene.sh`
