### PR TITLE
clas: normalize CLASLIB OSR ZD dumps

### DIFF
--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -217,8 +217,13 @@ CLASLIB-side disposable dumps must first be normalized with
 `scripts/analysis/claslib_zd_component_export.py`.  That export step converts
 numeric CLASLIB `sys`/`prn`/RTKLIB `code` fields into the native row-key space
 (`G14`, `J01`, `E07`, `C2W`, `L2W`, and related exact RINEX identities) without
-linking CLASLIB into the production binaries.  Use the normalized CSV as
-`GNSSPP_CLAS_ZD_BASE_CSV` for optional oracle-backed CI.
+linking CLASLIB into the production binaries.  Unmodified CLASLIB `.osr`
+`OSRRES(ch*)` output is also accepted for the current A4b GPS L2W probe: pass
+`--gps-week` because the `.osr` row carries TOW but not week, and use the
+resulting normalized CSV as `GNSSPP_CLAS_ZD_BASE_CSV`.  The `.osr` path maps
+only GPS L1/L2/L5 slots where the exact row identity is deterministic; QZSS and
+Galileo still need explicit disposable dumps until their ZD materialization and
+admission sources are fixed.
 
 The native side of the A4b `G14/C2W` slice is generated in CI by
 `scripts/ci/run_clas_a4b_native_selfdiff.py`.  That wrapper sparse-checks out

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -173,6 +173,20 @@ python3 scripts/analysis/clas_zd_component_diff.py \
   --details-csv /tmp/clas_a4b_native_vs_claslib_code.csv
 ```
 
+Unmodified CLASLIB `rnx2rtkp` can also write an `.osr` file when run with its
+OSR output option. That file carries `OSRRES(ch*)` rows with `tow`, `sys`,
+`prn`, and L1/L2/L5 component columns, but no GPS week or exact observation
+code. For the current A4b GPS L2W probe, the exporter maps GPS slot 2 to
+`C2W`/`L2W`; provide the GPS week explicitly so the diff key is not ambiguous:
+
+```bash
+python3 scripts/analysis/claslib_zd_component_export.py \
+  /tmp/claslib_solution.osr \
+  --output /tmp/claslib_solution.osr.normalized.csv \
+  --stage-label post \
+  --gps-week 2068
+```
+
 On the 300-epoch 2019 sample smoke, current `develop` produces 5,400 native code
 rows. The GPS L2W slice has 300 rows, all with exact bias identity and exact
 observation matches, and zero observation-family or code-bias fallback rows.

--- a/scripts/analysis/claslib_zd_component_export.py
+++ b/scripts/analysis/claslib_zd_component_export.py
@@ -104,6 +104,7 @@ FIELDNAMES = [
     "receiver_antenna_m",
     "relativity_m",
     "windup_m",
+    "phase_compensation_m",
     "orbit_projection_m",
     "clock_correction_m",
     "residual_m",
@@ -116,6 +117,31 @@ FIELDNAMES = [
     "rx_y_m",
     "rx_z_m",
 ]
+
+CLASLIB_OSR_REQUIRED_COLUMNS = {
+    "msg",
+    "tow",
+    "sys",
+    "prn",
+    "pbias1",
+    "pbias2",
+    "pbias5",
+    "cbias1",
+    "cbias2",
+    "cbias5",
+    "CPC1",
+    "CPC2",
+    "CPC5",
+    "PRC1",
+    "PRC2",
+    "PRC5",
+}
+
+CLASLIB_OSR_GPS_SLOTS = (
+    (0, "1", 1),   # GPS L1C
+    (1, "2", 20),  # GPS L2W, the current CLAS A4b target
+    (2, "5", 26),  # GPS L5X
+)
 
 
 class ExportError(ValueError):
@@ -155,6 +181,20 @@ def rinex_pair(rtklib_code: int) -> tuple[str, str]:
     if suffix is None:
         raise ExportError(f"unsupported RTKLIB observation code: {rtklib_code}")
     return f"C{suffix}", f"L{suffix}"
+
+
+def is_claslib_osr_header(fieldnames: Iterable[str]) -> bool:
+    return CLASLIB_OSR_REQUIRED_COLUMNS.issubset(set(fieldnames))
+
+
+def is_invalid_osr_value(value: str) -> bool:
+    if value == "":
+        return True
+    try:
+        parsed = float(value)
+    except ValueError:
+        return True
+    return abs(parsed + 10000.0) < 0.0005
 
 
 def detect_row_type(row: dict[str, str]) -> str:
@@ -219,6 +259,7 @@ def normalize_row(
             "receiver_antenna_m": first_present(row, ("receiver_antenna_m", "receiver_ant_m", "receiver_ant")),
             "relativity_m": first_present(row, ("relativity_m", "relativity_correction_m")),
             "windup_m": first_present(row, ("windup_m",)),
+            "phase_compensation_m": first_present(row, ("phase_compensation_m", "comp_m")),
             "orbit_projection_m": first_present(row, ("orbit_projection_m", "orb_m")),
             "clock_correction_m": first_present(row, ("clock_correction_m", "clk_m")),
             "residual_m": first_present(row, ("residual_m", "zd_residual_m")),
@@ -235,15 +276,126 @@ def normalize_row(
     return output
 
 
-def export_csv(input_path: Path, output_path: Path, *, stage_label: Optional[str]) -> int:
+def osr_week(row: dict[str, str], *, gps_week: Optional[int], input_path: Path, row_number: int) -> str:
+    week = first_present(row, ("week",))
+    if week:
+        return week
+    if gps_week is None:
+        raise ExportError(
+            f"{input_path}: CLASLIB OSR row {row_number} has no GPS week; pass --gps-week"
+        )
+    return str(gps_week)
+
+
+def normalize_osrres_rows(
+    row: dict[str, str],
+    *,
+    row_number: int,
+    stage_label: Optional[str],
+    gps_week: Optional[int],
+    input_path: Path,
+) -> list[dict[str, str]]:
+    sys_id = parse_int(first_present(row, ("sys", "system")), field=f"row {row_number} sys")
+    prn = parse_int(first_present(row, ("prn",)), field=f"row {row_number} prn")
+    if sys_id != 1:
+        return []
+
+    stage = row.get("stage", "") or (stage_label or "")
+    week = osr_week(row, gps_week=gps_week, input_path=input_path, row_number=row_number)
+    sat = sat_label(sys_id, prn)
+    output_rows: list[dict[str, str]] = []
+
+    for freq_index, suffix, rtklib_code in CLASLIB_OSR_GPS_SLOTS:
+        pseudorange_code, carrier_code = rinex_pair(rtklib_code)
+        common = {
+            "stage": stage,
+            "week": week,
+            "tow": first_present(row, ("tow",)),
+            "sat": sat,
+            "freq": str(freq_index),
+            "pseudorange_rinex_code": pseudorange_code,
+            "carrier_rinex_code": carrier_code,
+            "pseudorange_rtklib_code": str(rtklib_code),
+            "carrier_rtklib_code": str(rtklib_code),
+            "source_sys": str(sys_id),
+            "source_prn": str(prn),
+            "source_satno": first_present(row, ("sat", "satno")),
+            "source_rtklib_code": str(rtklib_code),
+            "trop_correction_m": first_present(row, ("trop", "trop_m")),
+            "iono_l1_m": first_present(row, ("iono", "iono_l1_m", "l1_iono_m")),
+            "receiver_antenna_m": first_present(row, (f"antr{suffix}",)),
+            "relativity_m": first_present(row, ("relatv", "relativity_m", "relativity_correction_m")),
+            "windup_m": first_present(row, (f"wup{suffix}",)),
+            "phase_compensation_m": first_present(row, (f"compI{suffix}",)),
+            "orbit_projection_m": first_present(row, ("orb", "orb_m")),
+            "clock_correction_m": first_present(row, ("clk", "clk_m")),
+        }
+
+        prc = first_present(row, (f"PRC{suffix}",))
+        cbias = first_present(row, (f"cbias{suffix}",))
+        if not is_invalid_osr_value(prc) and not is_invalid_osr_value(cbias):
+            code_row = {field: "" for field in FIELDNAMES}
+            code_row.update(
+                {
+                    **common,
+                    "record": "CODE",
+                    "row_type": "code",
+                    "signal": pseudorange_code,
+                    "applied_pr_corr_m": prc,
+                    "prc_m": prc,
+                    "code_bias_m": cbias,
+                }
+            )
+            output_rows.append(code_row)
+
+        cpc = first_present(row, (f"CPC{suffix}",))
+        pbias = first_present(row, (f"pbias{suffix}",))
+        if not is_invalid_osr_value(cpc) and not is_invalid_osr_value(pbias):
+            phase_row = {field: "" for field in FIELDNAMES}
+            phase_row.update(
+                {
+                    **common,
+                    "record": "PHASE",
+                    "row_type": "phase",
+                    "signal": carrier_code,
+                    "carrier_correction_m": cpc,
+                    "cpc_m": cpc,
+                    "phase_bias_m": pbias,
+                }
+            )
+            output_rows.append(phase_row)
+
+    return output_rows
+
+
+def export_csv(
+    input_path: Path,
+    output_path: Path,
+    *,
+    stage_label: Optional[str],
+    gps_week: Optional[int] = None,
+) -> int:
     with input_path.open(newline="", encoding="utf-8") as input_handle:
         reader = csv.DictReader(input_handle)
         if reader.fieldnames is None:
             raise ExportError(f"{input_path}: missing CSV header")
-        rows = [
-            normalize_row(row, row_number=index, stage_label=stage_label)
-            for index, row in enumerate(reader, start=2)
-        ]
+        if is_claslib_osr_header(reader.fieldnames):
+            rows = []
+            for index, row in enumerate(reader, start=2):
+                rows.extend(
+                    normalize_osrres_rows(
+                        row,
+                        row_number=index,
+                        stage_label=stage_label,
+                        gps_week=gps_week,
+                        input_path=input_path,
+                    )
+                )
+        else:
+            rows = [
+                normalize_row(row, row_number=index, stage_label=stage_label)
+                for index, row in enumerate(reader, start=2)
+            ]
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
     with output_path.open("w", newline="", encoding="utf-8") as output_handle:
@@ -267,13 +419,24 @@ def parse_args(argv: Optional[list[str]] = None) -> argparse.Namespace:
         default=None,
         help="Stage label to use only for input rows that do not already have a stage column",
     )
+    parser.add_argument(
+        "--gps-week",
+        type=int,
+        default=None,
+        help="GPS week to attach to CLASLIB .osr/OSRRES rows, which carry TOW only",
+    )
     return parser.parse_args(argv)
 
 
 def main(argv: Optional[list[str]] = None) -> int:
     args = parse_args(argv)
     try:
-        rows_written = export_csv(args.input_csv, args.output, stage_label=args.stage_label)
+        rows_written = export_csv(
+            args.input_csv,
+            args.output,
+            stage_label=args.stage_label,
+            gps_week=args.gps_week,
+        )
     except ExportError as exc:
         print(f"claslib_zd_component_export: {exc}", file=sys.stderr)
         return 2

--- a/tests/test_claslib_zd_component_export.py
+++ b/tests/test_claslib_zd_component_export.py
@@ -68,6 +68,43 @@ RAW_FIELDNAMES = [
     "rx_z_m",
 ]
 
+OSR_FIELDNAMES = [
+    "msg",
+    "tow",
+    "sys",
+    "prn",
+    "pbias1",
+    "pbias2",
+    "pbias5",
+    "cbias1",
+    "cbias2",
+    "cbias5",
+    "trop",
+    "iono",
+    "antr1",
+    "antr2",
+    "antr5",
+    "relatv",
+    "wup1",
+    "wup2",
+    "wup5",
+    "compI1",
+    "compI2",
+    "compI5",
+    "compN",
+    "CPC1",
+    "CPC2",
+    "CPC5",
+    "PRC1",
+    "PRC2",
+    "PRC5",
+    "orb",
+    "clk",
+    "lat",
+    "lon",
+    "alt",
+]
+
 
 def write_csv(path: Path, rows: list[dict[str, str]], fieldnames: list[str]) -> None:
     with path.open("w", newline="", encoding="utf-8") as handle:
@@ -128,6 +165,105 @@ class ClaslibZdComponentExportTest(unittest.TestCase):
             self.assertEqual(row["receiver_antenna_m"], "-0.02")
             self.assertEqual(row["trop_correction_m"], "2.4")
             self.assertEqual(row["residual_m"], "-0.5")
+
+    def test_normalizes_claslib_osrres_gps_l2w_rows(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="claslib_zd_export_test_") as temp_dir:
+            input_path = Path(temp_dir) / "claslib.osr"
+            output_path = Path(temp_dir) / "normalized.csv"
+            write_csv(
+                input_path,
+                [
+                    {
+                        "msg": "OSRRES(ch0)",
+                        "tow": "230420.0",
+                        "sys": "1",
+                        "prn": "14",
+                        "pbias1": "0.101",
+                        "pbias2": "0.202",
+                        "pbias5": "0.505",
+                        "cbias1": "0.011",
+                        "cbias2": "0.022",
+                        "cbias5": "0.055",
+                        "trop": "2.345",
+                        "iono": "1.234",
+                        "antr1": "-0.010",
+                        "antr2": "-0.020",
+                        "antr5": "-0.050",
+                        "relatv": "0.003",
+                        "wup1": "0.100",
+                        "wup2": "0.200",
+                        "wup5": "0.500",
+                        "compI1": "0.001",
+                        "compI2": "0.002",
+                        "compI5": "0.005",
+                        "compN": "0.000",
+                        "CPC1": "3.101",
+                        "CPC2": "3.202",
+                        "CPC5": "3.505",
+                        "PRC1": "4.101",
+                        "PRC2": "4.202",
+                        "PRC5": "4.505",
+                        "orb": "-0.321",
+                        "clk": "0.654",
+                        "lat": "35.0",
+                        "lon": "139.0",
+                        "alt": "10.0",
+                    }
+                ],
+                OSR_FIELDNAMES,
+            )
+
+            rows_written = export.export_csv(input_path, output_path, stage_label="post", gps_week=2068)
+            self.assertEqual(rows_written, 6)
+            rows = read_csv(output_path)
+            code_l2w = next(row for row in rows if row["row_type"] == "code" and row["signal"] == "C2W")
+            phase_l2w = next(row for row in rows if row["row_type"] == "phase" and row["signal"] == "L2W")
+            self.assertEqual(code_l2w["stage"], "post")
+            self.assertEqual(code_l2w["week"], "2068")
+            self.assertEqual(code_l2w["tow"], "230420.0")
+            self.assertEqual(code_l2w["sat"], "G14")
+            self.assertEqual(code_l2w["freq"], "1")
+            self.assertEqual(code_l2w["pseudorange_rtklib_code"], "20")
+            self.assertEqual(code_l2w["carrier_rtklib_code"], "20")
+            self.assertEqual(code_l2w["applied_pr_corr_m"], "4.202")
+            self.assertEqual(code_l2w["prc_m"], "4.202")
+            self.assertEqual(code_l2w["code_bias_m"], "0.022")
+            self.assertEqual(code_l2w["trop_correction_m"], "2.345")
+            self.assertEqual(code_l2w["iono_l1_m"], "1.234")
+            self.assertEqual(code_l2w["receiver_antenna_m"], "-0.020")
+            self.assertEqual(code_l2w["orbit_projection_m"], "-0.321")
+            self.assertEqual(code_l2w["clock_correction_m"], "0.654")
+            self.assertEqual(phase_l2w["week"], "2068")
+            self.assertEqual(phase_l2w["freq"], "1")
+            self.assertEqual(phase_l2w["carrier_correction_m"], "3.202")
+            self.assertEqual(phase_l2w["cpc_m"], "3.202")
+            self.assertEqual(phase_l2w["phase_bias_m"], "0.202")
+            self.assertEqual(phase_l2w["phase_compensation_m"], "0.002")
+            self.assertEqual(phase_l2w["windup_m"], "0.200")
+
+    def test_claslib_osrres_requires_gps_week(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="claslib_zd_export_test_") as temp_dir:
+            input_path = Path(temp_dir) / "claslib.osr"
+            output_path = Path(temp_dir) / "normalized.csv"
+            write_csv(
+                input_path,
+                [
+                    {
+                        "msg": "OSRRES(ch0)",
+                        "tow": "230420.0",
+                        "sys": "1",
+                        "prn": "14",
+                        "pbias2": "0.202",
+                        "cbias2": "0.022",
+                        "CPC2": "3.202",
+                        "PRC2": "4.202",
+                    }
+                ],
+                OSR_FIELDNAMES,
+            )
+
+            with self.assertRaisesRegex(export.ExportError, "pass --gps-week"):
+                export.export_csv(input_path, output_path, stage_label="post")
 
     def test_normalizes_qzss_phase_and_galileo_code_rows(self) -> None:
         with tempfile.TemporaryDirectory(prefix="claslib_zd_export_test_") as temp_dir:


### PR DESCRIPTION
## Summary

- teach `claslib_zd_component_export.py` to normalize unmodified CLASLIB `.osr` / `OSRRES(ch*)` output into the native CLAS ZD component diff key space
- map deterministic GPS L1/L2/L5 OSR slots, including the A4b `G14/C2W` / `L2W` path, while requiring `--gps-week` because CLASLIB OSR rows carry TOW only
- document the `.osr` route and add focused tests for GPS L2W code/phase rows and the missing-week failure mode

## Validation

- `python3 -m py_compile scripts/analysis/claslib_zd_component_export.py tests/test_claslib_zd_component_export.py`
- `python3 tests/test_claslib_zd_component_export.py`
- `ctest --test-dir build --output-on-failure -R python_claslib_zd_component_export_tests`
- `python3 tests/test_clas_zd_component_summary.py`
- `python3 tests/test_optional_clas_zd_component_diff.py`
- `python3 tests/test_clas_zd_component_diff.py`
- `python3 -m mkdocs build --strict`
- `git diff --check`
