### PR TITLE
fix CLAS code bias boundary selection

### DIFF
--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -1559,7 +1559,7 @@ bool SSRProducts::interpolateCorrection(const SatelliteId& sat,
             selected_network_id = atmos_source->atmos_network_id;
         }
         const auto pickBias = [&](bool phase) {
-            return [&](size_t begin, size_t end) -> const SSROrbitClockCorrection* {
+            return [&, phase](size_t begin, size_t end) -> const SSROrbitClockCorrection* {
                 const SSROrbitClockCorrection* best = nullptr;
                 int best_score = -1;
                 for (size_t index = begin; index < end; ++index) {
@@ -1787,18 +1787,32 @@ bool SSRProducts::interpolateCorrection(const SatelliteId& sat,
         // through older entries to find the most recent bias, matching the
         // CLASLIB behaviour of holding the last received bias indefinitely.
         auto scanBackwardBias = [&](bool phase) -> const SSROrbitClockCorrection* {
-            const SSROrbitClockCorrection* best = nullptr;
-            int best_score = -1;
-            for (auto scan = lower; scan != entries.begin(); ) {
-                --scan;
-                if (std::abs(scan->time - time) > kPreciseInterpolationGapSeconds) break;
-                const int score = biasScore(*scan, phase);
-                if (score > best_score) {
-                    best_score = score;
-                    best = &(*scan);
+            size_t group_end = static_cast<size_t>(lower - entries.begin());
+            while (group_end > 0) {
+                const size_t group_last = group_end - 1;
+                const GNSSTime group_time = entries[group_last].time;
+                if (std::abs(group_time - time) > kPreciseInterpolationGapSeconds) break;
+
+                size_t group_begin = group_last;
+                while (group_begin > 0 && entries[group_begin - 1].time == group_time) {
+                    --group_begin;
                 }
+
+                const SSROrbitClockCorrection* best = nullptr;
+                int best_score = -1;
+                for (size_t index = group_begin; index < group_end; ++index) {
+                    const int score = biasScore(entries[index], phase);
+                    if (score > best_score) {
+                        best_score = score;
+                        best = &entries[index];
+                    }
+                }
+                if (best != nullptr) {
+                    return best;
+                }
+                group_end = group_begin;
             }
-            return best;
+            return nullptr;
         };
         if (code_bias_m != nullptr) {
             // Code biases are stepwise corrections.  Do not consume a future
@@ -1806,10 +1820,10 @@ bool SSRProducts::interpolateCorrection(const SatelliteId& sat,
             // one; CLAS holds the last received code-bias bank until a new
             // bank is causally available.
             const SSROrbitClockCorrection* picked = nullptr;
-            if (before->code_bias_valid && !before->code_bias_m.empty()) {
-                picked = before;
-            } else if (const auto* scanned = scanBackwardBias(false)) {
+            if (const auto* scanned = scanBackwardBias(false)) {
                 picked = scanned;
+            } else if (before->code_bias_valid && !before->code_bias_m.empty()) {
+                picked = before;
             }
             if (picked != nullptr) {
                 *code_bias_m = picked->code_bias_m;

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -1402,6 +1402,97 @@ TEST(PPPTest, SSRProductsDoesNotUseFutureCodeBiasBetweenClockRows) {
     std::filesystem::remove(ssr_path);
 }
 
+TEST(PPPTest, SSRProductsUsesNearestCodeBiasGroupBeforeOlderLargerBank) {
+    const auto ssr_path = tempFilePath("libgnss_ppp_ssr_code_bias_nearest_group_test.csv");
+    std::filesystem::remove(ssr_path);
+
+    const std::string ssr_text =
+        "# week,tow,sat,dx,dy,dz,dclock_m[,cbias:<id>=<m>...][,bias_network_id=<n>][,atmos_<name>=<value>...]\n"
+        "2414,345570.0,G01,0.0,0.0,0.0,0.5,cbias:2=-0.120000,cbias:8=0.050000,bias_network_id=7\n"
+        "2414,345590.0,G01,0.0,0.0,0.0,0.6,cbias:2=0.040000,bias_network_id=7\n"
+        "2414,345590.0,G01,0.0,0.0,0.0,0.6,atmos_network_id=7,atmos_trop_quality=9\n"
+        "2414,345595.0,G01,0.0,0.0,0.0,0.7\n";
+    writeTextFile(ssr_path, ssr_text);
+
+    SSRProducts ssr_products;
+    ASSERT_TRUE(ssr_products.loadCSVFile(ssr_path.string()));
+
+    Vector3d orbit_correction = Vector3d::Zero();
+    double clock_correction_m = 0.0;
+    std::map<uint8_t, double> code_bias_m;
+    SSRCorrectionStatus status;
+    ASSERT_TRUE(ssr_products.interpolateCorrection(
+        SatelliteId(GNSSSystem::GPS, 1),
+        GNSSTime(2414, 345592.0),
+        orbit_correction,
+        clock_correction_m,
+        nullptr,
+        &code_bias_m,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        7,
+        nullptr,
+        nullptr,
+        &status));
+
+    ASSERT_EQ(code_bias_m.size(), 1U);
+    EXPECT_NEAR(code_bias_m.at(2U), 0.04, 1e-12);
+    EXPECT_TRUE(status.code_bias_valid);
+    EXPECT_EQ(status.code_bias_reference_time.week, 2414);
+    EXPECT_NEAR(status.code_bias_reference_time.tow, 345590.0, 1e-12);
+
+    std::filesystem::remove(ssr_path);
+}
+
+TEST(PPPTest, SSRProductsUsesExactCodeBiasNetworkRefreshAtBoundary) {
+    const auto ssr_path = tempFilePath("libgnss_ppp_ssr_code_bias_exact_boundary_test.csv");
+    std::filesystem::remove(ssr_path);
+
+    const std::string ssr_text =
+        "# week,tow,sat,dx,dy,dz,dclock_m[,cbias:<id>=<m>...][,bias_network_id=<n>][,atmos_<name>=<value>...]\n"
+        "2068,230430.000,G14,0.0,0.0,0.0,0.2,cbias:2=0.000000,cbias:9=0.760000,bias_network_id=7\n"
+        "2068,230445.000,G14,0.0,0.0,0.0,0.0,cbias:2=0.000000,cbias:9=0.740000\n"
+        "2068,230445.000,G14,0.0,0.0,0.0,0.0,cbias:2=0.000000,cbias:9=0.740000,bias_network_id=7\n"
+        "2068,230445.000,G14,0.0,0.0,0.0,0.0,atmos_network_id=7,atmos_trop_quality=9\n"
+        "2068,230445.000,G14,0.0,0.0,0.0,0.2\n";
+    writeTextFile(ssr_path, ssr_text);
+
+    SSRProducts ssr_products;
+    ASSERT_TRUE(ssr_products.loadCSVFile(ssr_path.string()));
+
+    Vector3d orbit_correction = Vector3d::Zero();
+    double clock_correction_m = 0.0;
+    std::map<uint8_t, double> code_bias_m;
+    SSRCorrectionStatus status;
+    ASSERT_TRUE(ssr_products.interpolateCorrection(
+        SatelliteId(GNSSSystem::GPS, 14),
+        GNSSTime(2068, 230445.0),
+        orbit_correction,
+        clock_correction_m,
+        nullptr,
+        &code_bias_m,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        7,
+        nullptr,
+        nullptr,
+        &status));
+
+    ASSERT_EQ(code_bias_m.size(), 2U);
+    EXPECT_NEAR(code_bias_m.at(9U), 0.74, 1e-12);
+    EXPECT_TRUE(status.code_bias_valid);
+    EXPECT_EQ(status.code_bias_reference_time.week, 2068);
+    EXPECT_NEAR(status.code_bias_reference_time.tow, 230445.0, 1e-12);
+
+    std::filesystem::remove(ssr_path);
+}
+
 TEST(PPPTest, ProcessorLoadsRtcmSsrCorrectionsFromFile) {
     const auto rtcm_path = tempFilePath("libgnss_ppp_ssr_rtcm_test.rtcm3");
     std::filesystem::remove(rtcm_path);


### PR DESCRIPTION
## Summary
- Fix exact SSR bias picker capture so code/phase selection uses the requested bias kind deterministically.
- Make non-exact code-bias backfill choose the nearest prior time group before scoring rows, so older fuller banks cannot beat newer refresh rows.
- Add SSRProducts regression tests for exact CLAS boundary refreshes and nearest-group code-bias selection.

## Impact
This closes the remaining CLAS A4b G14/C2W code-bias boundary mismatch: `code_bias_m` is now 0.0 RMS/max against the CLASLIB ZD oracle window, while the A4b native selfdiff remains byte-stable.

## Validation
- `cmake --build build --target run_tests -j2`
- `build/tests/run_tests --gtest_filter='PPPTest.SSRProductsLoadCsvParsesOptionalUraCodeBiasPhaseBiasAndAtmosTokens:PPPTest.SSRProductsDoesNotUseFutureCodeBiasBetweenClockRows:PPPTest.SSRProductsUsesNearestCodeBiasGroupBeforeOlderLargerBank:PPPTest.SSRProductsUsesExactCodeBiasNetworkRefreshAtBoundary'`
- `build/tests/run_tests`
- `python3 -m pytest tests/test_clas_a4b_native_selfdiff.py tests/test_cli_ux.py tests/test_experiment_runner.py -q`
- `GNSSPP_CLAS_A4B_DATA_ROOT=/tmp/claslib/data GNSSPP_CLAS_A4B_AUTO_FETCH=0 python3 scripts/ci/run_clas_a4b_native_selfdiff.py --output-dir /tmp/gnss_code_bias_boundary_capture_native`
- `python3 scripts/ci/run_optional_clas_zd_component_diff.py ... --output-dir /tmp/gnss_code_bias_boundary_capture_diff`

## Measured CLAS A4b Effect
- G14/C2W `code_bias_m`: mean/RMS/max all `0.0 m` over 280 common rows.
- G14/C2W `code_bias_m` mismatch rows: `16/280 -> 0/280`.
- G14/C2W `prc_m` RMS: `0.0148074706 m -> 0.0139457489 m`.
- Native selfdiff: 300 common rows, max delta `0.0 m`.
