### PR TITLE
claslib osr iono provenance

### DIFF
--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -238,9 +238,12 @@ raw display `iono` column, so the diff compares the ionosphere term that was
 actually applied to `PRC1/PRC2/PRC5`.  `iono_l1_m` is the L1-equivalent of that
 same frequency-slot-specific closure value; it is not copied from the L1 slot.
 The normalized `stec_tecu` field is derived from that L1-equivalent delay with
-the GPS L1 TECU-to-meter factor.  The CI wrapper passes `clas_grid.def` to the
-normalizer so `.osr` rows also carry test-only CLASLIB-side grid provenance
-derived from the row receiver latitude/longitude.
+the GPS L1 TECU-to-meter factor.  The exporter also writes
+`claslib_iono_source=prc_closure`, `claslib_raw_iono_l1_m`, and
+`claslib_raw_stec_tecu`, so the raw `.osr` display ionosphere is visible
+without changing the default effective-PRC component diff.  The CI wrapper
+passes `clas_grid.def` to the normalizer so `.osr` rows also carry test-only
+CLASLIB-side grid provenance derived from the row receiver latitude/longitude.
 The `.osr` path maps only GPS L1/L2/L5 slots where the exact row identity is
 deterministic; QZSS and Galileo still need explicit disposable dumps until
 their ZD materialization and admission sources are fixed.
@@ -296,6 +299,9 @@ valid-grid count, materialized STEC grid-value count, and selected-grid STEC
 value count used for each OSR row.  The `clas_zd_component_summary.v2`
 snapshot summary reports numeric min/max stats for those fields, so lifecycle
 or epoch-selection mismatches can be diagnosed before changing the STEC model.
+CLASLIB `.osr` summaries also report numeric stats for
+`claslib_raw_iono_l1_m` and `claslib_raw_stec_tecu`; those raw display fields
+remain explicit diagnostics and are not part of the default native diff.
 The GitHub step summary highlights raw STEC, L1 ionosphere, scaled ionosphere,
 code-bias, trop, L1-from-STEC, L1-STEC closure, scaled-ionosphere closure, PRC
 closure, and atmosphere-reference components, keeping the primary review

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -193,8 +193,12 @@ closure instead of the raw `.osr` `iono` display column, so it matches the
 correction actually applied in `PRC1/PRC2/PRC5`.  `iono_l1_m` is the
 frequency-slot-specific L1-equivalent of that reconstructed value, not a copy
 of the L1 slot's display or closure value.  The normalized `stec_tecu` field is
-derived from that L1-equivalent delay with the GPS L1 TECU-to-meter factor, so
-the diff can separate TECU materialization drift from frequency-scaling drift:
+derived from that L1-equivalent delay with the GPS L1 TECU-to-meter factor.
+The exporter also writes `claslib_iono_source=prc_closure`,
+`claslib_raw_iono_l1_m`, and `claslib_raw_stec_tecu`, so raw CLASLIB `.osr`
+display ionosphere can be inspected separately from the effective
+PRC-closure ionosphere used by the default diff.  This lets the diff separate
+TECU materialization drift from frequency-scaling drift:
 
 ```bash
 python3 scripts/analysis/claslib_zd_component_export.py \
@@ -337,7 +341,10 @@ bank was materialized before opening the raw CSV.  For the leading
 row-breakdown, v11 summaries also include
 CLASLIB/native/delta values for highlighted present components and the native
 value of each highlighted missing field, which ties the largest PRC/iono/trop
-delta back to the selected reference epoch.
+delta back to the selected reference epoch.  CLASLIB `.osr` snapshot summaries
+also include `claslib_raw_iono_l1_m` and `claslib_raw_stec_tecu` numeric stats
+as explicit diagnostics; they are intentionally outside the default native diff
+component set.
 If either generated side is missing, the optional diff reports
 `blocked_infrastructure`, not a passing sign-off.
 

--- a/scripts/analysis/clas_zd_component_diff.py
+++ b/scripts/analysis/clas_zd_component_diff.py
@@ -36,6 +36,8 @@ COMPONENT_ALIASES: dict[str, tuple[str, ...]] = {
     "iono_scaled_m": ("iono_scaled_m",),
     "iono_scale": ("iono_scale",),
     "iono_scaled_closure_residual_m": ("iono_scaled_closure_residual_m",),
+    "claslib_raw_iono_l1_m": ("claslib_raw_iono_l1_m", "raw_iono_l1_m"),
+    "claslib_raw_stec_tecu": ("claslib_raw_stec_tecu", "raw_stec_tecu"),
     "iono_cpc_m": ("iono_cpc_m",),
     "code_bias_m": ("code_bias_m", "code_bias"),
     "phase_bias_m": ("phase_bias_m", "phase_bias"),

--- a/scripts/analysis/claslib_zd_component_export.py
+++ b/scripts/analysis/claslib_zd_component_export.py
@@ -103,6 +103,9 @@ FIELDNAMES = [
     "stec_tecu",
     "iono_scaled_m",
     "iono_scale",
+    "claslib_iono_source",
+    "claslib_raw_iono_l1_m",
+    "claslib_raw_stec_tecu",
     "code_bias_m",
     "phase_bias_m",
     "receiver_antenna_m",
@@ -589,6 +592,9 @@ def normalize_row(
             "stec_tecu": first_present(row, ("stec_tecu",)),
             "iono_scaled_m": first_present(row, ("iono_scaled_m",)),
             "iono_scale": first_present(row, ("iono_scale",)),
+            "claslib_iono_source": first_present(row, ("claslib_iono_source", "iono_source")),
+            "claslib_raw_iono_l1_m": first_present(row, ("claslib_raw_iono_l1_m", "raw_iono_l1_m")),
+            "claslib_raw_stec_tecu": first_present(row, ("claslib_raw_stec_tecu", "raw_stec_tecu")),
             "code_bias_m": first_present(row, ("code_bias_m", "code_bias", "cbias_m")),
             "phase_bias_m": first_present(row, ("phase_bias_m", "phase_bias", "pbias_m", "comp_m")),
             "receiver_antenna_m": first_present(row, ("receiver_antenna_m", "receiver_ant_m", "receiver_ant")),
@@ -669,6 +675,7 @@ def normalize_osrres_rows(
         pseudorange_code, carrier_code = rinex_pair(rtklib_code)
         effective_iono_l1_m = prc_iono_l1_from_osrres(row, suffix)
         effective_iono_scaled_m = format_component(prc_iono_scaled_from_osrres(row, suffix))
+        raw_iono_l1_m = format_component(parse_osr_float(first_present(row, ("iono", "iono_l1_m", "l1_iono_m"))))
         common = {
             "stage": stage,
             "week": week,
@@ -688,6 +695,9 @@ def normalize_osrres_rows(
             "stec_tecu": stec_tecu_from_iono_l1_m(effective_iono_l1_m),
             "iono_scaled_m": effective_iono_scaled_m,
             "iono_scale": format_component(GPS_IONO_SCALE_BY_SUFFIX[suffix]),
+            "claslib_iono_source": "prc_closure",
+            "claslib_raw_iono_l1_m": raw_iono_l1_m,
+            "claslib_raw_stec_tecu": stec_tecu_from_iono_l1_m(raw_iono_l1_m),
             "receiver_antenna_m": first_present(row, (f"antr{suffix}",)),
             "relativity_m": first_present(row, ("relatv", "relativity_m", "relativity_correction_m")),
             "windup_m": first_present(row, (f"wup{suffix}",)),

--- a/tests/test_claslib_zd_component_export.py
+++ b/tests/test_claslib_zd_component_export.py
@@ -278,6 +278,21 @@ class ClaslibZdComponentExportTest(unittest.TestCase):
                 float(code_l2w["iono_scale"]),
                 export.GPS_IONO_SCALE_BY_SUFFIX["2"],
             )
+            self.assertEqual(code_l2w["claslib_iono_source"], "prc_closure")
+            self.assertAlmostEqual(float(code_l2w["claslib_raw_iono_l1_m"]), 1.234)
+            self.assertAlmostEqual(
+                float(code_l2w["claslib_raw_stec_tecu"]),
+                1.234 / export.GPS_L1_TECU_TO_METERS,
+            )
+            self.assertNotAlmostEqual(
+                float(code_l2w["claslib_raw_iono_l1_m"]),
+                float(code_l2w["iono_l1_m"]),
+            )
+            components = component_diff.extract_components(
+                code_l2w,
+                ("claslib_raw_iono_l1_m", "claslib_raw_stec_tecu"),
+            )
+            self.assertAlmostEqual(components["claslib_raw_iono_l1_m"], 1.234)
             self.assertAlmostEqual(
                 float(code_l2w["iono_l1_m"]) * export.GPS_IONO_SCALE_BY_SUFFIX["2"],
                 float(code_l2w["iono_scaled_m"]),


### PR DESCRIPTION
## Summary

- Add CLASLIB `.osr` ionosphere provenance columns to normalized ZD dumps: `claslib_iono_source`, `claslib_raw_iono_l1_m`, and `claslib_raw_stec_tecu`.
- Register the raw ionosphere fields as optional numeric diff/summary components without adding them to the default native diff list.
- Document that existing `iono_l1_m`/`stec_tecu` remain PRC-closure effective values, while the new fields expose raw `.osr` display ionosphere for diagnostics.

## Why

The A4b investigation showed that the apparent G14/C2W STEC jump around TOW 230430 is not a native lifecycle-bank miss. The CLASLIB normalized `.osr` `stec_tecu` value is derived from PRC closure, while the raw `.osr` display ionosphere can remain unchanged. This PR makes that provenance visible in the artifacts so the next model PR does not chase a raw STEC mismatch that is actually a PRC-closure convention difference.

## Validation

- `python3 -m pytest tests/test_claslib_zd_component_export.py tests/test_clas_zd_component_diff.py tests/test_clas_zd_component_summary.py tests/test_optional_clas_zd_component_diff.py -q`
- `python3 -m pytest tests/test_claslib_osr_zd_export.py tests/test_claslib_zd_component_export.py -q`
- `python3 -m py_compile scripts/analysis/claslib_zd_component_export.py scripts/analysis/clas_zd_component_diff.py scripts/analysis/clas_zd_component_summary.py scripts/ci/run_claslib_osr_zd_export.py scripts/ci/run_optional_clas_zd_component_diff.py`
- `GNSSPP_CLASLIB_OSR_SOURCE_ROOT=/tmp/claslib GNSSPP_CLASLIB_OSR_AUTO_FETCH=0 python3 scripts/ci/run_claslib_osr_zd_export.py --output-dir /tmp/gnss_claslib_iono_prov`
- `GNSSPP_CLAS_ZD_BASE_CSV=/tmp/gnss_claslib_iono_prov/claslib_osr_zd_export/claslib_osr.normalized.csv GNSSPP_CLAS_ZD_CANDIDATE_CSV=/tmp/gnss_lifecycle_prov/clas_a4b_native_selfdiff/native_code_dump.csv GNSSPP_CLAS_ZD_STAGE=post GNSSPP_CLAS_ZD_ROW_TYPE=code GNSSPP_CLAS_ZD_SAT=G14 GNSSPP_CLAS_ZD_FREQ=1 GNSSPP_CLAS_ZD_RINEX_CODE=C2W GNSSPP_CLAS_ZD_DUPLICATE_POLICY=mean python3 scripts/ci/run_optional_clas_zd_component_diff.py --output-dir /tmp/gnss_claslib_iono_diff`
- `mkdocs build --strict`
- `git diff --check`
