### PR TITLE
ci: generate CLASLIB OSR ZD base dump

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -340,6 +340,40 @@ jobs:
           output/clas_a4b_native_selfdiff/selfdiff.csv
         if-no-files-found: error
 
+    - name: Install CLASLIB LAPACK dependencies
+      run: |
+        set -euo pipefail
+        sudo apt-get -o Acquire::Retries=3 install -y --no-install-recommends \
+          libblas-dev \
+          liblapack-dev
+
+    - name: CLASLIB OSR ZD export
+      env:
+        GNSSPP_CLASLIB_OSR_SOURCE_ROOT: ${{ vars.GNSSPP_CLASLIB_OSR_SOURCE_ROOT }}
+        GNSSPP_CLASLIB_OSR_AUTO_FETCH: ${{ vars.GNSSPP_CLASLIB_OSR_AUTO_FETCH }}
+        GNSSPP_CLASLIB_OSR_REPO: ${{ vars.GNSSPP_CLASLIB_OSR_REPO }}
+        GNSSPP_CLASLIB_OSR_REF: ${{ vars.GNSSPP_CLASLIB_OSR_REF }}
+        GNSSPP_CLASLIB_OSR_GPS_WEEK: ${{ vars.GNSSPP_CLASLIB_OSR_GPS_WEEK }}
+        GNSSPP_CLASLIB_OSR_MAX_EPOCHS: ${{ vars.GNSSPP_CLASLIB_OSR_MAX_EPOCHS }}
+        GNSSPP_CLASLIB_OSR_GPS_L2W_ROWS_MIN: ${{ vars.GNSSPP_CLASLIB_OSR_GPS_L2W_ROWS_MIN }}
+        GNSSPP_CLASLIB_OSR_FAIL_ON_BLOCKED: ${{ vars.GNSSPP_CLASLIB_OSR_FAIL_ON_BLOCKED }}
+      run: python3 scripts/ci/run_claslib_osr_zd_export.py
+
+    - name: Upload CLASLIB OSR ZD export artifacts
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: claslib-osr-zd-export-ubuntu
+        path: |
+          output/ci_claslib_osr_zd_export_summary.json
+          output/ci_claslib_osr_zd_export/*.log
+          output/claslib_osr_zd_export/static_linux.conf
+          output/claslib_osr_zd_export/claslib.nmea
+          output/claslib_osr_zd_export/claslib.nmea.osr
+          output/claslib_osr_zd_export/claslib_osr.normalized.csv
+          output/claslib_osr_zd_export/claslib_osr_summary.json
+        if-no-files-found: error
+
     - name: Optional CLAS ZD component diff
       env:
         GNSSPP_CLAS_ZD_BASE_CSV: ${{ vars.GNSSPP_CLAS_ZD_BASE_CSV }}
@@ -354,10 +388,19 @@ jobs:
         GNSSPP_CLAS_ZD_DUPLICATE_POLICY: ${{ vars.GNSSPP_CLAS_ZD_DUPLICATE_POLICY }}
         GNSSPP_CLAS_ZD_THRESHOLD_M: ${{ vars.GNSSPP_CLAS_ZD_THRESHOLD_M }}
         GNSSPP_CLAS_ZD_FAIL_ON_DIFF: ${{ vars.GNSSPP_CLAS_ZD_FAIL_ON_DIFF }}
-      run: bash scripts/ci/run_optional_clas_zd_component_diff.sh
+      run: |
+        set -euo pipefail
+        export GNSSPP_CLAS_ZD_BASE_CSV="${GNSSPP_CLAS_ZD_BASE_CSV:-output/claslib_osr_zd_export/claslib_osr.normalized.csv}"
+        export GNSSPP_CLAS_ZD_STAGE="${GNSSPP_CLAS_ZD_STAGE:-post}"
+        export GNSSPP_CLAS_ZD_ROW_TYPE="${GNSSPP_CLAS_ZD_ROW_TYPE:-code}"
+        export GNSSPP_CLAS_ZD_SAT="${GNSSPP_CLAS_ZD_SAT:-G14}"
+        export GNSSPP_CLAS_ZD_FREQ="${GNSSPP_CLAS_ZD_FREQ:-1}"
+        export GNSSPP_CLAS_ZD_RINEX_CODE="${GNSSPP_CLAS_ZD_RINEX_CODE:-C2W}"
+        export GNSSPP_CLAS_ZD_DUPLICATE_POLICY="${GNSSPP_CLAS_ZD_DUPLICATE_POLICY:-mean}"
+        bash scripts/ci/run_optional_clas_zd_component_diff.sh
 
     - name: Upload CLAS ZD component diff artifacts
-      if: always()
+      if: always() && hashFiles('output/ci_optional_clas_zd_component_summary.json') != ''
       uses: actions/upload-artifact@v4
       with:
         name: clas-zd-component-diff-ubuntu
@@ -380,7 +423,7 @@ jobs:
       run: bash scripts/ci/run_optional_madoca_materialization_diff.sh
 
     - name: Upload MADOCA materialization diff artifacts
-      if: always()
+      if: always() && hashFiles('output/ci_optional_madoca_materialization_summary.json') != ''
       uses: actions/upload-artifact@v4
       with:
         name: madoca-materialization-diff-ubuntu
@@ -407,7 +450,7 @@ jobs:
       run: python3 scripts/ci/run_madoca_materialization_selfdiff.py
 
     - name: Upload MADOCA materialization native self-diff artifacts
-      if: always()
+      if: always() && hashFiles('output/ci_madoca_materialization_selfdiff_summary.json') != ''
       uses: actions/upload-artifact@v4
       with:
         name: madoca-materialization-selfdiff-ubuntu
@@ -438,7 +481,7 @@ jobs:
       run: bash scripts/ci/run_optional_madoca_residual_component_diff.sh
 
     - name: Upload MADOCA residual-component diff artifacts
-      if: always()
+      if: always() && hashFiles('output/ci_optional_madoca_residual_component_summary.json') != ''
       uses: actions/upload-artifact@v4
       with:
         name: madoca-residual-component-diff-ubuntu

--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -225,6 +225,13 @@ only GPS L1/L2/L5 slots where the exact row identity is deterministic; QZSS and
 Galileo still need explicit disposable dumps until their ZD materialization and
 admission sources are fixed.
 
+In CI, `scripts/ci/run_claslib_osr_zd_export.py` now performs that CLASLIB-side
+step from public data: it checks out pinned CLASLIB as a test-only source tree,
+builds `rnx2rtkp`, runs `-s` on the A4b window, normalizes the emitted `.osr`,
+and validates the normalized dump with `clas_zd_component_summary.v2`.  If
+`GNSSPP_CLAS_ZD_BASE_CSV` is unset, the optional CLAS ZD diff uses this generated
+normalized dump as the CLASLIB base side.
+
 The native side of the A4b `G14/C2W` slice is generated in CI by
 `scripts/ci/run_clas_a4b_native_selfdiff.py`.  That wrapper sparse-checks out
 the public CLASLIB data fixture, runs the gated native CLAS command with

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -248,12 +248,24 @@ fetching public data. CI treats that blocked state as a failure by default; set
 `GNSSPP_CLAS_A4B_FAIL_ON_BLOCKED=0` only for diagnostic-only local runs.
 
 The optional CLAS ZD oracle/native diff runs after this native self-diff in CI.
+CI also builds pinned CLASLIB as a test-only tool, runs unmodified `rnx2rtkp -s`
+on the same public A4b window, normalizes its `.osr` file, and uploads
+`ci_claslib_osr_zd_export_summary.json`, `claslib.nmea.osr`,
+`claslib_osr.normalized.csv`, and `claslib_osr_summary.json`:
+
+```bash
+python3 scripts/ci/run_claslib_osr_zd_export.py
+```
+
 When `GNSSPP_CLAS_ZD_CANDIDATE_CSV` is unset, the workflow sets
 `GNSSPP_CLAS_ZD_NATIVE_CSV=output/clas_a4b_native_selfdiff/native_code_dump.csv`
-so the generated public-data native dump becomes the candidate side. That still
-leaves `GNSSPP_CLAS_ZD_BASE_CSV` as an explicit normalized CLASLIB dump input;
-until CLASLIB-side dump generation is also automated, a missing base CSV is
-reported as `blocked_infrastructure`, not as a passing sign-off.
+so the generated public-data native dump becomes the candidate side. When
+`GNSSPP_CLAS_ZD_BASE_CSV` is unset, the workflow uses
+`output/claslib_osr_zd_export/claslib_osr.normalized.csv` as the CLASLIB base
+side and defaults the optional diff filter to `post`/`code`/`G14`/`f1`/`C2W`;
+explicit workflow variables still override those defaults.
+If either generated side is missing, the optional diff reports
+`blocked_infrastructure`, not a passing sign-off.
 
 Build with CLASLIB linked only when you need oracle-backed unit tests:
 

--- a/scripts/ci/run_claslib_osr_zd_export.py
+++ b/scripts/ci/run_claslib_osr_zd_export.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python3
+"""Generate a normalized CLASLIB OSR ZD dump for CLAS A4b CI diffing."""
+
+from __future__ import annotations
+
+import argparse
+from dataclasses import dataclass
+import json
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import time
+from typing import Mapping, Sequence
+
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from optional_diff_runner import artifact_record, truthy  # noqa: E402
+
+
+SUMMARY_SCHEMA = "ci_claslib_osr_zd_export.v1"
+CONTRACT = "claslib_osr_zd_export.v1"
+DEFAULT_CLASLIB_REPO = "https://github.com/QZSS-Strategy-Office/claslib.git"
+DEFAULT_CLASLIB_REF = "23cfd363a2db6d8d8144e292c82e9d97ca2d3015"
+DEFAULT_GPS_WEEK = 2068
+DEFAULT_MAX_EPOCHS = 300
+DEFAULT_START_DATE = "2019/08/27"
+DEFAULT_START_TIME = "16:00:00"
+REQUIRED_DATA_FILES = (
+    "0627239Q.obs",
+    "sept_2019239.nav",
+    "2019239Q.l6",
+    "igs14_L5copy.atx",
+    "clas_grid.def",
+    "clas_grid.blq",
+    "igu00p01.erp",
+    "isb.tbl",
+    "l2csft.tbl",
+)
+
+
+@dataclass(frozen=True)
+class RunPaths:
+    output_dir: Path
+    work_dir: Path
+    log_path: Path
+    summary_json: Path
+    checkout_dir: Path
+    claslib_config: Path
+    claslib_solution: Path
+    claslib_osr: Path
+    normalized_csv: Path
+    normalized_summary_json: Path
+
+
+@dataclass(frozen=True)
+class RunConfig:
+    repo_root: Path
+    output_dir: Path
+    source_root: Path | None
+    auto_fetch: bool
+    fail_on_blocked: bool
+    claslib_repo: str
+    claslib_ref: str
+    gps_week: int
+    max_epochs: int
+    gps_l2w_rows_min: int
+    start_date: str
+    start_time: str
+    python_executable: str
+
+
+def repo_root_from_script() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def default_paths(output_dir: Path) -> RunPaths:
+    work_dir = output_dir / "claslib_osr_zd_export"
+    return RunPaths(
+        output_dir=output_dir,
+        work_dir=work_dir,
+        log_path=output_dir / "ci_claslib_osr_zd_export" / "claslib_osr_zd_export.log",
+        summary_json=output_dir / "ci_claslib_osr_zd_export_summary.json",
+        checkout_dir=work_dir / "claslib",
+        claslib_config=work_dir / "static_linux.conf",
+        claslib_solution=work_dir / "claslib.nmea",
+        claslib_osr=work_dir / "claslib.nmea.osr",
+        normalized_csv=work_dir / "claslib_osr.normalized.csv",
+        normalized_summary_json=work_dir / "claslib_osr_summary.json",
+    )
+
+
+def resolve_optional_path(repo_root: Path, value: str) -> Path | None:
+    text = value.strip()
+    if not text:
+        return None
+    path = Path(text)
+    return path if path.is_absolute() else repo_root / path
+
+
+def env_or(environ: Mapping[str, str], name: str, default: str) -> str:
+    value = environ.get(name, "").strip()
+    return value if value else default
+
+
+def parse_config(args: argparse.Namespace, environ: Mapping[str, str]) -> RunConfig:
+    repo_root = args.repo_root.resolve()
+    output_dir = (args.output_dir if args.output_dir is not None else repo_root / "output").resolve()
+    max_epochs = int(env_or(environ, "GNSSPP_CLASLIB_OSR_MAX_EPOCHS", str(DEFAULT_MAX_EPOCHS)))
+    return RunConfig(
+        repo_root=repo_root,
+        output_dir=output_dir,
+        source_root=resolve_optional_path(repo_root, environ.get("GNSSPP_CLASLIB_OSR_SOURCE_ROOT", "")),
+        auto_fetch=truthy(env_or(environ, "GNSSPP_CLASLIB_OSR_AUTO_FETCH", "1")),
+        fail_on_blocked=truthy(env_or(environ, "GNSSPP_CLASLIB_OSR_FAIL_ON_BLOCKED", "1")),
+        claslib_repo=env_or(environ, "GNSSPP_CLASLIB_OSR_REPO", DEFAULT_CLASLIB_REPO),
+        claslib_ref=env_or(environ, "GNSSPP_CLASLIB_OSR_REF", DEFAULT_CLASLIB_REF),
+        gps_week=int(env_or(environ, "GNSSPP_CLASLIB_OSR_GPS_WEEK", str(DEFAULT_GPS_WEEK))),
+        max_epochs=max_epochs,
+        gps_l2w_rows_min=int(
+            env_or(environ, "GNSSPP_CLASLIB_OSR_GPS_L2W_ROWS_MIN", str(max_epochs))
+        ),
+        start_date=env_or(environ, "GNSSPP_CLASLIB_OSR_START_DATE", DEFAULT_START_DATE),
+        start_time=env_or(environ, "GNSSPP_CLASLIB_OSR_START_TIME", DEFAULT_START_TIME),
+        python_executable=sys.executable,
+    )
+
+
+def data_root_failures(source_root: Path) -> list[str]:
+    data_root = source_root / "data"
+    return [name for name in REQUIRED_DATA_FILES if not (data_root / name).is_file()]
+
+
+def run_logged(
+    command: Sequence[str],
+    *,
+    cwd: Path,
+    log_path: Path,
+    env: Mapping[str, str] | None = None,
+) -> subprocess.CompletedProcess[str]:
+    display = " ".join(command)
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(f"$ {display}\n")
+    started = time.monotonic()
+    completed = subprocess.run(
+        list(command),
+        cwd=cwd,
+        env=dict(env) if env is not None else None,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    elapsed = time.monotonic() - started
+    combined = completed.stdout
+    if completed.stderr:
+        if combined and not combined.endswith("\n"):
+            combined += "\n"
+        combined += completed.stderr
+    with log_path.open("a", encoding="utf-8") as handle:
+        handle.write(combined)
+        if combined and not combined.endswith("\n"):
+            handle.write("\n")
+        handle.write(f"# exit={completed.returncode} elapsed_s={elapsed:.3f}\n\n")
+    return completed
+
+
+def checkout_claslib_source(config: RunConfig, paths: RunPaths) -> tuple[Path | None, str | None]:
+    if config.source_root is not None:
+        missing = data_root_failures(config.source_root)
+        if not missing:
+            return config.source_root, None
+        return None, f"configured CLASLIB source root is missing data files: {', '.join(missing)}"
+
+    if not config.auto_fetch:
+        return None, "GNSSPP_CLASLIB_OSR_SOURCE_ROOT is unset and auto-fetch is disabled"
+
+    if paths.checkout_dir.exists():
+        shutil.rmtree(paths.checkout_dir)
+    paths.checkout_dir.parent.mkdir(parents=True, exist_ok=True)
+    commands = [
+        ["git", "init", str(paths.checkout_dir)],
+        ["git", "-C", str(paths.checkout_dir), "remote", "add", "origin", config.claslib_repo],
+        ["git", "-C", str(paths.checkout_dir), "fetch", "--depth", "1", "origin", config.claslib_ref],
+        ["git", "-C", str(paths.checkout_dir), "checkout", "--detach", "FETCH_HEAD"],
+    ]
+    for command in commands:
+        completed = run_logged(command, cwd=config.repo_root, log_path=paths.log_path)
+        if completed.returncode != 0:
+            return None, f"failed to fetch CLASLIB source: {' '.join(command)}"
+
+    missing = data_root_failures(paths.checkout_dir)
+    if missing:
+        return None, f"fetched CLASLIB source is missing data files: {', '.join(missing)}"
+    return paths.checkout_dir, None
+
+
+def write_linux_config(source_root: Path, paths: RunPaths) -> None:
+    source_config = source_root / "util" / "rnx2rtkp" / "static.conf"
+    text = source_config.read_text(encoding="utf-8")
+    data_prefix = str(source_root / "data") + "/"
+    text = text.replace("..\\..\\data\\", data_prefix)
+    text = text.replace("../../data/", data_prefix)
+    paths.claslib_config.write_text(text, encoding="utf-8")
+
+
+def end_time(start_time: str, max_epochs: int) -> str:
+    hour, minute, second = (int(part) for part in start_time.split(":"))
+    total = hour * 3600 + minute * 60 + second + max(max_epochs - 1, 0)
+    return f"{(total // 3600) % 24:02d}:{(total % 3600) // 60:02d}:{total % 60:02d}"
+
+
+def build_claslib_command(source_root: Path) -> list[str]:
+    return ["make", "-C", str(source_root / "util" / "rnx2rtkp")]
+
+
+def build_rnx2rtkp_command(config: RunConfig, paths: RunPaths, source_root: Path) -> list[str]:
+    data_root = source_root / "data"
+    binary = source_root / "util" / "rnx2rtkp" / "rnx2rtkp"
+    return [
+        str(binary),
+        "-ti",
+        "1",
+        "-ts",
+        config.start_date,
+        config.start_time,
+        "-te",
+        config.start_date,
+        end_time(config.start_time, config.max_epochs),
+        "-l6w",
+        str(config.gps_week),
+        "-x",
+        "0",
+        "-s",
+        "-k",
+        str(paths.claslib_config),
+        "-o",
+        str(paths.claslib_solution),
+        str(data_root / "0627239Q.obs"),
+        str(data_root / "sept_2019239.nav"),
+        str(data_root / "2019239Q.l6"),
+    ]
+
+
+def build_normalize_command(config: RunConfig, paths: RunPaths) -> list[str]:
+    return [
+        config.python_executable,
+        str(config.repo_root / "scripts" / "analysis" / "claslib_zd_component_export.py"),
+        str(paths.claslib_osr),
+        "--output",
+        str(paths.normalized_csv),
+        "--stage-label",
+        "post",
+        "--gps-week",
+        str(config.gps_week),
+    ]
+
+
+def build_summary_command(config: RunConfig, paths: RunPaths) -> list[str]:
+    return [
+        config.python_executable,
+        str(config.repo_root / "scripts" / "analysis" / "clas_zd_component_summary.py"),
+        str(paths.normalized_csv),
+        "--json-out",
+        str(paths.normalized_summary_json),
+        "--fail-on-issue",
+        "--require-system",
+        "GPS",
+        "--require-row-type",
+        "code",
+        "--require-rinex-code",
+        "C2W",
+        "--require-component",
+        "prc_m",
+        "--require-gps-l2w-rows-min",
+        str(config.gps_l2w_rows_min),
+    ]
+
+
+def load_json(path: Path) -> dict[str, object]:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise ValueError(f"{path}: expected JSON object")
+    return payload
+
+
+def count_csv_data_rows(path: Path) -> int:
+    if not path.is_file():
+        return 0
+    with path.open(encoding="utf-8") as handle:
+        return max(sum(1 for _line in handle) - 1, 0)
+
+
+def evaluate(
+    config: RunConfig,
+    normalized_summary: Mapping[str, object],
+    normalized_rows: int,
+) -> tuple[dict[str, object], dict[str, object], list[str]]:
+    identity = normalized_summary.get("identity_provenance")
+    if not isinstance(identity, dict):
+        identity = {}
+    gps_l2w_rows = int(identity.get("gps_l2w_rows", 0))
+    metrics = {
+        "normalized_rows": normalized_rows,
+        "normalized_summary_schema": normalized_summary.get("schema"),
+        "normalized_summary_status": normalized_summary.get("status"),
+        "normalized_summary_rows": normalized_summary.get("rows"),
+        "gps_l2w_rows": gps_l2w_rows,
+    }
+    thresholds = {
+        "normalized_rows_min": 1,
+        "gps_l2w_rows_min": config.gps_l2w_rows_min,
+    }
+    failures: list[str] = []
+    if normalized_rows <= 0:
+        failures.append("normalized CLASLIB OSR dump has no data rows")
+    if metrics["normalized_summary_schema"] != "clas_zd_component_summary.v2":
+        failures.append(
+            f"normalized summary schema {metrics['normalized_summary_schema']} != clas_zd_component_summary.v2"
+        )
+    if metrics["normalized_summary_status"] != "passed":
+        failures.append(f"normalized summary status {metrics['normalized_summary_status']} != passed")
+    if metrics["normalized_summary_rows"] != normalized_rows:
+        failures.append(
+            f"normalized summary rows {metrics['normalized_summary_rows']} != normalized rows {normalized_rows}"
+        )
+    if gps_l2w_rows < config.gps_l2w_rows_min:
+        failures.append(f"GPS L2W rows {gps_l2w_rows} < {config.gps_l2w_rows_min}")
+    return metrics, thresholds, failures
+
+
+def summarize_artifacts(paths: RunPaths) -> list[dict[str, object]]:
+    return [
+        artifact_record(paths.log_path, role="log", required=True),
+        artifact_record(paths.claslib_config, role="claslib_linux_config", required=True),
+        artifact_record(paths.claslib_solution, role="claslib_solution", required=True),
+        artifact_record(paths.claslib_osr, role="claslib_osr", required=True),
+        artifact_record(paths.normalized_csv, role="normalized_zd_component_dump", required=True),
+        artifact_record(paths.normalized_summary_json, role="normalized_zd_component_summary", required=True),
+    ]
+
+
+def write_summary(paths: RunPaths, payload: dict[str, object]) -> None:
+    paths.summary_json.parent.mkdir(parents=True, exist_ok=True)
+    paths.summary_json.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def build_payload(
+    *,
+    config: RunConfig,
+    paths: RunPaths,
+    status: str,
+    source_root: Path | None,
+    metrics: dict[str, object] | None = None,
+    thresholds: dict[str, object] | None = None,
+    failures: list[str] | None = None,
+    block_reason: str | None = None,
+) -> dict[str, object]:
+    next_actions: list[str] = []
+    if status == "blocked_infrastructure":
+        next_actions.append("Provide CLASLIB source with GNSSPP_CLASLIB_OSR_SOURCE_ROOT or allow auto-fetch.")
+        next_actions.append("Treat blocked_infrastructure as missing CLASLIB OSR oracle evidence.")
+        if config.fail_on_blocked:
+            next_actions.append("Set GNSSPP_CLASLIB_OSR_FAIL_ON_BLOCKED=0 only for diagnostic-only local runs.")
+    elif status == "failed":
+        next_actions.append("Inspect the CLASLIB build/run log and normalized summary before changing CLAS model behavior.")
+    return {
+        "summary_schema": SUMMARY_SCHEMA,
+        "contract": CONTRACT,
+        "status": status,
+        "block_reason": block_reason,
+        "failures": failures or [],
+        "next_actions": next_actions,
+        "input_provenance": {
+            "claslib_repo": config.claslib_repo,
+            "claslib_ref": config.claslib_ref,
+            "source_root": str(source_root) if source_root is not None else None,
+            "required_data_files": list(REQUIRED_DATA_FILES),
+        },
+        "configuration": {
+            "gps_week": config.gps_week,
+            "max_epochs": config.max_epochs,
+            "start_date": config.start_date,
+            "start_time": config.start_time,
+            "end_time": end_time(config.start_time, config.max_epochs),
+            "fail_on_blocked": config.fail_on_blocked,
+            "zd_filter": {"stage": "post", "row_type": "code", "sat": "G14", "freq": 1, "rinex_code": "C2W"},
+        },
+        "metrics": metrics or {},
+        "thresholds": thresholds or {},
+        "artifacts": summarize_artifacts(paths),
+    }
+
+
+def parse_args(argv: Sequence[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--repo-root", type=Path, default=repo_root_from_script())
+    parser.add_argument("--output-dir", type=Path, default=None)
+    return parser.parse_args(argv)
+
+
+def main(argv: Sequence[str] | None = None, environ: Mapping[str, str] | None = None) -> int:
+    args = parse_args(argv)
+    env = os.environ if environ is None else environ
+    config = parse_config(args, env)
+    paths = default_paths(config.output_dir)
+    paths.work_dir.mkdir(parents=True, exist_ok=True)
+    paths.log_path.parent.mkdir(parents=True, exist_ok=True)
+    paths.log_path.write_text("", encoding="utf-8")
+
+    source_root, block_reason = checkout_claslib_source(config, paths)
+    if source_root is None:
+        payload = build_payload(
+            config=config,
+            paths=paths,
+            status="blocked_infrastructure",
+            source_root=None,
+            block_reason=block_reason,
+        )
+        write_summary(paths, payload)
+        print(f"CLASLIB OSR ZD export blocked: {block_reason}")
+        print(f"  summary: {paths.summary_json}")
+        return 1 if config.fail_on_blocked else 0
+
+    write_linux_config(source_root, paths)
+
+    build_result = run_logged(build_claslib_command(source_root), cwd=config.repo_root, log_path=paths.log_path)
+    if build_result.returncode != 0:
+        payload = build_payload(
+            config=config,
+            paths=paths,
+            status="failed",
+            source_root=source_root,
+            failures=["CLASLIB rnx2rtkp build failed"],
+        )
+        write_summary(paths, payload)
+        print(f"CLASLIB build failed; see {paths.log_path}")
+        return 1
+
+    rnx_result = run_logged(build_rnx2rtkp_command(config, paths, source_root), cwd=config.repo_root, log_path=paths.log_path)
+    if rnx_result.returncode != 0 or not paths.claslib_osr.is_file():
+        payload = build_payload(
+            config=config,
+            paths=paths,
+            status="failed",
+            source_root=source_root,
+            failures=["CLASLIB rnx2rtkp OSR run failed or did not produce .osr"],
+        )
+        write_summary(paths, payload)
+        print(f"CLASLIB OSR run failed; see {paths.log_path}")
+        return 1
+
+    normalize_result = run_logged(build_normalize_command(config, paths), cwd=config.repo_root, log_path=paths.log_path)
+    if normalize_result.returncode != 0:
+        payload = build_payload(
+            config=config,
+            paths=paths,
+            status="failed",
+            source_root=source_root,
+            failures=["CLASLIB OSR normalization failed"],
+        )
+        write_summary(paths, payload)
+        print(f"CLASLIB OSR normalization failed; see {paths.log_path}")
+        return 1
+
+    summary_result = run_logged(build_summary_command(config, paths), cwd=config.repo_root, log_path=paths.log_path)
+    if summary_result.returncode != 0:
+        payload = build_payload(
+            config=config,
+            paths=paths,
+            status="failed",
+            source_root=source_root,
+            failures=["CLASLIB OSR normalized summary failed"],
+        )
+        write_summary(paths, payload)
+        print(f"CLASLIB OSR normalized summary failed; see {paths.log_path}")
+        return 1
+
+    normalized_summary = load_json(paths.normalized_summary_json)
+    metrics, thresholds, failures = evaluate(
+        config,
+        normalized_summary,
+        count_csv_data_rows(paths.normalized_csv),
+    )
+    status = "failed" if failures else "passed"
+    payload = build_payload(
+        config=config,
+        paths=paths,
+        status=status,
+        source_root=source_root,
+        metrics=metrics,
+        thresholds=thresholds,
+        failures=failures,
+    )
+    write_summary(paths, payload)
+    print("CLASLIB OSR ZD export:", status)
+    print(f"  summary: {paths.summary_json}")
+    print(f"  normalized dump: {paths.normalized_csv}")
+    if failures:
+        for failure in failures:
+            print(f"  - {failure}")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -150,6 +150,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_clas_a4b_native_selfdiff.py
     )
     add_test(
+        NAME python_claslib_osr_zd_export_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_claslib_osr_zd_export.py
+    )
+    add_test(
         NAME python_madoca_satellite_set_diff_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_madoca_satellite_set_diff.py
     )
@@ -287,6 +291,7 @@ if(GTest_FOUND)
         python_clas_a4b_native_selfdiff_tests
         python_clas_zd_component_diff_tests
         python_clas_zd_component_summary_tests
+        python_claslib_osr_zd_export_tests
         python_claslib_zd_component_export_tests
         python_cli_json_contract_validator_tests
         python_cli_ux_tests

--- a/tests/test_claslib_osr_zd_export.py
+++ b/tests/test_claslib_osr_zd_export.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Tests for the CLASLIB OSR ZD export CI wrapper."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT_DIR / "scripts" / "ci" / "run_claslib_osr_zd_export.py"
+
+spec = importlib.util.spec_from_file_location("run_claslib_osr_zd_export", SCRIPT_PATH)
+assert spec is not None and spec.loader is not None
+runner = importlib.util.module_from_spec(spec)
+sys.modules[spec.name] = runner
+spec.loader.exec_module(runner)
+
+
+def make_source_root(root: Path) -> Path:
+    source_root = root / "claslib"
+    data_root = source_root / "data"
+    config_root = source_root / "util" / "rnx2rtkp"
+    data_root.mkdir(parents=True)
+    config_root.mkdir(parents=True)
+    for name in runner.REQUIRED_DATA_FILES:
+        (data_root / name).write_text(f"{name}\n", encoding="ascii")
+    (config_root / "static.conf").write_text(
+        "file-cssrgridfile  =..\\..\\data\\clas_grid.def\n"
+        "file-blqfile       =..\\..\\data\\clas_grid.blq\n",
+        encoding="ascii",
+    )
+    return source_root
+
+
+class ClaslibOsrZdExportTest(unittest.TestCase):
+    def test_parse_config_defaults_to_public_claslib_source_fetch(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_claslib_osr_config_") as temp_dir:
+            config = runner.parse_config(
+                runner.parse_args(["--repo-root", str(ROOT_DIR), "--output-dir", temp_dir]),
+                {},
+            )
+
+            self.assertTrue(config.auto_fetch)
+            self.assertTrue(config.fail_on_blocked)
+            self.assertEqual(config.claslib_repo, runner.DEFAULT_CLASLIB_REPO)
+            self.assertEqual(config.claslib_ref, runner.DEFAULT_CLASLIB_REF)
+            self.assertEqual(config.gps_week, runner.DEFAULT_GPS_WEEK)
+            self.assertEqual(config.max_epochs, runner.DEFAULT_MAX_EPOCHS)
+            self.assertEqual(config.gps_l2w_rows_min, runner.DEFAULT_MAX_EPOCHS)
+
+    def test_data_root_failures_reports_missing_source_data(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_claslib_osr_data_") as temp_dir:
+            source_root = Path(temp_dir)
+            (source_root / "data").mkdir()
+            (source_root / "data" / "0627239Q.obs").write_text("", encoding="ascii")
+
+            failures = runner.data_root_failures(source_root)
+
+            self.assertIn("sept_2019239.nav", failures)
+            self.assertIn("clas_grid.def", failures)
+            self.assertNotIn("0627239Q.obs", failures)
+
+    def test_write_linux_config_rewrites_claslib_data_paths(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_claslib_osr_config_") as temp_dir:
+            root = Path(temp_dir)
+            source_root = make_source_root(root)
+            paths = runner.default_paths(root / "output")
+            paths.work_dir.mkdir(parents=True)
+
+            runner.write_linux_config(source_root, paths)
+
+            written = paths.claslib_config.read_text(encoding="utf-8")
+            self.assertIn(str(source_root / "data") + "/clas_grid.def", written)
+            self.assertIn(str(source_root / "data") + "/clas_grid.blq", written)
+            self.assertNotIn("..\\..\\data\\", written)
+
+    def test_build_rnx2rtkp_command_sets_osr_window_and_inputs(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_claslib_osr_command_") as temp_dir:
+            root = Path(temp_dir)
+            source_root = make_source_root(root)
+            output_dir = root / "output"
+            paths = runner.default_paths(output_dir)
+            config = runner.RunConfig(
+                repo_root=ROOT_DIR,
+                output_dir=output_dir,
+                source_root=source_root,
+                auto_fetch=False,
+                fail_on_blocked=True,
+                claslib_repo=runner.DEFAULT_CLASLIB_REPO,
+                claslib_ref=runner.DEFAULT_CLASLIB_REF,
+                gps_week=2068,
+                max_epochs=30,
+                gps_l2w_rows_min=30,
+                start_date="2019/08/27",
+                start_time="16:00:00",
+                python_executable=sys.executable,
+            )
+
+            command = runner.build_rnx2rtkp_command(config, paths, source_root)
+
+            self.assertIn("-s", command)
+            self.assertIn("-l6w", command)
+            self.assertIn("2068", command)
+            self.assertIn("-te", command)
+            self.assertIn("16:00:29", command)
+            self.assertIn(str(paths.claslib_config), command)
+            self.assertIn(str(paths.claslib_solution), command)
+            self.assertIn(str(source_root / "data" / "0627239Q.obs"), command)
+            self.assertIn(str(source_root / "data" / "2019239Q.l6"), command)
+
+    def test_evaluate_accepts_normalized_osr_summary(self) -> None:
+        config = runner.RunConfig(
+            repo_root=ROOT_DIR,
+            output_dir=ROOT_DIR / "output",
+            source_root=None,
+            auto_fetch=True,
+            fail_on_blocked=True,
+            claslib_repo=runner.DEFAULT_CLASLIB_REPO,
+            claslib_ref=runner.DEFAULT_CLASLIB_REF,
+            gps_week=2068,
+            max_epochs=30,
+            gps_l2w_rows_min=30,
+            start_date="2019/08/27",
+            start_time="16:00:00",
+            python_executable=sys.executable,
+        )
+        summary = {
+            "schema": "clas_zd_component_summary.v2",
+            "status": "passed",
+            "rows": 100,
+            "identity_provenance": {"gps_l2w_rows": 40},
+        }
+
+        metrics, thresholds, failures = runner.evaluate(config, summary, 100)
+
+        self.assertEqual(failures, [])
+        self.assertEqual(metrics["normalized_rows"], 100)
+        self.assertEqual(metrics["gps_l2w_rows"], 40)
+        self.assertEqual(thresholds["gps_l2w_rows_min"], 30)
+
+    def test_evaluate_rejects_bad_normalized_summary(self) -> None:
+        config = runner.RunConfig(
+            repo_root=ROOT_DIR,
+            output_dir=ROOT_DIR / "output",
+            source_root=None,
+            auto_fetch=True,
+            fail_on_blocked=True,
+            claslib_repo=runner.DEFAULT_CLASLIB_REPO,
+            claslib_ref=runner.DEFAULT_CLASLIB_REF,
+            gps_week=2068,
+            max_epochs=30,
+            gps_l2w_rows_min=30,
+            start_date="2019/08/27",
+            start_time="16:00:00",
+            python_executable=sys.executable,
+        )
+        summary = {
+            "schema": "clas_zd_component_summary.v2",
+            "status": "failed",
+            "rows": 99,
+            "identity_provenance": {"gps_l2w_rows": 20},
+        }
+
+        _metrics, _thresholds, failures = runner.evaluate(config, summary, 100)
+
+        self.assertIn("normalized summary status failed != passed", failures)
+        self.assertIn("normalized summary rows 99 != normalized rows 100", failures)
+        self.assertIn("GPS L2W rows 20 < 30", failures)
+
+    def test_blocked_summary_contract_has_next_action(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_claslib_osr_summary_") as temp_dir:
+            output_dir = Path(temp_dir) / "output"
+            paths = runner.default_paths(output_dir)
+            paths.log_path.parent.mkdir(parents=True)
+            paths.log_path.write_text("blocked\n", encoding="ascii")
+            config = runner.RunConfig(
+                repo_root=ROOT_DIR,
+                output_dir=output_dir,
+                source_root=None,
+                auto_fetch=False,
+                fail_on_blocked=False,
+                claslib_repo=runner.DEFAULT_CLASLIB_REPO,
+                claslib_ref=runner.DEFAULT_CLASLIB_REF,
+                gps_week=2068,
+                max_epochs=30,
+                gps_l2w_rows_min=30,
+                start_date="2019/08/27",
+                start_time="16:00:00",
+                python_executable=sys.executable,
+            )
+
+            payload = runner.build_payload(
+                config=config,
+                paths=paths,
+                status="blocked_infrastructure",
+                source_root=None,
+                block_reason="no source",
+            )
+            runner.write_summary(paths, payload)
+            written = json.loads(paths.summary_json.read_text(encoding="utf-8"))
+
+        self.assertEqual(written["summary_schema"], runner.SUMMARY_SCHEMA)
+        self.assertEqual(written["contract"], runner.CONTRACT)
+        self.assertEqual(written["status"], "blocked_infrastructure")
+        self.assertIn("missing CLASLIB OSR oracle evidence", written["next_actions"][1])
+        self.assertEqual(written["configuration"]["zd_filter"]["rinex_code"], "C2W")
+
+    def test_artifacts_include_normalized_dump_summary(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_claslib_osr_artifacts_") as temp_dir:
+            paths = runner.default_paths(Path(temp_dir) / "output")
+            artifacts = runner.summarize_artifacts(paths)
+
+        roles = {artifact["role"]: artifact["path"] for artifact in artifacts}
+        self.assertEqual(
+            roles["normalized_zd_component_summary"],
+            str(paths.normalized_summary_json),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add `run_claslib_osr_zd_export.py` to checkout pinned CLASLIB as a test-only source, build `rnx2rtkp`, run `-s`, normalize the `.osr` dump, and validate it with `clas_zd_component_summary.v2`
- wire CI so optional CLAS ZD diff uses the generated CLASLIB normalized dump as base and the generated native A4b dump as candidate when explicit CSVs are not configured
- document the remote CI artifact contract and add focused unit coverage for the new runner

## Validation

- `python3 -m py_compile scripts/ci/run_claslib_osr_zd_export.py tests/test_claslib_osr_zd_export.py`
- `python3 tests/test_claslib_osr_zd_export.py`
- `GNSSPP_CLASLIB_OSR_SOURCE_ROOT=/tmp/gnss_claslib_src_509771 GNSSPP_CLASLIB_OSR_MAX_EPOCHS=300 python3 scripts/ci/run_claslib_osr_zd_export.py --output-dir /tmp/gnss_claslib_osr_runner_probe2`
- `GNSSPP_CLAS_ZD_BASE_CSV=/tmp/gnss_claslib_osr_runner_probe2/claslib_osr_zd_export/claslib_osr.normalized.csv GNSSPP_CLAS_ZD_NATIVE_CSV=/tmp/gnss_native_probe/clas_a4b_native_selfdiff/native_code_dump.csv GNSSPP_CLAS_ZD_STAGE=post GNSSPP_CLAS_ZD_ROW_TYPE=code GNSSPP_CLAS_ZD_SAT=G14 GNSSPP_CLAS_ZD_FREQ=1 GNSSPP_CLAS_ZD_RINEX_CODE=C2W GNSSPP_CLAS_ZD_DUPLICATE_POLICY=mean python3 scripts/ci/run_optional_clas_zd_component_diff.py --output-dir /tmp/gnss_clas_zd_optional_probe2`
- `cmake -S . -B build && ctest --test-dir build --output-on-failure -R "python_claslib_osr_zd_export_tests|python_optional_clas_zd_component_diff_tests|python_claslib_zd_component_export_tests"`
- `python3 -m mkdocs build --strict`
- `git diff --check`
