### PR TITLE
analysis: normalize CLASLIB OSR iono per frequency slot

### DIFF
--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -221,12 +221,13 @@ linking CLASLIB into the production binaries.  Unmodified CLASLIB `.osr`
 `OSRRES(ch*)` output is also accepted for the current A4b GPS L2W probe: pass
 `--gps-week` because the `.osr` row carries TOW but not week, and use the
 resulting normalized CSV as `GNSSPP_CLAS_ZD_BASE_CSV`.  For `.osr` input,
-`iono_l1_m` and `iono_scaled_m` are reconstructed from the CLASLIB `PRC`
-closure, not from the raw display `iono` column, so the diff compares the
-ionosphere term that was actually applied to `PRC1/PRC2/PRC5`.  The `.osr` path
-maps only GPS L1/L2/L5 slots where the exact row identity is deterministic;
-QZSS and Galileo still need explicit disposable dumps until their ZD
-materialization and admission sources are fixed.
+`iono_scaled_m` is reconstructed from the CLASLIB `PRC` closure, not from the
+raw display `iono` column, so the diff compares the ionosphere term that was
+actually applied to `PRC1/PRC2/PRC5`.  `iono_l1_m` is the L1-equivalent of that
+same frequency-slot-specific closure value; it is not copied from the L1 slot.
+The `.osr` path maps only GPS L1/L2/L5 slots where the exact row identity is
+deterministic; QZSS and Galileo still need explicit disposable dumps until
+their ZD materialization and admission sources are fixed.
 
 In CI, `scripts/ci/run_claslib_osr_zd_export.py` now performs that CLASLIB-side
 step from public data: it checks out pinned CLASLIB as a test-only source tree,

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -183,9 +183,11 @@ OSR output option. That file carries `OSRRES(ch*)` rows with `tow`, `sys`,
 `prn`, and L1/L2/L5 component columns, but no GPS week or exact observation
 code. For the current A4b GPS L2W probe, the exporter maps GPS slot 2 to
 `C2W`/`L2W`; provide the GPS week explicitly so the diff key is not ambiguous.
-The normalized `iono_l1_m`/`iono_scaled_m` fields are reconstructed from the
-CLASLIB `PRC` closure instead of the raw `.osr` `iono` display column, so they
-match the correction actually applied in `PRC1/PRC2/PRC5`:
+The normalized `iono_scaled_m` field is reconstructed from the CLASLIB `PRC`
+closure instead of the raw `.osr` `iono` display column, so it matches the
+correction actually applied in `PRC1/PRC2/PRC5`.  `iono_l1_m` is the
+frequency-slot-specific L1-equivalent of that reconstructed value, not a copy
+of the L1 slot's display or closure value:
 
 ```bash
 python3 scripts/analysis/claslib_zd_component_export.py \

--- a/scripts/analysis/claslib_zd_component_export.py
+++ b/scripts/analysis/claslib_zd_component_export.py
@@ -231,15 +231,11 @@ def prc_iono_scaled_from_osrres(row: dict[str, str], suffix: str) -> Optional[fl
     return prc - (trop + antr + relativity + cbias)
 
 
-def prc_iono_l1_from_osrres(row: dict[str, str]) -> str:
-    l1_scaled = prc_iono_scaled_from_osrres(row, "1")
-    if l1_scaled is not None:
-        return format_component(l1_scaled)
-    for suffix in ("2", "5"):
-        scaled = prc_iono_scaled_from_osrres(row, suffix)
-        scale = GPS_IONO_SCALE_BY_SUFFIX.get(suffix, 0.0)
-        if scaled is not None and scale > 0.0:
-            return format_component(scaled / scale)
+def prc_iono_l1_from_osrres(row: dict[str, str], suffix: str) -> str:
+    scaled = prc_iono_scaled_from_osrres(row, suffix)
+    scale = GPS_IONO_SCALE_BY_SUFFIX.get(suffix, 0.0)
+    if scaled is not None and scale > 0.0:
+        return format_component(scaled / scale)
     return first_present(row, ("iono", "iono_l1_m", "l1_iono_m"))
 
 
@@ -349,11 +345,11 @@ def normalize_osrres_rows(
     stage = row.get("stage", "") or (stage_label or "")
     week = osr_week(row, gps_week=gps_week, input_path=input_path, row_number=row_number)
     sat = sat_label(sys_id, prn)
-    effective_iono_l1_m = prc_iono_l1_from_osrres(row)
     output_rows: list[dict[str, str]] = []
 
     for freq_index, suffix, rtklib_code in CLASLIB_OSR_GPS_SLOTS:
         pseudorange_code, carrier_code = rinex_pair(rtklib_code)
+        effective_iono_l1_m = prc_iono_l1_from_osrres(row, suffix)
         effective_iono_scaled_m = format_component(prc_iono_scaled_from_osrres(row, suffix))
         common = {
             "stage": stage,

--- a/tests/test_claslib_zd_component_export.py
+++ b/tests/test_claslib_zd_component_export.py
@@ -216,8 +216,10 @@ class ClaslibZdComponentExportTest(unittest.TestCase):
             rows_written = export.export_csv(input_path, output_path, stage_label="post", gps_week=2068)
             self.assertEqual(rows_written, 6)
             rows = read_csv(output_path)
+            code_l1c = next(row for row in rows if row["row_type"] == "code" and row["signal"] == "C1C")
             code_l2w = next(row for row in rows if row["row_type"] == "code" and row["signal"] == "C2W")
             phase_l2w = next(row for row in rows if row["row_type"] == "phase" and row["signal"] == "L2W")
+            l2w_iono_l1 = (4.202 - (2.345 - 0.020 + 0.003 + 0.022)) / export.GPS_IONO_SCALE_BY_SUFFIX["2"]
             self.assertEqual(code_l2w["stage"], "post")
             self.assertEqual(code_l2w["week"], "2068")
             self.assertEqual(code_l2w["tow"], "230420.0")
@@ -229,8 +231,13 @@ class ClaslibZdComponentExportTest(unittest.TestCase):
             self.assertEqual(code_l2w["prc_m"], "4.202")
             self.assertEqual(code_l2w["code_bias_m"], "0.022")
             self.assertEqual(code_l2w["trop_correction_m"], "2.345")
-            self.assertAlmostEqual(float(code_l2w["iono_l1_m"]), 1.752)
+            self.assertAlmostEqual(float(code_l1c["iono_l1_m"]), 1.752)
+            self.assertAlmostEqual(float(code_l2w["iono_l1_m"]), l2w_iono_l1)
             self.assertAlmostEqual(float(code_l2w["iono_scaled_m"]), 1.852)
+            self.assertAlmostEqual(
+                float(code_l2w["iono_l1_m"]) * export.GPS_IONO_SCALE_BY_SUFFIX["2"],
+                float(code_l2w["iono_scaled_m"]),
+            )
             self.assertEqual(code_l2w["receiver_antenna_m"], "-0.020")
             self.assertEqual(code_l2w["orbit_projection_m"], "-0.321")
             self.assertEqual(code_l2w["clock_correction_m"], "0.654")


### PR DESCRIPTION
## Summary
- normalize CLASLIB `.osr` `iono_l1_m` per GPS frequency slot from that slot's PRC closure
- keep `iono_scaled_m` as the correction actually applied to the PRC slot
- document the row-specific L1-equivalent semantics and update exporter tests

## Verification
- `python3 -m py_compile scripts/analysis/claslib_zd_component_export.py tests/test_claslib_zd_component_export.py`
- `python3 tests/test_claslib_zd_component_export.py`
- `python3 tests/test_clas_zd_component_diff.py`
- `python3 tests/test_claslib_osr_zd_export.py`
- `ctest --test-dir build --output-on-failure -R "python_(claslib_osr_zd_export|claslib_zd_component_export|clas_zd_component_diff|optional_clas_zd_component_diff)_tests"`
- `python3 -m mkdocs build --strict`
- public-data local CLAS A4b native selfdiff + CLASLIB OSR export + optional ZD diff

Local public-data diff now reports `iono_l1_m` max delta 0.0315463046 m while `iono_scaled_m` remains the dominant ionosphere term at 0.0519550111 m, which keeps the sign-off focused on the applied PRC component rather than a copied L1-slot diagnostic.
