### PR TITLE
[codex] ci: surface CLAS ZD top-row values

### DIFF
--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -203,8 +203,10 @@ evidence.  The `ci_optional_clas_zd_component_diff.v7` and later summaries surfa
 the global largest component delta, the top ZD row's dominant component, and a
 per-component max-delta map, so the next A4b model PR can be scoped to one
 correction component instead of tuning final solution RMS.  The
-`ci_optional_clas_zd_component_diff.v10` summary also carries top-row values for
-highlighted components that exist on only one side, such as native
+`ci_optional_clas_zd_component_diff.v11` summary also carries top-row values for
+highlighted components. Present-on-both components, such as `stec_tecu`,
+`iono_l1_m`, `iono_scaled_m`, `code_bias_m`, and `trop_correction_m`, include
+CLASLIB/native/delta values; present-on-one-side components still expose native
 `atmos_ref_tow`, `clock_ref_tow`, and `atmos_clock_gap_s` when CLASLIB has no
 comparable reference-epoch columns.
 Optional filters are `GNSSPP_CLAS_ZD_COMPONENTS`, `GNSSPP_CLAS_ZD_STAGE`,
@@ -282,10 +284,11 @@ The native code-row dump also carries the atmosphere reference TOW, clock
 reference TOW, and atmosphere-clock gap used for each OSR row.  The
 `clas_zd_component_summary.v2` snapshot summary reports numeric min/max stats
 for those fields, so lifecycle or epoch-selection mismatches can be diagnosed
-before changing the STEC model.  The GitHub step summary highlights the
-L1-from-STEC, L1-STEC closure, scaled-ionosphere closure, PRC closure, and
-atmosphere-reference components, keeping the primary review evidence in the CI
-summary while the full row breakdown remains in the JSON artifact.
+before changing the STEC model.  The GitHub step summary highlights raw STEC,
+L1 ionosphere, scaled ionosphere, code-bias, trop, L1-from-STEC, L1-STEC
+closure, scaled-ionosphere closure, PRC closure, and atmosphere-reference
+components, keeping the primary review evidence in the CI summary while the
+full row breakdown remains in the JSON artifact.
 When `GNSS_PPP_CLAS_DD_FILTER=1` and
 `GNSS_PPP_CLAS_CODE_ROW_PARITY=bias,full-prc` are set, the CLAS OSR
 materializer uses that exact GPS L2 RINEX identity to choose the code/phase SSR

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -246,10 +246,12 @@ changing the gated correction model. The optional CI summary schema
 leading row-breakdown component, and a per-component max-delta map into summary
 metrics, so release artifacts show the next single-component target without
 manually opening the full diff JSON.  Schema
-`ci_optional_clas_zd_component_diff.v10` additionally surfaces top-row values
-for highlighted components that are present on only one side, so native
-atmosphere/clock reference epochs remain visible even when the CLASLIB export
-cannot provide comparable fields.
+`ci_optional_clas_zd_component_diff.v11` additionally surfaces top-row values
+for highlighted components. Present-on-both components, such as `stec_tecu`,
+`iono_l1_m`, `iono_scaled_m`, `code_bias_m`, and `trop_correction_m`, carry
+CLASLIB/native/delta values in the CI summary; present-on-one-side components
+still expose the native atmosphere/clock reference epochs when the CLASLIB
+export cannot provide comparable fields.
 
 CI can regenerate the native side of this A4b probe without a pre-staged native
 CSV:
@@ -312,16 +314,19 @@ which separates frequency-scaling mistakes from upstream STEC/L1-delay
 mismatches.  The aggregate `applied_pr_corr_m` remains available for
 explicit diagnostic runs, but the default sign-off points the top-row evidence
 at the underlying ZD correction component.
-The GitHub step summary highlights `iono_l1_from_stec_m`,
-`iono_l1_stec_closure_residual_m`, `iono_scaled_closure_residual_m`, and
-`prc_closure_residual_m` from the per-component max-delta map, and reports
-missing counts for highlighted atmosphere-reference fields when CLASLIB cannot
-provide a comparable value.  The native `clas_zd_component_summary.v2` snapshot
-also reports numeric min/max stats for `atmos_ref_tow`, `clock_ref_tow`, and
-`atmos_clock_gap_s`, so reviewers can see which lifecycle stage is selected
-without opening the raw CSV.  For the leading row-breakdown, v10 summaries also
-include the native value of each highlighted missing field, which ties the
-largest PRC/iono/trop delta back to the selected reference epoch.
+The GitHub step summary highlights `stec_tecu`, `iono_l1_m`,
+`iono_scaled_m`, `iono_l1_from_stec_m`,
+`iono_l1_stec_closure_residual_m`, `iono_scaled_closure_residual_m`,
+`code_bias_m`, `trop_correction_m`, and `prc_closure_residual_m` from the
+per-component max-delta map, and reports missing counts for highlighted
+atmosphere-reference fields when CLASLIB cannot provide a comparable value.
+The native `clas_zd_component_summary.v2` snapshot also reports numeric
+min/max stats for `atmos_ref_tow`, `clock_ref_tow`, and `atmos_clock_gap_s`,
+so reviewers can see which lifecycle stage is selected without opening the raw
+CSV.  For the leading row-breakdown, v11 summaries also include
+CLASLIB/native/delta values for highlighted present components and the native
+value of each highlighted missing field, which ties the largest PRC/iono/trop
+delta back to the selected reference epoch.
 If either generated side is missing, the optional diff reports
 `blocked_infrastructure`, not a passing sign-off.
 

--- a/scripts/ci/optional_diff_runner.py
+++ b/scripts/ci/optional_diff_runner.py
@@ -409,6 +409,27 @@ def load_diff_metrics(config: DiffRunnerConfig, report_json: Path) -> dict[str, 
                         metrics["top_row_dominant_delta"] = float(delta)
                     if isinstance(abs_delta, (int, float)):
                         metrics["top_row_dominant_abs_delta"] = float(abs_delta)
+                highlighted_components: list[dict[str, object]] = []
+                highlight_set = set(config.highlight_components)
+                for item in components:
+                    if not isinstance(item, dict):
+                        continue
+                    component = item.get("component")
+                    if not isinstance(component, str) or component not in highlight_set:
+                        continue
+                    normalized: dict[str, object] = {"component": component}
+                    for source_key, target_key in (
+                        ("base_value_m", "base_value"),
+                        ("candidate_value_m", "candidate_value"),
+                        ("delta_m", "delta"),
+                        ("abs_delta_m", "abs_delta"),
+                    ):
+                        value = item.get(source_key)
+                        if isinstance(value, (int, float)):
+                            normalized[target_key] = float(value)
+                    highlighted_components.append(normalized)
+                if highlighted_components:
+                    metrics["top_row_highlight_components"] = highlighted_components
             missing_components = first_row.get("missing_components")
             if isinstance(missing_components, list) and missing_components:
                 normalized_missing: list[dict[str, object]] = []
@@ -670,6 +691,36 @@ def render_result_detail(config: DiffRunnerConfig, result: dict[str, object]) ->
                         f"{config.candidate_label} "
                         f"{format_metric(item.get('candidate_value'))}"
                     )
+                if value_parts:
+                    detail_parts.append(f"top row `{component}` " + "/".join(value_parts))
+        top_row_highlight_components = metrics.get("top_row_highlight_components")
+        if isinstance(top_row_highlight_components, list):
+            top_row_highlight_by_component: dict[str, dict[str, object]] = {}
+            for item in top_row_highlight_components:
+                if not isinstance(item, dict):
+                    continue
+                component = item.get("component")
+                if isinstance(component, str):
+                    top_row_highlight_by_component[component] = item
+            for component in config.highlight_components:
+                item = top_row_highlight_by_component.get(component)
+                if item is None:
+                    continue
+                abs_delta = item.get("abs_delta")
+                if isinstance(abs_delta, (int, float)) and abs(float(abs_delta)) <= 1e-12:
+                    continue
+                value_parts: list[str] = []
+                if "base_value" in item:
+                    value_parts.append(
+                        f"{config.base_label} {format_metric(item.get('base_value'))}"
+                    )
+                if "candidate_value" in item:
+                    value_parts.append(
+                        f"{config.candidate_label} "
+                        f"{format_metric(item.get('candidate_value'))}"
+                    )
+                if "delta" in item:
+                    value_parts.append(f"delta {format_metric(item.get('delta'))}")
                 if value_parts:
                     detail_parts.append(f"top row `{component}` " + "/".join(value_parts))
         top_delta_component = metrics.get("top_delta_component")

--- a/scripts/ci/run_optional_clas_zd_component_diff.py
+++ b/scripts/ci/run_optional_clas_zd_component_diff.py
@@ -13,7 +13,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 import optional_diff_runner as runner  # noqa: E402
 
 
-SUMMARY_SCHEMA = "ci_optional_clas_zd_component_diff.v10"
+SUMMARY_SCHEMA = "ci_optional_clas_zd_component_diff.v11"
 
 CONFIG = runner.DiffRunnerConfig(
     summary_schema=SUMMARY_SCHEMA,
@@ -41,9 +41,14 @@ CONFIG = runner.DiffRunnerConfig(
     input_summary_schema="clas_zd_component_summary.v2",
     input_summary_fail_on_issue=True,
     highlight_components=(
+        "stec_tecu",
+        "iono_l1_m",
+        "iono_scaled_m",
         "iono_l1_from_stec_m",
         "iono_l1_stec_closure_residual_m",
         "iono_scaled_closure_residual_m",
+        "code_bias_m",
+        "trop_correction_m",
         "prc_closure_residual_m",
         "atmos_ref_tow",
         "clock_ref_tow",

--- a/tests/test_optional_clas_zd_component_diff.py
+++ b/tests/test_optional_clas_zd_component_diff.py
@@ -38,6 +38,10 @@ FIELDNAMES = [
     "code_bias_fallback",
     "prc_m",
     "code_bias_m",
+    "trop_correction_m",
+    "iono_l1_m",
+    "stec_tecu",
+    "iono_scaled_m",
 ]
 
 
@@ -54,6 +58,11 @@ def write_zd_component_csv(
     observation_exact_match: str = "",
     observation_family_fallback: str = "",
     code_bias_fallback: str = "",
+    code_bias_m: str = "0.5",
+    trop_correction_m: str = "2.7",
+    iono_l1_m: str = "-0.3",
+    stec_tecu: str = "-1.9",
+    iono_scaled_m: str = "-0.5",
 ) -> None:
     with path.open("w", newline="", encoding="utf-8") as handle:
         writer = csv.DictWriter(handle, fieldnames=FIELDNAMES)
@@ -74,7 +83,11 @@ def write_zd_component_csv(
                 "observation_family_fallback": observation_family_fallback,
                 "code_bias_fallback": code_bias_fallback,
                 "prc_m": prc_m,
-                "code_bias_m": "0.5",
+                "code_bias_m": code_bias_m,
+                "trop_correction_m": trop_correction_m,
+                "iono_l1_m": iono_l1_m,
+                "stec_tecu": stec_tecu,
+                "iono_scaled_m": iono_scaled_m,
             }
         )
 
@@ -309,6 +322,76 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
                 ],
             )
 
+    def test_load_diff_metrics_keeps_top_row_highlight_component_values(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_ci_clas_zd_highlight_") as temp_dir:
+            report_path = Path(temp_dir) / "clas_zd_component_diff.json"
+            report_path.write_text(
+                json.dumps(
+                    {
+                        "schema": "clas_zd_component_diff.v1",
+                        "top_row_component_breakdowns": [
+                            {
+                                "week": 2360,
+                                "tow": 172800.0,
+                                "row_type": "code",
+                                "sat": "G14",
+                                "freq": 1,
+                                "rinex_code": "C2W",
+                                "sum_abs_delta_m": 0.25,
+                                "max_abs_delta_m": 0.2,
+                                "components": [
+                                    {
+                                        "component": "iono_scaled_m",
+                                        "base_value_m": -0.625,
+                                        "candidate_value_m": -0.677,
+                                        "delta_m": -0.052,
+                                        "abs_delta_m": 0.052,
+                                    },
+                                    {
+                                        "component": "stec_tecu",
+                                        "base_value_m": -2.3,
+                                        "candidate_value_m": -2.49,
+                                        "delta_m": -0.19,
+                                        "abs_delta_m": 0.19,
+                                    },
+                                    {
+                                        "component": "unhighlighted_m",
+                                        "base_value_m": 1.0,
+                                        "candidate_value_m": 2.0,
+                                        "delta_m": 1.0,
+                                        "abs_delta_m": 1.0,
+                                    },
+                                ],
+                                "missing_components": [],
+                            }
+                        ],
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            metrics = runner.runner.load_diff_metrics(runner.CONFIG, report_path)
+
+            self.assertEqual(
+                metrics["top_row_highlight_components"],
+                [
+                    {
+                        "component": "iono_scaled_m",
+                        "base_value": -0.625,
+                        "candidate_value": -0.677,
+                        "delta": -0.052,
+                        "abs_delta": 0.052,
+                    },
+                    {
+                        "component": "stec_tecu",
+                        "base_value": -2.3,
+                        "candidate_value": -2.49,
+                        "delta": -0.19,
+                        "abs_delta": 0.19,
+                    },
+                ],
+            )
+
     def test_run_step_fails_when_snapshot_summary_fails(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ci_clas_zd_input_summary_") as temp_dir:
             root = Path(temp_dir)
@@ -399,6 +482,22 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
                         "top_row_sum_abs_delta": 0.375,
                         "top_row_dominant_component": "prc_m",
                         "top_row_dominant_abs_delta": 0.25,
+                        "top_row_highlight_components": [
+                            {
+                                "component": "stec_tecu",
+                                "base_value": -2.3,
+                                "candidate_value": -2.49,
+                                "delta": -0.19,
+                                "abs_delta": 0.19,
+                            },
+                            {
+                                "component": "iono_scaled_m",
+                                "base_value": -0.625,
+                                "candidate_value": -0.677,
+                                "delta": -0.052,
+                                "abs_delta": 0.052,
+                            },
+                        ],
                         "top_row_missing_components": [
                             {
                                 "component": "atmos_ref_tow",
@@ -461,6 +560,11 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
         self.assertIn("top row `atmos_ref_tow` native 230430", markdown)
         self.assertIn("top row `clock_ref_tow` native 230420", markdown)
         self.assertIn("top row `atmos_clock_gap_s` native 10", markdown)
+        self.assertIn("top row `stec_tecu` claslib -2.3/native -2.49/delta -0.19", markdown)
+        self.assertIn(
+            "top row `iono_scaled_m` claslib -0.625/native -0.677/delta -0.052",
+            markdown,
+        )
         self.assertIn("top delta `prc_m` |delta| 0.25", markdown)
         self.assertIn("top row sum |delta| 0.375", markdown)
         self.assertIn("top component `prc_m` |delta| 0.25", markdown)
@@ -490,7 +594,7 @@ class OptionalClasZdComponentDiffTest(unittest.TestCase):
 
             payload = json.loads(summary_path.read_text(encoding="utf-8"))
             self.assertEqual(payload["summary_schema"], runner.SUMMARY_SCHEMA)
-            self.assertEqual(payload["summary_schema"], "ci_optional_clas_zd_component_diff.v10")
+            self.assertEqual(payload["summary_schema"], "ci_optional_clas_zd_component_diff.v11")
             self.assertEqual(payload["contract"], "optional_diff_artifact_contract.v1")
             self.assertEqual(payload["status"], "blocked_infrastructure")
             self.assertIn("missing evidence", payload["next_actions"][1])


### PR DESCRIPTION
## Summary

- bump the optional CLAS ZD component summary contract to `ci_optional_clas_zd_component_diff.v11`
- lift highlighted top-row component values into CI metrics and step-summary text
- highlight raw STEC, L1/scaled ionosphere, code-bias, and trop values so the next A4b model slice is visible without opening the full JSON artifact

## Validation

- `python3 -m pytest tests/test_optional_clas_zd_component_diff.py -q`
- `python3 -m py_compile scripts/ci/optional_diff_runner.py scripts/ci/run_optional_clas_zd_component_diff.py`
- `git diff --check`
- `ctest --test-dir build -R 'python_(optional_clas_zd_component_diff|clas_zd_component_diff|clas_zd_component_summary|claslib_zd_component_export)_tests' --output-on-failure`\n- ran `scripts/ci/run_optional_clas_zd_component_diff.py` against local A4b CLASLIB/native CSVs and confirmed `stec_tecu` is surfaced as the top row/top component delta\n