### PR TITLE
clas refresh delayed code bias rows

### DIFF
--- a/apps/gnss_qzss_l6_info.py
+++ b/apps/gnss_qzss_l6_info.py
@@ -1111,6 +1111,116 @@ def store_base_code_bias_bank_entry(
     bank.setdefault(satellite_token, {})[signal_id] = bias_m
 
 
+def materialize_delayed_code_bias_bank_refresh_rows(
+    *,
+    gps_week: int | None,
+    tow: int,
+    mask_satellites: list[CSSRSatellite],
+    base_rows_by_satellite: dict[str, dict[int, float]],
+    code_bias_bank_policy: str,
+) -> list[CompactSSRCorrection]:
+    if (
+        gps_week is None
+        or code_bias_bank_policy != COMPACT_CODE_BIAS_BANK_POLICY_DELAYED_15S_BANK
+        or not base_rows_by_satellite
+    ):
+        return []
+    refresh_tow = tow + CODE_BIAS_BANK_EFFECTIVE_DELAY_SECONDS
+    rows: list[CompactSSRCorrection] = []
+    for satellite in mask_satellites:
+        code_bias = base_rows_by_satellite.get(satellite.sat)
+        if not code_bias:
+            continue
+        rows.append(
+            CompactSSRCorrection(
+                week=gps_week,
+                tow=float(refresh_tow),
+                system=satellite.system,
+                prn=satellite.prn,
+                dx=0.0,
+                dy=0.0,
+                dz=0.0,
+                dclock_m=0.0,
+                code_bias_m=dict(code_bias),
+            )
+        )
+    return rows
+
+
+def materialize_delayed_code_bias_network_refresh_rows(
+    *,
+    gps_week: int | None,
+    tow: int,
+    state: CSSRDecoderState,
+    mask_satellites: list[CSSRSatellite],
+    selected_satellites: set[str],
+    network_id: int | None,
+    code_bias_composition_policy: str,
+    code_bias_bank_policy: str,
+) -> list[CompactSSRCorrection]:
+    if (
+        gps_week is None
+        or network_id is None
+        or code_bias_bank_policy != COMPACT_CODE_BIAS_BANK_POLICY_DELAYED_15S_BANK
+        or code_bias_composition_policy == COMPACT_CODE_BIAS_COMPOSITION_POLICY_DIRECT
+        or not selected_satellites
+        or not state.pending_code_bias
+    ):
+        return []
+    refresh_tow = tow + CODE_BIAS_BANK_EFFECTIVE_DELAY_SECONDS
+    rows: list[CompactSSRCorrection] = []
+    for satellite in mask_satellites:
+        if satellite.sat not in selected_satellites:
+            continue
+        current_rows = state.pending_code_bias.get(satellite.sat, {})
+        if not current_rows:
+            continue
+        refresh_base_rows = resolve_base_code_bias_rows(
+            state,
+            refresh_tow,
+            satellite.sat,
+            code_bias_bank_policy,
+        )
+        if not refresh_base_rows:
+            continue
+        current_base_rows = resolve_base_code_bias_rows(
+            state,
+            tow,
+            satellite.sat,
+            code_bias_bank_policy,
+        )
+        refresh_code_bias: dict[int, float] = {}
+        for signal_id, current_bias_m in current_rows.items():
+            refresh_base_m = refresh_base_rows.get(signal_id)
+            if refresh_base_m is None:
+                continue
+            if (
+                code_bias_composition_policy == COMPACT_CODE_BIAS_COMPOSITION_POLICY_BASE_PLUS_NETWORK
+                and signal_id in current_base_rows
+            ):
+                network_delta_m = current_bias_m - current_base_rows[signal_id]
+                refresh_code_bias[signal_id] = refresh_base_m + network_delta_m
+            else:
+                refresh_code_bias[signal_id] = refresh_base_m
+        if not refresh_code_bias:
+            continue
+        rows.append(
+            CompactSSRCorrection(
+                week=gps_week,
+                tow=float(refresh_tow),
+                system=satellite.system,
+                prn=satellite.prn,
+                dx=0.0,
+                dy=0.0,
+                dz=0.0,
+                dclock_m=0.0,
+                code_bias_m=refresh_code_bias,
+                bias_network_id=network_id,
+            )
+        )
+    return rows
+
+
 def lookup_base_code_bias_bank_entry(
     state: CSSRDecoderState,
     tow: int,
@@ -2033,6 +2143,7 @@ def decode_cssr_code_bias_message(
     flush_policy: str = COMPACT_SSR_FLUSH_POLICY_LAG_TOLERANT,
     atmos_merge_policy: str = COMPACT_ATMOS_MERGE_POLICY_STEC_COEFF_CARRY,
     code_bias_composition_policy: str = COMPACT_CODE_BIAS_COMPOSITION_POLICY_DIRECT,
+    code_bias_bank_policy: str = COMPACT_CODE_BIAS_BANK_POLICY_PENDING_EPOCH,
 ) -> tuple[CSSRMessage, list[CompactSSRCorrection], int]:
     mask = require_mask_state(state, CSSR_SUBTYPE_CODE_BIAS)
     header, bit_offset = decode_cssr_header(payload, bit_offset, CSSR_SUBTYPE_CODE_BIAS, state)
@@ -2050,6 +2161,7 @@ def decode_cssr_code_bias_message(
     assert state.pending_code_bias is not None
     assert state.pending_base_code_bias is not None
     mapped_count = 0
+    base_rows_by_satellite: dict[str, dict[int, float]] = {}
     for satellite in mask.satellites:
         satellite_biases = state.pending_code_bias.setdefault(satellite.sat, {})
         for signal_slot in satellite.signal_slots:
@@ -2059,6 +2171,7 @@ def decode_cssr_code_bias_message(
                 continue
             satellite_biases[signal_id] = bias_m
             state.pending_base_code_bias.setdefault(satellite.sat, {})[signal_id] = bias_m
+            base_rows_by_satellite.setdefault(satellite.sat, {})[signal_id] = bias_m
             store_base_code_bias_bank_entry(
                 state,
                 int(header["tow"]),
@@ -2070,6 +2183,15 @@ def decode_cssr_code_bias_message(
     corrections: list[CompactSSRCorrection] = []
     if not bool(header["sync"]):
         corrections = flush_pending_corrections(state, gps_week, mask.satellites, flush_policy)
+    corrections.extend(
+        materialize_delayed_code_bias_bank_refresh_rows(
+            gps_week=gps_week,
+            tow=int(header["tow"]),
+            mask_satellites=mask.satellites,
+            base_rows_by_satellite=base_rows_by_satellite,
+            code_bias_bank_policy=code_bias_bank_policy,
+        )
+    )
     state.message_index += 1
     return (
         CSSRMessage(
@@ -2270,8 +2392,19 @@ def decode_cssr_code_phase_bias_message(
             )
 
     corrections: list[CompactSSRCorrection] = []
+    network_refresh_rows = materialize_delayed_code_bias_network_refresh_rows(
+        gps_week=gps_week,
+        tow=int(header["tow"]),
+        state=state,
+        mask_satellites=mask.satellites,
+        selected_satellites=selected_satellites,
+        network_id=network_id if network_bias_correction else None,
+        code_bias_composition_policy=code_bias_composition_policy,
+        code_bias_bank_policy=code_bias_bank_policy,
+    )
     if not bool(header["sync"]):
         corrections = flush_pending_corrections(state, gps_week, mask.satellites, flush_policy)
+    corrections.extend(network_refresh_rows)
     state.message_index += 1
     return (
         CSSRMessage(
@@ -3072,6 +3205,7 @@ def decode_cssr_messages(
                     flush_policy,
                     atmos_merge_policy,
                     code_bias_composition_policy,
+                    code_bias_bank_policy,
                 )
                 corrections.extend(message_corrections)
             elif subtype == CSSR_SUBTYPE_PHASE_BIAS:

--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -319,11 +319,14 @@ to `0.00857 m` and `rms` from `0.01493 m` to `0.01309 m`.  The A4b expansion
 then applies `--compact-code-bias-bank-policy delayed-15s-bank` so code-bias
 base-bank lookup uses the latest bank effective at `tow - 15 s`.  This moves
 the same slice to 112/280 `code_bias_m` mismatches with `mean_abs=0.00800 m`
-and `rms=0.01265 m`.  The remaining code-bias gap is selected network
-replacement materialization: native still keeps `0.760 m` through TOW `230454`
-while CLASLIB switches to `0.740 m` at `230445`.  Treat remaining PRC imbalance
-as an ionosphere/materialization issue rather than tuning residual variance or
-AR.
+and `rms=0.01265 m`.  The A4b L6 expansion also materializes delayed base-bank
+refresh rows for selected subtype-6 network replacements, so the preferred
+network lookup can switch at the same half-window boundary.  This moves the
+same G14/C2W slice to 16/280 `code_bias_m` mismatches with
+`mean_abs=0.00114 m` and `rms=0.00478 m`; aggregate `PRC` moves to
+`mean_abs=0.00879 m` and `rms=0.01481 m`.  The remaining code-bias rows are
+5-second boundary epochs, so treat the next step as lifecycle/materialization
+alignment rather than residual variance or AR tuning.
 The GitHub step summary highlights raw STEC, L1 ionosphere, scaled ionosphere,
 code-bias, trop, L1-from-STEC, L1-STEC closure, scaled-ionosphere closure, PRC
 closure, and atmosphere-reference components, keeping the primary review

--- a/docs/clas_validated_datasets.md
+++ b/docs/clas_validated_datasets.md
@@ -208,7 +208,7 @@ python3 scripts/analysis/claslib_zd_component_export.py \
   --gps-week 2068
 ```
 
-On the 300-epoch 2019 sample smoke, current `develop` produces 5,400 native code
+On the 300-epoch 2019 sample smoke, current `develop` produces 5,350 native code
 rows. The GPS L2W slice has 300 rows, all with exact bias identity and exact
 observation matches, and zero observation-family or code-bias fallback rows.
 Use `base-only-if-present` with the latest preceding base bank for this A4b
@@ -352,10 +352,13 @@ longer applies the `230430` bank to TOW `230426..230429`, and it holds the
 previous bank through the first half of each 30-second bank.  On the CLASLIB
 `.osr` slice this moves G14/C2W `code_bias_m` from `mean_abs=0.00857 m,
 rms=0.01309 m` to `mean_abs=0.00800 m, rms=0.01265 m`, with mismatch count
-moving from 120/280 to 112/280 common rows.  The remaining code-bias mismatch is
-not a future-sample read: selected network replacement rows still keep `0.760 m`
-through TOW `230454` while CLASLIB switches to `0.740 m` at `230445`.  Treat
-that as the next correction-materialization target.  The CLASLIB `.osr`
+moving from 120/280 to 112/280 common rows.  The L6 expansion then emits delayed
+base-bank refresh rows for selected subtype-6 network replacements, moving the
+same G14/C2W slice to 16/280 mismatches with `mean_abs=0.00114 m` and
+`rms=0.00478 m`; aggregate `PRC` moves to `mean_abs=0.00879 m` and
+`rms=0.01481 m`.  The remaining code-bias mismatches are 5-second boundary
+epochs, so the next correction-materialization target is boundary lifecycle
+alignment rather than a broad row or variance change.  The CLASLIB `.osr`
 snapshot summaries also include `claslib_raw_iono_l1_m` and
 `claslib_raw_stec_tecu` numeric stats
 as explicit diagnostics; they are intentionally outside the default native diff

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -5796,11 +5796,126 @@ class CLIToolsTest(unittest.TestCase):
             row_14s = [line for line in delayed_rows if line.startswith("2200,518444.000,G,3")]
             row_15s = [line for line in delayed_rows if line.startswith("2200,518445.000,G,3")]
             self.assertEqual(len(row_14s), 1)
-            self.assertEqual(len(row_15s), 1)
+            self.assertEqual(len(row_15s), 2)
             self.assertIn("cbias:2=-0.080000", row_14s[0])
             self.assertNotIn("cbias:2=0.100000", row_14s[0])
-            self.assertIn("cbias:2=0.100000", row_15s[0])
-            self.assertNotIn("cbias:2=-0.080000", row_15s[0])
+            row_15s_base = [line for line in row_15s if "bias_network_id=" not in line]
+            row_15s_network = [line for line in row_15s if "bias_network_id=" in line]
+            self.assertEqual(len(row_15s_base), 1)
+            self.assertEqual(len(row_15s_network), 1)
+            self.assertIn("cbias:2=0.060000", row_15s_base[0])
+            self.assertIn("cbias:2=0.100000", row_15s_network[0])
+            self.assertNotIn("cbias:2=-0.080000", row_15s_network[0])
+
+    def test_qzss_l6_info_delayed_15s_code_bias_bank_emits_base_refresh_row(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_qzss_l6_code_bias_bank_refresh_") as temp_dir:
+            temp_root = Path(temp_dir)
+            input_path = temp_root / "session_l6_code_bias_bank_refresh.bin"
+            default_path = temp_root / "pending_epoch.csv"
+            delayed_path = temp_root / "delayed_15s.csv"
+            input_path.write_bytes(
+                build_qzss_l6_subframe_stream(
+                    [
+                        build_qzss_cssr_mask_message(tow=518400, iod=3, prn=3, sync=True),
+                        build_qzss_cssr_code_bias_message(
+                            tow_delta=30,
+                            iod=3,
+                            bias_m=0.06,
+                            sync=True,
+                        ),
+                    ]
+                )
+            )
+
+            default_result = self.run_gnss(
+                "qzss-l6-info",
+                "--input",
+                str(input_path),
+                "--extract-compact-corrections",
+                str(default_path),
+                "--gps-week",
+                "2200",
+            )
+            self.assertEqual(default_result.returncode, 0, msg=default_result.stderr)
+            self.assertNotIn("518445.000", default_path.read_text(encoding="ascii"))
+
+            delayed_result = self.run_gnss(
+                "qzss-l6-info",
+                "--input",
+                str(input_path),
+                "--extract-compact-corrections",
+                str(delayed_path),
+                "--gps-week",
+                "2200",
+                "--compact-code-bias-bank-policy",
+                "delayed-15s-bank",
+            )
+            self.assertEqual(delayed_result.returncode, 0, msg=delayed_result.stderr)
+            delayed_rows = delayed_path.read_text(encoding="ascii").splitlines()
+            refresh_rows = [line for line in delayed_rows if line.startswith("2200,518445.000,G,3")]
+            self.assertEqual(len(refresh_rows), 1)
+            self.assertIn("cbias:2=0.060000", refresh_rows[0])
+            self.assertNotIn("bias_network_id=", refresh_rows[0])
+
+    def test_qzss_l6_info_delayed_15s_code_bias_bank_refreshes_network_rows(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_qzss_l6_code_bias_network_refresh_") as temp_dir:
+            temp_root = Path(temp_dir)
+            input_path = temp_root / "session_l6_code_bias_network_refresh.bin"
+            delayed_path = temp_root / "delayed_15s.csv"
+            input_path.write_bytes(
+                build_qzss_l6_subframe_stream(
+                    [
+                        build_qzss_cssr_mask_message(tow=518400, iod=3, prn=3, sync=True),
+                        build_qzss_cssr_code_bias_message(
+                            tow_delta=0,
+                            iod=3,
+                            bias_m=-0.12,
+                            sync=True,
+                        ),
+                        build_qzss_cssr_code_bias_message(
+                            tow_delta=30,
+                            iod=3,
+                            bias_m=0.06,
+                            sync=True,
+                        ),
+                        build_qzss_cssr_code_phase_bias_message(
+                            tow_delta=30,
+                            iod=3,
+                            sync=False,
+                            network_bias=True,
+                            code_bias_exists=False,
+                            phase_bias_exists=True,
+                            selected_mask=0b1,
+                            phase_bias_m=0.02,
+                        ),
+                    ]
+                )
+            )
+
+            delayed_result = self.run_gnss(
+                "qzss-l6-info",
+                "--input",
+                str(input_path),
+                "--extract-compact-corrections",
+                str(delayed_path),
+                "--gps-week",
+                "2200",
+                "--compact-code-bias-composition-policy",
+                "base-only-if-present",
+                "--compact-code-bias-bank-policy",
+                "delayed-15s-bank",
+                "--compact-bias-row-materialization",
+                "selected-satellite-base-extend",
+            )
+            self.assertEqual(delayed_result.returncode, 0, msg=delayed_result.stderr)
+            delayed_rows = delayed_path.read_text(encoding="ascii").splitlines()
+            network_rows = [
+                line
+                for line in delayed_rows
+                if line.startswith("2200,518445.000,G,3") and "bias_network_id=1" in line
+            ]
+            self.assertEqual(len(network_rows), 1)
+            self.assertIn("cbias:2=0.060000", network_rows[0])
 
     def test_qzss_l6_info_compact_code_bias_base_only_uses_prior_anchor(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_qzss_l6_code_bias_base_only_prev_") as temp_dir:


### PR DESCRIPTION
## Summary
- emit delayed base-bank refresh rows for Compact SSR code-bias banks under `delayed-15s-bank`
- emit selected subtype-6 network refresh rows at the same half-window boundary so preferred-network lookup does not keep stale code bias rows
- update A4b documentation with the new G14/C2W CLASLIB diff metrics

## Validation
- `python3 -m py_compile apps/gnss_qzss_l6_info.py apps/gnss_clas_ppp.py scripts/ci/run_clas_a4b_native_selfdiff.py`
- `python3 -m pytest tests/test_cli_tools.py -k "compact_code_bias_bank_policy or code_bias_bank_emits_base_refresh_row or code_bias_bank_refreshes_network_rows or qzss_l6_info_compact_code_bias_base_only_uses_prior_anchor or compact_bias_row_materialization_selected_satellite_extends_missing_code_bias_rows or clas_ppp_cli_accepts_direct_qzss_l6_code_bias_bank_policy" -q`
- `python3 -m pytest tests/test_clas_a4b_native_selfdiff.py tests/test_cli_ux.py tests/test_experiment_runner.py -q`
- `GNSSPP_CLAS_A4B_DATA_ROOT=/tmp/claslib/data GNSSPP_CLAS_A4B_AUTO_FETCH=0 python3 scripts/ci/run_clas_a4b_native_selfdiff.py --output-dir /tmp/gnss_code_bias_refresh_native`
- `GNSSPP_CLAS_ZD_BASE_CSV=/tmp/gnss_code_bias_ref_claslib/claslib_osr_zd_export/claslib_osr.normalized.csv GNSSPP_CLAS_ZD_CANDIDATE_CSV=/tmp/gnss_code_bias_refresh_native/clas_a4b_native_selfdiff/native_code_dump.csv GNSSPP_CLAS_ZD_STAGE=post GNSSPP_CLAS_ZD_ROW_TYPE=code GNSSPP_CLAS_ZD_SAT=G14 GNSSPP_CLAS_ZD_FREQ=1 GNSSPP_CLAS_ZD_RINEX_CODE=C2W GNSSPP_CLAS_ZD_DUPLICATE_POLICY=mean python3 scripts/ci/run_optional_clas_zd_component_diff.py --output-dir /tmp/gnss_code_bias_refresh_diff`
- `mkdocs build --strict`

## A4b metric change
- G14/C2W `code_bias_m`: 112/280 mismatches -> 16/280 mismatches
- `code_bias_m` mean abs/RMS: 0.00800 m / 0.01265 m -> 0.00114 m / 0.00478 m
- `prc_m` mean abs/RMS: 0.01483 m / 0.01919 m -> 0.00879 m / 0.01481 m
