### PR TITLE
clas apply sis continuity at update boundaries behind env gate

### DIFF
--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -387,3 +387,95 @@ follow-up slice that applies the SIS delta with boundary semantics (lag ≈ 0,
 matching CLASLIB's `adjust_prc`/`adjust_cpc`); that slice changes PRC/solution
 output and requires full #161 sign-off.  This commit only adds the dump
 plumbing it will rely on.
+
+## A4b: SIS-boundary apply behind `GNSS_PPP_CLAS_SIS_BOUNDARY` (gated)
+
+### Pinned boundary rule
+
+Correlating the 135 nonzero `network_compensation_m` (`compN`) rows for the
+G14/C2W probe against `tow` in the CLASLIB oracle CSV shows a clean,
+consistent rule across all 9 SSR update cycles in the 300s reference window:
+`compN` is nonzero and **constant** for observation epochs with
+`tow % 30` in `[0, 14]` (the first half of each 30s SSR update cycle) and
+exactly `0.0` for `tow % 30` in `[15, 29]` (the second half). Every nonzero
+segment starts precisely at a `tow % 30 == 0` boundary and runs for exactly
+15 consecutive 1 Hz epochs, e.g. `[230430, 230444]`, `[230460, 230474]`,
+... `[230670, 230684]`; the held value equals the SIS delta computed at the
+5s-consecutive clock-reference-time transition that crosses the 30s orbit
+boundary (`current_sis_m(offset0) - previous_sis_m(offset25)`, matching
+`updateSisContinuity()`'s existing formula) and does **not** change again
+until the next boundary.
+
+Two subtleties surfaced while pinning the rule against the actual native
+harness (`scripts/ci/run_clas_a4b_native_selfdiff.py`, which decodes CLAS L6
+live rather than reading a pre-expanded CSV):
+
+- Native's `clock_reference_time` reaches a new 30s-aligned value a few
+  seconds *before* the observation epoch with the same `tow` is processed
+  (e.g. `clock_reference_time.tow == 230430` first appears at observation
+  `tow == 230426`). CLASLIB's own dumped `compN` window has no such lead, so
+  the boundary *capture* and the 15s hold window are both anchored to the
+  **observation epoch** (`obs.time`), not to `clock_reference_time` — see
+  `captureClasSisBoundary()` in `src/algorithms/ppp_osr.cpp`.
+- Real CLAS data has brief (multi-epoch) `clock_reference_time` gaps
+  (`clock_time_valid == false`) that can fall *inside* a 15s hold window.
+  CLASLIB's held `satcorr[].currsis` outlives such gaps, so the held
+  `boundary_delta_m` is explicitly preserved across a `clock_time_valid`
+  reset in `updateSisContinuity()`, and `computeClasSisApplyDecision()`'s
+  gated branch no longer requires `clock_time_valid` for the *current*
+  epoch. With both fixes the native gate-ON window position, duration, and
+  held-value-constancy match the CLASLIB oracle exactly for all 9 cycles in
+  the reference window.
+
+### Implementation
+
+`GNSS_PPP_CLAS_SIS_BOUNDARY=1` (exact-`"1"`, `envExactOne`-style, default
+off) switches the apply branch in `ppp_osr.cpp` from the legacy
+(real-data-unreachable) 30s phase-bias-lag condition to the boundary rule
+above: `osr.CPC[f]`/`osr.PRC[f]` are decremented by, and
+`osr.network_compensation_m` is set to, the delta captured by
+`captureClasSisBoundary()`, applied by `computeClasSisApplyDecision()`. The
+decision logic is factored into small, directly gtest-covered pure functions
+(`isSsrOrbitBoundaryTow`, `captureClasSisBoundary`,
+`computeClasSisApplyDecision`, plus the preservation behavior in
+`updateSisContinuity`) because `PPPEnvOverrides` is memoized per-process, so
+toggling `GNSS_PPP_CLAS_SIS_BOUNDARY` mid-gtest-binary is not reliable;
+env-integration itself is exercised through the CLI harness scripts, matching
+the existing convention for other `GNSS_PPP_CLAS_*` gates. Gate-off output
+(dump/`.pos`) is unaffected: the legacy branch is untouched, and the new
+boundary-tracking fields on `CLASSisContinuityInfo` are only written when the
+gate is on.
+
+### Measured effect (gate-ON, not yet default)
+
+Gate-OFF bit-exactness is preserved: the A4b native selfdiff dump md5
+(`61faeccafb63cfebe101357c3cb3163d`) and the standard CLAS `.pos` md5
+(`e63f4d63357abed86fd4fd5b58208f07`) are both unchanged.
+
+With the gate on, the G14/C2W `compN` window now lines up with the
+regenerated CLASLIB oracle exactly (same 9 boundary-aligned 15-row segments),
+but the **held delta magnitude** does not: `network_compensation_m` RMS moves
+from `0.0526 m` (gate-off, native always `0.0`) to `0.132 m` (gate-on) against
+the regenerated oracle — worse, not better. Root cause is a pre-existing,
+separate defect: the raw CLAS-expanded SSR product carries a spurious/
+differently-scoped orbit-correction record at the mid-cycle (`tow % 30 == 25`)
+sample that native's `orbit_projection_m` picks up (e.g. `dx=-0.2512,
+dy=-0.832` versus the neighboring `dx≈-0.31, dy≈+0.70` records), while
+CLASLIB's own `orbit_projection_m` stays flat across the same window. This
+inflates the boundary-crossing SIS delta computed by the existing (unchanged)
+`updateSisContinuity()` formula; it is unrelated to, and predates, the
+boundary-gating logic in this change, which the window-alignment result
+above shows is otherwise correct. Fixing it is out of scope here and is
+deferred to a follow-up slice on the SSR compact-message orbit-record
+selection.
+
+Position-level impact (full 3600-epoch standard CLAS run, `.pos` vs the
+CLASLIB same-epoch oracle, row-index-matched at 1 Hz since this `.pos` format
+does not populate `GPS_TOW`) is roughly neutral: fixed-epoch count drops
+slightly (270 → 259), fixed-only mean/p95/max 3D error each improve slightly
+(`1.584 m` → `1.437 m` mean, `5.018 m` → `4.981 m` p95, `5.028 m` → `4.999 m`
+max), and all-epoch mean is unchanged (`1.549 m`) with a lower max
+(`39.796 m` → `34.318 m`). Given the diagnosed root cause and the mixed
+position signal, the default stays off pending the orbit-record-selection
+fix; `GNSS_PPP_CLAS_SIS_BOUNDARY` remains available for further
+investigation.

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -175,6 +175,14 @@ struct PPPEnvOverrides {
     // scaffold when set exactly to "1". Default false; exact "0" and unset are
     // no-ops for bit-exact legacy CLAS/MADOCA output.
     bool clas_dd_filter = false;
+    // GNSS_PPP_CLAS_SIS_BOUNDARY: apply the CLAS SIS continuity delta with
+    // CLASLIB-style SSR-update-boundary semantics (hold the delta captured at
+    // a 30s orbit/clock boundary for the following 15s, matching the
+    // CLASLIB adjust_prc/adjust_cpc boundary window) when set exactly to
+    // "1", replacing the (unreachable on real CLAS data) 30s phase-bias-lag
+    // condition for the gated path. Default false; exact "0" and unset are
+    // no-ops for bit-exact legacy CLAS output.
+    bool clas_sis_boundary = false;
     // GNSS_PPP_CLAS_AMB_DATUM: align CLAS OSR carrier phase ambiguity states
     // with CLASLIB by subtracting the full CPC before ambiguity estimation.
     // Default follows the residual-phase-trop surface; explicit boolean values

--- a/include/libgnss++/algorithms/ppp_osr.hpp
+++ b/include/libgnss++/algorithms/ppp_osr.hpp
@@ -48,6 +48,55 @@ GNSSTime selectClasPhaseBiasReferenceTime(
 bool usesClasSisContinuity(
     ppp_shared::PPPConfig::ClasPhaseContinuityPolicy policy);
 
+/// Update SIS (Signal-In-Space) continuity tracking for a satellite: detects
+/// clock reference time transitions and computes `last_delta_m` for SIS
+/// correction. When `clock_time_valid` is false, resets `info` EXCEPT for
+/// the CLASLIB-style boundary-held fields (`boundary_time`,
+/// `boundary_delta_m`, `has_boundary_delta`), which survive transient
+/// per-epoch SSR gaps so a brief gap inside the 15s hold window (observed on
+/// real CLAS data) does not drop an already-captured boundary delta.
+void updateSisContinuity(
+    CLASSisContinuityInfo& info,
+    const OSRCorrection& osr,
+    bool clock_time_valid);
+
+/// True when `tow` sits on (within tolerance of) the 30s CLASLIB SSR orbit
+/// update boundary grid (tow % 30 in [0, 0.5) or (29.5, 30)).
+bool isSsrOrbitBoundaryTow(double tow);
+
+/// Capture the CLASLIB-style SSR-update-boundary SIS delta (gated feature):
+/// when `epoch_time` (the current observation epoch) lands on the 30s
+/// boundary grid and `info` already holds a fresh boundary-aligned
+/// clock-reference-time delta, freeze it into `info.boundary_delta_m` /
+/// `info.boundary_time` for the following 15s of observation epochs. A
+/// no-op otherwise (including when `info` has no delta yet, or the epoch is
+/// off the 30s grid).
+void captureClasSisBoundary(
+    CLASSisContinuityInfo& info,
+    const GNSSTime& epoch_time);
+
+/// Result of deciding whether/how much CLAS SIS continuity delta to apply
+/// to a CPC/PRC row for the current epoch.
+struct ClasSisApplyDecision {
+    bool applied = false;
+    double delta_m = 0.0;
+};
+
+/// Decide whether to apply the CLAS SIS continuity delta this epoch, and
+/// which value to use. When `sis_boundary_gate_enabled` is false, reproduces
+/// the legacy (real-data-unreachable) 30s phase-bias-lag condition
+/// byte-for-byte (using `clock_reference_time`). When true, uses
+/// CLASLIB-style SSR-update-boundary semantics: the delta captured by
+/// captureClasSisBoundary() at the most recent 30s orbit/clock boundary,
+/// held for the following 15s of observation epochs (`epoch_time`).
+ClasSisApplyDecision computeClasSisApplyDecision(
+    const CLASSisContinuityInfo& info,
+    const GNSSTime& epoch_time,
+    const GNSSTime& clock_reference_time,
+    const GNSSTime& effective_phase_bias_reference_time,
+    bool clock_time_valid,
+    bool sis_boundary_gate_enabled);
+
 bool usesClasPhaseBiasRepair(
     ppp_shared::PPPConfig::ClasPhaseContinuityPolicy policy);
 

--- a/include/libgnss++/algorithms/ppp_osr_types.hpp
+++ b/include/libgnss++/algorithms/ppp_osr_types.hpp
@@ -102,6 +102,13 @@ struct CLASSisContinuityInfo {
     bool has_current = false;
     bool has_previous = false;
     bool has_last_delta = false;
+    // SSR-update-boundary (CLASLIB-style) tracking: the SIS delta captured at
+    // the most recent 30s orbit/clock update boundary, held fixed until the
+    // next boundary. Only populated when GNSS_PPP_CLAS_SIS_BOUNDARY is set;
+    // consumed by the gated apply path in ppp_osr.cpp.
+    GNSSTime boundary_time;
+    double boundary_delta_m = 0.0;
+    bool has_boundary_delta = false;
 };
 
 struct CLASEpochContext {

--- a/scripts/analysis/claslib_zd_component_export.py
+++ b/scripts/analysis/claslib_zd_component_export.py
@@ -507,6 +507,23 @@ def claslib_grid_provenance(
     return fields
 
 
+def osrres_network_compensation(row: dict[str, str]) -> Optional[float]:
+    comp_n = parse_osr_float(first_present(row, ("compN", "network_compensation_m")))
+    if comp_n is None:
+        return None
+    return comp_n
+
+
+# CLASLIB's adjust_prc/adjust_cpc (ephemeris.c) subtract the SIS continuity
+# delta directly from PRC/CPC at SSR update boundaries (`prc -= sis`), while
+# dumping the applied delta as compN = +sis (see osrres_network_compensation
+# above and GNSS_PPP_CLAS_SIS_BOUNDARY in src/algorithms/ppp_osr.cpp). The
+# PRC-closure iono reconstruction below must add compN back before backing
+# out trop/antr/relativity/cbias, otherwise the sis residual leaks into the
+# reconstructed iono_l1_m/stec_tecu columns (observed as a ~0.0527m RMS
+# artifact tracking compN almost exactly). Missing compN (older dumps
+# without the column) defaults to 0.0, matching the zero-unless-boundary
+# semantics of the delta itself.
 def prc_iono_scaled_from_osrres(row: dict[str, str], suffix: str) -> Optional[float]:
     prc = parse_osr_float(first_present(row, (f"PRC{suffix}",)))
     trop = parse_osr_float(first_present(row, ("trop", "trop_m")))
@@ -517,14 +534,8 @@ def prc_iono_scaled_from_osrres(row: dict[str, str], suffix: str) -> Optional[fl
     )
     if prc is None or trop is None or cbias is None or antr is None or relativity is None:
         return None
-    return prc - (trop + antr + relativity + cbias)
-
-
-def osrres_network_compensation(row: dict[str, str]) -> Optional[float]:
-    comp_n = parse_osr_float(first_present(row, ("compN", "network_compensation_m")))
-    if comp_n is None:
-        return None
-    return comp_n
+    comp_n = osrres_network_compensation(row) or 0.0
+    return prc - (trop + antr + relativity + cbias) + comp_n
 
 
 def prc_iono_l1_from_osrres(row: dict[str, str], suffix: str) -> str:

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -191,6 +191,8 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
         envExactOne("GNSS_PPP_CLAS_RESAMB");
     overrides.clas_dd_filter =
         envExactOne("GNSS_PPP_CLAS_DD_FILTER");
+    overrides.clas_sis_boundary =
+        envExactOne("GNSS_PPP_CLAS_SIS_BOUNDARY");
     overrides.clas_amb_datum_residual_phase_trop =
         !envExactZero("GNSS_PPP_CLAS_AMB_DATUM_RESIDUAL_PHASE_TROP");
     overrides.clas_amb_datum =

--- a/src/algorithms/ppp_osr.cpp
+++ b/src/algorithms/ppp_osr.cpp
@@ -407,36 +407,16 @@ constexpr double kPhaseBiasLagSeconds = 30.0;
 constexpr double kPhaseBiasJumpLowerCycles = 95.0;
 constexpr double kPhaseBiasJumpUpperCycles = 105.0;
 constexpr double kPhaseBiasJumpCorrectionCycles = 100.0;
-
-/// Update SIS (Signal-In-Space) continuity tracking for a satellite.
-/// Detects clock epoch transitions and computes delta for SIS correction.
-void updateSisContinuity(
-    CLASSisContinuityInfo& info,
-    const OSRCorrection& osr,
-    bool clock_time_valid) {
-    const double current_sis_m = -osr.clock_correction_m + osr.orbit_projection_m;
-    if (!clock_time_valid) {
-        info = CLASSisContinuityInfo{};
-    } else if (!info.has_current) {
-        info.current_time = osr.clock_reference_time;
-        info.current_sis_m = current_sis_m;
-        info.has_current = true;
-    } else if (info.current_time != osr.clock_reference_time) {
-        const double dt_clock = osr.clock_reference_time - info.current_time;
-        info.previous_time = info.current_time;
-        info.previous_sis_m = info.current_sis_m;
-        info.current_time = osr.clock_reference_time;
-        info.current_sis_m = current_sis_m;
-        info.has_previous = true;
-        if (std::abs(dt_clock - kSsrClockIntervalSeconds) < 0.5) {
-            info.last_delta_m = info.current_sis_m - info.previous_sis_m;
-            info.has_last_delta = true;
-        } else {
-            info.last_delta_m = 0.0;
-            info.has_last_delta = false;
-        }
-    }
-}
+// CLASLIB SSR update boundary cadence: orbit/clock corrections realign on a
+// 30s grid (see ephemeris.c satpos_ssr_sis prevtow/currtow bookkeeping).
+constexpr double kSsrOrbitBoundaryIntervalSeconds = 30.0;
+// Tolerance (seconds) for detecting that a clock reference time sits on the
+// 30s orbit boundary grid.
+constexpr double kSsrOrbitBoundaryToleranceSeconds = 0.5;
+// CLASLIB holds the boundary-captured SIS delta for the first half of the
+// 30s orbit cycle (observed empirically: nonzero for tow%30 in [0,14],
+// zero for tow%30 in [15,29]; see docs/clas_dd_filter_a5.md).
+constexpr double kSsrOrbitBoundaryApplyWindowSeconds = 15.0;
 
 /// Detect phase bias epoch change and update repair tracking state.
 /// Returns {epoch_changed, phase_bias_dt} for use in PRC/CPC aggregation.
@@ -582,6 +562,127 @@ bool usesClasSisContinuity(
                ppp_shared::PPPConfig::ClasPhaseContinuityPolicy::FULL_REPAIR ||
            policy ==
                ppp_shared::PPPConfig::ClasPhaseContinuityPolicy::SIS_CONTINUITY_ONLY;
+}
+
+void updateSisContinuity(
+    CLASSisContinuityInfo& info,
+    const OSRCorrection& osr,
+    bool clock_time_valid) {
+    const double current_sis_m = -osr.clock_correction_m + osr.orbit_projection_m;
+    if (!clock_time_valid) {
+        // Preserve the CLASLIB-style boundary-held delta (gated feature)
+        // across transient clock-reference-time gaps: CLASLIB's satcorr[]
+        // state (currtow/currsis) is keyed to message reception and outlives
+        // a few epochs of missing per-epoch SSR data, so a brief gap inside
+        // the 15s hold window (observed on real CLAS data) must not drop the
+        // already-captured boundary delta. The rest of the continuity state
+        // (current/previous SIS samples, last_delta_m) legitimately resets,
+        // matching pre-existing (gate-OFF) behavior.
+        const GNSSTime preserved_boundary_time = info.boundary_time;
+        const double preserved_boundary_delta_m = info.boundary_delta_m;
+        const bool preserved_has_boundary_delta = info.has_boundary_delta;
+        info = CLASSisContinuityInfo{};
+        info.boundary_time = preserved_boundary_time;
+        info.boundary_delta_m = preserved_boundary_delta_m;
+        info.has_boundary_delta = preserved_has_boundary_delta;
+    } else if (!info.has_current) {
+        info.current_time = osr.clock_reference_time;
+        info.current_sis_m = current_sis_m;
+        info.has_current = true;
+    } else if (info.current_time != osr.clock_reference_time) {
+        const double dt_clock = osr.clock_reference_time - info.current_time;
+        info.previous_time = info.current_time;
+        info.previous_sis_m = info.current_sis_m;
+        info.current_time = osr.clock_reference_time;
+        info.current_sis_m = current_sis_m;
+        info.has_previous = true;
+        if (std::abs(dt_clock - kSsrClockIntervalSeconds) < 0.5) {
+            info.last_delta_m = info.current_sis_m - info.previous_sis_m;
+            info.has_last_delta = true;
+        } else {
+            info.last_delta_m = 0.0;
+            info.has_last_delta = false;
+        }
+    }
+}
+
+bool isSsrOrbitBoundaryTow(double tow) {
+    double remainder = std::fmod(tow, kSsrOrbitBoundaryIntervalSeconds);
+    if (remainder < 0.0) {
+        remainder += kSsrOrbitBoundaryIntervalSeconds;
+    }
+    return remainder < kSsrOrbitBoundaryToleranceSeconds ||
+        remainder > (kSsrOrbitBoundaryIntervalSeconds -
+                      kSsrOrbitBoundaryToleranceSeconds);
+}
+
+void captureClasSisBoundary(
+    CLASSisContinuityInfo& info,
+    const GNSSTime& epoch_time) {
+    // CLASLIB only refreshes its held "currsis" value (satcorr[].currtow /
+    // currsis) at the 30s orbit boundary transition, freezing it until the
+    // next boundary; the CLASLIB oracle's dumped compN window is aligned to
+    // the *observation* epoch tow (tow % 30 == 0), not to the (few-second-
+    // early-available) internal SSR clock reference time. Anchor both the
+    // capture trigger and the held boundary_time on `epoch_time` (the
+    // current observation epoch) so the held window lines up with CLASLIB's
+    // per-obs-epoch dump; the delta VALUE still comes from the
+    // clock-reference-time-driven SIS math in updateSisContinuity().
+    if (!info.has_last_delta || !isSsrOrbitBoundaryTow(epoch_time.tow) ||
+        !isSsrOrbitBoundaryTow(info.current_time.tow)) {
+        return;
+    }
+    info.boundary_time = epoch_time;
+    info.boundary_delta_m = info.last_delta_m;
+    info.has_boundary_delta = true;
+}
+
+ClasSisApplyDecision computeClasSisApplyDecision(
+    const CLASSisContinuityInfo& info,
+    const GNSSTime& epoch_time,
+    const GNSSTime& clock_reference_time,
+    const GNSSTime& effective_phase_bias_reference_time,
+    bool clock_time_valid,
+    bool sis_boundary_gate_enabled) {
+    ClasSisApplyDecision decision;
+    if (sis_boundary_gate_enabled) {
+        // GATED path: CLASLIB-style SSR-update-boundary semantics. The delta
+        // captured at the most recent 30s orbit/clock boundary (see
+        // captureClasSisBoundary()) is held and applied for the following
+        // 15s of observation epochs (empirically pinned against the CLASLIB
+        // oracle; see docs/clas_dd_filter_a5.md), then zeroed until the next
+        // boundary. This replaces the (unreachable on real CLAS data) 30s
+        // phase-bias-lag condition used below when the gate is off.
+        //
+        // Deliberately independent of `clock_time_valid`/`has_last_delta`
+        // for *this* epoch: CLASLIB's held satcorr[] state outlives
+        // transient per-epoch SSR gaps inside the hold window (observed on
+        // real CLAS data), and captureClasSisBoundary()/updateSisContinuity()
+        // already preserve `boundary_delta_m` across such gaps.
+        if (!info.has_boundary_delta) {
+            return decision;
+        }
+        const double dt_since_boundary = epoch_time - info.boundary_time;
+        if (dt_since_boundary > -kSsrOrbitBoundaryToleranceSeconds &&
+            dt_since_boundary <
+                (kSsrOrbitBoundaryApplyWindowSeconds -
+                 kSsrOrbitBoundaryToleranceSeconds)) {
+            decision.applied = true;
+            decision.delta_m = info.boundary_delta_m;
+        }
+        return decision;
+    }
+    if (!clock_time_valid || !gnsstimeIsSet(effective_phase_bias_reference_time) ||
+        !info.has_last_delta) {
+        return decision;
+    }
+    const double pbias_lag =
+        clock_reference_time - effective_phase_bias_reference_time;
+    if (std::abs(pbias_lag - kPhaseBiasLagSeconds) < 0.5) {
+        decision.applied = true;
+        decision.delta_m = info.last_delta_m;
+    }
+    return decision;
 }
 
 bool usesClasPhaseBiasRepair(
@@ -1273,6 +1374,9 @@ std::vector<OSRCorrection> computeOSR(
             config.clas_phase_continuity_policy;
         const bool clock_time_valid = gnsstimeIsSet(osr.clock_reference_time);
         updateSisContinuity(sis_continuity_info, osr, clock_time_valid);
+        if (pppEnvOverrides().clas_sis_boundary) {
+            captureClasSisBoundary(sis_continuity_info, obs.time);
+        }
         const GNSSTime effective_phase_bias_reference_time =
             selectClasPhaseBiasReferenceTime(
                 config.clas_phase_bias_reference_time_policy,
@@ -1310,19 +1414,25 @@ std::vector<OSRCorrection> computeOSR(
                        + phase_bias_term + osr.windup_m[f]
                        + phase_compensation_term;
 
-            if (clock_time_valid && gnsstimeIsSet(effective_phase_bias_reference_time) &&
-                sis_continuity_info.has_last_delta &&
-                usesClasSisContinuity(phase_continuity_policy)) {
-                const double pbias_lag =
-                    osr.clock_reference_time - effective_phase_bias_reference_time;
-                if (std::abs(pbias_lag - kPhaseBiasLagSeconds) < 0.5) {
-                    osr.CPC[f] -= sis_continuity_info.last_delta_m;
-                    osr.PRC[f] -= sis_continuity_info.last_delta_m;
-                    osr.network_compensation_m = sis_continuity_info.last_delta_m;
+            if (usesClasSisContinuity(phase_continuity_policy)) {
+                const bool sis_boundary_gate_enabled =
+                    pppEnvOverrides().clas_sis_boundary;
+                const auto sis_decision = computeClasSisApplyDecision(
+                    sis_continuity_info,
+                    obs.time,
+                    osr.clock_reference_time,
+                    effective_phase_bias_reference_time,
+                    clock_time_valid,
+                    sis_boundary_gate_enabled);
+                if (sis_decision.applied) {
+                    osr.CPC[f] -= sis_decision.delta_m;
+                    osr.PRC[f] -= sis_decision.delta_m;
+                    osr.network_compensation_m = sis_decision.delta_m;
                     if (pppDebugEnabled() && f == 0) {
-                        std::cerr << "[OSR-SIS] " << sat.toString()
-                                  << " lag_s=" << pbias_lag
-                                  << " sis_delta_m=" << sis_continuity_info.last_delta_m
+                        std::cerr << (sis_boundary_gate_enabled ?
+                                          "[OSR-SIS-BOUNDARY] " : "[OSR-SIS] ")
+                                  << sat.toString()
+                                  << " sis_delta_m=" << sis_decision.delta_m
                                   << " ref_policy="
                                   << clasPhaseBiasReferenceTimePolicyName(
                                          config.clas_phase_bias_reference_time_policy)

--- a/tests/test_claslib_zd_component_export.py
+++ b/tests/test_claslib_zd_component_export.py
@@ -385,11 +385,17 @@ class ClaslibZdComponentExportTest(unittest.TestCase):
             )
             self.assertEqual(code_l1c["network_compensation_m"], "-0.052")
             self.assertEqual(code_l2w["network_compensation_m"], "-0.052")
-            self.assertAlmostEqual(float(code_l1c["iono_scaled_m"]), -0.359)
-            self.assertAlmostEqual(float(code_l2w["iono_scaled_m"]), -0.625)
+            # CLASLIB's adjust_prc subtracts the SIS continuity delta from PRC
+            # (prc -= sis) while dumping compN = +sis, so the PRC-closure
+            # iono reconstruction must add compN back: -0.359 + (-0.052) and
+            # -0.625 + (-0.052) (see prc_iono_scaled_from_osrres). Without
+            # this the sis residual leaks into iono_scaled_m/iono_l1_m/
+            # stec_tecu.
+            self.assertAlmostEqual(float(code_l1c["iono_scaled_m"]), -0.411)
+            self.assertAlmostEqual(float(code_l2w["iono_scaled_m"]), -0.677)
             self.assertAlmostEqual(
                 float(code_l2w["iono_l1_m"]),
-                -0.625 / export.GPS_IONO_SCALE_BY_SUFFIX["2"],
+                -0.677 / export.GPS_IONO_SCALE_BY_SUFFIX["2"],
             )
 
     def test_claslib_osrres_requires_gps_week(self) -> None:

--- a/tests/test_ppp_osr.cpp
+++ b/tests/test_ppp_osr.cpp
@@ -777,3 +777,169 @@ TEST(PPPOSRTest, NetworkCompensationMaterializesOnlyWhenSisContinuityApplied) {
         EXPECT_DOUBLE_EQ(sis_disabled_osr.front().network_compensation_m, 0.0);
     }
 }
+
+TEST(PPPOSRTest, UpdateSisContinuityPreservesBoundaryDeltaAcrossClockInvalidGap) {
+    CLASSisContinuityInfo info;
+    info.has_boundary_delta = true;
+    info.boundary_time = GNSSTime(2068, 230430.0);
+    info.boundary_delta_m = -0.052;
+    // Seed "live" continuity state that SHOULD be wiped by the gap.
+    info.has_current = true;
+    info.has_previous = true;
+    info.has_last_delta = true;
+    info.current_time = GNSSTime(2068, 230435.0);
+    info.previous_time = GNSSTime(2068, 230430.0);
+    info.current_sis_m = 1.0;
+    info.previous_sis_m = 0.5;
+    info.last_delta_m = 0.5;
+
+    OSRCorrection osr;  // orbit/clock fields irrelevant when clock_time_valid=false
+    updateSisContinuity(info, osr, /*clock_time_valid=*/false);
+
+    // The CLASLIB-style boundary-held delta survives a transient
+    // clock-reference-time gap (real CLAS data has these mid-window).
+    EXPECT_TRUE(info.has_boundary_delta);
+    EXPECT_EQ(info.boundary_time, GNSSTime(2068, 230430.0));
+    EXPECT_DOUBLE_EQ(info.boundary_delta_m, -0.052);
+
+    // Everything else resets, matching pre-existing (gate-OFF) behavior.
+    EXPECT_FALSE(info.has_current);
+    EXPECT_FALSE(info.has_previous);
+    EXPECT_FALSE(info.has_last_delta);
+    EXPECT_DOUBLE_EQ(info.last_delta_m, 0.0);
+}
+
+TEST(PPPOSRTest, IsSsrOrbitBoundaryTowMatchesClaslibThirtySecondGrid) {
+    // Boundary instants (tow % 30 == 0) are on the grid.
+    EXPECT_TRUE(isSsrOrbitBoundaryTow(230430.0));
+    EXPECT_TRUE(isSsrOrbitBoundaryTow(230460.0));
+    EXPECT_TRUE(isSsrOrbitBoundaryTow(0.0));
+    // Values within tolerance of the grid still count.
+    EXPECT_TRUE(isSsrOrbitBoundaryTow(230430.2));
+    EXPECT_TRUE(isSsrOrbitBoundaryTow(230429.8));
+    // Mid-cycle clock ticks (5, 10, 15, 20, 25 offset) are off the grid.
+    EXPECT_FALSE(isSsrOrbitBoundaryTow(230435.0));
+    EXPECT_FALSE(isSsrOrbitBoundaryTow(230440.0));
+    EXPECT_FALSE(isSsrOrbitBoundaryTow(230445.0));
+    EXPECT_FALSE(isSsrOrbitBoundaryTow(230450.0));
+    EXPECT_FALSE(isSsrOrbitBoundaryTow(230455.0));
+}
+
+TEST(PPPOSRTest, ClasSisApplyDecisionGateOffReproducesLegacyLagWindowCondition) {
+    const GNSSTime clock_ref(2068, 230430.0);
+
+    CLASSisContinuityInfo info;
+    info.has_last_delta = true;
+    info.last_delta_m = 0.42;
+
+    // Legacy behavior: applies only when clock_reference_time leads
+    // effective_phase_bias_reference_time by exactly ~30s (unreachable on
+    // real CLAS data, but must remain byte-identical for gate-OFF callers).
+    // epoch_time is unused on the gate-OFF path; pass clock_ref for it too.
+    const GNSSTime pbias_ref_30s_lag = clock_ref - 30.0;
+    const auto applied = computeClasSisApplyDecision(
+        info, clock_ref, clock_ref, pbias_ref_30s_lag, /*clock_time_valid=*/true,
+        /*sis_boundary_gate_enabled=*/false);
+    EXPECT_TRUE(applied.applied);
+    EXPECT_DOUBLE_EQ(applied.delta_m, 0.42);
+
+    const GNSSTime pbias_ref_synced = clock_ref;
+    const auto not_applied = computeClasSisApplyDecision(
+        info, clock_ref, clock_ref, pbias_ref_synced, /*clock_time_valid=*/true,
+        /*sis_boundary_gate_enabled=*/false);
+    EXPECT_FALSE(not_applied.applied);
+    EXPECT_DOUBLE_EQ(not_applied.delta_m, 0.0);
+
+    // Boundary-delta state must never leak into the gate-OFF decision, even
+    // when populated (e.g. a caller that also runs the gated code path).
+    info.has_boundary_delta = true;
+    info.boundary_time = clock_ref;
+    info.boundary_delta_m = 99.0;
+    const auto still_legacy = computeClasSisApplyDecision(
+        info, clock_ref, clock_ref, pbias_ref_30s_lag, /*clock_time_valid=*/true,
+        /*sis_boundary_gate_enabled=*/false);
+    EXPECT_TRUE(still_legacy.applied);
+    EXPECT_DOUBLE_EQ(still_legacy.delta_m, 0.42);
+}
+
+TEST(PPPOSRTest, CaptureClasSisBoundaryOnlyFreezesOnObsEpochThirtySecondGrid) {
+    const GNSSTime off_boundary_clock_ref(2068, 230430.0);
+
+    // A transition whose clock_reference_time is NOT on the 30s grid (e.g. a
+    // stray mid-cycle recompute) must never be captured, even if the epoch
+    // happens to be on the grid.
+    CLASSisContinuityInfo info_off_grid;
+    info_off_grid.has_last_delta = true;
+    info_off_grid.last_delta_m = 0.111;
+    info_off_grid.current_time = GNSSTime(2068, 230435.0);  // mid-cycle, not 30-aligned
+    captureClasSisBoundary(info_off_grid, off_boundary_clock_ref);
+    EXPECT_FALSE(info_off_grid.has_boundary_delta);
+
+    // A grid-aligned clock_reference_time delta, observed on an off-grid
+    // epoch (the "early availability" case from real CLAS data, where
+    // clock_reference_time reaches the boundary a few seconds before the
+    // observation epoch tow does): not captured yet.
+    CLASSisContinuityInfo info_early;
+    info_early.has_last_delta = true;
+    info_early.last_delta_m = 0.131951;
+    info_early.current_time = GNSSTime(2068, 230430.0);  // on the grid
+    captureClasSisBoundary(info_early, GNSSTime(2068, 230426.0));  // epoch off-grid
+    EXPECT_FALSE(info_early.has_boundary_delta);
+
+    // Once the observation epoch itself reaches the 30s grid (with the same
+    // still-held clock_reference_time delta), the boundary is captured and
+    // anchored to the epoch time (not the earlier clock_reference_time).
+    captureClasSisBoundary(info_early, GNSSTime(2068, 230430.0));
+    ASSERT_TRUE(info_early.has_boundary_delta);
+    EXPECT_DOUBLE_EQ(info_early.boundary_delta_m, 0.131951);
+    EXPECT_EQ(info_early.boundary_time, GNSSTime(2068, 230430.0));
+
+    // No last_delta_m yet: never captures.
+    CLASSisContinuityInfo info_no_delta;
+    captureClasSisBoundary(info_no_delta, GNSSTime(2068, 230430.0));
+    EXPECT_FALSE(info_no_delta.has_boundary_delta);
+}
+
+TEST(PPPOSRTest, ClasSisApplyDecisionGateOnHoldsBoundaryDeltaForFifteenObsSeconds) {
+    const GNSSTime boundary_time(2068, 230430.0);
+    const GNSSTime phase_bias_ref = boundary_time;  // synced; irrelevant when gated.
+    const GNSSTime clock_ref = boundary_time;  // irrelevant when gated.
+
+    CLASSisContinuityInfo info;
+    info.has_last_delta = true;
+    info.last_delta_m = 0.111;  // stale per-5s value; must NOT be applied when gated.
+    info.has_boundary_delta = true;
+    info.boundary_time = boundary_time;
+    info.boundary_delta_m = -0.052;
+
+    // Observation epoch offsets 0..14s after the boundary: held delta
+    // applies, unchanged (matches the CLASLIB oracle's 15-row window).
+    for (const double offset : {0.0, 5.0, 10.0, 14.0}) {
+        const GNSSTime epoch_time = boundary_time + offset;
+        const auto decision = computeClasSisApplyDecision(
+            info, epoch_time, clock_ref, phase_bias_ref, /*clock_time_valid=*/true,
+            /*sis_boundary_gate_enabled=*/true);
+        EXPECT_TRUE(decision.applied) << "offset=" << offset;
+        EXPECT_DOUBLE_EQ(decision.delta_m, -0.052) << "offset=" << offset;
+    }
+
+    // Observation epoch offsets 15..29s after the boundary: zero (second
+    // half of the 30s orbit cycle), matching the CLASLIB oracle windowing.
+    for (const double offset : {15.0, 20.0, 25.0, 29.0}) {
+        const GNSSTime epoch_time = boundary_time + offset;
+        const auto decision = computeClasSisApplyDecision(
+            info, epoch_time, clock_ref, phase_bias_ref, /*clock_time_valid=*/true,
+            /*sis_boundary_gate_enabled=*/true);
+        EXPECT_FALSE(decision.applied) << "offset=" << offset;
+        EXPECT_DOUBLE_EQ(decision.delta_m, 0.0) << "offset=" << offset;
+    }
+
+    // No boundary captured yet: never applies even inside the window.
+    CLASSisContinuityInfo no_boundary;
+    no_boundary.has_last_delta = true;
+    no_boundary.last_delta_m = 0.111;
+    const auto decision_no_boundary = computeClasSisApplyDecision(
+        no_boundary, boundary_time, clock_ref, phase_bias_ref, /*clock_time_valid=*/true,
+        /*sis_boundary_gate_enabled=*/true);
+    EXPECT_FALSE(decision_no_boundary.applied);
+}


### PR DESCRIPTION
## Summary
A4b model slice, **gated + default OFF** (`GNSS_PPP_CLAS_SIS_BOUNDARY`, envExactOne style): applies the CLAS SIS continuity delta with SSR-update-boundary semantics matching CLASLIB `adjust_prc`/`adjust_cpc`, replacing the structurally unreachable 30 s phase-bias-lag window (see #275 findings) on the gated path. Second commit fixes the CLASLIB ZD exporter attribution (compN leaked into reconstructed stec/iono via PRC closure).

Stacked on #275 (needs its dump plumbing).

## Pinned boundary rule (empirical, verified against CLASLIB's own dumped orbit/clock)
- compN is nonzero and held constant for obs epochs `tow % 30 ∈ [0,14]`, exactly 0.0 for `[15,29]`; every segment starts at `tow % 30 == 0` and runs 15 epochs (9×15 = 135 rows on the G14/C2W probe, matching the oracle exactly).
- Held value = `sis(new cycle offset 0) − sis(prior cycle offset 25)`, `sis = −clock + orbit_projection` — the existing `updateSisContinuity()` formula.
- Two real-data subtleties handled: native's `clock_reference_time` reaches the 30 s boundary ~4 s before the matching obs epoch (capture/hold anchored to `obs.time`), and transient `clock_time_valid` gaps inside the 15 s hold window (boundary state preserved across the reset).

## Gate-ON result and why default stays OFF
- **Window/timing: exact.** Native nonzero tows == CLASLIB nonzero tows for all 9 segments in the reference window.
- **Magnitude: blocked by a separate pre-existing defect.** compN diff RMS 0.0526 → 0.132 m because the L6 expander writes ST11 (`flg_net=1`) network-scoped orbit deltas (arriving at `tow%30==25`) into the flat CSV as if they were base ST2 orbit refreshes; CLASLIB banks network orbit separately and its OSR projection uses the base bank only. Fix is a follow-up solution-changing slice (branch `clas-st11-network-orbit`, in progress).
- Gate-ON #161 (3600-epoch standard run vs CLASLIB same-epoch oracle): fixed 270→259, fixed-only 3D mean 1.584→1.437 m, all-epoch 3D mean flat 1.549 m — not sign-off-ready until the ST11 fix lands.

## Exporter attribution fix (2nd commit)
`network_compensation_m` added to the PRC-closure inputs in `claslib_zd_component_export.py`; reconstructed stec/iono no longer carry the sis residue (previously `stec_tecu` diff RMS 0.0527 ≈ compN RMS 0.0526; now iono_scaled RMS 0.0515 in both gate states, fully decoupled). Fixture assertions updated accordingly.

## Validation
- Gate-OFF bit-exact: standard `.pos` md5 `e63f4d63357abed86fd4fd5b58208f07` and selfdiff dump md5 `61faeccafb63cfebe101357c3cb3163d` unchanged (independently re-verified at HEAD)
- gtests: 342 passed / 0 failed / 43 skipped (5 new tests for boundary detection, capture/hold, gate-off legacy-condition equivalence, clock-gap preservation)
- pytest (4 CLAS suites): 46 passed
- `mkdocs build --strict` clean
- Full report: /tmp/gnss_sis_boundary_report.md (boundary-rule evidence, component tables, #161 tables)

🤖 Generated with [Claude Code](https://claude.com/claude-code)