### PR TITLE
ci: add CLAS PRC closure diff component

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,7 +397,7 @@ jobs:
         export GNSSPP_CLAS_ZD_FREQ="${GNSSPP_CLAS_ZD_FREQ:-1}"
         export GNSSPP_CLAS_ZD_RINEX_CODE="${GNSSPP_CLAS_ZD_RINEX_CODE:-C2W}"
         export GNSSPP_CLAS_ZD_DUPLICATE_POLICY="${GNSSPP_CLAS_ZD_DUPLICATE_POLICY:-mean}"
-        export GNSSPP_CLAS_ZD_COMPONENTS="${GNSSPP_CLAS_ZD_COMPONENTS:-prc_m,iono_l1_m,trop_correction_m,code_bias_m,receiver_antenna_m,relativity_m}"
+        export GNSSPP_CLAS_ZD_COMPONENTS="${GNSSPP_CLAS_ZD_COMPONENTS:-prc_m,prc_component_sum_m,prc_closure_residual_m,iono_l1_m,iono_scaled_m,trop_correction_m,code_bias_m,receiver_antenna_m,relativity_m}"
         bash scripts/ci/run_optional_clas_zd_component_diff.sh
 
     - name: Upload CLAS ZD component diff artifacts

--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -199,10 +199,10 @@ and component presence before any deltas are compared.  When those inputs are
 absent, the CI step records `status: blocked_infrastructure` with next actions
 instead of silently treating the missing oracle/native evidence as a passing
 sign-off.  The workflow upload treats the summary/log bundle as required
-evidence.  The `ci_optional_clas_zd_component_diff.v5` summary also surfaces
-the global largest component delta and the top ZD row's dominant component, so
-the next A4b model PR can be scoped to one correction component instead of
-tuning final solution RMS.
+evidence.  The `ci_optional_clas_zd_component_diff.v6` summary also surfaces
+the global largest component delta, the top ZD row's dominant component, and a
+per-component max-delta map, so the next A4b model PR can be scoped to one
+correction component instead of tuning final solution RMS.
 Optional filters are `GNSSPP_CLAS_ZD_COMPONENTS`, `GNSSPP_CLAS_ZD_STAGE`,
 `GNSSPP_CLAS_ZD_ROW_TYPE`, `GNSSPP_CLAS_ZD_THRESHOLD_M`, and
 `GNSSPP_CLAS_ZD_FAIL_ON_DIFF`.  GPS L2W A4b probes can also narrow the row set
@@ -255,9 +255,13 @@ current `SignalType::GPS_L2C` runtime family.  The CLAS ZD component diff keys
 rows by the exact row-specific RINEX code so alias mismatches show up as row-set
 differences before component deltas are computed.
 When `GNSSPP_CLAS_ZD_COMPONENTS` is unset, the optional CI diff compares the
-component-level `prc_m`, `iono_l1_m`, `trop_correction_m`, `code_bias_m`,
+component-level `prc_m`, `prc_component_sum_m`, `prc_closure_residual_m`,
+`iono_l1_m`, `iono_scaled_m`, `trop_correction_m`, `code_bias_m`,
 `receiver_antenna_m`, and `relativity_m` fields rather than using the aggregate
-`applied_pr_corr_m` to select the dominant row component.
+`applied_pr_corr_m` to select the dominant row component.  The closure residual
+is derived at diff time from the PRC component inputs, which makes the remote
+artifact show whether the remaining GPS L2W PRC gap is explained by component
+deltas or by a PRC convention/rounding mismatch.
 When `GNSS_PPP_CLAS_DD_FILTER=1` and
 `GNSS_PPP_CLAS_CODE_ROW_PARITY=bias,full-prc` are set, the CLAS OSR
 materializer uses that exact GPS L2 RINEX identity to choose the code/phase SSR

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -228,9 +228,10 @@ component deltas across all matched rows, and `top_row_component_breakdowns`,
 which groups all component deltas for the same ZD key. Use those fields to
 distinguish the global largest component from the most unbalanced row before
 changing the gated correction model. The optional CI summary schema
-`ci_optional_clas_zd_component_diff.v5` lifts both the global top delta and the
-leading row-breakdown component into summary metrics, so release artifacts show
-the next single-component target without manually opening the full diff JSON.
+`ci_optional_clas_zd_component_diff.v6` lifts both the global top delta, the
+leading row-breakdown component, and a per-component max-delta map into summary
+metrics, so release artifacts show the next single-component target without
+manually opening the full diff JSON.
 
 CI can regenerate the native side of this A4b probe without a pre-staged native
 CSV:
@@ -274,10 +275,15 @@ so the generated public-data native dump becomes the candidate side. When
 side and defaults the optional diff filter to `post`/`code`/`G14`/`f1`/`C2W`;
 explicit workflow variables still override those defaults.
 When `GNSSPP_CLAS_ZD_COMPONENTS` is unset, the remote diff compares the
-component-level fields `prc_m`, `iono_l1_m`, `trop_correction_m`, `code_bias_m`,
-`receiver_antenna_m`, and `relativity_m`. The aggregate `applied_pr_corr_m`
-remains available for explicit diagnostic runs, but the default sign-off points
-the top-row evidence at the underlying ZD correction component.
+component-level fields `prc_m`, `prc_component_sum_m`,
+`prc_closure_residual_m`, `iono_l1_m`, `iono_scaled_m`,
+`trop_correction_m`, `code_bias_m`, `receiver_antenna_m`, and
+`relativity_m`.  The derived `prc_closure_residual_m` value is computed by the
+diff tool as `PRC - (trop + relativity + receiver antenna + scaled iono + code
+bias)`, so it diagnoses PRC convention/rounding gaps without changing either
+input CSV schema. The aggregate `applied_pr_corr_m` remains available for
+explicit diagnostic runs, but the default sign-off points the top-row evidence
+at the underlying ZD correction component.
 If either generated side is missing, the optional diff reports
 `blocked_infrastructure`, not a passing sign-off.
 

--- a/scripts/analysis/clas_zd_component_diff.py
+++ b/scripts/analysis/clas_zd_component_diff.py
@@ -23,6 +23,8 @@ COMPONENT_ALIASES: dict[str, tuple[str, ...]] = {
     "applied_pr_corr_m": ("applied_pr_corr_m", "pseudorange_correction_m"),
     "carrier_correction_m": ("carrier_correction_m", "carrier_phase_correction_m"),
     "prc_m": ("prc_m", "PRC", "PRC_m"),
+    "prc_component_sum_m": ("prc_component_sum_m",),
+    "prc_closure_residual_m": ("prc_closure_residual_m",),
     "cpc_m": ("cpc_m", "CPC", "CPC_m"),
     "prc_minus_trop_m": ("prc_minus_trop_m",),
     "cpc_minus_trop_m": ("cpc_minus_trop_m",),
@@ -67,6 +69,13 @@ IDENTITY_PROVENANCE_COMPONENTS = (
     "phase_bias_present",
     "code_bias_fallback",
     "phase_bias_fallback",
+)
+PRC_COMPONENT_SUM_INPUTS = (
+    "trop_correction_m",
+    "relativity_m",
+    "receiver_antenna_m",
+    "iono_scaled_m",
+    "code_bias_m",
 )
 
 
@@ -118,6 +127,28 @@ def first_present(row: Row, names: Iterable[str], default: str = "") -> str:
     return default
 
 
+def row_component_value(row: Row, component: str) -> Optional[float]:
+    aliases = COMPONENT_ALIASES.get(component, (component,))
+    return to_float(first_present(row, aliases))
+
+
+def derived_component_value(row: Row, component: str) -> Optional[float]:
+    if component not in {"prc_component_sum_m", "prc_closure_residual_m"}:
+        return None
+
+    inputs = [row_component_value(row, name) for name in PRC_COMPONENT_SUM_INPUTS]
+    if any(value is None for value in inputs):
+        return None
+    component_sum = sum(float(value) for value in inputs if value is not None)
+    if component == "prc_component_sum_m":
+        return component_sum
+
+    prc = row_component_value(row, "prc_m")
+    if prc is None:
+        return None
+    return prc - component_sum
+
+
 def detect_row_type(row: Row) -> str:
     value = first_present(row, ("row_type", "kind", "type", "record"), "")
     normalized = value.strip().lower()
@@ -167,9 +198,9 @@ def observation_identity(row: Row, row_type: str) -> str:
 def extract_components(row: Row, component_names: Sequence[str]) -> ComponentMap:
     components: ComponentMap = {}
     for component in component_names:
-        aliases = COMPONENT_ALIASES.get(component, (component,))
-        raw_value = first_present(row, aliases)
-        parsed = to_float(raw_value)
+        parsed = row_component_value(row, component)
+        if parsed is None:
+            parsed = derived_component_value(row, component)
         if parsed is not None:
             components[component] = parsed
     return components

--- a/scripts/ci/optional_diff_runner.py
+++ b/scripts/ci/optional_diff_runner.py
@@ -337,13 +337,20 @@ def load_diff_metrics(config: DiffRunnerConfig, report_json: Path) -> dict[str, 
         per_component = payload.get("per_numeric_component")
     if isinstance(per_component, list):
         max_abs_delta = 0.0
+        per_component_max_abs_delta: dict[str, float] = {}
         for item in per_component:
             if not isinstance(item, dict):
                 continue
+            component = item.get("component")
             value = item.get(config.per_component_max_key)
             if isinstance(value, (int, float)):
-                max_abs_delta = max(max_abs_delta, float(value))
+                parsed_value = float(value)
+                max_abs_delta = max(max_abs_delta, parsed_value)
+                if isinstance(component, str) and component:
+                    per_component_max_abs_delta[component] = parsed_value
         metrics["max_abs_delta"] = max_abs_delta
+        if per_component_max_abs_delta:
+            metrics["per_component_max_abs_delta"] = per_component_max_abs_delta
     top_component_deltas = payload.get("top_component_deltas")
     if isinstance(top_component_deltas, list) and top_component_deltas:
         first_delta = top_component_deltas[0]

--- a/scripts/ci/run_optional_clas_zd_component_diff.py
+++ b/scripts/ci/run_optional_clas_zd_component_diff.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import optional_diff_runner as runner  # noqa: E402
 
 
-SUMMARY_SCHEMA = "ci_optional_clas_zd_component_diff.v5"
+SUMMARY_SCHEMA = "ci_optional_clas_zd_component_diff.v6"
 
 CONFIG = runner.DiffRunnerConfig(
     summary_schema=SUMMARY_SCHEMA,

--- a/scripts/ci/run_optional_madoca_residual_component_diff.py
+++ b/scripts/ci/run_optional_madoca_residual_component_diff.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import optional_diff_runner as runner  # noqa: E402
 
 
-SUMMARY_SCHEMA = "ci_optional_madoca_residual_component_diff.v5"
+SUMMARY_SCHEMA = "ci_optional_madoca_residual_component_diff.v6"
 
 CONFIG = runner.DiffRunnerConfig(
     summary_schema=SUMMARY_SCHEMA,

--- a/tests/test_clas_zd_component_diff.py
+++ b/tests/test_clas_zd_component_diff.py
@@ -57,6 +57,8 @@ FIELDNAMES = [
     "receiver_ant_m",
     "receiver_antenna_m",
     "trop_correction_m",
+    "iono_scaled_m",
+    "relativity_m",
 ]
 
 
@@ -74,6 +76,9 @@ def code_row(
     prc: str,
     code_bias: str,
     receiver_ant: str,
+    trop: str = "2.0",
+    iono_scaled: str = "0.0",
+    relativity: str = "0.0",
     record: str = "CODE",
     stage: str = "",
     signal: str = "",
@@ -128,11 +133,49 @@ def code_row(
         "phase_bias_m": "",
         "receiver_ant_m": receiver_ant,
         "receiver_antenna_m": "",
-        "trop_correction_m": "2.0",
+        "trop_correction_m": trop,
+        "iono_scaled_m": iono_scaled,
+        "relativity_m": relativity,
     }
 
 
 class ClasZdComponentDiffTest(unittest.TestCase):
+    def test_derives_prc_closure_components_from_existing_fields(self) -> None:
+        components = component_diff.extract_components(
+            code_row(
+                sat="G14",
+                freq="1",
+                prc="3.0",
+                code_bias="0.5",
+                receiver_ant="0.1",
+                trop="2.0",
+                iono_scaled="0.3",
+                relativity="0.02",
+            ),
+            ["prc_component_sum_m", "prc_closure_residual_m"],
+        )
+
+        self.assertAlmostEqual(components["prc_component_sum_m"], 2.92)
+        self.assertAlmostEqual(components["prc_closure_residual_m"], 0.08)
+
+    def test_skips_prc_closure_when_required_component_is_missing(self) -> None:
+        components = component_diff.extract_components(
+            code_row(
+                sat="G14",
+                freq="1",
+                prc="3.0",
+                code_bias="",
+                receiver_ant="0.1",
+                trop="2.0",
+                iono_scaled="0.3",
+                relativity="0.02",
+            ),
+            ["prc_component_sum_m", "prc_closure_residual_m"],
+        )
+
+        self.assertNotIn("prc_component_sum_m", components)
+        self.assertNotIn("prc_closure_residual_m", components)
+
     def test_observation_identity_prefers_row_type_specific_rinex_code(self) -> None:
         self.assertEqual(
             component_diff.observation_identity(

--- a/tests/test_optional_clas_zd_component_diff.py
+++ b/tests/test_optional_clas_zd_component_diff.py
@@ -226,6 +226,8 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
             self.assertEqual(metrics["rinex_code_filter"], ["C2W"])
             self.assertEqual(metrics["duplicate_policy"], "mean")
             self.assertAlmostEqual(metrics["max_abs_delta"], 0.05)
+            self.assertEqual(set(metrics["per_component_max_abs_delta"]), {"prc_m"})
+            self.assertAlmostEqual(metrics["per_component_max_abs_delta"]["prc_m"], 0.05)
             self.assertEqual(metrics["top_delta_component"], "prc_m")
             self.assertAlmostEqual(metrics["top_delta_delta"], 0.05)
             self.assertAlmostEqual(metrics["top_delta_abs_delta"], 0.05)
@@ -388,7 +390,7 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
 
             payload = json.loads(summary_path.read_text(encoding="utf-8"))
             self.assertEqual(payload["summary_schema"], runner.SUMMARY_SCHEMA)
-            self.assertEqual(payload["summary_schema"], "ci_optional_clas_zd_component_diff.v5")
+            self.assertEqual(payload["summary_schema"], "ci_optional_clas_zd_component_diff.v6")
             self.assertEqual(payload["contract"], "optional_diff_artifact_contract.v1")
             self.assertEqual(payload["status"], "blocked_infrastructure")
             self.assertIn("missing evidence", payload["next_actions"][1])

--- a/tests/test_optional_madoca_residual_component_diff.py
+++ b/tests/test_optional_madoca_residual_component_diff.py
@@ -192,6 +192,11 @@ class OptionalMadocaResidualComponentDiffTest(unittest.TestCase):
             self.assertEqual(metrics["common_rows"], 1)
             self.assertEqual(metrics["components_compared"], 1)
             self.assertAlmostEqual(metrics["max_abs_delta"], 0.05)
+            self.assertEqual(set(metrics["per_component_max_abs_delta"]), {"residual_m"})
+            self.assertAlmostEqual(
+                metrics["per_component_max_abs_delta"]["residual_m"],
+                0.05,
+            )
             self.assertEqual(metrics["top_delta_component"], "residual_m")
             self.assertAlmostEqual(metrics["top_delta_delta"], 0.05)
             self.assertAlmostEqual(metrics["top_delta_abs_delta"], 0.05)
@@ -346,7 +351,7 @@ class OptionalMadocaResidualComponentDiffTest(unittest.TestCase):
 
             payload = json.loads(summary_path.read_text(encoding="utf-8"))
             self.assertEqual(payload["summary_schema"], runner.SUMMARY_SCHEMA)
-            self.assertEqual(payload["summary_schema"], "ci_optional_madoca_residual_component_diff.v5")
+            self.assertEqual(payload["summary_schema"], "ci_optional_madoca_residual_component_diff.v6")
             self.assertEqual(payload["contract"], "optional_diff_artifact_contract.v1")
             self.assertEqual(payload["status"], "blocked_infrastructure")
             self.assertIn("missing evidence", payload["next_actions"][1])


### PR DESCRIPTION
## Summary
- derive `prc_component_sum_m` and `prc_closure_residual_m` in the CLAS ZD component diff without changing input CSV schemas
- include PRC closure fields and `iono_scaled_m` in the default A4b CLAS optional diff component set
- expose `per_component_max_abs_delta` in optional diff summaries and bump CLAS/MADOCA residual optional schemas to v6

## Why
The A4b artifact now shows the remaining GPS L2W `prc_m` gap, but it does not show whether the gap is explained by component deltas or by a PRC convention/rounding mismatch. The derived closure residual makes that distinction visible in remote sign-off artifacts.

## Validation
- `python3 -m py_compile scripts/analysis/clas_zd_component_diff.py scripts/ci/optional_diff_runner.py scripts/ci/run_optional_clas_zd_component_diff.py scripts/ci/run_optional_madoca_residual_component_diff.py tests/test_clas_zd_component_diff.py tests/test_optional_clas_zd_component_diff.py tests/test_optional_madoca_residual_component_diff.py`
- `python3 tests/test_clas_zd_component_diff.py`
- `python3 tests/test_optional_clas_zd_component_diff.py`
- `python3 tests/test_optional_madoca_residual_component_diff.py`
- `ctest --test-dir build --output-on-failure -R "python_(clas_zd_component_diff|optional_clas_zd_component_diff|optional_madoca_residual_component_diff)_tests"`
- `python3 -m mkdocs build --strict`
- `git diff --check`
