### PR TITLE
clas avoid future code bias

### DIFF
--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -307,6 +307,20 @@ before changing the STEC model.
 CLASLIB `.osr` summaries also report numeric stats for
 `claslib_raw_iono_l1_m` and `claslib_raw_stec_tecu`; those raw display fields
 remain explicit diagnostics and are not part of the default native diff.
+
+Native SSR interpolation must not consume a future code-bias sample merely
+because the next clock neighbour carries one.  The A4b G14/C2W slice exposed
+this as an early bank switch: native selected the `230430` code-bias row at
+TOW `230426` before the row was causally available.  The core SSRProducts
+contract now forward-fills code bias only from current or older rows.  On the
+same CLASLIB/native G14/C2W comparison this reduces `code_bias_m` mismatches
+from 156/280 common rows to 120/280, with `mean_abs` moving from `0.01114 m`
+to `0.00857 m` and `rms` from `0.01493 m` to `0.01309 m`.  The remaining
+120-row mismatch is the CLASLIB effective-bank delay: CLASLIB keeps the
+previous bank through the first 15 seconds of each 30-second code-bias bank
+(`230430` native versus `230445` CLASLIB for the first visible transition).
+Treat that as the next A4b correction-materialization target rather than
+tuning residual variance or AR.
 The GitHub step summary highlights raw STEC, L1 ionosphere, scaled ionosphere,
 code-bias, trop, L1-from-STEC, L1-STEC closure, scaled-ionosphere closure, PRC
 closure, and atmosphere-reference components, keeping the primary review

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -339,11 +339,20 @@ min/max stats for `atmos_ref_tow`, `clock_ref_tow`, `code_bias_ref_tow`,
 `atmos_clock_gap_s`, `atmos_lifecycle_tow`, `atmos_selected_satellite_count`,
 `atmos_valid_grid_count`, `atmos_stec_grid_value_count`, and
 `atmos_selected_grid_stec_value_count`, so reviewers can see which lifecycle
-bank was materialized before opening the raw CSV.  For the leading
-row-breakdown, v11 summaries also include
-CLASLIB/native/delta values for highlighted present components and the native
-value of each highlighted missing field, which ties the largest PRC/iono/trop
-delta back to the selected reference epoch.  CLASLIB `.osr` snapshot summaries
+bank was materialized before opening the raw CSV.  For the leading-row
+breakdown, v11 summaries also include CLASLIB/native/delta values for
+highlighted present components and the native value of each highlighted missing
+field, which ties the largest PRC/iono/trop delta back to the selected
+reference epoch.
+
+For the G14/C2W code-bias timing issue, native SSR interpolation now forbids
+future code-bias samples and therefore no longer applies the `230430`
+code-bias bank to TOW `230426..230429`.  This reduces G14/C2W `code_bias_m`
+mismatches against the CLASLIB `.osr` slice from 156/280 common rows to
+120/280.  The remaining gap is the CLASLIB effective-bank delay: CLASLIB
+switches each 30-second bank at the half-window boundary, for example keeping
+`0.760 m` through `230444` and switching to `0.740 m` at `230445`.
+The CLASLIB `.osr` snapshot summaries
 also include `claslib_raw_iono_l1_m` and `claslib_raw_stec_tecu` numeric stats
 as explicit diagnostics; they are intentionally outside the default native diff
 component set.

--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -1801,24 +1801,21 @@ bool SSRProducts::interpolateCorrection(const SatelliteId& sat,
             return best;
         };
         if (code_bias_m != nullptr) {
-            if (biasScore(*before, false) >= biasScore(*after, false) &&
-                before->code_bias_valid && !before->code_bias_m.empty()) {
-                *code_bias_m = before->code_bias_m;
-                if (status != nullptr) {
-                    status->code_bias_valid = true;
-                    status->code_bias_reference_time = before->time;
-                }
-            } else if (after->code_bias_valid && !after->code_bias_m.empty()) {
-                *code_bias_m = after->code_bias_m;
-                if (status != nullptr) {
-                    status->code_bias_valid = true;
-                    status->code_bias_reference_time = after->time;
-                }
+            // Code biases are stepwise corrections.  Do not consume a future
+            // bias row just because the next clock interpolation neighbour has
+            // one; CLAS holds the last received code-bias bank until a new
+            // bank is causally available.
+            const SSROrbitClockCorrection* picked = nullptr;
+            if (before->code_bias_valid && !before->code_bias_m.empty()) {
+                picked = before;
             } else if (const auto* scanned = scanBackwardBias(false)) {
-                *code_bias_m = scanned->code_bias_m;
+                picked = scanned;
+            }
+            if (picked != nullptr) {
+                *code_bias_m = picked->code_bias_m;
                 if (status != nullptr) {
                     status->code_bias_valid = true;
-                    status->code_bias_reference_time = scanned->time;
+                    status->code_bias_reference_time = picked->time;
                 }
             }
         }

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -1357,6 +1357,51 @@ TEST(PPPTest, SSRProductsLoadCsvParsesOptionalUraCodeBiasPhaseBiasAndAtmosTokens
     std::filesystem::remove(ssr_path);
 }
 
+TEST(PPPTest, SSRProductsDoesNotUseFutureCodeBiasBetweenClockRows) {
+    const auto ssr_path = tempFilePath("libgnss_ppp_ssr_code_bias_no_future_test.csv");
+    std::filesystem::remove(ssr_path);
+
+    const std::string ssr_text =
+        "# week,tow,sat,dx,dy,dz,dclock_m[,cbias:<id>=<m>...]\n"
+        "2414,345570.0,G01,0.0,0.0,0.0,0.5,cbias:2=-0.120000\n"
+        "2414,345600.0,G01,1.0,-2.0,3.0,4.0\n"
+        "2414,345605.0,G01,1.1,-2.1,3.1,4.5\n"
+        "2414,345610.0,G01,1.2,-2.2,3.2,5.0,cbias:2=0.040000\n";
+    writeTextFile(ssr_path, ssr_text);
+
+    SSRProducts ssr_products;
+    ASSERT_TRUE(ssr_products.loadCSVFile(ssr_path.string()));
+
+    Vector3d orbit_correction = Vector3d::Zero();
+    double clock_correction_m = 0.0;
+    std::map<uint8_t, double> code_bias_m;
+    SSRCorrectionStatus status;
+    ASSERT_TRUE(ssr_products.interpolateCorrection(
+        SatelliteId(GNSSSystem::GPS, 1),
+        GNSSTime(2414, 345607.0),
+        orbit_correction,
+        clock_correction_m,
+        nullptr,
+        &code_bias_m,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        0,
+        nullptr,
+        nullptr,
+        &status));
+
+    ASSERT_EQ(code_bias_m.size(), 1U);
+    EXPECT_NEAR(code_bias_m.at(2U), -0.12, 1e-12);
+    EXPECT_TRUE(status.code_bias_valid);
+    EXPECT_EQ(status.code_bias_reference_time.week, 2414);
+    EXPECT_NEAR(status.code_bias_reference_time.tow, 345570.0, 1e-12);
+
+    std::filesystem::remove(ssr_path);
+}
+
 TEST(PPPTest, ProcessorLoadsRtcmSsrCorrectionsFromFile) {
     const auto rtcm_path = tempFilePath("libgnss_ppp_ssr_rtcm_test.rtcm3");
     std::filesystem::remove(rtcm_path);


### PR DESCRIPTION
## Summary
- prevent non-exact SSR interpolation from using a future code-bias row when interpolating between clock rows
- add a regression test covering the causal code-bias forward-fill contract
- document the A4b G14/C2W impact and leave the remaining CLASLIB +15s effective-bank delay as the next correction-materialization target

## Impact
The A4b G14/C2W CLASLIB/native comparison now avoids the early switch to the 230430 code-bias bank at TOW 230426..230429. The code-bias mismatch count improves from 156/280 common rows to 120/280, with mean_abs moving from 0.01114 m to 0.00857 m and RMS from 0.01493 m to 0.01309 m.

The remaining mismatch is still isolated to the CLASLIB effective-bank delay, where CLASLIB keeps the previous 30-second bank through the half-window boundary.

## Validation
- `cmake --build build --target run_tests -j2 && ./build/tests/run_tests --gtest_filter='PPPTest.SSRProducts*:PPPOSRTest.*'`
- `GNSSPP_CLAS_A4B_DATA_ROOT=/tmp/claslib/data GNSSPP_CLAS_A4B_AUTO_FETCH=0 python3 scripts/ci/run_clas_a4b_native_selfdiff.py --output-dir /tmp/gnss_code_bias_no_future_native`
- optional CLAS ZD diff with `GNSSPP_CLAS_ZD_BASE_CSV=/tmp/gnss_code_bias_ref_claslib/claslib_osr_zd_export/claslib_osr.normalized.csv` and candidate `/tmp/gnss_code_bias_no_future_native/clas_a4b_native_selfdiff/native_code_dump.csv`
- `mkdocs build --strict`
- `git diff --check`
- `./build/tests/run_tests`
