### PR TITLE
clas suppress st11 network orbit and close sis boundary compN

### DIFF
--- a/apps/gnss_clas_ppp.py
+++ b/apps/gnss_clas_ppp.py
@@ -364,6 +364,7 @@ def expand_compact_ssr_text(text: str, output_path: Path) -> dict[str, object]:
             dz = float(columns[6])
             dclock_m = float(columns[7])
             high_rate_clock_m = 0.0
+            clock_network_id = 0
             ura_sigma_token = None
             code_bias_tokens: list[str] = []
             phase_bias_tokens: list[str] = []
@@ -373,6 +374,13 @@ def expand_compact_ssr_text(text: str, output_path: Path) -> dict[str, object]:
             if extras and "=" not in extras[0] and not extras[0].startswith("cbias:"):
                 high_rate_clock_m = float(extras[0])
                 extras = extras[1:]
+            if extras and "=" not in extras[0] and not extras[0].startswith("cbias:"):
+                try:
+                    clock_network_id = int(extras[0])
+                except ValueError:
+                    pass
+                else:
+                    extras = extras[1:]
             for token in extras:
                 if token.startswith("ura_sigma_m="):
                     ura_sigma_token = token
@@ -407,6 +415,8 @@ def expand_compact_ssr_text(text: str, output_path: Path) -> dict[str, object]:
             ]
             if ura_sigma_token is not None:
                 output_tokens.append(ura_sigma_token)
+            if clock_network_id != 0:
+                output_tokens.append(f"clock_network_id={clock_network_id}")
             output_tokens.extend(code_bias_tokens)
             output_tokens.extend(phase_bias_tokens)
             output_tokens.extend(bias_network_tokens)

--- a/apps/gnss_qzss_l6_info.py
+++ b/apps/gnss_qzss_l6_info.py
@@ -396,6 +396,7 @@ class CompactSSRCorrection:
     dz: float
     dclock_m: float
     high_rate_clock_m: float = 0.0
+    clock_network_id: int = 0
     ura_sigma_m: float | None = None
     code_bias_m: dict[int, float] | None = None
     phase_bias_m: dict[int, float] | None = None
@@ -440,6 +441,8 @@ class CSSRDecoderState:
     message_index: int = 0
     pending_orbit: dict[str, tuple[float, float, float]] | None = None
     pending_clock: dict[str, float] | None = None
+    pending_base_clock: dict[str, float] | None = None
+    pending_clock_network: dict[str, int] | None = None
     pending_tow: int | None = None
     pending_iod: int | None = None
     pending_udi_seconds: float | None = None
@@ -1017,6 +1020,8 @@ def update_pending_lifecycle_atmos(
 def reset_pending_corrections(state: CSSRDecoderState) -> None:
     state.pending_orbit = None
     state.pending_clock = None
+    state.pending_base_clock = None
+    state.pending_clock_network = None
     state.pending_tow = None
     state.pending_iod = None
     state.pending_udi_seconds = None
@@ -1889,6 +1894,8 @@ def ensure_pending_epoch(
     state.pending_udi_seconds = udi_seconds
     state.pending_orbit = {}
     state.pending_clock = {}
+    state.pending_base_clock = {}
+    state.pending_clock_network = {}
     state.pending_ura = {}
     state.pending_code_bias = {}
     state.pending_base_code_bias = {}
@@ -1910,6 +1917,8 @@ def flush_pending_corrections(
         return []
     orbit_map = state.pending_orbit or {}
     clock_map = state.pending_clock or {}
+    base_clock_map = state.pending_base_clock or {}
+    clock_network_map = state.pending_clock_network or {}
     ura_map = state.pending_ura or {}
     code_bias_map = state.pending_code_bias or {}
     phase_bias_map = state.pending_phase_bias or {}
@@ -1958,33 +1967,68 @@ def flush_pending_corrections(
         if satellite is None:
             continue
         dx, dy, dz = orbit_map.get(sat_token, (0.0, 0.0, 0.0))
-        dclock_m = clock_map.get(sat_token, 0.0)
+        merged_dclock_m = clock_map.get(sat_token, 0.0)
+        base_dclock_m = base_clock_map.get(sat_token)
+        clock_network_id = clock_network_map.get(sat_token, 0)
         code_bias = code_bias_map.get(sat_token, {})
         phase_bias = phase_bias_map.get(sat_token, {})
+        shared_fields = dict(
+            week=gps_week,
+            tow=float(state.pending_tow),
+            system=satellite.system,
+            prn=satellite.prn,
+            ura_sigma_m=ura_map.get(sat_token),
+            code_bias_m=dict(code_bias) if code_bias else None,
+            phase_bias_m=dict(phase_bias) if phase_bias else None,
+            bias_network_id=state.pending_bias_network_id,
+            atmos_network_id=int(atmos["atmos_network_id"]) if "atmos_network_id" in atmos else None,
+            atmos_trop_avail=int(atmos["atmos_trop_avail"]) if "atmos_trop_avail" in atmos else None,
+            atmos_stec_avail=int(atmos["atmos_stec_avail"]) if "atmos_stec_avail" in atmos else None,
+            atmos_grid_count=int(atmos["atmos_grid_count"]) if "atmos_grid_count" in atmos else None,
+            atmos_selected_satellites=(
+                int(atmos["atmos_selected_satellites"])
+                if "atmos_selected_satellites" in atmos
+                else None
+            ),
+            atmos_tokens=dict(atmos) if atmos else None,
+        )
+        if (
+            clock_network_id == 1
+            and base_dclock_m is not None
+            and abs(base_dclock_m - merged_dclock_m) > 1e-12
+        ):
+            rows.append(
+                CompactSSRCorrection(
+                    **shared_fields,
+                    dx=dx,
+                    dy=dy,
+                    dz=dz,
+                    dclock_m=base_dclock_m,
+                    clock_network_id=0,
+                )
+            )
+            rows.append(
+                CompactSSRCorrection(
+                    week=gps_week,
+                    tow=float(state.pending_tow),
+                    system=satellite.system,
+                    prn=satellite.prn,
+                    dx=0.0,
+                    dy=0.0,
+                    dz=0.0,
+                    dclock_m=merged_dclock_m,
+                    clock_network_id=1,
+                )
+            )
+            continue
         rows.append(
             CompactSSRCorrection(
-                week=gps_week,
-                tow=float(state.pending_tow),
-                system=satellite.system,
-                prn=satellite.prn,
+                **shared_fields,
                 dx=dx,
                 dy=dy,
                 dz=dz,
-                dclock_m=dclock_m,
-                ura_sigma_m=ura_map.get(sat_token),
-                code_bias_m=dict(code_bias) if code_bias else None,
-                phase_bias_m=dict(phase_bias) if phase_bias else None,
-                bias_network_id=state.pending_bias_network_id,
-                atmos_network_id=int(atmos["atmos_network_id"]) if "atmos_network_id" in atmos else None,
-                atmos_trop_avail=int(atmos["atmos_trop_avail"]) if "atmos_trop_avail" in atmos else None,
-                atmos_stec_avail=int(atmos["atmos_stec_avail"]) if "atmos_stec_avail" in atmos else None,
-                atmos_grid_count=int(atmos["atmos_grid_count"]) if "atmos_grid_count" in atmos else None,
-                atmos_selected_satellites=(
-                    int(atmos["atmos_selected_satellites"])
-                    if "atmos_selected_satellites" in atmos
-                    else None
-                ),
-                atmos_tokens=dict(atmos) if atmos else None,
+                dclock_m=merged_dclock_m,
+                clock_network_id=clock_network_id,
             )
         )
     for atmos_tokens in lifecycle_atmos_rows:
@@ -2111,6 +2155,8 @@ def decode_cssr_clock_message(
     for satellite in mask.satellites:
         dclock_m, bit_offset = decode_scaled_signed(payload, bit_offset, 15, 0.0016)
         state.pending_clock[satellite.sat] = dclock_m
+        state.pending_base_clock[satellite.sat] = dclock_m
+        state.pending_clock_network[satellite.sat] = 0
     corrections: list[CompactSSRCorrection] = []
     if not bool(header["sync"]):
         corrections = flush_pending_corrections(state, gps_week, mask.satellites, flush_policy)
@@ -2929,10 +2975,14 @@ def decode_cssr_combined_message(
         # should refresh pending_orbit for the expanded SSR product.
         if not flg_net:
             state.pending_orbit[satellite.sat] = (dx, dy, dz)
-        # CLASLIB keeps network clock in a separate bank; only base-clock samples
-        # should refresh pending_clock for the expanded SSR product.
-        if flg_clock and not flg_net:
-            state.pending_clock[satellite.sat] = dclock_m
+        if flg_clock:
+            if not flg_net:
+                state.pending_clock[satellite.sat] = dclock_m
+                state.pending_base_clock[satellite.sat] = dclock_m
+                state.pending_clock_network[satellite.sat] = 0
+            else:
+                state.pending_clock[satellite.sat] = dclock_m
+                state.pending_clock_network[satellite.sat] = 1
     corrections: list[CompactSSRCorrection] = []
     if not bool(header["sync"]):
         corrections = flush_pending_corrections(state, gps_week, mask.satellites, flush_policy)
@@ -3364,7 +3414,9 @@ def write_compact_corrections(path: Path, corrections: list[CompactSSRCorrection
     path.parent.mkdir(parents=True, exist_ok=True)
     with path.open("w", encoding="ascii", newline="") as handle:
         handle.write(
-            "# week,tow,system,prn,dx,dy,dz,dclock_m,high_rate_clock_m[,ura_sigma_m=<m>][,cbias:<id>=<m>...][,pbias:<id>=<m>...][,bias_network_id=<n>][,atmos_<name>=<value>...]\n"
+            "# week,tow,system,prn,dx,dy,dz,dclock_m,high_rate_clock_m,clock_network_id"
+            "[,ura_sigma_m=<m>][,cbias:<id>=<m>...][,pbias:<id>=<m>...]"
+            "[,bias_network_id=<n>][,atmos_<name>=<value>...]\n"
         )
         writer = csv.writer(handle)
         for correction in corrections:
@@ -3378,6 +3430,7 @@ def write_compact_corrections(path: Path, corrections: list[CompactSSRCorrection
                 f"{correction.dz:.6f}",
                 f"{correction.dclock_m:.6f}",
                 f"{correction.high_rate_clock_m:.6f}",
+                correction.clock_network_id,
             ]
             if correction.ura_sigma_m is not None:
                 row.append(f"ura_sigma_m={correction.ura_sigma_m:.6f}")

--- a/apps/gnss_qzss_l6_info.py
+++ b/apps/gnss_qzss_l6_info.py
@@ -2925,8 +2925,14 @@ def decode_cssr_combined_message(
             dclock_m, bit_offset = decode_scaled_signed(payload, bit_offset, 15, 0.0016)
         else:
             dclock_m = 0.0
-        state.pending_orbit[satellite.sat] = (dx, dy, dz)
-        state.pending_clock[satellite.sat] = dclock_m
+        # CLASLIB keeps network orbit in a separate bank; only base-orbit samples
+        # should refresh pending_orbit for the expanded SSR product.
+        if not flg_net:
+            state.pending_orbit[satellite.sat] = (dx, dy, dz)
+        # CLASLIB keeps network clock in a separate bank; only base-clock samples
+        # should refresh pending_clock for the expanded SSR product.
+        if flg_clock and not flg_net:
+            state.pending_clock[satellite.sat] = dclock_m
     corrections: list[CompactSSRCorrection] = []
     if not bool(header["sync"]):
         corrections = flush_pending_corrections(state, gps_week, mask.satellites, flush_policy)

--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -403,7 +403,7 @@ segment starts precisely at a `tow % 30 == 0` boundary and runs for exactly
 ... `[230670, 230684]`; the held value equals the SIS delta computed at the
 5s-consecutive clock-reference-time transition that crosses the 30s orbit
 boundary (`current_sis_m(offset0) - previous_sis_m(offset25)`, matching
-`updateSisContinuity()`'s existing formula) and does **not** change again
+`captureClasSisBoundary()`'s observation-epoch pairing) and does **not** change again
 until the next boundary.
 
 Two subtleties surfaced while pinning the rule against the actual native
@@ -479,3 +479,35 @@ max), and all-epoch mean is unchanged (`1.549 m`) with a lower max
 position signal, the default stays off pending the orbit-record-selection
 fix; `GNSS_PPP_CLAS_SIS_BOUNDARY` remains available for further
 investigation.
+
+## ST11 network-orbit suppression in the L6 expander
+
+CSSR subtype 11 (`flg_net=1`) mid-cycle records (`tow % 30 == 25`) carry
+network-scoped orbit deltas that CLASLIB stores in a separate bank and does
+not apply to base-orbit projection.  The Python L6 expander
+(`decode_cssr_combined_message` in `apps/gnss_qzss_l6_info.py`) previously
+wrote those network orbit values into `pending_orbit` unconditionally, so the
+expanded SSR CSV treated them as base-orbit refreshes.  Native
+`interpolateCorrection` then swung `orbit_projection_m` through the outlier
+(e.g. G14 ~0.356→0.221→0.356 m) and inflated the SIS-boundary delta when
+`GNSS_PPP_CLAS_SIS_BOUNDARY=1` was enabled.
+
+The expander now skips `pending_orbit` and `pending_clock` updates when
+`flg_net` is set while still consuming the orbit/clock bits from the
+message.  This restores piecewise-constant base-orbit and base-clock behavior
+across each 30 s cycle, matching CLASLIB's dumped `orbit_projection_m` and
+base-clock bank (flat ~0.356 m for G14 through tow 230420–230434 with the
+ST3 base clock preserved at 230425).  See the ST11-fix measurement report
+for before/after component-diff and #161 tables.
+
+### SIS boundary delta pairing at observation epochs
+
+The gated `captureClasSisBoundary()` path now samples SIS
+(`-clock_correction_m + orbit_projection_m`) at the **observation epoch**
+rather than reusing the 5 s `clock_reference_time` step delta from
+`updateSisContinuity()`.  CLASLIB captures `prevsis` at the mid-cycle
+offset-25 obs epoch (`tow % 30 == 25`) and forms the held compN delta at the
+following offset-0 boundary (`tow % 30 == 0`) as `currsis - prevsis`
+(`ephemeris.c` `satpos_ssr_sis`).  This avoids pairing a boundary clock step
+with an orbit sample that `interpolateCorrection` may have advanced early via
+`clock_reference_time`.

--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -492,18 +492,19 @@ expanded SSR CSV treated them as base-orbit refreshes.  Native
 (e.g. G14 ~0.356→0.221→0.356 m) and inflated the SIS-boundary delta when
 `GNSS_PPP_CLAS_SIS_BOUNDARY=1` was enabled.
 
-The expander now skips `pending_orbit` and `pending_clock` updates when
-`flg_net` is set while still consuming the orbit/clock bits from the
-message.  This restores piecewise-constant base-orbit and base-clock behavior
-across each 30 s cycle, matching CLASLIB's dumped `orbit_projection_m` and
-base-clock bank (flat ~0.356 m for G14 through tow 230420–230434 with the
-ST3 base clock preserved at 230425).  See the ST11-fix measurement report
-for before/after component-diff and #161 tables.
+The expander now skips `pending_orbit` updates when `flg_net` is set while
+still consuming the orbit bits from the message.  Network ST11 clock samples
+are written to `pending_clock` again and tagged with `clock_network_id=1` in
+the compact CSV; the SSR loader stashes the base clock on merged variants so
+the gated SIS capture path can sample base-only SIS while the default PPP path
+keeps network-wins merged clocks (State B byte identity).
 
 ### SIS boundary delta pairing at observation epochs
 
 The gated `captureClasSisBoundary()` path now samples SIS
-(`-clock_correction_m + orbit_projection_m`) at the **observation epoch**
+(`-base_clock_correction_m + orbit_projection_m` when a stashed base clock
+exists, otherwise `-clock_correction_m + orbit_projection_m`) at the
+**observation epoch**
 rather than reusing the 5 s `clock_reference_time` step delta from
 `updateSisContinuity()`.  CLASLIB captures `prevsis` at the mid-cycle
 offset-25 obs epoch (`tow % 30 == 25`) and forms the held compN delta at the

--- a/include/libgnss++/algorithms/ppp_osr.hpp
+++ b/include/libgnss++/algorithms/ppp_osr.hpp
@@ -64,16 +64,21 @@ void updateSisContinuity(
 /// update boundary grid (tow % 30 in [0, 0.5) or (29.5, 30)).
 bool isSsrOrbitBoundaryTow(double tow);
 
+/// True when `tow` sits on (within tolerance of) the mid-cycle offset-25 grid
+/// (tow % 30 in [24.5, 25.5)), where CLASLIB captures `prevsis`.
+bool isSsrOrbitBoundaryOffset25Tow(double tow);
+
 /// Capture the CLASLIB-style SSR-update-boundary SIS delta (gated feature):
-/// when `epoch_time` (the current observation epoch) lands on the 30s
-/// boundary grid and `info` already holds a fresh boundary-aligned
-/// clock-reference-time delta, freeze it into `info.boundary_delta_m` /
-/// `info.boundary_time` for the following 15s of observation epochs. A
-/// no-op otherwise (including when `info` has no delta yet, or the epoch is
-/// off the 30s grid).
+/// sample `current_sis_m` at the observation epoch.  At tow%30==25 store
+/// `prevsis`; at the following tow%30==0 boundary compute
+/// `currsis = current_sis_m - prevsis` and freeze it into
+/// `info.boundary_delta_m` / `info.boundary_time` for the following 15s of
+/// observation epochs.  A no-op otherwise (including when the epoch is off
+/// the expected grid or no offset-25 sample precedes the boundary).
 void captureClasSisBoundary(
     CLASSisContinuityInfo& info,
-    const GNSSTime& epoch_time);
+    const GNSSTime& epoch_time,
+    double current_sis_m);
 
 /// Result of deciding whether/how much CLAS SIS continuity delta to apply
 /// to a CPC/PRC row for the current epoch.

--- a/include/libgnss++/algorithms/ppp_osr_types.hpp
+++ b/include/libgnss++/algorithms/ppp_osr_types.hpp
@@ -109,6 +109,11 @@ struct CLASSisContinuityInfo {
     GNSSTime boundary_time;
     double boundary_delta_m = 0.0;
     bool has_boundary_delta = false;
+    // Observation-epoch pairing (CLASLIB satcorr[].prevsis/currsis): prevsis
+    // sampled at tow%30==25, delta formed at the following tow%30==0 epoch.
+    GNSSTime boundary_prev_time;
+    double boundary_prev_sis_m = 0.0;
+    bool has_boundary_prev_sis = false;
 };
 
 struct CLASEpochContext {

--- a/include/libgnss++/algorithms/ppp_osr_types.hpp
+++ b/include/libgnss++/algorithms/ppp_osr_types.hpp
@@ -31,6 +31,8 @@ struct OSRCorrection {
     double network_compensation_m = 0.0;
     double orbit_projection_m = 0.0;
     double clock_correction_m = 0.0;
+    double base_clock_correction_m = 0.0;
+    bool base_clock_valid = false;
 
     Vector3d satellite_position = Vector3d::Zero();
     Vector3d satellite_velocity = Vector3d::Zero();

--- a/include/libgnss++/core/navigation.hpp
+++ b/include/libgnss++/core/navigation.hpp
@@ -393,12 +393,15 @@ struct SSROrbitClockCorrection {
 
     Vector3d orbit_correction_ecef = Vector3d::Zero();   ///< Orbit delta in meters (ECEF or RAC per container flag)
     double clock_correction_m = 0.0;                     ///< Clock delta in meters
+    double base_clock_correction_m = 0.0;                  ///< Base (ST3) clock delta stashed for SIS sampling
+    GNSSTime base_clock_reference_time;                    ///< Reference time for base_clock_correction_m
     double ura_sigma_m = 0.0;                            ///< SSR URA sigma in meters
     std::map<uint8_t, double> code_bias_m;               ///< SSR code biases keyed by RTCM signal id
     std::map<uint8_t, double> phase_bias_m;              ///< SSR phase biases keyed by RTCM signal id
     std::map<uint8_t, int> phase_bias_discnt;            ///< SSR phase-bias discontinuity counters keyed by RTCM signal id
     int bias_network_id = 0;                             ///< Optional CLAS bias network id (0 when unset)
     int atmos_network_id = 0;                            ///< Optional CLAS atmosphere network id (0 when unset)
+    int clock_network_id = 0;                            ///< Clock provenance on ingest (0=base ST3, >0=ST11 network)
     int iode = -1;                                       ///< IODE the orbit correction references (-1 when unset)
     int ssr_orbit_iod = -1;
     int ssr_clock_iod = -1;
@@ -406,6 +409,7 @@ struct SSROrbitClockCorrection {
 
     bool orbit_valid = false;
     bool clock_valid = false;
+    bool base_clock_valid = false;
     bool ura_valid = false;
     bool code_bias_valid = false;
     bool phase_bias_valid = false;
@@ -459,7 +463,9 @@ public:
                                int* orbit_iode = nullptr,
                                std::map<uint8_t, int>* phase_bias_discnt = nullptr,
                                SSRCorrectionStatus* status = nullptr,
-                               bool allow_future_samples = true) const;
+                               bool allow_future_samples = true,
+                               double* base_clock_correction_m = nullptr,
+                               bool* base_clock_valid = nullptr) const;
 
     bool loadCSVFile(const std::string& filename);
 

--- a/include/libgnss++/io/qzss_l6.hpp
+++ b/include/libgnss++/io/qzss_l6.hpp
@@ -82,6 +82,7 @@ struct CssrOrbitCorrection {
 /// Per-satellite clock correction.
 struct CssrClockCorrection {
     double dclock_m = 0.0;
+    int clock_network_id = 0;
 };
 
 /// Decoded CSSR corrections for one epoch.

--- a/src/algorithms/ppp_osr.cpp
+++ b/src/algorithms/ppp_osr.cpp
@@ -1138,6 +1138,8 @@ std::vector<OSRCorrection> computeOSR(
         GNSSTime phase_bias_reference_time;
         GNSSTime clock_reference_time;
         SSRCorrectionStatus ssr_status;
+        double base_clock_corr = 0.0;
+        bool base_clock_valid = false;
         if (ssr.interpolateCorrection(sat, obs.time, orbit_corr, clock_corr,
                                        &ura_sigma, &ssr_cbias, &ssr_pbias,
                                        &atmos_tokens,
@@ -1147,7 +1149,10 @@ std::vector<OSRCorrection> computeOSR(
                                        preferred_network_id,
                                        nullptr,
                                        nullptr,
-                                       &ssr_status)) {
+                                       &ssr_status,
+                                       true,
+                                       &base_clock_corr,
+                                       &base_clock_valid)) {
             // CSV-expanded CLAS corrections carry orbit deltas in RAC, while
             // sampled RTCM SSR products are already stored in ECEF.
             // RAC frame follows RTCM-10403.1 / CLASLIB convention:
@@ -1191,6 +1196,8 @@ std::vector<OSRCorrection> computeOSR(
             osr.code_bias_reference_time = ssr_status.code_bias_reference_time;
             osr.clock_reference_time = clock_reference_time;
             osr.clock_correction_m = clock_corr;
+            osr.base_clock_correction_m = base_clock_valid ? base_clock_corr : clock_corr;
+            osr.base_clock_valid = base_clock_valid;
         } else {
             if (pppDebugEnabled() && sat.system == GNSSSystem::QZSS) {
                 std::cerr << "[OSR-QZSS-SKIP] " << sat.toString()
@@ -1402,7 +1409,9 @@ std::vector<OSRCorrection> computeOSR(
         const auto phase_continuity_policy =
             config.clas_phase_continuity_policy;
         const bool clock_time_valid = gnsstimeIsSet(osr.clock_reference_time);
-        const double current_sis_m = -osr.clock_correction_m + osr.orbit_projection_m;
+        const double sis_clock_m = osr.base_clock_valid ?
+            osr.base_clock_correction_m : osr.clock_correction_m;
+        const double current_sis_m = -sis_clock_m + osr.orbit_projection_m;
         updateSisContinuity(sis_continuity_info, osr, clock_time_valid);
         if (pppEnvOverrides().clas_sis_boundary) {
             captureClasSisBoundary(sis_continuity_info, obs.time, current_sis_m);

--- a/src/algorithms/ppp_osr.cpp
+++ b/src/algorithms/ppp_osr.cpp
@@ -417,6 +417,11 @@ constexpr double kSsrOrbitBoundaryToleranceSeconds = 0.5;
 // 30s orbit cycle (observed empirically: nonzero for tow%30 in [0,14],
 // zero for tow%30 in [15,29]; see docs/clas_dd_filter_a5.md).
 constexpr double kSsrOrbitBoundaryApplyWindowSeconds = 15.0;
+// Mid-cycle offset where CLASLIB captures prevsis (timediff(clock,orbit)==25).
+constexpr double kSsrOrbitBoundaryOffset25Seconds = 25.0;
+// CLASLIB requires exactly one 5s clock step between prevsis capture and the
+// following 30s boundary (offset-25 obs epoch to offset-0 obs epoch).
+constexpr double kSsrOrbitBoundaryPrevToBoundarySeconds = 5.0;
 
 /// Detect phase bias epoch change and update repair tracking state.
 /// Returns {epoch_changed, phase_bias_dt} for use in PRC/CPC aggregation.
@@ -581,10 +586,16 @@ void updateSisContinuity(
         const GNSSTime preserved_boundary_time = info.boundary_time;
         const double preserved_boundary_delta_m = info.boundary_delta_m;
         const bool preserved_has_boundary_delta = info.has_boundary_delta;
+        const GNSSTime preserved_boundary_prev_time = info.boundary_prev_time;
+        const double preserved_boundary_prev_sis_m = info.boundary_prev_sis_m;
+        const bool preserved_has_boundary_prev_sis = info.has_boundary_prev_sis;
         info = CLASSisContinuityInfo{};
         info.boundary_time = preserved_boundary_time;
         info.boundary_delta_m = preserved_boundary_delta_m;
         info.has_boundary_delta = preserved_has_boundary_delta;
+        info.boundary_prev_time = preserved_boundary_prev_time;
+        info.boundary_prev_sis_m = preserved_boundary_prev_sis_m;
+        info.has_boundary_prev_sis = preserved_has_boundary_prev_sis;
     } else if (!info.has_current) {
         info.current_time = osr.clock_reference_time;
         info.current_sis_m = current_sis_m;
@@ -616,24 +627,42 @@ bool isSsrOrbitBoundaryTow(double tow) {
                       kSsrOrbitBoundaryToleranceSeconds);
 }
 
+bool isSsrOrbitBoundaryOffset25Tow(double tow) {
+    double remainder = std::fmod(tow, kSsrOrbitBoundaryIntervalSeconds);
+    if (remainder < 0.0) {
+        remainder += kSsrOrbitBoundaryIntervalSeconds;
+    }
+    return std::abs(remainder - kSsrOrbitBoundaryOffset25Seconds) <
+        kSsrOrbitBoundaryToleranceSeconds;
+}
+
 void captureClasSisBoundary(
     CLASSisContinuityInfo& info,
-    const GNSSTime& epoch_time) {
-    // CLASLIB only refreshes its held "currsis" value (satcorr[].currtow /
-    // currsis) at the 30s orbit boundary transition, freezing it until the
-    // next boundary; the CLASLIB oracle's dumped compN window is aligned to
-    // the *observation* epoch tow (tow % 30 == 0), not to the (few-second-
-    // early-available) internal SSR clock reference time. Anchor both the
-    // capture trigger and the held boundary_time on `epoch_time` (the
-    // current observation epoch) so the held window lines up with CLASLIB's
-    // per-obs-epoch dump; the delta VALUE still comes from the
-    // clock-reference-time-driven SIS math in updateSisContinuity().
-    if (!info.has_last_delta || !isSsrOrbitBoundaryTow(epoch_time.tow) ||
-        !isSsrOrbitBoundaryTow(info.current_time.tow)) {
+    const GNSSTime& epoch_time,
+    double current_sis_m) {
+    // CLASLIB pairs sis(offset-25 obs epoch) with sis(offset-0 obs epoch):
+    // prevsis is captured at the mid-cycle clock step (tow % 30 == 25) using
+    // the orbit/clock corrections in effect at that observation epoch; the
+    // held compN delta is formed at the following 30s boundary (tow % 30 == 0)
+    // as currsis - prevsis.  This matches ephemeris.c satpos_ssr_sis and
+    // avoids mistiming from clock_reference_time steps that arrive a few
+    // seconds before the observation epoch reaches the boundary grid.
+    if (isSsrOrbitBoundaryOffset25Tow(epoch_time.tow)) {
+        info.boundary_prev_time = epoch_time;
+        info.boundary_prev_sis_m = current_sis_m;
+        info.has_boundary_prev_sis = true;
+        return;
+    }
+    if (!isSsrOrbitBoundaryTow(epoch_time.tow) || !info.has_boundary_prev_sis) {
+        return;
+    }
+    const double dt_prev_to_boundary = epoch_time - info.boundary_prev_time;
+    if (std::abs(dt_prev_to_boundary - kSsrOrbitBoundaryPrevToBoundarySeconds) >
+        kSsrOrbitBoundaryToleranceSeconds) {
         return;
     }
     info.boundary_time = epoch_time;
-    info.boundary_delta_m = info.last_delta_m;
+    info.boundary_delta_m = current_sis_m - info.boundary_prev_sis_m;
     info.has_boundary_delta = true;
 }
 
@@ -1373,9 +1402,10 @@ std::vector<OSRCorrection> computeOSR(
         const auto phase_continuity_policy =
             config.clas_phase_continuity_policy;
         const bool clock_time_valid = gnsstimeIsSet(osr.clock_reference_time);
+        const double current_sis_m = -osr.clock_correction_m + osr.orbit_projection_m;
         updateSisContinuity(sis_continuity_info, osr, clock_time_valid);
         if (pppEnvOverrides().clas_sis_boundary) {
-            captureClasSisBoundary(sis_continuity_info, obs.time);
+            captureClasSisBoundary(sis_continuity_info, obs.time, current_sis_m);
         }
         const GNSSTime effective_phase_bias_reference_time =
             selectClasPhaseBiasReferenceTime(

--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -140,7 +140,15 @@ void mergeCorrectionFields(SSROrbitClockCorrection& target,
         target.ssr_orbit_iod = correction.ssr_orbit_iod;
     }
     if (correction.clock_valid) {
-        target.clock_correction_m = correction.clock_correction_m;
+        if (correction.clock_network_id == 0) {
+            target.clock_correction_m = correction.clock_correction_m;
+            target.base_clock_correction_m = correction.clock_correction_m;
+            target.base_clock_valid = true;
+            target.base_clock_reference_time = correction.clock_reference_time.week != 0 ?
+                correction.clock_reference_time : correction.time;
+        } else {
+            target.clock_correction_m = correction.clock_correction_m;
+        }
         target.clock_valid = true;
         target.clock_reference_time = correction.clock_reference_time.week != 0 ?
             correction.clock_reference_time : correction.time;
@@ -181,6 +189,65 @@ GNSSTime orbitReferenceTime(const SSROrbitClockCorrection& correction) {
 GNSSTime clockReferenceTime(const SSROrbitClockCorrection& correction) {
     return correction.clock_reference_time.week != 0 ?
         correction.clock_reference_time : correction.time;
+}
+
+double sampleBaseClockM(const SSROrbitClockCorrection& sample, bool& valid) {
+    if (sample.base_clock_valid) {
+        valid = true;
+        return sample.base_clock_correction_m;
+    }
+    valid = sample.clock_valid;
+    return sample.clock_correction_m;
+}
+
+void assignBaseClockOutputs(const SSROrbitClockCorrection& sample,
+                            double merged_clock_m,
+                            double* base_clock_correction_m,
+                            bool* base_clock_valid) {
+    if (base_clock_correction_m == nullptr || base_clock_valid == nullptr) {
+        return;
+    }
+    bool valid = false;
+    const double base_m = sampleBaseClockM(sample, valid);
+    if (valid) {
+        *base_clock_correction_m = base_m;
+        *base_clock_valid = true;
+        return;
+    }
+    *base_clock_correction_m = merged_clock_m;
+    *base_clock_valid = false;
+}
+
+void interpolateBaseClockOutputs(const SSROrbitClockCorrection* before,
+                                 const SSROrbitClockCorrection* after,
+                                 double alpha,
+                                 double merged_clock_m,
+                                 double* base_clock_correction_m,
+                                 bool* base_clock_valid) {
+    if (base_clock_correction_m == nullptr || base_clock_valid == nullptr) {
+        return;
+    }
+    const bool before_base = before != nullptr && before->base_clock_valid;
+    const bool after_base = after != nullptr && after->base_clock_valid;
+    if (before_base && after_base) {
+        *base_clock_correction_m =
+            before->base_clock_correction_m +
+            alpha * (after->base_clock_correction_m - before->base_clock_correction_m);
+        *base_clock_valid = true;
+        return;
+    }
+    if (before_base) {
+        *base_clock_correction_m = before->base_clock_correction_m;
+        *base_clock_valid = true;
+        return;
+    }
+    if (after_base) {
+        *base_clock_correction_m = after->base_clock_correction_m;
+        *base_clock_valid = true;
+        return;
+    }
+    *base_clock_correction_m = merged_clock_m;
+    *base_clock_valid = false;
 }
 
 bool parseEpochFields(int year,
@@ -1305,7 +1372,14 @@ void SSRProducts::addCorrection(const SSROrbitClockCorrection& correction) {
         return;
     }
 
-    entries.insert(upper, correction);
+    SSROrbitClockCorrection to_insert = correction;
+    if (to_insert.clock_valid && to_insert.clock_network_id == 0) {
+        to_insert.base_clock_correction_m = to_insert.clock_correction_m;
+        to_insert.base_clock_valid = true;
+        to_insert.base_clock_reference_time = to_insert.clock_reference_time.week != 0 ?
+            to_insert.clock_reference_time : to_insert.time;
+    }
+    entries.insert(upper, to_insert);
 }
 
 void SSRProducts::addCorrections(const std::vector<SSROrbitClockCorrection>& corrections) {
@@ -1392,7 +1466,9 @@ bool SSRProducts::interpolateCorrection(const SatelliteId& sat,
                                         int* orbit_iode,
                                         std::map<uint8_t, int>* phase_bias_discnt,
                                         SSRCorrectionStatus* status,
-                                        bool allow_future_samples) const {
+                                        bool allow_future_samples,
+                                        double* base_clock_correction_m,
+                                        bool* base_clock_valid) const {
     if (status != nullptr) {
         *status = SSRCorrectionStatus{};
     }
@@ -1622,6 +1698,8 @@ bool SSRProducts::interpolateCorrection(const SatelliteId& sat,
         }
         if (clock_source != nullptr && clock_source->clock_valid) {
             clock_correction_m = clock_source->clock_correction_m;
+            assignBaseClockOutputs(*clock_source, clock_correction_m,
+                                   base_clock_correction_m, base_clock_valid);
             if (clock_reference_time != nullptr) {
                 *clock_reference_time = clock_source->time;
             }
@@ -1762,6 +1840,10 @@ bool SSRProducts::interpolateCorrection(const SatelliteId& sat,
             }
         } else {
             clock_correction_m = 0.0;
+        }
+        if (before != nullptr || after != nullptr) {
+            interpolateBaseClockOutputs(before, after, alpha, clock_correction_m,
+                                        base_clock_correction_m, base_clock_valid);
         }
         if (ura_sigma_m != nullptr) {
             if (before->ura_valid && after->ura_valid) {
@@ -1946,6 +2028,8 @@ bool SSRProducts::interpolateCorrection(const SatelliteId& sat,
     orbit_correction_ecef =
         orbit_source->orbit_valid ? orbit_source->orbit_correction_ecef : Vector3d::Zero();
     clock_correction_m = clock_source->clock_valid ? clock_source->clock_correction_m : 0.0;
+    assignBaseClockOutputs(*clock_source, clock_correction_m,
+                           base_clock_correction_m, base_clock_valid);
     if (orbit_source->orbit_valid) {
         if (orbit_iode != nullptr) {
             *orbit_iode = orbit_source->iode;
@@ -2157,6 +2241,13 @@ bool SSRProducts::loadCSVFile(const std::string& filename) {
                 }
                 continue;
             }
+            if (extra.rfind("clock_network_id=", 0) == 0) {
+                try {
+                    correction.clock_network_id = std::max(0, std::stoi(extra.substr(17)));
+                } catch (const std::exception&) {
+                }
+                continue;
+            }
             if (extra.rfind("atmos_", 0) == 0) {
                 const auto equal_pos = extra.find('=');
                 if (equal_pos == std::string::npos || equal_pos <= 6) {
@@ -2210,6 +2301,9 @@ bool SSRProducts::loadCSVFile(const std::string& filename) {
         (void)sat;
         Vector3d last_orbit = Vector3d::Zero();
         bool has_last_orbit = false;
+        double last_base_clock = 0.0;
+        bool has_last_base_clock = false;
+        GNSSTime last_base_clock_reference_time;
         for (auto& entry : entries) {
             if (entry.orbit_valid) {
                 last_orbit = entry.orbit_correction_ecef;
@@ -2217,6 +2311,16 @@ bool SSRProducts::loadCSVFile(const std::string& filename) {
             } else if (has_last_orbit && entry.clock_valid) {
                 entry.orbit_correction_ecef = last_orbit;
                 entry.orbit_valid = true;
+            }
+            if (entry.base_clock_valid) {
+                last_base_clock = entry.base_clock_correction_m;
+                has_last_base_clock = true;
+                last_base_clock_reference_time = entry.base_clock_reference_time.week != 0 ?
+                    entry.base_clock_reference_time : entry.time;
+            } else if (has_last_base_clock && entry.clock_valid) {
+                entry.base_clock_correction_m = last_base_clock;
+                entry.base_clock_valid = true;
+                entry.base_clock_reference_time = last_base_clock_reference_time;
             }
         }
     }

--- a/src/io/qzss_l6.cpp
+++ b/src/io/qzss_l6.cpp
@@ -209,6 +209,7 @@ void L6Decoder::decodeSubtype3(BitReader& reader) {
         const SatelliteId sat_id(sat.system, sat.prn);
         CssrClockCorrection corr;
         corr.dclock_m = reader.readS(15) * kClockScale;
+        corr.clock_network_id = 0;
         current_epoch_.clocks[sat_id] = corr;
     }
     current_epoch_.has_clock = true;
@@ -306,14 +307,11 @@ void L6Decoder::decodeSubtype11(BitReader& reader) {
             }
         }
         if (flg_clock) {
-            if (!flg_net) {
-                CssrClockCorrection corr;
-                corr.dclock_m = reader.readS(15) * kClockScale;
-                current_epoch_.clocks[sat_id] = corr;
-                current_epoch_.has_clock = true;
-            } else {
-                reader.readS(15);
-            }
+            CssrClockCorrection corr;
+            corr.dclock_m = reader.readS(15) * kClockScale;
+            corr.clock_network_id = flg_net ? 1 : 0;
+            current_epoch_.clocks[sat_id] = corr;
+            current_epoch_.has_clock = true;
         }
     }
 }
@@ -764,6 +762,7 @@ void populateSSRProducts(
             corr.time = time;
             corr.clock_correction_m = clock_corr.dclock_m;
             corr.clock_valid = true;
+            corr.clock_network_id = clock_corr.clock_network_id;
 
             // Orbit (may not be present every epoch)
             auto orbit_it = epoch.orbits.find(sat_id);

--- a/src/io/qzss_l6.cpp
+++ b/src/io/qzss_l6.cpp
@@ -292,18 +292,28 @@ void L6Decoder::decodeSubtype11(BitReader& reader) {
         if (flg_orbit) {
             const int iode_bits = (sat.system == GNSSSystem::Galileo) ? 10 : 8;
             reader.readU(iode_bits);
-            CssrOrbitCorrection corr;
-            corr.dx = reader.readS(15) * kOrbitRadialScale;
-            corr.dy = reader.readS(13) * kOrbitAlongCrossScale;
-            corr.dz = reader.readS(13) * kOrbitAlongCrossScale;
-            current_epoch_.orbits[sat_id] = corr;
-            current_epoch_.has_orbit = true;
+            if (!flg_net) {
+                CssrOrbitCorrection corr;
+                corr.dx = reader.readS(15) * kOrbitRadialScale;
+                corr.dy = reader.readS(13) * kOrbitAlongCrossScale;
+                corr.dz = reader.readS(13) * kOrbitAlongCrossScale;
+                current_epoch_.orbits[sat_id] = corr;
+                current_epoch_.has_orbit = true;
+            } else {
+                reader.readS(15);
+                reader.readS(13);
+                reader.readS(13);
+            }
         }
         if (flg_clock) {
-            CssrClockCorrection corr;
-            corr.dclock_m = reader.readS(15) * kClockScale;
-            current_epoch_.clocks[sat_id] = corr;
-            current_epoch_.has_clock = true;
+            if (!flg_net) {
+                CssrClockCorrection corr;
+                corr.dclock_m = reader.readS(15) * kClockScale;
+                current_epoch_.clocks[sat_id] = corr;
+                current_epoch_.has_clock = true;
+            } else {
+                reader.readS(15);
+            }
         }
     }
 }

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -5390,6 +5390,63 @@ class CLIToolsTest(unittest.TestCase):
             corrections_csv = corrections_path.read_text(encoding="ascii")
             self.assertIn("1316,518400.000,G,3,0.016000,0.012800,-0.012800,0.025600,0.000000", corrections_csv)
 
+    def test_qzss_l6_info_suppresses_st11_network_orbit_in_pending_orbit(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_qzss_l6_st11_net_orbit_") as temp_dir:
+            temp_root = Path(temp_dir)
+            input_path = temp_root / "session_l6_st11_net_orbit.bin"
+            corrections_path = temp_root / "session_st11_net_orbit_corrections.csv"
+            input_path.write_bytes(
+                build_qzss_l6_subframe_stream(
+                    [
+                        build_qzss_cssr_mask_message(tow=518400, iod=3, prn=3, sync=True),
+                        build_qzss_cssr_orbit_message(
+                            tow_delta=0,
+                            iod=3,
+                            dx=0.016,
+                            dy=0.0128,
+                            dz=-0.0128,
+                            sync=True,
+                        ),
+                        build_qzss_cssr_clock_message(tow_delta=0, iod=3, dclock_m=0.0256, sync=False),
+                        build_qzss_cssr_combined_message(
+                            tow_delta=25,
+                            iod=3,
+                            prn=3,
+                            sync=False,
+                            network_id=1,
+                            dx=-0.2512,
+                            dy=-0.8320,
+                            dz=0.0,
+                            dclock_m=0.0512,
+                        ),
+                    ]
+                )
+            )
+
+            result = self.run_gnss(
+                "qzss-l6-info",
+                "--input",
+                str(input_path),
+                "--limit",
+                "6",
+                "--gps-week",
+                "1316",
+                "--extract-compact-corrections",
+                str(corrections_path),
+            )
+
+            self.assertEqual(result.returncode, 0, msg=result.stderr)
+            corrections_csv = corrections_path.read_text(encoding="ascii")
+            self.assertIn(
+                "1316,518400.000,G,3,0.016000,0.012800,-0.012800,0.025600,0.000000",
+                corrections_csv,
+            )
+            # Network ST11 must not flush a clock-only row or overwrite base clock.
+            self.assertNotIn("518425.000", corrections_csv)
+            self.assertNotIn("0.051200", corrections_csv)
+            self.assertNotIn("-0.251200", corrections_csv)
+            self.assertNotIn("-0.832000", corrections_csv)
+
     def test_qzss_l6_info_extracts_code_bias_and_ura_corrections(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_qzss_l6_cbias_ura_") as temp_dir:
             temp_root = Path(temp_dir)

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -5347,8 +5347,8 @@ class CLIToolsTest(unittest.TestCase):
             self.assertIn("1,1,4073,1,518400,1.0,1,3,", messages_csv)
             self.assertIn("1,2,4073,11,518400,1.0,0,3,", messages_csv)
             corrections_csv = corrections_path.read_text(encoding="ascii")
-            self.assertIn("# week,tow,system,prn,dx,dy,dz,dclock_m,high_rate_clock_m", corrections_csv)
-            self.assertIn("1316,518400.000,G,3,0.000000,0.000000,0.000000,0.025600,0.000000", corrections_csv)
+            self.assertIn("# week,tow,system,prn,dx,dy,dz,dclock_m,high_rate_clock_m,clock_network_id", corrections_csv)
+            self.assertIn("1316,518400.000,G,3,0.000000,0.000000,0.000000,0.025600,0.000000,1", corrections_csv)
 
     def test_qzss_l6_info_extracts_separate_orbit_clock_corrections(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_qzss_l6_orbit_clock_") as temp_dir:
@@ -5438,12 +5438,12 @@ class CLIToolsTest(unittest.TestCase):
             self.assertEqual(result.returncode, 0, msg=result.stderr)
             corrections_csv = corrections_path.read_text(encoding="ascii")
             self.assertIn(
-                "1316,518400.000,G,3,0.016000,0.012800,-0.012800,0.025600,0.000000",
+                "1316,518400.000,G,3,0.016000,0.012800,-0.012800,0.025600,0.000000,0",
                 corrections_csv,
             )
-            # Network ST11 must not flush a clock-only row or overwrite base clock.
-            self.assertNotIn("518425.000", corrections_csv)
-            self.assertNotIn("0.051200", corrections_csv)
+            # Network ST11 clock is retained and tagged; network orbit stays suppressed.
+            self.assertIn("518425.000", corrections_csv)
+            self.assertIn("0.051200", corrections_csv)
             self.assertNotIn("-0.251200", corrections_csv)
             self.assertNotIn("-0.832000", corrections_csv)
 
@@ -6976,7 +6976,7 @@ class CLIToolsTest(unittest.TestCase):
             corrections_csv = corrections_path.read_text(encoding="ascii")
             self.assertEqual(
                 corrections_csv.strip(),
-                "# week,tow,system,prn,dx,dy,dz,dclock_m,high_rate_clock_m[,ura_sigma_m=<m>][,cbias:<id>=<m>...][,pbias:<id>=<m>...][,bias_network_id=<n>][,atmos_<name>=<value>...]",
+                "# week,tow,system,prn,dx,dy,dz,dclock_m,high_rate_clock_m,clock_network_id[,ura_sigma_m=<m>][,cbias:<id>=<m>...][,pbias:<id>=<m>...][,bias_network_id=<n>][,atmos_<name>=<value>...]",
             )
 
     def test_qzss_l6_info_compact_flush_policy_can_require_both_orbit_and_clock(self) -> None:
@@ -7026,7 +7026,7 @@ class CLIToolsTest(unittest.TestCase):
             orbit_and_clock_csv = orbit_and_clock_path.read_text(encoding="ascii")
             self.assertEqual(
                 orbit_and_clock_csv.strip(),
-                "# week,tow,system,prn,dx,dy,dz,dclock_m,high_rate_clock_m[,ura_sigma_m=<m>][,cbias:<id>=<m>...][,pbias:<id>=<m>...][,bias_network_id=<n>][,atmos_<name>=<value>...]",
+                "# week,tow,system,prn,dx,dy,dz,dclock_m,high_rate_clock_m,clock_network_id[,ura_sigma_m=<m>][,cbias:<id>=<m>...][,pbias:<id>=<m>...][,bias_network_id=<n>][,atmos_<name>=<value>...]",
             )
 
     def test_qzss_l6_info_compact_atmos_merge_policy_no_carry_drops_stec_coefficients_between_epochs(self) -> None:

--- a/tests/test_ppp_osr.cpp
+++ b/tests/test_ppp_osr.cpp
@@ -866,42 +866,43 @@ TEST(PPPOSRTest, ClasSisApplyDecisionGateOffReproducesLegacyLagWindowCondition) 
     EXPECT_DOUBLE_EQ(still_legacy.delta_m, 0.42);
 }
 
-TEST(PPPOSRTest, CaptureClasSisBoundaryOnlyFreezesOnObsEpochThirtySecondGrid) {
-    const GNSSTime off_boundary_clock_ref(2068, 230430.0);
+TEST(PPPOSRTest, IsSsrOrbitBoundaryOffset25TowMatchesClaslibMidCycleGrid) {
+    EXPECT_TRUE(isSsrOrbitBoundaryOffset25Tow(230425.0));
+    EXPECT_TRUE(isSsrOrbitBoundaryOffset25Tow(230455.0));
+    EXPECT_TRUE(isSsrOrbitBoundaryOffset25Tow(230425.2));
+    EXPECT_FALSE(isSsrOrbitBoundaryOffset25Tow(230430.0));
+    EXPECT_FALSE(isSsrOrbitBoundaryOffset25Tow(230435.0));
+}
 
-    // A transition whose clock_reference_time is NOT on the 30s grid (e.g. a
-    // stray mid-cycle recompute) must never be captured, even if the epoch
-    // happens to be on the grid.
-    CLASSisContinuityInfo info_off_grid;
-    info_off_grid.has_last_delta = true;
-    info_off_grid.last_delta_m = 0.111;
-    info_off_grid.current_time = GNSSTime(2068, 230435.0);  // mid-cycle, not 30-aligned
-    captureClasSisBoundary(info_off_grid, off_boundary_clock_ref);
-    EXPECT_FALSE(info_off_grid.has_boundary_delta);
+TEST(PPPOSRTest, CaptureClasSisBoundaryPairsOffset25AndOffset0AtObsEpochs) {
+    CLASSisContinuityInfo info;
 
-    // A grid-aligned clock_reference_time delta, observed on an off-grid
-    // epoch (the "early availability" case from real CLAS data, where
-    // clock_reference_time reaches the boundary a few seconds before the
-    // observation epoch tow does): not captured yet.
-    CLASSisContinuityInfo info_early;
-    info_early.has_last_delta = true;
-    info_early.last_delta_m = 0.131951;
-    info_early.current_time = GNSSTime(2068, 230430.0);  // on the grid
-    captureClasSisBoundary(info_early, GNSSTime(2068, 230426.0));  // epoch off-grid
-    EXPECT_FALSE(info_early.has_boundary_delta);
+    // Offset-25 obs epoch: capture prevsis only (no boundary delta yet).
+    captureClasSisBoundary(info, GNSSTime(2068, 230425.0), /*current_sis_m=*/0.30);
+    EXPECT_TRUE(info.has_boundary_prev_sis);
+    EXPECT_DOUBLE_EQ(info.boundary_prev_sis_m, 0.30);
+    EXPECT_FALSE(info.has_boundary_delta);
 
-    // Once the observation epoch itself reaches the 30s grid (with the same
-    // still-held clock_reference_time delta), the boundary is captured and
-    // anchored to the epoch time (not the earlier clock_reference_time).
-    captureClasSisBoundary(info_early, GNSSTime(2068, 230430.0));
-    ASSERT_TRUE(info_early.has_boundary_delta);
-    EXPECT_DOUBLE_EQ(info_early.boundary_delta_m, 0.131951);
-    EXPECT_EQ(info_early.boundary_time, GNSSTime(2068, 230430.0));
+    // Off-grid epoch between offset-25 and boundary: no-op.
+    captureClasSisBoundary(info, GNSSTime(2068, 230428.0), /*current_sis_m=*/0.31);
+    EXPECT_FALSE(info.has_boundary_delta);
 
-    // No last_delta_m yet: never captures.
-    CLASSisContinuityInfo info_no_delta;
-    captureClasSisBoundary(info_no_delta, GNSSTime(2068, 230430.0));
-    EXPECT_FALSE(info_no_delta.has_boundary_delta);
+    // Offset-0 boundary 5s after offset-25: delta = currsis - prevsis.
+    captureClasSisBoundary(info, GNSSTime(2068, 230430.0), /*current_sis_m=*/0.248);
+    ASSERT_TRUE(info.has_boundary_delta);
+    EXPECT_DOUBLE_EQ(info.boundary_delta_m, 0.248 - 0.30);
+    EXPECT_EQ(info.boundary_time, GNSSTime(2068, 230430.0));
+
+    // Wrong spacing (not 5s after prevsis): rejected.
+    CLASSisContinuityInfo bad_spacing;
+    captureClasSisBoundary(bad_spacing, GNSSTime(2068, 230420.0), 0.10);
+    captureClasSisBoundary(bad_spacing, GNSSTime(2068, 230430.0), 0.20);
+    EXPECT_FALSE(bad_spacing.has_boundary_delta);
+
+    // Boundary without prior offset-25 sample: rejected.
+    CLASSisContinuityInfo no_prev;
+    captureClasSisBoundary(no_prev, GNSSTime(2068, 230430.0), 0.20);
+    EXPECT_FALSE(no_prev.has_boundary_delta);
 }
 
 TEST(PPPOSRTest, ClasSisApplyDecisionGateOnHoldsBoundaryDeltaForFifteenObsSeconds) {
@@ -910,10 +911,8 @@ TEST(PPPOSRTest, ClasSisApplyDecisionGateOnHoldsBoundaryDeltaForFifteenObsSecond
     const GNSSTime clock_ref = boundary_time;  // irrelevant when gated.
 
     CLASSisContinuityInfo info;
-    info.has_last_delta = true;
-    info.last_delta_m = 0.111;  // stale per-5s value; must NOT be applied when gated.
     info.has_boundary_delta = true;
-    info.boundary_time = boundary_time;
+    info.boundary_time = GNSSTime(2068, 230430.0);
     info.boundary_delta_m = -0.052;
 
     // Observation epoch offsets 0..14s after the boundary: held delta

--- a/tests/test_ppp_osr.cpp
+++ b/tests/test_ppp_osr.cpp
@@ -4,6 +4,7 @@
 #include <libgnss++/algorithms/ppp_bias_identity.hpp>
 #include <libgnss++/algorithms/ppp_osr.hpp>
 #include <libgnss++/core/coordinates.hpp>
+#include <libgnss++/core/navigation.hpp>
 
 #include <chrono>
 #include <cmath>
@@ -903,6 +904,76 @@ TEST(PPPOSRTest, CaptureClasSisBoundaryPairsOffset25AndOffset0AtObsEpochs) {
     CLASSisContinuityInfo no_prev;
     captureClasSisBoundary(no_prev, GNSSTime(2068, 230430.0), 0.20);
     EXPECT_FALSE(no_prev.has_boundary_delta);
+}
+
+TEST(PPPOSRTest, ClasSisBoundaryUsesBaseClockWhenNetworkMergedAtOffset25) {
+    SSRProducts products;
+    products.setOrbitCorrectionsAreRac(false);
+
+    const SatelliteId satellite(GNSSSystem::GPS, 14);
+    const GNSSTime offset25(2068, 230425.0);
+
+    SSROrbitClockCorrection base_row;
+    base_row.satellite = satellite;
+    base_row.time = offset25;
+    base_row.orbit_correction_ecef = Vector3d(0.0, 0.0, 0.0);
+    base_row.orbit_valid = true;
+    base_row.clock_correction_m = -0.2192;
+    base_row.clock_valid = true;
+    base_row.clock_network_id = 0;
+    products.addCorrection(base_row);
+
+    SSROrbitClockCorrection network_row;
+    network_row.satellite = satellite;
+    network_row.time = offset25;
+    network_row.clock_correction_m = 0.2064;
+    network_row.clock_valid = true;
+    network_row.clock_network_id = 1;
+    products.addCorrection(network_row);
+
+    Vector3d orbit_corr = Vector3d::Zero();
+    double merged_clock_m = 0.0;
+    double base_clock_m = 0.0;
+    bool base_clock_valid = false;
+    ASSERT_TRUE(products.interpolateCorrection(
+        satellite,
+        offset25,
+        orbit_corr,
+        merged_clock_m,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        0,
+        nullptr,
+        nullptr,
+        nullptr,
+        true,
+        &base_clock_m,
+        &base_clock_valid));
+    EXPECT_DOUBLE_EQ(merged_clock_m, 0.2064);
+    ASSERT_TRUE(base_clock_valid);
+    EXPECT_DOUBLE_EQ(base_clock_m, -0.2192);
+
+    const double orbit_projection_m = 0.356;
+    const double merged_sis_m = -merged_clock_m + orbit_projection_m;
+    const double base_sis_m = -base_clock_m + orbit_projection_m;
+    EXPECT_NEAR(merged_sis_m, 0.1496, 1e-12);
+    EXPECT_NEAR(base_sis_m, 0.5752, 1e-12);
+
+    CLASSisContinuityInfo info;
+    captureClasSisBoundary(info, offset25, base_sis_m);
+    ASSERT_TRUE(info.has_boundary_prev_sis);
+    EXPECT_DOUBLE_EQ(info.boundary_prev_sis_m, base_sis_m);
+
+    const GNSSTime boundary0(2068, 230430.0);
+    const double boundary_sis_m = base_sis_m - 0.058;
+    captureClasSisBoundary(info, boundary0, boundary_sis_m);
+    ASSERT_TRUE(info.has_boundary_delta);
+    EXPECT_NEAR(info.boundary_delta_m, -0.058, 1e-12);
 }
 
 TEST(PPPOSRTest, ClasSisApplyDecisionGateOnHoldsBoundaryDeltaForFifteenObsSeconds) {


### PR DESCRIPTION
## Summary
A4b slice closing the `network_compensation_m` component. Three commits, stacked on #276:

1. **`8162cab` — suppress ST11 network orbit in the L6 expanders** (Python `gnss_qzss_l6_info.py` + C++ `decodeSubtype11`). CSSR ST11 (combined orbit+clock) messages with `flg_net=1` arrive at `tow%30==25` carrying network-scoped orbit deltas; CLASLIB banks them separately and its OSR orbit projection uses the base bank only (`get_close_orbit_correction`, `search=0`), while native wrote them into the flat product as if they were base ST2 refreshes, swinging `orbit_projection_m` mid-cycle. **This is the only solution-changing commit** (default `.pos` md5 `e63f4d63…` → `57012bec…`, see sign-off below).
2. **`3c791b3` — pair the SIS boundary delta at observation epochs** (gated path only): CLASLIB pairs `sis(offset-25 obs epoch)` with `sis(offset-0 obs epoch)` exactly (`ephemeris.c:854-875`); native's 5 s `clock_reference_time` stepping adopted the next boundary's corrections ~4 s early. Scoped entirely to `ppp_osr` capture logic.
3. **`c28b682` — stash the base clock for SIS sampling**: `SSRProducts::addCorrection` merges ST11 network clocks into the same variant as ST3 base clocks (network overwrites base, +0.43 m verified at tow 230425). Global suppression of ST11 clocks was tested and **rejected** — it fixed compN but changed default-path clock behavior everywhere (AR fix inflation 270→355 + a 36 m fixed outlier via future-sample anchoring). Final design: keep the merged (network-wins) value byte-identical for every default-path read, tag provenance (`clock_network_id` column), stash the base clock in parallel fields, and have only the gated SIS capture read the base value.

## Measured result (G14/C2W probe vs CLASLIB oracle)
| | before | after |
|---|---|---|
| gate-ON `network_compensation_m` diff RMS | 0.0526 m (native emitted 0) | **0.000135 m** (max 0.34 mm, 9/9 boundaries) |
| gate-ON per-boundary window alignment | — | exact (9×15-row segments) |
| `prc_m` diff on compN==0 rows | 0.0139 m | **0.0033 m** |

## Sign-off: default-path change (#161)
Only commit 1 moves the default solution. 3600-epoch standard CLAS run vs CLASLIB same-epoch oracle:
| metric | before | after |
|---|---|---|
| fixed count | 270 | **276** ✓ |
| all-epoch 3D mean | 1.549 m | **1.544 m** ✓ |
| all-epoch 3D max | **39.80 m** | **5.07 m** ✓ (gross-divergence episode removed) |
| fixed-only 3D mean | 1.584 m | 1.630 m ✗ |

The fixed-only regression is a fix-set reshuffle, not a quality loss: only 72 fixed epochs are common before/after, and on those the accuracy is identical (3D 1.577→1.578 m, V 0.700→0.703 m); the delta comes from newly-gained marginal fixes. The change removes objectively spurious network-orbit contamination (CLASLIB parity) and is prerequisite to the compN closure. User signed off 2026-07-03.

## Validation
- Default-path byte-identity of commits 2+3: gate-OFF `.pos` md5 `57012becb3f6c1e16958e00c621dba51` and A4b selfdiff dump md5 `5ec711bfe4d3fde615edcf88747b9581` identical with only commit 1 vs full branch (independently re-run)
- gtests 344 passed / 0 failed / 43 skipped; CLAS pytest suites + expander tests green; `mkdocs build --strict` clean
- Gate stays default OFF. Known gate-ON followups (documented): single-epoch 39.8 m fixed spike at tow≈230480; default-path clock contamination itself (CLASLIB uses the base clock bank) is a candidate future #161 slice
- Full reports: /tmp/gnss_st11_v3_report.md, /tmp/gnss_st11fix_report.md, investigation trail in docs/clas_dd_filter_a5.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)