### PR TITLE
ci: add CLAS STEC closure diff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,7 +397,7 @@ jobs:
         export GNSSPP_CLAS_ZD_FREQ="${GNSSPP_CLAS_ZD_FREQ:-1}"
         export GNSSPP_CLAS_ZD_RINEX_CODE="${GNSSPP_CLAS_ZD_RINEX_CODE:-C2W}"
         export GNSSPP_CLAS_ZD_DUPLICATE_POLICY="${GNSSPP_CLAS_ZD_DUPLICATE_POLICY:-mean}"
-        export GNSSPP_CLAS_ZD_COMPONENTS="${GNSSPP_CLAS_ZD_COMPONENTS:-prc_m,prc_component_sum_m,prc_closure_residual_m,iono_l1_m,iono_scaled_m,iono_scale,iono_scaled_closure_residual_m,trop_correction_m,code_bias_m,receiver_antenna_m,relativity_m}"
+        export GNSSPP_CLAS_ZD_COMPONENTS="${GNSSPP_CLAS_ZD_COMPONENTS:-prc_m,prc_component_sum_m,prc_closure_residual_m,iono_l1_m,iono_l1_from_stec_m,iono_l1_stec_closure_residual_m,iono_scaled_m,iono_scale,iono_scaled_closure_residual_m,trop_correction_m,code_bias_m,receiver_antenna_m,relativity_m}"
         bash scripts/ci/run_optional_clas_zd_component_diff.sh
 
     - name: Upload CLAS ZD component diff artifacts

--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -225,6 +225,8 @@ resulting normalized CSV as `GNSSPP_CLAS_ZD_BASE_CSV`.  For `.osr` input,
 raw display `iono` column, so the diff compares the ionosphere term that was
 actually applied to `PRC1/PRC2/PRC5`.  `iono_l1_m` is the L1-equivalent of that
 same frequency-slot-specific closure value; it is not copied from the L1 slot.
+The normalized `stec_tecu` field is derived from that L1-equivalent delay with
+the GPS L1 TECU-to-meter factor.
 The `.osr` path maps only GPS L1/L2/L5 slots where the exact row identity is
 deterministic; QZSS and Galileo still need explicit disposable dumps until
 their ZD materialization and admission sources are fixed.
@@ -257,15 +259,20 @@ rows by the exact row-specific RINEX code so alias mismatches show up as row-set
 differences before component deltas are computed.
 When `GNSSPP_CLAS_ZD_COMPONENTS` is unset, the optional CI diff compares the
 component-level `prc_m`, `prc_component_sum_m`, `prc_closure_residual_m`,
-`iono_l1_m`, `iono_scaled_m`, `iono_scale`,
+`iono_l1_m`, `iono_l1_from_stec_m`,
+`iono_l1_stec_closure_residual_m`, `iono_scaled_m`, `iono_scale`,
 `iono_scaled_closure_residual_m`, `trop_correction_m`, `code_bias_m`,
 `receiver_antenna_m`, and `relativity_m` fields rather than using the aggregate
-`applied_pr_corr_m` to select the dominant row component.  The PRC closure
-residual is derived at diff time from the PRC component inputs, and the
-ionosphere closure residual is derived as `iono_scaled_m - iono_scale * iono_l1_m`.
+`applied_pr_corr_m` to select the dominant row component.  The raw `stec_tecu`
+column remains available for explicit diagnostic runs, but it is not part of
+the default component list because the diff summary reports component deltas in
+meters.  The PRC closure residual is derived at diff time from the PRC
+component inputs, the L1-STEC closure residual is derived as
+`iono_l1_m - stec_tecu * GPS_L1_TECU_TO_METERS`, and the ionosphere scale
+closure residual is derived as `iono_scaled_m - iono_scale * iono_l1_m`.
 Together these make the remote artifact show whether the remaining GPS L2W PRC
-gap is explained by component
-deltas or by a PRC convention/rounding mismatch.
+gap is explained by component deltas, TECU/L1 conversion, frequency scaling, or
+a PRC convention/rounding mismatch.
 When `GNSS_PPP_CLAS_DD_FILTER=1` and
 `GNSS_PPP_CLAS_CODE_ROW_PARITY=bias,full-prc` are set, the CLAS OSR
 materializer uses that exact GPS L2 RINEX identity to choose the code/phase SSR

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -187,7 +187,9 @@ The normalized `iono_scaled_m` field is reconstructed from the CLASLIB `PRC`
 closure instead of the raw `.osr` `iono` display column, so it matches the
 correction actually applied in `PRC1/PRC2/PRC5`.  `iono_l1_m` is the
 frequency-slot-specific L1-equivalent of that reconstructed value, not a copy
-of the L1 slot's display or closure value:
+of the L1 slot's display or closure value.  The normalized `stec_tecu` field is
+derived from that L1-equivalent delay with the GPS L1 TECU-to-meter factor, so
+the diff can separate TECU materialization drift from frequency-scaling drift:
 
 ```bash
 python3 scripts/analysis/claslib_zd_component_export.py \
@@ -278,15 +280,21 @@ side and defaults the optional diff filter to `post`/`code`/`G14`/`f1`/`C2W`;
 explicit workflow variables still override those defaults.
 When `GNSSPP_CLAS_ZD_COMPONENTS` is unset, the remote diff compares the
 component-level fields `prc_m`, `prc_component_sum_m`,
-`prc_closure_residual_m`, `iono_l1_m`, `iono_scaled_m`, `iono_scale`,
+`prc_closure_residual_m`, `iono_l1_m`, `iono_l1_from_stec_m`,
+`iono_l1_stec_closure_residual_m`, `iono_scaled_m`, `iono_scale`,
 `iono_scaled_closure_residual_m`, `trop_correction_m`, `code_bias_m`,
-`receiver_antenna_m`, and `relativity_m`.  The derived `prc_closure_residual_m`
-value is computed by the diff tool as `PRC - (trop + relativity + receiver
-antenna + scaled iono + code bias)`, so it diagnoses PRC convention/rounding
-gaps without changing either input CSV schema.  The derived
+`receiver_antenna_m`, and `relativity_m`.  The raw `stec_tecu` column remains
+available for explicit diagnostic runs, but it is not part of the default
+component list because the diff summary reports component deltas in meters.
+The derived `prc_closure_residual_m` value is computed by the diff tool as
+`PRC - (trop + relativity + receiver antenna + scaled iono + code bias)`, so it
+diagnoses PRC convention/rounding gaps without changing either input CSV schema.
+The derived `iono_l1_stec_closure_residual_m` is
+`iono_l1_m - stec_tecu * GPS_L1_TECU_TO_METERS`, which separates TECU-to-meter
+unit mistakes from upstream STEC materialization mismatches.  The derived
 `iono_scaled_closure_residual_m` is `iono_scaled_m - iono_scale * iono_l1_m`,
 which separates frequency-scaling mistakes from upstream STEC/L1-delay
-mismatches. The aggregate `applied_pr_corr_m` remains available for
+mismatches.  The aggregate `applied_pr_corr_m` remains available for
 explicit diagnostic runs, but the default sign-off points the top-row evidence
 at the underlying ZD correction component.
 If either generated side is missing, the optional diff reports

--- a/include/libgnss++/algorithms/ppp_osr_types.hpp
+++ b/include/libgnss++/algorithms/ppp_osr_types.hpp
@@ -19,6 +19,7 @@ struct OSRCorrection {
     double relativity_correction_m = 0.0;
     double receiver_antenna_m[OSR_MAX_FREQ] = {};
     double iono_l1_m = 0.0;
+    double stec_tecu = 0.0;
     double code_bias_m[OSR_MAX_FREQ] = {};
     double phase_bias_m[OSR_MAX_FREQ] = {};
     double windup_cycles = 0.0;

--- a/scripts/analysis/clas_zd_component_diff.py
+++ b/scripts/analysis/clas_zd_component_diff.py
@@ -30,6 +30,9 @@ COMPONENT_ALIASES: dict[str, tuple[str, ...]] = {
     "cpc_minus_trop_m": ("cpc_minus_trop_m",),
     "trop_correction_m": ("trop_correction_m", "trop_m"),
     "iono_l1_m": ("iono_l1_m", "l1_iono_m"),
+    "stec_tecu": ("stec_tecu",),
+    "iono_l1_from_stec_m": ("iono_l1_from_stec_m",),
+    "iono_l1_stec_closure_residual_m": ("iono_l1_stec_closure_residual_m",),
     "iono_scaled_m": ("iono_scaled_m",),
     "iono_scale": ("iono_scale",),
     "iono_scaled_closure_residual_m": ("iono_scaled_closure_residual_m",),
@@ -84,6 +87,7 @@ GPS_IONO_SCALE_BY_BAND = {
     "2": (1575.42 / 1227.60) ** 2,
     "5": (1575.42 / 1176.45) ** 2,
 }
+GPS_L1_TECU_TO_METERS = 40.3e16 / ((1575.42 * 1e6) ** 2)
 
 
 @dataclass(frozen=True)
@@ -154,6 +158,19 @@ def row_iono_scale(row: Row) -> Optional[float]:
 def derived_component_value(row: Row, component: str) -> Optional[float]:
     if component == "iono_scale":
         return row_iono_scale(row)
+
+    if component == "iono_l1_from_stec_m":
+        stec_tecu = row_component_value(row, "stec_tecu")
+        if stec_tecu is None:
+            return None
+        return stec_tecu * GPS_L1_TECU_TO_METERS
+
+    if component == "iono_l1_stec_closure_residual_m":
+        iono_l1 = row_component_value(row, "iono_l1_m")
+        stec_tecu = row_component_value(row, "stec_tecu")
+        if iono_l1 is None or stec_tecu is None:
+            return None
+        return iono_l1 - stec_tecu * GPS_L1_TECU_TO_METERS
 
     if component == "iono_scaled_closure_residual_m":
         iono_scaled = row_component_value(row, "iono_scaled_m")

--- a/scripts/analysis/claslib_zd_component_export.py
+++ b/scripts/analysis/claslib_zd_component_export.py
@@ -98,6 +98,7 @@ FIELDNAMES = [
     "cpc_m",
     "trop_correction_m",
     "iono_l1_m",
+    "stec_tecu",
     "iono_scaled_m",
     "iono_scale",
     "code_bias_m",
@@ -149,6 +150,7 @@ GPS_IONO_SCALE_BY_SUFFIX = {
     "2": (1575.42 / 1227.60) ** 2,
     "5": (1575.42 / 1176.45) ** 2,
 }
+GPS_L1_TECU_TO_METERS = 40.3e16 / ((1575.42 * 1e6) ** 2)
 
 
 class ExportError(ValueError):
@@ -240,6 +242,13 @@ def prc_iono_l1_from_osrres(row: dict[str, str], suffix: str) -> str:
     return first_present(row, ("iono", "iono_l1_m", "l1_iono_m"))
 
 
+def stec_tecu_from_iono_l1_m(value: str) -> str:
+    iono_l1_m = parse_osr_float(value)
+    if iono_l1_m is None or GPS_L1_TECU_TO_METERS <= 0.0:
+        return ""
+    return format_component(iono_l1_m / GPS_L1_TECU_TO_METERS)
+
+
 def detect_row_type(row: dict[str, str]) -> str:
     value = first_present(row, ("row_type", "record", "type", "kind"), "").strip().lower()
     if value in {"code", "pseudorange", "pr"} or value.startswith("code"):
@@ -296,6 +305,7 @@ def normalize_row(
             "cpc_m": first_present(row, ("cpc_m", "CPC", "CPC_m")),
             "trop_correction_m": first_present(row, ("trop_correction_m", "trop_m")),
             "iono_l1_m": first_present(row, ("iono_l1_m", "l1_iono_m")),
+            "stec_tecu": first_present(row, ("stec_tecu",)),
             "iono_scaled_m": first_present(row, ("iono_scaled_m",)),
             "iono_scale": first_present(row, ("iono_scale",)),
             "code_bias_m": first_present(row, ("code_bias_m", "code_bias", "cbias_m")),
@@ -369,6 +379,7 @@ def normalize_osrres_rows(
             "source_rtklib_code": str(rtklib_code),
             "trop_correction_m": first_present(row, ("trop", "trop_m")),
             "iono_l1_m": effective_iono_l1_m,
+            "stec_tecu": stec_tecu_from_iono_l1_m(effective_iono_l1_m),
             "iono_scaled_m": effective_iono_scaled_m,
             "iono_scale": format_component(GPS_IONO_SCALE_BY_SUFFIX[suffix]),
             "receiver_antenna_m": first_present(row, (f"antr{suffix}",)),

--- a/scripts/ci/run_optional_clas_zd_component_diff.py
+++ b/scripts/ci/run_optional_clas_zd_component_diff.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import optional_diff_runner as runner  # noqa: E402
 
 
-SUMMARY_SCHEMA = "ci_optional_clas_zd_component_diff.v7"
+SUMMARY_SCHEMA = "ci_optional_clas_zd_component_diff.v8"
 
 CONFIG = runner.DiffRunnerConfig(
     summary_schema=SUMMARY_SCHEMA,

--- a/src/algorithms/ppp_clas.cpp
+++ b/src/algorithms/ppp_clas.cpp
@@ -214,7 +214,7 @@ std::ofstream* clasCodeDumpStream() {
                    << "phase_bias_present,code_bias_fallback,phase_bias_fallback,"
                    << "raw_p_m,corrected_p_m,applied_pr_corr_m,prc_m,"
                    << "prc_minus_trop_m,trop_correction_m,iono_l1_m,"
-                   << "iono_scaled_m,code_bias_m,receiver_ant_m,relativity_m,"
+                   << "stec_tecu,iono_scaled_m,code_bias_m,receiver_ant_m,relativity_m,"
                    << "geo_m,sat_clk_m,receiver_clock_m,trop_model_m,"
                    << "iono_state_m,iono_scale,predicted_m,residual_m,"
                    << "variance_m2,los_e_m,los_n_m,los_u_m,az_rad,el_rad,"
@@ -367,6 +367,7 @@ void dumpClasCodeRows(
                   << (osr.PRC[f] - osr.trop_correction_m) << ','
                   << osr.trop_correction_m << ','
                   << osr.iono_l1_m << ','
+                  << osr.stec_tecu << ','
                   << iono_scaled << ','
                   << osr.code_bias_m[f] << ','
                   << osr.receiver_antenna_m[f] << ','

--- a/src/algorithms/ppp_osr.cpp
+++ b/src/algorithms/ppp_osr.cpp
@@ -1090,6 +1090,7 @@ std::vector<OSRCorrection> computeOSR(
                 config.clas_subtype12_value_construction_policy,
                 config.clas_expanded_residual_sampling_policy);
             if (std::isfinite(stec_tecu) && std::abs(stec_tecu) > 0.001) {
+                osr.stec_tecu = stec_tecu;
                 osr.iono_l1_m = ppp_atmosphere::ionosphereDelayMetersFromTecu(
                     l1_obs->signal, eph, stec_tecu);
                 osr.has_iono = true;

--- a/tests/test_clas_zd_component_diff.py
+++ b/tests/test_clas_zd_component_diff.py
@@ -58,6 +58,7 @@ FIELDNAMES = [
     "receiver_antenna_m",
     "trop_correction_m",
     "iono_l1_m",
+    "stec_tecu",
     "iono_scaled_m",
     "iono_scale",
     "relativity_m",
@@ -80,6 +81,7 @@ def code_row(
     receiver_ant: str,
     trop: str = "2.0",
     iono_l1: str = "0.0",
+    stec_tecu: str = "",
     iono_scaled: str = "0.0",
     iono_scale: str = "",
     relativity: str = "0.0",
@@ -139,6 +141,7 @@ def code_row(
         "receiver_antenna_m": "",
         "trop_correction_m": trop,
         "iono_l1_m": iono_l1,
+        "stec_tecu": stec_tecu,
         "iono_scaled_m": iono_scaled,
         "iono_scale": iono_scale,
         "relativity_m": relativity,
@@ -233,6 +236,41 @@ class ClasZdComponentDiffTest(unittest.TestCase):
         )
 
         self.assertAlmostEqual(components["iono_scaled_closure_residual_m"], 0.01)
+
+    def test_derives_iono_l1_from_stec_tecu(self) -> None:
+        components = component_diff.extract_components(
+            code_row(
+                sat="G14",
+                freq="1",
+                prc="3.0",
+                code_bias="0.5",
+                receiver_ant="0.1",
+                stec_tecu="2.0",
+            ),
+            ["iono_l1_from_stec_m"],
+        )
+
+        self.assertAlmostEqual(
+            components["iono_l1_from_stec_m"],
+            2.0 * component_diff.GPS_L1_TECU_TO_METERS,
+        )
+
+    def test_derives_iono_l1_stec_closure_residual(self) -> None:
+        iono_l1_from_stec = 2.0 * component_diff.GPS_L1_TECU_TO_METERS
+        components = component_diff.extract_components(
+            code_row(
+                sat="G14",
+                freq="1",
+                prc="3.0",
+                code_bias="0.5",
+                receiver_ant="0.1",
+                iono_l1=str(iono_l1_from_stec + 0.02),
+                stec_tecu="2.0",
+            ),
+            ["iono_l1_stec_closure_residual_m"],
+        )
+
+        self.assertAlmostEqual(components["iono_l1_stec_closure_residual_m"], 0.02)
 
     def test_observation_identity_prefers_row_type_specific_rinex_code(self) -> None:
         self.assertEqual(

--- a/tests/test_claslib_zd_component_export.py
+++ b/tests/test_claslib_zd_component_export.py
@@ -48,6 +48,7 @@ RAW_FIELDNAMES = [
     "cpc_m",
     "trop_m",
     "iono_l1_m",
+    "stec_tecu",
     "iono_scaled_m",
     "iono_scale",
     "cbias_m",
@@ -234,6 +235,10 @@ class ClaslibZdComponentExportTest(unittest.TestCase):
             self.assertEqual(code_l2w["trop_correction_m"], "2.345")
             self.assertAlmostEqual(float(code_l1c["iono_l1_m"]), 1.752)
             self.assertAlmostEqual(float(code_l2w["iono_l1_m"]), l2w_iono_l1)
+            self.assertAlmostEqual(
+                float(code_l2w["stec_tecu"]),
+                l2w_iono_l1 / export.GPS_L1_TECU_TO_METERS,
+            )
             self.assertAlmostEqual(float(code_l2w["iono_scaled_m"]), 1.852)
             self.assertAlmostEqual(
                 float(code_l2w["iono_scale"]),

--- a/tests/test_optional_clas_zd_component_diff.py
+++ b/tests/test_optional_clas_zd_component_diff.py
@@ -390,7 +390,7 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
 
             payload = json.loads(summary_path.read_text(encoding="utf-8"))
             self.assertEqual(payload["summary_schema"], runner.SUMMARY_SCHEMA)
-            self.assertEqual(payload["summary_schema"], "ci_optional_clas_zd_component_diff.v7")
+            self.assertEqual(payload["summary_schema"], "ci_optional_clas_zd_component_diff.v8")
             self.assertEqual(payload["contract"], "optional_diff_artifact_contract.v1")
             self.assertEqual(payload["status"], "blocked_infrastructure")
             self.assertIn("missing evidence", payload["next_actions"][1])


### PR DESCRIPTION
## Summary
- carry CLAS OSR `stec_tecu` into the native code dump and normalize CLASLIB `.osr` ionosphere rows into the same diagnostic field
- add derived `iono_l1_from_stec_m` and `iono_l1_stec_closure_residual_m` components to the CLAS ZD diff contract
- bump the optional CLAS ZD summary schema to v8 and keep raw TECU out of the default meter-valued component list

## Local Validation
- `cmake --build build --target gnss_lib gnss_ppp tests --parallel 2`
- `ctest --test-dir build --output-on-failure -R "python_(clas_zd_component_diff|claslib_zd_component_export|optional_clas_zd_component_diff|clas_zd_component_summary)_tests|PPP|ppp_osr|ppp_clas"`
- `python3 -m py_compile scripts/analysis/clas_zd_component_diff.py scripts/analysis/claslib_zd_component_export.py scripts/ci/run_optional_clas_zd_component_diff.py tests/test_clas_zd_component_diff.py tests/test_claslib_zd_component_export.py tests/test_optional_clas_zd_component_diff.py`
- `python3 tests/test_clas_zd_component_diff.py && python3 tests/test_claslib_zd_component_export.py && python3 tests/test_optional_clas_zd_component_diff.py`
- `python3 -m mkdocs build --strict`
- `git diff --check`
- local public-data CLASLIB OSR export + native selfdiff + optional CLAS ZD diff: v8 passed, `iono_l1_stec_closure_residual_m` max `8.33e-16`, `iono_l1_from_stec_m` max delta `0.03154630460526958` m
