### PR TITLE
ci: highlight CLAS ZD closure metrics

### DIFF
--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -273,6 +273,10 @@ closure residual is derived as `iono_scaled_m - iono_scale * iono_l1_m`.
 Together these make the remote artifact show whether the remaining GPS L2W PRC
 gap is explained by component deltas, TECU/L1 conversion, frequency scaling, or
 a PRC convention/rounding mismatch.
+The GitHub step summary highlights the L1-from-STEC, L1-STEC closure,
+scaled-ionosphere closure, and PRC closure components from the per-component
+max-delta map, keeping the primary review evidence in the CI summary while the
+full row breakdown remains in the JSON artifact.
 When `GNSS_PPP_CLAS_DD_FILTER=1` and
 `GNSS_PPP_CLAS_CODE_ROW_PARITY=bias,full-prc` are set, the CLAS OSR
 materializer uses that exact GPS L2 RINEX identity to choose the code/phase SSR

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -297,6 +297,10 @@ which separates frequency-scaling mistakes from upstream STEC/L1-delay
 mismatches.  The aggregate `applied_pr_corr_m` remains available for
 explicit diagnostic runs, but the default sign-off points the top-row evidence
 at the underlying ZD correction component.
+The GitHub step summary highlights `iono_l1_from_stec_m`,
+`iono_l1_stec_closure_residual_m`, `iono_scaled_closure_residual_m`, and
+`prc_closure_residual_m` from the per-component max-delta map so reviewers can
+see which ladder stage is closed without opening the raw JSON artifact.
 If either generated side is missing, the optional diff reports
 `blocked_infrastructure`, not a passing sign-off.
 

--- a/scripts/ci/optional_diff_runner.py
+++ b/scripts/ci/optional_diff_runner.py
@@ -49,6 +49,7 @@ class DiffRunnerConfig:
     input_summary_fail_on_issue: bool = False
     input_summary_extra_options: tuple[EnvOption, ...] = ()
     input_summary_require_components: bool = False
+    highlight_components: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -574,7 +575,7 @@ def format_metric(value: object) -> str:
     return str(value)
 
 
-def render_result_detail(result: dict[str, object]) -> str:
+def render_result_detail(config: DiffRunnerConfig, result: dict[str, object]) -> str:
     status = str(result["status"])
     if status in {"blocked_infrastructure", "not_applicable", "skipped"}:
         return str(result.get("block_reason") or result.get("skip_reason", ""))
@@ -604,6 +605,12 @@ def render_result_detail(result: dict[str, object]) -> str:
         max_abs_delta = metrics.get("max_abs_delta")
         if max_abs_delta is not None:
             detail_parts.append(f"max |delta| {format_metric(max_abs_delta)}")
+        per_component = metrics.get("per_component_max_abs_delta")
+        if isinstance(per_component, dict):
+            for component in config.highlight_components:
+                value = per_component.get(component)
+                if isinstance(value, (int, float)):
+                    detail_parts.append(f"`{component}` |delta| {format_metric(value)}")
         top_delta_component = metrics.get("top_delta_component")
         top_delta_component_abs = metrics.get("top_delta_abs_delta")
         if top_delta_component is not None:
@@ -680,7 +687,9 @@ def render_markdown_summary(config: DiffRunnerConfig, results: list[dict[str, ob
         "| --- | --- | --- |",
     ]
     for result in results:
-        lines.append(f"| {result['name']} | `{result['status']}` | {render_result_detail(result)} |")
+        lines.append(
+            f"| {result['name']} | `{result['status']}` | {render_result_detail(config, result)} |"
+        )
     lines.append("")
     return "\n".join(lines)
 

--- a/scripts/ci/run_optional_clas_zd_component_diff.py
+++ b/scripts/ci/run_optional_clas_zd_component_diff.py
@@ -40,6 +40,12 @@ CONFIG = runner.DiffRunnerConfig(
     input_summary_script="clas_zd_component_summary.py",
     input_summary_schema="clas_zd_component_summary.v2",
     input_summary_fail_on_issue=True,
+    highlight_components=(
+        "iono_l1_from_stec_m",
+        "iono_l1_stec_closure_residual_m",
+        "iono_scaled_closure_residual_m",
+        "prc_closure_residual_m",
+    ),
     extra_options=(
         runner.EnvOption(("GNSSPP_CLAS_ZD_STAGE",), "--stage"),
         runner.EnvOption(("GNSSPP_CLAS_ZD_ROW_TYPE",), "--row-type"),

--- a/tests/test_optional_clas_zd_component_diff.py
+++ b/tests/test_optional_clas_zd_component_diff.py
@@ -327,6 +327,12 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
                         "candidate_only_rows": 2,
                         "components_compared": 24,
                         "max_abs_delta": 0.125,
+                        "per_component_max_abs_delta": {
+                            "iono_l1_from_stec_m": 0.031,
+                            "iono_l1_stec_closure_residual_m": 1e-15,
+                            "iono_scaled_closure_residual_m": 2e-15,
+                            "prc_closure_residual_m": 3e-15,
+                        },
                         "top_delta_component": "prc_m",
                         "top_delta_abs_delta": 0.25,
                         "top_row_sum_abs_delta": 0.375,
@@ -361,6 +367,10 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
         self.assertIn("unmatched `1/2`", markdown)
         self.assertIn("components `24`", markdown)
         self.assertIn("max |delta| 0.125", markdown)
+        self.assertIn("`iono_l1_from_stec_m` |delta| 0.031", markdown)
+        self.assertIn("`iono_l1_stec_closure_residual_m` |delta| 1e-15", markdown)
+        self.assertIn("`iono_scaled_closure_residual_m` |delta| 2e-15", markdown)
+        self.assertIn("`prc_closure_residual_m` |delta| 3e-15", markdown)
         self.assertIn("top delta `prc_m` |delta| 0.25", markdown)
         self.assertIn("top row sum |delta| 0.375", markdown)
         self.assertIn("top component `prc_m` |delta| 0.25", markdown)


### PR DESCRIPTION
## Summary

- add optional diff support for configured highlight components in the GitHub step summary
- surface the CLAS ZD closure metrics for STEC/L1 conversion, ionosphere scaling, and PRC closure directly in the summary table
- document the highlighted CLAS ZD ladder evidence in the A5 and validated dataset docs

## Impact

This does not change solver behavior, artifact schemas, or CLAS/MADOCA model logic. It only makes the existing CLAS ZD sign-off evidence easier to review without opening the raw JSON artifact.

## Validation

- `git diff --check`
- `python3 -m py_compile scripts/ci/optional_diff_runner.py scripts/ci/run_optional_clas_zd_component_diff.py tests/test_optional_clas_zd_component_diff.py`
- `python3 tests/test_optional_clas_zd_component_diff.py`

Previously run before publishing this branch:

- `python3 tests/test_optional_madoca_materialization_diff.py`
- `python3 tests/test_optional_madoca_residual_component_diff.py`
- `python3 -m mkdocs build --strict`
- `ctest --test-dir build --output-on-failure -R "python_(optional_clas_zd_component_diff|optional_madoca_materialization_diff|optional_madoca_residual_component_diff)_tests"`