### PR TITLE
clas a4b atmos provenance

### DIFF
--- a/apps/gnss_clas_ppp.py
+++ b/apps/gnss_clas_ppp.py
@@ -129,6 +129,18 @@ def parse_args() -> argparse.Namespace:
         default=qzss_l6_info.COMPACT_ROW_CONSTRUCTION_POLICY_INDEPENDENT,
         help="Compact SSR row construction policy controlling how subtype-4/subtype-6 row and value construction interact.",
     )
+    parser.add_argument(
+        "--clas-atmos-selection",
+        choices=("grid-first", "grid-guarded", "balanced", "freshness-first"),
+        default="grid-first",
+        help="CLAS atmosphere network selection policy forwarded to PPP.",
+    )
+    parser.add_argument(
+        "--clas-atmos-stale-after-seconds",
+        type=float,
+        default=15.0,
+        help="Freshness threshold for CLAS atmosphere selection forwarded to PPP.",
+    )
     parser.add_argument("--out", type=Path, required=True, help="Output PPP .pos file.")
     parser.add_argument("--summary-json", type=Path, default=None, help="Optional summary JSON path.")
     parser.add_argument("--sp3", type=Path, default=None, help="Optional precise SP3 file.")
@@ -778,6 +790,11 @@ def main() -> int:
         # enable per-satellite ionosphere estimation with STEC constraints.
         command.append("--no-ionosphere-free")
         command.append("--estimate-ionosphere")
+        command.extend(["--clas-atmos-selection", args.clas_atmos_selection])
+        command.extend([
+            "--clas-atmos-stale-after-seconds",
+            str(args.clas_atmos_stale_after_seconds),
+        ])
         if args.profile == "clas":
             command.append("--clas-osr")
         if args.sp3 is not None:

--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -208,7 +208,10 @@ highlighted components. Present-on-both components, such as `stec_tecu`,
 `iono_l1_m`, `iono_scaled_m`, `code_bias_m`, and `trop_correction_m`, include
 CLASLIB/native/delta values; present-on-one-side components still expose native
 `atmos_ref_tow`, `clock_ref_tow`, and `atmos_clock_gap_s` when CLASLIB has no
-comparable reference-epoch columns.
+comparable reference-epoch columns. Native code dumps also include selected
+CLAS atmosphere network/grid provenance (`atmos_network_id`, `atmos_grid_no`,
+`atmos_grid*_no`, and `atmos_grid*_weight`) so A4b STEC differences can be
+separated into correction-value versus grid-weight selection issues.
 Optional filters are `GNSSPP_CLAS_ZD_COMPONENTS`, `GNSSPP_CLAS_ZD_STAGE`,
 `GNSSPP_CLAS_ZD_ROW_TYPE`, `GNSSPP_CLAS_ZD_THRESHOLD_M`, and
 `GNSSPP_CLAS_ZD_FAIL_ON_DIFF`.  GPS L2W A4b probes can also narrow the row set

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -128,6 +128,7 @@ python3 apps/gnss.py clas-ppp \
   --qzss-l6 "$DATA/2019239Q.l6" \
   --qzss-gps-week 2068 \
   --antex "$DATA/igs14_L5copy.atx" \
+  --clas-atmos-selection freshness-first \
   --receiver-antenna-type "TRM59800.80     NONE" \
   --compact-code-bias-composition-policy base-only-if-present \
   --compact-code-bias-bank-policy latest-preceding-bank \

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -267,6 +267,8 @@ For compact-SSR ingestion experiments, the shared decode boundary also exposes:
 - `gnss clas-ppp --compact-code-bias-bank-policy <pending-epoch|same-30s-bank|close-30s-bank|latest-preceding-bank>`
 - `gnss clas-ppp --antex <antennas.atx>`
 - `gnss clas-ppp --receiver-antenna-type <type>`
+- `gnss clas-ppp --clas-atmos-selection <grid-first|grid-guarded|balanced|freshness-first>`
+- `gnss clas-ppp --clas-atmos-stale-after-seconds <seconds>`
 - `gnss clas-ppp --compact-bias-row-materialization <overlap-only|selected-satellite-base-extend|all-base-satellite-extend>`
 - `gnss clas-ppp --compact-phase-bias-composition-policy <direct-values|base-plus-network|base-only-if-present>`
 - `gnss clas-ppp --compact-phase-bias-bank-policy <pending-epoch|same-30s-bank|close-30s-bank|latest-preceding-bank>`

--- a/include/libgnss++/algorithms/ppp_osr_types.hpp
+++ b/include/libgnss++/algorithms/ppp_osr_types.hpp
@@ -59,6 +59,12 @@ struct OSRCorrection {
     bool has_code_bias = false;
     bool has_phase_bias = false;
     GNSSTime atmos_reference_time;
+    int atmos_network_id = 0;
+    int atmos_grid_no = 0;
+    int atmos_interpolation_grid_count = 0;
+    std::array<int, 4> atmos_interpolation_grid_no{{0, 0, 0, 0}};
+    std::array<double, 4> atmos_interpolation_weights{{0.0, 0.0, 0.0, 0.0}};
+    double atmos_nearest_grid_distance_m = 0.0;
     GNSSTime phase_bias_reference_time;
     GNSSTime clock_reference_time;
 };

--- a/scripts/ci/run_clas_a4b_native_selfdiff.py
+++ b/scripts/ci/run_clas_a4b_native_selfdiff.py
@@ -228,6 +228,8 @@ def build_native_command(
         "latest-preceding-bank",
         "--compact-bias-row-materialization",
         "selected-satellite-base-extend",
+        "--clas-atmos-selection",
+        "freshness-first",
         "--out",
         str(paths.native_pos),
         "--summary-json",

--- a/src/algorithms/ppp_clas.cpp
+++ b/src/algorithms/ppp_clas.cpp
@@ -217,7 +217,12 @@ std::ofstream* clasCodeDumpStream() {
                    << "prc_minus_trop_m,trop_correction_m,iono_l1_m,"
                    << "stec_tecu,iono_scaled_m,code_bias_m,receiver_ant_m,relativity_m,"
                    << "atmos_ref_week,atmos_ref_tow,clock_ref_week,clock_ref_tow,"
-                   << "atmos_clock_gap_s,"
+                   << "atmos_clock_gap_s,atmos_network_id,atmos_grid_no,"
+                   << "atmos_grid_distance_m,atmos_grid_count,"
+                   << "atmos_grid1_no,atmos_grid1_weight,"
+                   << "atmos_grid2_no,atmos_grid2_weight,"
+                   << "atmos_grid3_no,atmos_grid3_weight,"
+                   << "atmos_grid4_no,atmos_grid4_weight,"
                    << "geo_m,sat_clk_m,receiver_clock_m,trop_model_m,"
                    << "iono_state_m,iono_scale,predicted_m,residual_m,"
                    << "variance_m2,los_e_m,los_n_m,los_u_m,az_rad,el_rad,"
@@ -409,6 +414,18 @@ void dumpClasCodeRows(
                   << timeWeekField(osr.clock_reference_time, have_clock_ref) << ','
                   << timeTowField(osr.clock_reference_time, have_clock_ref) << ','
                   << secondsField(atmos_clock_gap_s, have_atmos_ref && have_clock_ref) << ','
+                  << osr.atmos_network_id << ','
+                  << osr.atmos_grid_no << ','
+                  << osr.atmos_nearest_grid_distance_m << ','
+                  << osr.atmos_interpolation_grid_count << ','
+                  << osr.atmos_interpolation_grid_no[0] << ','
+                  << osr.atmos_interpolation_weights[0] << ','
+                  << osr.atmos_interpolation_grid_no[1] << ','
+                  << osr.atmos_interpolation_weights[1] << ','
+                  << osr.atmos_interpolation_grid_no[2] << ','
+                  << osr.atmos_interpolation_weights[2] << ','
+                  << osr.atmos_interpolation_grid_no[3] << ','
+                  << osr.atmos_interpolation_weights[3] << ','
                   << geo << ','
                   << sat_clk_m << ','
                   << receiver_clock_m << ','

--- a/src/algorithms/ppp_osr.cpp
+++ b/src/algorithms/ppp_osr.cpp
@@ -1058,6 +1058,43 @@ std::vector<OSRCorrection> computeOSR(
 
         // CLAS troposphere grid correction (if available)
         if (!atmos_tokens.empty()) {
+            ppp_atmosphere::ClasGridReference grid_reference;
+            if (ppp_atmosphere::resolveClasGridReference(
+                    atmos_tokens,
+                    receiver_pos,
+                    grid_reference)) {
+                osr.atmos_network_id = grid_reference.network_id;
+                osr.atmos_grid_no = grid_reference.grid_no;
+                osr.atmos_nearest_grid_distance_m =
+                    grid_reference.nearest_grid_distance_m;
+                if (grid_reference.interpolation_grid_count > 0) {
+                    osr.atmos_interpolation_grid_count =
+                        grid_reference.interpolation_grid_count;
+                    for (int grid = 0;
+                         grid < grid_reference.interpolation_grid_count &&
+                         grid < static_cast<int>(osr.atmos_interpolation_grid_no.size());
+                         ++grid) {
+                        osr.atmos_interpolation_grid_no[grid] =
+                            static_cast<int>(
+                                grid_reference.interpolation_grid_indices[grid]) + 1;
+                        osr.atmos_interpolation_weights[grid] =
+                            grid_reference.interpolation_weights[grid];
+                    }
+                } else if (grid_reference.has_bilinear) {
+                    osr.atmos_interpolation_grid_count = 4;
+                    for (int grid = 0; grid < 4; ++grid) {
+                        osr.atmos_interpolation_grid_no[grid] =
+                            static_cast<int>(
+                                grid_reference.bilinear_grid_indices[grid]) + 1;
+                        osr.atmos_interpolation_weights[grid] =
+                            grid_reference.bilinear_weights[grid];
+                    }
+                } else if (grid_reference.grid_no > 0) {
+                    osr.atmos_interpolation_grid_count = 1;
+                    osr.atmos_interpolation_grid_no[0] = grid_reference.grid_no;
+                    osr.atmos_interpolation_weights[0] = 1.0;
+                }
+            }
             const double clas_trop = ppp_atmosphere::atmosphericTroposphereCorrectionMeters(
                 atmos_tokens,
                 receiver_pos,

--- a/tests/test_benchmark_scripts.py
+++ b/tests/test_benchmark_scripts.py
@@ -499,6 +499,10 @@ class ClasCompactHelpersTest(unittest.TestCase):
                 str(antex_path),
                 "--receiver-antenna-type",
                 "TEST-ANT",
+                "--clas-atmos-selection",
+                "freshness-first",
+                "--clas-atmos-stale-after-seconds",
+                "12.5",
                 "--out",
                 str(output_path),
                 "--summary-json",
@@ -517,6 +521,10 @@ class ClasCompactHelpersTest(unittest.TestCase):
             self.assertEqual(command[command.index("--antex") + 1], str(antex_path))
             self.assertIn("--receiver-antenna-type", command)
             self.assertEqual(command[command.index("--receiver-antenna-type") + 1], "TEST-ANT")
+            self.assertIn("--clas-atmos-selection", command)
+            self.assertEqual(command[command.index("--clas-atmos-selection") + 1], "freshness-first")
+            self.assertIn("--clas-atmos-stale-after-seconds", command)
+            self.assertEqual(command[command.index("--clas-atmos-stale-after-seconds") + 1], "12.5")
             self.assertIn("--clas-osr", command)
             payload = json.loads(summary_path.read_text(encoding="utf-8"))
             self.assertEqual(payload["antex"], str(antex_path))

--- a/tests/test_clas_a4b_native_selfdiff.py
+++ b/tests/test_clas_a4b_native_selfdiff.py
@@ -92,6 +92,8 @@ class ClasA4bNativeSelfdiffTest(unittest.TestCase):
             self.assertIn("latest-preceding-bank", command)
             self.assertIn("--compact-bias-row-materialization", command)
             self.assertIn("selected-satellite-base-extend", command)
+            self.assertIn("--clas-atmos-selection", command)
+            self.assertEqual(command[command.index("--clas-atmos-selection") + 1], "freshness-first")
             self.assertIn("--receiver-antenna-type", command)
             self.assertIn("TEST ANT", command)
             self.assertEqual(command[-2:], ["--max-epochs", "30"])


### PR DESCRIPTION
## Summary
- Forward CLAS atmosphere selection options through `gnss clas-ppp` and pin the A4b native self-diff runner to `freshness-first`.
- Add selected CLAS atmosphere network/grid provenance to native code dumps so STEC deltas can be separated into correction-value versus grid-weight selection issues.
- Update A4b docs and command-construction tests for the new contract.

## Root Cause / Impact
The latest A4b evidence shows the dominant G14/C2W delta is still STEC/iono. Local reproduction with the new dump fields shows native is using network 7 with grid 17/18 dominant weights at the top-row epochs, which makes the next model PR target grid-weight selection instead of TECU scaling or iono frequency scaling.

## Validation
- `python3 -m pytest tests/test_clas_a4b_native_selfdiff.py tests/test_benchmark_scripts.py -q`
- `python3 -m pytest tests/test_cli_ux.py tests/test_clas_a4b_native_selfdiff.py tests/test_benchmark_scripts.py -q`
- `python3 -m py_compile apps/gnss_clas_ppp.py scripts/ci/run_clas_a4b_native_selfdiff.py`
- `cmake --build build -j2`
- `build/tests/run_tests --gtest_filter='PPPOSRTest.*:PPPAtmosphereTest.*'`
- `GNSSPP_CLAS_A4B_DATA_ROOT=/tmp/claslib/data GNSSPP_CLAS_A4B_AUTO_FETCH=0 python3 scripts/ci/run_clas_a4b_native_selfdiff.py --output-dir /tmp/gnss_a4b_grid_provenance_probe`
- `mkdocs build --strict`
- `git diff --check`
