### PR TITLE
clas materialize network compensation in code dumps

### DIFF
--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -365,3 +365,25 @@ CLASLIB rows, while adding base plus network leaves the same rows near
 `+0.06 m`. The base-only policy removes that 30-second sign flip without
 changing default CLAS behavior, and the delayed bank policy matches CLASLIB's
 first-half hold before the next selected-network replacement rows are handled.
+
+## A4b: network_compensation_m materialization (plumbing) and SIS-window finding
+
+Native now wires the applied SIS continuity delta into the `network_compensation_m`
+dump column, which was a `0.0` stub.  On the reference dataset the column remains
+`0.0` and the dump/`.pos` output stay byte-identical, because instrumentation
+proved the 30-second phase-bias-lag apply window never matches on real data:
+the phase-bias lag cycles `0..25 s` on real CLAS updates, so the `abs(pbias_lag
+- 30) < 0.5` gate is unreachable by construction.  In other words, native
+currently never applies the SIS delta, while CLASLIB applies `compN` at SSR
+update boundaries (G14/C2W: 135/280 nonzero rows, `rms=0.0526 m`,
+`max=0.219 m`).
+
+Because the CLASLIB exporter reconstructs ionosphere from PRC closure,
+CLASLIB's SIS subtraction currently surfaces inside the stec/iono diff columns
+instead of a dedicated component (`stec_tecu rms=0.0527 m` is close to the
+`compN rms=0.0526 m` above), so the residual stec/iono mismatch reported by the
+A4b diff is largely misattributed `compN`.  Closing that gap is deferred to a
+follow-up slice that applies the SIS delta with boundary semantics (lag ≈ 0,
+matching CLASLIB's `adjust_prc`/`adjust_cpc`); that slice changes PRC/solution
+output and requires full #161 sign-off.  This commit only adds the dump
+plumbing it will rely on.

--- a/include/libgnss++/algorithms/ppp_osr_types.hpp
+++ b/include/libgnss++/algorithms/ppp_osr_types.hpp
@@ -28,6 +28,7 @@ struct OSRCorrection {
     double PRC[OSR_MAX_FREQ] = {};
     double CPC[OSR_MAX_FREQ] = {};
     double phase_compensation_m[OSR_MAX_FREQ] = {};
+    double network_compensation_m = 0.0;
     double orbit_projection_m = 0.0;
     double clock_correction_m = 0.0;
 

--- a/src/algorithms/ppp_clas.cpp
+++ b/src/algorithms/ppp_clas.cpp
@@ -424,7 +424,7 @@ void dumpClasCodeRows(
                   << osr.stec_tecu << ','
                   << iono_scaled << ','
                   << osr.code_bias_m[f] << ','
-                  << 0.0 << ','
+                  << osr.network_compensation_m << ','
                   << osr.receiver_antenna_m[f] << ','
                   << osr.relativity_correction_m << ','
                   << timeWeekField(osr.atmos_reference_time, have_atmos_ref) << ','

--- a/src/algorithms/ppp_osr.cpp
+++ b/src/algorithms/ppp_osr.cpp
@@ -1318,6 +1318,7 @@ std::vector<OSRCorrection> computeOSR(
                 if (std::abs(pbias_lag - kPhaseBiasLagSeconds) < 0.5) {
                     osr.CPC[f] -= sis_continuity_info.last_delta_m;
                     osr.PRC[f] -= sis_continuity_info.last_delta_m;
+                    osr.network_compensation_m = sis_continuity_info.last_delta_m;
                     if (pppDebugEnabled() && f == 0) {
                         std::cerr << "[OSR-SIS] " << sat.toString()
                                   << " lag_s=" << pbias_lag

--- a/tests/test_ppp_osr.cpp
+++ b/tests/test_ppp_osr.cpp
@@ -66,6 +66,146 @@ Observation makeGpsL2Observation(
     return obs;
 }
 
+Observation makeGpsObservation(
+    const SatelliteId& satellite,
+    SignalType signal,
+    const char* pseudorange_code,
+    const char* carrier_code,
+    double pseudorange,
+    double carrier_phase) {
+    Observation obs(satellite, signal);
+    obs.valid = true;
+    obs.has_pseudorange = true;
+    obs.has_carrier_phase = true;
+    obs.pseudorange_observation_type = pseudorange_code;
+    obs.carrier_phase_observation_type = carrier_code;
+    obs.pseudorange = pseudorange;
+    obs.carrier_phase = carrier_phase;
+    return obs;
+}
+
+Ephemeris makeNetworkCompensationGpsEphemeris(
+    const SatelliteId& satellite,
+    const GNSSTime& toe) {
+    Ephemeris eph;
+    eph.satellite = satellite;
+    eph.week = static_cast<uint16_t>(toe.week);
+    eph.toe = toe;
+    eph.toc = toe;
+    eph.tof = toe;
+    eph.toes = toe.tow;
+    eph.sqrt_a = 5153.79548931;
+    eph.e = 0.0123456789;
+    eph.i0 = 0.9599310886;
+    eph.omega0 = 1.2345678901;
+    eph.omega = -0.9876543210;
+    eph.m0 = 0.4567890123;
+    eph.delta_n = 4.56789e-09;
+    eph.idot = -2.34567e-10;
+    eph.i_dot = eph.idot;
+    eph.omega_dot = -8.76543e-09;
+    eph.cuc = -1.234567e-06;
+    eph.cus = 2.345678e-06;
+    eph.crc = 245.25;
+    eph.crs = -88.75;
+    eph.cic = 8.765432e-08;
+    eph.cis = -7.654321e-08;
+    eph.af0 = 2.345678e-04;
+    eph.af1 = -4.567890e-12;
+    eph.af2 = 0.0;
+    eph.tgd = -1.2345678e-08;
+    eph.ura = 2;
+    eph.sv_accuracy = 4.85;
+    eph.health = 0;
+    eph.sv_health = 0.0;
+    eph.iode = 77;
+    eph.iodc = 301;
+    eph.valid = true;
+    return eph;
+}
+
+Vector3d receiverPositionUnderSatellite(
+    const NavigationData& nav,
+    const SatelliteId& satellite,
+    const GNSSTime& time) {
+    Vector3d sat_pos = Vector3d::Zero();
+    Vector3d sat_vel = Vector3d::Zero();
+    double sat_clk = 0.0;
+    double sat_drift = 0.0;
+    EXPECT_TRUE(nav.calculateSatelliteState(satellite, time, sat_pos, sat_vel, sat_clk, sat_drift));
+    return sat_pos.normalized() * 6378137.0;
+}
+
+ObservationData makeNetworkCompensationObservation(
+    const SatelliteId& satellite,
+    const GNSSTime& time) {
+    ObservationData obs(time);
+    obs.addObservation(makeGpsObservation(
+        satellite, SignalType::GPS_L1CA, "C1C", "L1C", 24000000.0, 100000.0));
+    obs.addObservation(makeGpsObservation(
+        satellite, SignalType::GPS_L2C, "C2W", "L2W", 24000006.0, 100010.0));
+    return obs;
+}
+
+SSROrbitClockCorrection makeClockAtmosCorrection(
+    const SatelliteId& satellite,
+    const GNSSTime& time,
+    double clock_correction_m) {
+    SSROrbitClockCorrection correction;
+    correction.satellite = satellite;
+    correction.time = time;
+    correction.clock_correction_m = clock_correction_m;
+    correction.clock_valid = true;
+    correction.atmos_valid = true;
+    correction.atmos_network_id = 1;
+    correction.atmos_tokens = {
+        {"atmos_network_id", "1"},
+        {"atmos_trop_t00_m", "2.4"},
+        {"atmos_stec_c00_tecu:" + satellite.toString(), "10.0"},
+    };
+    return correction;
+}
+
+SSROrbitClockCorrection makePhaseBiasCorrection(
+    const SatelliteId& satellite,
+    const GNSSTime& time) {
+    SSROrbitClockCorrection correction;
+    correction.satellite = satellite;
+    correction.time = time;
+    correction.phase_bias_valid = true;
+    correction.phase_bias_m = {
+        {2U, 0.10},
+        {8U, 0.20},
+        {9U, 0.20},
+    };
+    return correction;
+}
+
+std::vector<OSRCorrection> computeNetworkCompensationOsr(
+    const ObservationData& obs,
+    const NavigationData& nav,
+    const SSRProducts& ssr,
+    const Vector3d& receiver_position,
+    const ppp_shared::PPPConfig& config,
+    std::map<SatelliteId, CLASSisContinuityInfo>& sis_continuity,
+    std::map<SatelliteId, CLASPhaseBiasRepairInfo>& phase_bias_repair) {
+    std::map<SatelliteId, double> prev_windup;
+    std::map<SatelliteId, CLASDispersionCompensationInfo> dispersion_compensation;
+    return computeOSR(
+        obs,
+        nav,
+        ssr,
+        {},
+        receiver_position,
+        0.0,
+        2.3,
+        config,
+        prev_windup,
+        dispersion_compensation,
+        sis_continuity,
+        phase_bias_repair);
+}
+
 }  // namespace
 
 TEST(PPPOSRTest, GridFirstPrefersNearestGridEvenWhenStale) {
@@ -536,4 +676,104 @@ TEST(PPPOSRTest, ClockBoundAtmosAndPhaseBiasPolicyGuardsBothTimingLayers) {
     EXPECT_STREQ(
         clasSsrTimingPolicyName(Policy::CLOCK_BOUND_ATMOS_AND_PHASE_BIAS),
         "clock-bound-atmos-and-phase-bias");
+}
+
+TEST(PPPOSRTest, NetworkCompensationMaterializesOnlyWhenSisContinuityApplied) {
+    const SatelliteId satellite(GNSSSystem::GPS, 1);
+    const GNSSTime t0(2068, 230430.0);
+    const GNSSTime t1 = t0 + 5.0;
+    const GNSSTime t2 = t1 + 5.0;
+
+    NavigationData nav;
+    nav.addEphemeris(makeNetworkCompensationGpsEphemeris(satellite, t0 - 30.0));
+    const Vector3d receiver_position =
+        receiverPositionUnderSatellite(nav, satellite, t0);
+
+    SSRProducts ssr;
+    ssr.addCorrection(makePhaseBiasCorrection(satellite, t0 - 30.0));
+    ssr.addCorrection(makePhaseBiasCorrection(satellite, t1 - 30.0));
+    ssr.addCorrection(makeClockAtmosCorrection(satellite, t0, 1.25));
+    ssr.addCorrection(makeClockAtmosCorrection(satellite, t1, 0.75));
+    ssr.addCorrection(makeClockAtmosCorrection(satellite, t2, 0.60));
+
+    ppp_shared::PPPConfig config;
+    config.clas_phase_continuity_policy =
+        ppp_shared::PPPConfig::ClasPhaseContinuityPolicy::FULL_REPAIR;
+
+    std::map<SatelliteId, CLASSisContinuityInfo> sis_continuity;
+    std::map<SatelliteId, CLASPhaseBiasRepairInfo> phase_bias_repair;
+    ASSERT_EQ(
+        computeNetworkCompensationOsr(
+            makeNetworkCompensationObservation(satellite, t0),
+            nav,
+            ssr,
+            receiver_position,
+            config,
+            sis_continuity,
+            phase_bias_repair).size(),
+        1U);
+
+    const auto boundary_osr = computeNetworkCompensationOsr(
+        makeNetworkCompensationObservation(satellite, t1),
+        nav,
+        ssr,
+        receiver_position,
+        config,
+        sis_continuity,
+        phase_bias_repair);
+    ASSERT_EQ(boundary_osr.size(), 1U);
+    EXPECT_NEAR(boundary_osr.front().network_compensation_m, 0.5, 1e-12);
+    ASSERT_GE(boundary_osr.front().num_frequencies, 2);
+    EXPECT_NEAR(
+        boundary_osr.front().PRC[0],
+        boundary_osr.front().trop_correction_m +
+            boundary_osr.front().relativity_correction_m +
+            boundary_osr.front().receiver_antenna_m[0] +
+            boundary_osr.front().iono_l1_m +
+            boundary_osr.front().code_bias_m[0] -
+            boundary_osr.front().network_compensation_m,
+        1e-12);
+    EXPECT_NEAR(boundary_osr.front().network_compensation_m, 0.5, 1e-12);
+
+    const auto off_boundary_osr = computeNetworkCompensationOsr(
+        makeNetworkCompensationObservation(satellite, t2),
+        nav,
+        ssr,
+        receiver_position,
+        config,
+        sis_continuity,
+        phase_bias_repair);
+    ASSERT_EQ(off_boundary_osr.size(), 1U);
+    EXPECT_DOUBLE_EQ(off_boundary_osr.front().network_compensation_m, 0.0);
+
+    const ppp_shared::PPPConfig::ClasPhaseContinuityPolicy sis_disabled_policies[] = {
+        ppp_shared::PPPConfig::ClasPhaseContinuityPolicy::REPAIR_ONLY,
+        ppp_shared::PPPConfig::ClasPhaseContinuityPolicy::RAW_PHASE_BIAS,
+        ppp_shared::PPPConfig::ClasPhaseContinuityPolicy::NO_PHASE_BIAS,
+    };
+    for (const auto policy : sis_disabled_policies) {
+        config.clas_phase_continuity_policy = policy;
+        sis_continuity.clear();
+        phase_bias_repair.clear();
+        ASSERT_EQ(
+            computeNetworkCompensationOsr(
+                makeNetworkCompensationObservation(satellite, t0),
+                nav,
+                ssr,
+                receiver_position,
+                config,
+                sis_continuity,
+                phase_bias_repair).size(),
+            1U);
+        const auto sis_disabled_osr = computeNetworkCompensationOsr(
+            makeNetworkCompensationObservation(satellite, t1),
+            nav,
+            ssr,
+            receiver_position,
+            config,
+            sis_continuity,
+            phase_bias_repair);
+        ASSERT_EQ(sis_disabled_osr.size(), 1U);
+        EXPECT_DOUBLE_EQ(sis_disabled_osr.front().network_compensation_m, 0.0);
+    }
 }


### PR DESCRIPTION
## Summary
A4b slice: wire the applied SIS continuity delta into the `network_compensation_m` CLAS code-dump column (was a `0.0` stub since #274). **Plumbing only — verified no-op on the reference dataset** (dump and `.pos` byte-identical), plus the investigation finding that defines the follow-up model slice.

## Changes
- `OSRCorrection::network_compensation_m` field (ppp_osr_types.hpp)
- One-line assignment inside the SIS-continuity apply branch (ppp_osr.cpp) — positive sign, matching CLASLIB's `compN=+sis` dump convention while `PRC -= sis`
- Dump stub `0.0` → field (ppp_clas.cpp)
- gtest `NetworkCompensationMaterializesOnlyWhenSisContinuityApplied`: populated when the SIS subtraction fires; stays `0.0` off-boundary and for REPAIR_ONLY / RAW_PHASE_BIAS / NO_PHASE_BIAS policies
- docs/clas_dd_filter_a5.md: findings section

## Finding (why the column stays 0.0 on the reference dataset)
Env-gated probe counters (`GNSS_PPP_CLAS_SIS_PROBE` instrumentation, removed before commit) over the A4b selfdiff run:
`policy_uses_sis=2675/2675, clock_dt_5s=449/449, has_last_delta=2236, lag_30s=0, applied=0` with `lag_hist 0s=531 5s=445 10s=15 15s=445 20s=441 25s=359`.
The 30 s phase-bias-lag apply window `abs(pbias_lag-30)<0.5` is **unreachable by construction** on real CLAS data: phase-bias updates every 30 s reset the lag cycle 0→25 s before it reaches 30. Native therefore never applies the SIS delta, while CLASLIB applies `compN` at SSR update boundaries (G14/C2W probe: 135/280 nonzero rows, RMS 0.0526 m, max 0.219 m). The unit test fires the path only because its synthetic fixture places the phase bias exactly 30 s older than the clock epoch.

Secondary: the CLASLIB exporter reconstructs iono from PRC closure, so CLASLIB's SIS subtraction surfaces in the stec/iono diff columns (`stec_tecu` RMS 0.0527 ≈ `compN` RMS 0.0526) — the residual stec/iono mismatch is largely misattributed `compN`.

**Follow-up slice (separate PR, changes PRC/solution, full #161 sign-off):** apply the SIS delta with boundary semantics (lag ≈ 0, matching CLASLIB `adjust_prc`/`adjust_cpc`), then re-measure the stec/iono attribution. This PR provides the dump plumbing it relies on.

## Validation
- Full gtests: 337 passed / 0 failed / 43 skipped (normal full-suite skip count)
- A4b native selfdiff: passed
- Native code dump byte-identical pre/post: md5 `61faeccafb63cfebe101357c3cb3163d`
- Standard CLAS `.pos` byte-identical pre/post: md5 `e63f4d63357abed86fd4fd5b58208f07`
- G14/C2W component diff vs CLASLIB oracle: `prc_m` RMS unchanged at 0.0139457489 m (PR #273 value), `code_bias_m` still 0.0
- `mkdocs build --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)