### PR TITLE
ci: surface top optional diff component delta

### DIFF
--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -199,10 +199,10 @@ and component presence before any deltas are compared.  When those inputs are
 absent, the CI step records `status: blocked_infrastructure` with next actions
 instead of silently treating the missing oracle/native evidence as a passing
 sign-off.  The workflow upload treats the summary/log bundle as required
-evidence.  The `ci_optional_clas_zd_component_diff.v4` summary also surfaces the
-top ZD row's dominant component and its absolute delta, so the next A4b model
-PR can be scoped to one correction component instead of tuning final solution
-RMS.
+evidence.  The `ci_optional_clas_zd_component_diff.v5` summary also surfaces
+the global largest component delta and the top ZD row's dominant component, so
+the next A4b model PR can be scoped to one correction component instead of
+tuning final solution RMS.
 Optional filters are `GNSSPP_CLAS_ZD_COMPONENTS`, `GNSSPP_CLAS_ZD_STAGE`,
 `GNSSPP_CLAS_ZD_ROW_TYPE`, `GNSSPP_CLAS_ZD_THRESHOLD_M`, and
 `GNSSPP_CLAS_ZD_FAIL_ON_DIFF`.  GPS L2W A4b probes can also narrow the row set

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -223,13 +223,14 @@ remaining top-row deltas are then dominated by residual and atmosphere terms
 rather than the 30-second code-bias sign flip, phase-only code-bias gaps, or
 receiver-antenna slot mismatch.
 
-The diff JSON also includes `top_row_component_breakdowns`, which groups all
-component deltas for the same ZD key. Use that field to decide whether the next
-GPS L2W A4b slice is dominated by `receiver_antenna_m`, `prc_m`, atmosphere, or
-another component before changing the gated correction model. The optional CI
-summary schema `ci_optional_clas_zd_component_diff.v4` lifts the leading
-breakdown component into summary metrics so release artifacts show the next
-single-component target without manually opening the full diff JSON.
+The diff JSON also includes `top_component_deltas`, the largest individual
+component deltas across all matched rows, and `top_row_component_breakdowns`,
+which groups all component deltas for the same ZD key. Use those fields to
+distinguish the global largest component from the most unbalanced row before
+changing the gated correction model. The optional CI summary schema
+`ci_optional_clas_zd_component_diff.v5` lifts both the global top delta and the
+leading row-breakdown component into summary metrics, so release artifacts show
+the next single-component target without manually opening the full diff JSON.
 
 CI can regenerate the native side of this A4b probe without a pre-staged native
 CSV:

--- a/scripts/ci/optional_diff_runner.py
+++ b/scripts/ci/optional_diff_runner.py
@@ -344,6 +344,31 @@ def load_diff_metrics(config: DiffRunnerConfig, report_json: Path) -> dict[str, 
             if isinstance(value, (int, float)):
                 max_abs_delta = max(max_abs_delta, float(value))
         metrics["max_abs_delta"] = max_abs_delta
+    top_component_deltas = payload.get("top_component_deltas")
+    if isinstance(top_component_deltas, list) and top_component_deltas:
+        first_delta = top_component_deltas[0]
+        if isinstance(first_delta, dict):
+            component = first_delta.get("component")
+            delta = first_delta.get("delta_m")
+            if not isinstance(delta, (int, float)):
+                delta = first_delta.get("delta")
+            abs_delta = first_delta.get("abs_delta_m")
+            if not isinstance(abs_delta, (int, float)):
+                abs_delta = first_delta.get("abs_delta")
+            if isinstance(component, str) and component:
+                metrics["top_delta_component"] = component
+            if isinstance(delta, (int, float)):
+                metrics["top_delta_delta"] = float(delta)
+            if isinstance(abs_delta, (int, float)):
+                metrics["top_delta_abs_delta"] = float(abs_delta)
+            key_parts = []
+            for key in ("week", "tow", "iteration", "stage", "row_type", "sat", "freq", "rinex_code"):
+                value = first_delta.get(key)
+                if value is not None:
+                    metrics[f"top_delta_{key}"] = value
+                    key_parts.append(str(value))
+            if key_parts:
+                metrics["top_delta_key"] = "/".join(key_parts)
     top_row_breakdowns = payload.get("top_row_component_breakdowns")
     if isinstance(top_row_breakdowns, list) and top_row_breakdowns:
         first_row = top_row_breakdowns[0]
@@ -572,6 +597,16 @@ def render_result_detail(result: dict[str, object]) -> str:
         max_abs_delta = metrics.get("max_abs_delta")
         if max_abs_delta is not None:
             detail_parts.append(f"max |delta| {format_metric(max_abs_delta)}")
+        top_delta_component = metrics.get("top_delta_component")
+        top_delta_component_abs = metrics.get("top_delta_abs_delta")
+        if top_delta_component is not None:
+            if top_delta_component_abs is not None:
+                detail_parts.append(
+                    "top delta "
+                    f"`{top_delta_component}` |delta| {format_metric(top_delta_component_abs)}"
+                )
+            else:
+                detail_parts.append(f"top delta `{top_delta_component}`")
         top_row_sum = metrics.get("top_row_sum_abs_delta")
         if top_row_sum is not None:
             detail_parts.append(f"top row sum |delta| {format_metric(top_row_sum)}")

--- a/scripts/ci/run_optional_clas_zd_component_diff.py
+++ b/scripts/ci/run_optional_clas_zd_component_diff.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import optional_diff_runner as runner  # noqa: E402
 
 
-SUMMARY_SCHEMA = "ci_optional_clas_zd_component_diff.v4"
+SUMMARY_SCHEMA = "ci_optional_clas_zd_component_diff.v5"
 
 CONFIG = runner.DiffRunnerConfig(
     summary_schema=SUMMARY_SCHEMA,

--- a/scripts/ci/run_optional_madoca_residual_component_diff.py
+++ b/scripts/ci/run_optional_madoca_residual_component_diff.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import optional_diff_runner as runner  # noqa: E402
 
 
-SUMMARY_SCHEMA = "ci_optional_madoca_residual_component_diff.v4"
+SUMMARY_SCHEMA = "ci_optional_madoca_residual_component_diff.v5"
 
 CONFIG = runner.DiffRunnerConfig(
     summary_schema=SUMMARY_SCHEMA,

--- a/tests/test_optional_clas_zd_component_diff.py
+++ b/tests/test_optional_clas_zd_component_diff.py
@@ -226,6 +226,12 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
             self.assertEqual(metrics["rinex_code_filter"], ["C2W"])
             self.assertEqual(metrics["duplicate_policy"], "mean")
             self.assertAlmostEqual(metrics["max_abs_delta"], 0.05)
+            self.assertEqual(metrics["top_delta_component"], "prc_m")
+            self.assertAlmostEqual(metrics["top_delta_delta"], 0.05)
+            self.assertAlmostEqual(metrics["top_delta_abs_delta"], 0.05)
+            self.assertEqual(metrics["top_delta_key"], "2360/172800.0/code/G01/1/C2W")
+            self.assertEqual(metrics["top_delta_sat"], "G01")
+            self.assertEqual(metrics["top_delta_rinex_code"], "C2W")
             self.assertAlmostEqual(metrics["top_row_sum_abs_delta"], 0.05)
             self.assertAlmostEqual(metrics["top_row_max_abs_delta"], 0.05)
             self.assertEqual(metrics["top_row_sat"], "G01")
@@ -319,6 +325,8 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
                         "candidate_only_rows": 2,
                         "components_compared": 24,
                         "max_abs_delta": 0.125,
+                        "top_delta_component": "prc_m",
+                        "top_delta_abs_delta": 0.25,
                         "top_row_sum_abs_delta": 0.375,
                         "top_row_dominant_component": "prc_m",
                         "top_row_dominant_abs_delta": 0.25,
@@ -351,6 +359,7 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
         self.assertIn("unmatched `1/2`", markdown)
         self.assertIn("components `24`", markdown)
         self.assertIn("max |delta| 0.125", markdown)
+        self.assertIn("top delta `prc_m` |delta| 0.25", markdown)
         self.assertIn("top row sum |delta| 0.375", markdown)
         self.assertIn("top component `prc_m` |delta| 0.25", markdown)
         self.assertIn("threshold exceedances `3`", markdown)
@@ -379,7 +388,7 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
 
             payload = json.loads(summary_path.read_text(encoding="utf-8"))
             self.assertEqual(payload["summary_schema"], runner.SUMMARY_SCHEMA)
-            self.assertEqual(payload["summary_schema"], "ci_optional_clas_zd_component_diff.v4")
+            self.assertEqual(payload["summary_schema"], "ci_optional_clas_zd_component_diff.v5")
             self.assertEqual(payload["contract"], "optional_diff_artifact_contract.v1")
             self.assertEqual(payload["status"], "blocked_infrastructure")
             self.assertIn("missing evidence", payload["next_actions"][1])

--- a/tests/test_optional_madoca_residual_component_diff.py
+++ b/tests/test_optional_madoca_residual_component_diff.py
@@ -192,6 +192,12 @@ class OptionalMadocaResidualComponentDiffTest(unittest.TestCase):
             self.assertEqual(metrics["common_rows"], 1)
             self.assertEqual(metrics["components_compared"], 1)
             self.assertAlmostEqual(metrics["max_abs_delta"], 0.05)
+            self.assertEqual(metrics["top_delta_component"], "residual_m")
+            self.assertAlmostEqual(metrics["top_delta_delta"], 0.05)
+            self.assertAlmostEqual(metrics["top_delta_abs_delta"], 0.05)
+            self.assertEqual(metrics["top_delta_key"], "2360/172800.0/1/code/G01")
+            self.assertEqual(metrics["top_delta_iteration"], 1)
+            self.assertEqual(metrics["top_delta_sat"], "G01")
             self.assertEqual(metrics["madocalib_snapshot_schema"], "madoca_residual_component_summary.v2")
             self.assertEqual(metrics["native_snapshot_schema"], "madoca_residual_component_summary.v2")
             self.assertEqual(metrics["madocalib_snapshot_status"], "passed")
@@ -269,6 +275,8 @@ class OptionalMadocaResidualComponentDiffTest(unittest.TestCase):
                         "candidate_only_rows": 2,
                         "components_compared": 24,
                         "max_abs_delta": 0.125,
+                        "top_delta_component": "residual_m",
+                        "top_delta_abs_delta": 0.25,
                         "threshold_exceedances": 3,
                     },
                 },
@@ -299,6 +307,7 @@ class OptionalMadocaResidualComponentDiffTest(unittest.TestCase):
         self.assertIn("unmatched `1/2`", markdown)
         self.assertIn("components `24`", markdown)
         self.assertIn("max |delta| 0.125", markdown)
+        self.assertIn("top delta `residual_m` |delta| 0.25", markdown)
         self.assertIn("threshold exceedances `3`", markdown)
         self.assertIn("see `/tmp/madoca.log`", markdown)
         self.assertIn("missing `/tmp/missing.json`", markdown)
@@ -337,7 +346,7 @@ class OptionalMadocaResidualComponentDiffTest(unittest.TestCase):
 
             payload = json.loads(summary_path.read_text(encoding="utf-8"))
             self.assertEqual(payload["summary_schema"], runner.SUMMARY_SCHEMA)
-            self.assertEqual(payload["summary_schema"], "ci_optional_madoca_residual_component_diff.v4")
+            self.assertEqual(payload["summary_schema"], "ci_optional_madoca_residual_component_diff.v5")
             self.assertEqual(payload["contract"], "optional_diff_artifact_contract.v1")
             self.assertEqual(payload["status"], "blocked_infrastructure")
             self.assertIn("missing evidence", payload["next_actions"][1])


### PR DESCRIPTION
## Summary
- add `top_delta_*` metrics from `top_component_deltas[0]` to optional diff summaries
- render the global top component delta separately from the top-row breakdown component
- bump CLAS ZD and MADOCA residual optional summary schemas to v5 and update docs/tests

## Validation
- `python3 -m py_compile scripts/ci/optional_diff_runner.py scripts/ci/run_optional_clas_zd_component_diff.py scripts/ci/run_optional_madoca_residual_component_diff.py tests/test_optional_clas_zd_component_diff.py tests/test_optional_madoca_residual_component_diff.py`
- `python3 tests/test_optional_clas_zd_component_diff.py`
- `python3 tests/test_optional_madoca_residual_component_diff.py`
- `ctest --test-dir build --output-on-failure -R "python_optional_(clas_zd_component|madoca_residual_component)_diff_tests"`
- `python3 -m mkdocs build --strict`
- `git diff --check`
