### PR TITLE
clas add delayed code bias bank policy

### DIFF
--- a/apps/gnss_qzss_l6_info.py
+++ b/apps/gnss_qzss_l6_info.py
@@ -91,12 +91,15 @@ COMPACT_CODE_BIAS_BANK_POLICY_PENDING_EPOCH = "pending-epoch"
 COMPACT_CODE_BIAS_BANK_POLICY_SAME_30S_BANK = "same-30s-bank"
 COMPACT_CODE_BIAS_BANK_POLICY_CLOSE_30S_BANK = "close-30s-bank"
 COMPACT_CODE_BIAS_BANK_POLICY_LATEST_PRECEDING_BANK = "latest-preceding-bank"
+COMPACT_CODE_BIAS_BANK_POLICY_DELAYED_15S_BANK = "delayed-15s-bank"
 COMPACT_CODE_BIAS_BANK_POLICIES = (
     COMPACT_CODE_BIAS_BANK_POLICY_PENDING_EPOCH,
     COMPACT_CODE_BIAS_BANK_POLICY_SAME_30S_BANK,
     COMPACT_CODE_BIAS_BANK_POLICY_CLOSE_30S_BANK,
     COMPACT_CODE_BIAS_BANK_POLICY_LATEST_PRECEDING_BANK,
+    COMPACT_CODE_BIAS_BANK_POLICY_DELAYED_15S_BANK,
 )
+CODE_BIAS_BANK_EFFECTIVE_DELAY_SECONDS = 15
 COMPACT_BIAS_ROW_MATERIALIZATION_POLICY_OVERLAP_ONLY = "overlap-only"
 COMPACT_BIAS_ROW_MATERIALIZATION_POLICY_SELECTED_SATELLITE_BASE_EXTEND = (
     "selected-satellite-base-extend"
@@ -1135,6 +1138,14 @@ def lookup_base_code_bias_bank_entry(
             if anchor <= tow and (current_anchor - anchor) <= PHASE_BIAS_BANK_BUCKET_SECONDS
         ]
         anchors.sort(reverse=True)
+    elif bank_policy == COMPACT_CODE_BIAS_BANK_POLICY_DELAYED_15S_BANK:
+        effective_tow = tow - CODE_BIAS_BANK_EFFECTIVE_DELAY_SECONDS
+        anchors = [
+            anchor
+            for anchor in state.base_code_bias_banks
+            if anchor <= effective_tow
+        ]
+        anchors.sort(reverse=True)
     else:
         anchors = [
             anchor
@@ -1176,6 +1187,14 @@ def lookup_base_code_bias_bank_rows(
             anchor
             for anchor in state.base_code_bias_banks
             if anchor <= tow and (current_anchor - anchor) <= PHASE_BIAS_BANK_BUCKET_SECONDS
+        ]
+        anchors.sort(reverse=True)
+    elif bank_policy == COMPACT_CODE_BIAS_BANK_POLICY_DELAYED_15S_BANK:
+        effective_tow = tow - CODE_BIAS_BANK_EFFECTIVE_DELAY_SECONDS
+        anchors = [
+            anchor
+            for anchor in state.base_code_bias_banks
+            if anchor <= effective_tow
         ]
         anchors.sort(reverse=True)
     else:

--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -315,12 +315,15 @@ TOW `230426` before the row was causally available.  The core SSRProducts
 contract now forward-fills code bias only from current or older rows.  On the
 same CLASLIB/native G14/C2W comparison this reduces `code_bias_m` mismatches
 from 156/280 common rows to 120/280, with `mean_abs` moving from `0.01114 m`
-to `0.00857 m` and `rms` from `0.01493 m` to `0.01309 m`.  The remaining
-120-row mismatch is the CLASLIB effective-bank delay: CLASLIB keeps the
-previous bank through the first 15 seconds of each 30-second code-bias bank
-(`230430` native versus `230445` CLASLIB for the first visible transition).
-Treat that as the next A4b correction-materialization target rather than
-tuning residual variance or AR.
+to `0.00857 m` and `rms` from `0.01493 m` to `0.01309 m`.  The A4b expansion
+then applies `--compact-code-bias-bank-policy delayed-15s-bank` so code-bias
+base-bank lookup uses the latest bank effective at `tow - 15 s`.  This moves
+the same slice to 112/280 `code_bias_m` mismatches with `mean_abs=0.00800 m`
+and `rms=0.01265 m`.  The remaining code-bias gap is selected network
+replacement materialization: native still keeps `0.760 m` through TOW `230454`
+while CLASLIB switches to `0.740 m` at `230445`.  Treat remaining PRC imbalance
+as an ionosphere/materialization issue rather than tuning residual variance or
+AR.
 The GitHub step summary highlights raw STEC, L1 ionosphere, scaled ionosphere,
 code-bias, trop, L1-from-STEC, L1-STEC closure, scaled-ionosphere closure, PRC
 closure, and atmosphere-reference components, keeping the primary review
@@ -352,9 +355,10 @@ from exact `C2W/L2W` matches.  The native dumps also carry the requested
 observation lookup fallback before the A4b GPS L2W correction model changes.
 For the GPS L2W A4b correction-materialization probe, run the raw CLAS L6
 expansion with `--compact-code-bias-composition-policy base-only-if-present` and
-`--compact-code-bias-bank-policy latest-preceding-bank`. The 2019 G14/C2W
+`--compact-code-bias-bank-policy delayed-15s-bank`. The 2019 G14/C2W
 network code-bias rows behave as subtype-4 base-value replacements: using direct
 subtype-6 values leaves periodic `-0.70 m` native rows against `+0.76 m`
 CLASLIB rows, while adding base plus network leaves the same rows near
 `+0.06 m`. The base-only policy removes that 30-second sign flip without
-changing default CLAS behavior.
+changing default CLAS behavior, and the delayed bank policy matches CLASLIB's
+first-half hold before the next selected-network replacement rows are handled.

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -131,7 +131,7 @@ python3 apps/gnss.py clas-ppp \
   --clas-atmos-selection freshness-first \
   --receiver-antenna-type "TRM59800.80     NONE" \
   --compact-code-bias-composition-policy base-only-if-present \
-  --compact-code-bias-bank-policy latest-preceding-bank \
+  --compact-code-bias-bank-policy delayed-15s-bank \
   --compact-bias-row-materialization selected-satellite-base-extend \
   --out /tmp/gnsspp_clas_a4b_native.pos \
   --summary-json /tmp/gnsspp_clas_a4b_native_summary.json \
@@ -345,15 +345,19 @@ highlighted present components and the native value of each highlighted missing
 field, which ties the largest PRC/iono/trop delta back to the selected
 reference epoch.
 
-For the G14/C2W code-bias timing issue, native SSR interpolation now forbids
-future code-bias samples and therefore no longer applies the `230430`
-code-bias bank to TOW `230426..230429`.  This reduces G14/C2W `code_bias_m`
-mismatches against the CLASLIB `.osr` slice from 156/280 common rows to
-120/280.  The remaining gap is the CLASLIB effective-bank delay: CLASLIB
-switches each 30-second bank at the half-window boundary, for example keeping
-`0.760 m` through `230444` and switching to `0.740 m` at `230445`.
-The CLASLIB `.osr` snapshot summaries
-also include `claslib_raw_iono_l1_m` and `claslib_raw_stec_tecu` numeric stats
+For the G14/C2W code-bias timing issue, native SSR interpolation forbids future
+code-bias samples and the A4b L6 expansion uses `delayed-15s-bank` so base-bank
+lookup uses the latest bank effective at `tow - 15 s`.  Native therefore no
+longer applies the `230430` bank to TOW `230426..230429`, and it holds the
+previous bank through the first half of each 30-second bank.  On the CLASLIB
+`.osr` slice this moves G14/C2W `code_bias_m` from `mean_abs=0.00857 m,
+rms=0.01309 m` to `mean_abs=0.00800 m, rms=0.01265 m`, with mismatch count
+moving from 120/280 to 112/280 common rows.  The remaining code-bias mismatch is
+not a future-sample read: selected network replacement rows still keep `0.760 m`
+through TOW `230454` while CLASLIB switches to `0.740 m` at `230445`.  Treat
+that as the next correction-materialization target.  The CLASLIB `.osr`
+snapshot summaries also include `claslib_raw_iono_l1_m` and
+`claslib_raw_stec_tecu` numeric stats
 as explicit diagnostics; they are intentionally outside the default native diff
 component set.
 If either generated side is missing, the optional diff reports

--- a/docs/interfaces.md
+++ b/docs/interfaces.md
@@ -15,7 +15,7 @@ Examples:
 - `gnss solve`
 - `gnss ppp` (`--nav`, `--sp3`, `--clk`, `--ionex`, `--dcb`, `--ssr`, `--ssr-rtcm`)
 - `gnss clas-ppp`
-- `gnss qzss-l6-info` (`--compact-flush-policy <lag-tolerant-union|orbit-or-clock-only|orbit-and-clock-only>`, `--compact-atmos-merge-policy <stec-coeff-carry|no-carry|network-locked-stec-coeff-carry>`, `--compact-atmos-subtype-merge-policy <union|gridded-priority|combined-priority>`, `--compact-phase-bias-merge-policy <latest-union|message-reset|selected-mask-prune>`, `--compact-phase-bias-source-policy <arrival-order|subtype5-priority|subtype6-priority>`, `--compact-code-bias-composition-policy <direct-values|base-plus-network|base-only-if-present>`, `--compact-phase-bias-composition-policy <direct-values|base-plus-network|base-only-if-present>`, `--compact-phase-bias-bank-policy <pending-epoch|same-30s-bank|close-30s-bank|latest-preceding-bank>`, `--compact-bias-row-materialization <overlap-only|selected-satellite-base-extend|all-base-satellite-extend>`, `--compact-row-construction-policy <independent|coupled-code-phase|row-first-value-second|network-row-driven>`)
+- `gnss qzss-l6-info` (`--compact-flush-policy <lag-tolerant-union|orbit-or-clock-only|orbit-and-clock-only>`, `--compact-atmos-merge-policy <stec-coeff-carry|no-carry|network-locked-stec-coeff-carry>`, `--compact-atmos-subtype-merge-policy <union|gridded-priority|combined-priority>`, `--compact-phase-bias-merge-policy <latest-union|message-reset|selected-mask-prune>`, `--compact-phase-bias-source-policy <arrival-order|subtype5-priority|subtype6-priority>`, `--compact-code-bias-composition-policy <direct-values|base-plus-network|base-only-if-present>`, `--compact-code-bias-bank-policy <pending-epoch|same-30s-bank|close-30s-bank|latest-preceding-bank|delayed-15s-bank>`, `--compact-phase-bias-composition-policy <direct-values|base-plus-network|base-only-if-present>`, `--compact-phase-bias-bank-policy <pending-epoch|same-30s-bank|close-30s-bank|latest-preceding-bank>`, `--compact-bias-row-materialization <overlap-only|selected-satellite-base-extend|all-base-satellite-extend>`, `--compact-row-construction-policy <independent|coupled-code-phase|row-first-value-second|network-row-driven>`)
 - `gnss fetch-products`
 - `gnss ppp-products-signoff`
 - `gnss ionex-info`
@@ -254,7 +254,7 @@ For compact-SSR ingestion experiments, the shared decode boundary also exposes:
 - `gnss qzss-l6-info --compact-phase-bias-merge-policy <latest-union|message-reset|selected-mask-prune>`
 - `gnss qzss-l6-info --compact-phase-bias-source-policy <arrival-order|subtype5-priority|subtype6-priority>`
 - `gnss qzss-l6-info --compact-code-bias-composition-policy <direct-values|base-plus-network|base-only-if-present>`
-- `gnss qzss-l6-info --compact-code-bias-bank-policy <pending-epoch|same-30s-bank|close-30s-bank|latest-preceding-bank>`
+- `gnss qzss-l6-info --compact-code-bias-bank-policy <pending-epoch|same-30s-bank|close-30s-bank|latest-preceding-bank|delayed-15s-bank>`
 - `gnss qzss-l6-info --compact-bias-row-materialization <overlap-only|selected-satellite-base-extend|all-base-satellite-extend>`
 - `gnss qzss-l6-info --compact-phase-bias-composition-policy <direct-values|base-plus-network|base-only-if-present>`
 - `gnss qzss-l6-info --compact-phase-bias-bank-policy <pending-epoch|same-30s-bank|close-30s-bank|latest-preceding-bank>`
@@ -264,7 +264,7 @@ For compact-SSR ingestion experiments, the shared decode boundary also exposes:
 - `gnss clas-ppp --compact-phase-bias-merge-policy <latest-union|message-reset|selected-mask-prune>`
 - `gnss clas-ppp --compact-phase-bias-source-policy <arrival-order|subtype5-priority|subtype6-priority>`
 - `gnss clas-ppp --compact-code-bias-composition-policy <direct-values|base-plus-network|base-only-if-present>`
-- `gnss clas-ppp --compact-code-bias-bank-policy <pending-epoch|same-30s-bank|close-30s-bank|latest-preceding-bank>`
+- `gnss clas-ppp --compact-code-bias-bank-policy <pending-epoch|same-30s-bank|close-30s-bank|latest-preceding-bank|delayed-15s-bank>`
 - `gnss clas-ppp --antex <antennas.atx>`
 - `gnss clas-ppp --receiver-antenna-type <type>`
 - `gnss clas-ppp --clas-atmos-selection <grid-first|grid-guarded|balanced|freshness-first>`

--- a/scripts/ci/run_clas_a4b_native_selfdiff.py
+++ b/scripts/ci/run_clas_a4b_native_selfdiff.py
@@ -225,7 +225,7 @@ def build_native_command(
         "--compact-code-bias-composition-policy",
         "base-only-if-present",
         "--compact-code-bias-bank-policy",
-        "latest-preceding-bank",
+        "delayed-15s-bank",
         "--compact-bias-row-materialization",
         "selected-satellite-base-extend",
         "--clas-atmos-selection",

--- a/tests/test_clas_a4b_native_selfdiff.py
+++ b/tests/test_clas_a4b_native_selfdiff.py
@@ -89,7 +89,7 @@ class ClasA4bNativeSelfdiffTest(unittest.TestCase):
             self.assertIn("--compact-code-bias-composition-policy", command)
             self.assertIn("base-only-if-present", command)
             self.assertIn("--compact-code-bias-bank-policy", command)
-            self.assertIn("latest-preceding-bank", command)
+            self.assertIn("delayed-15s-bank", command)
             self.assertIn("--compact-bias-row-materialization", command)
             self.assertIn("selected-satellite-base-extend", command)
             self.assertIn("--clas-atmos-selection", command)

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -5733,6 +5733,75 @@ class CLIToolsTest(unittest.TestCase):
             self.assertEqual(preceding_result.returncode, 0, msg=preceding_result.stderr)
             self.assertIn("cbias:2=-0.080000", preceding_path.read_text(encoding="ascii"))
 
+    def test_qzss_l6_info_compact_code_bias_bank_policy_delayed_15s_uses_half_window_boundary(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_qzss_l6_code_bias_bank_delay15_") as temp_dir:
+            temp_root = Path(temp_dir)
+            input_path = temp_root / "session_l6_code_bias_bank_delay15.bin"
+            delayed_path = temp_root / "delayed_15s.csv"
+            input_path.write_bytes(
+                build_qzss_l6_subframe_stream(
+                    [
+                        build_qzss_cssr_mask_message(tow=518400, iod=3, prn=3, sync=True),
+                        build_qzss_cssr_code_bias_message(
+                            tow_delta=0,
+                            iod=3,
+                            bias_m=-0.12,
+                            sync=True,
+                        ),
+                        build_qzss_cssr_code_bias_message(
+                            tow_delta=30,
+                            iod=3,
+                            bias_m=0.06,
+                            sync=True,
+                        ),
+                        build_qzss_cssr_code_phase_bias_message(
+                            tow_delta=44,
+                            iod=3,
+                            sync=False,
+                            network_bias=True,
+                            code_bias_exists=True,
+                            phase_bias_exists=False,
+                            selected_mask=0b1,
+                            code_bias_m=0.04,
+                        ),
+                        build_qzss_cssr_code_phase_bias_message(
+                            tow_delta=45,
+                            iod=3,
+                            sync=False,
+                            network_bias=True,
+                            code_bias_exists=True,
+                            phase_bias_exists=False,
+                            selected_mask=0b1,
+                            code_bias_m=0.04,
+                        ),
+                    ]
+                )
+            )
+
+            delayed_result = self.run_gnss(
+                "qzss-l6-info",
+                "--input",
+                str(input_path),
+                "--extract-compact-corrections",
+                str(delayed_path),
+                "--gps-week",
+                "2200",
+                "--compact-code-bias-composition-policy",
+                "base-plus-network",
+                "--compact-code-bias-bank-policy",
+                "delayed-15s-bank",
+            )
+            self.assertEqual(delayed_result.returncode, 0, msg=delayed_result.stderr)
+            delayed_rows = delayed_path.read_text(encoding="ascii").splitlines()
+            row_14s = [line for line in delayed_rows if line.startswith("2200,518444.000,G,3")]
+            row_15s = [line for line in delayed_rows if line.startswith("2200,518445.000,G,3")]
+            self.assertEqual(len(row_14s), 1)
+            self.assertEqual(len(row_15s), 1)
+            self.assertIn("cbias:2=-0.080000", row_14s[0])
+            self.assertNotIn("cbias:2=0.100000", row_14s[0])
+            self.assertIn("cbias:2=0.100000", row_15s[0])
+            self.assertNotIn("cbias:2=-0.080000", row_15s[0])
+
     def test_qzss_l6_info_compact_code_bias_base_only_uses_prior_anchor(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_qzss_l6_code_bias_base_only_prev_") as temp_dir:
             temp_root = Path(temp_dir)


### PR DESCRIPTION
## Summary
- add a `delayed-15s-bank` Compact SSR code-bias bank policy
- switch the CLAS A4b native self-diff runner to use that policy with `base-only-if-present`
- document the measured G14/C2W impact and the remaining selected-network replacement mismatch

## Impact
The new policy resolves base-bank lookup using the latest code-bias bank effective at `tow - 15 s`. On the 2019 CLAS A4b G14/C2W CLASLIB/native slice, this moves `code_bias_m` from 120/280 mismatches to 112/280 common rows, with mean_abs `0.00857 m -> 0.00800 m` and RMS `0.01309 m -> 0.01265 m`.

The remaining mismatch is now isolated to selected-network replacement materialization: native keeps `0.760 m` through TOW `230454`, while CLASLIB switches to `0.740 m` at `230445`.

## Validation
- `python3 -m pytest tests/test_cli_tools.py -k "compact_code_bias_bank_policy or qzss_l6_info_compact_code_bias_base_only_uses_prior_anchor or compact_bias_row_materialization_selected_satellite_extends_missing_code_bias_rows or clas_ppp_cli_accepts_direct_qzss_l6_code_bias_bank_policy" -q`
- `python3 -m pytest tests/test_clas_a4b_native_selfdiff.py tests/test_cli_ux.py tests/test_experiment_runner.py -q`
- `python3 -m py_compile apps/gnss_qzss_l6_info.py apps/gnss_clas_ppp.py scripts/ci/run_clas_a4b_native_selfdiff.py`
- `GNSSPP_CLAS_A4B_DATA_ROOT=/tmp/claslib/data GNSSPP_CLAS_A4B_AUTO_FETCH=0 python3 scripts/ci/run_clas_a4b_native_selfdiff.py --output-dir /tmp/gnss_code_bias_delay15_native`
- optional CLAS ZD diff against `/tmp/gnss_code_bias_ref_claslib/claslib_osr_zd_export/claslib_osr.normalized.csv`
- `mkdocs build --strict`
- `git diff --check`

Note: a full local `python3 -m pytest tests/test_cli_tools.py -q` run hit an existing environment-dependent MCAP reader assertion unrelated to this change (`mcap reader unavailable` vs `read failed`).
