### PR TITLE
ci: surface CLAS ZD top-row context

### DIFF
--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -202,7 +202,11 @@ sign-off.  The workflow upload treats the summary/log bundle as required
 evidence.  The `ci_optional_clas_zd_component_diff.v7` and later summaries surface
 the global largest component delta, the top ZD row's dominant component, and a
 per-component max-delta map, so the next A4b model PR can be scoped to one
-correction component instead of tuning final solution RMS.
+correction component instead of tuning final solution RMS.  The
+`ci_optional_clas_zd_component_diff.v10` summary also carries top-row values for
+highlighted components that exist on only one side, such as native
+`atmos_ref_tow`, `clock_ref_tow`, and `atmos_clock_gap_s` when CLASLIB has no
+comparable reference-epoch columns.
 Optional filters are `GNSSPP_CLAS_ZD_COMPONENTS`, `GNSSPP_CLAS_ZD_STAGE`,
 `GNSSPP_CLAS_ZD_ROW_TYPE`, `GNSSPP_CLAS_ZD_THRESHOLD_M`, and
 `GNSSPP_CLAS_ZD_FAIL_ON_DIFF`.  GPS L2W A4b probes can also narrow the row set

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -235,7 +235,11 @@ changing the gated correction model. The optional CI summary schema
 `ci_optional_clas_zd_component_diff.v7` and later summaries lift both the global top delta, the
 leading row-breakdown component, and a per-component max-delta map into summary
 metrics, so release artifacts show the next single-component target without
-manually opening the full diff JSON.
+manually opening the full diff JSON.  Schema
+`ci_optional_clas_zd_component_diff.v10` additionally surfaces top-row values
+for highlighted components that are present on only one side, so native
+atmosphere/clock reference epochs remain visible even when the CLASLIB export
+cannot provide comparable fields.
 
 CI can regenerate the native side of this A4b probe without a pre-staged native
 CSV:
@@ -305,7 +309,9 @@ missing counts for highlighted atmosphere-reference fields when CLASLIB cannot
 provide a comparable value.  The native `clas_zd_component_summary.v2` snapshot
 also reports numeric min/max stats for `atmos_ref_tow`, `clock_ref_tow`, and
 `atmos_clock_gap_s`, so reviewers can see which lifecycle stage is selected
-without opening the raw CSV.
+without opening the raw CSV.  For the leading row-breakdown, v10 summaries also
+include the native value of each highlighted missing field, which ties the
+largest PRC/iono/trop delta back to the selected reference epoch.
 If either generated side is missing, the optional diff reports
 `blocked_infrastructure`, not a passing sign-off.
 

--- a/scripts/analysis/clas_zd_component_diff.py
+++ b/scripts/analysis/clas_zd_component_diff.py
@@ -468,10 +468,20 @@ def row_component_breakdown(
     candidate_row: ComponentRow,
 ) -> dict[str, Any]:
     components: list[dict[str, Any]] = []
+    missing_components: list[dict[str, Any]] = []
     for component in sorted(set(base_row.components) | set(candidate_row.components)):
         base_value = base_row.components.get(component)
         candidate_value = candidate_row.components.get(component)
         if base_value is None or candidate_value is None:
+            missing_components.append(
+                {
+                    "component": component,
+                    "base_present": base_value is not None,
+                    "candidate_present": candidate_value is not None,
+                    "base_value": base_value,
+                    "candidate_value": candidate_value,
+                }
+            )
             continue
         delta = candidate_value - base_value
         components.append(
@@ -493,12 +503,14 @@ def row_component_breakdown(
         "base_source_row": base_row.source_row,
         "candidate_source_row": candidate_row.source_row,
         "component_count": len(components),
+        "missing_component_count": len(missing_components),
         "max_abs_delta_m": max(
             (item["abs_delta_m"] for item in components),
             default=0.0,
         ),
         "sum_abs_delta_m": sum(item["abs_delta_m"] for item in components),
         "components": components,
+        "missing_components": missing_components,
     }
 
 

--- a/scripts/ci/optional_diff_runner.py
+++ b/scripts/ci/optional_diff_runner.py
@@ -409,6 +409,27 @@ def load_diff_metrics(config: DiffRunnerConfig, report_json: Path) -> dict[str, 
                         metrics["top_row_dominant_delta"] = float(delta)
                     if isinstance(abs_delta, (int, float)):
                         metrics["top_row_dominant_abs_delta"] = float(abs_delta)
+            missing_components = first_row.get("missing_components")
+            if isinstance(missing_components, list) and missing_components:
+                normalized_missing: list[dict[str, object]] = []
+                for item in missing_components:
+                    if not isinstance(item, dict):
+                        continue
+                    component = item.get("component")
+                    if not isinstance(component, str) or not component:
+                        continue
+                    normalized: dict[str, object] = {"component": component}
+                    for key in (
+                        "base_present",
+                        "candidate_present",
+                        "base_value",
+                        "candidate_value",
+                    ):
+                        if key in item:
+                            normalized[key] = item[key]
+                    normalized_missing.append(normalized)
+                if normalized_missing:
+                    metrics["top_row_missing_components"] = normalized_missing
     identity_provenance = payload.get("identity_provenance")
     if isinstance(identity_provenance, dict):
         for label, summary in identity_provenance.items():
@@ -626,6 +647,31 @@ def render_result_detail(config: DiffRunnerConfig, result: dict[str, object]) ->
                 rows = missing_by_component.get(component)
                 if rows is not None:
                     detail_parts.append(f"`{component}` missing `{rows}`")
+        top_row_missing_components = metrics.get("top_row_missing_components")
+        if isinstance(top_row_missing_components, list):
+            top_row_missing_by_component: dict[str, dict[str, object]] = {}
+            for item in top_row_missing_components:
+                if not isinstance(item, dict):
+                    continue
+                component = item.get("component")
+                if isinstance(component, str):
+                    top_row_missing_by_component[component] = item
+            for component in config.highlight_components:
+                item = top_row_missing_by_component.get(component)
+                if item is None:
+                    continue
+                value_parts: list[str] = []
+                if item.get("base_present") is True:
+                    value_parts.append(
+                        f"{config.base_label} {format_metric(item.get('base_value'))}"
+                    )
+                if item.get("candidate_present") is True:
+                    value_parts.append(
+                        f"{config.candidate_label} "
+                        f"{format_metric(item.get('candidate_value'))}"
+                    )
+                if value_parts:
+                    detail_parts.append(f"top row `{component}` " + "/".join(value_parts))
         top_delta_component = metrics.get("top_delta_component")
         top_delta_component_abs = metrics.get("top_delta_abs_delta")
         if top_delta_component is not None:

--- a/scripts/ci/run_optional_clas_zd_component_diff.py
+++ b/scripts/ci/run_optional_clas_zd_component_diff.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import optional_diff_runner as runner  # noqa: E402
 
 
-SUMMARY_SCHEMA = "ci_optional_clas_zd_component_diff.v9"
+SUMMARY_SCHEMA = "ci_optional_clas_zd_component_diff.v10"
 
 CONFIG = runner.DiffRunnerConfig(
     summary_schema=SUMMARY_SCHEMA,

--- a/tests/test_clas_zd_component_diff.py
+++ b/tests/test_clas_zd_component_diff.py
@@ -591,6 +591,9 @@ class ClasZdComponentDiffTest(unittest.TestCase):
                 stage="accepted",
                 signal="3",
                 pseudorange_rinex_code="C2W",
+                atmos_ref_tow="230430.0",
+                clock_ref_tow="230420.0",
+                atmos_clock_gap_s="10.0",
             ),
             code_row(
                 sat="J02",
@@ -605,13 +608,27 @@ class ClasZdComponentDiffTest(unittest.TestCase):
 
         base = component_diff.normalize_rows(
             base_rows,
-            component_names=["prc_m", "code_bias_m", "receiver_antenna_m"],
+            component_names=[
+                "prc_m",
+                "code_bias_m",
+                "receiver_antenna_m",
+                "atmos_ref_tow",
+                "clock_ref_tow",
+                "atmos_clock_gap_s",
+            ],
             stage_filter=None,
             row_type_filter="code",
         )
         candidate = component_diff.normalize_rows(
             candidate_rows,
-            component_names=["prc_m", "code_bias_m", "receiver_antenna_m"],
+            component_names=[
+                "prc_m",
+                "code_bias_m",
+                "receiver_antenna_m",
+                "atmos_ref_tow",
+                "clock_ref_tow",
+                "atmos_clock_gap_s",
+            ],
             stage_filter=None,
             row_type_filter="code",
         )
@@ -641,12 +658,21 @@ class ClasZdComponentDiffTest(unittest.TestCase):
         self.assertEqual(row_breakdown["sat"], "G14")
         self.assertEqual(row_breakdown["rinex_code"], "C2W")
         self.assertEqual(row_breakdown["component_count"], 3)
+        self.assertEqual(row_breakdown["missing_component_count"], 3)
         self.assertAlmostEqual(row_breakdown["sum_abs_delta_m"], 0.27)
         self.assertEqual(
             [item["component"] for item in row_breakdown["components"]],
             ["prc_m", "receiver_antenna_m", "code_bias_m"],
         )
         self.assertAlmostEqual(row_breakdown["components"][0]["delta_m"], 0.25)
+        missing_by_component = {
+            item["component"]: item for item in row_breakdown["missing_components"]
+        }
+        self.assertFalse(missing_by_component["atmos_ref_tow"]["base_present"])
+        self.assertTrue(missing_by_component["atmos_ref_tow"]["candidate_present"])
+        self.assertEqual(missing_by_component["atmos_ref_tow"]["candidate_value"], 230430.0)
+        self.assertEqual(missing_by_component["clock_ref_tow"]["candidate_value"], 230420.0)
+        self.assertEqual(missing_by_component["atmos_clock_gap_s"]["candidate_value"], 10.0)
 
     def test_report_summarizes_gps_l2w_identity_provenance(self) -> None:
         base = component_diff.normalize_rows(

--- a/tests/test_optional_clas_zd_component_diff.py
+++ b/tests/test_optional_clas_zd_component_diff.py
@@ -253,6 +253,62 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
             self.assertIn(str(output_dir / "clas_zd_component_diff_claslib_snapshot_summary.json"), artifact_paths)
             self.assertIn(str(output_dir / "clas_zd_component_diff_native_snapshot_summary.json"), artifact_paths)
 
+    def test_load_diff_metrics_keeps_top_row_missing_component_context(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_clas_zd_metrics_") as temp_dir:
+            report_path = Path(temp_dir) / "clas_zd_component_diff.json"
+            report_path.write_text(
+                json.dumps(
+                    {
+                        "schema": "clas_zd_component_diff.v1",
+                        "top_row_component_breakdowns": [
+                            {
+                                "week": 2360,
+                                "tow": 172800.0,
+                                "row_type": "code",
+                                "sat": "G14",
+                                "freq": 1,
+                                "rinex_code": "C2W",
+                                "sum_abs_delta_m": 0.25,
+                                "max_abs_delta_m": 0.2,
+                                "components": [
+                                    {
+                                        "component": "prc_m",
+                                        "delta_m": 0.2,
+                                        "abs_delta_m": 0.2,
+                                    }
+                                ],
+                                "missing_components": [
+                                    {
+                                        "component": "atmos_ref_tow",
+                                        "base_present": False,
+                                        "candidate_present": True,
+                                        "base_value": None,
+                                        "candidate_value": 230430.0,
+                                    }
+                                ],
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            metrics = runner.runner.load_diff_metrics(runner.CONFIG, report_path)
+
+            self.assertEqual(metrics["top_row_key"], "2360/172800.0/code/G14/1/C2W")
+            self.assertEqual(
+                metrics["top_row_missing_components"],
+                [
+                    {
+                        "component": "atmos_ref_tow",
+                        "base_present": False,
+                        "candidate_present": True,
+                        "base_value": None,
+                        "candidate_value": 230430.0,
+                    }
+                ],
+            )
+
     def test_run_step_fails_when_snapshot_summary_fails(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ci_clas_zd_input_summary_") as temp_dir:
             root = Path(temp_dir)
@@ -343,6 +399,29 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
                         "top_row_sum_abs_delta": 0.375,
                         "top_row_dominant_component": "prc_m",
                         "top_row_dominant_abs_delta": 0.25,
+                        "top_row_missing_components": [
+                            {
+                                "component": "atmos_ref_tow",
+                                "base_present": False,
+                                "candidate_present": True,
+                                "base_value": None,
+                                "candidate_value": 230430.0,
+                            },
+                            {
+                                "component": "clock_ref_tow",
+                                "base_present": False,
+                                "candidate_present": True,
+                                "base_value": None,
+                                "candidate_value": 230420.0,
+                            },
+                            {
+                                "component": "atmos_clock_gap_s",
+                                "base_present": False,
+                                "candidate_present": True,
+                                "base_value": None,
+                                "candidate_value": 10.0,
+                            },
+                        ],
                         "threshold_exceedances": 3,
                         "identity_native_gps_l2w_rows": 2,
                         "identity_native_gps_l2w_bias_exact_identity_rows": 1,
@@ -379,6 +458,9 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
         self.assertIn("`atmos_ref_tow` missing `12`", markdown)
         self.assertIn("`clock_ref_tow` missing `12`", markdown)
         self.assertIn("`atmos_clock_gap_s` missing `12`", markdown)
+        self.assertIn("top row `atmos_ref_tow` native 230430", markdown)
+        self.assertIn("top row `clock_ref_tow` native 230420", markdown)
+        self.assertIn("top row `atmos_clock_gap_s` native 10", markdown)
         self.assertIn("top delta `prc_m` |delta| 0.25", markdown)
         self.assertIn("top row sum |delta| 0.375", markdown)
         self.assertIn("top component `prc_m` |delta| 0.25", markdown)
@@ -408,7 +490,7 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
 
             payload = json.loads(summary_path.read_text(encoding="utf-8"))
             self.assertEqual(payload["summary_schema"], runner.SUMMARY_SCHEMA)
-            self.assertEqual(payload["summary_schema"], "ci_optional_clas_zd_component_diff.v9")
+            self.assertEqual(payload["summary_schema"], "ci_optional_clas_zd_component_diff.v10")
             self.assertEqual(payload["contract"], "optional_diff_artifact_contract.v1")
             self.assertEqual(payload["status"], "blocked_infrastructure")
             self.assertIn("missing evidence", payload["next_actions"][1])


### PR DESCRIPTION
## Summary

- add `missing_components` context to CLAS ZD top-row breakdowns so one-sided fields keep their values in diff JSON
- carry the top-row missing component context into optional CI metrics and step-summary detail
- bump the optional CLAS ZD summary schema to `ci_optional_clas_zd_component_diff.v10` and document the new artifact evidence

## Why

#260 exposed native atmosphere and clock reference epochs, but CLASLIB does not emit comparable fields. The optional diff could only report missing counts, so reviewers still had to open the native CSV to connect the largest PRC/iono/trop row to the selected reference epoch. This keeps that context in the sign-off artifact without changing solver behavior.

## Validation

- `python3 -m py_compile scripts/analysis/clas_zd_component_diff.py scripts/ci/optional_diff_runner.py scripts/ci/run_optional_clas_zd_component_diff.py tests/test_clas_zd_component_diff.py tests/test_optional_clas_zd_component_diff.py`
- `python3 tests/test_clas_zd_component_diff.py`
- `python3 tests/test_optional_clas_zd_component_diff.py`
- `ctest --test-dir build --output-on-failure -R "python_optional|python_madoca_materialization_diff|python_madoca_residual_component_diff|python_clas_zd_component_diff"`
- `python3 -m mkdocs build --strict`
- `git diff --check`
- local v10 probe using #260 CLASLIB/native artifacts
