### PR TITLE
clas add claslib base-clock parity gate with bias hold and sd-mar blunder rejection

### DIFF
--- a/docs/clas_dd_filter_a5.md
+++ b/docs/clas_dd_filter_a5.md
@@ -512,3 +512,28 @@ following offset-0 boundary (`tow % 30 == 0`) as `currsis - prevsis`
 (`ephemeris.c` `satpos_ssr_sis`).  This avoids pairing a boundary clock step
 with an orbit sample that `interpolateCorrection` may have advanced early via
 `clock_reference_time`.
+
+## CLAS base-clock parity gate (`GNSS_PPP_CLAS_BASE_CLOCK_PARITY`)
+
+Default-path CLAS OSR positioning still uses merged network-wins clocks with
+linear interpolation between 5 s SSR grid points (State B byte identity).
+Setting `GNSS_PPP_CLAS_BASE_CLOCK_PARITY=1` switches the positioning clock
+branch to CLASLIB-equivalent semantics:
+
+- base bank only (`base_clock_valid` / `clock_network_id == 0`)
+- no future clock samples (`clock.time <= obs.time`)
+- orbit-anchored age (newest `orbit_valid` with `orbit.time <= obs.time` within
+  180 s; clock within `[orbit_ref, orbit_ref + 30 s)` and `<= obs.time`)
+- newest-eligible step-hold (no linear interpolation)
+- failure sets `clock_valid = false` and excludes the satellite
+
+The gated SIS capture path (`captureClasSisBoundary`) is unchanged and
+continues to sample stashed base clocks.  `sameCorrectionVariant` merge
+semantics are unchanged.
+
+Acceptance targets with the gate on:
+
+- `clock_correction_m` RMS vs CLASLIB oracle `< 5 mm` over the 300-epoch A4b
+  selfdiff window
+- gate-OFF `.pos` md5 and A4b selfdiff md5 unchanged (State B identity)
+- `GNSS_PPP_CLAS_SIS_BOUNDARY=1` compN RMS stays `<= 0.001 m`

--- a/include/libgnss++/algorithms/ppp_clas_sd.hpp
+++ b/include/libgnss++/algorithms/ppp_clas_sd.hpp
@@ -34,6 +34,10 @@ struct SdEpochResult {
     int num_observations = 0;
     double code_rms = 0.0;
     double phase_rms = 0.0;
+    /// LAMBDA ratio when multi-epoch SD AR fixes ambiguities (0 otherwise).
+    double ar_ratio = 0.0;
+    /// Position shift from the seed when SD AR applies a fixed solution.
+    double position_shift_m = 0.0;
 };
 
 /// Accumulated DD ambiguity state for multi-epoch AR.

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -183,6 +183,12 @@ struct PPPEnvOverrides {
     // condition for the gated path. Default false; exact "0" and unset are
     // no-ops for bit-exact legacy CLAS output.
     bool clas_sis_boundary = false;
+    // GNSS_PPP_CLAS_BASE_CLOCK_PARITY: select CLASLIB-equivalent base-bank
+    // step-hold clocks (orbit-anchored, no future samples, no merged-network
+    // overwrite, no linear interpolation) for CLAS OSR positioning when set
+    // exactly to "1". Default false; exact "0" and unset preserve State B
+    // merged-clock byte identity.
+    bool clas_base_clock_parity = false;
     // GNSS_PPP_CLAS_AMB_DATUM: align CLAS OSR carrier phase ambiguity states
     // with CLASLIB by subtracting the full CPC before ambiguity estimation.
     // Default follows the residual-phase-trop surface; explicit boolean values

--- a/include/libgnss++/core/navigation.hpp
+++ b/include/libgnss++/core/navigation.hpp
@@ -416,6 +416,11 @@ struct SSROrbitClockCorrection {
     bool atmos_valid = false;
 };
 
+enum class SSRClockSelectionPolicy {
+    MergedInterpolate,
+    ClaslibBaseHold,
+};
+
 struct SSRCorrectionStatus {
     bool orbit_valid = false;
     bool clock_valid = false;
@@ -465,7 +470,9 @@ public:
                                SSRCorrectionStatus* status = nullptr,
                                bool allow_future_samples = true,
                                double* base_clock_correction_m = nullptr,
-                               bool* base_clock_valid = nullptr) const;
+                               bool* base_clock_valid = nullptr,
+                               SSRClockSelectionPolicy clock_selection_policy =
+                                   SSRClockSelectionPolicy::MergedInterpolate) const;
 
     bool loadCSVFile(const std::string& filename);
 

--- a/src/algorithms/ppp_ambiguity.cpp
+++ b/src/algorithms/ppp_ambiguity.cpp
@@ -101,8 +101,18 @@ bool PPPProcessor::resolveAmbiguities(const ObservationData& obs, const Navigati
             if (ssr_products_loaded_) {
                 Vector3d orbit_corr;
                 double clock_corr = 0.0;
-                if (ssr_products_.interpolateCorrection(real_satellite, obs.time, orbit_corr, clock_corr,
-                                                        nullptr, nullptr, nullptr, nullptr)) {
+                const auto clock_policy = pppEnvOverrides().clas_base_clock_parity
+                    ? SSRClockSelectionPolicy::ClaslibBaseHold
+                    : SSRClockSelectionPolicy::MergedInterpolate;
+                const bool allow_future_samples =
+                    !pppEnvOverrides().clas_base_clock_parity;
+                if (ssr_products_.interpolateCorrection(
+                        real_satellite, obs.time, orbit_corr, clock_corr,
+                        nullptr, nullptr, nullptr, nullptr,
+                        nullptr, nullptr, nullptr,
+                        0, nullptr, nullptr, nullptr,
+                        allow_future_samples, nullptr, nullptr,
+                        clock_policy)) {
                     if (ssr_products_.orbitCorrectionsAreRac()) {
                         orbit_corr = ssrRacToEcef(sat_pos, sat_vel, orbit_corr);
                     }

--- a/src/algorithms/ppp_clas_epoch.cpp
+++ b/src/algorithms/ppp_clas_epoch.cpp
@@ -31,6 +31,8 @@ bool pppDebugEnabled() {
 }
 
 constexpr double kClasNlDatumJumpThresholdCycles = 0.5;
+// Good WL-NL / SD-MAR fixes stay below ~0.7 m; parity-path blunders were 38–595 m.
+constexpr double kClasBaseClockParitySdMarMaxPositionShiftM = 2.0;
 
 std::ofstream* clasFloatDumpStream() {
     const auto& path = pppEnvOverrides().clas_float_dump_path;
@@ -79,11 +81,12 @@ void clearClasWlnlFixedDatumState(PPPAmbiguityInfo& ambiguity) {
     ambiguity.mw_mean_cycles = 0.0;
 }
 
-void applyClasNlDatumReset(
+bool applyClasNlDatumReset(
     const GNSSTime& time,
     const std::vector<OSRCorrection>& osr_corrections,
     std::map<SatelliteId, PPPAmbiguityInfo>& ambiguity_states,
     bool debug_enabled) {
+    bool any_reset = false;
     for (const auto& osr : osr_corrections) {
         if (!osr.valid || osr.num_frequencies < 2) {
             continue;
@@ -98,6 +101,7 @@ void applyClasNlDatumReset(
             const double step_cycles =
                 datum_cycles - ambiguity.clas_nl_phase_bias_datum_cycles;
             if (std::abs(step_cycles) > kClasNlDatumJumpThresholdCycles) {
+                any_reset = true;
                 clearClasWlnlFixedDatumState(ambiguity);
                 const SatelliteId l2_satellite(
                     osr.satellite.system,
@@ -119,6 +123,7 @@ void applyClasNlDatumReset(
         ambiguity.clas_nl_phase_bias_datum_cycles = datum_cycles;
         ambiguity.has_clas_nl_phase_bias_datum = true;
     }
+    return any_reset;
 }
 
 void dumpClasFloatPosition(
@@ -324,8 +329,10 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         ppp_config_.use_clas_osr_filter &&
         !ppp_config_.use_ionosphere_free &&
         ppp_config_.estimate_ionosphere) {
-        applyClasNlDatumReset(
-            obs.time, osr_corrections, ambiguity_states_, pppDebugEnabled());
+        if (applyClasNlDatumReset(
+                obs.time, osr_corrections, ambiguity_states_, pppDebugEnabled())) {
+            clas_dd_accumulator_ = {};
+        }
     }
     ppp_clas::applyPendingPhaseBiasStateShifts(
         filter_state_, osr_corrections, clas_phase_bias_repair_, pppDebugEnabled());
@@ -499,9 +506,19 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
             3.0,   // AR ratio threshold
             20,    // Min accumulation epochs before attempting LAMBDA
             pppDebugEnabled());
-        if (sd_ar_result.valid && sd_ar_result.code_rms >= 3.0) {
+        const bool sd_ar_fixed =
+            sd_ar_result.valid && sd_ar_result.ar_ratio >= 3.0;
+        const bool sd_ar_position_ok =
+            !env_overrides_.clas_base_clock_parity ||
+            sd_ar_result.position_shift_m <=
+                kClasBaseClockParitySdMarMaxPositionShiftM;
+        if (sd_ar_fixed && sd_ar_position_ok) {
             solution.position_ecef = sd_ar_result.position;
             solution.status = SolutionStatus::PPP_FIXED;
+        } else if (sd_ar_fixed && pppDebugEnabled()) {
+            std::cerr << "[CLAS-SD-MAR] reject parity pos_shift="
+                      << sd_ar_result.position_shift_m
+                      << " ratio=" << sd_ar_result.ar_ratio << "\n";
         }
     }
 

--- a/src/algorithms/ppp_clas_sd.cpp
+++ b/src/algorithms/ppp_clas_sd.cpp
@@ -496,12 +496,14 @@ SdEpochResult solveMultiEpochSdAr(
     result.valid = true;
     result.position = refined + dx;
     result.num_satellites = static_cast<int>(sat_obs.size());
-    result.code_rms = ratio;  // Store ratio
+    result.code_rms = ratio;
+    result.ar_ratio = ratio;
+    result.position_shift_m = dx.norm();
     result.phase_rms = 0.0;
 
     if (debug_enabled) {
         std::cerr << "[CLAS-SD-MAR] FIXED ratio=" << ratio
-                  << " pos_shift=" << dx.norm() << "\n";
+                  << " pos_shift=" << result.position_shift_m << "\n";
     }
 
     return result;

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -193,6 +193,8 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
         envExactOne("GNSS_PPP_CLAS_DD_FILTER");
     overrides.clas_sis_boundary =
         envExactOne("GNSS_PPP_CLAS_SIS_BOUNDARY");
+    overrides.clas_base_clock_parity =
+        envExactOne("GNSS_PPP_CLAS_BASE_CLOCK_PARITY");
     overrides.clas_amb_datum_residual_phase_trop =
         !envExactZero("GNSS_PPP_CLAS_AMB_DATUM_RESIDUAL_PHASE_TROP");
     overrides.clas_amb_datum =

--- a/src/algorithms/ppp_osr.cpp
+++ b/src/algorithms/ppp_osr.cpp
@@ -1140,6 +1140,11 @@ std::vector<OSRCorrection> computeOSR(
         SSRCorrectionStatus ssr_status;
         double base_clock_corr = 0.0;
         bool base_clock_valid = false;
+        const auto& env = pppEnvOverrides();
+        const auto clock_policy = env.clas_base_clock_parity
+            ? SSRClockSelectionPolicy::ClaslibBaseHold
+            : SSRClockSelectionPolicy::MergedInterpolate;
+        const bool allow_future_samples = !env.clas_base_clock_parity;
         if (ssr.interpolateCorrection(sat, obs.time, orbit_corr, clock_corr,
                                        &ura_sigma, &ssr_cbias, &ssr_pbias,
                                        &atmos_tokens,
@@ -1150,9 +1155,10 @@ std::vector<OSRCorrection> computeOSR(
                                        nullptr,
                                        nullptr,
                                        &ssr_status,
-                                       true,
+                                       allow_future_samples,
                                        &base_clock_corr,
-                                       &base_clock_valid)) {
+                                       &base_clock_valid,
+                                       clock_policy)) {
             // CSV-expanded CLAS corrections carry orbit deltas in RAC, while
             // sampled RTCM SSR products are already stored in ECEF.
             // RAC frame follows RTCM-10403.1 / CLASLIB convention:

--- a/src/algorithms/ppp_wlnl.cpp
+++ b/src/algorithms/ppp_wlnl.cpp
@@ -591,8 +591,18 @@ bool PPPProcessor::buildWlnlNlInfoForSatellite(
         if (ssr_products_loaded_) {
             Vector3d orbit_corr;
             double clock_corr = 0.0;
+            const auto clock_policy = pppEnvOverrides().clas_base_clock_parity
+                ? SSRClockSelectionPolicy::ClaslibBaseHold
+                : SSRClockSelectionPolicy::MergedInterpolate;
+            const bool allow_future_samples =
+                !pppEnvOverrides().clas_base_clock_parity;
             if (ssr_products_.interpolateCorrection(
-                    sat, obs.time, orbit_corr, clock_corr, nullptr, nullptr, nullptr, nullptr)) {
+                    sat, obs.time, orbit_corr, clock_corr,
+                    nullptr, nullptr, nullptr, nullptr,
+                    nullptr, nullptr, nullptr,
+                    0, nullptr, nullptr, nullptr,
+                    allow_future_samples, nullptr, nullptr,
+                    clock_policy)) {
                 if (ssr_products_.orbitCorrectionsAreRac()) {
                     orbit_corr = ppp_utils::ssrRacToEcef(sat_pos, sat_vel, orbit_corr);
                 }
@@ -931,8 +941,18 @@ bool PPPProcessor::buildFixedNlObservationForSatellite(
         if (ssr_products_loaded_) {
             Vector3d orbit_corr;
             double clock_corr = 0.0;
+            const auto clock_policy = pppEnvOverrides().clas_base_clock_parity
+                ? SSRClockSelectionPolicy::ClaslibBaseHold
+                : SSRClockSelectionPolicy::MergedInterpolate;
+            const bool allow_future_samples =
+                !pppEnvOverrides().clas_base_clock_parity;
             if (ssr_products_.interpolateCorrection(
-                    satellite, obs.time, orbit_corr, clock_corr, nullptr, nullptr, nullptr, nullptr)) {
+                    satellite, obs.time, orbit_corr, clock_corr,
+                    nullptr, nullptr, nullptr, nullptr,
+                    nullptr, nullptr, nullptr,
+                    0, nullptr, nullptr, nullptr,
+                    allow_future_samples, nullptr, nullptr,
+                    clock_policy)) {
                 if (ssr_products_.orbitCorrectionsAreRac()) {
                     orbit_corr = ppp_utils::ssrRacToEcef(sat_pos, sat_vel, orbit_corr);
                 }

--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -223,8 +223,21 @@ void interpolateBaseClockOutputs(const SSROrbitClockCorrection* before,
                                  double alpha,
                                  double merged_clock_m,
                                  double* base_clock_correction_m,
-                                 bool* base_clock_valid) {
+                                 bool* base_clock_valid,
+                                 SSRClockSelectionPolicy clock_selection_policy =
+                                     SSRClockSelectionPolicy::MergedInterpolate) {
     if (base_clock_correction_m == nullptr || base_clock_valid == nullptr) {
+        return;
+    }
+    if (clock_selection_policy == SSRClockSelectionPolicy::ClaslibBaseHold) {
+        const SSROrbitClockCorrection* sample = before != nullptr ? before : after;
+        if (sample != nullptr) {
+            assignBaseClockOutputs(*sample, merged_clock_m,
+                                   base_clock_correction_m, base_clock_valid);
+        } else {
+            *base_clock_correction_m = merged_clock_m;
+            *base_clock_valid = false;
+        }
         return;
     }
     const bool before_base = before != nullptr && before->base_clock_valid;
@@ -248,6 +261,123 @@ void interpolateBaseClockOutputs(const SSROrbitClockCorrection* before,
     }
     *base_clock_correction_m = merged_clock_m;
     *base_clock_valid = false;
+}
+
+constexpr double kClaslibMaxOrbitAgeFromObsSeconds = 180.0;
+constexpr double kClaslibMaxClockAgeFromObsSeconds = 30.0;
+constexpr double kClaslibMaxClockAgeFromOrbitSeconds = 30.0;
+
+struct ClaslibClockPick {
+    bool valid = false;
+    double clock_correction_m = 0.0;
+    GNSSTime clock_time;
+    GNSSTime clock_reference_time;
+    int ssr_clock_iod = -1;
+};
+
+ClaslibClockPick pickClaslibBaseClock(
+    const std::vector<SSROrbitClockCorrection>& entries,
+    const GNSSTime& obs_time) {
+    const SSROrbitClockCorrection* orbit_ref = nullptr;
+    GNSSTime orbit_ref_time;
+    for (const auto& entry : entries) {
+        if (!entry.orbit_valid) {
+            continue;
+        }
+        const GNSSTime orbit_time = orbitReferenceTime(entry);
+        const double obs_age = obs_time - orbit_time;
+        if (obs_age < 0.0 || obs_age > kClaslibMaxOrbitAgeFromObsSeconds) {
+            continue;
+        }
+        if (orbit_ref == nullptr || orbit_time > orbit_ref_time) {
+            orbit_ref = &entry;
+            orbit_ref_time = orbit_time;
+        }
+    }
+    if (orbit_ref == nullptr) {
+        return {};
+    }
+
+    const SSROrbitClockCorrection* best = nullptr;
+    for (const auto& entry : entries) {
+        if (!entry.base_clock_valid) {
+            continue;
+        }
+
+        const GNSSTime clock_time = entry.time;
+        if (clock_time > obs_time) {
+            continue;
+        }
+        const double obs_age = obs_time - clock_time;
+        if (obs_age < 0.0 || obs_age > kClaslibMaxClockAgeFromObsSeconds) {
+            continue;
+        }
+        const double orbit_age = clock_time - orbit_ref_time;
+        if (orbit_age < 0.0 || orbit_age >= kClaslibMaxClockAgeFromOrbitSeconds) {
+            continue;
+        }
+        if (best == nullptr || clock_time > best->time) {
+            best = &entry;
+        }
+    }
+    if (best == nullptr) {
+        return {};
+    }
+
+    ClaslibClockPick pick;
+    pick.valid = true;
+    pick.clock_correction_m = best->base_clock_correction_m;
+    pick.clock_time = best->time;
+    pick.clock_reference_time = clockReferenceTime(*best);
+    pick.ssr_clock_iod = best->ssr_clock_iod;
+    return pick;
+}
+
+bool applyClaslibClockSelection(
+    SSRClockSelectionPolicy clock_selection_policy,
+    const std::vector<SSROrbitClockCorrection>& entries,
+    const GNSSTime& time,
+    double& clock_correction_m,
+    double* base_clock_correction_m,
+    bool* base_clock_valid,
+    GNSSTime* clock_reference_time,
+    SSRCorrectionStatus* status,
+    bool base_result) {
+    if (clock_selection_policy != SSRClockSelectionPolicy::ClaslibBaseHold) {
+        return base_result;
+    }
+
+    const ClaslibClockPick pick = pickClaslibBaseClock(entries, time);
+    if (!pick.valid) {
+        clock_correction_m = 0.0;
+        if (base_clock_correction_m != nullptr && base_clock_valid != nullptr) {
+            *base_clock_correction_m = 0.0;
+            *base_clock_valid = false;
+        }
+        if (clock_reference_time != nullptr) {
+            *clock_reference_time = GNSSTime();
+        }
+        if (status != nullptr) {
+            status->clock_valid = false;
+        }
+        return false;
+    }
+
+    clock_correction_m = pick.clock_correction_m;
+    if (base_clock_correction_m != nullptr && base_clock_valid != nullptr) {
+        *base_clock_correction_m = pick.clock_correction_m;
+        *base_clock_valid = true;
+    }
+    if (clock_reference_time != nullptr) {
+        *clock_reference_time = pick.clock_time;
+    }
+    if (status != nullptr) {
+        status->clock_valid = true;
+        status->clock_reference_time = pick.clock_reference_time;
+        status->ssr_clock_iod = pick.ssr_clock_iod;
+    }
+    const bool orbit_ok = status == nullptr || status->orbit_valid;
+    return pick.valid && orbit_ok;
 }
 
 bool parseEpochFields(int year,
@@ -1468,7 +1598,8 @@ bool SSRProducts::interpolateCorrection(const SatelliteId& sat,
                                         SSRCorrectionStatus* status,
                                         bool allow_future_samples,
                                         double* base_clock_correction_m,
-                                        bool* base_clock_valid) const {
+                                        bool* base_clock_valid,
+                                        SSRClockSelectionPolicy clock_selection_policy) const {
     if (status != nullptr) {
         *status = SSRCorrectionStatus{};
     }
@@ -1746,8 +1877,17 @@ bool SSRProducts::interpolateCorrection(const SatelliteId& sat,
                 status->atmos_reference_time = atmos_source->time;
             }
         }
-        return orbit_source != nullptr || clock_source != nullptr || ura_source != nullptr ||
-               code_source != nullptr || phase_source != nullptr || atmos_source != nullptr;
+        return applyClaslibClockSelection(
+            clock_selection_policy,
+            entries,
+            time,
+            clock_correction_m,
+            base_clock_correction_m,
+            base_clock_valid,
+            clock_reference_time,
+            status,
+            orbit_source != nullptr || clock_source != nullptr || ura_source != nullptr ||
+                code_source != nullptr || phase_source != nullptr || atmos_source != nullptr);
     }
 
     const SSROrbitClockCorrection* before = nullptr;
@@ -1843,7 +1983,8 @@ bool SSRProducts::interpolateCorrection(const SatelliteId& sat,
         }
         if (before != nullptr || after != nullptr) {
             interpolateBaseClockOutputs(before, after, alpha, clock_correction_m,
-                                        base_clock_correction_m, base_clock_valid);
+                                        base_clock_correction_m, base_clock_valid,
+                                        clock_selection_policy);
         }
         if (ura_sigma_m != nullptr) {
             if (before->ura_valid && after->ura_valid) {
@@ -1990,12 +2131,21 @@ bool SSRProducts::interpolateCorrection(const SatelliteId& sat,
                 }
             }
         }
-        return before->orbit_valid || after->orbit_valid ||
-               before->clock_valid || after->clock_valid ||
-               before->ura_valid || after->ura_valid ||
-               before->code_bias_valid || after->code_bias_valid ||
-               before->phase_bias_valid || after->phase_bias_valid ||
-               before->atmos_valid || after->atmos_valid;
+        return applyClaslibClockSelection(
+            clock_selection_policy,
+            entries,
+            time,
+            clock_correction_m,
+            base_clock_correction_m,
+            base_clock_valid,
+            clock_reference_time,
+            status,
+            before->orbit_valid || after->orbit_valid ||
+                before->clock_valid || after->clock_valid ||
+                before->ura_valid || after->ura_valid ||
+                before->code_bias_valid || after->code_bias_valid ||
+                before->phase_bias_valid || after->phase_bias_valid ||
+                before->atmos_valid || after->atmos_valid);
     }
 
     const SSROrbitClockCorrection* sample = before != nullptr ? before : after;
@@ -2129,8 +2279,17 @@ bool SSRProducts::interpolateCorrection(const SatelliteId& sat,
             }
         }
     }
-    return sample->orbit_valid || sample->clock_valid || sample->ura_valid ||
-           sample->code_bias_valid || sample->phase_bias_valid || sample->atmos_valid;
+    return applyClaslibClockSelection(
+        clock_selection_policy,
+        entries,
+        time,
+        clock_correction_m,
+        base_clock_correction_m,
+        base_clock_valid,
+        clock_reference_time,
+        status,
+        sample->orbit_valid || sample->clock_valid || sample->ura_valid ||
+            sample->code_bias_valid || sample->phase_bias_valid || sample->atmos_valid);
 }
 
 bool SSRProducts::loadCSVFile(const std::string& filename) {

--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -1695,6 +1695,37 @@ bool SSRProducts::interpolateCorrection(const SatelliteId& sat,
         return score;
     };
 
+    const auto scanBackwardBias = [&](bool phase) -> const SSROrbitClockCorrection* {
+        size_t group_end = static_cast<size_t>(lower - entries.begin());
+        while (group_end > 0) {
+            const size_t group_last = group_end - 1;
+            const GNSSTime group_time = entries[group_last].time;
+            if (std::abs(group_time - time) > kPreciseInterpolationGapSeconds) {
+                break;
+            }
+
+            size_t group_begin = group_last;
+            while (group_begin > 0 && entries[group_begin - 1].time == group_time) {
+                --group_begin;
+            }
+
+            const SSROrbitClockCorrection* best = nullptr;
+            int best_score = -1;
+            for (size_t index = group_begin; index < group_end; ++index) {
+                const int score = biasScore(entries[index], phase);
+                if (score > best_score) {
+                    best_score = score;
+                    best = &entries[index];
+                }
+            }
+            if (best != nullptr) {
+                return best;
+            }
+            group_end = group_begin;
+        }
+        return nullptr;
+    };
+
     if (lower != entries.end() && lower->time == time) {
         const size_t lower_index = static_cast<size_t>(lower - entries.begin());
         size_t exact_begin = lower_index;
@@ -2013,34 +2044,6 @@ bool SSRProducts::interpolateCorrection(const SatelliteId& sat,
         // which are typically clock-only rows with no bias.  Scan backwards
         // through older entries to find the most recent bias, matching the
         // CLASLIB behaviour of holding the last received bias indefinitely.
-        auto scanBackwardBias = [&](bool phase) -> const SSROrbitClockCorrection* {
-            size_t group_end = static_cast<size_t>(lower - entries.begin());
-            while (group_end > 0) {
-                const size_t group_last = group_end - 1;
-                const GNSSTime group_time = entries[group_last].time;
-                if (std::abs(group_time - time) > kPreciseInterpolationGapSeconds) break;
-
-                size_t group_begin = group_last;
-                while (group_begin > 0 && entries[group_begin - 1].time == group_time) {
-                    --group_begin;
-                }
-
-                const SSROrbitClockCorrection* best = nullptr;
-                int best_score = -1;
-                for (size_t index = group_begin; index < group_end; ++index) {
-                    const int score = biasScore(entries[index], phase);
-                    if (score > best_score) {
-                        best_score = score;
-                        best = &entries[index];
-                    }
-                }
-                if (best != nullptr) {
-                    return best;
-                }
-                group_end = group_begin;
-            }
-            return nullptr;
-        };
         if (code_bias_m != nullptr) {
             // Code biases are stepwise corrections.  Do not consume a future
             // bias row just because the next clock interpolation neighbour has
@@ -2207,39 +2210,46 @@ bool SSRProducts::interpolateCorrection(const SatelliteId& sat,
         }
     }
     if (code_bias_m != nullptr) {
-        if (sample->code_bias_valid && !sample->code_bias_m.empty()) {
-            *code_bias_m = sample->code_bias_m;
+        const SSROrbitClockCorrection* picked = nullptr;
+        if (clock_selection_policy == SSRClockSelectionPolicy::ClaslibBaseHold) {
+            picked = scanBackwardBias(false);
+        }
+        if (picked == nullptr && sample->code_bias_valid && !sample->code_bias_m.empty()) {
+            picked = sample;
+        } else if (picked == nullptr && orbit_source != sample &&
+                   orbit_source->code_bias_valid && !orbit_source->code_bias_m.empty()) {
+            picked = orbit_source;
+        }
+        if (picked != nullptr) {
+            *code_bias_m = picked->code_bias_m;
             if (status != nullptr) {
                 status->code_bias_valid = true;
-                status->code_bias_reference_time = sample->time;
-            }
-        } else if (orbit_source != sample && orbit_source->code_bias_valid && !orbit_source->code_bias_m.empty()) {
-            *code_bias_m = orbit_source->code_bias_m;
-            if (status != nullptr) {
-                status->code_bias_valid = true;
-                status->code_bias_reference_time = orbit_source->time;
+                status->code_bias_reference_time = picked->time;
             }
         }
     }
     if (phase_bias_m != nullptr) {
-        if (sample->phase_bias_valid && !sample->phase_bias_m.empty()) {
-            *phase_bias_m = sample->phase_bias_m;
+        const SSROrbitClockCorrection* picked = nullptr;
+        if (clock_selection_policy == SSRClockSelectionPolicy::ClaslibBaseHold) {
+            picked = scanBackwardBias(true);
+        }
+        if (picked == nullptr && sample->phase_bias_valid && !sample->phase_bias_m.empty()) {
+            picked = sample;
+        } else if (picked == nullptr && orbit_source != sample &&
+                   orbit_source->phase_bias_valid && !orbit_source->phase_bias_m.empty()) {
+            picked = orbit_source;
+        }
+        if (picked != nullptr) {
+            *phase_bias_m = picked->phase_bias_m;
+            if (phase_bias_discnt != nullptr) {
+                *phase_bias_discnt = picked->phase_bias_discnt;
+            }
             if (phase_bias_reference_time != nullptr) {
-                *phase_bias_reference_time = sample->time;
+                *phase_bias_reference_time = picked->time;
             }
             if (status != nullptr) {
                 status->phase_bias_valid = true;
-                status->phase_bias_reference_time = sample->time;
-            }
-        } else if (orbit_source != sample && orbit_source->phase_bias_valid &&
-                   !orbit_source->phase_bias_m.empty()) {
-            *phase_bias_m = orbit_source->phase_bias_m;
-            if (phase_bias_reference_time != nullptr) {
-                *phase_bias_reference_time = orbit_source->time;
-            }
-            if (status != nullptr) {
-                status->phase_bias_valid = true;
-                status->phase_bias_reference_time = orbit_source->time;
+                status->phase_bias_reference_time = picked->time;
             }
         }
     }

--- a/tests/test_ppp_osr.cpp
+++ b/tests/test_ppp_osr.cpp
@@ -976,6 +976,223 @@ TEST(PPPOSRTest, ClasSisBoundaryUsesBaseClockWhenNetworkMergedAtOffset25) {
     EXPECT_NEAR(info.boundary_delta_m, -0.058, 1e-12);
 }
 
+namespace {
+
+SSROrbitClockCorrection makeClasClockTestOrbitRow(const SatelliteId& satellite,
+                                                    const GNSSTime& time,
+                                                    double clock_m,
+                                                    int clock_network_id) {
+    SSROrbitClockCorrection row;
+    row.satellite = satellite;
+    row.time = time;
+    row.orbit_correction_ecef = Vector3d(0.1, 0.2, 0.3);
+    row.orbit_valid = true;
+    row.orbit_reference_time = time;
+    row.clock_correction_m = clock_m;
+    row.clock_valid = true;
+    row.clock_network_id = clock_network_id;
+    if (clock_network_id == 0) {
+        row.base_clock_correction_m = clock_m;
+        row.base_clock_valid = true;
+    }
+    return row;
+}
+
+}  // namespace
+
+TEST(PPPOSRTest, ClaslibBaseHoldStepHoldsBetweenFiveSecondGridPoints) {
+    SSRProducts products;
+    products.setOrbitCorrectionsAreRac(false);
+
+    const SatelliteId satellite(GNSSSystem::GPS, 14);
+    const GNSSTime orbit_time(2068, 230400.0);
+    const GNSSTime clock_t0(2068, 230420.0);
+    const GNSSTime clock_t1(2068, 230425.0);
+    const GNSSTime obs_between(2068, 230422.0);
+
+    SSROrbitClockCorrection orbit_row;
+    orbit_row.satellite = satellite;
+    orbit_row.time = orbit_time;
+    orbit_row.orbit_correction_ecef = Vector3d(0.1, 0.2, 0.3);
+    orbit_row.orbit_valid = true;
+    orbit_row.orbit_reference_time = orbit_time;
+    products.addCorrection(orbit_row);
+
+    products.addCorrection(
+        makeClasClockTestOrbitRow(satellite, clock_t0, -0.2016, 0));
+    products.addCorrection(
+        makeClasClockTestOrbitRow(satellite, clock_t1, -0.2192, 0));
+
+    Vector3d orbit_corr = Vector3d::Zero();
+    double clock_m = 0.0;
+    ASSERT_TRUE(products.interpolateCorrection(
+        satellite,
+        obs_between,
+        orbit_corr,
+        clock_m,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        0,
+        nullptr,
+        nullptr,
+        nullptr,
+        false,
+        nullptr,
+        nullptr,
+        SSRClockSelectionPolicy::ClaslibBaseHold));
+    EXPECT_DOUBLE_EQ(clock_m, -0.2016);
+}
+
+TEST(PPPOSRTest, ClaslibBaseHoldIgnoresNetworkMergedClock) {
+    SSRProducts products;
+    products.setOrbitCorrectionsAreRac(false);
+
+    const SatelliteId satellite(GNSSSystem::GPS, 14);
+    const GNSSTime orbit_time(2068, 230400.0);
+    const GNSSTime offset25(2068, 230425.0);
+
+    SSROrbitClockCorrection orbit_row;
+    orbit_row.satellite = satellite;
+    orbit_row.time = orbit_time;
+    orbit_row.orbit_correction_ecef = Vector3d(0.1, 0.2, 0.3);
+    orbit_row.orbit_valid = true;
+    orbit_row.orbit_reference_time = orbit_time;
+    products.addCorrection(orbit_row);
+
+    SSROrbitClockCorrection base_row =
+        makeClasClockTestOrbitRow(satellite, offset25, -0.2192, 0);
+    products.addCorrection(base_row);
+
+    SSROrbitClockCorrection network_row;
+    network_row.satellite = satellite;
+    network_row.time = offset25;
+    network_row.clock_correction_m = 0.2064;
+    network_row.clock_valid = true;
+    network_row.clock_network_id = 1;
+    products.addCorrection(network_row);
+
+    Vector3d orbit_corr = Vector3d::Zero();
+    double gated_clock_m = 0.0;
+    ASSERT_TRUE(products.interpolateCorrection(
+        satellite,
+        offset25,
+        orbit_corr,
+        gated_clock_m,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        0,
+        nullptr,
+        nullptr,
+        nullptr,
+        false,
+        nullptr,
+        nullptr,
+        SSRClockSelectionPolicy::ClaslibBaseHold));
+    EXPECT_DOUBLE_EQ(gated_clock_m, -0.2192);
+}
+
+TEST(PPPOSRTest, ClaslibBaseHoldRejectsFutureClockSample) {
+    SSRProducts products;
+    products.setOrbitCorrectionsAreRac(false);
+
+    const SatelliteId satellite(GNSSSystem::GPS, 14);
+    const GNSSTime orbit_time(2068, 230400.0);
+    const GNSSTime obs_time(2068, 230422.0);
+    const GNSSTime future_clock(2068, 230425.0);
+
+    SSROrbitClockCorrection orbit_row;
+    orbit_row.satellite = satellite;
+    orbit_row.time = orbit_time;
+    orbit_row.orbit_correction_ecef = Vector3d(0.1, 0.2, 0.3);
+    orbit_row.orbit_valid = true;
+    orbit_row.orbit_reference_time = orbit_time;
+    products.addCorrection(orbit_row);
+
+    products.addCorrection(
+        makeClasClockTestOrbitRow(satellite, future_clock, -0.2192, 0));
+
+    Vector3d orbit_corr = Vector3d::Zero();
+    double clock_m = 0.0;
+    EXPECT_FALSE(products.interpolateCorrection(
+        satellite,
+        obs_time,
+        orbit_corr,
+        clock_m,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        0,
+        nullptr,
+        nullptr,
+        nullptr,
+        false,
+        nullptr,
+        nullptr,
+        SSRClockSelectionPolicy::ClaslibBaseHold));
+}
+
+TEST(PPPOSRTest, ClaslibBaseHoldFailsWhenNoEligibleClock) {
+    SSRProducts products;
+    products.setOrbitCorrectionsAreRac(false);
+
+    const SatelliteId satellite(GNSSSystem::GPS, 14);
+    const GNSSTime orbit_time(2068, 230400.0);
+    const GNSSTime obs_time(2068, 230422.0);
+
+    SSROrbitClockCorrection orbit_row;
+    orbit_row.satellite = satellite;
+    orbit_row.time = orbit_time;
+    orbit_row.orbit_correction_ecef = Vector3d(0.1, 0.2, 0.3);
+    orbit_row.orbit_valid = true;
+    orbit_row.orbit_reference_time = orbit_time;
+    products.addCorrection(orbit_row);
+
+    SSROrbitClockCorrection network_only;
+    network_only.satellite = satellite;
+    network_only.time = orbit_time;
+    network_only.clock_correction_m = 0.2064;
+    network_only.clock_valid = true;
+    network_only.clock_network_id = 1;
+    products.addCorrection(network_only);
+
+    Vector3d orbit_corr = Vector3d::Zero();
+    double clock_m = 0.0;
+    EXPECT_FALSE(products.interpolateCorrection(
+        satellite,
+        obs_time,
+        orbit_corr,
+        clock_m,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        0,
+        nullptr,
+        nullptr,
+        nullptr,
+        false,
+        nullptr,
+        nullptr,
+        SSRClockSelectionPolicy::ClaslibBaseHold));
+}
+
 TEST(PPPOSRTest, ClasSisApplyDecisionGateOnHoldsBoundaryDeltaForFifteenObsSeconds) {
     const GNSSTime boundary_time(2068, 230430.0);
     const GNSSTime phase_bias_ref = boundary_time;  // synced; irrelevant when gated.


### PR DESCRIPTION
## Summary

Stacked on #277 (merge order: #275 → #276 → #277 → this).

Adds `GNSS_PPP_CLAS_BASE_CLOCK_PARITY` (default **OFF**; default path byte-identical) which makes the CLAS SSR clock selection match CLASLIB semantics, plus the two follow-up fixes needed to make the gated config land #161-positive:

1. **`4c66cac` — base-clock parity gate**: CLASLIB-rule clock pick (base bank only, newest-eligible step-hold, reject future samples, orbit-anchored age) behind `SSRClockSelectionPolicy::ClaslibBaseHold`, wired at the CLAS OSR call sites (`ppp_osr` / `ppp_ambiguity` / `ppp_wlnl`). Pick verified vs CLASLIB oracle: RMS **0.000276 m** (n=1590). Resolves the gate-ON 39.8 m spike at tow≈230480.
2. **`5cfb2f2` — bias hold on step-hold path**: the step-hold path used clock-only grid rows and dropped code/phase biases from epoch 2 (`pbias_n=0` → MW never accumulates → 0 WL fixes → AR collapse 276→6 fixed). Reuse `scanBackwardBias` (CLASLIB hold-last-bias semantics) on that path.
3. **`26ecc37` — SD-MAR blunder rejection**: with AR restored, 5 catastrophic wrong-FIX epochs (43–595 m) remained. Forensics: WL-NL correctly rejected (ratio 1.5–1.6 < 2.0) but multi-epoch **CLAS-SD-MAR** forced FIXED (ratio ~4.5) with no position gate; CLASLIB has no equivalent layer. Fix: clear the SD accumulator on NL datum jumps, and (parity-gated) reject SD-MAR fixes with position shift > 2.0 m (good fixes 0.14–0.64 m vs blunders 38–595 m).

## Results (3600 epochs, 0627239Q vs CLASLIB oracle; independently re-run and verified)

| Config | Fixed | Fixed-only 3D mean | All-epoch 3D mean | Blunders (>10 m) | Max err | .pos md5 |
|---|---|---|---|---|---|---|
| gate-OFF (default) | 276 | 1.630 m | 1.544 m | 0 | 5.07 m | `57012bec…` (**byte-identical** to #277) |
| parity-ON | **313** | **1.452 m** | **1.506 m** | **0** | 4.20 m | `7b2a8169…` |
| parity + `GNSS_PPP_CLAS_SIS_BOUNDARY` | 281 | **1.409 m** | **1.497 m** | **0** | 4.20 m | `b4c1409b…` |

#161 (parity-ON vs baseline): fixed 313 ≥ 276 ✓, fixed-only 1.452 < 1.630 ✓, all-epoch 1.506 < 1.544 ✓. Both-gates config is the best on accuracy and also passes.

- A4b gate-OFF dump anchor unchanged: `5ec711bf…`
- Runs are deterministic (md5-stable across repeated runs)
- Tests: `ctest -R clas` 6/6, `PPPOSRTest.ClaslibBaseHold*` 4/4

Reports: `/tmp/gnss_clock_parity_report.md`, `/tmp/gnss_clock_parity_fix_report.md`, `/tmp/gnss_blunder_fix_report.md` (with verification addendum).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Sxnf4745UU5XCEvk9Kws8k