### PR TITLE
GTSAM FGO backend with tightly-coupled GNSS/IMU RTK and urban robustness

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,6 +32,11 @@ if(GTSAM_FOUND)
 else()
     message(STATUS "GTSAM not found; optional FGO GTSAM backend disabled")
 endif()
+# GNSSPP_HAS_GTSAM (compile definition, exported PUBLIC below) gates all
+# GTSAM-dependent code (see src/algorithms/fgo_gtsam_backend.cpp and the
+# FGOProcessor::optimizeProblem backend selector in src/algorithms/fgo.cpp).
+# A build without GTSAM_FOUND is unchanged: FGOBackend::GTSAM silently falls
+# back to the native Eigen backend.
 option(GNSSPP_USE_CHOLMOD "Use CHOLMOD for optional FGO sparse covariance solves" ON)
 if(GNSSPP_USE_CHOLMOD)
     find_path(CHOLMOD_INCLUDE_DIR
@@ -228,6 +233,28 @@ if(CHOLMOD_INCLUDE_DIR AND CHOLMOD_LIBRARY)
     target_include_directories(gnss_lib_noopt PRIVATE ${CHOLMOD_INCLUDE_DIR})
     target_compile_definitions(gnss_lib_noopt PRIVATE GNSSPP_HAS_CHOLMOD=1)
     target_link_libraries(gnss_lib_noopt PRIVATE ${CHOLMOD_LIBRARY})
+endif()
+if(GTSAM_FOUND)
+    # fgo.cpp (FGOProcessor::optimizeProblem) lives in gnss_lib_noopt, so the
+    # GTSAM backend TU and the gtsam link dependency must live here too, not
+    # on gnss_lib, otherwise the backend-selector forward declaration in
+    # fgo.cpp would be an unresolved symbol at link time.
+    target_sources(gnss_lib_noopt PRIVATE src/algorithms/fgo_gtsam_backend.cpp)
+    target_link_libraries(gnss_lib_noopt PUBLIC gtsam)
+    target_compile_definitions(gnss_lib_noopt PUBLIC GNSSPP_HAS_GTSAM=1)
+    if(MSVC)
+        # gtsam.dll dllexports a handful of STL template instantiations that back
+        # its Key containers (std::map<uint64,uint64>, std::vector<uint64>, ...).
+        # Those same instantiations also appear as COMDAT symbols in our own
+        # object files (e.g. fgo.obj), so every executable that links both
+        # gnss_lib_noopt and gtsam hits LNK2005 "already defined". /FORCE:MULTIPLE
+        # tells the linker to keep the first definition and drop the duplicates;
+        # this is the standard GTSAM-on-Windows shared-build workaround and is
+        # safe here because the colliding symbols are identical inline STL code.
+        # Propagated as an INTERFACE option so every consumer (apps, tests) that
+        # transitively links gtsam through gnss_lib_noopt inherits it.
+        target_link_options(gnss_lib_noopt INTERFACE /FORCE:MULTIPLE)
+    endif()
 endif()
 
 set(GNSS_INSTALL_TARGETS gnss_lib gnss_lib_noopt sofa ginan_iers2010)

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -29,6 +29,15 @@ if(GTSAM_FOUND)
     target_link_libraries(gnss_fgo PRIVATE gtsam)
 endif()
 
+# Real-data Eigen-vs-GTSAM FGO backend parity harness. Only meaningful when the
+# library is built with the GTSAM backend (otherwise FGOBackend::GTSAM falls
+# back to Eigen). gnss_lib_noopt carries the gtsam link + /FORCE:MULTIPLE as an
+# INTERFACE requirement, so this target inherits both automatically.
+if(GTSAM_FOUND)
+    add_executable(gnss_fgo_parity gnss_fgo_parity.cpp)
+    target_link_libraries(gnss_fgo_parity PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)
+endif()
+
 add_executable(gnss_fuse gnss_fuse.cpp)
 target_link_libraries(gnss_fuse PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)
 

--- a/apps/gnss_fgo_parity.cpp
+++ b/apps/gnss_fgo_parity.cpp
@@ -108,6 +108,22 @@ struct Args {
     double varerr_a = -1.0;        // >=0: override elevation_sigma_err_a_m
     double varerr_b = -1.0;        // >=0: override elevation_sigma_err_b_m
     double varerr_eratio = -1.0;   // >=0: override elevation_sigma_pseudorange_ratio
+    // H1: IMU noise-grade alignment vs the reference's IMU_PRESETS['tactical']
+    // (config.py ~line 32). -1 = leave buildImuInput()'s current default.
+    double imu_accel_noise = -1.0;  // >=0: override accel_noise_sigma [m/s^2/sqrt(Hz)]
+    double imu_gyro_noise = -1.0;   // >=0: override gyro_noise_sigma [rad/s/sqrt(Hz)]
+    double imu_accel_bias = -1.0;   // >=0: override accel_bias_rw_sigma [m/s^3/sqrt(Hz)]
+    double imu_gyro_bias = -1.0;    // >=0: override gyro_bias_rw_sigma [rad/s^2/sqrt(Hz)]
+    bool imu_preset_tactical = false;  // convenience: apply all four tactical-grade values at once
+    // Reference parity: IMU integration-covariance value semantics + per-
+    // epoch inflation (FGOConfig::imu_integration_covariance /
+    // use_imu_integration_covariance_inflation, fgo.hpp) and gravity
+    // (ImuNoiseParams::gravity_mps2, currently hardcoded 9.80665 in
+    // buildImuInput() vs the reference's utils/imu.py:39 9.81).
+    double integ_cov = -1.0;       // >=0: override config.imu_integration_covariance (reference imu_integ_cov; 1e-3 is the reference value)
+    bool integ_cov_inflate = false;  // enable use_imu_integration_covariance_inflation
+    double integ_cov_max = -1.0;   // >=0: override config.imu_integration_covariance_max (reference imu_integ_cov_max, default 0.5)
+    double gravity_mps2 = -1.0;    // >=0: override problem.imu.noise.gravity_mps2 (reference 9.81; ours defaults 9.80665)
 };
 
 Args parseArgs(int argc, char** argv) {
@@ -258,6 +274,24 @@ Args parseArgs(int argc, char** argv) {
             args.varerr_b = std::stod(argv[++i]);
         } else if (a == "--varerr-eratio" && i + 1 < argc) {
             args.varerr_eratio = std::stod(argv[++i]);
+        } else if (a == "--imu-accel-noise" && i + 1 < argc) {
+            args.imu_accel_noise = std::stod(argv[++i]);
+        } else if (a == "--imu-gyro-noise" && i + 1 < argc) {
+            args.imu_gyro_noise = std::stod(argv[++i]);
+        } else if (a == "--imu-accel-bias" && i + 1 < argc) {
+            args.imu_accel_bias = std::stod(argv[++i]);
+        } else if (a == "--imu-gyro-bias" && i + 1 < argc) {
+            args.imu_gyro_bias = std::stod(argv[++i]);
+        } else if (a == "--imu-preset-tactical") {
+            args.imu_preset_tactical = true;
+        } else if (a == "--integ-cov" && i + 1 < argc) {
+            args.integ_cov = std::stod(argv[++i]);
+        } else if (a == "--integ-cov-inflate") {
+            args.integ_cov_inflate = true;
+        } else if (a == "--integ-cov-max" && i + 1 < argc) {
+            args.integ_cov_max = std::stod(argv[++i]);
+        } else if (a == "--gravity" && i + 1 < argc) {
+            args.gravity_mps2 = std::stod(argv[++i]);
         } else {
             std::cerr << "Unknown/incomplete arg: " << a << "\n";
             std::exit(2);
@@ -692,6 +726,28 @@ bool buildImuInput(const std::string& imu_path,
     return true;
 }
 
+// H1: apply CLI IMU noise overrides on top of buildImuInput()'s defaults.
+// --imu-preset-tactical sets all four to the reference's IMU_PRESETS['tactical']
+// (gnss_fgo/config.py ~line 32); individual --imu-accel-noise etc. win over the
+// preset when both are given, so a preset + single-field sweep composes cleanly.
+void applyImuNoiseOverrides(const Args& args, libgnss::FGOProcessor::FGOProblem& problem) {
+    if (args.imu_preset_tactical) {
+        problem.imu.noise.accel_noise_sigma = 2.84e-4;
+        problem.imu.noise.gyro_noise_sigma = 4.01e-5;
+        problem.imu.noise.accel_bias_rw_sigma = 3.14e-4;
+        problem.imu.noise.gyro_bias_rw_sigma = 9.70e-6;
+    }
+    if (args.imu_accel_noise >= 0.0) problem.imu.noise.accel_noise_sigma = args.imu_accel_noise;
+    if (args.imu_gyro_noise >= 0.0) problem.imu.noise.gyro_noise_sigma = args.imu_gyro_noise;
+    if (args.imu_accel_bias >= 0.0) problem.imu.noise.accel_bias_rw_sigma = args.imu_accel_bias;
+    if (args.imu_gyro_bias >= 0.0) problem.imu.noise.gyro_bias_rw_sigma = args.imu_gyro_bias;
+    // Gravity measured variant (see Args::gravity_mps2): the reference's
+    // utils/imu.py:39 uses gtsam::PreintegrationCombinedParams::MakeSharedU(9.81);
+    // buildImuInput() here defaults to 9.80665. Not applied silently -- only
+    // when --gravity is passed.
+    if (args.gravity_mps2 >= 0.0) problem.imu.noise.gravity_mps2 = args.gravity_mps2;
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -930,6 +986,15 @@ int main(int argc, char** argv) {
     if (args.varerr_eratio >= 0.0) {
         config.elevation_sigma_pseudorange_ratio = args.varerr_eratio;
     }
+    if (args.integ_cov >= 0.0) {
+        config.imu_integration_covariance = args.integ_cov;
+    }
+    if (args.integ_cov_inflate) {
+        config.use_imu_integration_covariance_inflation = true;
+    }
+    if (args.integ_cov_max >= 0.0) {
+        config.imu_integration_covariance_max = args.integ_cov_max;
+    }
     const libgnss::FGOProcessor builder(config);
     const libgnss::FGOProcessor::FGOProblem problem =
         builder.buildDoubleDifferenceProblem(rover_epochs, base_epochs, nav, base_position);
@@ -1066,6 +1131,7 @@ int main(int argc, char** argv) {
             std::cerr << "Error: could not build IMU input for fixed-lag run.\n";
             return 1;
         }
+        applyImuNoiseOverrides(args, problem_imu);
         std::vector<RefRow> ref_rows;
         if (!args.ref_path.empty()) ref_rows = loadReference(args.ref_path);
 
@@ -1148,7 +1214,12 @@ int main(int argc, char** argv) {
                   << " m, err_b=" << config.elevation_sigma_err_b_m
                   << " m, eratio_pr=" << config.elevation_sigma_pseudorange_ratio
                   << ", sclkstab=" << config.elevation_sigma_clock_stability
-                  << " s/s)\n";
+                  << " s/s)\n"
+                  << "  IMU integration covariance: value=" << config.imu_integration_covariance
+                  << " m^2/s, inflation=" << (args.integ_cov_inflate ? "on" : "off")
+                  << " (cap=" << config.imu_integration_covariance_max
+                  << ", stale_epochs=" << config.imu_integration_covariance_stale_epochs
+                  << "), gravity=" << problem_imu.imu.noise.gravity_mps2 << " m/s^2\n";
         if (!ref_rows.empty()) {
             std::cout << "  horizontal error vs reference.csv:\n"
                       << "    FLOAT: n=" << he.n_float << " rms=" << he.float_rms
@@ -1349,6 +1420,7 @@ int main(int argc, char** argv) {
     if (!args.imu_path.empty()) {
         libgnss::FGOProcessor::FGOProblem problem_imu = problem;
         if (buildImuInput(args.imu_path, problem_imu)) {
+            applyImuNoiseOverrides(args, problem_imu);
             std::vector<RefRow> ref_rows;
             if (!args.ref_path.empty()) ref_rows = loadReference(args.ref_path);
 

--- a/apps/gnss_fgo_parity.cpp
+++ b/apps/gnss_fgo_parity.cpp
@@ -99,6 +99,15 @@ struct Args {
     double sat_badness_cp_scale = -1.0;   // >=0: override sat_badness_carrier_sigma_scale
     double sat_badness_pr_scale = -1.0;   // >=0: override sat_badness_pseudorange_sigma_scale
     double sat_badness_ddpr_thresh = -1.0; // >=0: override sat_badness_ddpr_threshold_m
+    // CLAMPED-variant overrides (see FGOConfig's sat_badness_residual_clamp_m /
+    // sat_badness_score_cap / sat_badness_cppr_decay for the full rationale).
+    double sat_badness_clamp = -1.0;      // >=0: override sat_badness_residual_clamp_m (0 = no clamp = faithful)
+    double sat_badness_cap = -1.0;        // >=0: override sat_badness_score_cap (0 = no cap = faithful)
+    double sat_badness_cppr_decay = -1.0; // >=0: override sat_badness_cppr_decay (1.0 = never decays = faithful)
+    bool varerr = false;           // elevation-dependent DD sigma (RTKLIB-demo5 varerr port)
+    double varerr_a = -1.0;        // >=0: override elevation_sigma_err_a_m
+    double varerr_b = -1.0;        // >=0: override elevation_sigma_err_b_m
+    double varerr_eratio = -1.0;   // >=0: override elevation_sigma_pseudorange_ratio
 };
 
 Args parseArgs(int argc, char** argv) {
@@ -235,6 +244,20 @@ Args parseArgs(int argc, char** argv) {
             args.sat_badness_pr_scale = std::stod(argv[++i]);
         } else if (a == "--sat-badness-ddpr-thresh" && i + 1 < argc) {
             args.sat_badness_ddpr_thresh = std::stod(argv[++i]);
+        } else if (a == "--sat-badness-clamp" && i + 1 < argc) {
+            args.sat_badness_clamp = std::stod(argv[++i]);
+        } else if (a == "--sat-badness-cap" && i + 1 < argc) {
+            args.sat_badness_cap = std::stod(argv[++i]);
+        } else if (a == "--sat-badness-cppr-decay" && i + 1 < argc) {
+            args.sat_badness_cppr_decay = std::stod(argv[++i]);
+        } else if (a == "--varerr") {
+            args.varerr = true;
+        } else if (a == "--varerr-a" && i + 1 < argc) {
+            args.varerr_a = std::stod(argv[++i]);
+        } else if (a == "--varerr-b" && i + 1 < argc) {
+            args.varerr_b = std::stod(argv[++i]);
+        } else if (a == "--varerr-eratio" && i + 1 < argc) {
+            args.varerr_eratio = std::stod(argv[++i]);
         } else {
             std::cerr << "Unknown/incomplete arg: " << a << "\n";
             std::exit(2);
@@ -886,6 +909,27 @@ int main(int argc, char** argv) {
     if (args.sat_badness_ddpr_thresh >= 0.0) {
         config.sat_badness_ddpr_threshold_m = args.sat_badness_ddpr_thresh;
     }
+    if (args.sat_badness_clamp >= 0.0) {
+        config.sat_badness_residual_clamp_m = args.sat_badness_clamp;
+    }
+    if (args.sat_badness_cap >= 0.0) {
+        config.sat_badness_score_cap = args.sat_badness_cap;
+    }
+    if (args.sat_badness_cppr_decay >= 0.0) {
+        config.sat_badness_cppr_decay = args.sat_badness_cppr_decay;
+    }
+    if (args.varerr) {
+        config.use_elevation_dependent_sigma = true;
+    }
+    if (args.varerr_a >= 0.0) {
+        config.elevation_sigma_err_a_m = args.varerr_a;
+    }
+    if (args.varerr_b >= 0.0) {
+        config.elevation_sigma_err_b_m = args.varerr_b;
+    }
+    if (args.varerr_eratio >= 0.0) {
+        config.elevation_sigma_pseudorange_ratio = args.varerr_eratio;
+    }
     const libgnss::FGOProcessor builder(config);
     const libgnss::FGOProcessor::FGOProblem problem =
         builder.buildDoubleDifferenceProblem(rover_epochs, base_epochs, nav, base_position);
@@ -1095,7 +1139,16 @@ int main(int argc, char** argv) {
                   << "  sat-badness down-weighting: " << (args.sat_badness ? "on" : "off")
                   << " (downweighted_factors=" << fl.diagnostics.sat_badness_downweighted_factors
                   << ", max_score_seen=" << fl.diagnostics.sat_badness_max_score_seen
-                  << ")\n";
+                  << ", clamp_m=" << config.sat_badness_residual_clamp_m
+                  << ", score_cap=" << config.sat_badness_score_cap
+                  << ", cppr_decay=" << config.sat_badness_cppr_decay
+                  << ")\n"
+                  << "  varerr elevation-dependent DD sigma: " << (args.varerr ? "on" : "off")
+                  << " (err_a=" << config.elevation_sigma_err_a_m
+                  << " m, err_b=" << config.elevation_sigma_err_b_m
+                  << " m, eratio_pr=" << config.elevation_sigma_pseudorange_ratio
+                  << ", sclkstab=" << config.elevation_sigma_clock_stability
+                  << " s/s)\n";
         if (!ref_rows.empty()) {
             std::cout << "  horizontal error vs reference.csv:\n"
                       << "    FLOAT: n=" << he.n_float << " rms=" << he.float_rms

--- a/apps/gnss_fgo_parity.cpp
+++ b/apps/gnss_fgo_parity.cpp
@@ -51,6 +51,18 @@ struct Args {
     double elev_mask_deg = -1.0; // milestone 2e: >0 overrides preset elevation mask
     double snr_mask_dbhz = -1.0; // milestone 2e: >0 sets an SNR mask
     bool diag = false;           // milestone 2e: Eigen-vs-GTSAM apples fix-rate + freq analysis
+    bool single_freq = false;    // multi-freq control: force L1/E1/B1-only DD (single-frequency baseline)
+    bool multi_freq = false;     // force multi-frequency DD on (library default is now OFF)
+    bool no_oneband = false;     // MF-AR ablation: disable one-band-per-satellite LAMBDA restriction
+    bool no_band_sigma = false;  // MF-AR ablation: disable per-band (secondary) sigma de-weighting
+    bool no_code_align = false;  // MF hygiene ablation: disable secondary-band code alignment
+    bool dd_resid = false;       // per-signal DD residuals at the reference trajectory (no solve)
+    bool partial_ar = false;     // MF-AR step 2: partial AR in the fixed-lag LAMBDA
+    bool no_gal_ar = false;      // MF-AR step 2: exclude Galileo arcs from LAMBDA / hold
+    double ratio_threshold = 0.0;  // >0: override lambda_ratio_threshold
+    double hold_ratio = 0.0;       // >0: override ambiguity_hold_ratio_threshold
+    int hold_min = 0;              // >0: override ambiguity_hold_min_fixed
+    int min_fixed = 0;             // >0: override min_fixed_ambiguities (partial-AR floor)
 };
 
 Args parseArgs(int argc, char** argv) {
@@ -91,6 +103,30 @@ Args parseArgs(int argc, char** argv) {
             args.snr_mask_dbhz = std::stod(argv[++i]);
         } else if (a == "--diag") {
             args.diag = true;
+        } else if (a == "--single-freq") {
+            args.single_freq = true;
+        } else if (a == "--multi-freq") {
+            args.multi_freq = true;
+        } else if (a == "--no-oneband") {
+            args.no_oneband = true;
+        } else if (a == "--no-band-sigma") {
+            args.no_band_sigma = true;
+        } else if (a == "--no-code-align") {
+            args.no_code_align = true;
+        } else if (a == "--dd-resid") {
+            args.dd_resid = true;
+        } else if (a == "--partial-ar") {
+            args.partial_ar = true;
+        } else if (a == "--no-gal-ar") {
+            args.no_gal_ar = true;
+        } else if (a == "--ratio" && i + 1 < argc) {
+            args.ratio_threshold = std::stod(argv[++i]);
+        } else if (a == "--hold-ratio" && i + 1 < argc) {
+            args.hold_ratio = std::stod(argv[++i]);
+        } else if (a == "--hold-min" && i + 1 < argc) {
+            args.hold_min = std::stoi(argv[++i]);
+        } else if (a == "--min-fixed" && i + 1 < argc) {
+            args.min_fixed = std::stoi(argv[++i]);
         } else {
             std::cerr << "Unknown/incomplete arg: " << a << "\n";
             std::exit(2);
@@ -597,6 +633,43 @@ int main(int argc, char** argv) {
         config.double_difference_reference_min_snr_dbhz = args.snr_mask_dbhz;
         config.double_difference_base_min_snr_dbhz = args.snr_mask_dbhz;
     }
+    // Multi-freq control: --single-freq forces the front-end back to L1/E1/B1I
+    // only (the pre-change behaviour) so the SAME harness invocation yields a
+    // single-frequency baseline for apples-to-apples comparison.
+    if (args.single_freq) {
+        config.use_multi_frequency_double_difference = false;
+    }
+    if (args.multi_freq) {
+        config.use_multi_frequency_double_difference = true;
+    }
+    if (args.no_oneband) {
+        config.double_difference_lambda_one_band_per_satellite = false;
+    }
+    if (args.no_band_sigma) {
+        config.double_difference_secondary_carrier_sigma_scale = 1.0;
+        config.double_difference_secondary_pseudorange_sigma_scale = 1.0;
+    }
+    if (args.no_code_align) {
+        config.use_double_difference_secondary_code_alignment = false;
+    }
+    if (args.partial_ar) {
+        config.use_fixed_lag_partial_lambda = true;
+    }
+    if (args.no_gal_ar) {
+        config.exclude_galileo_ambiguity_fixing = true;
+    }
+    if (args.ratio_threshold > 0.0) {
+        config.lambda_ratio_threshold = args.ratio_threshold;
+    }
+    if (args.hold_ratio > 0.0) {
+        config.ambiguity_hold_ratio_threshold = args.hold_ratio;
+    }
+    if (args.hold_min > 0) {
+        config.ambiguity_hold_min_fixed = args.hold_min;
+    }
+    if (args.min_fixed > 0) {
+        config.min_fixed_ambiguities = args.min_fixed;
+    }
     const libgnss::FGOProcessor builder(config);
     const libgnss::FGOProcessor::FGOProblem problem =
         builder.buildDoubleDifferenceProblem(rover_epochs, base_epochs, nav, base_position);
@@ -606,6 +679,107 @@ int main(int argc, char** argv) {
               << " dd_cp_factors=" << problem.double_difference_carrier_factors.size()
               << " ambiguity_states=" << problem.ambiguity_states.size()
               << " pr_factors=" << problem.pseudorange_factors.size() << "\n";
+
+    // --- MF hygiene diagnostics: per-signal DD residuals at the reference
+    // trajectory (no solver). PR residual mean exposes per-band code/DCB
+    // bias; per-arc carrier residual fractional-cycle offset exposes phase
+    // misalignment / broken integer-ness. ---
+    if (args.dd_resid) {
+        const std::vector<RefRow> ref_rows = loadReference(args.ref_path);
+        if (ref_rows.empty()) {
+            std::cerr << "Error: --dd-resid requires --ref reference.csv\n";
+            return 1;
+        }
+        // Nearest-truth lookup per problem epoch (both time-sorted).
+        std::vector<libgnss::Vector3d> truth(problem.epochs.size(),
+                                             libgnss::Vector3d::Zero());
+        std::vector<bool> has_truth(problem.epochs.size(), false);
+        {
+            std::size_t ri = 0;
+            for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
+                const auto& t = problem.epochs[i].time;
+                while (ri + 1 < ref_rows.size() &&
+                       std::abs(ref_rows[ri + 1].time - t) <
+                           std::abs(ref_rows[ri].time - t)) {
+                    ++ri;
+                }
+                if (std::abs(ref_rows[ri].time - t) <= 0.11) {
+                    truth[i] = ref_rows[ri].ecef;
+                    has_truth[i] = true;
+                }
+            }
+        }
+        auto dd_geom = [](const auto& f, const libgnss::Vector3d& x) {
+            return ((f.rover_satellite_position_ecef - x).norm() -
+                    (f.base_satellite_position_ecef - f.base_position_ecef).norm()) -
+                   ((f.rover_reference_position_ecef - x).norm() -
+                    (f.base_reference_position_ecef - f.base_position_ecef).norm());
+        };
+        struct PrStats {
+            std::size_t n = 0;
+            double sum = 0.0, sq = 0.0;
+        };
+        std::map<int, PrStats> pr_stats;
+        for (const auto& f : problem.double_difference_pseudorange_factors) {
+            if (f.epoch_index >= truth.size() || !has_truth[f.epoch_index]) continue;
+            const double r = f.observed_dd_pseudorange_m - dd_geom(f, truth[f.epoch_index]);
+            auto& s = pr_stats[static_cast<int>(f.signal)];
+            ++s.n;
+            s.sum += r;
+            s.sq += r * r;
+        }
+        // Carrier: per-arc mean residual -> fractional cycles from nearest int.
+        struct ArcAcc {
+            std::size_t n = 0;
+            double sum = 0.0;
+            int signal = 0;
+            double wavelength = 0.0;
+        };
+        std::map<std::size_t, ArcAcc> arcs;
+        for (const auto& f : problem.double_difference_carrier_factors) {
+            if (f.epoch_index >= truth.size() || !has_truth[f.epoch_index]) continue;
+            if (f.ambiguity_index >= problem.ambiguity_states.size()) continue;
+            auto& a = arcs[f.ambiguity_index];
+            ++a.n;
+            a.sum += f.observed_dd_carrier_m - dd_geom(f, truth[f.epoch_index]);
+            a.signal = static_cast<int>(f.signal);
+            a.wavelength = problem.ambiguity_states[f.ambiguity_index].wavelength_m;
+        }
+        struct CarrierStats {
+            std::size_t arcs = 0, tight = 0;
+            std::vector<double> fracs;
+        };
+        std::map<int, CarrierStats> cp_stats;
+        for (const auto& [idx, a] : arcs) {
+            if (a.n < 10 || a.wavelength <= 0.0) continue;
+            const double cycles = (a.sum / double(a.n)) / a.wavelength;
+            const double frac = std::abs(cycles - std::round(cycles));
+            auto& s = cp_stats[a.signal];
+            ++s.arcs;
+            if (frac < 0.15) ++s.tight;
+            s.fracs.push_back(frac);
+        }
+        std::cout << "\n=== --dd-resid: per-signal DD residuals at the reference trajectory ===\n"
+                  << "  DD pseudorange (bias -> code/DCB mismatch):\n";
+        for (auto& [sig, s] : pr_stats) {
+            const double mean = s.sum / double(s.n);
+            const double rms = std::sqrt(s.sq / double(s.n));
+            std::cout << "    signal_enum=" << sig << "  n=" << s.n
+                      << "  mean=" << mean << " m  rms=" << rms << " m\n";
+        }
+        std::cout << "  DD carrier per-arc mean, fractional cycles from nearest integer\n"
+                  << "  (arcs with >=10 epochs; frac<0.15 = integer-consistent):\n";
+        for (auto& [sig, s] : cp_stats) {
+            std::sort(s.fracs.begin(), s.fracs.end());
+            const double med = s.fracs.empty() ? 0.0 : s.fracs[s.fracs.size() / 2];
+            std::cout << "    signal_enum=" << sig << "  arcs=" << s.arcs
+                      << "  median_frac=" << med << "  frac<0.15: "
+                      << (s.arcs > 0 ? 100.0 * double(s.tight) / double(s.arcs) : 0.0)
+                      << "%\n";
+        }
+        std::cout.flush();
+        return 0;
+    }
 
     if (problem.epochs.empty() ||
         (problem.double_difference_carrier_factors.empty() &&
@@ -738,6 +912,10 @@ int main(int argc, char** argv) {
             for (const auto& f : problem_imu.double_difference_carrier_factors) {
                 ++signal_counts[static_cast<int>(f.signal)];
                 if (isSecondFreq(f.signal)) ++second_freq;
+            }
+            std::cout << "\n  (i0) per-signal DD-carrier factor histogram:\n";
+            for (const auto& [sig, cnt] : signal_counts) {
+                std::cout << "       signal_enum=" << sig << "  count=" << cnt << "\n";
             }
             std::cout << "\n=== (2e diag) gap attribution on the SAME full-run1 FGOProblem ===\n"
                       << "  (i) DD-carrier signal content: " << signal_counts.size()

--- a/apps/gnss_fgo_parity.cpp
+++ b/apps/gnss_fgo_parity.cpp
@@ -63,6 +63,10 @@ struct Args {
     double hold_ratio = 0.0;       // >0: override ambiguity_hold_ratio_threshold
     int hold_min = 0;              // >0: override ambiguity_hold_min_fixed
     int min_fixed = 0;             // >0: override min_fixed_ambiguities (partial-AR floor)
+    bool gates = false;            // per-epoch quality gates (reference gate.py/postfit.py port)
+    double gate_res = -1.0;        // >=0: override gate_ddpr_res_max_m (0 disables)
+    double gate_sat_res = -1.0;    // >=0: override gate_per_sat_res_max_m (0 disables)
+    double gate_gdop = 0.0;        // >0: override gate_gdop_max
 };
 
 Args parseArgs(int argc, char** argv) {
@@ -127,6 +131,14 @@ Args parseArgs(int argc, char** argv) {
             args.hold_min = std::stoi(argv[++i]);
         } else if (a == "--min-fixed" && i + 1 < argc) {
             args.min_fixed = std::stoi(argv[++i]);
+        } else if (a == "--gates") {
+            args.gates = true;
+        } else if (a == "--gate-res" && i + 1 < argc) {
+            args.gate_res = std::stod(argv[++i]);
+        } else if (a == "--gate-sat-res" && i + 1 < argc) {
+            args.gate_sat_res = std::stod(argv[++i]);
+        } else if (a == "--gate-gdop" && i + 1 < argc) {
+            args.gate_gdop = std::stod(argv[++i]);
         } else {
             std::cerr << "Unknown/incomplete arg: " << a << "\n";
             std::exit(2);
@@ -670,6 +682,18 @@ int main(int argc, char** argv) {
     if (args.min_fixed > 0) {
         config.min_fixed_ambiguities = args.min_fixed;
     }
+    if (args.gates) {
+        config.use_epoch_quality_gates = true;
+    }
+    if (args.gate_res >= 0.0) {
+        config.gate_ddpr_res_max_m = args.gate_res;
+    }
+    if (args.gate_sat_res >= 0.0) {
+        config.gate_per_sat_res_max_m = args.gate_sat_res;
+    }
+    if (args.gate_gdop > 0.0) {
+        config.gate_gdop_max = args.gate_gdop;
+    }
     const libgnss::FGOProcessor builder(config);
     const libgnss::FGOProcessor::FGOProblem problem =
         builder.buildDoubleDifferenceProblem(rover_epochs, base_epochs, nav, base_position);
@@ -828,6 +852,9 @@ int main(int argc, char** argv) {
                   << "  NHC/ZUPT: nhc=" << (args.use_nhc ? "on" : "off")
                   << " (applied " << fl.diagnostics.nhc_epochs << " epochs), zupt="
                   << (args.use_zupt ? "on" : "off") << " (applied " << fl.diagnostics.zupt_epochs
+                  << " epochs)\n"
+                  << "  quality-gates: " << (args.gates ? "on" : "off")
+                  << " (fixing suppressed on " << fl.diagnostics.quality_gated_epochs
                   << " epochs)\n"
                   << "  fix-and-hold: " << (args.use_hold ? "on" : "off")
                   << " (pinned " << fl.diagnostics.ambiguity_hold_arcs << " arcs, "

--- a/apps/gnss_fgo_parity.cpp
+++ b/apps/gnss_fgo_parity.cpp
@@ -95,6 +95,10 @@ struct Args {
     double fde_cp = -1.0;          // >=0: override fde_carrier_threshold_m
     double fde_frac = -1.0;        // >=0: override fde_max_rejected_fraction
     int fde_iters = 0;             // >0: override fde_max_iterations
+    bool sat_badness = false;          // sat-badness EWMA down-weighting (sat_quality.py port)
+    double sat_badness_cp_scale = -1.0;   // >=0: override sat_badness_carrier_sigma_scale
+    double sat_badness_pr_scale = -1.0;   // >=0: override sat_badness_pseudorange_sigma_scale
+    double sat_badness_ddpr_thresh = -1.0; // >=0: override sat_badness_ddpr_threshold_m
 };
 
 Args parseArgs(int argc, char** argv) {
@@ -223,6 +227,14 @@ Args parseArgs(int argc, char** argv) {
             args.fde_frac = std::stod(argv[++i]);
         } else if (a == "--fde-iters" && i + 1 < argc) {
             args.fde_iters = std::stoi(argv[++i]);
+        } else if (a == "--sat-badness") {
+            args.sat_badness = true;
+        } else if (a == "--sat-badness-cp-scale" && i + 1 < argc) {
+            args.sat_badness_cp_scale = std::stod(argv[++i]);
+        } else if (a == "--sat-badness-pr-scale" && i + 1 < argc) {
+            args.sat_badness_pr_scale = std::stod(argv[++i]);
+        } else if (a == "--sat-badness-ddpr-thresh" && i + 1 < argc) {
+            args.sat_badness_ddpr_thresh = std::stod(argv[++i]);
         } else {
             std::cerr << "Unknown/incomplete arg: " << a << "\n";
             std::exit(2);
@@ -862,6 +874,18 @@ int main(int argc, char** argv) {
     if (args.fde_iters > 0) {
         config.fde_max_iterations = args.fde_iters;
     }
+    if (args.sat_badness) {
+        config.use_sat_badness_downweight = true;
+    }
+    if (args.sat_badness_cp_scale >= 0.0) {
+        config.sat_badness_carrier_sigma_scale = args.sat_badness_cp_scale;
+    }
+    if (args.sat_badness_pr_scale >= 0.0) {
+        config.sat_badness_pseudorange_sigma_scale = args.sat_badness_pr_scale;
+    }
+    if (args.sat_badness_ddpr_thresh >= 0.0) {
+        config.sat_badness_ddpr_threshold_m = args.sat_badness_ddpr_thresh;
+    }
     const libgnss::FGOProcessor builder(config);
     const libgnss::FGOProcessor::FGOProblem problem =
         builder.buildDoubleDifferenceProblem(rover_epochs, base_epochs, nav, base_position);
@@ -1067,6 +1091,10 @@ int main(int argc, char** argv) {
                   << ", cp_rejections=" << fl.diagnostics.fde_carrier_rejections
                   << ", safeguard_skips=" << fl.diagnostics.fde_safeguard_skips
                   << ", fde_epochs=" << fl.diagnostics.fde_epochs
+                  << ")\n"
+                  << "  sat-badness down-weighting: " << (args.sat_badness ? "on" : "off")
+                  << " (downweighted_factors=" << fl.diagnostics.sat_badness_downweighted_factors
+                  << ", max_score_seen=" << fl.diagnostics.sat_badness_max_score_seen
                   << ")\n";
         if (!ref_rows.empty()) {
             std::cout << "  horizontal error vs reference.csv:\n"

--- a/apps/gnss_fgo_parity.cpp
+++ b/apps/gnss_fgo_parity.cpp
@@ -26,6 +26,7 @@
 #include <cstddef>
 #include <fstream>
 #include <iostream>
+#include <map>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -46,6 +47,10 @@ struct Args {
     double fixed_lag_s = 0.0;    // milestone 2c: >0 enables the fixed-lag smoother
     bool use_nhc = false;        // milestone 2d
     bool use_zupt = false;       // milestone 2d
+    bool use_hold = false;       // milestone 2e: fix-and-hold
+    double elev_mask_deg = -1.0; // milestone 2e: >0 overrides preset elevation mask
+    double snr_mask_dbhz = -1.0; // milestone 2e: >0 sets an SNR mask
+    bool diag = false;           // milestone 2e: Eigen-vs-GTSAM apples fix-rate + freq analysis
 };
 
 Args parseArgs(int argc, char** argv) {
@@ -78,6 +83,14 @@ Args parseArgs(int argc, char** argv) {
             args.use_nhc = true;
         } else if (a == "--zupt") {
             args.use_zupt = true;
+        } else if (a == "--hold") {
+            args.use_hold = true;
+        } else if (a == "--elev-mask" && i + 1 < argc) {
+            args.elev_mask_deg = std::stod(argv[++i]);
+        } else if (a == "--snr-mask" && i + 1 < argc) {
+            args.snr_mask_dbhz = std::stod(argv[++i]);
+        } else if (a == "--diag") {
+            args.diag = true;
         } else {
             std::cerr << "Unknown/incomplete arg: " << a << "\n";
             std::exit(2);
@@ -230,7 +243,8 @@ libgnss::FGOProcessor::FGOResult run(const libgnss::FGOProcessor::FGOProblem& pr
                                      bool use_imu = false,
                                      double fixed_lag_s = 0.0,
                                      bool use_nhc = false,
-                                     bool use_zupt = false) {
+                                     bool use_zupt = false,
+                                     bool use_hold = false) {
     config.backend = backend;
     config.use_lambda_ambiguity_fix = use_lambda;
     config.fix_ambiguities = use_lambda;
@@ -258,6 +272,8 @@ libgnss::FGOProcessor::FGOResult run(const libgnss::FGOProcessor::FGOProblem& pr
     // Milestone 2d: NHC / ZUPT pseudo-measurements.
     config.use_nhc = use_nhc;
     config.use_zupt = use_zupt;
+    // Milestone 2e: fix-and-hold ambiguity resolution.
+    config.use_ambiguity_hold = use_hold;
     libgnss::FGOProcessor processor(config);
     const auto t0 = std::chrono::high_resolution_clock::now();
     auto result = processor.optimizeProblem(problem);
@@ -571,6 +587,16 @@ int main(int argc, char** argv) {
         // undifferenced-pseudorange modeling differences between backends.
         config.use_pseudorange_factors = false;
     }
+    // Milestone 2e lever 2: elevation / SNR masks on the DD observations
+    // (applied at problem-build time -- attacks deep-urban multipath float).
+    if (args.elev_mask_deg > 0.0) {
+        config.min_elevation_deg = args.elev_mask_deg;
+    }
+    if (args.snr_mask_dbhz > 0.0) {
+        config.min_snr_dbhz = args.snr_mask_dbhz;
+        config.double_difference_reference_min_snr_dbhz = args.snr_mask_dbhz;
+        config.double_difference_base_min_snr_dbhz = args.snr_mask_dbhz;
+    }
     const libgnss::FGOProcessor builder(config);
     const libgnss::FGOProcessor::FGOProblem problem =
         builder.buildDoubleDifferenceProblem(rover_epochs, base_epochs, nav, base_position);
@@ -604,7 +630,7 @@ int main(int argc, char** argv) {
         double t_fl = 0.0;
         const auto fl = run(problem_imu, config, libgnss::FGOBackend::GTSAM, true, t_fl,
                             /*use_pose3=*/true, /*use_imu=*/true, args.fixed_lag_s,
-                            args.use_nhc, args.use_zupt);
+                            args.use_nhc, args.use_zupt, args.use_hold);
         std::size_t nonfinite = 0, none_epochs = 0;
         for (const auto& s : fl.solution.solutions) {
             if (s.status == libgnss::SolutionStatus::NONE) ++none_epochs;
@@ -628,7 +654,10 @@ int main(int argc, char** argv) {
                   << "  NHC/ZUPT: nhc=" << (args.use_nhc ? "on" : "off")
                   << " (applied " << fl.diagnostics.nhc_epochs << " epochs), zupt="
                   << (args.use_zupt ? "on" : "off") << " (applied " << fl.diagnostics.zupt_epochs
-                  << " epochs)\n";
+                  << " epochs)\n"
+                  << "  fix-and-hold: " << (args.use_hold ? "on" : "off")
+                  << " (pinned " << fl.diagnostics.ambiguity_hold_arcs << " arcs, "
+                  << fl.diagnostics.ambiguity_hold_epochs << " epochs FIXED via held integers)\n";
         if (!ref_rows.empty()) {
             std::cout << "  horizontal error vs reference.csv:\n"
                       << "    FLOAT: n=" << he.n_float << " rms=" << he.float_rms
@@ -681,8 +710,75 @@ int main(int argc, char** argv) {
                       << "    batch-float horiz err vs ref:    rms=" << he_batch.float_rms << " m\n"
                       << "    smoother-float horiz err vs ref: rms=" << he_flf.float_rms << " m\n";
         }
-        const bool go_2c = fl.diagnostics.smoother_updates == ne && nonfinite == 0 &&
-                           fl.diagnostics.lambda_ambiguity_attempts > 0;
+        // --- 2e gap-attribution diagnostics (--diag) ---
+        if (args.diag) {
+            // (i) Frequency / signal content of the DD carrier factors: is this
+            // single-frequency (L1/E1/B1 only) or multi-frequency? inuex35 runs
+            // NF=3. This is an upstream (front-end / observation-model) property.
+            std::map<int, std::size_t> signal_counts;
+            auto isSecondFreq = [](libgnss::SignalType s) {
+                switch (s) {
+                    case libgnss::SignalType::GPS_L2P:
+                    case libgnss::SignalType::GPS_L2C:
+                    case libgnss::SignalType::GPS_L5:
+                    case libgnss::SignalType::GLO_L2CA:
+                    case libgnss::SignalType::GLO_L2P:
+                    case libgnss::SignalType::GAL_E5A:
+                    case libgnss::SignalType::GAL_E5B:
+                    case libgnss::SignalType::BDS_B2I:
+                    case libgnss::SignalType::BDS_B2A:
+                    case libgnss::SignalType::QZS_L2C:
+                    case libgnss::SignalType::QZS_L5:
+                        return true;
+                    default:
+                        return false;
+                }
+            };
+            std::size_t second_freq = 0;
+            for (const auto& f : problem_imu.double_difference_carrier_factors) {
+                ++signal_counts[static_cast<int>(f.signal)];
+                if (isSecondFreq(f.signal)) ++second_freq;
+            }
+            std::cout << "\n=== (2e diag) gap attribution on the SAME full-run1 FGOProblem ===\n"
+                      << "  (i) DD-carrier signal content: " << signal_counts.size()
+                      << " distinct signal(s); L2/L5/E5/B2 (2nd-freq) DD factors = " << second_freq
+                      << " / " << problem_imu.double_difference_carrier_factors.size() << "  => "
+                      << (second_freq > 0 ? "MULTI-frequency" : "SINGLE-frequency (L1/E1/B1 only)")
+                      << "\n";
+
+            // (ii) Apples-to-apples per-epoch ratio-gated fix-rate WITHOUT
+            // fix-and-hold: Eigen native backend vs GTSAM fixed-lag. Same
+            // problem, same ratio gate (config.lambda_ratio_threshold).
+            double t_e = 0.0, t_g = 0.0;
+            const auto eigen_fix = run(problem_imu, config, libgnss::FGOBackend::Eigen, true, t_e);
+            const std::size_t eigen_fixed = countFixedEpochs(eigen_fix);
+            const auto gtsam_nohold =
+                run(problem_imu, config, libgnss::FGOBackend::GTSAM, true, t_g,
+                    /*use_pose3=*/true, /*use_imu=*/true, args.fixed_lag_s, args.use_nhc,
+                    args.use_zupt, /*use_hold=*/false);
+            const std::size_t gtsam_nohold_fixed = countFixedEpochs(gtsam_nohold);
+            const HorizError he_eigen = horizontalErrorVsRef(eigen_fix, ref_rows);
+            std::cout << "  (ii) per-epoch ratio-gated fix-rate (NO fix-and-hold), same problem:\n"
+                      << "       Eigen native backend: " << eigen_fixed << "/" << ne << " ("
+                      << (ne > 0 ? 100.0 * double(eigen_fixed) / double(ne) : 0.0)
+                      << "%), FIXED horiz rms=" << he_eigen.fixed_rms << " m (" << t_e << " s)\n"
+                      << "       GTSAM fixed-lag:      " << gtsam_nohold_fixed << "/" << ne << " ("
+                      << (ne > 0 ? 100.0 * double(gtsam_nohold_fixed) / double(ne) : 0.0)
+                      << "%) (" << t_g << " s)\n"
+                      << "       => port-faithfulness: GTSAM-no-hold vs Eigen within "
+                      << std::abs(double(gtsam_nohold_fixed) - double(eigen_fixed)) << " epochs\n";
+
+            // (iii) fix-and-hold before -> after (this run has hold on).
+            std::cout << "  (iii) fix-and-hold effect: " << gtsam_nohold_fixed << "/" << ne << " ("
+                      << (ne > 0 ? 100.0 * double(gtsam_nohold_fixed) / double(ne) : 0.0)
+                      << "%) WITHOUT hold  ->  " << fl_fixed << "/" << ne << " ("
+                      << (ne > 0 ? 100.0 * double(fl_fixed) / double(ne) : 0.0)
+                      << "%) WITH hold\n";
+            std::cout.flush();
+        }
+
+        const bool go_2c = fl.diagnostics.smoother_updates >= ne && nonfinite == 0 &&
+                           none_epochs == 0 && fl.diagnostics.lambda_ambiguity_attempts > 0;
         std::cout << "\nRESULT (milestone 2c): fixed-lag full-scale run "
                   << (go_2c ? "GO" : "NO-GO") << " (epochs=" << ne
                   << ", peak_window_vars=" << fl.diagnostics.smoother_max_window_vars

--- a/apps/gnss_fgo_parity.cpp
+++ b/apps/gnss_fgo_parity.cpp
@@ -72,6 +72,29 @@ struct Args {
     double cmc_level = -1.0;       // >=0: override code_minus_carrier_level_threshold_m
     int cmc_warmup = 0;            // >0: override code_minus_carrier_warmup_epochs
     double cmc_alpha = -1.0;       // >=0: override code_minus_carrier_baseline_alpha
+    bool cp_hold = false;                  // CP-hold / sanity FSM (validation/postfit.py + recovery.py port)
+    double cp_hold_res = -1.0;             // >=0: override cp_hold_main_residual_threshold_m
+    double cp_hold_catastrophic = -1.0;    // >=0: override cp_hold_catastrophic_threshold_m
+    double cp_hold_fast_worst_sat = -1.0;  // >=0: override cp_hold_fast_worst_satellite_min_m
+    int cp_hold_persist = 0;               // >0: override cp_hold_persist_epochs
+    int cp_hold_epochs_n = 0;              // >0: override cp_hold_epochs
+    double cp_hold_release_res = -1.0;     // >=0: override cp_hold_release_threshold_m
+    int cp_hold_release_n = 0;             // >0: override cp_hold_release_count
+    double cp_hold_pose_replace = -1.0;    // >=0: override cp_hold_pose_replace_threshold_m
+    double cp_hold_gdop = -1.0;            // >=0: override cp_hold_max_gdop
+    bool exc_recovery = false;             // solve-exception recovery (recovery.py handle_solve_exception port)
+    bool ddpr_anchor = false;              // DDPR-LS anchor (ls_solvers.py + anchor stages of postfit/recovery/stage.py)
+    double ddpr_anchor_max_res = -1.0;     // >=0: override ddpr_anchor_max_residual_m
+    double ddpr_anchor_fde = -1.0;         // >=0: override ddpr_anchor_fde_threshold_m
+    int ddpr_anchor_min_n = 0;             // >0: override ddpr_anchor_min_factors
+    int ddpr_anchor_boot_epochs = -1;      // >=0: override ddpr_anchor_bootstrap_epochs
+    double ddpr_anchor_boot_sigma = -1.0;  // >=0: override ddpr_anchor_bootstrap_sigma_m
+    int ddpr_anchor_boot_after_mass = -1;  // 0/1: override cp_hold_bootstrap_after_mass_reset
+    bool fde = false;              // GICI-style FDE (validation/postfit.py apply_fde port)
+    double fde_pr = -1.0;          // >=0: override fde_pseudorange_threshold_m
+    double fde_cp = -1.0;          // >=0: override fde_carrier_threshold_m
+    double fde_frac = -1.0;        // >=0: override fde_max_rejected_fraction
+    int fde_iters = 0;             // >0: override fde_max_iterations
 };
 
 Args parseArgs(int argc, char** argv) {
@@ -154,6 +177,52 @@ Args parseArgs(int argc, char** argv) {
             args.cmc_warmup = std::stoi(argv[++i]);
         } else if (a == "--cmc-alpha" && i + 1 < argc) {
             args.cmc_alpha = std::stod(argv[++i]);
+        } else if (a == "--cp-hold") {
+            args.cp_hold = true;
+        } else if (a == "--cp-hold-res" && i + 1 < argc) {
+            args.cp_hold_res = std::stod(argv[++i]);
+        } else if (a == "--cp-hold-catastrophic" && i + 1 < argc) {
+            args.cp_hold_catastrophic = std::stod(argv[++i]);
+        } else if (a == "--cp-hold-fast-worst-sat" && i + 1 < argc) {
+            args.cp_hold_fast_worst_sat = std::stod(argv[++i]);
+        } else if (a == "--cp-hold-persist" && i + 1 < argc) {
+            args.cp_hold_persist = std::stoi(argv[++i]);
+        } else if (a == "--cp-hold-epochs" && i + 1 < argc) {
+            args.cp_hold_epochs_n = std::stoi(argv[++i]);
+        } else if (a == "--cp-hold-release-res" && i + 1 < argc) {
+            args.cp_hold_release_res = std::stod(argv[++i]);
+        } else if (a == "--cp-hold-release-count" && i + 1 < argc) {
+            args.cp_hold_release_n = std::stoi(argv[++i]);
+        } else if (a == "--cp-hold-pose-replace" && i + 1 < argc) {
+            args.cp_hold_pose_replace = std::stod(argv[++i]);
+        } else if (a == "--cp-hold-gdop" && i + 1 < argc) {
+            args.cp_hold_gdop = std::stod(argv[++i]);
+        } else if (a == "--exc-recovery") {
+            args.exc_recovery = true;
+        } else if (a == "--ddpr-anchor") {
+            args.ddpr_anchor = true;
+        } else if (a == "--ddpr-anchor-max-res" && i + 1 < argc) {
+            args.ddpr_anchor_max_res = std::stod(argv[++i]);
+        } else if (a == "--ddpr-anchor-fde" && i + 1 < argc) {
+            args.ddpr_anchor_fde = std::stod(argv[++i]);
+        } else if (a == "--ddpr-anchor-min-n" && i + 1 < argc) {
+            args.ddpr_anchor_min_n = std::stoi(argv[++i]);
+        } else if (a == "--ddpr-anchor-boot-epochs" && i + 1 < argc) {
+            args.ddpr_anchor_boot_epochs = std::stoi(argv[++i]);
+        } else if (a == "--ddpr-anchor-boot-sigma" && i + 1 < argc) {
+            args.ddpr_anchor_boot_sigma = std::stod(argv[++i]);
+        } else if (a == "--ddpr-anchor-boot-after-mass" && i + 1 < argc) {
+            args.ddpr_anchor_boot_after_mass = std::stoi(argv[++i]);
+        } else if (a == "--fde") {
+            args.fde = true;
+        } else if (a == "--fde-pr" && i + 1 < argc) {
+            args.fde_pr = std::stod(argv[++i]);
+        } else if (a == "--fde-cp" && i + 1 < argc) {
+            args.fde_cp = std::stod(argv[++i]);
+        } else if (a == "--fde-frac" && i + 1 < argc) {
+            args.fde_frac = std::stod(argv[++i]);
+        } else if (a == "--fde-iters" && i + 1 < argc) {
+            args.fde_iters = std::stoi(argv[++i]);
         } else {
             std::cerr << "Unknown/incomplete arg: " << a << "\n";
             std::exit(2);
@@ -724,6 +793,75 @@ int main(int argc, char** argv) {
     if (args.cmc_alpha >= 0.0) {
         config.code_minus_carrier_baseline_alpha = args.cmc_alpha;
     }
+    if (args.cp_hold) {
+        config.use_cp_hold_recovery = true;
+    }
+    if (args.cp_hold_res >= 0.0) {
+        config.cp_hold_main_residual_threshold_m = args.cp_hold_res;
+    }
+    if (args.cp_hold_catastrophic >= 0.0) {
+        config.cp_hold_catastrophic_threshold_m = args.cp_hold_catastrophic;
+    }
+    if (args.cp_hold_fast_worst_sat >= 0.0) {
+        config.cp_hold_fast_worst_satellite_min_m = args.cp_hold_fast_worst_sat;
+    }
+    if (args.cp_hold_persist > 0) {
+        config.cp_hold_persist_epochs = args.cp_hold_persist;
+    }
+    if (args.cp_hold_epochs_n > 0) {
+        config.cp_hold_epochs = args.cp_hold_epochs_n;
+    }
+    if (args.cp_hold_release_res >= 0.0) {
+        config.cp_hold_release_threshold_m = args.cp_hold_release_res;
+    }
+    if (args.cp_hold_release_n > 0) {
+        config.cp_hold_release_count = args.cp_hold_release_n;
+    }
+    if (args.cp_hold_pose_replace >= 0.0) {
+        config.cp_hold_pose_replace_threshold_m = args.cp_hold_pose_replace;
+    }
+    if (args.cp_hold_gdop >= 0.0) {
+        config.cp_hold_max_gdop = args.cp_hold_gdop;
+    }
+    if (args.exc_recovery) {
+        config.use_solve_exception_recovery = true;
+    }
+    if (args.ddpr_anchor) {
+        config.use_ddpr_anchor = true;
+    }
+    if (args.ddpr_anchor_max_res >= 0.0) {
+        config.ddpr_anchor_max_residual_m = args.ddpr_anchor_max_res;
+    }
+    if (args.ddpr_anchor_fde >= 0.0) {
+        config.ddpr_anchor_fde_threshold_m = args.ddpr_anchor_fde;
+    }
+    if (args.ddpr_anchor_min_n > 0) {
+        config.ddpr_anchor_min_factors = args.ddpr_anchor_min_n;
+    }
+    if (args.ddpr_anchor_boot_epochs >= 0) {
+        config.ddpr_anchor_bootstrap_epochs = args.ddpr_anchor_boot_epochs;
+    }
+    if (args.ddpr_anchor_boot_sigma >= 0.0) {
+        config.ddpr_anchor_bootstrap_sigma_m = args.ddpr_anchor_boot_sigma;
+    }
+    if (args.ddpr_anchor_boot_after_mass >= 0) {
+        config.cp_hold_bootstrap_after_mass_reset = (args.ddpr_anchor_boot_after_mass != 0);
+    }
+    if (args.fde) {
+        config.use_fde = true;
+    }
+    if (args.fde_pr >= 0.0) {
+        config.fde_pseudorange_threshold_m = args.fde_pr;
+    }
+    if (args.fde_cp >= 0.0) {
+        config.fde_carrier_threshold_m = args.fde_cp;
+    }
+    if (args.fde_frac >= 0.0) {
+        config.fde_max_rejected_fraction = args.fde_frac;
+    }
+    if (args.fde_iters > 0) {
+        config.fde_max_iterations = args.fde_iters;
+    }
     const libgnss::FGOProcessor builder(config);
     const libgnss::FGOProcessor::FGOProblem problem =
         builder.buildDoubleDifferenceProblem(rover_epochs, base_epochs, nav, base_position);
@@ -900,6 +1038,35 @@ int main(int argc, char** argv) {
                   << "  CMC screening: " << (args.cmc ? "on" : "off")
                   << " (jump_resets=" << fl.diagnostics.code_minus_carrier_jump_resets
                   << ", level_exclusions=" << fl.diagnostics.code_minus_carrier_level_exclusions
+                  << ")\n"
+                  << "  CP-hold/sanity FSM: " << (args.cp_hold ? "on" : "off")
+                  << " (triggers=" << fl.diagnostics.cp_hold_triggers
+                  << ", epochs_held=" << fl.diagnostics.cp_hold_epochs_held
+                  << ", mass_resets=" << fl.diagnostics.sanity_mass_resets
+                  << ", fast_resets=" << fl.diagnostics.sanity_fast_resets
+                  << ", pose_replacements=" << fl.diagnostics.sanity_pose_replacements
+                  << ", multipath_skips=" << fl.diagnostics.sanity_multipath_skips
+                  << ", gdop_skips=" << fl.diagnostics.sanity_gdop_skips
+                  << ", generation_bumps=" << fl.diagnostics.ambiguity_generation_bumps
+                  << ")\n"
+                  << "  exception recovery: " << (args.exc_recovery ? "on" : "off")
+                  << " (smoother_recovery_epochs=" << fl.diagnostics.smoother_recovery_epochs
+                  << ", loose_prior_recoveries=" << fl.diagnostics.solve_exception_recoveries
+                  << ", full_warm_resets=" << fl.diagnostics.solve_exception_warm_resets
+                  << ")\n"
+                  << "  DDPR-LS anchor: " << (args.ddpr_anchor ? "on" : "off")
+                  << " (solves=" << fl.diagnostics.ddpr_anchor_solves
+                  << ", successes=" << fl.diagnostics.ddpr_anchor_successes
+                  << ", gated_resets_skipped=" << fl.diagnostics.ddpr_anchor_gated_resets_skipped
+                  << ", gated_resets_allowed=" << fl.diagnostics.ddpr_anchor_gated_resets_allowed
+                  << ", anchored_warm_resets=" << fl.diagnostics.ddpr_anchored_warm_resets
+                  << ", bootstrap_prior_epochs=" << fl.diagnostics.ddpr_anchor_bootstrap_prior_epochs
+                  << ")\n"
+                  << "  FDE: " << (args.fde ? "on" : "off")
+                  << " (pr_rejections=" << fl.diagnostics.fde_pseudorange_rejections
+                  << ", cp_rejections=" << fl.diagnostics.fde_carrier_rejections
+                  << ", safeguard_skips=" << fl.diagnostics.fde_safeguard_skips
+                  << ", fde_epochs=" << fl.diagnostics.fde_epochs
                   << ")\n";
         if (!ref_rows.empty()) {
             std::cout << "  horizontal error vs reference.csv:\n"

--- a/apps/gnss_fgo_parity.cpp
+++ b/apps/gnss_fgo_parity.cpp
@@ -1,0 +1,954 @@
+// Real-data Eigen-vs-GTSAM FGO parity harness (Phase 1 validation).
+//
+// Loads a real tokyo/nagoya PPC run (rover.obs + base.obs + base.nav) exactly
+// the way apps/gnss_fgo.cpp does, materializes ONE production FGOProblem via
+// FGOProcessor::buildDoubleDifferenceProblem(), then runs that identical
+// problem through BOTH FGOProcessor backends (FGOBackend::Eigen and
+// FGOBackend::GTSAM) and reports:
+//   (a) per-epoch ECEF float-solution delta (max / RMS),
+//   (b) fixed-solution / fix agreement with LAMBDA enabled on both backends.
+//
+// This is an app (not a unit test) because it needs the real dataset files.
+// It only builds when the library was configured with GTSAM (otherwise the
+// GTSAM backend silently falls back to Eigen and the comparison is trivial).
+
+#include <libgnss++/algorithms/fgo.hpp>
+#include <libgnss++/core/coordinates.hpp>
+#include <libgnss++/core/navigation.hpp>
+#include <libgnss++/core/observation.hpp>
+#include <libgnss++/fusion/fusion_initialization.hpp>
+#include <libgnss++/io/imu.hpp>
+#include <libgnss++/io/rinex.hpp>
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <vector>
+
+namespace {
+
+struct Args {
+    std::string rover_path;
+    std::string base_path;
+    std::string nav_path;
+    int max_epochs = 0;      // 0 = all
+    int max_iters = 0;       // 0 = use preset default
+    bool no_pr_factors = false;  // pure double-difference path (clock-free)
+    bool no_robust = false;      // disable Huber robust loss (convexity check)
+    bool float_only = false;     // skip the LAMBDA/Marginals fix comparison
+    std::string imu_path;        // milestone 2b: imu.csv -> IMU-coupled Pose3 run
+    std::string ref_path;        // optional reference.csv for attitude sanity
+    double fixed_lag_s = 0.0;    // milestone 2c: >0 enables the fixed-lag smoother
+    bool use_nhc = false;        // milestone 2d
+    bool use_zupt = false;       // milestone 2d
+};
+
+Args parseArgs(int argc, char** argv) {
+    Args args;
+    for (int i = 1; i < argc; ++i) {
+        const std::string a = argv[i];
+        if (a == "--rover" && i + 1 < argc) {
+            args.rover_path = argv[++i];
+        } else if (a == "--base" && i + 1 < argc) {
+            args.base_path = argv[++i];
+        } else if (a == "--nav" && i + 1 < argc) {
+            args.nav_path = argv[++i];
+        } else if (a == "--max-epochs" && i + 1 < argc) {
+            args.max_epochs = std::stoi(argv[++i]);
+        } else if (a == "--max-iters" && i + 1 < argc) {
+            args.max_iters = std::stoi(argv[++i]);
+        } else if (a == "--no-pr") {
+            args.no_pr_factors = true;
+        } else if (a == "--no-robust") {
+            args.no_robust = true;
+        } else if (a == "--float-only") {
+            args.float_only = true;
+        } else if (a == "--imu" && i + 1 < argc) {
+            args.imu_path = argv[++i];
+        } else if (a == "--ref" && i + 1 < argc) {
+            args.ref_path = argv[++i];
+        } else if (a == "--fixed-lag" && i + 1 < argc) {
+            args.fixed_lag_s = std::stod(argv[++i]);
+        } else if (a == "--nhc") {
+            args.use_nhc = true;
+        } else if (a == "--zupt") {
+            args.use_zupt = true;
+        } else {
+            std::cerr << "Unknown/incomplete arg: " << a << "\n";
+            std::exit(2);
+        }
+    }
+    if (args.rover_path.empty() || args.base_path.empty() || args.nav_path.empty()) {
+        std::cerr << "Usage: gnss_fgo_parity --rover <rover.obs> --base <base.obs> "
+                     "--nav <base.nav> [--max-epochs N]\n";
+        std::exit(2);
+    }
+    return args;
+}
+
+// Mirrors apps/gnss_fgo.cpp's "real-data-float" preset for the DD RTK path so
+// the FGOProblem we build matches a realistic production configuration.
+libgnss::FGOProcessor::FGOConfig makeRealDataDdConfig() {
+    libgnss::FGOProcessor::FGOConfig config;
+    config.max_iterations = 12;
+    config.pseudorange_sigma_m = 4.0;
+    config.motion_sigma_m = 100.0;
+    config.clock_motion_sigma_m = 600.0;
+    config.tdcp_sigma_m = 0.05;
+    config.carrier_phase_sigma_m = 0.02;
+    config.double_difference_pseudorange_sigma_m = 1.0;
+    config.double_difference_carrier_sigma_m = 0.02;
+    config.ambiguity_prior_sigma_m = 2000.0;
+    config.pseudorange_huber_threshold_sigma = 3.0;
+    config.carrier_phase_huber_threshold_sigma = 3.0;
+    config.tdcp_huber_threshold_sigma = 3.0;
+    config.max_tdcp_gap_s = 1.5;
+    config.min_elevation_deg = 15.0;
+    config.use_robust_loss = true;
+    config.use_double_difference_factors = true;
+    config.use_pseudorange_factors = true;
+    config.use_carrier_phase_factors = false;
+    config.use_tdcp_factors = true;
+    config.use_ambiguity_priors = true;
+    config.fix_ambiguities = false;
+    // Per-epoch LAMBDA on this urban multipath data tops out around ratio ~2.5;
+    // the default 3.0 gate fixes nothing on EITHER backend's per-epoch path
+    // (Eigen only "fixes" via its lenient global nearest-integer snap). Use 2.0
+    // so both backends' per-epoch LAMBDA actually engage and can be compared.
+    config.lambda_ratio_threshold = 2.0;
+    config.use_inter_system_biases = true;
+    return config;
+}
+
+std::vector<libgnss::ObservationData> loadEpochs(const std::string& path,
+                                                 int max_epochs,
+                                                 const libgnss::Vector3d& fixed_position,
+                                                 bool assign_fixed_position) {
+    libgnss::io::RINEXReader reader;
+    std::vector<libgnss::ObservationData> epochs;
+    if (!reader.open(path)) {
+        std::cerr << "Error: cannot open " << path << "\n";
+        std::exit(1);
+    }
+    libgnss::io::RINEXReader::RINEXHeader header;
+    if (!reader.readHeader(header)) {
+        std::cerr << "Error: cannot read header " << path << "\n";
+        std::exit(1);
+    }
+    libgnss::ObservationData epoch;
+    while (reader.readObservationEpoch(epoch)) {
+        if (assign_fixed_position) {
+            epoch.receiver_position = fixed_position;
+        } else if (header.approximate_position.norm() > 0.0) {
+            epoch.receiver_position = header.approximate_position;
+        }
+        epochs.push_back(epoch);
+        if (max_epochs > 0 && static_cast<int>(epochs.size()) >= max_epochs) {
+            break;
+        }
+    }
+    return epochs;
+}
+
+struct FloatParity {
+    std::size_t compared_epochs = 0;
+    double max_delta_m = 0.0;
+    double rms_delta_m = 0.0;
+    std::size_t nonfinite_eigen = 0;
+    std::size_t nonfinite_gtsam = 0;
+    std::size_t status_disagreements = 0;
+};
+
+const char* statusName(libgnss::SolutionStatus s) {
+    switch (s) {
+        case libgnss::SolutionStatus::NONE: return "NONE";
+        case libgnss::SolutionStatus::SPP: return "SPP";
+        case libgnss::SolutionStatus::FLOAT: return "FLOAT";
+        case libgnss::SolutionStatus::FIXED: return "FIXED";
+        default: return "?";
+    }
+}
+
+FloatParity compareFloat(const libgnss::FGOProcessor::FGOResult& e,
+                         const libgnss::FGOProcessor::FGOResult& g) {
+    FloatParity fp;
+    const std::size_t n = std::min(e.solution.solutions.size(), g.solution.solutions.size());
+    double sum_sq = 0.0;
+    for (std::size_t i = 0; i < n; ++i) {
+        const auto& es = e.solution.solutions[i];
+        const auto& gs = g.solution.solutions[i];
+        if (es.status != gs.status) {
+            ++fp.status_disagreements;
+        }
+        const bool ef = es.position_ecef.allFinite();
+        const bool gf = gs.position_ecef.allFinite();
+        if (!ef) ++fp.nonfinite_eigen;
+        if (!gf) ++fp.nonfinite_gtsam;
+        // Only compare epochs where BOTH produced a usable (non-NONE) finite fix.
+        if (!ef || !gf || es.status == libgnss::SolutionStatus::NONE ||
+            gs.status == libgnss::SolutionStatus::NONE) {
+            continue;
+        }
+        const double d = (es.position_ecef - gs.position_ecef).norm();
+        fp.max_delta_m = std::max(fp.max_delta_m, d);
+        sum_sq += d * d;
+        ++fp.compared_epochs;
+    }
+    if (fp.compared_epochs > 0) {
+        fp.rms_delta_m = std::sqrt(sum_sq / static_cast<double>(fp.compared_epochs));
+    }
+    return fp;
+}
+
+std::size_t countFixedEpochs(const libgnss::FGOProcessor::FGOResult& r) {
+    std::size_t n = 0;
+    for (const auto& s : r.solution.solutions) {
+        if (s.status == libgnss::SolutionStatus::FIXED) {
+            ++n;
+        }
+    }
+    return n;
+}
+
+// Tokyo IMU->antenna lever arm, body FLU (docs/imu_fusion.md, project memory);
+// used only when the caller asks for the milestone-2a Pose3 GTSAM path.
+constexpr double kTokyoLeverArmX = 0.31;
+constexpr double kTokyoLeverArmY = 0.0;
+constexpr double kTokyoLeverArmZ = 0.55;
+
+libgnss::FGOProcessor::FGOResult run(const libgnss::FGOProcessor::FGOProblem& problem,
+                                     libgnss::FGOProcessor::FGOConfig config,
+                                     libgnss::FGOBackend backend,
+                                     bool use_lambda,
+                                     double& seconds,
+                                     bool use_pose3 = false,
+                                     bool use_imu = false,
+                                     double fixed_lag_s = 0.0,
+                                     bool use_nhc = false,
+                                     bool use_zupt = false) {
+    config.backend = backend;
+    config.use_lambda_ambiguity_fix = use_lambda;
+    config.fix_ambiguities = use_lambda;
+    // Drive BOTH backends through their per-epoch LAMBDA path (fixed-position
+    // output) so the fix comparison is apples-to-apples: the native backend's
+    // per-epoch fixing and the GTSAM backend's per-epoch fixing both mark
+    // epochs FIXED and snap positions to the fixed ambiguities.
+    config.use_epoch_lambda_fixed_output = use_lambda;
+    config.collect_lambda_debug = false;
+    if (use_pose3) {
+        // Milestone 2a (docs/gtsam_backend_design.md): key the GTSAM rover
+        // state as a body Pose3 + lever arm instead of a bare Point3.
+        config.use_pose3_state = true;
+        config.pose3_lever_arm_body_m =
+            libgnss::Vector3d(kTokyoLeverArmX, kTokyoLeverArmY, kTokyoLeverArmZ);
+    }
+    // Milestone 2b: enable IMU tight coupling (the problem must already carry
+    // a valid ImuInput; the backend checks problem.imu.valid).
+    config.use_imu = use_imu;
+    // Milestone 2c: enable the incremental fixed-lag smoother.
+    if (fixed_lag_s > 0.0) {
+        config.use_fixed_lag_smoother = true;
+        config.fixed_lag_smoother_lag_s = fixed_lag_s;
+    }
+    // Milestone 2d: NHC / ZUPT pseudo-measurements.
+    config.use_nhc = use_nhc;
+    config.use_zupt = use_zupt;
+    libgnss::FGOProcessor processor(config);
+    const auto t0 = std::chrono::high_resolution_clock::now();
+    auto result = processor.optimizeProblem(problem);
+    const auto t1 = std::chrono::high_resolution_clock::now();
+    seconds = std::chrono::duration_cast<std::chrono::duration<double>>(t1 - t0).count();
+    return result;
+}
+
+// Per-epoch ECEF delta between two results restricted to epochs both mark FIXED.
+struct FixedDelta {
+    std::size_t both_fixed = 0;
+    double max_delta_m = 0.0;
+    double rms_delta_m = 0.0;
+};
+
+FixedDelta compareFixedPositions(const libgnss::FGOProcessor::FGOResult& e,
+                                 const libgnss::FGOProcessor::FGOResult& g) {
+    FixedDelta fd;
+    const std::size_t n = std::min(e.solution.solutions.size(), g.solution.solutions.size());
+    double sum_sq = 0.0;
+    for (std::size_t i = 0; i < n; ++i) {
+        const auto& es = e.solution.solutions[i];
+        const auto& gs = g.solution.solutions[i];
+        if (es.status != libgnss::SolutionStatus::FIXED ||
+            gs.status != libgnss::SolutionStatus::FIXED ||
+            !es.position_ecef.allFinite() || !gs.position_ecef.allFinite()) {
+            continue;
+        }
+        const double d = (es.position_ecef - gs.position_ecef).norm();
+        fd.max_delta_m = std::max(fd.max_delta_m, d);
+        sum_sq += d * d;
+        ++fd.both_fixed;
+    }
+    if (fd.both_fixed > 0) {
+        fd.rms_delta_m = std::sqrt(sum_sq / static_cast<double>(fd.both_fixed));
+    }
+    return fd;
+}
+
+// --- Milestone 2b IMU plumbing (harness side) ---
+//
+// Loads imu.csv (already-FLU raw axes, gyro converted to rad/s by loadImuCsv),
+// runs the SAME Stage-1 ESKF alignment used by `gnss fuse` to get the initial
+// body->ENU attitude + gyro/accel bias, latches heading off the first GNSS
+// motion, and packages everything into FGOProblem::ImuInput. Keeping this in
+// the harness (rather than the backend) means the GTSAM backend depends only
+// on the packaged ImuInput, not on the fusion/ alignment module.
+struct RefRow {
+    libgnss::GNSSTime time;
+    double roll_deg = 0.0, pitch_deg = 0.0, heading_deg = 0.0;
+    double ve = 0.0, vn = 0.0, vu = 0.0;
+    libgnss::Vector3d ecef = libgnss::Vector3d::Zero();
+};
+
+std::vector<RefRow> loadReference(const std::string& path) {
+    std::vector<RefRow> rows;
+    std::ifstream in(path);
+    if (!in) return rows;
+    std::string line;
+    std::getline(in, line);  // header
+    while (std::getline(in, line)) {
+        std::stringstream ss(line);
+        std::string cell;
+        std::vector<double> v;
+        while (std::getline(ss, cell, ',')) {
+            try { v.push_back(std::stod(cell)); } catch (...) { v.push_back(0.0); }
+        }
+        if (v.size() < 14) continue;
+        RefRow r;
+        r.time = libgnss::GNSSTime(static_cast<int>(v[1]), v[0]);
+        r.ecef = libgnss::Vector3d(v[5], v[6], v[7]);
+        r.roll_deg = v[8]; r.pitch_deg = v[9]; r.heading_deg = v[10];
+        r.ve = v[11]; r.vn = v[12]; r.vu = v[13];
+        rows.push_back(r);
+    }
+    return rows;
+}
+
+// Horizontal (E/N) position error of a result vs reference.csv, split by
+// FLOAT vs FIXED solution status. Matches epochs to reference rows by time.
+struct HorizError {
+    std::size_t n_float = 0, n_fixed = 0;
+    double float_rms = 0.0, float_max = 0.0;
+    double fixed_rms = 0.0, fixed_max = 0.0;
+    double frac_all_under_50cm = 0.0;  ///< fraction of all (float+fixed) epochs with horiz<0.5 m
+};
+
+HorizError horizontalErrorVsRef(const libgnss::FGOProcessor::FGOResult& r,
+                                const std::vector<RefRow>& ref) {
+    HorizError he;
+    if (ref.empty()) return he;
+    double lat0 = 0.0, lon0 = 0.0, h0 = 0.0;
+    libgnss::ecef2geodetic(ref.front().ecef, lat0, lon0, h0);
+    double fsum = 0.0, xsum = 0.0;
+    std::size_t ri = 0;  // reference cursor (both streams time-sorted)
+    std::size_t n_all = 0, n_all_under50 = 0;
+    for (const auto& s : r.solution.solutions) {
+        if (s.status == libgnss::SolutionStatus::NONE || !s.position_ecef.allFinite()) continue;
+        // Advance reference cursor to the nearest row in time.
+        while (ri + 1 < ref.size() &&
+               std::abs(ref[ri + 1].time - s.time) < std::abs(ref[ri].time - s.time)) {
+            ++ri;
+        }
+        if (std::abs(ref[ri].time - s.time) > 0.11) continue;
+        const libgnss::Vector3d enu =
+            libgnss::ecef2enu(s.position_ecef - ref[ri].ecef, lat0, lon0);
+        const double horiz = std::hypot(enu.x(), enu.y());
+        ++n_all;
+        if (horiz < 0.5) ++n_all_under50;
+        if (s.status == libgnss::SolutionStatus::FIXED) {
+            xsum += horiz * horiz;
+            he.fixed_max = std::max(he.fixed_max, horiz);
+            ++he.n_fixed;
+        } else {
+            fsum += horiz * horiz;
+            he.float_max = std::max(he.float_max, horiz);
+            ++he.n_float;
+        }
+    }
+    if (he.n_float > 0) he.float_rms = std::sqrt(fsum / double(he.n_float));
+    if (he.n_fixed > 0) he.fixed_rms = std::sqrt(xsum / double(he.n_fixed));
+    if (n_all > 0) he.frac_all_under_50cm = double(n_all_under50) / double(n_all);
+    return he;
+}
+
+// Populate problem.imu from an imu.csv + the already-built FGOProblem epochs.
+// Returns false (and leaves problem.imu.valid=false) if anything is missing.
+bool buildImuInput(const std::string& imu_path,
+                   libgnss::FGOProcessor::FGOProblem& problem) {
+    if (problem.epochs.size() < 2) return false;
+    libgnss::ImuSeries imu_series;
+    const auto load = libgnss::loadImuCsv(imu_path, imu_series);
+    if (!load.ok || imu_series.isEmpty()) {
+        std::cerr << "Error: cannot load IMU csv " << imu_path
+                  << " (" << load.error << ")\n";
+        return false;
+    }
+    // tokyo imu.csv is already body FLU (identity axis convention, same default
+    // as gnss_fuse.cpp) with gyro converted to rad/s at load time.
+    const libgnss::ImuAxisConvention axis;  // identity
+    for (auto& s : imu_series.samples) {
+        s.accel_raw = axis.apply(s.accel_raw);
+        s.gyro_raw_radps = axis.apply(s.gyro_raw_radps);
+    }
+
+    auto& imu = problem.imu;
+    imu.samples_body_flu = imu_series.samples;
+
+    // Nav (ENU) origin: first epoch antenna ECEF -> geodetic lat/lon.
+    const libgnss::Vector3d origin_ecef = problem.epochs.front().position_ecef;
+    double lat = 0.0, lon = 0.0, h = 0.0;
+    libgnss::ecef2geodetic(origin_ecef, lat, lon, h);
+    imu.nav_origin_ecef = origin_ecef;
+    imu.nav_origin_lat_rad = lat;
+    imu.nav_origin_lon_rad = lon;
+
+    // Stage-1 static leveling, reusing fusion_initialization::alignStatic.
+    // The tokyo run starts stationary (reference velocity ~0 for the first
+    // seconds) and the IMU stream begins essentially concurrent with the first
+    // GNSS epoch, so the leveling window is the first ~2.5 s of IMU samples at
+    // or after the first epoch time (samples strictly "before" the first epoch
+    // do not exist). A short leading gyro/accel-quiet check guards against
+    // starting mid-motion.
+    const libgnss::GNSSTime t_first = problem.epochs.front().time;
+    std::vector<libgnss::ImuSample> stationary;
+    for (const auto& s : imu.samples_body_flu) {
+        if (s.time < t_first) continue;
+        if (stationary.size() >= 250) break;  // ~2.5 s at 100 Hz
+        stationary.push_back(s);
+    }
+    const libgnss::NominalState aligned = libgnss::fusion_initialization::alignStatic(
+        stationary, libgnss::Vector3d::Zero(), imu.noise.gravity_mps2);
+
+    // Heading latch: first epoch whose GNSS ENU speed exceeds threshold sets
+    // yaw = course (mirrors fusion_initialization::tryAlignHeading). Compute
+    // ENU velocity by finite difference of consecutive antenna positions.
+    libgnss::FusionState fstate;
+    fstate.nominal = aligned;
+    libgnss::Vector3d init_vel_enu = libgnss::Vector3d::Zero();
+    bool heading_latched = false;
+    for (std::size_t i = 0; i + 1 < problem.epochs.size(); ++i) {
+        const double dt = problem.epochs[i + 1].time - problem.epochs[i].time;
+        if (dt <= 1e-3) continue;
+        const libgnss::Vector3d enu0 = libgnss::ecef2enu(
+            problem.epochs[i].position_ecef - origin_ecef, lat, lon);
+        const libgnss::Vector3d enu1 = libgnss::ecef2enu(
+            problem.epochs[i + 1].position_ecef - origin_ecef, lat, lon);
+        const libgnss::Vector3d vel = (enu1 - enu0) / dt;
+        if (!heading_latched) {
+            if (libgnss::fusion_initialization::tryAlignHeading(fstate, vel, 1.0, 5.0)) {
+                heading_latched = true;
+                init_vel_enu = vel;
+            }
+        }
+    }
+    // If never moved fast enough in the batch, fall back to first-interval vel.
+    if (!heading_latched && problem.epochs.size() >= 2) {
+        const double dt = problem.epochs[1].time - problem.epochs[0].time;
+        if (dt > 1e-3) {
+            init_vel_enu = libgnss::ecef2enu(
+                problem.epochs[1].position_ecef - origin_ecef, lat, lon) / dt -
+                libgnss::ecef2enu(problem.epochs[0].position_ecef - origin_ecef, lat, lon) / dt;
+        }
+    }
+
+    imu.init_attitude_body_to_nav = fstate.nominal.attitude_body_to_enu.toRotationMatrix();
+    imu.init_velocity_nav = init_vel_enu;
+    imu.init_accel_bias = aligned.accel_bias;
+    imu.init_gyro_bias = aligned.gyro_bias;
+    // Low-cost MEMS-ish noise (order of the tokyo low-cost preset); 2b is a
+    // wiring/sanity gate, tuning is 2c/2e.
+    // Tighter than the initial 2b sanity setting so the IMU actually bridges
+    // weak-GNSS urban stretches (still conservative MEMS-grade; deep tuning is
+    // 2e). Loose IMU let the float wander to metres in canyon; tightening pulls
+    // it back toward the IMU-predicted trajectory between good fixes.
+    imu.noise.accel_noise_sigma = 2.0e-2;
+    imu.noise.gyro_noise_sigma = 2.0e-3;
+    imu.noise.accel_bias_rw_sigma = 3.0e-3;
+    imu.noise.gyro_bias_rw_sigma = 3.0e-4;
+    imu.noise.integration_sigma = 1.0e-3;
+    imu.init_attitude_sigma_roll_pitch_rad = 0.05;
+    imu.init_attitude_sigma_yaw_rad = heading_latched ? 0.15 : 3.0;
+    imu.init_velocity_sigma_mps = 0.5;
+    imu.init_accel_bias_sigma = 0.1;
+    imu.init_gyro_bias_sigma = 0.01;
+    imu.valid = true;
+
+    {
+        // Epoch/IMU cadence sanity (helps diagnose preintegration dt issues).
+        const double dt_epoch = problem.epochs.size() >= 2
+                                    ? (problem.epochs[1].time - problem.epochs[0].time)
+                                    : 0.0;
+        double dt_imu = 0.0;
+        for (std::size_t k = 1; k < imu.samples_body_flu.size() && k < 5; ++k) {
+            dt_imu = imu.samples_body_flu[k].time - imu.samples_body_flu[k - 1].time;
+        }
+        std::cout << "IMU cadence: epoch dt=" << dt_epoch << " s, imu dt~=" << dt_imu
+                  << " s; epoch0.tow=" << problem.epochs[0].time.tow
+                  << " imu0.tow=" << imu.samples_body_flu[0].time.tow
+                  << " (weeks e" << problem.epochs[0].time.week << "/i"
+                  << imu.samples_body_flu[0].time.week << ")\n";
+    }
+    std::cout << "IMU: loaded " << imu.samples_body_flu.size() << " samples, stationary_window="
+              << stationary.size() << ", heading_latched=" << (heading_latched ? "yes" : "no")
+              << "\n  init attitude(body->ENU) roll/pitch from leveling; init_vel_enu=["
+              << init_vel_enu.transpose() << "] m/s\n"
+              << "  init_gyro_bias=[" << aligned.gyro_bias.transpose() << "] rad/s"
+              << " init_accel_bias=[" << aligned.accel_bias.transpose() << "] m/s^2\n";
+    return true;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    const Args args = parseArgs(argc, argv);
+
+    // Navigation.
+    libgnss::io::RINEXReader nav_reader;
+    if (!nav_reader.open(args.nav_path)) {
+        std::cerr << "Error: cannot open nav " << args.nav_path << "\n";
+        return 1;
+    }
+    libgnss::NavigationData nav;
+    if (!nav_reader.readNavigationData(nav)) {
+        std::cerr << "Error: cannot read nav " << args.nav_path << "\n";
+        return 1;
+    }
+
+    // Base station position from its RINEX header (mirrors gnss_fgo.cpp).
+    libgnss::io::RINEXReader base_header_reader;
+    if (!base_header_reader.open(args.base_path)) {
+        std::cerr << "Error: cannot open base " << args.base_path << "\n";
+        return 1;
+    }
+    libgnss::io::RINEXReader::RINEXHeader base_header;
+    if (!base_header_reader.readHeader(base_header)) {
+        std::cerr << "Error: cannot read base header " << args.base_path << "\n";
+        return 1;
+    }
+    if (base_header.approximate_position.norm() <= 1e6) {
+        std::cerr << "Error: base approximate position unavailable in " << args.base_path << "\n";
+        return 1;
+    }
+    const libgnss::Vector3d base_position = base_header.approximate_position;
+
+    const std::vector<libgnss::ObservationData> rover_epochs =
+        loadEpochs(args.rover_path, args.max_epochs, libgnss::Vector3d::Zero(), false);
+    // Base is read fully (its epochs are matched/interpolated to rover time
+    // inside buildDoubleDifferenceProblem); no rover-side epoch cap on base.
+    const std::vector<libgnss::ObservationData> base_epochs =
+        loadEpochs(args.base_path, 0, base_position, true);
+
+    std::cout << "Dataset:\n"
+              << "  rover=" << args.rover_path << " (" << rover_epochs.size() << " epochs"
+              << (args.max_epochs > 0 ? " capped" : "") << ")\n"
+              << "  base=" << args.base_path << " (" << base_epochs.size() << " epochs)\n"
+              << "  nav=" << args.nav_path << "\n"
+              << "  base_pos_ecef=[" << base_position.transpose() << "]\n";
+
+    libgnss::FGOProcessor::FGOConfig config = makeRealDataDdConfig();
+    if (args.max_iters > 0) {
+        config.max_iterations = args.max_iters;
+    }
+    if (args.no_robust) {
+        config.use_robust_loss = false;
+    }
+    if (args.no_pr_factors) {
+        // Pure DD path: no undifferenced pseudorange factors, so there are no
+        // receiver-clock / inter-system-bias states at all -- this isolates the
+        // clock-free double-difference RTK path (the Phase-1 target) from the
+        // undifferenced-pseudorange modeling differences between backends.
+        config.use_pseudorange_factors = false;
+    }
+    const libgnss::FGOProcessor builder(config);
+    const libgnss::FGOProcessor::FGOProblem problem =
+        builder.buildDoubleDifferenceProblem(rover_epochs, base_epochs, nav, base_position);
+
+    std::cout << "FGOProblem: epochs=" << problem.epochs.size()
+              << " dd_pr_factors=" << problem.double_difference_pseudorange_factors.size()
+              << " dd_cp_factors=" << problem.double_difference_carrier_factors.size()
+              << " ambiguity_states=" << problem.ambiguity_states.size()
+              << " pr_factors=" << problem.pseudorange_factors.size() << "\n";
+
+    if (problem.epochs.empty() ||
+        (problem.double_difference_carrier_factors.empty() &&
+         problem.double_difference_pseudorange_factors.empty())) {
+        std::cerr << "Error: no DD factors built; cannot compare backends.\n";
+        return 1;
+    }
+
+    // --- (a4) MILESTONE 2c: IncrementalFixedLagSmoother at scale. Runs FIRST
+    // and returns, so the full run does NOT pay for the heavy batch (a)/(a2)/(b)
+    // DD comparisons (whose full-batch gtsam::Marginals is exactly what 2c
+    // avoids). Requires --imu + --fixed-lag S. ---
+    if (args.fixed_lag_s > 0.0 && !args.imu_path.empty()) {
+        libgnss::FGOProcessor::FGOProblem problem_imu = problem;
+        if (!buildImuInput(args.imu_path, problem_imu)) {
+            std::cerr << "Error: could not build IMU input for fixed-lag run.\n";
+            return 1;
+        }
+        std::vector<RefRow> ref_rows;
+        if (!args.ref_path.empty()) ref_rows = loadReference(args.ref_path);
+
+        double t_fl = 0.0;
+        const auto fl = run(problem_imu, config, libgnss::FGOBackend::GTSAM, true, t_fl,
+                            /*use_pose3=*/true, /*use_imu=*/true, args.fixed_lag_s,
+                            args.use_nhc, args.use_zupt);
+        std::size_t nonfinite = 0, none_epochs = 0;
+        for (const auto& s : fl.solution.solutions) {
+            if (s.status == libgnss::SolutionStatus::NONE) ++none_epochs;
+            else if (!s.position_ecef.allFinite()) ++nonfinite;
+        }
+        const std::size_t fl_fixed = countFixedEpochs(fl);
+        const std::size_t ne = fl.solution.solutions.size();
+        const HorizError he = horizontalErrorVsRef(fl, ref_rows);
+
+        std::cout << "\n=== (a4) MILESTONE 2c: IncrementalFixedLagSmoother (full-scale) ===\n"
+                  << "  lag=" << args.fixed_lag_s << " s, epochs=" << ne
+                  << ", smoother_updates=" << fl.diagnostics.smoother_updates
+                  << ", peak_window_vars=" << fl.diagnostics.smoother_max_window_vars << "\n"
+                  << "  wall_clock=" << t_fl << " s ("
+                  << (ne > 0 ? t_fl / double(ne) * 1e3 : 0.0)
+                  << " ms/epoch), nonfinite=" << nonfinite << ", NONE_epochs=" << none_epochs << "\n"
+                  << "  per-epoch LAMBDA: attempts=" << fl.diagnostics.lambda_ambiguity_attempts
+                  << ", fixed_epochs=" << fl_fixed << "/" << ne << " ("
+                  << (ne > 0 ? 100.0 * double(fl_fixed) / double(ne) : 0.0)
+                  << "% fix-rate), best_ratio=" << fl.diagnostics.lambda_ambiguity_ratio << "\n"
+                  << "  NHC/ZUPT: nhc=" << (args.use_nhc ? "on" : "off")
+                  << " (applied " << fl.diagnostics.nhc_epochs << " epochs), zupt="
+                  << (args.use_zupt ? "on" : "off") << " (applied " << fl.diagnostics.zupt_epochs
+                  << " epochs)\n";
+        if (!ref_rows.empty()) {
+            std::cout << "  horizontal error vs reference.csv:\n"
+                      << "    FLOAT: n=" << he.n_float << " rms=" << he.float_rms
+                      << " m max=" << he.float_max << " m\n"
+                      << "    FIXED: n=" << he.n_fixed << " rms=" << he.fixed_rms
+                      << " m max=" << he.fixed_max << " m\n"
+                      << "    ALL (float+fixed) <50cm rate=" << (100.0 * he.frac_all_under_50cm)
+                      << "%\n"
+                      << "    (inuex35 truth target run1: FixRMS 0.815 m / fix 49.5% / <50cm 56.7%)\n";
+            // Stationary-epoch velocity: should collapse to ~0 with ZUPT.
+            if (!fl.epoch_velocity_nav_mps.empty()) {
+                double vsum = 0.0, vmax = 0.0;
+                std::size_t vn = 0, ri = 0;
+                for (std::size_t i = 0; i < ne && i < fl.epoch_velocity_nav_mps.size(); ++i) {
+                    const auto& sol = fl.solution.solutions[i];
+                    while (ri + 1 < ref_rows.size() &&
+                           std::abs(ref_rows[ri + 1].time - sol.time) <
+                               std::abs(ref_rows[ri].time - sol.time)) {
+                        ++ri;
+                    }
+                    if (std::abs(ref_rows[ri].time - sol.time) > 0.11) continue;
+                    const double ref_speed = std::hypot(ref_rows[ri].ve, ref_rows[ri].vn);
+                    if (ref_speed > 0.1) continue;  // reference-stationary epochs only
+                    const auto& v = fl.epoch_velocity_nav_mps[i];
+                    const double sp = v.norm();
+                    vsum += sp * sp;
+                    vmax = std::max(vmax, sp);
+                    ++vn;
+                }
+                if (vn > 0) {
+                    std::cout << "    stationary-epoch |velocity| (ref speed<0.1): rms="
+                              << std::sqrt(vsum / double(vn)) << " m/s max=" << vmax
+                              << " m/s (n=" << vn << ")\n";
+                }
+            }
+        }
+        // Consistency vs 2b batch on the overlap (only when small enough that
+        // the batch path is safe). Apples-to-apples: both float-only.
+        if (ne <= 600) {
+            double t_b = 0.0, t_flf = 0.0;
+            const auto batch = run(problem_imu, config, libgnss::FGOBackend::GTSAM, false, t_b,
+                                   /*use_pose3=*/true, /*use_imu=*/true);
+            const auto fl_float = run(problem_imu, config, libgnss::FGOBackend::GTSAM, false, t_flf,
+                                      /*use_pose3=*/true, /*use_imu=*/true, args.fixed_lag_s);
+            const FloatParity cons = compareFloat(batch, fl_float);
+            const HorizError he_batch = horizontalErrorVsRef(batch, ref_rows);
+            const HorizError he_flf = horizontalErrorVsRef(fl_float, ref_rows);
+            std::cout << "  consistency vs 2b batch (float-vs-float, over " << cons.compared_epochs
+                      << " epochs): max=" << cons.max_delta_m << " m rms=" << cons.rms_delta_m << " m\n"
+                      << "    batch-float horiz err vs ref:    rms=" << he_batch.float_rms << " m\n"
+                      << "    smoother-float horiz err vs ref: rms=" << he_flf.float_rms << " m\n";
+        }
+        const bool go_2c = fl.diagnostics.smoother_updates == ne && nonfinite == 0 &&
+                           fl.diagnostics.lambda_ambiguity_attempts > 0;
+        std::cout << "\nRESULT (milestone 2c): fixed-lag full-scale run "
+                  << (go_2c ? "GO" : "NO-GO") << " (epochs=" << ne
+                  << ", peak_window_vars=" << fl.diagnostics.smoother_max_window_vars
+                  << ", fix-rate=" << (ne > 0 ? 100.0 * double(fl_fixed) / double(ne) : 0.0)
+                  << "%, wall=" << t_fl << " s)\n";
+        std::cout.flush();
+        return 0;
+    }
+
+    // --- (a) Float parity: LAMBDA off on both backends ---
+    double t_ef = 0.0, t_gf = 0.0;
+    const auto eigen_float = run(problem, config, libgnss::FGOBackend::Eigen, false, t_ef);
+    const auto gtsam_float = run(problem, config, libgnss::FGOBackend::GTSAM, false, t_gf);
+    const FloatParity fp = compareFloat(eigen_float, gtsam_float);
+
+    std::cout << "\n=== (a) FLOAT parity (LAMBDA off) ===\n"
+              << "  eigen: " << t_ef << " s, final_cost=" << eigen_float.diagnostics.final_cost
+              << ", dd_cp_rms=" << eigen_float.diagnostics.double_difference_carrier_residual_rms_m
+              << " m\n"
+              << "  gtsam: " << t_gf << " s, iters=" << gtsam_float.diagnostics.iterations
+              << ", final_cost=" << gtsam_float.diagnostics.final_cost
+              << ", dd_cp_rms=" << gtsam_float.diagnostics.double_difference_carrier_residual_rms_m
+              << " m, graph_values=" << gtsam_float.diagnostics.graph_values
+              << " graph_factors=" << gtsam_float.diagnostics.graph_factors << "\n"
+              << "  compared_epochs=" << fp.compared_epochs << "\n"
+              << "  max ECEF delta = " << fp.max_delta_m << " m\n"
+              << "  rms ECEF delta = " << fp.rms_delta_m << " m\n"
+              << "  status_disagreements=" << fp.status_disagreements
+              << " nonfinite(eigen=" << fp.nonfinite_eigen << ", gtsam=" << fp.nonfinite_gtsam
+              << ")\n";
+    std::cout.flush();
+
+    // --- (a2) Milestone 2a: Pose3-GTSAM (lever-arm '...FactorArm' DD factors)
+    // vs Point3-GTSAM antenna position parity, both with LAMBDA off. Attitude
+    // is unobservable without IMU (2b), so only the recovered ANTENNA
+    // position is validated here; the 2a success gate is Pose3 vs Point3
+    // sub-cm agreement (docs/gtsam_backend_design.md, milestone 2a). ---
+    double t_gp3 = 0.0;
+    const auto gtsam_pose3_float =
+        run(problem, config, libgnss::FGOBackend::GTSAM, false, t_gp3, /*use_pose3=*/true);
+    const FloatParity fp_pose3_vs_point3 = compareFloat(gtsam_float, gtsam_pose3_float);
+    const FloatParity fp_pose3_vs_eigen = compareFloat(eigen_float, gtsam_pose3_float);
+
+    std::cout << "\n=== (a2) MILESTONE 2a: Pose3-GTSAM vs Point3-GTSAM antenna position parity ===\n"
+              << "  lever_arm_body_flu=[" << kTokyoLeverArmX << ", " << kTokyoLeverArmY << ", "
+              << kTokyoLeverArmZ << "] m\n"
+              << "  pose3-gtsam: " << t_gp3 << " s, iters=" << gtsam_pose3_float.diagnostics.iterations
+              << ", final_cost=" << gtsam_pose3_float.diagnostics.final_cost
+              << ", dd_cp_rms=" << gtsam_pose3_float.diagnostics.double_difference_carrier_residual_rms_m
+              << " m\n"
+              << "  compared_epochs=" << fp_pose3_vs_point3.compared_epochs << "\n"
+              << "  Pose3 vs Point3 (both GTSAM) max ECEF delta = " << fp_pose3_vs_point3.max_delta_m
+              << " m\n"
+              << "  Pose3 vs Point3 (both GTSAM) rms ECEF delta = " << fp_pose3_vs_point3.rms_delta_m
+              << " m\n"
+              << "  Pose3 (GTSAM) vs Eigen      max ECEF delta = " << fp_pose3_vs_eigen.max_delta_m
+              << " m\n"
+              << "  Pose3 (GTSAM) vs Eigen      rms ECEF delta = " << fp_pose3_vs_eigen.rms_delta_m
+              << " m\n"
+              << "  status_disagreements=" << fp_pose3_vs_point3.status_disagreements
+              << " nonfinite(point3=" << fp_pose3_vs_point3.nonfinite_eigen
+              << ", pose3=" << fp_pose3_vs_point3.nonfinite_gtsam << ")\n";
+    std::cout.flush();
+
+    const bool go_2a = fp_pose3_vs_point3.compared_epochs > 0 && fp_pose3_vs_point3.max_delta_m < 0.01;
+    std::cout << "\nRESULT (milestone 2a): Pose3-vs-Point3 antenna-position parity "
+              << (go_2a ? "GO" : "NO-GO") << " (max=" << fp_pose3_vs_point3.max_delta_m
+              << " m rms=" << fp_pose3_vs_point3.rms_delta_m << " m over "
+              << fp_pose3_vs_point3.compared_epochs << " epochs)\n";
+    std::cout.flush();
+
+    // --- IMU-coupled paths (2b batch or 2c fixed-lag). Attach IMU once. ---
+    if (!args.imu_path.empty()) {
+        libgnss::FGOProcessor::FGOProblem problem_imu = problem;
+        if (buildImuInput(args.imu_path, problem_imu)) {
+            std::vector<RefRow> ref_rows;
+            if (!args.ref_path.empty()) ref_rows = loadReference(args.ref_path);
+
+            // ============================================================
+            // (a3) MILESTONE 2b: IMU-coupled batch Pose3 (CombinedImuFactor).
+            // (Fixed-lag 2c is handled earlier, before section (a).)
+            // ============================================================
+            double t_imu = 0.0;
+            const auto gtsam_imu =
+                run(problem_imu, config, libgnss::FGOBackend::GTSAM, false, t_imu,
+                    /*use_pose3=*/true, /*use_imu=*/true);
+            const FloatParity fp_imu_vs_pose3 = compareFloat(gtsam_pose3_float, gtsam_imu);
+            const FloatParity fp_imu_vs_eigen = compareFloat(eigen_float, gtsam_imu);
+
+            // Divergence / NaN check.
+            std::size_t nonfinite = 0;
+            for (const auto& s : gtsam_imu.solution.solutions) {
+                if (!s.position_ecef.allFinite()) ++nonfinite;
+            }
+
+            std::cout << "\n=== (a3) MILESTONE 2b: IMU-coupled Pose3 (CombinedImuFactor) ===\n"
+                      << "  imu: " << t_imu << " s, iters=" << gtsam_imu.diagnostics.iterations
+                      << ", imu_intervals=" << gtsam_imu.diagnostics.imu_intervals
+                      << ", initial_cost=" << gtsam_imu.diagnostics.initial_cost
+                      << ", final_cost=" << gtsam_imu.diagnostics.final_cost
+                      << ", graph_values=" << gtsam_imu.diagnostics.graph_values
+                      << ", graph_factors=" << gtsam_imu.diagnostics.graph_factors << "\n"
+                      << "  solve_ok=" << (gtsam_imu.diagnostics.converged ? "yes" : "no")
+                      << ", nonfinite_epochs=" << nonfinite << "\n"
+                      << "  IMU-Pose3 vs 2a-Pose3 (no IMU) antenna delta: max="
+                      << fp_imu_vs_pose3.max_delta_m << " m rms=" << fp_imu_vs_pose3.rms_delta_m
+                      << " m (over " << fp_imu_vs_pose3.compared_epochs << " epochs)\n"
+                      << "  IMU-Pose3 vs Eigen antenna delta:            max="
+                      << fp_imu_vs_eigen.max_delta_m << " m rms=" << fp_imu_vs_eigen.rms_delta_m
+                      << " m\n";
+
+            // Attitude observability + sanity (vs reference.csv if provided).
+            const std::vector<RefRow>& ref = ref_rows;
+            auto refAt = [&](const libgnss::GNSSTime& t) -> const RefRow* {
+                const RefRow* best = nullptr;
+                double best_dt = 0.25;
+                for (const auto& r : ref) {
+                    const double d = std::abs(r.time - t);
+                    if (d < best_dt) { best_dt = d; best = &r; }
+                }
+                return best;
+            };
+            if (!gtsam_imu.epoch_attitude_rpy_deg.empty()) {
+                const std::size_t ne = gtsam_imu.epoch_attitude_rpy_deg.size();
+                const std::size_t samples[3] = {std::size_t(0), ne / 2, ne - 1};
+                std::cout << "  estimated attitude [roll pitch heading] deg / velocity ENU (m/s):\n";
+                for (std::size_t k = 0; k < 3; ++k) {
+                    const std::size_t i = samples[k];
+                    const auto& a = gtsam_imu.epoch_attitude_rpy_deg[i];
+                    const auto& v = gtsam_imu.epoch_velocity_nav_mps[i];
+                    std::cout << "    epoch " << i << ": [" << a.transpose() << "]  v=["
+                              << v.transpose() << "]";
+                    const RefRow* r = refAt(gtsam_imu.solution.solutions[i].time);
+                    if (r) {
+                        std::cout << "  ref[roll pitch heading]=[" << r->roll_deg << " "
+                                  << r->pitch_deg << " " << r->heading_deg << "] ref_v=["
+                                  << r->ve << " " << r->vn << " " << r->vu << "]";
+                    }
+                    std::cout << "\n";
+                }
+                // Heading RMS error vs reference over moving epochs (speed>1 m/s).
+                if (!ref.empty()) {
+                    double sum_sq = 0.0; std::size_t cnt = 0;
+                    for (std::size_t i = 0; i < ne; ++i) {
+                        const auto& v = gtsam_imu.epoch_velocity_nav_mps[i];
+                        if (std::hypot(v.x(), v.y()) < 1.0) continue;
+                        const RefRow* r = refAt(gtsam_imu.solution.solutions[i].time);
+                        if (!r) continue;
+                        double dh = gtsam_imu.epoch_attitude_rpy_deg[i].z() - r->heading_deg;
+                        while (dh > 180.0) dh -= 360.0;
+                        while (dh < -180.0) dh += 360.0;
+                        sum_sq += dh * dh; ++cnt;
+                    }
+                    if (cnt > 0) {
+                        std::cout << "  heading RMS error vs reference (moving epochs, n=" << cnt
+                                  << ") = " << std::sqrt(sum_sq / double(cnt)) << " deg\n";
+                    }
+                }
+            }
+            // Confirm per-epoch LAMBDA (gtsam::Marginals over the now
+            // IMU-augmented graph, with the 2a rotation pin removed) still
+            // factorizes -- the 2b requirement that Marginals succeeds.
+            double t_imu_fix = 0.0;
+            const auto gtsam_imu_fix =
+                run(problem_imu, config, libgnss::FGOBackend::GTSAM, true, t_imu_fix,
+                    /*use_pose3=*/true, /*use_imu=*/true);
+            const std::size_t imu_fixed_epochs = countFixedEpochs(gtsam_imu_fix);
+            const bool marginals_ok = gtsam_imu_fix.diagnostics.lambda_ambiguity_attempts > 0;
+            std::cout << "  IMU + per-epoch LAMBDA: marginals_ok=" << (marginals_ok ? "yes" : "no")
+                      << " attempts=" << gtsam_imu_fix.diagnostics.lambda_ambiguity_attempts
+                      << " fixed_epochs=" << imu_fixed_epochs << "/"
+                      << gtsam_imu_fix.solution.solutions.size()
+                      << " lambda_ratio=" << gtsam_imu_fix.diagnostics.lambda_ambiguity_ratio
+                      << " (" << t_imu_fix << " s)\n";
+
+            const bool go_2b = gtsam_imu.diagnostics.converged && nonfinite == 0 &&
+                               gtsam_imu.diagnostics.imu_intervals > 0 &&
+                               fp_imu_vs_pose3.compared_epochs > 0 && marginals_ok;
+            std::cout << "\nRESULT (milestone 2b): IMU-coupled solve "
+                      << (go_2b ? "GO" : "NO-GO") << " (imu_intervals="
+                      << gtsam_imu.diagnostics.imu_intervals << ", nonfinite=" << nonfinite
+                      << ", IMU-vs-2a max delta=" << fp_imu_vs_pose3.max_delta_m << " m)\n";
+            std::cout.flush();
+        }
+    }
+
+    if (args.float_only) {
+        const bool go = fp.compared_epochs > 0 && fp.max_delta_m < 0.05;
+        std::cout << "\nRESULT (float-only): float-parity " << (go ? "GO" : "NO-GO")
+                  << " (max=" << fp.max_delta_m << " m rms=" << fp.rms_delta_m << " m over "
+                  << fp.compared_epochs << " epochs)\n";
+        std::cout.flush();
+        return 0;
+    }
+
+    // --- (b) Fix agreement: LAMBDA on both backends ---
+    double t_ex = 0.0, t_gx = 0.0;
+    const auto eigen_fix = run(problem, config, libgnss::FGOBackend::Eigen, true, t_ex);
+    const auto gtsam_fix = run(problem, config, libgnss::FGOBackend::GTSAM, true, t_gx);
+
+    const std::size_t e_fixed_epochs = countFixedEpochs(eigen_fix);
+    const std::size_t g_fixed_epochs = countFixedEpochs(gtsam_fix);
+    // Per-epoch fix-status disagreement (one FIXED, the other not).
+    std::size_t fix_disagreements = 0;
+    const std::size_t nfx =
+        std::min(eigen_fix.solution.solutions.size(), gtsam_fix.solution.solutions.size());
+    for (std::size_t i = 0; i < nfx; ++i) {
+        const bool ef = eigen_fix.solution.solutions[i].status == libgnss::SolutionStatus::FIXED;
+        const bool gf = gtsam_fix.solution.solutions[i].status == libgnss::SolutionStatus::FIXED;
+        if (ef != gf) {
+            ++fix_disagreements;
+        }
+    }
+
+    const FixedDelta fd = compareFixedPositions(eigen_fix, gtsam_fix);
+
+    std::cout << "\n=== (b) FIXED / LAMBDA agreement (per-epoch LAMBDA on both) ===\n"
+              << "  eigen: fixed_solution=" << (eigen_fix.diagnostics.fixed_solution ? "1" : "0")
+              << " fixed_ambiguities=" << eigen_fix.diagnostics.fixed_ambiguities
+              << " lambda_ratio=" << eigen_fix.diagnostics.lambda_ambiguity_ratio
+              << " fixed_epochs=" << e_fixed_epochs << "/" << eigen_fix.solution.solutions.size()
+              << " (" << t_ex << " s)\n"
+              << "  gtsam: fixed_solution=" << (gtsam_fix.diagnostics.fixed_solution ? "1" : "0")
+              << " fixed_ambiguities=" << gtsam_fix.diagnostics.fixed_ambiguities
+              << " lambda_ratio=" << gtsam_fix.diagnostics.lambda_ambiguity_ratio
+              << " lambda_candidates=" << gtsam_fix.diagnostics.lambda_ambiguity_candidates
+              << " fixed_epochs=" << g_fixed_epochs << "/" << gtsam_fix.solution.solutions.size()
+              << " (" << t_gx << " s)\n"
+              << "  per-epoch fix-status disagreements=" << fix_disagreements << "\n"
+              << "  both-fixed epochs=" << fd.both_fixed
+              << ", fixed-position delta: max=" << fd.max_delta_m << " m rms=" << fd.rms_delta_m
+              << " m\n";
+
+    // --- (b2) Milestone 2a: does per-epoch LAMBDA still work on the Pose3
+    // path? gtsam::Marginals needs the graph Hessian to be non-singular;
+    // the Pose3RotationPrior gauge pin (fgo_gtsam_backend.cpp) exists
+    // specifically so Cholesky succeeds here. ---
+    double t_gp3x = 0.0;
+    const auto gtsam_pose3_fix =
+        run(problem, config, libgnss::FGOBackend::GTSAM, true, t_gp3x, /*use_pose3=*/true);
+    const std::size_t gp3_fixed_epochs = countFixedEpochs(gtsam_pose3_fix);
+    const FixedDelta fd_pose3 = compareFixedPositions(gtsam_fix, gtsam_pose3_fix);
+    std::size_t fix_disagreements_pose3 = 0;
+    const std::size_t nfx3 =
+        std::min(gtsam_fix.solution.solutions.size(), gtsam_pose3_fix.solution.solutions.size());
+    for (std::size_t i = 0; i < nfx3; ++i) {
+        const bool gf = gtsam_fix.solution.solutions[i].status == libgnss::SolutionStatus::FIXED;
+        const bool pf = gtsam_pose3_fix.solution.solutions[i].status == libgnss::SolutionStatus::FIXED;
+        if (gf != pf) {
+            ++fix_disagreements_pose3;
+        }
+    }
+    std::cout << "\n=== (b2) MILESTONE 2a: Pose3-GTSAM per-epoch LAMBDA (Marginals/Cholesky) ===\n"
+              << "  pose3-gtsam: fixed_solution=" << (gtsam_pose3_fix.diagnostics.fixed_solution ? "1" : "0")
+              << " fixed_ambiguities=" << gtsam_pose3_fix.diagnostics.fixed_ambiguities
+              << " lambda_ratio=" << gtsam_pose3_fix.diagnostics.lambda_ambiguity_ratio
+              << " fixed_epochs=" << gp3_fixed_epochs << "/" << gtsam_pose3_fix.solution.solutions.size()
+              << " (" << t_gp3x << " s)\n"
+              << "  per-epoch fix-status disagreements vs Point3-GTSAM=" << fix_disagreements_pose3 << "\n"
+              << "  both-fixed epochs=" << fd_pose3.both_fixed
+              << ", fixed-position delta vs Point3-GTSAM: max=" << fd_pose3.max_delta_m
+              << " m rms=" << fd_pose3.rms_delta_m << " m\n";
+
+    // Go/No-go on the float parity (the Phase-1 gate).
+    const bool go = fp.compared_epochs > 0 && fp.max_delta_m < 0.05 /* 5 cm */;
+    std::cout << "\nRESULT: float-parity " << (go ? "GO" : "NO-GO")
+              << " (max=" << fp.max_delta_m << " m over " << fp.compared_epochs << " epochs)\n";
+    return 0;
+}

--- a/apps/gnss_fgo_parity.cpp
+++ b/apps/gnss_fgo_parity.cpp
@@ -67,6 +67,11 @@ struct Args {
     double gate_res = -1.0;        // >=0: override gate_ddpr_res_max_m (0 disables)
     double gate_sat_res = -1.0;    // >=0: override gate_per_sat_res_max_m (0 disables)
     double gate_gdop = 0.0;        // >0: override gate_gdop_max
+    bool cmc = false;              // Code-Minus-Carrier multipath screening (slip_detect.py port)
+    double cmc_jump = -1.0;        // >=0: override code_minus_carrier_jump_threshold_m
+    double cmc_level = -1.0;       // >=0: override code_minus_carrier_level_threshold_m
+    int cmc_warmup = 0;            // >0: override code_minus_carrier_warmup_epochs
+    double cmc_alpha = -1.0;       // >=0: override code_minus_carrier_baseline_alpha
 };
 
 Args parseArgs(int argc, char** argv) {
@@ -139,6 +144,16 @@ Args parseArgs(int argc, char** argv) {
             args.gate_sat_res = std::stod(argv[++i]);
         } else if (a == "--gate-gdop" && i + 1 < argc) {
             args.gate_gdop = std::stod(argv[++i]);
+        } else if (a == "--cmc") {
+            args.cmc = true;
+        } else if (a == "--cmc-jump" && i + 1 < argc) {
+            args.cmc_jump = std::stod(argv[++i]);
+        } else if (a == "--cmc-level" && i + 1 < argc) {
+            args.cmc_level = std::stod(argv[++i]);
+        } else if (a == "--cmc-warmup" && i + 1 < argc) {
+            args.cmc_warmup = std::stoi(argv[++i]);
+        } else if (a == "--cmc-alpha" && i + 1 < argc) {
+            args.cmc_alpha = std::stod(argv[++i]);
         } else {
             std::cerr << "Unknown/incomplete arg: " << a << "\n";
             std::exit(2);
@@ -694,6 +709,21 @@ int main(int argc, char** argv) {
     if (args.gate_gdop > 0.0) {
         config.gate_gdop_max = args.gate_gdop;
     }
+    if (args.cmc) {
+        config.use_code_minus_carrier_screening = true;
+    }
+    if (args.cmc_jump >= 0.0) {
+        config.code_minus_carrier_jump_threshold_m = args.cmc_jump;
+    }
+    if (args.cmc_level >= 0.0) {
+        config.code_minus_carrier_level_threshold_m = args.cmc_level;
+    }
+    if (args.cmc_warmup > 0) {
+        config.code_minus_carrier_warmup_epochs = args.cmc_warmup;
+    }
+    if (args.cmc_alpha >= 0.0) {
+        config.code_minus_carrier_baseline_alpha = args.cmc_alpha;
+    }
     const libgnss::FGOProcessor builder(config);
     const libgnss::FGOProcessor::FGOProblem problem =
         builder.buildDoubleDifferenceProblem(rover_epochs, base_epochs, nav, base_position);
@@ -703,6 +733,14 @@ int main(int argc, char** argv) {
               << " dd_cp_factors=" << problem.double_difference_carrier_factors.size()
               << " ambiguity_states=" << problem.ambiguity_states.size()
               << " pr_factors=" << problem.pseudorange_factors.size() << "\n";
+    std::cout << "  CMC screening: " << (args.cmc ? "on" : "off")
+              << " (jump=" << config.code_minus_carrier_jump_threshold_m
+              << " m, level=" << config.code_minus_carrier_level_threshold_m
+              << " m, warmup=" << config.code_minus_carrier_warmup_epochs
+              << ", alpha=" << config.code_minus_carrier_baseline_alpha << ")"
+              << " -- jump_resets=" << problem.diagnostics.code_minus_carrier_jump_resets
+              << ", level_exclusions=" << problem.diagnostics.code_minus_carrier_level_exclusions
+              << "\n";
 
     // --- MF hygiene diagnostics: per-signal DD residuals at the reference
     // trajectory (no solver). PR residual mean exposes per-band code/DCB
@@ -858,7 +896,11 @@ int main(int argc, char** argv) {
                   << " epochs)\n"
                   << "  fix-and-hold: " << (args.use_hold ? "on" : "off")
                   << " (pinned " << fl.diagnostics.ambiguity_hold_arcs << " arcs, "
-                  << fl.diagnostics.ambiguity_hold_epochs << " epochs FIXED via held integers)\n";
+                  << fl.diagnostics.ambiguity_hold_epochs << " epochs FIXED via held integers)\n"
+                  << "  CMC screening: " << (args.cmc ? "on" : "off")
+                  << " (jump_resets=" << fl.diagnostics.code_minus_carrier_jump_resets
+                  << ", level_exclusions=" << fl.diagnostics.code_minus_carrier_level_exclusions
+                  << ")\n";
         if (!ref_rows.empty()) {
             std::cout << "  horizontal error vs reference.csv:\n"
                       << "    FLOAT: n=" << he.n_float << " rms=" << he.float_rms

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -312,6 +312,49 @@ public:
         // so Galileo candidates mostly poison the all-or-nothing ratio test.
         bool exclude_galileo_ambiguity_fixing = false;
 
+        // --- Code-Minus-Carrier (CMC) multipath screening ---
+        // Port of the inuex35 reference's preprocess/slip_detect.py CMC logic
+        // (single-difference CMC = (PR_rover - PR_base) - (CP_rover -
+        // CP_base) * wavelength, per (satellite, signal), computed only when
+        // the DD builder already has both rover and base pseudorange+carrier
+        // for that pair this epoch). Two independent checks:
+        //  1. Jump check (this port's primary target): |cmc - previous_epoch
+        //     cmc| > code_minus_carrier_jump_threshold_m forces the SAME arc
+        //     break the existing loss-of-lock / gap logic already performs
+        //     (new ambiguity_index at the next DD carrier factor for that
+        //     (satellite, signal)) -- a multipath jump breaks the integer N
+        //     just like a cycle slip does.
+        //  2. Sustained-level check (reference default OFF via level_thresh
+        //     == 0.0, ported for parity but not expected to be the lever):
+        //     maintains a per-(satellite, signal) baseline (seeded by the
+        //     first observation, running-averaged for
+        //     code_minus_carrier_warmup_epochs, then EWMA-updated with
+        //     code_minus_carrier_baseline_alpha in steady state); a
+        //     steady-state baseline deviation beyond
+        //     code_minus_carrier_level_threshold_m excludes THAT (satellite,
+        //     signal) pair's DD pseudorange AND carrier factors for the
+        //     epoch (both, matching the reference's single `continue` before
+        //     either is built) without updating the baseline.
+        //
+        // Deliberate deviation from the reference: whenever the arc for a
+        // (satellite, signal) resets for ANY reason (CMC jump, cycle slip /
+        // loss-of-lock, or outage -- i.e. the rover-side single-receiver
+        // carrier arc restarts and a fresh ambiguity_index is assigned), this
+        // port ALSO resets that (satellite, signal)'s CMC baseline/warmup
+        // count/previous-epoch value. CMC embeds a -wavelength*N term, so a
+        // new ambiguity invalidates any baseline computed under the old one;
+        // the reference does not reset it (state.cmc / cmc_baseline survive
+        // amb_key resets in slip_detect.py), which looks like an oversight --
+        // it is harmless there only because the reference ships the level
+        // check OFF by default.
+        //
+        // Default OFF: bit-identical to the pre-port baseline when false.
+        bool use_code_minus_carrier_screening = false;
+        double code_minus_carrier_jump_threshold_m = 3.0;
+        double code_minus_carrier_level_threshold_m = 0.0;  ///< 0 = level check off (reference default)
+        int code_minus_carrier_warmup_epochs = 5;
+        double code_minus_carrier_baseline_alpha = 0.05;
+
         // --- Per-epoch quality gates (port of the inuex35 reference's
         // preprocess/gate.py + validation/postfit.py policy) ---
         // The reference never lets the integer search run on a corrupt epoch:
@@ -495,6 +538,8 @@ public:
         std::size_t tdcp_rejected_missing_previous = 0;
         std::size_t tdcp_rejected_loss_of_lock = 0;
         std::size_t tdcp_rejected_code_phase_jump = 0;
+        std::size_t code_minus_carrier_jump_resets = 0;       ///< CMC screening: arc breaks forced
+        std::size_t code_minus_carrier_level_exclusions = 0;  ///< CMC screening: (sat,signal) epochs excluded
     };
 
     // --- Phase 2 milestone 2b: IMU preintegration inputs ---
@@ -609,6 +654,8 @@ public:
         std::size_t ambiguity_hold_epochs = 0;  ///< 2e: epochs FIXED via held (not fresh) integers
         std::size_t ambiguity_hold_arcs = 0;    ///< 2e: distinct arcs pinned at their integer
         std::size_t quality_gated_epochs = 0;   ///< epochs where the quality gates suppressed fixing
+        std::size_t code_minus_carrier_jump_resets = 0;       ///< CMC screening: arc breaks forced
+        std::size_t code_minus_carrier_level_exclusions = 0;  ///< CMC screening: (sat,signal) epochs excluded
         std::size_t float_rejected_seed_position_divergence = 0;
         std::size_t float_rejected_position_jump = 0;
         bool fixed_solution = false;

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -628,6 +628,100 @@ public:
         double fde_max_rejected_fraction = 0.5;     ///< reference fde_max_frac
         int fde_max_iterations = 1;                 ///< reference fde_max_iter (1 = single-pass, the reference default)
         bool fde_median_subtraction = false;        ///< reference FDE_MEDIAN_SUB env knob (default off)
+
+        // --- Sat-badness EWMA down-weighting (port of the inuex35 reference's
+        // preprocess/sat_quality.py SatQualityState.sat_badness() score and its
+        // consumption in buildfactor/factors.py's DD sigma inflation
+        // (_add_ddpr_factor / _compute_cp_sigma)). ---
+        //
+        // A continuous per-(reference, target, signal) "badness" score, built
+        // from persistent per-satellite quality memory that the GTSAM backend
+        // now tracks alongside the existing CP-hold/sanity FSM and FDE state
+        // (see fgo_gtsam_backend.cpp's optimizeProblemFixedLag): an EWMA and a
+        // consecutive-bad-epoch streak of last-epoch's post-fit per-sat DDPR
+        // residual, a decayed "was this the worst satellite" indicator, a
+        // decayed "bad while serving as DD reference" indicator, an optional
+        // decayed directional-pair indicator, and (when the data reaches the
+        // backend -- see below) an elevation and SNR penalty. At each DD
+        // factor's build time, bad_pair = max(badness(ref_sat), badness(
+        // target_sat, paired with ref_sat)) inflates that factor's sigma
+        // BEFORE robust-loss wrapping: sigma *= (1 + scale * bad_pair). This
+        // mirrors the reference's timing exactly: the state feeding a given
+        // epoch's bad_pair is always the PREVIOUS epoch's post-fit residuals
+        // (postfit-then-next-epoch-factor-build), never the current epoch's
+        // own not-yet-computed residual.
+        //
+        // Master switch, default OFF (bit-identical baseline without it: the
+        // score is forced to 0.0 and every sigma computation is a no-op
+        // multiply-by-one that is skipped entirely).
+        //
+        // Deliberate deviations from the reference (see the .cpp change-site
+        // comments for the exact mechanics):
+        //  1. cppr / recent_cppr: the reference's direct-and-recent "CP-vs-PR
+        //     innovation consistency" reject terms are fed by a gate
+        //     (factors.py's rejc_cp_pr) this codebase never ported. Both
+        //     terms are instead fed by a persistent per-(satellite, signal)
+        //     count of THIS backend's own FDE carrier rejections
+        //     (use_fde) -- the closest existing analogue (both flag a
+        //     specific arc's carrier observation as inconsistent with the
+        //     rest of the solution). Unlike the reference's gate, this count
+        //     is never reset (no analogue of the reference's unported
+        //     cp_pr_rejc_max-triggered wipe), so it behaves like the
+        //     reference run with that reset gate disabled. Structurally 0
+        //     whenever use_fde is off, matching "reference with the gate
+        //     disabled" behaviour.
+        //  2. Satellite/pair identity: keyed by this backend's SatelliteId
+        //     and SignalType (the AmbiguityState / DoubleDifference*Factor
+        //     structs already carry per-factor satellite/reference_satellite/
+        //     signal identity) instead of the reference's raw integer sat id
+        //     -- a representational substitution only, not a behavioural one.
+        //  3. Elevation is wired: DoubleDifferencePseudorangeFactor already
+        //     carries the target satellite's elevation_rad, and the
+        //     reference satellite's elevation is available via
+        //     rover_reference_model.elevation_rad -- both populated upstream
+        //     in fgo.cpp, so the el penalty term needed no new plumbing.
+        //  4. SNR required a small addition: ObservationModelDebug gained a
+        //     snr_dbhz field (populated from Observation::snr at both
+        //     model_debug construction sites in fgo.cpp) so the backend can
+        //     read rover_satellite_model.snr_dbhz / rover_reference_model.
+        //     snr_dbhz per DD factor. Deemed small enough to do rather than
+        //     skip (per the port's own scoping note); the snr penalty term
+        //     defaults nonzero like the reference profile.
+        //  5. update_pair_quality's per-(ref, target, signal) memory is only
+        //     updated when sat_badness_alpha_recent_pair > 0 (the reference
+        //     profile ships it at 0.0, i.e. contributing nothing); gating the
+        //     UPDATE itself (not just its consumption) on the alpha avoids
+        //     bookkeeping a term that is provably inert at the shipped
+        //     defaults. No behavioural difference at any alpha value.
+        // Sats not observed in a given epoch hard-reset (not decay) their
+        // EWMA/streak entries to 0/0, exactly matching the reference.
+        bool use_sat_badness_downweight = false;
+        double sat_badness_ddpr_threshold_m = 1.0;        ///< reference sat_badness_ddpr_thresh
+        int sat_badness_cppr_threshold = 1;               ///< reference sat_badness_cppr_thresh
+        double sat_badness_alpha_ddpr = 1.0;
+        double sat_badness_alpha_cppr = 1.0;
+        double sat_badness_alpha_recent_cppr = 0.25;
+        double sat_badness_alpha_recent_worst = 0.75;
+        double sat_badness_alpha_recent_ref = 0.5;
+        double sat_badness_alpha_recent_pair = 0.0;       ///< reference profile default: inert (see deviation 5)
+        double sat_badness_alpha_el = 0.05;
+        double sat_badness_alpha_snr = 0.05;
+        double sat_badness_carrier_sigma_scale = 1.5;     ///< reference sigma_scale_cp
+        double sat_badness_pseudorange_sigma_scale = 0.0; ///< reference sigma_scale_pr
+        double sat_badness_el_ref_deg = 30.0;
+        double sat_badness_snr_ref_dbhz = 40.0;
+        double sat_badness_snr_span_db = 10.0;
+        // --- obsq_* (reference SatQualityState/TcConfig dataclass defaults) ---
+        double sat_badness_obsq_res_threshold_m = 2.0;         ///< reference obsq_res_thresh
+        int sat_badness_obsq_bad_streak_cap = 8;               ///< reference obsq_bad_streak_cap
+        double sat_badness_alpha_obsq_ewma = 1.0;
+        double sat_badness_alpha_obsq_streak = 0.5;
+        double sat_badness_obsq_ewma_alpha = 0.2;               ///< reference obsq_ewma_alpha (getattr default)
+        double sat_badness_obsq_bad_streak_threshold_m = 2.0;   ///< reference obsq_bad_streak_thresh
+        double sat_badness_recent_worst_decay = 0.8;            ///< reference obsq_recent_worst_decay
+        double sat_badness_recent_cppr_decay = 0.8;             ///< reference obsq_recent_cppr_decay
+        double sat_badness_recent_ref_decay = 0.85;             ///< reference obsq_recent_ref_decay
+        double sat_badness_recent_pair_decay = 0.85;            ///< reference obsq_recent_pair_decay
     };
 
     struct EpochSeed {
@@ -648,6 +742,12 @@ public:
         double geometric_range_m = 0.0;
         double elevation_rad = 0.0;
         double azimuth_rad = 0.0;
+        // Raw rover-receiver SNR/CN0 [dB-Hz] for this observation (Observation::snr
+        // at the point this model_debug was built). Added for the sat-badness
+        // EWMA down-weighting port's elevation/SNR penalty terms (see
+        // FGOConfig::use_sat_badness_downweight); unused elsewhere. 0.0 when the
+        // source Observation carried no SNR.
+        double snr_dbhz = 0.0;
     };
 
     struct PseudorangeFactor {
@@ -934,6 +1034,9 @@ public:
         std::size_t fde_carrier_rejections = 0;      ///< total DD CP factors removed
         std::size_t fde_safeguard_skips = 0;         ///< epochs where the reject-fraction safeguard aborted FDE
         std::size_t fde_epochs = 0;                  ///< epochs where >=1 factor was actually removed
+        // --- Sat-badness EWMA down-weighting diagnostics (use_sat_badness_downweight) ---
+        std::size_t sat_badness_downweighted_factors = 0;  ///< DD PR/CP factors whose sigma was inflated (bad_pair>0 and its scale>0)
+        double sat_badness_max_score_seen = 0.0;            ///< max bad_pair score observed across the run
         std::size_t float_rejected_seed_position_divergence = 0;
         std::size_t float_rejected_position_jump = 0;
         bool fixed_solution = false;

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -311,6 +311,26 @@ public:
         // multipath-corrupted (vs ~75-90% integer-consistent for GPS/BDS/QZS),
         // so Galileo candidates mostly poison the all-or-nothing ratio test.
         bool exclude_galileo_ambiguity_fixing = false;
+
+        // --- Per-epoch quality gates (port of the inuex35 reference's
+        // preprocess/gate.py + validation/postfit.py policy) ---
+        // The reference never lets the integer search run on a corrupt epoch:
+        // a GDOP/nsat gate skips weak-geometry epochs entirely, per-satellite
+        // post-fit DD-pseudorange residuals drop multipath satellites from
+        // the NEXT epoch's LAMBDA tree, and a main-DDPR-RMS sanity threshold
+        // suppresses carrier fixing while the solution is inconsistent.
+        // This port applies the same three screens to the fixed-lag path as
+        // FIXING gates: DD factors still enter the graph (robust loss handles
+        // them), but a gated epoch attempts no LAMBDA, adds no holds, and is
+        // never labelled FIXED via held integers -- killing the meaningless
+        // deep-urban FIXED labels measured on tokyo1 full-run (FIXED rms 6-11
+        // m). Thresholds default to the reference's config.py values.
+        // Master switch, default OFF (bit-identical baseline without it).
+        bool use_epoch_quality_gates = false;
+        double gate_gdop_max = 10.0;          ///< reference gdop_max
+        int gate_min_satellites = 6;          ///< reference nsat_min
+        double gate_ddpr_res_max_m = 3.0;     ///< reference main_ddpr_res_thresh
+        double gate_per_sat_res_max_m = 3.0;  ///< reference per_sat_res_thresh
     };
 
     struct EpochSeed {
@@ -588,6 +608,7 @@ public:
         std::size_t zupt_epochs = 0;  ///< 2d: epochs a ZUPT prior was applied
         std::size_t ambiguity_hold_epochs = 0;  ///< 2e: epochs FIXED via held (not fresh) integers
         std::size_t ambiguity_hold_arcs = 0;    ///< 2e: distinct arcs pinned at their integer
+        std::size_t quality_gated_epochs = 0;   ///< epochs where the quality gates suppressed fixing
         std::size_t float_rejected_seed_position_divergence = 0;
         std::size_t float_rejected_position_jump = 0;
         bool fixed_solution = false;

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -189,6 +189,21 @@ public:
         double zupt_max_gyro_std = 0.030;        ///< stationary gate: gyro deviation std [rad/s]
         double zupt_max_gyro_median = 0.020;     ///< stationary gate: gyro deviation median [rad/s]
         int zupt_min_samples = 5;                ///< minimum IMU samples in window to test
+
+        // --- Phase 2 milestone 2e: fix-and-hold ambiguity resolution ---
+        // In the fixed-lag path, once an arc's DD ambiguity is validated-fixed
+        // (LAMBDA ratio above ambiguity_hold_ratio_threshold), pin it in the
+        // graph with a tight prior at the integer for the remainder of the arc.
+        // Held ambiguities have ~zero variance, so subsequent per-epoch LAMBDA
+        // over the remaining floats passes far more often (fix-rate lever) and
+        // the held integers stabilize the float. Reset is automatic: a cycle
+        // slip / gap makes the problem builder assign a NEW ambiguity index
+        // (fgo.cpp segments arcs on loss_of_lock), which is not in the held set.
+        // Gated; default OFF.
+        bool use_ambiguity_hold = false;
+        double ambiguity_hold_ratio_threshold = 3.0;  ///< min ratio to hold (stricter than fix)
+        double ambiguity_hold_sigma_cycles = 1e-3;    ///< tight prior sigma at the held integer
+        int ambiguity_hold_min_fixed = 4;             ///< min ambiguities in a passing epoch to hold
     };
 
     struct EpochSeed {
@@ -461,8 +476,11 @@ public:
         std::size_t imu_intervals = 0;  ///< 2b: CombinedImuFactors added between epochs
         std::size_t smoother_max_window_vars = 0;  ///< 2c: peak in-window variable count
         std::size_t smoother_updates = 0;          ///< 2c: number of smoother.update() calls
+        std::size_t smoother_recovery_epochs = 0;  ///< 2e: epochs re-anchored after an indeterminate update
         std::size_t nhc_epochs = 0;   ///< 2d: epochs an NHC factor was applied
         std::size_t zupt_epochs = 0;  ///< 2d: epochs a ZUPT prior was applied
+        std::size_t ambiguity_hold_epochs = 0;  ///< 2e: epochs FIXED via held (not fresh) integers
+        std::size_t ambiguity_hold_arcs = 0;    ///< 2e: distinct arcs pinned at their integer
         std::size_t float_rejected_seed_position_divergence = 0;
         std::size_t float_rejected_position_jump = 0;
         bool fixed_solution = false;

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -64,6 +64,81 @@ public:
         bool use_tdcp_factors = true;
         bool use_carrier_phase_factors = false;
         bool use_double_difference_factors = false;
+        // When true (default) AND use_double_difference_factors, the DD
+        // problem builder emits DD pseudorange + carrier factors for
+        // secondary-band signals too (GPS L2C/L5, Galileo E5A/E5B/E6, BeiDou
+        // B2I/B3I/B2A, QZSS L2C/L5), not just the primary band (L1CA/E1/B1I).
+        // Each (satellite, signal, arc) still gets its own AmbiguityState /
+        // ambiguity index with its own wavelength (see signals.hpp), and the
+        // reference satellite is selected independently per (system, signal)
+        // group so a band with fewer tracked satellites doesn't starve. This
+        // is the front-end lever for closing the fix-rate gap vs multi-
+        // frequency references (inuex35 runs NF=3): feeding the raw per-
+        // frequency DD carrier factors to the joint LAMBDA search already
+        // exploits the inter-frequency information without needing explicit
+        // widelane/narrowlane combinations. GLONASS is unaffected: its DD
+        // factors are already skipped upstream (FDMA, no shared wavelength).
+        // Ignored when use_multi_constellation is false (single GPS-L1 mode).
+        //
+        // Default OFF: on the tokyo1 low-cost PPC data, adding raw L2/L5 DD
+        // measurements REGRESSES the DD-RTK solution vs single-frequency
+        // (fix-rate 52.5% -> 47%, FLOAT 1.6 m -> 7.8 m, <50cm 58% -> 37% on the
+        // first-2500 good-geometry subset), and neither per-band weighting nor
+        // the LAMBDA-independence lever below recovers it (best multi-freq
+        // fix-rate 43.9% still < 52.5%). The secondary-band DD carries a
+        // systematic bias that degrades the float even when correctly
+        // down-weighted -- most consistent with a rover/base observation-CODE
+        // mismatch per band (RINEX C2W/C2L at the rover vs C2W/C2X at the base
+        // both collapse to GPS_L2C, leaving an uncancelled inter-code/DCB bias
+        // in the DD). The capability is fully wired; enable it only after the
+        // secondary-band measurement hygiene (identical code selection at
+        // rover+base, or DCB correction) lands. A wide-lane combination would
+        // INHERIT the same bias, so it is not the right next step.
+        bool use_multi_frequency_double_difference = false;
+
+        // --- MF hygiene: secondary-band observation-code alignment ---
+        // Port of the cssrlib/inuex35 (RTKLIB-style) signal-selection policy:
+        // each receiver uses exactly ONE RINEX observation code per (system,
+        // band) for the whole file (chosen from its own data by an RTKLIB
+        // code-priority table), so all satellites contribute the same code per
+        // band and the between-satellite difference cancels the receiver-side
+        // inter-code bias. Cures the mixed-code DD bias (rover GPS L2 mixing
+        // C2W/C2L across satellites; base BDS B2I C7D vs rover C7I) diagnosed
+        // as the multi-frequency FLOAT blowup. Secondary bands only; the
+        // primary-band single-frequency path is untouched. No-op when
+        // use_multi_frequency_double_difference is false.
+        bool use_double_difference_secondary_code_alignment = true;
+
+        // --- MF-AR step 1: multi-frequency ambiguity-resolution robustness ---
+        // Per-band DD measurement weighting. Secondary-band (L2C/L5/E5a/E5b/
+        // B2I/B2a/...) DD carrier & pseudorange factors are noisier and more
+        // slip-prone on low-cost receivers; adding them at L1-identical sigma
+        // over-weights them and drags the float (observed: naive multi-freq
+        // blew the FLOAT RMS 1.6 m -> 7.8 m). The per-factor sigma is
+        // multiplied by these scales for secondary-band signals only, on top
+        // of the existing elevation weighting. 1.0 = no de-weighting (the old
+        // behaviour). No-op for single-frequency DD (no secondary factors).
+        double double_difference_secondary_carrier_sigma_scale = 3.0;
+        double double_difference_secondary_pseudorange_sigma_scale = 2.0;
+        // LAMBDA candidate independence. When true, the per-epoch LAMBDA
+        // ratio-test candidate set keeps at most one ambiguity per satellite
+        // (primary band preferred, else the longest-wavelength secondary), so
+        // the integer set spans INDEPENDENT satellites instead of multiple
+        // highly-correlated bands of the same satellite. Multiple bands of one
+        // satellite share the same line-of-sight, so they add little to the DD
+        // geometry but do inflate the all-or-nothing ratio test and lower the
+        // ratio (observed: naive multi-freq dropped fix-rate 52.5% -> 47.0%).
+        // The dropped bands' DD factors still constrain the float; they are
+        // just not forced into the integer ratio test. No-op for single-
+        // frequency DD (one band per satellite already).
+        //
+        // Default OFF: measured net-harmful on tokyo1. Because this pipeline's
+        // fix-rate is dominated by fix-and-hold (pinning many arcs early), a
+        // SMALLER integer candidate set pins fewer arcs and lowers the
+        // sustained fix-rate (observed: enabling it dropped multi-freq fix-rate
+        // from 47% to 29%). Kept as an opt-in knob for a future partial-AR
+        // scheme that fixes independent satellites first, then adds bands.
+        bool double_difference_lambda_one_band_per_satellite = false;
         bool use_single_difference_doppler_factors = false;
         bool use_single_difference_tdcp_factors = false;
         bool use_velocity_states = false;
@@ -204,6 +279,38 @@ public:
         double ambiguity_hold_ratio_threshold = 3.0;  ///< min ratio to hold (stricter than fix)
         double ambiguity_hold_sigma_cycles = 1e-3;    ///< tight prior sigma at the held integer
         int ambiguity_hold_min_fixed = 4;             ///< min ambiguities in a passing epoch to hold
+
+        // --- MF-AR step 2: partial AR in the fixed-lag per-epoch LAMBDA ---
+        // Port of the native Eigen path's use_partial_lambda_ambiguity_fix
+        // semantics into the GTSAM fixed-lag smoother's per-epoch LAMBDA:
+        // rank the epoch's ambiguity candidates best-first by (fractional
+        // cycles from the nearest integer, then float variance), cap the set
+        // at max_lambda_ambiguities, and when the ratio test fails retry on
+        // shrinking best-ranked prefixes down to min_fixed_ambiguities. The
+        // validated subset is marked FIXED (and pinned by fix-and-hold as
+        // usual); dropped candidates simply stay float. This is the
+        // all-or-nothing -> partial upgrade: with multipath-corrupted arcs in
+        // the window (urban), P(the ENTIRE candidate set validates) collapses
+        // as the set grows, which is what capped multi-frequency fix-rates.
+        // Separate knob from use_partial_lambda_ambiguity_fix (which is
+        // default-ON and consumed by the Eigen batch path) so the existing
+        // fixed-lag behaviour stays bit-identical unless opted in.
+        bool use_fixed_lag_partial_lambda = false;
+        // Partial-AR subset floor as a fraction of the (capped) candidate
+        // set. Classic partial AR drops a FEW outliers, never the majority:
+        // in deep urban the ratio test over an arbitrarily shrunken subset of
+        // multipath-corrupted candidates passes by chance and labels wrong
+        // integers FIXED (measured on tokyo1 full-run: FIXED rms 5-11 m when
+        // subsets may shrink to min_fixed_ambiguities). The subset never
+        // shrinks below ceil(min_fraction * candidates) (and never below
+        // min_fixed_ambiguities). 1.0 degenerates to all-or-nothing.
+        double fixed_lag_partial_lambda_min_fraction = 0.7;
+        // Exclude Galileo arcs from the LAMBDA candidate set / fix-and-hold
+        // (their DD factors still constrain the float). On tokyo1 the truth-
+        // trajectory DD residuals show ~50% of Galileo arcs (E1 AND E5a) are
+        // multipath-corrupted (vs ~75-90% integer-consistent for GPS/BDS/QZS),
+        // so Galileo candidates mostly poison the all-or-nothing ratio test.
+        bool exclude_galileo_ambiguity_fixing = false;
     };
 
     struct EpochSeed {

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -167,6 +167,75 @@ public:
         double single_difference_tdcp_sigma_m = 0.003;
         double double_difference_pseudorange_sigma_m = 1.0;
         double double_difference_carrier_sigma_m = 0.02;
+
+        // --- Elevation-dependent DD sigma (RTKLIB-demo5 "varerr", rtkpos.c:402)
+        // ---
+        // Port of the inuex35 reference's preprocess/prefit.py varerr_dd_sigma
+        // + buildfactor/factors.py pair_sigma. This was a previously-UNPORTED
+        // piece: it ran DEFAULT-ON in every reference benchmark (its enable
+        // flag, config.py's varerr_enable, is a dataclass default of 1, never
+        // toggled by the benchmark profile dicts we had scraped), so earlier
+        // parity work missed it entirely.
+        //
+        // When enabled, the DD pseudorange/carrier base sigma (fed to BOTH
+        // double_difference_pseudorange_factor.sigma_m and
+        // double_difference_carrier_factor.sigma_m, before the secondary-band
+        // scale and sat-badness inflation multiply on top -- see
+        // buildDoubleDifferenceProblem in fgo.cpp) is, per (reference,target)
+        // pair:
+        //
+        //   el_pair  = max(min(el_ref_rad, el_target_rad), el_min_rad)
+        //   el_min_rad = radians(max(1.0, min_elevation_deg))
+        //   fact     = elevation_sigma_pseudorange_ratio (pseudorange) | 1.0 (carrier)
+        //   a        = fact * elevation_sigma_err_a_m
+        //   b        = fact * elevation_sigma_err_b_m
+        //   d        = SPEED_OF_LIGHT * elevation_sigma_clock_stability * dt_s
+        //   sinel    = max(sin(el_pair), 0.05)   // cap below ~3 deg
+        //   var_sd   = 2*(a*a + b*b/(sinel*sinel)) + d*d   // single-difference variance
+        //   sigma_dd = sqrt(2 * var_sd)                    // DD = difference of 2 SDs
+        //
+        // dt_s mapping decision: the reference's tc._epoch_dt is "actual
+        // seconds since the runner's last process() call" -- i.e. the ROVER's
+        // own epoch-to-epoch interval (defaults to 0.2 s / 5 Hz until the
+        // first real update; see runner.py's _update_epoch_dt), NOT the
+        // rover-base differential/interpolation age. Our port mirrors this
+        // exactly: dt_s is the elapsed time between the current and the
+        // immediately-preceding ROVER epoch in the batch (problem.epochs[i].time
+        // - problem.epochs[i-1].time), persisted across epochs and only
+        // updated when positive (same "keep last known dt" behaviour as the
+        // reference), defaulting to 0.2 s before the first update -- which
+        // also happens to match the tokyo PPC dataset's actual 0.200 s rover
+        // observation interval (data/PPC-Dataset/tokyo/run*/rover.obs
+        // INTERVAL header). The clock term's contribution is small next to
+        // the a/b terms at these defaults, so this default's exact value is
+        // not performance-critical.
+        //
+        // Undifferenced-PR decision: the reference's varerr_dd_sigma /
+        // pair_sigma are only ever called from factors.py's DD pseudorange
+        // and DD carrier factor builders -- nothing in the reference feeds
+        // varerr into the undifferenced (single-receiver SPP-style)
+        // pseudorange factor. This port matches that: use_elevation_dependent_sigma
+        // affects ONLY the DD pseudorange/carrier sigma_m computed in
+        // buildDoubleDifferenceProblem; FGOConfig::pseudorange_sigma_m and the
+        // undifferenced PseudorangeFactor path (buildPseudorangeProblem) are
+        // untouched.
+        //
+        // Default OFF (use_elevation_dependent_sigma = false): bit-identical
+        // to the pre-existing flat/elevation-power sigma
+        // (band_scale * double_difference_{pseudorange,carrier}_sigma_m /
+        // sqrt(sin(el))). Turning it on switches the DD base-sigma SOURCE only;
+        // composition order with the other sigma multipliers is unchanged:
+        // varerr (or the flat fallback) -> secondary-band scale
+        // (double_difference_secondary_{carrier,pseudorange}_sigma_scale,
+        // still multiplies on top) -> sat-badness EWMA inflation (still
+        // multiplies factor.sigma_m in the GTSAM backend, unaffected by this
+        // knob) -> robust/Huber wrapping (unaffected).
+        bool use_elevation_dependent_sigma = false;
+        double elevation_sigma_err_a_m = 0.001;             ///< reference err_a (RTKLIB err[1]=0.003)
+        double elevation_sigma_err_b_m = 0.001;              ///< reference err_b (RTKLIB err[2]=0.003)
+        double elevation_sigma_pseudorange_ratio = 100.0;    ///< reference err_eratio_pr (RTKLIB eratio[0]=300)
+        double elevation_sigma_clock_stability = 5e-12;      ///< reference err_sclkstab [s/s]
+
         double pseudorange_huber_threshold_sigma = 4.0;
         double carrier_phase_huber_threshold_sigma = 4.0;
         double tdcp_huber_threshold_sigma = 4.0;
@@ -722,6 +791,76 @@ public:
         double sat_badness_recent_cppr_decay = 0.8;             ///< reference obsq_recent_cppr_decay
         double sat_badness_recent_ref_decay = 0.85;             ///< reference obsq_recent_ref_decay
         double sat_badness_recent_pair_decay = 0.85;            ///< reference obsq_recent_pair_decay
+
+        // --- CLAMPED variant (DEVIATION from the reference; first
+        // non-port invention in this series -- see fgo_gtsam_backend.cpp's
+        // satBadness()/runFde() change-sites for the exact mechanics). ---
+        //
+        // Measured failure of the faithful port above: sat_badness() is
+        // uncapped and directly proportional to the raw post-fit DDPR
+        // residual. In the reference's own operating regime (FLOAT error
+        // stays ~1-2 m) that self-limits to O(1) scores -> a gentle 2-5x
+        // carrier-sigma inflation. This codebase's deep-urban FLOAT
+        // excursions instead reach 100s of meters, driving scores into the
+        // hundreds to low thousands -> carrier sigma inflated ~1000x
+        // graph-wide -> AR starves -> FLOAT never recovers (positive
+        // feedback with no exit). Full-run verdict when shipped faithfully
+        // (use_sat_badness_downweight on, these three knobs at their
+        // faithful/no-op values below): fix-rate 39/63/66% -> 6/8/6%.
+        //
+        // These three knobs bound that feedback loop by construction while
+        // leaving the reference's own gentle regime numerically untouched
+        // (a run whose residuals/rejects never approach the clamp/cap is
+        // bit-identical to the faithful port). Each defaults to a bound
+        // (clamp=15 m, cap=3.0, cppr_decay=0.8); setting clamp=0, cap=0,
+        // cppr_decay=1.0 together is the exact faithful-port escape hatch.
+        // All three are no-ops whenever use_sat_badness_downweight is off.
+        //
+        // 1. Residual input clamp: caps the per-satellite post-fit DDPR
+        //    residual BEFORE it feeds any badness term, at the single point
+        //    (per_sat_res) all of them read it: the obsq EWMA input, the
+        //    obsq bad-streak comparison, the next-epoch res_s term (via the
+        //    sb_last_ddpr_per_sat snapshot), and the recent_ref_bad/
+        //    recent_pair_bad increment inputs (both already separately
+        //    min(2,.)-limited by the reference -- that existing limit is
+        //    left in place; this clamp is strictly upstream of it). Chosen
+        //    at 15 m = this codebase's own CP-hold/sanity FSM catastrophic
+        //    residual threshold, i.e. "residual big enough that OUR OWN
+        //    other recovery machinery already treats this epoch as
+        //    catastrophic" -- beyond that point, charging MORE badness to
+        //    the reference satellite for a residual that is almost
+        //    certainly a FLOAT-wide problem (not that satellite's fault)
+        //    is exactly the poisoning mechanism above. Does NOT touch the
+        //    shared per_sat_res map itself (that map is also read raw by
+        //    use_epoch_quality_gates/use_cp_hold_recovery, which must stay
+        //    numerically untouched) -- only badness's own reads of it.
+        //    0 = no clamp = faithful.
+        double sat_badness_residual_clamp_m = 15.0;
+        // 2. Final score cap: applied to sat_badness()'s returned score,
+        //    after every additive term (including the now-clamped residual
+        //    term above) but before the caller multiplies it into a sigma
+        //    scale. At the defaults, max carrier-sigma inflation becomes
+        //    1 + 1.5*3.0 = 5.5x -- the reference's own gentle regime,
+        //    versus the uncapped port's observed 400-1550 (~1000x). Bounds
+        //    the OTHER additive terms too (recent_worst/recent_ref/etc.),
+        //    not just the residual one, since those can also accumulate.
+        //    0 = no cap = faithful.
+        double sat_badness_score_cap = 3.0;
+        // 3. FDE-carrier-reject counter decay: the faithful port's cppr
+        //    substitute (sb_fde_cp_reject_count; see use_sat_badness_
+        //    downweight's deviation 1 above) is a persistent per-(satellite,
+        //    signal) integer count that NEVER resets -- a second, independent
+        //    source of unbounded growth alongside the residual-proportional
+        //    term. This turns it into a decayed float, updated once per
+        //    epoch as cppr[s,sig] = decay*prev + this_epoch_rejects (the
+        //    number of that satellite/signal's FDE carrier rejections
+        //    DURING that epoch's runFde() call, not cumulative). Feeds both
+        //    sat_badness()'s direct cppr term and (via cppr_this_epoch)
+        //    recent_cppr's own separate decay (sat_badness_recent_cppr_decay,
+        //    unchanged) -- previously that decay chased an ever-growing
+        //    target and could never plateau either. 1.0 = never decays =
+        //    exactly the old (faithful) ever-growing-counter behaviour.
+        double sat_badness_cppr_decay = 0.8;
     };
 
     struct EpochSeed {

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -374,6 +374,260 @@ public:
         int gate_min_satellites = 6;          ///< reference nsat_min
         double gate_ddpr_res_max_m = 3.0;     ///< reference main_ddpr_res_thresh
         double gate_per_sat_res_max_m = 3.0;  ///< reference per_sat_res_thresh
+
+        // --- CP-hold / sanity FSM (port of the inuex35 reference's
+        // validation/postfit.py + validation/recovery.py + state.py +
+        // preprocess/gate.py "wrong integer basin" recovery policy) ---
+        //
+        // The quality gates above (use_epoch_quality_gates) stop the pipeline
+        // from FIXING on a corrupt epoch, but do nothing when the graph has
+        // already locked onto a WRONG integer basin (a bad LAMBDA fix earlier
+        // got pinned by fix-and-hold and now poisons every subsequent epoch's
+        // float, since the held priors keep dragging the solution back to the
+        // wrong integers). This FSM detects that condition from post-fit DD
+        // pseudorange residuals (which see the wrong-basin float pose, not the
+        // held carrier terms) and recovers by mass-invalidating every current
+        // ambiguity: bump each arc's "generation" so the next observation gets
+        // a FRESH graph symbol (new prior, no held integer -- see the
+        // per-ambiguity generation-overlay comment beside ambSymbolId() in
+        // fgo_gtsam_backend.cpp), and suspend carrier fixing (CP-hold) for a
+        // configured number of epochs so the float can re-converge on
+        // pseudorange alone before AR is attempted again.
+        //
+        // NOTE: this port originally skipped the DDPR-LS anchor stages
+        // (_ddpr_sanity_fetch_anchor / _anchor_vs_imu in postfit.py). They are
+        // now ported below (FGOConfig::use_ddpr_anchor) -- see that switch's
+        // comment for why the anchor turns out to be diagnostic-only in
+        // THIS particular slot (the reference's own control flow converges
+        // on the same reset regardless of anchor trust) and for where the
+        // anchor position actually changes behaviour (exception recovery +
+        // bootstrap re-seed).
+        //
+        // Master switch, default OFF (bit-identical baseline without it).
+        bool use_cp_hold_recovery = false;
+        double cp_hold_main_residual_threshold_m = 3.0;    ///< reference main_ddpr_res_thresh
+        double cp_hold_catastrophic_threshold_m = 15.0;    ///< reference main_ddpr_res_catastrophic
+        double cp_hold_fast_worst_satellite_min_m = 10.0;  ///< reference ddpr_fast_worst_sat_min (tokyo profile)
+        int cp_hold_persist_epochs = 3;                    ///< reference ddpr_sanity_persist
+        int cp_hold_epochs = 5;                            ///< reference recov_cp_hold
+        double cp_hold_release_threshold_m = 2.0;          ///< reference recov_cp_release_thresh (tokyo profile)
+        int cp_hold_release_count = 5;                     ///< reference recov_cp_release_count (tokyo profile)
+        double cp_hold_pose_replace_threshold_m = 5.0;     ///< reference sanity_pose_replace_thresh
+        double cp_hold_multipath_median_ratio = 5.0;       ///< reference sanity_max_median_ratio
+        int cp_hold_multipath_min_satellites = 6;          ///< reference sanity_max_median_min_sats
+        double cp_hold_max_gdop = 5.0;                     ///< reference sanity_max_gdop (tokyo profile)
+        // Break the IMU preintegration chain at the epoch after a mass/fast
+        // reset (reference sanity_break_pim, default on): the next epoch adds
+        // a loose PriorPose3/PriorVector seeded at the IMU prediction instead
+        // of a CombinedImuFactor linking back to the pre-reset state, so a
+        // wrong pre-reset pose cannot drag the post-reset solution back.
+        bool cp_hold_break_imu_chain = true;
+        // Translation sigma [m] of that loose post-reset pose prior (reference
+        // pim_break_trans_sigma; the tokyo profile widens this from the 1.0 m
+        // dataclass default to 100.0 m -- i.e. barely constrain translation at
+        // all after a wrong-basin reset).
+        double cp_hold_imu_break_translation_sigma_m = 100.0;
+
+        // --- Exception recovery (port of recovery.py's handle_solve_exception)
+        // ---
+        // Independent switch: when the smoother throws (numerical failure,
+        // e.g. IndeterminantLinearSystemException from a rank-deficient
+        // epoch) and use_ddpr_anchor is OFF, retry the epoch with ONLY loose
+        // re-seed priors (pose sigma 1.0 m, vel sigma 1.0 m/s, bias sigma 0.1)
+        // at the IMU-predicted state, discarding that epoch's GNSS/IMU
+        // factors. When use_ddpr_anchor is ON, the reference's actual first
+        // choice (recovery.handle_solve_exception: try_ddpr_reset before the
+        // loose-prior fallback) is tried FIRST instead -- see
+        // use_ddpr_anchor's comment. If THAT retry also
+        // throws, perform a full warm reset: destroy and recreate the
+        // IncrementalFixedLagSmoother from scratch (reference
+        // warm_reset_phase2) with fresh priors at the last good (or
+        // IMU-predicted) pose -- rotation sigma from
+        // cp_hold_warm_reset_rotation_sigma_deg, position sigma [2,2,3] m
+        // (ENU), velocity isotropic 3.0 m/s (seeded to zero), bias isotropic
+        // 0.01 -- bump every tracked ambiguity's generation, and engage
+        // CP-hold. This targets the known IndeterminantLinearSystemException
+        // tail failure on the tokyo run2 dataset (~epoch 6390): the retry lets
+        // a single bad epoch pass without giving up on the whole run, and the
+        // warm reset recovers from a genuinely poisoned linearization point.
+        // Default OFF (bit-identical baseline without it).
+        bool use_solve_exception_recovery = false;
+        double solve_exception_pose_sigma_m = 1.0;
+        double solve_exception_velocity_sigma_mps = 1.0;
+        double solve_exception_bias_sigma = 0.1;
+        double cp_hold_warm_reset_rotation_sigma_deg = 1.0;  ///< reference body_rot_std
+
+        // --- DDPR-LS anchor (port of the inuex35 reference's
+        // utils/ls_solvers.py ddpr_only_position + the anchor stages of
+        // validation/postfit.py/recovery.py/optimize/stage.py that the
+        // CP-hold FSM port above deliberately skipped). ---
+        //
+        // The anchor is a standalone DDPR-only least-squares position solve
+        // (single Pose3 key, THIS epoch's DD pseudorange factors only, no
+        // carrier/IMU/ambiguity coupling) built by reusing the same
+        // DoubleDifferencePseudorangeFactorArm construction the main graph
+        // uses (see solveDdprAnchor() in fgo_gtsam_backend.cpp): a tight-
+        // rotation/loose-translation PriorPose3 around the IMU-predicted
+        // pose, plain (non-robust -- matching the reference's huber_pr=0
+        // default) noise, LevenbergMarquardt (max 10 iterations), then up to
+        // 3 rounds of single-pass FDE (drop factors with raw residual >
+        // ddpr_anchor_fde_threshold_m while >= ddpr_anchor_min_factors
+        // remain, re-solve).
+        //
+        // It is wired into THREE places:
+        //  1. Diagnostics inside the CP-hold FSM's persist (mass-reset) path
+        //     (postfit.py's _ddpr_sanity_fetch_anchor / _anchor_vs_imu).
+        //     IMPORTANT / faithfully-ported reference quirk: in the
+        //     reference, EVERY branch of run_ddpr_sanity past the persist
+        //     gate -- anchor untrusted, anchor disagrees with the IMU
+        //     prediction, or anchor agrees -- converges on the exact same
+        //     _apply_sanity_reset() call with the exact same arguments (the
+        //     anchor ECEF itself is never read by _apply_sanity_reset). So
+        //     this stage does NOT gate whether the mass reset fires here --
+        //     it only records whether the anchor WOULD have been trusted /
+        //     agreed with the IMU (diagnostics: ddpr_anchor_gated_resets_
+        //     skipped/allowed), exactly mirroring the reference's info-dict-
+        //     only behaviour. Requires use_cp_hold_recovery.
+        //  2. Exception recovery (recovery.py's handle_solve_exception /
+        //     try_ddpr_reset): here the anchor's POSITION does matter. When
+        //     the smoother throws, this is now tried FIRST -- warm-reset the
+        //     smoother seeded at (anchor translation, IMU-predicted
+        //     rotation, zero velocity) -- and only when the anchor is
+        //     untrusted (solve failed, too few factors, or res_rms too high)
+        //     does control fall through to the existing loose-prior retry /
+        //     IMU-seeded full warm reset. Requires use_solve_exception_recovery.
+        //  3. Bootstrap re-seed (optimize/stage.py's BOOT_DDPR_EPOCHS /
+        //     tightly_coupled.py's Phase-2-init arming): our primary lever
+        //     against the CP-hold FSM's known FLOAT-degradation cost. Once
+        //     armed (see cp_hold_bootstrap_after_mass_reset below), every
+        //     epoch for ddpr_anchor_bootstrap_epochs epochs gets a
+        //     translation-only PriorPose3 at that epoch's anchor position
+        //     (rotation sigma ~unconstrained, translation sigma
+        //     ddpr_anchor_bootstrap_sigma_m) added alongside the normal
+        //     graph -- a pull-back channel to truth that does not depend on
+        //     carrier/AR recovering first. The countdown decrements every
+        //     armed epoch regardless of whether that epoch's anchor solve
+        //     succeeds (matches the reference: stage.py decrements outside
+        //     the try/except). While armed, effective CP-hold length is
+        //     forced to 0 (bootstrap and CP-hold are mutually exclusive in
+        //     the reference's state.effective_cp_hold_epochs -- bootstrap
+        //     wins) via effectiveCpHoldEpochs() in the .cpp.
+        //
+        // Deliberate deviation from the reference: the reference only arms
+        // the bootstrap countdown once, at Phase-2 initialization (there is
+        // no equivalent "Phase 2 init" moment in this backend -- it runs the
+        // TC graph from epoch 0). This port instead arms it after EVERY full
+        // warm reset (both the anchor-seeded and IMU-seeded paths, since
+        // both destroy and recreate the smoother from scratch) and,
+        // opt-in via cp_hold_bootstrap_after_mass_reset, after the CP-hold
+        // FSM's mass/fast ambiguity resets too (those do NOT recreate the
+        // smoother, but DO invalidate every held integer, which is the same
+        // "float needs a pull-back channel" situation the bootstrap targets).
+        // Shipped default for cp_hold_bootstrap_after_mass_reset: FALSE.
+        // Measured on the tokyo full runs (FSM+anchor, boot-after-mass on,
+        // reference-default sigma 0.5 m / 20 epochs): mass/fast resets fire
+        // hundreds of times per run, concentrated in exactly the deepest-
+        // multipath sections, so arming there injects sub-metre-sigma
+        // anchor priors at the LEAST trustworthy DDPR-LS positions AND (per
+        // the reference's bootstrap-suppresses-CP-hold rule) disables the
+        // FSM's protective carrier suppression in those same sections --
+        // run1 FLOAT RMS 26.9 -> 95.9 m and FIXED RMS 0.80 -> 17.7 m; run2
+        // FLOAT 6.9 -> 26.4 m, FIXED 0.50 -> 4.05 m. The reference's arming
+        // moment (Phase-2 init, right after a window of verified-good fixes
+        // in workable sky) has no analogue at a mid-canyon mass reset. With
+        // this false the bootstrap still arms after full warm resets (rare:
+        // solver-exception recovery), where the smoother has genuinely lost
+        // its history and the anchor is the only absolute-position channel.
+        //
+        // Master switch, default OFF (bit-identical baseline without it;
+        // when true, requires use_cp_hold_recovery and/or
+        // use_solve_exception_recovery to actually do anything -- see above).
+        bool use_ddpr_anchor = false;
+        double ddpr_anchor_max_residual_m = 2.0;       ///< reference ddpr_max_res
+        double ddpr_anchor_fde_threshold_m = 4.0;      ///< reference fde_pr
+        int ddpr_anchor_min_factors = 4;               ///< reference ddpr_only_position's hard floor
+        double ddpr_anchor_imu_max_gap_m = 20.0;       ///< reference anchor_imu_max_gap
+        double ddpr_anchor_imu_hard_max_m = 200.0;     ///< reference anchor_imu_hard_max
+        double ddpr_anchor_clean_residual_m = 1.0;     ///< reference anchor_imu_clean_res / ddpr_clean_res
+        double ddpr_anchor_clean_main_residual_m = 15.0;  ///< reference anchor_imu_clean_main_res
+        int ddpr_anchor_persist_override = 6;          ///< reference ddpr_bad_persist_override
+        int ddpr_anchor_bootstrap_epochs = 20;         ///< reference BOOT_DDPR_EPOCHS
+        double ddpr_anchor_bootstrap_sigma_m = 0.5;    ///< reference BOOT_DDPR_SIGMA
+        bool cp_hold_bootstrap_after_mass_reset = false;  ///< see deviation + validation note above
+
+        // --- FDE: GICI-style Fault Detection and Exclusion (port of the
+        // inuex35 reference's validation/postfit.py apply_fde + its call
+        // site in optimize/stage.py's _compute_postfit_diagnostics). Runs
+        // AFTER this epoch's main iSAM2 solve but BEFORE the per-epoch
+        // LAMBDA / fix-and-hold block (reference: apply_fde is called
+        // right after the shared main_ddpr_residuals diagnostics pass --
+        // which is what feeds BOTH the quality gates and the CP-hold/
+        // sanity FSM trigger -- and strictly before _run_lambda_ar), so
+        // ambiguity resolution sees a float already cleaned of gross
+        // outliers while the sanity FSM's residual INPUT stays pre-FDE
+        // (see fgo_gtsam_backend.cpp's insertion point for the exact
+        // ordering rationale).
+        //
+        // Evaluates each of THIS epoch's just-added DD pseudorange/
+        // carrier factors at the current (post-solve, pre-FDE) estimate via
+        // evaluateError() -- NOT factor->error() -- to get the raw
+        // (unwhitened) residual in meters directly. This is a deliberate
+        // improvement over a literal port of the reference's res_m =
+        // sqrt(2*err)*cfg.sigma_pr*sqrt(2) (which reconstructs the raw
+        // residual from factor->error()'s chi-squared value and the
+        // factor's own sigma): factor->error() runs the noise model's
+        // loss(), which for a Robust/Huber-wrapped factor returns the
+        // DOWN-WEIGHTED loss rather than the raw chi-squared distance,
+        // silently weakening outlier detection for exactly the large
+        // residuals FDE exists to catch. The reference sidesteps this only
+        // in main_ddpr_residuals (its _ddpr_factor_error has a
+        // rebuild_for_robust branch that bypasses error() the same way)
+        // but NOT in apply_fde's own _fde_collect_residuals -- harmless
+        // there only because the reference's DD factors default to
+        // non-robust (huber_pr=0.0). Our use_robust_loss defaults to TRUE,
+        // so evaluateError() is used unconditionally here to stay correct
+        // under both settings.
+        //
+        // SINGLE-PASS (fde_max_iterations<=1, the reference default):
+        // scans ONLY this epoch's own DD PR/CP factors (their live graph
+        // indices, resolved precisely via ISAM2Result::newFactorsIndices
+        // -- strictly more precise than the reference's "last g3.size()
+        // slots of the live factor array" heuristic, which can
+        // mis-attribute a factor when findUnusedFactorSlots recycles an
+        // older, now-unused slot). Rejects every PR entry with res_m >
+        // fde_pseudorange_threshold_m and every CP entry with res_m >
+        // fde_carrier_threshold_m (optional per-group median subtraction,
+        // default off, mirroring the reference's FDE_MEDIAN_SUB env
+        // knob). If the rejected count exceeds
+        // fde_max_rejected_fraction * nv (nv = this epoch's own PR+CP
+        // factor count), FDE is abandoned entirely for the epoch and
+        // (mirroring the reference's trigger_cp_hold(...,
+        // skip_if_active=True)) CP-hold is engaged at full strength
+        // UNLESS it is already active. Deliberate deviation: when
+        // use_cp_hold_recovery is off there is no hold to engage, so the
+        // safeguard then simply skips FDE for the epoch with no other
+        // effect.
+        //
+        // ITERATIVE (fde_max_iterations>1): scans the WHOLE live graph by
+        // factor type (refreshed every iteration, so a removal never
+        // leaves a stale index dangling) and removes only the single
+        // worst |res-median| exceeder per round, re-estimating between
+        // rounds; no safeguard (matching the reference, which only
+        // guards the single-pass branch).
+        //
+        // Every rejected CP factor is treated as a cycle slip (reference
+        // _fde_reset_rejected_amb): release any fix-and-hold pin for that
+        // arc and bump its ambiguity generation so the next observation
+        // gets a fresh graph symbol (see the ambSymbolId overlay). PR
+        // rejects get no ambiguity-side action, matching the reference.
+        //
+        // Master switch, default OFF (bit-identical baseline without it).
+        bool use_fde = false;
+        double fde_pseudorange_threshold_m = 4.0;   ///< reference fde_pr
+        double fde_carrier_threshold_m = 0.5;       ///< reference fde_cp
+        double fde_max_rejected_fraction = 0.5;     ///< reference fde_max_frac
+        int fde_max_iterations = 1;                 ///< reference fde_max_iter (1 = single-pass, the reference default)
+        bool fde_median_subtraction = false;        ///< reference FDE_MEDIAN_SUB env knob (default off)
     };
 
     struct EpochSeed {
@@ -656,6 +910,30 @@ public:
         std::size_t quality_gated_epochs = 0;   ///< epochs where the quality gates suppressed fixing
         std::size_t code_minus_carrier_jump_resets = 0;       ///< CMC screening: arc breaks forced
         std::size_t code_minus_carrier_level_exclusions = 0;  ///< CMC screening: (sat,signal) epochs excluded
+        // --- CP-hold / sanity FSM diagnostics (use_cp_hold_recovery) ---
+        std::size_t cp_hold_triggers = 0;         ///< times CP-hold was (re)engaged/extended
+        std::size_t cp_hold_epochs_held = 0;      ///< cumulative epochs with carrier suppressed
+        std::size_t sanity_mass_resets = 0;       ///< persist-path (3 consecutive bad) resets
+        std::size_t sanity_fast_resets = 0;       ///< catastrophic fast-path resets
+        std::size_t sanity_pose_replacements = 0; ///< epochs where the reported pose was IMU-predicted
+        std::size_t sanity_multipath_skips = 0;   ///< bad epochs skipped as single-satellite multipath
+        std::size_t sanity_gdop_skips = 0;        ///< persist-eligible resets skipped for weak geometry
+        std::size_t ambiguity_generation_bumps = 0;  ///< total per-arc generation bumps (fresh symbols)
+        // --- Exception recovery diagnostics (use_solve_exception_recovery) ---
+        std::size_t solve_exception_recoveries = 0;   ///< loose-prior retries that succeeded
+        std::size_t solve_exception_warm_resets = 0;  ///< full smoother re-creations
+        // --- DDPR-LS anchor diagnostics (use_ddpr_anchor) ---
+        std::size_t ddpr_anchor_solves = 0;         ///< mini DDPR-LS solve attempts (any of the 3 call sites)
+        std::size_t ddpr_anchor_successes = 0;      ///< of which trusted (n>=min_factors, res_rms<=max)
+        std::size_t ddpr_anchor_gated_resets_skipped = 0;  ///< diagnostic-only: gate would have rejected the reset (persist path; the reset still fires -- see use_ddpr_anchor comment)
+        std::size_t ddpr_anchor_gated_resets_allowed = 0;  ///< diagnostic-only: gate would have accepted the reset
+        std::size_t ddpr_anchored_warm_resets = 0;  ///< exception recoveries that used the DDPR anchor (vs the IMU-seeded fallback)
+        std::size_t ddpr_anchor_bootstrap_prior_epochs = 0;  ///< epochs an anchor bootstrap translation prior was actually added
+        // --- FDE diagnostics (use_fde) ---
+        std::size_t fde_pseudorange_rejections = 0;  ///< total DD PR factors removed
+        std::size_t fde_carrier_rejections = 0;      ///< total DD CP factors removed
+        std::size_t fde_safeguard_skips = 0;         ///< epochs where the reject-fraction safeguard aborted FDE
+        std::size_t fde_epochs = 0;                  ///< epochs where >=1 factor was actually removed
         std::size_t float_rejected_seed_position_divergence = 0;
         std::size_t float_rejected_position_jump = 0;
         bool fixed_solution = false;

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -289,6 +289,74 @@ public:
         // for gauge. Ignored unless use_pose3_state is also set. Default OFF.
         bool use_imu = false;
 
+        // --- Reference parity: IMU preintegration covariance value semantics
+        // + residual-driven per-epoch inflation (port of the inuex35
+        // reference's buildfactor/imu_preintegration.py's
+        // _apply_mres_integ_cov_override + config.py's imu_integ_cov /
+        // imu_integ_cov_max). Fixed-lag GTSAM path only
+        // (optimizeProblemFixedLag in fgo_gtsam_backend.cpp); the batch path
+        // (optimizeProblemWithGtsam) is untouched. ---
+        //
+        // The reference passes imu_integ_cov (dataclass default 1e-3)
+        // DIRECTLY to gtsam's setIntegrationCovariance (utils/imu.py:44,
+        // `p.setIntegrationCovariance(integ_cov * np.eye(3))`) -- i.e. it IS
+        // the covariance, not a sigma to be squared. This backend's
+        // ImuNoiseParams::integration_sigma is instead squared before that
+        // same GTSAM call (`sq(problem.imu.noise.integration_sigma)`); this
+        // field replaces that computation for the fixed-lag path so the
+        // value semantics match exactly (no squaring). Default 1e-6
+        // reproduces the harness's current hardcoded covariance
+        // (integration_sigma=1e-3, squared) bit-for-bit, so leaving this
+        // field untouched changes nothing.
+        double imu_integration_covariance = 1e-6;
+
+        // Per-epoch inflation (reference _apply_mres_integ_cov_override,
+        // imu_preintegration.py:53-72). Before building EACH epoch's PIM the
+        // reference recomputes:
+        //   is_stale = stale_max > 0 && (epoch - last_mres_epoch) > stale_max
+        //   integ_eff = is_stale ? imu_integ_cov
+        //                        : clamp(max(imu_integ_cov, last_mres^2 / dt),
+        //                                upper = imu_integ_cov_max)
+        // and mutates the ONE shared PreintegrationCombinedParams instance in
+        // place (tc.imu_params) before gtsam::PreintegratedCombinedMeasurements
+        // is constructed for the interval -- this backend mirrors that
+        // exactly: imu_params (this function's local shared_ptr, built once)
+        // is mutated in place immediately before each epoch's PIM object is
+        // constructed, so it affects only the PIM about to be integrated,
+        // never factors already linearized into the graph.
+        //
+        //   last_mres  = the PREVIOUS epoch's post-fit main DDPR RMS residual
+        //                [m] -- reference tc._last_main_ddpr_res /
+        //                _mres_signals.last_res, written once per epoch in
+        //                optimize/stage.py's _compute_postfit_diagnostics
+        //                immediately after main_ddpr_residuals() runs (i.e.
+        //                AFTER that epoch's ISAM2 update, using the smoothed
+        //                estimate, pre-FDE). This backend's equivalent is
+        //                the existing `last_ddpr_rms` local (already
+        //                computed under use_cp_hold_recovery /
+        //                use_epoch_quality_gates / use_sat_badness_downweight
+        //                for the CP-hold FSM) -- no new residual computation
+        //                needed, just a new consumer of the same value.
+        //   dt         = real elapsed seconds since the previous epoch
+        //                (reference tc._epoch_dt) -- this backend's
+        //                (epoch[i].time - epoch[i-1].time), floored the same
+        //                way (max(dt, 1e-3)).
+        //   stale_max  = imu_integration_covariance_stale_epochs (reference
+        //                reuses its unrelated-by-name
+        //                ddcp_res_weight_stale_max_epochs config field for
+        //                this same staleness test; ported here as its own
+        //                dedicated field since the two features are
+        //                independent in this backend). A long IMU-only
+        //                outage (no recent DDPR solve) must not carry
+        //                forward a possibly ancient inflation value, so the
+        //                override falls back to the static floor instead.
+        //
+        // Requires imu_integration_covariance to be set as the static floor.
+        // Master switch, default OFF (bit-identical baseline without it).
+        bool use_imu_integration_covariance_inflation = false;
+        double imu_integration_covariance_max = 0.5;       ///< reference imu_integ_cov_max
+        int imu_integration_covariance_stale_epochs = 2;   ///< reference ddcp_res_weight_stale_max_epochs
+
         // --- Phase 2 milestone 2c: incremental fixed-lag smoother ---
         // When true AND use_imu (implies use_pose3_state, GTSAM backend), the
         // GTSAM backend streams the graph through a

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -4,6 +4,7 @@
 #include <libgnss++/core/observation.hpp>
 #include <libgnss++/core/solution.hpp>
 #include <libgnss++/core/types.hpp>
+#include <libgnss++/io/imu.hpp>
 
 #include <cstddef>
 #include <map>
@@ -12,6 +13,22 @@
 #include <vector>
 
 namespace libgnss {
+
+/**
+ * @brief Selects which numerical backend FGOProcessor::optimizeProblem uses.
+ *
+ * `Eigen` (default) is the native dense/sparse Gauss-Newton-ish solver
+ * implemented directly in fgo.cpp. `GTSAM` delegates to a GTSAM
+ * NonlinearFactorGraph + LevenbergMarquardtOptimizer built in
+ * fgo_gtsam_backend.cpp (only available when the library is built with
+ * GTSAM found, i.e. GNSSPP_HAS_GTSAM is defined). Selecting GTSAM when the
+ * library was built without it is a no-op: optimizeProblem falls back to the
+ * Eigen backend.
+ */
+enum class FGOBackend {
+    Eigen,
+    GTSAM,
+};
 
 /**
  * @brief Batch pseudorange factor-graph optimizer.
@@ -23,6 +40,7 @@ namespace libgnss {
 class FGOProcessor {
 public:
     struct FGOConfig {
+        FGOBackend backend = FGOBackend::Eigen;
         int max_iterations = 8;
         double convergence_threshold_m = 1e-4;
         double relative_cost_convergence_threshold = 0.0;
@@ -95,6 +113,82 @@ public:
         bool use_troposphere_model = true;
         bool use_multi_constellation = true;
         bool collect_lambda_debug = false;
+
+        // --- Phase 2 milestone 2a (docs/gtsam_backend_design.md) ---
+        // When true AND backend == FGOBackend::GTSAM, the GTSAM backend keys
+        // the rover state as a body gtsam::Pose3 (translation + attitude) per
+        // epoch instead of a bare gtsam::Point3, and builds the DD factors
+        // with the lever-arm '...FactorArm' variants (antenna_ecef =
+        // pose.translation() + pose.rotation() * pose3_lever_arm_body_m).
+        // Attitude is unobservable from GNSS DD alone (no IMU until
+        // milestone 2b) and is pinned near its identity seed by a dedicated
+        // rotation-only prior; only the recovered ANTENNA position is a
+        // validated output of this mode. Ignored by the native Eigen backend
+        // and by the GTSAM backend when false (existing Point3 path,
+        // unchanged). Default OFF.
+        bool use_pose3_state = false;
+        // Body-frame (FLU) translation from the body/IMU origin to the GNSS
+        // antenna, used only when use_pose3_state is true. Zero means the
+        // Pose3 state's translation IS the antenna (degenerate lever arm).
+        Vector3d pose3_lever_arm_body_m = Vector3d::Zero();
+
+        // --- Phase 2 milestone 2b: IMU tight coupling ---
+        // When true AND use_pose3_state AND the GTSAM backend AND the problem
+        // carries a valid ImuInput, the GTSAM backend augments each epoch with
+        // a Vector3 velocity node V(i) and an imuBias::ConstantBias node B(i),
+        // links consecutive epochs with a gtsam::CombinedImuFactor built from
+        // PreintegratedCombinedMeasurements, and interprets the per-epoch Pose3
+        // as body-in-nav (local ENU) with the DD '...FactorArm' consuming it
+        // through ecef_T_nav (the same Pose3 is shared with the IMU factor).
+        // Attitude/velocity become observable, so the per-epoch 2a rotation pin
+        // is dropped in favour of first-state priors (attitude/velocity/bias)
+        // for gauge. Ignored unless use_pose3_state is also set. Default OFF.
+        bool use_imu = false;
+
+        // --- Phase 2 milestone 2c: incremental fixed-lag smoother ---
+        // When true AND use_imu (implies use_pose3_state, GTSAM backend), the
+        // GTSAM backend streams the graph through a
+        // gtsam::IncrementalFixedLagSmoother instead of a single batch LM
+        // solve: each epoch's Pose3/Vel/Bias + factors are added incrementally
+        // with key timestamps, and states older than fixed_lag_smoother_lag_s
+        // (relative to the newest epoch) are marginalized. This bounds memory
+        // and makes per-epoch LAMBDA feasible at full-dataset scale (the batch
+        // gtsam::Marginals hit bad_alloc at ~25k vars). Ignored unless use_imu.
+        // Default OFF (batch LM path unchanged).
+        bool use_fixed_lag_smoother = false;
+        // Smoother lag in seconds. States (and ambiguity/clock nodes) whose
+        // last timestamp is older than this window are marginalized out.
+        double fixed_lag_smoother_lag_s = 5.0;
+
+        // --- Phase 2 milestone 2d: NHC + ZUPT pseudo-measurements ---
+        // Applied per-epoch in the IMU-coupled fixed-lag path (gated), mirror
+        // inuex35 buildfactor/nhc.py + zupt.py. Default OFF.
+        //
+        // NHC: a ground vehicle's body-frame lateral (left) and vertical (up)
+        // velocity is ~0. Binary factor on (Pose3(i), Vel(i)) with residual
+        // [v_body.y, v_body.z] = [ (R^T v_nav).y, (R^T v_nav).z ]. Gated to
+        // moving, non-turning epochs so it never fights legitimate lateral
+        // motion.
+        bool use_nhc = false;
+        double nhc_min_speed_mps = 2.0;          ///< only apply NHC above this speed
+        double nhc_max_yaw_rate_radps = 0.20;    ///< skip NHC when |yaw rate| exceeds this (turn)
+        double nhc_sigma_lateral_mps = 0.3;      ///< body-lateral velocity sigma
+        double nhc_sigma_vertical_mps = 0.2;     ///< body-vertical velocity sigma
+        // ZUPT: when the epoch's IMU window is stationary, pin Vel(i) ~ 0 with a
+        // PriorFactor. Stationary detection mirrors the Stage-1 ESKF detector
+        // (accel_std / gyro_std / gyro_median of bias-referenced IMU samples).
+        bool use_zupt = false;
+        double zupt_sigma_mps = 0.05;            ///< zero-velocity prior sigma
+        // Velocity gate (mirrors inuex35): only fire ZUPT when the current
+        // (IMU-predicted) speed is already below this. Without it, a quiet
+        // accelerometer during CONSTANT-VELOCITY cruising is misread as
+        // stationary and ZUPT freezes the vehicle (observed: FLOAT max 94 m).
+        // 0 disables the gate.
+        double zupt_max_speed_mps = 0.5;
+        double zupt_max_accel_std = 0.55;        ///< stationary gate: accel deviation std [m/s^2]
+        double zupt_max_gyro_std = 0.030;        ///< stationary gate: gyro deviation std [rad/s]
+        double zupt_max_gyro_median = 0.020;     ///< stationary gate: gyro deviation median [rad/s]
+        int zupt_min_samples = 5;                ///< minimum IMU samples in window to test
     };
 
     struct EpochSeed {
@@ -261,8 +355,57 @@ public:
         std::size_t tdcp_rejected_code_phase_jump = 0;
     };
 
+    // --- Phase 2 milestone 2b: IMU preintegration inputs ---
+    //
+    // Continuous-time IMU noise densities + bias random-walk for the GTSAM
+    // PreintegrationCombinedParams. Sigmas, not covariances; the backend
+    // squares them. Defaults are a reasonable consumer/industrial MEMS grade
+    // (order of the tokyo low-cost preset) and can be overridden by the caller.
+    // Defaults are the (deliberately conservative) values validated on tokyo1
+    // in milestone 2b; final tuning is deferred to 2c/2e.
+    struct ImuNoiseParams {
+        double accel_noise_sigma = 1.0e-1;      ///< accel white noise [m/s^2/sqrt(Hz)]
+        double gyro_noise_sigma = 1.0e-2;       ///< gyro white noise [rad/s/sqrt(Hz)]
+        double accel_bias_rw_sigma = 1.0e-2;    ///< accel bias random walk [m/s^3/sqrt(Hz)]
+        double gyro_bias_rw_sigma = 1.0e-3;     ///< gyro bias random walk [rad/s^2/sqrt(Hz)]
+        double integration_sigma = 1.0e-2;      ///< integration uncertainty [m/s/sqrt(Hz)]
+        double gravity_mps2 = 9.80665;          ///< local gravity magnitude
+    };
+
+    // Everything the GTSAM backend needs to add IMU factors, computed by the
+    // caller (harness): the local nav (ENU) frame definition, the per-sample
+    // IMU stream already remapped to body FLU with gyro in rad/s, the initial
+    // navigation state (from Stage-1 alignment) and its prior sigmas, and the
+    // preintegration noise. The nav frame is ENU (Z-up); gravity points to -Z.
+    struct ImuInput {
+        bool valid = false;
+        // Local ENU nav-frame origin: pose translations are expressed as the
+        // body/IMU origin in this ENU frame, and ecef_T_nav maps them to ECEF.
+        Vector3d nav_origin_ecef = Vector3d::Zero();
+        double nav_origin_lat_rad = 0.0;
+        double nav_origin_lon_rad = 0.0;
+        // Time-sorted IMU samples, already body-FLU (ImuAxisConvention applied)
+        // with gyro converted to rad/s. The backend preintegrates the samples
+        // falling in each [epoch[i].time, epoch[i+1].time) interval.
+        std::vector<ImuSample> samples_body_flu;
+        // Initial navigation state (first epoch), nav = ENU frame. Attitude is
+        // the body->nav rotation from Stage-1 static leveling + heading align.
+        Matrix3d init_attitude_body_to_nav = Matrix3d::Identity();
+        Vector3d init_velocity_nav = Vector3d::Zero();
+        Vector3d init_accel_bias = Vector3d::Zero();
+        Vector3d init_gyro_bias = Vector3d::Zero();
+        // First-state prior sigmas (gauge/anchor for the IMU chain).
+        double init_attitude_sigma_roll_pitch_rad = 0.02;
+        double init_attitude_sigma_yaw_rad = 0.5;
+        double init_velocity_sigma_mps = 0.5;
+        double init_accel_bias_sigma = 0.05;
+        double init_gyro_bias_sigma = 0.01;
+        ImuNoiseParams noise;
+    };
+
     struct FGOProblem {
         std::vector<EpochSeed> epochs;
+        ImuInput imu;  ///< Milestone 2b IMU inputs (valid only when populated).
         std::vector<bool> clock_jumps;
         std::vector<PseudorangeFactor> pseudorange_factors;
         std::vector<TimeDifferencedCarrierFactor> tdcp_factors;
@@ -315,6 +458,11 @@ public:
         std::size_t robust_tdcp_factors = 0;
         std::size_t graph_factors = 0;
         std::size_t graph_values = 0;
+        std::size_t imu_intervals = 0;  ///< 2b: CombinedImuFactors added between epochs
+        std::size_t smoother_max_window_vars = 0;  ///< 2c: peak in-window variable count
+        std::size_t smoother_updates = 0;          ///< 2c: number of smoother.update() calls
+        std::size_t nhc_epochs = 0;   ///< 2d: epochs an NHC factor was applied
+        std::size_t zupt_epochs = 0;  ///< 2d: epochs a ZUPT prior was applied
         std::size_t float_rejected_seed_position_divergence = 0;
         std::size_t float_rejected_position_jump = 0;
         bool fixed_solution = false;
@@ -401,6 +549,12 @@ public:
         std::vector<Vector3d> epoch_velocities_ecef_mps;
         std::vector<LambdaDebugEntry> lambda_debug_entries;
         std::vector<CostTraceEntry> cost_trace_entries;
+        // Milestone 2b (populated only by the GTSAM IMU-coupled path):
+        // per-epoch estimated attitude as [roll, pitch, heading] in degrees
+        // (body FLU -> nav ENU; heading is clockwise from North) and estimated
+        // velocity in the ENU nav frame [m/s].
+        std::vector<Vector3d> epoch_attitude_rpy_deg;
+        std::vector<Vector3d> epoch_velocity_nav_mps;
     };
 
     FGOProcessor() = default;

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -25,6 +25,17 @@
 #include <tuple>
 
 namespace libgnss {
+
+#ifdef GNSSPP_HAS_GTSAM
+// Implemented in fgo_gtsam_backend.cpp. Kept as a free function (rather than
+// another FGOProcessor member) so all GTSAM includes/types stay confined to
+// that translation unit; fgo.cpp itself never includes any GTSAM header.
+FGOProcessor::FGOResult optimizeProblemWithGtsam(
+    const FGOProcessor::FGOProblem& problem,
+    const FGOProcessor::FGOConfig& config,
+    FGOProcessor::FGOResult result);
+#endif
+
 namespace {
 
 bool isPrimaryFgoSignal(SignalType signal, bool use_multi_constellation) {
@@ -1918,6 +1929,12 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
          problem.single_difference_tdcp_factors.empty())) {
         return result;
     }
+
+#ifdef GNSSPP_HAS_GTSAM
+    if (config_.backend == FGOBackend::GTSAM) {
+        return optimizeProblemWithGtsam(problem, config_, std::move(result));
+    }
+#endif
 
     const int num_epochs = static_cast<int>(problem.epochs.size());
     std::vector<GNSSSystem> bias_groups;

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -699,6 +699,7 @@ std::map<CarrierKey, PreparedCarrierObservation> prepareCarrierObservationsForRe
         model_debug.geometric_range_m = corrected_range;
         model_debug.elevation_rad = geometry.elevation;
         model_debug.azimuth_rad = geometry.azimuth;
+        model_debug.snr_dbhz = observation.snr;
 
         const double sin_el = std::max(0.1, std::sin(geometry.elevation));
         PreparedCarrierObservation carrier;
@@ -1140,6 +1141,7 @@ FGOProcessor::FGOProblem FGOProcessor::buildPseudorangeProblem(
             model_debug.geometric_range_m = corrected_range;
             model_debug.elevation_rad = geometry.elevation;
             model_debug.azimuth_rad = geometry.azimuth;
+            model_debug.snr_dbhz = observation.snr;
 
             PreparedCarrierObservation carrier;
             carrier.satellite = observation.satellite;

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -468,6 +468,30 @@ struct ActiveCarrierSegment {
     std::size_t last_epoch_index = 0;
 };
 
+// --- Elevation-dependent DD sigma ("varerr") ---
+//
+// Port of the inuex35 reference's preprocess/prefit.py varerr_dd_sigma
+// (itself a port of RTKLIB-demo5's rtkpos.c:402 varerr()), gated by
+// FGOConfig::use_elevation_dependent_sigma (see that knob's doc comment in
+// fgo.hpp for the full formula, dt_s mapping, and composition-order
+// rationale). `is_pseudorange` selects the reference's `fact` term
+// (elevation_sigma_pseudorange_ratio for pseudorange, 1.0 for carrier);
+// `el_pair_rad` is the caller-computed max(min(el_ref, el_target), el_min);
+// `dt_s` is the rover epoch-to-epoch interval.
+double varerrDdSigma(bool is_pseudorange, double el_pair_rad, double dt_s,
+                     const FGOProcessor::FGOConfig& config) {
+    // No clamping on the ratio -- faithful to the reference's
+    // `fact = cfg.err_eratio_pr if code else 1.0` (no floor/ceiling there).
+    const double fact =
+        is_pseudorange ? config.elevation_sigma_pseudorange_ratio : 1.0;
+    const double a = fact * config.elevation_sigma_err_a_m;
+    const double b = fact * config.elevation_sigma_err_b_m;
+    const double d = constants::SPEED_OF_LIGHT * config.elevation_sigma_clock_stability * dt_s;
+    const double sinel = std::max(std::sin(el_pair_rad), 0.05);
+    const double var_sd = 2.0 * (a * a + b * b / (sinel * sinel)) + d * d;
+    return std::sqrt(2.0 * var_sd);
+}
+
 struct FixedAmbiguityConstraint {
     std::size_t ambiguity_index = 0;
     double fixed_ambiguity_m = 0.0;
@@ -1512,6 +1536,17 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
         std::max(1e-3, config_.double_difference_pseudorange_sigma_m);
     const double carrier_sigma =
         std::max(1e-4, config_.double_difference_carrier_sigma_m);
+    // Elevation-dependent DD sigma ("varerr", FGOConfig::use_elevation_
+    // dependent_sigma): el_min_rad is the pair-elevation floor (reference:
+    // np.radians(max(1.0, cfg.el_mask_deg))); epoch_dt_s is the rover
+    // epoch-to-epoch interval fed to the clock-stability term, persisted
+    // across the epoch loop below and only updated on a positive delta --
+    // mirroring the reference's tc._epoch_dt / _update_epoch_dt exactly
+    // (state carried across epochs, default 0.2 s until the first update;
+    // see the knob's doc comment in fgo.hpp for why 0.2 s is also the right
+    // fallback for this dataset).
+    const double el_min_rad = M_PI / 180.0 * std::max(1.0, config_.min_elevation_deg);
+    double epoch_dt_s = 0.2;
     const double max_segment_gap = std::max(0.0, config_.max_tdcp_gap_s);
     std::map<DoubleDifferenceAmbiguityKey, ActiveCarrierSegment>
         active_dd_segments;
@@ -1535,6 +1570,16 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
     std::size_t cmc_level_exclusion_total = 0;
 
     for (std::size_t epoch_index = 0; epoch_index < problem.epochs.size(); ++epoch_index) {
+        // Reference: tc._update_epoch_dt(obs) runs unconditionally at the top
+        // of every epoch's processing, before any DD-eligibility gates below
+        // -- mirrored here the same way (only meaningful when varerr is on).
+        if (config_.use_elevation_dependent_sigma && epoch_index > 0) {
+            const double dt = problem.epochs[epoch_index].time -
+                              problem.epochs[epoch_index - 1].time;
+            if (dt > 0.0) {
+                epoch_dt_s = dt;
+            }
+        }
         const auto rover_it = rover_carriers_by_epoch.find(epoch_index);
         const auto rover_pseudorange_it =
             rover_pseudoranges_by_epoch.find(epoch_index);
@@ -1855,9 +1900,22 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
                                    config_
                                        .double_difference_secondary_pseudorange_sigma_scale)
                         : 1.0;
+                // Base DD-PR sigma: varerr (FGOConfig::use_elevation_
+                // dependent_sigma) when enabled, else the pre-existing flat/
+                // elevation-power fallback -- see the knob's doc comment in
+                // fgo.hpp for the full rationale/composition order. The
+                // secondary-band scale above still multiplies on top either
+                // way (unchanged).
+                double pseudorange_base_sigma = pseudorange_sigma / satellite_sqrt_sin_el;
+                if (config_.use_elevation_dependent_sigma) {
+                    const double el_pair_rad = std::max(
+                        std::min(reference->elevation_rad, satellite->elevation_rad),
+                        el_min_rad);
+                    pseudorange_base_sigma = varerrDdSigma(
+                        /*is_pseudorange=*/true, el_pair_rad, epoch_dt_s, config_);
+                }
                 pseudorange_factor.sigma_m =
-                    pseudorange_band_scale * pseudorange_sigma /
-                    satellite_sqrt_sin_el;
+                    pseudorange_band_scale * pseudorange_base_sigma;
                 pseudorange_factor.elevation_rad = satellite->elevation_rad;
                 pseudorange_factor.rover_satellite_model =
                     satellite->model_debug;
@@ -1950,8 +2008,20 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
                                    config_
                                        .double_difference_secondary_carrier_sigma_scale)
                         : 1.0;
-                factor.sigma_m =
-                    carrier_band_scale * carrier_sigma / satellite_sqrt_sin_el;
+                // Base DD-CP sigma: varerr when enabled, else the
+                // pre-existing flat/elevation-power fallback -- same source
+                // switch as the DD-PR site above (see that comment and the
+                // knob's doc comment in fgo.hpp). Secondary-band scale still
+                // multiplies on top either way.
+                double carrier_base_sigma = carrier_sigma / satellite_sqrt_sin_el;
+                if (config_.use_elevation_dependent_sigma) {
+                    const double el_pair_rad = std::max(
+                        std::min(reference->elevation_rad, satellite->elevation_rad),
+                        el_min_rad);
+                    carrier_base_sigma = varerrDdSigma(
+                        /*is_pseudorange=*/false, el_pair_rad, epoch_dt_s, config_);
+                }
+                factor.sigma_m = carrier_band_scale * carrier_base_sigma;
                 factor.elevation_rad = satellite->elevation_rad;
                 factor.rover_satellite_model = satellite->model_debug;
                 factor.rover_reference_model = reference->model_debug;

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -4,6 +4,7 @@
 #include <libgnss++/algorithms/spp.hpp>
 #include <libgnss++/core/constants.hpp>
 #include <libgnss++/core/coordinates.hpp>
+#include <libgnss++/core/signal_policy.hpp>
 #include <libgnss++/core/signals.hpp>
 #include <libgnss++/models/ionosphere.hpp>
 #include <libgnss++/models/troposphere.hpp>
@@ -54,6 +55,186 @@ bool isPrimaryFgoSignal(SignalType signal, bool use_multi_constellation) {
         default:
             return false;
     }
+}
+
+// Multi-frequency DD gate: primary-band signals are always eligible (same as
+// isPrimaryFgoSignal above). When use_multi_frequency_double_difference is
+// also enabled (and multi-constellation is on), secondary-band signals
+// (GPS L2C/L5, Galileo E5A/E5B/E6, BeiDou B2I/B3I/B2A, QZSS L2C/L5, ...) are
+// eligible too, keyed by the satellite's system via signal_policy. This is
+// the single choke point that previously restricted buildPseudorangeProblem /
+// buildDoubleDifferenceProblem to L1/E1/B1I-only DD factors.
+bool isEligibleFgoSignal(const SatelliteId& satellite,
+                         SignalType signal,
+                         bool use_multi_constellation,
+                         bool use_multi_frequency_double_difference) {
+    if (isPrimaryFgoSignal(signal, use_multi_constellation)) {
+        return true;
+    }
+    if (!use_multi_constellation || !use_multi_frequency_double_difference) {
+        return false;
+    }
+    return signal_policy::isSecondarySignal(satellite.system, signal);
+}
+
+// --- MF hygiene: per-receiver secondary-band observation-code alignment ---
+//
+// Port of the cssrlib/inuex35 (RTKLIB-style) signal-selection policy
+// (tightly-coupled-gnss-imu-fgo utils/sig_autodetect.py): each RECEIVER uses
+// exactly ONE RINEX observation code per (system, band) for the whole file,
+// so every satellite of a system contributes the same code per band and the
+// between-satellite (single) difference cancels the receiver-side inter-code
+// bias exactly. Without this, the RINEX reader's per-satellite first-nonzero
+// column selection MIXES codes across satellites within one band (observed on
+// tokyo1: rover GPS L2 = C2W for 2527 sat-epochs but C2L for the satellites/
+// epochs where C2W is empty; base BeiDou B2I = C7D vs rover C7I), leaving
+// uncancelled inter-code/DCB and carrier phase-alignment biases in the DD --
+// the measured multi-frequency FLOAT blowup. Satellites whose selected column
+// is a different code simply drop that band (like-vs-like or nothing),
+// exactly like cssrlib decoding only the chosen column.
+//
+// The preferred code per (system, SignalType) is chosen per receiver from the
+// codes actually observed in its data, ordered by an RTKLIB-style tracking-
+// code priority string (rtkcmn.c codepris), ties broken by observation count.
+// Applied to SECONDARY bands only: the primary band (L1/E1/B1I) single-
+// frequency path is measured-good and stays bit-identical.
+
+// RTKLIB-style per-(system, band) tracking-code priority (earlier = higher).
+const char* trackingCodePriorityString(GNSSSystem system, int band) {
+    switch (system) {
+        case GNSSSystem::GPS:
+            switch (band) {
+                case 1: return "CPYWMNSL";
+                case 2: return "PYWCMNDLSX";
+                case 5: return "IQX";
+                default: return "";
+            }
+        case GNSSSystem::GLONASS:
+            switch (band) {
+                case 1: return "PC";
+                case 2: return "PC";
+                case 3: return "IQX";
+                default: return "";
+            }
+        case GNSSSystem::Galileo:
+            switch (band) {
+                case 1: return "CABXZ";
+                case 5: return "IQX";
+                case 6: return "ABCXZ";
+                case 7: return "IQX";
+                case 8: return "IQX";
+                default: return "";
+            }
+        case GNSSSystem::BeiDou:
+            switch (band) {
+                case 1: return "DPX";
+                case 2: return "IQX";
+                case 5: return "DPX";
+                case 6: return "IQX";
+                case 7: return "IQXDZ";
+                case 8: return "DPX";
+                default: return "";
+            }
+        case GNSSSystem::QZSS:
+            switch (band) {
+                case 1: return "CLSXZ";
+                case 2: return "LSX";
+                case 5: return "IQXDPZ";
+                case 6: return "SXZ";
+                default: return "";
+            }
+        case GNSSSystem::NavIC:
+            switch (band) {
+                case 5: return "ABCX";
+                default: return "";
+            }
+        default:
+            return "";
+    }
+}
+
+int trackingCodePriority(GNSSSystem system, const std::string& obs_type) {
+    if (obs_type.size() < 3) {
+        return 100;
+    }
+    const int band = signal_policy::rinexBand(obs_type);
+    const char code = obs_type[2];
+    const char* priorities = trackingCodePriorityString(system, band);
+    for (int i = 0; priorities[i] != '\0'; ++i) {
+        if (priorities[i] == code) {
+            return i;
+        }
+    }
+    return 100;
+}
+
+// One preferred tracking-code char per (system, secondary SignalType),
+// derived from the receiver's own observations (single pre-scan pass).
+using SecondaryCodeTable = std::map<std::pair<GNSSSystem, SignalType>, char>;
+
+SecondaryCodeTable buildSecondaryCodeTable(
+    const std::vector<ObservationData>& epochs) {
+    struct CodeStats {
+        int priority = 100;
+        std::size_t count = 0;
+    };
+    std::map<std::pair<GNSSSystem, SignalType>, std::map<char, CodeStats>> stats;
+    for (const auto& epoch : epochs) {
+        for (const auto& observation : epoch.observations) {
+            if (!observation.valid || !observation.has_pseudorange) {
+                continue;
+            }
+            const GNSSSystem system = observation.satellite.system;
+            if (!signal_policy::isSecondarySignal(system, observation.signal)) {
+                continue;
+            }
+            const std::string& obs_type = observation.exactBiasObservationType();
+            if (obs_type.size() < 3) {
+                continue;
+            }
+            auto& entry = stats[{system, observation.signal}][obs_type[2]];
+            entry.priority = trackingCodePriority(system, obs_type);
+            ++entry.count;
+        }
+    }
+
+    SecondaryCodeTable table;
+    for (const auto& [key, codes] : stats) {
+        char best_code = '\0';
+        int best_priority = 101;
+        std::size_t best_count = 0;
+        for (const auto& [code, s] : codes) {
+            if (s.priority < best_priority ||
+                (s.priority == best_priority && s.count > best_count)) {
+                best_code = code;
+                best_priority = s.priority;
+                best_count = s.count;
+            }
+        }
+        if (best_code != '\0') {
+            table[key] = best_code;
+        }
+    }
+    return table;
+}
+
+// True when the observation either is primary-band (never filtered here) or
+// carries the receiver's preferred tracking code for its (system, signal).
+bool passesSecondaryCodeAlignment(const Observation& observation,
+                                  const SecondaryCodeTable* table) {
+    if (table == nullptr) {
+        return true;
+    }
+    const GNSSSystem system = observation.satellite.system;
+    if (!signal_policy::isSecondarySignal(system, observation.signal)) {
+        return true;
+    }
+    const auto it = table->find({system, observation.signal});
+    if (it == table->end()) {
+        return true;
+    }
+    const std::string& obs_type = observation.exactBiasObservationType();
+    return obs_type.size() >= 3 && obs_type[2] == it->second;
 }
 
 GNSSSystem clockBiasGroup(GNSSSystem system) {
@@ -363,7 +544,8 @@ std::map<CarrierKey, PreparedCarrierObservation> prepareCarrierObservationsForRe
     const FGOProcessor::FGOConfig& config,
     double min_snr_dbhz,
     bool require_carrier_phase = true,
-    bool apply_elevation_mask = true) {
+    bool apply_elevation_mask = true,
+    const SecondaryCodeTable* secondary_code_table = nullptr) {
     std::map<CarrierKey, PreparedCarrierObservation> carriers;
     if (receiver_position.norm() <= 1e6) {
         return carriers;
@@ -376,7 +558,13 @@ std::map<CarrierKey, PreparedCarrierObservation> prepareCarrierObservationsForRe
 
     const double min_elevation_rad = config.min_elevation_deg * M_PI / 180.0;
     for (const auto& observation : epoch.observations) {
-        if (!isPrimaryFgoSignal(observation.signal, config.use_multi_constellation)) {
+        if (!isEligibleFgoSignal(observation.satellite,
+                                 observation.signal,
+                                 config.use_multi_constellation,
+                                 config.use_multi_frequency_double_difference)) {
+            continue;
+        }
+        if (!passesSecondaryCodeAlignment(observation, secondary_code_table)) {
             continue;
         }
         const bool has_carrier_phase =
@@ -576,6 +764,18 @@ Observation interpolateObservation(const Observation& lower,
         lower.has_glonass_frequency_channel &&
         upper.has_glonass_frequency_channel &&
         lower.glonass_frequency_channel == upper.glonass_frequency_channel;
+    // MF hygiene: never blend two different observation codes of the same
+    // band across the interpolation boundary (e.g. BDS B2I C7D at t0 and C7I
+    // at t1) -- the blend would carry an inter-code bias under a single code
+    // label. Secondary bands only, so the single-frequency (primary band)
+    // path is bit-identical.
+    if (signal_policy::isSecondarySignal(lower.satellite.system, lower.signal) &&
+        (lower.pseudorange_observation_type !=
+             upper.pseudorange_observation_type ||
+         lower.carrier_phase_observation_type !=
+             upper.carrier_phase_observation_type)) {
+        interpolated.valid = false;
+    }
     return interpolated;
 }
 
@@ -699,6 +899,18 @@ FGOProcessor::FGOProblem FGOProcessor::buildPseudorangeProblem(
         return problem;
     }
 
+    // MF hygiene: one observation code per (system, secondary band) for this
+    // receiver (cssrlib/RTKLIB-style). Only meaningful when secondary bands
+    // are ingested at all.
+    SecondaryCodeTable rover_secondary_codes;
+    const SecondaryCodeTable* rover_secondary_codes_ptr = nullptr;
+    if (config_.use_multi_frequency_double_difference &&
+        config_.use_double_difference_secondary_code_alignment &&
+        config_.use_multi_constellation) {
+        rover_secondary_codes = buildSecondaryCodeTable(input_epochs);
+        rover_secondary_codes_ptr = &rover_secondary_codes;
+    }
+
     ProcessorConfig spp_processor_config;
     spp_processor_config.mode = PositioningMode::SPP;
     spp_processor_config.elevation_mask = config_.min_elevation_deg;
@@ -762,7 +974,14 @@ FGOProcessor::FGOProblem FGOProcessor::buildPseudorangeProblem(
         ecef2geodetic(seed.position_ecef, receiver_lat, receiver_lon, receiver_height);
 
         for (const auto& observation : epoch.observations) {
-            if (!isPrimaryFgoSignal(observation.signal, config_.use_multi_constellation)) {
+            if (!isEligibleFgoSignal(observation.satellite,
+                                     observation.signal,
+                                     config_.use_multi_constellation,
+                                     config_.use_multi_frequency_double_difference)) {
+                continue;
+            }
+            if (!passesSecondaryCodeAlignment(observation,
+                                              rover_secondary_codes_ptr)) {
                 continue;
             }
             if (!observation.valid || !observation.has_pseudorange ||
@@ -1258,6 +1477,17 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
         }
     }
 
+    // MF hygiene: the base receiver gets its own per-(system, secondary band)
+    // code table, mirroring the rover-side table in buildPseudorangeProblem.
+    SecondaryCodeTable base_secondary_codes;
+    const SecondaryCodeTable* base_secondary_codes_ptr = nullptr;
+    if (config_.use_multi_frequency_double_difference &&
+        config_.use_double_difference_secondary_code_alignment &&
+        config_.use_multi_constellation) {
+        base_secondary_codes = buildSecondaryCodeTable(base_epochs);
+        base_secondary_codes_ptr = &base_secondary_codes;
+    }
+
     std::size_t base_cursor = 0;
     const double match_tolerance = std::max(0.0, config_.base_epoch_match_tolerance_s);
     const double pseudorange_sigma =
@@ -1340,7 +1570,8 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
                 config_,
                 base_min_snr_dbhz,
                 true,
-                false);
+                false,
+                base_secondary_codes_ptr);
         const auto base_pseudorange_observations =
             prepareCarrierObservationsForReceiver(
                 matched_base_epoch,
@@ -1349,7 +1580,8 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
                 config_,
                 base_min_snr_dbhz,
                 false,
-                false);
+                false,
+                base_secondary_codes_ptr);
         const auto base_reference_observations =
             prepareCarrierObservationsForReceiver(
                 matched_base_epoch,
@@ -1358,7 +1590,8 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
                 config_,
                 reference_min_snr_dbhz,
                 false,
-                false);
+                false,
+                base_secondary_codes_ptr);
         if (rover_pseudorange_it != rover_pseudoranges_by_epoch.end()) {
             for (const auto* rover_factor : rover_pseudorange_it->second) {
                 const CarrierKey key{rover_factor->satellite,
@@ -1489,8 +1722,16 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
                      base_satellite.corrected_pseudorange_m) -
                     (reference->corrected_pseudorange_m -
                      base_reference.corrected_pseudorange_m);
+                const double pseudorange_band_scale =
+                    signal_policy::isSecondarySignal(satellite->satellite.system,
+                                                     satellite->signal)
+                        ? std::max(1.0,
+                                   config_
+                                       .double_difference_secondary_pseudorange_sigma_scale)
+                        : 1.0;
                 pseudorange_factor.sigma_m =
-                    pseudorange_sigma / satellite_sqrt_sin_el;
+                    pseudorange_band_scale * pseudorange_sigma /
+                    satellite_sqrt_sin_el;
                 pseudorange_factor.elevation_rad = satellite->elevation_rad;
                 pseudorange_factor.rover_satellite_model =
                     satellite->model_debug;
@@ -1576,7 +1817,15 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
                      base_satellite.corrected_carrier_m) -
                     (reference->corrected_carrier_m -
                      base_reference.corrected_carrier_m);
-                factor.sigma_m = carrier_sigma / satellite_sqrt_sin_el;
+                const double carrier_band_scale =
+                    signal_policy::isSecondarySignal(satellite->satellite.system,
+                                                     satellite->signal)
+                        ? std::max(1.0,
+                                   config_
+                                       .double_difference_secondary_carrier_sigma_scale)
+                        : 1.0;
+                factor.sigma_m =
+                    carrier_band_scale * carrier_sigma / satellite_sqrt_sin_el;
                 factor.elevation_rad = satellite->elevation_rad;
                 factor.rover_satellite_model = satellite->model_debug;
                 factor.rover_reference_model = reference->model_debug;

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -478,6 +478,22 @@ struct FixedAmbiguityConstraint {
 
 using CarrierKey = std::pair<SatelliteId, SignalType>;
 
+// --- Code-Minus-Carrier (CMC) multipath screening state ---
+//
+// Port of inuex35's preprocess/slip_detect.py per-(satellite, signal) CMC
+// tracking (see FGOConfig::use_code_minus_carrier_screening for the full
+// semantics). Kept as function-local state in buildDoubleDifferenceProblem
+// (like active_dd_segments below) rather than a FGOProcessor member: one
+// build call processes one ordered epoch stream, and buildDoubleDifference-
+// Problem is const.
+struct CmcState {
+    bool has_prev = false;
+    double prev_cmc_m = 0.0;
+    bool has_baseline = false;
+    double baseline_m = 0.0;
+    int warmup_count = 0;
+};
+
 struct DoubleDifferenceAmbiguityKey {
     SatelliteId satellite;
     SatelliteId reference_satellite;
@@ -1504,6 +1520,18 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
     std::map<SingleDifferenceDefaultReferenceKey, std::map<SatelliteId, std::size_t>>
         sd_default_reference_counts;
 
+    // --- CMC screening state (function-scope, persists across the epoch
+    // loop below; see FGOConfig::use_code_minus_carrier_screening). ---
+    std::map<CarrierKey, CmcState> cmc_states;
+    // Last rover-side (single-receiver) ambiguity_index seen per (satellite,
+    // signal); a change here (cycle slip / loss-of-lock / outage causing the
+    // rover carrier arc in buildPseudorangeProblem to restart) is this port's
+    // signal to also reset the CMC baseline for that key (deviation from the
+    // reference documented on the config knob).
+    std::map<CarrierKey, std::size_t> cmc_last_rover_ambiguity_index;
+    std::size_t cmc_jump_reset_total = 0;
+    std::size_t cmc_level_exclusion_total = 0;
+
     for (std::size_t epoch_index = 0; epoch_index < problem.epochs.size(); ++epoch_index) {
         const auto rover_it = rover_carriers_by_epoch.find(epoch_index);
         const auto rover_pseudorange_it =
@@ -1592,6 +1620,93 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
                 false,
                 false,
                 base_secondary_codes_ptr);
+
+        // --- CMC screening pre-pass (this epoch) ---
+        //
+        // Runs once per (satellite, signal) that has usable carrier at BOTH
+        // rover and base this epoch (same requirement as the reference:
+        // pr/cp nonzero on both sides), independent of which satellite ends
+        // up the DD reference for its (system, signal) group below. Results
+        // gate the PR-factor loop (level exclusion, which -- because the CP
+        // loop only builds a factor when a matching PR factor already exists
+        // -- transitively also excludes the CP factor for the same epoch,
+        // matching the reference's single `continue` before either) and the
+        // CP loop's ambiguity-arc bookkeeping (jump forces a new arc).
+        std::set<CarrierKey> cmc_level_exclude_this_epoch;
+        std::set<CarrierKey> cmc_jump_reset_this_epoch;
+        if (config_.use_code_minus_carrier_screening &&
+            rover_it != rover_carriers_by_epoch.end()) {
+            for (const auto* rover_factor : rover_it->second) {
+                const CarrierKey key{rover_factor->satellite, rover_factor->signal};
+                const auto base_it = base_carriers.find(key);
+                if (base_it == base_carriers.end()) {
+                    continue;
+                }
+                const auto& base_carrier = base_it->second;
+                const double pr_rover = rover_factor->model_debug.raw_pseudorange_m;
+                const double cp_rover = rover_factor->model_debug.raw_carrier_m;
+                const double pr_base = base_carrier.model_debug.raw_pseudorange_m;
+                const double cp_base = base_carrier.model_debug.raw_carrier_m;
+                if (pr_rover == 0.0 || cp_rover == 0.0 || pr_base == 0.0 ||
+                    cp_base == 0.0) {
+                    continue;
+                }
+                const double cmc = (pr_rover - pr_base) - (cp_rover - cp_base);
+
+                // Deviation from the reference: any rover-side arc restart
+                // (cycle slip / loss-of-lock / outage -- surfaced here as a
+                // change in the rover carrier's own ambiguity_index) resets
+                // this key's CMC baseline/prev/warmup state, since CMC
+                // embeds a -wavelength*N term that a new ambiguity
+                // invalidates.
+                const auto last_arc_it =
+                    cmc_last_rover_ambiguity_index.find(key);
+                const bool rover_arc_restarted =
+                    last_arc_it == cmc_last_rover_ambiguity_index.end() ||
+                    last_arc_it->second != rover_factor->ambiguity_index;
+                cmc_last_rover_ambiguity_index[key] = rover_factor->ambiguity_index;
+
+                CmcState& state = cmc_states[key];
+                if (rover_arc_restarted) {
+                    state = CmcState{};
+                } else if (state.has_prev &&
+                           std::abs(cmc - state.prev_cmc_m) >
+                               config_.code_minus_carrier_jump_threshold_m) {
+                    cmc_jump_reset_this_epoch.insert(key);
+                    ++cmc_jump_reset_total;
+                    // Same reasoning as above: the jump itself is a fresh
+                    // arc from this epoch on, so the baseline resets too.
+                    state = CmcState{};
+                }
+
+                state.prev_cmc_m = cmc;
+                state.has_prev = true;
+
+                const double level_threshold =
+                    config_.code_minus_carrier_level_threshold_m;
+                if (level_threshold > 0.0) {
+                    if (!state.has_baseline) {
+                        state.baseline_m = cmc;
+                        state.warmup_count = 1;
+                        state.has_baseline = true;
+                    } else if (state.warmup_count <
+                               config_.code_minus_carrier_warmup_epochs) {
+                        state.baseline_m =
+                            (state.baseline_m * state.warmup_count + cmc) /
+                            (state.warmup_count + 1);
+                        ++state.warmup_count;
+                    } else if (std::abs(cmc - state.baseline_m) > level_threshold) {
+                        cmc_level_exclude_this_epoch.insert(key);
+                        ++cmc_level_exclusion_total;
+                    } else {
+                        const double alpha = config_.code_minus_carrier_baseline_alpha;
+                        state.baseline_m =
+                            (1.0 - alpha) * state.baseline_m + alpha * cmc;
+                    }
+                }
+            }
+        }
+
         if (rover_pseudorange_it != rover_pseudoranges_by_epoch.end()) {
             for (const auto* rover_factor : rover_pseudorange_it->second) {
                 const CarrierKey key{rover_factor->satellite,
@@ -1691,6 +1806,15 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
                     continue;
                 }
                 const CarrierKey satellite_key{satellite->satellite, satellite->signal};
+                if (cmc_level_exclude_this_epoch.count(satellite_key) > 0) {
+                    // Sustained CMC multipath this epoch: skip the DD
+                    // pseudorange factor. The CP loop below only builds a
+                    // carrier factor when it finds a matching entry in
+                    // pseudorange_factors_by_key, so omitting the PR factor
+                    // here transitively excludes the CP factor too (matches
+                    // the reference's single `continue` before either).
+                    continue;
+                }
                 const auto base_satellite_it =
                     base_pseudorange_observations.find(satellite_key);
                 if (base_satellite_it == base_pseudorange_observations.end()) {
@@ -1861,6 +1985,13 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
                         (max_segment_gap > 0.0 && dt > max_segment_gap)) {
                         start_new_segment = true;
                     }
+                }
+                if (cmc_jump_reset_this_epoch.count(
+                        CarrierKey{satellite->satellite, satellite->signal}) > 0) {
+                    // CMC jump: force the same arc break the loss-of-lock /
+                    // gap checks above already perform (multipath jump
+                    // breaks the integer ambiguity).
+                    start_new_segment = true;
                 }
 
                 if (start_new_segment) {
@@ -2112,6 +2243,10 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
         }
     }
 
+    problem.diagnostics.code_minus_carrier_jump_resets = cmc_jump_reset_total;
+    problem.diagnostics.code_minus_carrier_level_exclusions =
+        cmc_level_exclusion_total;
+
     return problem;
 }
 
@@ -2167,6 +2302,10 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
         problem.diagnostics.double_difference_rejected_no_base_epoch;
     result.diagnostics.double_difference_rejected_no_reference =
         problem.diagnostics.double_difference_rejected_no_reference;
+    result.diagnostics.code_minus_carrier_jump_resets =
+        problem.diagnostics.code_minus_carrier_jump_resets;
+    result.diagnostics.code_minus_carrier_level_exclusions =
+        problem.diagnostics.code_minus_carrier_level_exclusions;
 
     if (problem.epochs.empty() ||
         (problem.pseudorange_factors.empty() &&

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -62,7 +62,10 @@
 #include <limits>
 #include <map>
 #include <numeric>
+#include <optional>
 #include <set>
+#include <tuple>
+#include <utility>
 #include <vector>
 
 namespace libgnss {
@@ -766,6 +769,118 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
     // apply_per_sat_residual_gate keeps them out of the LAMBDA tree).
     std::set<SatelliteId> gate_bad_sats;
 
+    // --- Sat-badness EWMA down-weighting state (FGOConfig::
+    // use_sat_badness_downweight; port of the inuex35 reference's
+    // preprocess/sat_quality.py SatQualityState). See use_sat_badness_
+    // downweight's comment in fgo.hpp for the full behavioural summary and
+    // deviations (cppr substitution, satellite identity, el/snr wiring,
+    // pair-update gating). All maps are no-ops (never populated, never
+    // read) whenever the master switch is off.
+    //
+    // last_ddpr_per_sat: snapshot of this epoch's (pre-FDE) per_sat_res,
+    // taken once per epoch below and read by the NEXT epoch's DD factor
+    // build for the res_s term -- reference tc._last_main_ddpr_per_sat /
+    // _mres_signals.per_sat, which is likewise set from main_ddpr_residuals'
+    // per-sat map and consumed one epoch later at factor-build time.
+    std::map<SatelliteId, double> sb_last_ddpr_per_sat;
+    std::map<SatelliteId, double> sb_obsq_ewma;
+    std::map<SatelliteId, int> sb_obsq_bad_streak;
+    std::map<SatelliteId, double> sb_recent_worst;
+    std::map<SatelliteId, double> sb_recent_cppr;
+    std::map<SatelliteId, double> sb_recent_ref_bad;
+    std::map<std::tuple<SatelliteId, SatelliteId, SignalType>, double> sb_recent_pair_bad;
+    std::map<SatelliteId, double> sb_latest_el_deg;
+    std::map<SatelliteId, double> sb_latest_snr_dbhz;
+    // Deviation (see fgo.hpp): substitute for the reference's unported
+    // CP-vs-PR innovation-consistency reject counter (rejc_cp_pr). Persistent
+    // per-(satellite, signal) count of THIS backend's own FDE carrier
+    // rejections; never reset (no analogue of the reference's unported
+    // cp_pr_rejc_max wipe). Structurally empty/0 whenever use_fde is off.
+    std::map<std::pair<SatelliteId, SignalType>, int> sb_fde_cp_reject_count;
+
+    // Continuous per-(reference, target, signal) badness score (0 when the
+    // master switch is off). `ref_sat` non-null adds the directional-pair
+    // term (only when sat_badness_alpha_recent_pair > 0 -- see fgo.hpp
+    // deviation 5). Mirrors SatQualityState.sat_badness() term-for-term.
+    auto satBadness = [&](SatelliteId sat_id, SignalType freq,
+                          const SatelliteId* ref_sat) -> double {
+        if (!config.use_sat_badness_downweight) return 0.0;
+        const double ddpr_thr = std::max(1e-6, config.sat_badness_ddpr_threshold_m);
+        const int cppr_thr = std::max(1, config.sat_badness_cppr_threshold);
+        const double alpha_ddpr = std::max(0.0, config.sat_badness_alpha_ddpr);
+        const double alpha_cppr = std::max(0.0, config.sat_badness_alpha_cppr);
+        const double alpha_recent_cppr = std::max(0.0, config.sat_badness_alpha_recent_cppr);
+        const double alpha_recent_worst = std::max(0.0, config.sat_badness_alpha_recent_worst);
+        const double alpha_recent_ref = std::max(0.0, config.sat_badness_alpha_recent_ref);
+        const double alpha_recent_pair = std::max(0.0, config.sat_badness_alpha_recent_pair);
+        const double alpha_obsq_ewma = std::max(0.0, config.sat_badness_alpha_obsq_ewma);
+        const double alpha_obsq_streak = std::max(0.0, config.sat_badness_alpha_obsq_streak);
+        const double alpha_el = std::max(0.0, config.sat_badness_alpha_el);
+        const double alpha_snr = std::max(0.0, config.sat_badness_alpha_snr);
+        const double obsq_thr = std::max(1e-6, config.sat_badness_obsq_res_threshold_m);
+        const int obsq_streak_cap = std::max(1, config.sat_badness_obsq_bad_streak_cap);
+        const double el_ref_deg = std::max(1.0, config.sat_badness_el_ref_deg);
+        const double snr_ref_dbhz = config.sat_badness_snr_ref_dbhz;
+        const double snr_span_db = std::max(1.0, config.sat_badness_snr_span_db);
+
+        double score = 0.0;
+        {
+            const auto it = sb_last_ddpr_per_sat.find(sat_id);
+            const double res_s = it != sb_last_ddpr_per_sat.end() ? it->second : 0.0;
+            if (res_s > 0.0) score += alpha_ddpr * (res_s / ddpr_thr);
+        }
+        {
+            const auto it = sb_fde_cp_reject_count.find(std::make_pair(sat_id, freq));
+            const int cppr = it != sb_fde_cp_reject_count.end() ? it->second : 0;
+            if (cppr > 0) score += alpha_cppr * (static_cast<double>(cppr) / cppr_thr);
+        }
+        {
+            const auto it = sb_recent_cppr.find(sat_id);
+            const double q = it != sb_recent_cppr.end() ? it->second : 0.0;
+            if (q > 0.0) score += alpha_recent_cppr * (q / cppr_thr);
+        }
+        {
+            const auto it = sb_recent_worst.find(sat_id);
+            const double q = it != sb_recent_worst.end() ? it->second : 0.0;
+            if (q > 0.0) score += alpha_recent_worst * q;
+        }
+        {
+            const auto it = sb_recent_ref_bad.find(sat_id);
+            const double q = it != sb_recent_ref_bad.end() ? it->second : 0.0;
+            if (q > 0.0) score += alpha_recent_ref * q;
+        }
+        if (ref_sat != nullptr && alpha_recent_pair > 0.0) {
+            const auto it = sb_recent_pair_bad.find(std::make_tuple(*ref_sat, sat_id, freq));
+            const double q = it != sb_recent_pair_bad.end() ? it->second : 0.0;
+            if (q > 0.0) score += alpha_recent_pair * q;
+        }
+        {
+            const auto it = sb_obsq_ewma.find(sat_id);
+            const double q = it != sb_obsq_ewma.end() ? it->second : 0.0;
+            if (q > 0.0) score += alpha_obsq_ewma * (q / obsq_thr);
+        }
+        {
+            const auto it = sb_obsq_bad_streak.find(sat_id);
+            const int streak = std::min(obsq_streak_cap, it != sb_obsq_bad_streak.end() ? it->second : 0);
+            if (streak > 0) {
+                score += alpha_obsq_streak * (static_cast<double>(streak) / obsq_streak_cap);
+            }
+        }
+        if (alpha_el > 0.0) {
+            const auto it = sb_latest_el_deg.find(sat_id);
+            const double el_deg = it != sb_latest_el_deg.end() ? it->second : 90.0;
+            const double penalty = std::max(0.0, std::min(1.0, (el_ref_deg - el_deg) / el_ref_deg));
+            score += alpha_el * penalty;
+        }
+        if (alpha_snr > 0.0) {
+            const auto it = sb_latest_snr_dbhz.find(sat_id);
+            const double snr = it != sb_latest_snr_dbhz.end() ? it->second : snr_ref_dbhz;
+            const double penalty = std::max(0.0, std::min(1.0, (snr_ref_dbhz - snr) / snr_span_db));
+            score += alpha_snr * penalty;
+        }
+        return std::max(0.0, score);
+    };
+
     // --- CP-hold / sanity FSM state (use_cp_hold_recovery) ---
     //
     // Arc-regeneration overlay: our front-end (fgo.cpp) statically assigns one
@@ -1100,6 +1215,15 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 ++result.diagnostics.ambiguity_generation_bumps;
                 live_ambiguity_indices.erase(amb_idx);
                 if (rejected_ambiguity_indices) rejected_ambiguity_indices->insert(amb_idx);
+                // Sat-badness cppr substitute (see fgo.hpp deviation 1): count
+                // this FDE carrier reject against the arc's physical
+                // (satellite, signal) identity. Cheap and harmless when the
+                // master switch is off; only actually consumed by satBadness()
+                // when config.use_sat_badness_downweight is true.
+                if (amb_idx < problem.ambiguity_states.size()) {
+                    const auto& amb = problem.ambiguity_states[amb_idx];
+                    ++sb_fde_cp_reject_count[std::make_pair(amb.satellite, amb.signal)];
+                }
             }
 
             gtsam::FactorIndices remove_indices;
@@ -1341,7 +1465,25 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 Point3(factor.base_satellite_position_ecef),
                 Point3(factor.base_reference_position_ecef),
                 Point3(factor.base_position_ecef)};
-            const auto noise = makeNoise(factor.sigma_m, robust,
+            // Sat-badness sigma inflation (FGOConfig::use_sat_badness_downweight;
+            // port of factors.py's _add_ddpr_factor): bad_pair = max badness of
+            // the pair's two satellites, computed from the PREVIOUS epoch's
+            // quality state (see satBadness()/sb_last_ddpr_per_sat above), then
+            // inflates the base sigma BEFORE robust-loss wrapping -- mirrors the
+            // reference's base noise -> scale -> robust-wrap order exactly.
+            double pr_sigma = factor.sigma_m;
+            if (config.use_sat_badness_downweight) {
+                const double bad_pair = std::max(
+                    satBadness(factor.reference_satellite, factor.signal, nullptr),
+                    satBadness(factor.satellite, factor.signal, &factor.reference_satellite));
+                result.diagnostics.sat_badness_max_score_seen =
+                    std::max(result.diagnostics.sat_badness_max_score_seen, bad_pair);
+                if (config.sat_badness_pseudorange_sigma_scale > 0.0 && bad_pair > 0.0) {
+                    pr_sigma *= (1.0 + config.sat_badness_pseudorange_sigma_scale * bad_pair);
+                    ++result.diagnostics.sat_badness_downweighted_factors;
+                }
+            }
+            const auto noise = makeNoise(pr_sigma, robust,
                                          config.pseudorange_huber_threshold_sigma);
             const std::size_t local_idx = new_factors.size();
             new_factors.emplace_shared<gtsam::DoubleDifferencePseudorangeFactorArm>(
@@ -1431,7 +1573,23 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 Point3(factor.base_satellite_position_ecef),
                 Point3(factor.base_reference_position_ecef),
                 Point3(factor.base_position_ecef)};
-            const auto noise = makeNoise(factor.sigma_m, robust,
+            // Sat-badness sigma inflation (port of factors.py's
+            // _compute_cp_sigma; the ddcp_res_weight_* block further down in
+            // the reference is a separate, unported mechanism -- out of
+            // scope). Same bad_pair formula as the DD PR site above.
+            double cp_sigma = factor.sigma_m;
+            if (config.use_sat_badness_downweight) {
+                const double bad_pair = std::max(
+                    satBadness(factor.reference_satellite, factor.signal, nullptr),
+                    satBadness(factor.satellite, factor.signal, &factor.reference_satellite));
+                result.diagnostics.sat_badness_max_score_seen =
+                    std::max(result.diagnostics.sat_badness_max_score_seen, bad_pair);
+                if (config.sat_badness_carrier_sigma_scale > 0.0 && bad_pair > 0.0) {
+                    cp_sigma *= (1.0 + config.sat_badness_carrier_sigma_scale * bad_pair);
+                    ++result.diagnostics.sat_badness_downweighted_factors;
+                }
+            }
+            const auto noise = makeNoise(cp_sigma, robust,
                                          config.carrier_phase_huber_threshold_sigma);
             const std::size_t cp_local_idx = new_factors.size();
             new_factors.emplace_shared<gtsam::DoubleDifferenceCarrierPhaseFactorArm>(
@@ -1724,11 +1882,18 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
         // (use_cp_hold_recovery) below -- the two features are independent
         // knobs but share this one (possibly expensive) residual pass. ---
         const bool need_ddpr_residuals =
-            config.use_epoch_quality_gates || config.use_cp_hold_recovery;
+            config.use_epoch_quality_gates || config.use_cp_hold_recovery ||
+            config.use_sat_badness_downweight;
         int nsat = 0;
         double gdop = std::numeric_limits<double>::infinity();
         double ddpr_rms = 0.0;
         std::map<SatelliteId, double> per_sat_res;
+        // Per-(ref, target, signal) residual rows, only collected when the
+        // sat-badness pair term is actually active (fgo.hpp deviation 5) --
+        // feeds update_pair_quality below.
+        const bool collect_pair_rows =
+            config.use_sat_badness_downweight && config.sat_badness_alpha_recent_pair > 0.0;
+        std::vector<std::tuple<SatelliteId, SatelliteId, SignalType, double>> sb_pair_rows;
         if (need_ddpr_residuals) {
             const Point3 ant_p = antennaOf(pose_i);
             const Vector3d ant(ant_p.x(), ant_p.y(), ant_p.z());
@@ -1778,8 +1943,150 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 worst = std::max(worst, res);
                 double& worst_ref = per_sat_res[fp->reference_satellite];
                 worst_ref = std::max(worst_ref, res);
+                if (collect_pair_rows) {
+                    sb_pair_rows.emplace_back(fp->reference_satellite, fp->satellite,
+                                              fp->signal, res);
+                }
             }
             ddpr_rms = res_n > 0 ? std::sqrt(res_sq_sum / static_cast<double>(res_n)) : 0.0;
+        }
+
+        // --- Sat-badness EWMA down-weighting: per-epoch state update
+        // (FGOConfig::use_sat_badness_downweight; port of the reference's
+        // update_reference_quality / update_observation_quality /
+        // update_pair_quality, called once per epoch directly off THIS
+        // epoch's pre-FDE per_sat_res -- same ordering as the reference's
+        // stage.py _compute_postfit_diagnostics, which calls these BEFORE
+        // apply_fde). ---
+        if (config.use_sat_badness_downweight) {
+            constexpr double kRadToDegSb = 180.0 / 3.14159265358979323846;
+
+            // (a) update_reference_quality: decay/update recent_ref_bad for
+            // every DISTINCT reference satellite backing this epoch's DD
+            // pseudorange factors (the reference selects one ref per
+            // (system, signal) group; only the set of currently-active refs
+            // matters here, not the group key itself).
+            {
+                const double decay = std::min(1.0, std::max(0.0, config.sat_badness_recent_ref_decay));
+                const double thr = std::max(1e-6, config.sat_badness_obsq_res_threshold_m);
+                std::set<SatelliteId> active_refs;
+                for (const auto* fp : pr_by_epoch[i]) active_refs.insert(fp->reference_satellite);
+                for (SatelliteId r : active_refs) {
+                    const double prev = sb_recent_ref_bad.count(r) ? sb_recent_ref_bad[r] : 0.0;
+                    const auto it = per_sat_res.find(r);
+                    const double res = it != per_sat_res.end() ? it->second : 0.0;
+                    const double incr = res > 0.0 ? std::min(2.0, res / thr) : 0.0;
+                    sb_recent_ref_bad[r] = decay * prev + incr;
+                }
+                for (auto& [sid, v] : sb_recent_ref_bad) {
+                    if (!active_refs.count(sid)) v = decay * v;
+                }
+            }
+
+            // (b) update_observation_quality: per-sat EWMA/streak (hard reset
+            // -- not decay -- for sats not seen this epoch), recent_worst /
+            // recent_cppr decay, and latest el/snr snapshot.
+            std::optional<SatelliteId> worst_sat;
+            {
+                const double alpha = std::min(1.0, std::max(0.0, config.sat_badness_obsq_ewma_alpha));
+                const double thr_obsq = config.sat_badness_obsq_bad_streak_threshold_m;
+                const double worst_decay = std::min(1.0, std::max(0.0, config.sat_badness_recent_worst_decay));
+                const double cppr_decay = std::min(1.0, std::max(0.0, config.sat_badness_recent_cppr_decay));
+
+                std::set<SatelliteId> seen;
+                double worst_val = -1.0;
+                for (const auto& [sid, rmax] : per_sat_res) {
+                    seen.insert(sid);
+                    const double prev = sb_obsq_ewma.count(sid) ? sb_obsq_ewma[sid] : 0.0;
+                    sb_obsq_ewma[sid] = prev <= 0.0 ? rmax : ((1.0 - alpha) * prev + alpha * rmax);
+                    if (rmax > thr_obsq) {
+                        sb_obsq_bad_streak[sid] = (sb_obsq_bad_streak.count(sid) ? sb_obsq_bad_streak[sid] : 0) + 1;
+                    } else {
+                        sb_obsq_bad_streak[sid] = 0;
+                    }
+                    if (rmax > worst_val) {
+                        worst_val = rmax;
+                        worst_sat = sid;
+                    }
+                }
+                for (auto& [sid, v] : sb_obsq_ewma) {
+                    if (!seen.count(sid)) v = 0.0;
+                }
+                for (auto& [sid, v] : sb_obsq_bad_streak) {
+                    if (!seen.count(sid)) v = 0;
+                }
+
+                // recent_cppr's "this epoch" input: our FDE-substitute reject
+                // count as of THIS point in the pipeline (i.e. as of the end
+                // of the LAST epoch FDE actually ran -- FDE for THIS epoch
+                // runs later, below), maxed across signal for each satellite
+                // (mirrors gate.py's sat_cppr_sat: max over freq of
+                // rejc_cp_pr). See fgo.hpp deviation 1.
+                std::map<SatelliteId, double> cppr_this_epoch;
+                for (const auto& [key, cnt] : sb_fde_cp_reject_count) {
+                    double& v = cppr_this_epoch[key.first];
+                    v = std::max(v, static_cast<double>(cnt));
+                }
+
+                std::set<SatelliteId> active_sats(seen);
+                if (worst_sat) active_sats.insert(*worst_sat);
+                for (const auto& [sid, v] : cppr_this_epoch) {
+                    (void)v;
+                    active_sats.insert(sid);
+                }
+
+                for (SatelliteId sid : active_sats) {
+                    const double prev_w = sb_recent_worst.count(sid) ? sb_recent_worst[sid] : 0.0;
+                    const double is_worst = (worst_sat && *worst_sat == sid) ? 1.0 : 0.0;
+                    sb_recent_worst[sid] = worst_decay * prev_w + is_worst;
+
+                    const double prev_c = sb_recent_cppr.count(sid) ? sb_recent_cppr[sid] : 0.0;
+                    const double cppr_cur = cppr_this_epoch.count(sid) ? cppr_this_epoch[sid] : 0.0;
+                    sb_recent_cppr[sid] = cppr_decay * prev_c + cppr_cur;
+                }
+                for (auto& [sid, v] : sb_recent_worst) {
+                    if (!active_sats.count(sid)) v = worst_decay * v;
+                }
+                for (auto& [sid, v] : sb_recent_cppr) {
+                    if (!active_sats.count(sid)) v = cppr_decay * v;
+                }
+
+                // Latest elevation/SNR: only entries observed THIS epoch are
+                // updated (reference: latest_el_deg/latest_snr_dbhz retain
+                // their last-seen value for sats absent this epoch).
+                for (const auto* fp : pr_by_epoch[i]) {
+                    sb_latest_el_deg[fp->satellite] = fp->elevation_rad * kRadToDegSb;
+                    sb_latest_el_deg[fp->reference_satellite] =
+                        fp->rover_reference_model.elevation_rad * kRadToDegSb;
+                    sb_latest_snr_dbhz[fp->satellite] = fp->rover_satellite_model.snr_dbhz;
+                    sb_latest_snr_dbhz[fp->reference_satellite] =
+                        fp->rover_reference_model.snr_dbhz;
+                }
+            }
+
+            // (c) update_pair_quality: gated on the alpha itself (fgo.hpp
+            // deviation 5) -- the reference profile ships alpha_recent_pair
+            // at 0.0, contributing nothing.
+            if (collect_pair_rows) {
+                const double decay = std::min(1.0, std::max(0.0, config.sat_badness_recent_pair_decay));
+                const double thr = std::max(1e-6, config.sat_badness_obsq_res_threshold_m);
+                std::set<std::tuple<SatelliteId, SatelliteId, SignalType>> seen_pairs;
+                for (const auto& [ref, sat, freq, res] : sb_pair_rows) {
+                    const auto key = std::make_tuple(ref, sat, freq);
+                    seen_pairs.insert(key);
+                    const double prev = sb_recent_pair_bad.count(key) ? sb_recent_pair_bad[key] : 0.0;
+                    const double incr = res > 0.0 ? std::min(2.0, res / thr) : 0.0;
+                    sb_recent_pair_bad[key] = decay * prev + incr;
+                }
+                for (auto& [key, v] : sb_recent_pair_bad) {
+                    if (!seen_pairs.count(key)) v = decay * v;
+                }
+            }
+
+            // (d) Snapshot THIS epoch's (pre-FDE) per_sat_res as "last epoch"
+            // for the NEXT epoch's res_s term (reference: tc._mres_signals.
+            // per_sat, set from this same pre-FDE per_sat_res pass).
+            sb_last_ddpr_per_sat = per_sat_res;
         }
 
         // --- Per-epoch quality gates (port of the reference's gate.py /

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -1,0 +1,1940 @@
+// GTSAM backend for FGOProcessor::optimizeProblem (Phase 1, RTK/DD-focused).
+//
+// Consumes the exact same FGOProcessor::FGOProblem the native Eigen backend
+// (fgo.cpp) consumes and produces an equivalent FGOProcessor::FGOResult.
+// Everything in this file is compiled only when GNSSPP_HAS_GTSAM is defined
+// (see CMakeLists.txt: only added to gnss_lib_noopt when find_package(GTSAM)
+// succeeds), so no other translation unit needs to guard against a missing
+// GTSAM install.
+//
+// --- Observation-convention note (see docs/gtsam_backend_design.md risk #2) ---
+// gtsam::gnss::DoubleDifferenceData::observed() computes
+//     (rovRef - baseRef) - (rovTarget - baseTarget)
+// while libgnss's FGOProcessor::DoubleDifferencePseudorangeFactor stores
+//     observed_dd_pseudorange_m = (satellite_* - base_satellite_*)
+//                                - (reference_* - base_reference_*)
+// i.e. (target - reference), the mirror image of GTSAM's (ref - target).
+// Feeding libgnss's "satellite" (target) into GTSAM's "Ref" slot and
+// libgnss's "reference_satellite" into GTSAM's "Target" slot makes the two
+// conventions coincide exactly (verified by the runtime assertion below,
+// and by the DD carrier equivalent). The same swap applies to the ambiguity
+// keys of DoubleDifferenceCarrierPhaseFactor: GTSAM forms
+// lam*(ambRef - ambTarget); libgnss tracks a single lumped DD ambiguity
+// equal to lam*(N_target - N_reference). So ambRef <- the real ambiguity
+// node (seeded with libgnss's lumped value, in cycles) and ambTarget <- a
+// single shared dummy node pinned to 0 with a tight prior.
+
+#include <libgnss++/algorithms/fgo.hpp>
+#include <libgnss++/algorithms/lambda.hpp>
+#include <libgnss++/core/constants.hpp>
+#include <libgnss++/core/coordinates.hpp>
+
+#include <gtsam/geometry/Point3.h>
+#include <gtsam/geometry/Pose3.h>
+#include <gtsam/geometry/Rot3.h>
+#include <gtsam/inference/Symbol.h>
+#include <gtsam/linear/NoiseModel.h>
+#include <gtsam/navigation/CarrierPhaseFactor.h>
+#include <gtsam/navigation/CombinedImuFactor.h>
+#include <gtsam/navigation/GnssCommon.h>
+#include <gtsam/navigation/ImuBias.h>
+#include <gtsam/navigation/PreintegrationCombinedParams.h>
+#include <gtsam/navigation/NavState.h>
+#include <gtsam/navigation/PseudorangeFactor.h>
+#include <gtsam/nonlinear/IncrementalFixedLagSmoother.h>
+#include <gtsam/nonlinear/ISAM2.h>
+#include <gtsam/nonlinear/LevenbergMarquardtOptimizer.h>
+#include <gtsam/nonlinear/Marginals.h>
+#include <gtsam/nonlinear/NonlinearFactorGraph.h>
+#include <gtsam/nonlinear/PriorFactor.h>
+#include <gtsam/nonlinear/Values.h>
+#include <gtsam/slam/BetweenFactor.h>
+
+#include <algorithm>
+#include <cassert>
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <limits>
+#include <map>
+#include <numeric>
+#include <set>
+#include <vector>
+
+namespace libgnss {
+namespace {
+
+using gtsam::Point3;
+using gtsam::Pose3;
+using gtsam::Rot3;
+using gtsam::Symbol;
+using SharedNoise = gtsam::SharedNoiseModel;
+
+// Mirror of fgo.cpp's clockBiasGroup(): which receiver-clock group a system
+// belongs to. GPS+QZSS share one clock; every other constellation gets its own
+// inter-system-bias clock. This matches the per-constellation bias columns the
+// native Eigen backend forms when config.use_inter_system_biases is set.
+GNSSSystem clockBiasGroup(GNSSSystem system) {
+    switch (system) {
+        case GNSSSystem::GPS:
+        case GNSSSystem::QZSS:
+            return GNSSSystem::GPS;
+        case GNSSSystem::Galileo:
+        case GNSSSystem::BeiDou:
+        case GNSSSystem::GLONASS:
+        case GNSSSystem::NavIC:
+            return system;
+        default:
+            return GNSSSystem::UNKNOWN;
+    }
+}
+
+// Key spaces: 'x' rover position per epoch, 'c' receiver base-clock bias [s]
+// per epoch (the GPS/QZSS group), 'i' a GLOBAL (time-constant) inter-system
+// bias [s] per non-GPS constellation shared across every epoch -- matching the
+// native backend, which carries one bias column per constellation, not a fresh
+// clock each epoch, 'a' per-ambiguity node (cycles for DD, meters for
+// undifferenced), 'z' a single shared dummy ambiguity node pinned at 0.
+inline gtsam::Key positionKey(std::size_t epoch) { return Symbol('x', epoch); }
+inline gtsam::Key clockKey(std::size_t epoch) { return Symbol('c', epoch); }
+inline gtsam::Key isbKey(int group_ordinal) { return Symbol('i', group_ordinal); }
+inline gtsam::Key ambiguityKey(std::size_t index) { return Symbol('a', index); }
+inline gtsam::Key dummyAmbiguityKey() { return Symbol('z', 0); }
+// Milestone 2b IMU states: 'v' body velocity in nav (ENU), 'b' IMU bias, per epoch.
+inline gtsam::Key velocityKey(std::size_t epoch) { return Symbol('v', epoch); }
+inline gtsam::Key biasKey(std::size_t epoch) { return Symbol('b', epoch); }
+
+// ENU-from-ECEF rotation whose columns are the East/North/Up basis vectors
+// expressed in ECEF, i.e. ecef_vec = R_ecef_enu * enu_vec. Matches
+// core/coordinates.hpp enu2ecef(). Used to build the ecef_T_nav Pose3 that
+// the DD '...FactorArm' factors and the IMU factor share (nav = local ENU).
+inline gtsam::Rot3 ecefFromEnuRotation(double lat, double lon) {
+    const double sinlat = std::sin(lat), coslat = std::cos(lat);
+    const double sinlon = std::sin(lon), coslon = std::cos(lon);
+    gtsam::Matrix3 R;
+    R << -sinlon, -sinlat * coslon, coslat * coslon,
+          coslon, -sinlat * sinlon, coslat * sinlon,
+          0.0,     coslat,          sinlat;
+    return gtsam::Rot3(R);
+}
+
+// Stable small ordinal per clock group. GPS/QZSS are group 0 (the base clock,
+// no ISB node); every other constellation gets its own global ISB node. UNKNOWN
+// groups (SBAS etc.) fold into GPS(0). When inter-system biases are disabled
+// everything is group 0 (single base clock, no ISB), matching the native
+// backend with use_inter_system_biases=false.
+int clockGroupOrdinal(GNSSSystem group, bool use_inter_system_biases) {
+    if (!use_inter_system_biases) {
+        return 0;
+    }
+    switch (group) {
+        case GNSSSystem::GPS: return 0;
+        case GNSSSystem::Galileo: return 1;
+        case GNSSSystem::BeiDou: return 2;
+        case GNSSSystem::GLONASS: return 3;
+        case GNSSSystem::NavIC: return 4;
+        default: return 0;
+    }
+}
+
+// Plain-Euclidean geometric range and its 1x3 Jacobian w.r.t. the receiver.
+//
+// NOTE ON SAGNAC: the native backend earth-rotation-corrects each satellite
+// position at build time (earthRotationCorrected, using the seed position) and
+// then forms the pseudorange residual with a *plain* Euclidean norm. GTSAM's
+// gtsam::gnss::geodist would apply its OWN first-order Sagnac correction on top
+// of those already-corrected positions -- a double correction that biases the
+// undifferenced-pseudorange position solution by ~1 m on multi-GNSS data (it
+// mostly cancels in the double-difference, which is why the stock DD factors
+// still reach cm parity). So these undifferenced factors use a plain norm to
+// match the native backend exactly.
+inline double plainRange(const Point3& satellite, const Point3& receiver,
+                         gtsam::Matrix13* H_receiver) {
+    const Point3 delta = receiver - satellite;
+    const double range = delta.norm();
+    if (H_receiver) {
+        if (range > 0.0) {
+            *H_receiver = (delta / range).transpose();
+        } else {
+            H_receiver->setZero();
+        }
+    }
+    return range;
+}
+
+// Undifferenced pseudorange factor with a global inter-system bias node.
+//   error = ||rcv - sat|| + c*(baseClock + isb) - measuredPseudorange
+// Base clock is per epoch; isb is one global (time-constant) node per non-GPS
+// constellation -- mirroring the native backend's per-epoch clock + shared
+// per-constellation bias column.
+class PseudorangeFactorISB : public gtsam::NoiseModelFactorN<Point3, double, double> {
+    double measurement_ = 0.0;
+    Point3 satellite_position_{0, 0, 0};
+
+ public:
+    using Base = gtsam::NoiseModelFactorN<Point3, double, double>;
+    using Base::evaluateError;
+    PseudorangeFactorISB(gtsam::Key position, gtsam::Key base_clock, gtsam::Key isb,
+                         double measured_pseudorange, const Point3& satellite_position,
+                         const gtsam::SharedNoiseModel& model)
+        : Base(model, position, base_clock, isb),
+          measurement_(measured_pseudorange),
+          satellite_position_(satellite_position) {}
+
+    gtsam::Vector evaluateError(const Point3& position, const double& base_clock,
+                                const double& isb, gtsam::OptionalMatrixType H_position,
+                                gtsam::OptionalMatrixType H_base_clock,
+                                gtsam::OptionalMatrixType H_isb) const override {
+        gtsam::Matrix13 H_range;
+        const double range = plainRange(satellite_position_, position, H_position ? &H_range : nullptr);
+        const double error =
+            range + gtsam::gnss::C_LIGHT * (base_clock + isb) - measurement_;
+        if (H_position) {
+            *H_position = H_range;
+        }
+        if (H_base_clock) {
+            *H_base_clock = (gtsam::Matrix(1, 1) << gtsam::gnss::C_LIGHT).finished();
+        }
+        if (H_isb) {
+            *H_isb = (gtsam::Matrix(1, 1) << gtsam::gnss::C_LIGHT).finished();
+        }
+        return (gtsam::Vector(1) << error).finished();
+    }
+};
+
+// GPS/base-group undifferenced pseudorange factor (no ISB node).
+//   error = ||rcv - sat|| + c*baseClock - measuredPseudorange
+class PseudorangeFactorPlain : public gtsam::NoiseModelFactorN<Point3, double> {
+    double measurement_ = 0.0;
+    Point3 satellite_position_{0, 0, 0};
+
+ public:
+    using Base = gtsam::NoiseModelFactorN<Point3, double>;
+    using Base::evaluateError;
+    PseudorangeFactorPlain(gtsam::Key position, gtsam::Key base_clock,
+                           double measured_pseudorange, const Point3& satellite_position,
+                           const gtsam::SharedNoiseModel& model)
+        : Base(model, position, base_clock),
+          measurement_(measured_pseudorange),
+          satellite_position_(satellite_position) {}
+
+    gtsam::Vector evaluateError(const Point3& position, const double& base_clock,
+                                gtsam::OptionalMatrixType H_position,
+                                gtsam::OptionalMatrixType H_base_clock) const override {
+        gtsam::Matrix13 H_range;
+        const double range = plainRange(satellite_position_, position, H_position ? &H_range : nullptr);
+        const double error = range + gtsam::gnss::C_LIGHT * base_clock - measurement_;
+        if (H_position) {
+            *H_position = H_range;
+        }
+        if (H_base_clock) {
+            *H_base_clock = (gtsam::Matrix(1, 1) << gtsam::gnss::C_LIGHT).finished();
+        }
+        return (gtsam::Vector(1) << error).finished();
+    }
+};
+
+// --- Milestone 2a: Pose3 + lever-arm plumbing (docs/gtsam_backend_design.md) ---
+//
+// Undifferenced plain-norm pseudorange factors are Pose3 analogs of
+// PseudorangeFactorPlain/ISB above: same "no double Sagnac correction"
+// reasoning (the satellite position is already earth-rotation-corrected by
+// the native builder), just evaluated at the ANTENNA position derived from
+// a body Pose3 + lever arm via gtsam::gnss::LeverArm (antenna_ecef =
+// pose.translation() + pose.rotation() * leverArm, exactly the convention
+// used by the stock '...FactorArm' factors and by this project's own
+// Stage-1 ESKF, see fusion_measurement.cpp). GTSAM's navigation module has
+// no stock plain-norm Arm factor (only geodist-based ones), hence these.
+
+class PseudorangeFactorPlainArm : public gtsam::NoiseModelFactorN<Pose3, double> {
+    double measurement_ = 0.0;
+    Point3 satellite_position_{0, 0, 0};
+    gtsam::gnss::LeverArm arm_;
+
+ public:
+    using Base = gtsam::NoiseModelFactorN<Pose3, double>;
+    using Base::evaluateError;
+    PseudorangeFactorPlainArm(gtsam::Key pose, gtsam::Key base_clock,
+                              double measured_pseudorange, const Point3& satellite_position,
+                              const gtsam::gnss::LeverArm& arm,
+                              const gtsam::SharedNoiseModel& model)
+        : Base(model, pose, base_clock),
+          measurement_(measured_pseudorange),
+          satellite_position_(satellite_position),
+          arm_(arm) {}
+
+    gtsam::Vector evaluateError(const Pose3& pose, const double& base_clock,
+                                gtsam::OptionalMatrixType H_pose,
+                                gtsam::OptionalMatrixType H_base_clock) const override {
+        gtsam::gnss::LeverArm::PoseFrame frame;
+        const Point3 antenna = arm_.antennaPosition(pose, H_pose ? &frame : nullptr);
+        gtsam::Matrix13 H_range;
+        const double range = plainRange(satellite_position_, antenna, H_pose ? &H_range : nullptr);
+        const double error = range + gtsam::gnss::C_LIGHT * base_clock - measurement_;
+        if (H_pose) {
+            *H_pose = arm_.antennaPoseJacobian(H_range, frame);
+        }
+        if (H_base_clock) {
+            *H_base_clock = (gtsam::Matrix(1, 1) << gtsam::gnss::C_LIGHT).finished();
+        }
+        return (gtsam::Vector(1) << error).finished();
+    }
+};
+
+class PseudorangeFactorISBArm : public gtsam::NoiseModelFactorN<Pose3, double, double> {
+    double measurement_ = 0.0;
+    Point3 satellite_position_{0, 0, 0};
+    gtsam::gnss::LeverArm arm_;
+
+ public:
+    using Base = gtsam::NoiseModelFactorN<Pose3, double, double>;
+    using Base::evaluateError;
+    PseudorangeFactorISBArm(gtsam::Key pose, gtsam::Key base_clock, gtsam::Key isb,
+                            double measured_pseudorange, const Point3& satellite_position,
+                            const gtsam::gnss::LeverArm& arm,
+                            const gtsam::SharedNoiseModel& model)
+        : Base(model, pose, base_clock, isb),
+          measurement_(measured_pseudorange),
+          satellite_position_(satellite_position),
+          arm_(arm) {}
+
+    gtsam::Vector evaluateError(const Pose3& pose, const double& base_clock, const double& isb,
+                                gtsam::OptionalMatrixType H_pose,
+                                gtsam::OptionalMatrixType H_base_clock,
+                                gtsam::OptionalMatrixType H_isb) const override {
+        gtsam::gnss::LeverArm::PoseFrame frame;
+        const Point3 antenna = arm_.antennaPosition(pose, H_pose ? &frame : nullptr);
+        gtsam::Matrix13 H_range;
+        const double range = plainRange(satellite_position_, antenna, H_pose ? &H_range : nullptr);
+        const double error =
+            range + gtsam::gnss::C_LIGHT * (base_clock + isb) - measurement_;
+        if (H_pose) {
+            *H_pose = arm_.antennaPoseJacobian(H_range, frame);
+        }
+        if (H_base_clock) {
+            *H_base_clock = (gtsam::Matrix(1, 1) << gtsam::gnss::C_LIGHT).finished();
+        }
+        if (H_isb) {
+            *H_isb = (gtsam::Matrix(1, 1) << gtsam::gnss::C_LIGHT).finished();
+        }
+        return (gtsam::Vector(1) << error).finished();
+    }
+};
+
+// Rotation-only gauge-fixing prior for a Pose3 state. Needed because the
+// DD/undifferenced '...Arm' factors only observe the ANTENNA position
+// (translation + R*leverArm): for a lever arm != 0 that is a rank<=3
+// function of the full 6-dim pose tangent, so every pose has an exact
+// (generic) 3-dim rotational null space that leaves gtsam::Marginals'
+// Cholesky factorization singular. Since attitude is genuinely unobservable
+// here (no IMU until milestone 2b), pinning it at its identity seed simply
+// resolves the gauge freedom -- it is not a modeling approximation on top of
+// real information, there is none to lose. Uses Pose3::rotation(H), whose
+// Jacobian w.r.t. the pose tangent is structurally [I3 | 0] (rotation never
+// depends on the translation tangent component, in any Pose3 chart), so the
+// translation block of this factor's Jacobian is exactly zero and it cannot
+// bias the estimated antenna position.
+class Pose3RotationPrior : public gtsam::NoiseModelFactorN<Pose3> {
+    Rot3 prior_;
+
+ public:
+    using Base = gtsam::NoiseModelFactorN<Pose3>;
+    using Base::evaluateError;
+    Pose3RotationPrior(gtsam::Key pose, const Rot3& prior_rotation,
+                       const gtsam::SharedNoiseModel& model)
+        : Base(model, pose), prior_(prior_rotation) {}
+
+    gtsam::Vector evaluateError(const Pose3& pose,
+                                gtsam::OptionalMatrixType H) const override {
+        gtsam::Matrix36 H_rot;
+        const Rot3 rot = pose.rotation(H_rot);
+        if (!H) {
+            return prior_.localCoordinates(rot);
+        }
+        gtsam::Matrix3 H_local;
+        const gtsam::Vector3 error = prior_.localCoordinates(rot, {}, H_local);
+        *H = H_local * H_rot;
+        return error;
+    }
+};
+
+// --- Milestone 2d: Non-Holonomic Constraint factor -------------------------
+// Mirrors inuex35 buildfactor/nhc.py: a ground vehicle's body-frame lateral
+// (Left, y) and vertical (Up, z) velocity is ~0. Binary factor on
+// (Pose3 body-in-nav, Vector3 velocity-in-nav) with the 2-D residual
+//   err = [ (R^T v_nav).y , (R^T v_nav).z ]      (R = nav_R_body = pose.rotation)
+// Exact Jacobians come from GTSAM's own Rot3::unrotate / Pose3::rotation, so
+// the linearization is correct in GTSAM's retract convention (no hand-derived
+// skew term as in the Python CustomFactor). Caller gates it to moving,
+// non-turning epochs. The NHC lever arm (evaluate at the rear axle) is left at
+// zero -- the antenna lever is separate and the omega x lever term is a small
+// correction inuex35 also defaults off (nhc_lever = 0).
+class NonHolonomicFactor : public gtsam::NoiseModelFactorN<Pose3, gtsam::Vector3> {
+ public:
+    using Base = gtsam::NoiseModelFactorN<Pose3, gtsam::Vector3>;
+    using Base::evaluateError;
+    NonHolonomicFactor(gtsam::Key pose, gtsam::Key velocity,
+                       const gtsam::SharedNoiseModel& model)
+        : Base(model, pose, velocity) {}
+
+    gtsam::Vector evaluateError(const Pose3& pose, const gtsam::Vector3& v_nav,
+                                gtsam::OptionalMatrixType H_pose,
+                                gtsam::OptionalMatrixType H_vel) const override {
+        gtsam::Matrix36 H_rot_pose;  // d(rot tangent)/d(pose tangent) = [I3|0]
+        const Rot3 R = pose.rotation(H_pose ? &H_rot_pose : nullptr);
+        gtsam::Matrix3 H_unrot_rot, H_unrot_v;
+        const gtsam::Point3 v_body =
+            R.unrotate(gtsam::Point3(v_nav), H_pose ? &H_unrot_rot : nullptr,
+                       H_vel ? &H_unrot_v : nullptr);
+        if (H_pose) {
+            const gtsam::Matrix36 dvb_dpose = H_unrot_rot * H_rot_pose;  // 3x6
+            gtsam::Matrix H = gtsam::Matrix::Zero(2, 6);
+            H.row(0) = dvb_dpose.row(1);  // d(v_body.y)/d(pose)
+            H.row(1) = dvb_dpose.row(2);  // d(v_body.z)/d(pose)
+            *H_pose = H;
+        }
+        if (H_vel) {
+            gtsam::Matrix H = gtsam::Matrix::Zero(2, 3);
+            H.row(0) = H_unrot_v.row(1);
+            H.row(1) = H_unrot_v.row(2);
+            *H_vel = H;
+        }
+        return (gtsam::Vector(2) << v_body.y(), v_body.z()).finished();
+    }
+};
+
+// Stationarity stats over an IMU sample sub-range [begin, end), mirroring the
+// Stage-1 ESKF LooseCouplingProcessor::detectStationary(): std of the norm of
+// (accel - accel_bias) and (gyro - gyro_bias), plus the median of the gyro
+// deviation norm. Bias-referenced against the Stage-1 init bias (not a running
+// estimate), exactly as inuex35's compute_zupt_stats recommends.
+struct ImuWindowStats {
+    int n = 0;
+    double accel_std = 0.0;
+    double gyro_std = 0.0;
+    double gyro_median = 0.0;
+    double yaw_rate_abs = 0.0;  ///< |mean(gyro_z - bias_z)|, for the NHC turn gate
+};
+
+inline ImuWindowStats imuWindowStats(const std::vector<ImuSample>& samples, std::size_t begin,
+                                     std::size_t end, const Vector3d& accel_bias,
+                                     const Vector3d& gyro_bias) {
+    ImuWindowStats s;
+    const std::size_t n = end > begin ? end - begin : 0;
+    s.n = static_cast<int>(n);
+    if (n == 0) {
+        return s;
+    }
+    std::vector<double> accel_devs, gyro_devs;
+    accel_devs.reserve(n);
+    gyro_devs.reserve(n);
+    double gyro_z_sum = 0.0;
+    for (std::size_t k = begin; k < end; ++k) {
+        accel_devs.push_back((samples[k].accel_raw - accel_bias).norm());
+        gyro_devs.push_back((samples[k].gyro_raw_radps - gyro_bias).norm());
+        gyro_z_sum += samples[k].gyro_raw_radps.z() - gyro_bias.z();
+    }
+    auto mean = [](const std::vector<double>& v) {
+        double m = 0.0;
+        for (double x : v) m += x;
+        return m / static_cast<double>(v.size());
+    };
+    auto stddev = [&](const std::vector<double>& v) {
+        const double m = mean(v);
+        double s2 = 0.0;
+        for (double x : v) {
+            const double d = x - m;
+            s2 += d * d;
+        }
+        return std::sqrt(s2 / static_cast<double>(v.size()));
+    };
+    std::vector<double> g = gyro_devs;
+    std::sort(g.begin(), g.end());
+    s.accel_std = stddev(accel_devs);
+    s.gyro_std = stddev(gyro_devs);
+    s.gyro_median = g[g.size() / 2];
+    s.yaw_rate_abs = std::abs(gyro_z_sum / static_cast<double>(n));
+    return s;
+}
+
+SharedNoise makeNoise(double sigma_m, bool robust, double huber_threshold_sigma) {
+    const double safe_sigma = std::max(1e-9, sigma_m);
+    SharedNoise base = gtsam::noiseModel::Isotropic::Sigma(1, safe_sigma);
+    if (robust && huber_threshold_sigma > 0.0) {
+        return gtsam::noiseModel::Robust::Create(
+            gtsam::noiseModel::mEstimator::Huber::Create(huber_threshold_sigma),
+            base);
+    }
+    return base;
+}
+
+// Cross-checks that gtsam::gnss::DoubleDifferenceData::observed() reproduces
+// libgnss's precomputed observed DD value for the mapping used below. Cheap
+// (a handful of subtractions) so it is left active in all builds rather than
+// only in debug; a mismatch indicates the obs-convention mapping regressed.
+void checkObservedDdMatches(double gtsam_observed,
+                            double libgnss_observed,
+                            const char* what) {
+    const double diff = std::abs(gtsam_observed - libgnss_observed);
+    if (diff > 1e-6) {
+        std::fprintf(stderr,
+                     "[fgo_gtsam_backend] WARNING: %s observed-DD mismatch: "
+                     "gtsam=%.9f libgnss=%.9f diff=%.9e\n",
+                     what, gtsam_observed, libgnss_observed, diff);
+        assert(false && "GTSAM/libgnss DD observation convention mismatch");
+    }
+}
+
+}  // namespace
+
+// ===========================================================================
+// Milestone 2c: IncrementalFixedLagSmoother path (docs/gtsam_backend_design.md)
+// ===========================================================================
+//
+// Streams the IMU-coupled DD-RTK graph through gtsam::IncrementalFixedLagSmoother
+// instead of a single batch LM solve, so memory and per-epoch marginals stay
+// bounded at full-dataset scale (the batch gtsam::Marginals over ~25k vars hit
+// bad_alloc). Only used when config.use_fixed_lag_smoother && the IMU path is
+// active; otherwise optimizeProblemWithGtsam runs its batch LM path unchanged.
+//
+// Key-timestamp scheme (nav = ENU): every key is timestamped with the epoch
+// time in seconds relative to epoch 0. Pose/Vel/Bias X(i)/V(i)/B(i) are stamped
+// with epoch i, so they marginalize out fixed_lag_smoother_lag_s after epoch i.
+// Ambiguity nodes and the shared dummy node are RE-STAMPED to the current epoch
+// every time they are observed, so an ambiguity persists in the window while
+// its arc is active and marginalizes lag-seconds after its last observation
+// (arc end) -- i.e. ambiguities spanning the lag are simply kept in-window by
+// re-stamping (no fix-and-hold; per-epoch LAMBDA is a read-out off the windowed
+// marginals, ambiguities stay float in the graph, matching Phase-1/2b).
+static FGOProcessor::FGOResult optimizeProblemFixedLag(
+    const FGOProcessor::FGOProblem& problem,
+    const FGOProcessor::FGOConfig& config,
+    FGOProcessor::FGOResult result) {
+    const auto start_time = std::chrono::high_resolution_clock::now();
+
+    const std::size_t num_epochs = problem.epochs.size();
+    const Point3 lever_arm_body(config.pose3_lever_arm_body_m.x(),
+                                config.pose3_lever_arm_body_m.y(),
+                                config.pose3_lever_arm_body_m.z());
+    const Rot3 R_ecef_nav = ecefFromEnuRotation(problem.imu.nav_origin_lat_rad,
+                                                problem.imu.nav_origin_lon_rad);
+    const Pose3 ecef_T_nav(R_ecef_nav, Point3(problem.imu.nav_origin_ecef));
+    const gtsam::gnss::LeverArm gnss_lever_arm(lever_arm_body, ecef_T_nav);
+    const Rot3 init_attitude_nav(problem.imu.init_attitude_body_to_nav);
+    const gtsam::imuBias::ConstantBias init_bias(problem.imu.init_accel_bias,
+                                                 problem.imu.init_gyro_bias);
+
+    auto antennaOf = [&](const Pose3& pose) -> Point3 {
+        return gnss_lever_arm.antennaPosition(pose);
+    };
+    auto navAntenna = [&](const Vector3d& ecef) -> Vector3d {
+        return ecef2enu(ecef - problem.imu.nav_origin_ecef, problem.imu.nav_origin_lat_rad,
+                        problem.imu.nav_origin_lon_rad);
+    };
+    auto stampOf = [&](std::size_t epoch) -> double {
+        return problem.epochs[epoch].time - problem.epochs[0].time;
+    };
+
+    // Group DD factors by epoch for O(1) streaming access.
+    std::vector<std::vector<const FGOProcessor::DoubleDifferencePseudorangeFactor*>> pr_by_epoch(
+        num_epochs);
+    std::vector<std::vector<const FGOProcessor::DoubleDifferenceCarrierFactor*>> cp_by_epoch(
+        num_epochs);
+    for (const auto& f : problem.double_difference_pseudorange_factors) {
+        if (f.epoch_index < num_epochs) pr_by_epoch[f.epoch_index].push_back(&f);
+    }
+    for (const auto& f : problem.double_difference_carrier_factors) {
+        if (f.epoch_index < num_epochs && f.ambiguity_index < problem.ambiguity_states.size()) {
+            cp_by_epoch[f.epoch_index].push_back(&f);
+        }
+    }
+
+    // IMU preintegration params (ENU / Z-up; gravity -Z).
+    auto imu_params = gtsam::PreintegrationCombinedParams::MakeSharedU(problem.imu.noise.gravity_mps2);
+    const auto sq = [](double s) { return s * s; };
+    imu_params->setAccelerometerCovariance(gtsam::I_3x3 * sq(problem.imu.noise.accel_noise_sigma));
+    imu_params->setGyroscopeCovariance(gtsam::I_3x3 * sq(problem.imu.noise.gyro_noise_sigma));
+    imu_params->setIntegrationCovariance(gtsam::I_3x3 * sq(problem.imu.noise.integration_sigma));
+    imu_params->setBiasAccCovariance(gtsam::I_3x3 * sq(problem.imu.noise.accel_bias_rw_sigma));
+    imu_params->setBiasOmegaCovariance(gtsam::I_3x3 * sq(problem.imu.noise.gyro_bias_rw_sigma));
+    const auto& imu_samples = problem.imu.samples_body_flu;
+
+    // Smoother. findUnusedFactorSlots is REQUIRED for fixed-lag marginalization;
+    // relinearize aggressively (skip=1, low threshold) since the IMU factors are
+    // strongly nonlinear and we take one update per epoch.
+    gtsam::ISAM2Params isam_params;
+    isam_params.findUnusedFactorSlots = true;
+    isam_params.relinearizeThreshold = 0.01;
+    isam_params.relinearizeSkip = 1;
+    isam_params.factorization = gtsam::ISAM2Params::CHOLESKY;
+    gtsam::IncrementalFixedLagSmoother smoother(config.fixed_lag_smoother_lag_s, isam_params);
+
+    // Per-epoch outputs.
+    std::vector<Point3> epoch_float_position(num_epochs, Point3(0, 0, 0));
+    std::vector<Point3> epoch_fixed_position(num_epochs, Point3(0, 0, 0));
+    std::vector<bool> epoch_has_fixed(num_epochs, false);
+    std::vector<bool> epoch_fixed(num_epochs, false);
+    std::vector<int> epoch_fixed_count(num_epochs, 0);
+    std::vector<double> epoch_ratio(num_epochs, 0.0);
+    std::vector<Vector3d> epoch_rpy_deg(num_epochs, Vector3d::Zero());
+    std::vector<Vector3d> epoch_vel_nav(num_epochs, Vector3d::Zero());
+    std::vector<bool> epoch_solved(num_epochs, false);
+    std::map<std::size_t, double> amb_float_cycles;
+    std::map<std::size_t, int> amb_fixed_cycles;
+    std::map<std::size_t, double> amb_fixed_residual;
+
+    std::set<std::size_t> ambiguity_created;
+    bool dummy_created = false;
+    constexpr double kDummyPinSigmaCycles = 1e-3;
+
+    // Previous refined nav state (seed source for the next epoch's prediction).
+    gtsam::NavState prev_nav;
+    gtsam::imuBias::ConstantBias prev_bias = init_bias;
+    std::size_t sample_cursor = 0;
+    std::size_t total_fixed_ambiguities = 0;
+    std::size_t marginals_failures = 0;
+    std::size_t lambda_attempts = 0;
+    double best_ratio = 0.0;
+    const int min_candidates = std::max(6, std::max(1, config.min_fixed_ambiguities + 1));
+
+    const bool robust = config.use_robust_loss;
+
+    for (std::size_t i = 0; i < num_epochs; ++i) {
+        gtsam::NonlinearFactorGraph new_factors;
+        gtsam::Values new_values;
+        gtsam::FixedLagSmoother::KeyTimestampMap ts;
+        const double te = stampOf(i);
+
+        // --- Pose / velocity / bias seed for epoch i ---
+        Pose3 pose_seed;
+        gtsam::Vector3 vel_seed;
+        std::size_t win_begin = sample_cursor, win_end = sample_cursor;  // IMU window for ZUPT/NHC
+        if (i == 0) {
+            const Vector3d antenna_nav = navAntenna(problem.epochs[0].position_ecef);
+            pose_seed = Pose3(init_attitude_nav,
+                              Point3(antenna_nav) - init_attitude_nav * lever_arm_body);
+            vel_seed = gtsam::Vector3(problem.imu.init_velocity_nav);
+            // ZUPT/NHC window for epoch 0: the first interval [epoch0, epoch1).
+            const GNSSTime a = problem.epochs[0].time;
+            const GNSSTime b = problem.epochs[1].time;
+            std::size_t k = 0;
+            while (k < imu_samples.size() && imu_samples[k].time < a) ++k;
+            win_begin = k;
+            while (k < imu_samples.size() && imu_samples[k].time < b) ++k;
+            win_end = k;
+        } else {
+            // Preintegrate [epoch i-1, epoch i) and IMU-predict the seed.
+            const GNSSTime t0 = problem.epochs[i - 1].time;
+            const GNSSTime t1 = problem.epochs[i].time;
+            while (sample_cursor < imu_samples.size() && imu_samples[sample_cursor].time < t0) {
+                ++sample_cursor;
+            }
+            win_begin = sample_cursor;
+            gtsam::PreintegratedCombinedMeasurements pim(imu_params, prev_bias);
+            std::size_t j = sample_cursor;
+            GNSSTime prev_time = t0;
+            std::size_t integrated = 0;
+            while (j < imu_samples.size() && imu_samples[j].time < t1) {
+                const double dt = imu_samples[j].time - prev_time;
+                if (dt > 1e-9) {
+                    pim.integrateMeasurement(gtsam::Vector3(imu_samples[j].accel_raw),
+                                             gtsam::Vector3(imu_samples[j].gyro_raw_radps), dt);
+                    ++integrated;
+                }
+                prev_time = imu_samples[j].time;
+                ++j;
+            }
+            win_end = j;
+            const double dt_tail = t1 - prev_time;
+            if (integrated > 0 && dt_tail > 1e-9 && j > 0) {
+                pim.integrateMeasurement(gtsam::Vector3(imu_samples[j - 1].accel_raw),
+                                         gtsam::Vector3(imu_samples[j - 1].gyro_raw_radps), dt_tail);
+            }
+            if (integrated > 0) {
+                const gtsam::NavState pred = pim.predict(prev_nav, prev_bias);
+                pose_seed = pred.pose();
+                vel_seed = pred.velocity();
+                new_factors.emplace_shared<gtsam::CombinedImuFactor>(
+                    positionKey(i - 1), velocityKey(i - 1), positionKey(i), velocityKey(i),
+                    biasKey(i - 1), biasKey(i), pim);
+            } else {
+                // IMU dropout: hold pose at the DD antenna seed, loose continuity.
+                const Vector3d antenna_nav = navAntenna(problem.epochs[i].position_ecef);
+                pose_seed = Pose3(prev_nav.attitude(),
+                                  Point3(antenna_nav) - prev_nav.attitude() * lever_arm_body);
+                vel_seed = prev_nav.velocity();
+                new_factors.emplace_shared<gtsam::BetweenFactor<gtsam::Vector3>>(
+                    velocityKey(i - 1), velocityKey(i), gtsam::Vector3::Zero(),
+                    gtsam::noiseModel::Isotropic::Sigma(3, 10.0));
+                new_factors.emplace_shared<gtsam::BetweenFactor<gtsam::imuBias::ConstantBias>>(
+                    biasKey(i - 1), biasKey(i), gtsam::imuBias::ConstantBias(),
+                    gtsam::noiseModel::Isotropic::Sigma(6, 1.0));
+            }
+        }
+        new_values.insert(positionKey(i), pose_seed);
+        new_values.insert(velocityKey(i), vel_seed);
+        new_values.insert(biasKey(i), prev_bias);
+        ts[positionKey(i)] = te;
+        ts[velocityKey(i)] = te;
+        ts[biasKey(i)] = te;
+
+        if (i == 0) {
+            gtsam::Vector6 pose_prior_sigmas;
+            pose_prior_sigmas << problem.imu.init_attitude_sigma_roll_pitch_rad,
+                problem.imu.init_attitude_sigma_roll_pitch_rad,
+                problem.imu.init_attitude_sigma_yaw_rad, 1e6, 1e6, 1e6;
+            new_factors.addPrior(positionKey(0), pose_seed,
+                                 gtsam::noiseModel::Diagonal::Sigmas(pose_prior_sigmas));
+            new_factors.addPrior(velocityKey(0), gtsam::Vector3(problem.imu.init_velocity_nav),
+                                 gtsam::noiseModel::Isotropic::Sigma(
+                                     3, problem.imu.init_velocity_sigma_mps));
+            gtsam::Vector6 bias_prior_sigmas;
+            bias_prior_sigmas << problem.imu.init_accel_bias_sigma,
+                problem.imu.init_accel_bias_sigma, problem.imu.init_accel_bias_sigma,
+                problem.imu.init_gyro_bias_sigma, problem.imu.init_gyro_bias_sigma,
+                problem.imu.init_gyro_bias_sigma;
+            new_factors.addPrior(biasKey(0), init_bias,
+                                 gtsam::noiseModel::Diagonal::Sigmas(bias_prior_sigmas));
+        }
+
+        // --- DD pseudorange factors at epoch i ---
+        for (const auto* fp : pr_by_epoch[i]) {
+            const auto& factor = *fp;
+            const gtsam::gnss::DoubleDifferenceData dd{
+                factor.rover_satellite_model.corrected_pseudorange_m,
+                factor.base_satellite_model.corrected_pseudorange_m,
+                factor.rover_reference_model.corrected_pseudorange_m,
+                factor.base_reference_model.corrected_pseudorange_m,
+                Point3(factor.rover_satellite_position_ecef),
+                Point3(factor.rover_reference_position_ecef),
+                Point3(factor.base_satellite_position_ecef),
+                Point3(factor.base_reference_position_ecef),
+                Point3(factor.base_position_ecef)};
+            const auto noise = makeNoise(factor.sigma_m, robust,
+                                         config.pseudorange_huber_threshold_sigma);
+            new_factors.emplace_shared<gtsam::DoubleDifferencePseudorangeFactorArm>(
+                positionKey(i), dd.rovRef, dd.baseRef, dd.rovTarget, dd.baseTarget, dd.satRefRov,
+                dd.satTargetRov, dd.satRefBase, dd.satTargetBase, dd.basePos, lever_arm_body,
+                ecef_T_nav, noise);
+        }
+
+        // --- DD carrier factors + ambiguity nodes at epoch i ---
+        std::vector<std::size_t> epoch_amb_indices;
+        for (const auto* fp : cp_by_epoch[i]) {
+            const auto& factor = *fp;
+            const auto& ambiguity = problem.ambiguity_states[factor.ambiguity_index];
+            if (!dummy_created) {
+                new_values.insert(dummyAmbiguityKey(), 0.0);
+                new_factors.addPrior(dummyAmbiguityKey(), 0.0,
+                                     gtsam::noiseModel::Isotropic::Sigma(1, kDummyPinSigmaCycles));
+                dummy_created = true;
+            }
+            if (ambiguity_created.insert(factor.ambiguity_index).second) {
+                const double seed_cycles = ambiguity.wavelength_m > 0.0
+                                               ? ambiguity.initial_ambiguity_m / ambiguity.wavelength_m
+                                               : ambiguity.initial_ambiguity_m;
+                new_values.insert(ambiguityKey(factor.ambiguity_index), seed_cycles);
+                if (config.use_ambiguity_priors && config.ambiguity_prior_sigma_m > 0.0 &&
+                    ambiguity.wavelength_m > 0.0) {
+                    new_factors.addPrior(
+                        ambiguityKey(factor.ambiguity_index), seed_cycles,
+                        gtsam::noiseModel::Isotropic::Sigma(
+                            1, config.ambiguity_prior_sigma_m / ambiguity.wavelength_m));
+                }
+            }
+            const gtsam::gnss::DoubleDifferenceData dd{
+                factor.rover_satellite_model.corrected_carrier_m,
+                factor.base_satellite_model.corrected_carrier_m,
+                factor.rover_reference_model.corrected_carrier_m,
+                factor.base_reference_model.corrected_carrier_m,
+                Point3(factor.rover_satellite_position_ecef),
+                Point3(factor.rover_reference_position_ecef),
+                Point3(factor.base_satellite_position_ecef),
+                Point3(factor.base_reference_position_ecef),
+                Point3(factor.base_position_ecef)};
+            const auto noise = makeNoise(factor.sigma_m, robust,
+                                         config.carrier_phase_huber_threshold_sigma);
+            new_factors.emplace_shared<gtsam::DoubleDifferenceCarrierPhaseFactorArm>(
+                positionKey(i), ambiguityKey(factor.ambiguity_index), dummyAmbiguityKey(),
+                dd.rovRef, dd.baseRef, dd.rovTarget, dd.baseTarget, dd.satRefRov, dd.satTargetRov,
+                dd.satRefBase, dd.satTargetBase, dd.basePos, ambiguity.wavelength_m, lever_arm_body,
+                ecef_T_nav, noise);
+            ts[ambiguityKey(factor.ambiguity_index)] = te;  // re-stamp: keep in-window while active
+            epoch_amb_indices.push_back(factor.ambiguity_index);
+        }
+        if (dummy_created) ts[dummyAmbiguityKey()] = te;  // dummy persists (re-stamped every epoch)
+
+        // --- Milestone 2d: NHC + ZUPT pseudo-measurements (gated per epoch) ---
+        const ImuWindowStats wstats =
+            (config.use_nhc || config.use_zupt)
+                ? imuWindowStats(imu_samples, win_begin, win_end, problem.imu.init_accel_bias,
+                                 problem.imu.init_gyro_bias)
+                : ImuWindowStats{};
+        const double seed_speed = vel_seed.norm();
+        const bool stationary =
+            config.use_zupt && wstats.n >= config.zupt_min_samples &&
+            wstats.accel_std <= config.zupt_max_accel_std &&
+            wstats.gyro_std <= config.zupt_max_gyro_std &&
+            wstats.gyro_median <= config.zupt_max_gyro_median &&
+            // Velocity gate: reject false ZUPT during constant-velocity motion
+            // (quiet accelerometer but non-zero speed).
+            (config.zupt_max_speed_mps <= 0.0 || seed_speed <= config.zupt_max_speed_mps);
+        if (stationary && config.zupt_sigma_mps > 0.0) {
+            // ZUPT: pin Vel(i) ~ 0 (mirrors inuex35 _add_zero_velocity_prior).
+            const gtsam::Vector3 zero_velocity = gtsam::Vector3::Zero();
+            new_factors.addPrior<gtsam::Vector3>(
+                velocityKey(i), zero_velocity,
+                gtsam::noiseModel::Isotropic::Sigma(3, config.zupt_sigma_mps));
+            ++result.diagnostics.zupt_epochs;
+        }
+        if (config.use_nhc && !stationary) {
+            // NHC: apply only to moving, non-turning epochs so it never fights
+            // legitimate lateral motion (mirrors nhc.py's speed gate + a
+            // yaw-rate gate for turns). Speed comes from the seed velocity.
+            const double speed = std::hypot(vel_seed.x(), vel_seed.y());
+            if (speed >= config.nhc_min_speed_mps &&
+                wstats.yaw_rate_abs <= config.nhc_max_yaw_rate_radps) {
+                gtsam::Vector2 nhc_sigmas(config.nhc_sigma_lateral_mps,
+                                          config.nhc_sigma_vertical_mps);
+                new_factors.emplace_shared<NonHolonomicFactor>(
+                    positionKey(i), velocityKey(i),
+                    gtsam::noiseModel::Diagonal::Sigmas(nhc_sigmas));
+                ++result.diagnostics.nhc_epochs;
+            }
+        }
+
+        // --- Smoother update ---
+        bool update_ok = true;
+        try {
+            smoother.update(new_factors, new_values, ts);
+        } catch (const std::exception& e) {
+            std::fprintf(stderr, "[fgo_gtsam_backend] smoother.update() epoch %zu threw: %s\n", i,
+                         e.what());
+            update_ok = false;
+        }
+        ++result.diagnostics.smoother_updates;
+        if (!update_ok) {
+            continue;
+        }
+        epoch_solved[i] = true;
+        result.diagnostics.smoother_max_window_vars = std::max(
+            result.diagnostics.smoother_max_window_vars, smoother.getLinearizationPoint().size());
+
+        // Refined state for epoch i (seed source for next epoch).
+        Pose3 pose_i = smoother.calculateEstimate<Pose3>(positionKey(i));
+        gtsam::Vector3 vel_i = smoother.calculateEstimate<gtsam::Vector3>(velocityKey(i));
+        prev_bias = smoother.calculateEstimate<gtsam::imuBias::ConstantBias>(biasKey(i));
+        prev_nav = gtsam::NavState(pose_i, vel_i);
+
+        // Re-read every still-in-window pose so each epoch's recorded estimate
+        // is its most-smoothed value at the moment it exits the window.
+        const gtsam::Values& lin = smoother.getLinearizationPoint();
+        for (std::size_t j = i + 1; j-- > 0;) {
+            if (!lin.exists(positionKey(j))) break;  // older keys already marginalized
+            const Pose3 pj = smoother.calculateEstimate<Pose3>(positionKey(j));
+            const gtsam::Vector3 vj = smoother.calculateEstimate<gtsam::Vector3>(velocityKey(j));
+            epoch_float_position[j] = antennaOf(pj);
+            const gtsam::Matrix3 R = pj.rotation().matrix();
+            const Eigen::Vector3d fwd = R.col(0);
+            const Eigen::Vector3d left = R.col(1);
+            constexpr double kRadToDeg = 180.0 / 3.14159265358979323846;
+            double heading = std::atan2(fwd.x(), fwd.y()) * kRadToDeg;
+            if (heading < 0.0) heading += 360.0;
+            const double pitch = std::asin(std::max(-1.0, std::min(1.0, fwd.z()))) * kRadToDeg;
+            const double roll = std::atan2(left.z(), R.col(2).z()) * kRadToDeg;
+            epoch_rpy_deg[j] = Vector3d(roll, pitch, heading);
+            epoch_vel_nav[j] = Vector3d(vj);
+        }
+
+        // --- Per-epoch LAMBDA off the bounded windowed marginals ---
+        if (config.use_lambda_ambiguity_fix && !epoch_amb_indices.empty()) {
+            std::sort(epoch_amb_indices.begin(), epoch_amb_indices.end(),
+                      [&](std::size_t a, std::size_t b) {
+                          const auto& sa = problem.ambiguity_states[a];
+                          const auto& sb = problem.ambiguity_states[b];
+                          return std::tie(sa.satellite, sa.reference_satellite, sa.signal, a) <
+                                 std::tie(sb.satellite, sb.reference_satellite, sb.signal, b);
+                      });
+            const int n = static_cast<int>(epoch_amb_indices.size());
+            if (n >= min_candidates) {
+                gtsam::KeyVector keys;
+                keys.reserve(n + 1);
+                keys.push_back(positionKey(i));
+                for (std::size_t idx : epoch_amb_indices) keys.push_back(ambiguityKey(idx));
+
+                Eigen::VectorXd float_amb(n);
+                Eigen::MatrixXd q_amb(n, n);
+                Eigen::MatrixXd pos_amb(3, n);
+                bool ok = true;
+                try {
+                    const gtsam::JointMarginal joint =
+                        smoother.getISAM2().jointMarginalCovariance(keys);
+                    // Cov(antenna, amb) via the 3x6 antenna Jacobian at pose_i.
+                    gtsam::Matrix36 H_antenna_pose;
+                    {
+                        gtsam::gnss::LeverArm::PoseFrame frame;
+                        gnss_lever_arm.antennaPosition(pose_i, &frame);
+                        for (int r3 = 0; r3 < 3; ++r3) {
+                            gtsam::Matrix13 unit = gtsam::Matrix13::Zero();
+                            unit(0, r3) = 1.0;
+                            H_antenna_pose.row(r3) = gnss_lever_arm.antennaPoseJacobian(unit, frame);
+                        }
+                    }
+                    for (int r = 0; r < n && ok; ++r) {
+                        const gtsam::Key rk = ambiguityKey(epoch_amb_indices[r]);
+                        float_amb(r) = smoother.calculateEstimate<double>(rk);
+                        const gtsam::Matrix pr = joint(positionKey(i), rk);  // 6x1
+                        const Eigen::Vector3d pr3 = H_antenna_pose * pr;
+                        pos_amb(0, r) = pr3(0);
+                        pos_amb(1, r) = pr3(1);
+                        pos_amb(2, r) = pr3(2);
+                        for (int c = 0; c < n; ++c) {
+                            q_amb(r, c) = joint(rk, ambiguityKey(epoch_amb_indices[c]))(0, 0);
+                        }
+                    }
+                } catch (const std::exception&) {
+                    ok = false;
+                }
+                if (ok && float_amb.allFinite() && q_amb.allFinite()) {
+                    q_amb = 0.5 * (q_amb + q_amb.transpose());
+                    for (int k = 0; k < n; ++k) {
+                        q_amb(k, k) += std::max(1e-12, std::abs(q_amb(k, k)) * 1e-9);
+                    }
+                    Eigen::VectorXd fixed_amb;
+                    double ratio = 0.0;
+                    ++lambda_attempts;
+                    ++result.diagnostics.lambda_ambiguity_attempts;
+                    result.diagnostics.lambda_ambiguity_candidates += static_cast<std::size_t>(n);
+                    if (lambdaSearch(float_amb, q_amb, fixed_amb, ratio)) {
+                        result.diagnostics.lambda_ambiguity_fix_solved = true;
+                        best_ratio = std::max(best_ratio, ratio);
+                        epoch_ratio[i] = ratio;
+                        const bool fixed_epoch =
+                            std::isfinite(ratio) &&
+                            (config.lambda_ratio_threshold <= 0.0 ||
+                             ratio > config.lambda_ratio_threshold) &&
+                            fixed_amb.size() == n;
+                        // Record float ambiguity values for the result mapping.
+                        for (int r = 0; r < n; ++r) {
+                            amb_float_cycles[epoch_amb_indices[r]] = float_amb(r);
+                        }
+                        if (fixed_epoch) {
+                            epoch_fixed[i] = true;
+                            epoch_fixed_count[i] = n;
+                            total_fixed_ambiguities += static_cast<std::size_t>(n);
+                            result.diagnostics.lambda_ambiguity_fix_used = true;
+                            result.diagnostics.lambda_ambiguity_used_candidates +=
+                                static_cast<std::size_t>(n);
+                            for (int r = 0; r < n; ++r) {
+                                const int fi = static_cast<int>(std::lround(fixed_amb(r)));
+                                amb_fixed_cycles[epoch_amb_indices[r]] = fi;
+                                amb_fixed_residual[epoch_amb_indices[r]] =
+                                    float_amb(r) - static_cast<double>(fi);
+                            }
+                            if (config.use_epoch_lambda_fixed_output) {
+                                const Eigen::VectorXd delta = float_amb - fixed_amb;
+                                const Eigen::LDLT<Eigen::MatrixXd> ldlt(q_amb);
+                                if (ldlt.info() == Eigen::Success) {
+                                    const Eigen::VectorXd corr = ldlt.solve(delta);
+                                    if (corr.allFinite()) {
+                                        const Eigen::Vector3d pd = pos_amb * corr;
+                                        if (pd.allFinite()) {
+                                            epoch_fixed_position[i] = antennaOf(pose_i) - Point3(pd);
+                                            epoch_has_fixed[i] = true;
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    ++marginals_failures;
+                }
+            }
+        }
+    }
+
+    // --- Diagnostics ---
+    result.diagnostics.converged = true;
+    result.diagnostics.iterations = static_cast<int>(result.diagnostics.smoother_updates);
+    result.diagnostics.imu_intervals = num_epochs > 0 ? num_epochs - 1 : 0;
+    result.diagnostics.lambda_ambiguity_ratio = best_ratio;
+    result.diagnostics.fixed_solution = total_fixed_ambiguities > 0;
+    result.diagnostics.fixed_ambiguities = total_fixed_ambiguities;
+    if (marginals_failures > 0) {
+        std::fprintf(stderr, "[fgo_gtsam_backend] fixed-lag: %zu epoch(s) LAMBDA marginal failure\n",
+                     marginals_failures);
+    }
+
+    // --- Ambiguity estimates (captured during streaming; window-marginalized
+    // nodes cannot be read from the final smoother) ---
+    result.ambiguity_estimates.reserve(problem.ambiguity_states.size());
+    for (std::size_t idx = 0; idx < problem.ambiguity_states.size(); ++idx) {
+        const auto& ambiguity = problem.ambiguity_states[idx];
+        FGOProcessor::AmbiguityEstimate est;
+        est.satellite = ambiguity.satellite;
+        est.signal = ambiguity.signal;
+        est.segment_index = ambiguity.segment_index;
+        est.wavelength_m = ambiguity.wavelength_m;
+        const auto fit = amb_float_cycles.find(idx);
+        if (fit != amb_float_cycles.end()) {
+            est.ambiguity_cycles = fit->second;
+            est.ambiguity_m = fit->second * ambiguity.wavelength_m;
+        }
+        const auto xit = amb_fixed_cycles.find(idx);
+        if (xit != amb_fixed_cycles.end()) {
+            est.is_fixed = true;
+            est.fixed_by_lambda = true;
+            est.fixed_cycles = xit->second;
+            est.fixed_ambiguity_m = xit->second * ambiguity.wavelength_m;
+            est.fix_residual_cycles = amb_fixed_residual.at(idx);
+        }
+        result.ambiguity_estimates.push_back(est);
+    }
+
+    // --- Per-epoch solutions ---
+    const bool have_amb = !problem.ambiguity_states.empty();
+    result.epoch_attitude_rpy_deg.resize(num_epochs);
+    result.epoch_velocity_nav_mps.resize(num_epochs);
+    for (std::size_t i = 0; i < num_epochs; ++i) {
+        PositionSolution solution;
+        solution.time = problem.epochs[i].time;
+        const bool fixed = epoch_fixed[i] && epoch_has_fixed[i];
+        if (fixed) {
+            solution.status = SolutionStatus::FIXED;
+            solution.position_ecef = epoch_fixed_position[i];
+        } else {
+            solution.status = have_amb ? SolutionStatus::FLOAT : SolutionStatus::SPP;
+            solution.position_ecef = epoch_float_position[i];
+        }
+        if (!epoch_solved[i]) {
+            solution.status = SolutionStatus::NONE;
+        }
+        solution.num_frequencies = 1;
+        solution.ratio = epoch_ratio[i];
+        solution.num_fixed_ambiguities = epoch_fixed_count[i];
+        double lat = 0.0, lon = 0.0, h = 0.0;
+        ecef2geodetic(solution.position_ecef, lat, lon, h);
+        solution.position_geodetic = GeodeticCoord(lat, lon, h);
+        result.solution.addSolution(solution);
+        result.epoch_attitude_rpy_deg[i] = epoch_rpy_deg[i];
+        result.epoch_velocity_nav_mps[i] = epoch_vel_nav[i];
+    }
+
+    const auto end_time = std::chrono::high_resolution_clock::now();
+    result.diagnostics.processing_time_ms =
+        std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(end_time - start_time)
+            .count();
+    result.diagnostics.total_processing_time_ms = result.diagnostics.processing_time_ms;
+    return result;
+}
+
+FGOProcessor::FGOResult optimizeProblemWithGtsam(
+    const FGOProcessor::FGOProblem& problem,
+    const FGOProcessor::FGOConfig& config,
+    FGOProcessor::FGOResult result) {
+    // Milestone 2c: dispatch to the incremental fixed-lag smoother when
+    // requested and the IMU-coupled Pose3 path is fully specified. Otherwise
+    // fall through to the batch LM path below (Phase-1 / 2a / 2b), unchanged.
+    if (config.use_fixed_lag_smoother && config.use_pose3_state && config.use_imu &&
+        problem.imu.valid && problem.epochs.size() >= 2) {
+        return optimizeProblemFixedLag(problem, config, std::move(result));
+    }
+    const auto start_time = std::chrono::high_resolution_clock::now();
+
+    gtsam::NonlinearFactorGraph graph;
+    gtsam::Values initial;
+
+    // --- Milestone 2a/2b: Pose3 + lever-arm state (docs/gtsam_backend_design.md) ---
+    // use_pose3 selects whether positionKey(epoch) holds a gtsam::Pose3 (body
+    // pose, antenna offset by pose3_lever_arm_body_m) or the Phase-1
+    // gtsam::Point3 (bare antenna position).
+    //
+    // use_imu (2b) additionally: interprets the Pose3 as body-in-nav (local
+    // ENU) via a real ecef_T_nav, adds Vector3 velocity + imuBias states per
+    // epoch, and links consecutive epochs with CombinedImuFactors. In 2a
+    // (use_pose3 without IMU) the pose is expressed directly in ECEF (no
+    // ecef_T_nav) and only the rotation gauge-pin constrains attitude.
+    const std::size_t num_epochs = problem.epochs.size();
+    const bool use_pose3 = config.use_pose3_state;
+    const bool use_imu =
+        use_pose3 && config.use_imu && problem.imu.valid && num_epochs >= 2;
+    const Point3 lever_arm_body(config.pose3_lever_arm_body_m.x(),
+                                config.pose3_lever_arm_body_m.y(),
+                                config.pose3_lever_arm_body_m.z());
+
+    // ecef_T_nav: identity/unused in 2a (pose in ECEF); the ENU-from-ECEF
+    // transform at the nav origin in 2b (pose in nav). The DD '...FactorArm'
+    // factors and the IMU factor share this same Pose3 through it.
+    gtsam::gnss::LeverArm gnss_lever_arm(lever_arm_body);
+    Pose3 ecef_T_nav;  // identity unless use_imu
+    if (use_imu) {
+        const Rot3 R_ecef_nav = ecefFromEnuRotation(problem.imu.nav_origin_lat_rad,
+                                                    problem.imu.nav_origin_lon_rad);
+        ecef_T_nav = Pose3(R_ecef_nav, Point3(problem.imu.nav_origin_ecef));
+        gnss_lever_arm = gtsam::gnss::LeverArm(lever_arm_body, ecef_T_nav);
+    }
+
+    // Initial body->nav (ENU) attitude from Stage-1 alignment; used as the
+    // dead-reckoning start point for the 2b pose attitude seeds below.
+    const Rot3 init_attitude_nav(problem.imu.init_attitude_body_to_nav);
+
+    // Antenna ECEF position for the optimized state at `epoch`, uniform across
+    // all three representations (Point3, 2a Pose3-in-ECEF, 2b Pose3-in-nav):
+    // gnss::LeverArm::antennaPosition applies ecef_T_nav internally when set.
+    // Used everywhere downstream that needs "the position": LAMBDA covariance
+    // propagation, residual RMS diagnostics, final per-epoch solution mapping.
+    auto antennaPositionOf = [&](const gtsam::Values& values,
+                                 std::size_t epoch) -> Point3 {
+        if (use_pose3) {
+            return gnss_lever_arm.antennaPosition(values.at<Pose3>(positionKey(epoch)));
+        }
+        return values.at<Point3>(positionKey(epoch));
+    };
+
+    // Pose seeds (Point3 and 2a Pose3-in-ECEF; the 2b IMU poses are seeded
+    // below, after preintegration, so their attitudes can be dead-reckoned).
+    for (std::size_t i = 0; i < num_epochs; ++i) {
+        if (use_imu) {
+            continue;
+        }
+        if (use_pose3) {
+            // 2a: pose in ECEF, identity attitude (unobservable without IMU);
+            // translation = antenna seed minus lever arm.
+            initial.insert(positionKey(i),
+                           Pose3(Rot3(), Point3(problem.epochs[i].position_ecef) - lever_arm_body));
+        } else {
+            initial.insert(positionKey(i), Point3(problem.epochs[i].position_ecef));
+        }
+    }
+
+    if (use_imu) {
+        const gtsam::imuBias::ConstantBias init_bias(problem.imu.init_accel_bias,
+                                                     problem.imu.init_gyro_bias);
+
+        // --- IMU preintegration params (ENU / Z-up; gravity along -Z) ---
+        auto imu_params = gtsam::PreintegrationCombinedParams::MakeSharedU(
+            problem.imu.noise.gravity_mps2);
+        const auto sq = [](double s) { return s * s; };
+        imu_params->setAccelerometerCovariance(gtsam::I_3x3 * sq(problem.imu.noise.accel_noise_sigma));
+        imu_params->setGyroscopeCovariance(gtsam::I_3x3 * sq(problem.imu.noise.gyro_noise_sigma));
+        imu_params->setIntegrationCovariance(gtsam::I_3x3 * sq(problem.imu.noise.integration_sigma));
+        imu_params->setBiasAccCovariance(gtsam::I_3x3 * sq(problem.imu.noise.accel_bias_rw_sigma));
+        imu_params->setBiasOmegaCovariance(gtsam::I_3x3 * sq(problem.imu.noise.gyro_bias_rw_sigma));
+
+        // --- Preintegrate each [epoch i, epoch i+1) interval up front ---
+        // We need the preintegrated rotations to dead-reckon attitude seeds
+        // BEFORE inserting the pose values: seeding every pose at the same
+        // initial attitude makes each IMU factor's rotation residual the full
+        // accumulated turn between epochs, which gives a huge initial cost and
+        // a divergent first LM step (observed: 1e19 cost, no convergence). By
+        // forward-propagating attitude through deltaRij() the rotation residual
+        // starts ~0 and the DD-accurate translation keeps position anchored, so
+        // the graph is well conditioned from iteration 0.
+        const auto& imu_samples = problem.imu.samples_body_flu;
+        std::vector<gtsam::PreintegratedCombinedMeasurements> pims;
+        pims.reserve(num_epochs > 0 ? num_epochs - 1 : 0);
+        std::vector<bool> pim_valid(num_epochs > 0 ? num_epochs - 1 : 0, false);
+        std::size_t sample_cursor = 0;
+        std::size_t imu_intervals = 0;
+        for (std::size_t i = 0; i + 1 < num_epochs; ++i) {
+            const GNSSTime t0 = problem.epochs[i].time;
+            const GNSSTime t1 = problem.epochs[i + 1].time;
+            while (sample_cursor < imu_samples.size() && imu_samples[sample_cursor].time < t0) {
+                ++sample_cursor;
+            }
+            gtsam::PreintegratedCombinedMeasurements pim(imu_params, init_bias);
+            std::size_t j = sample_cursor;
+            GNSSTime prev_time = t0;
+            std::size_t integrated = 0;
+            while (j < imu_samples.size() && imu_samples[j].time < t1) {
+                const double dt = imu_samples[j].time - prev_time;
+                if (dt > 1e-9) {
+                    pim.integrateMeasurement(gtsam::Vector3(imu_samples[j].accel_raw),
+                                             gtsam::Vector3(imu_samples[j].gyro_raw_radps), dt);
+                    ++integrated;
+                }
+                prev_time = imu_samples[j].time;
+                ++j;
+            }
+            const double dt_tail = t1 - prev_time;
+            if (integrated > 0 && dt_tail > 1e-9 && j > 0) {
+                pim.integrateMeasurement(gtsam::Vector3(imu_samples[j - 1].accel_raw),
+                                         gtsam::Vector3(imu_samples[j - 1].gyro_raw_radps), dt_tail);
+            }
+            pims.push_back(pim);
+            pim_valid[i] = integrated > 0;
+            if (integrated > 0) ++imu_intervals;
+        }
+
+        // --- Dead-reckon per-epoch attitude seeds from the aligned initial
+        // attitude (rotation residual ~0 at the seed). ---
+        std::vector<Rot3> attitude_seed(num_epochs, init_attitude_nav);
+        for (std::size_t i = 0; i + 1 < num_epochs; ++i) {
+            attitude_seed[i + 1] =
+                pim_valid[i] ? attitude_seed[i] * pims[i].deltaRij() : attitude_seed[i];
+        }
+
+        // GNSS antenna positions in nav, for translation + velocity seeds.
+        std::vector<Point3> antenna_nav(num_epochs);
+        for (std::size_t i = 0; i < num_epochs; ++i) {
+            antenna_nav[i] = Point3(ecef2enu(
+                problem.epochs[i].position_ecef - problem.imu.nav_origin_ecef,
+                problem.imu.nav_origin_lat_rad, problem.imu.nav_origin_lon_rad));
+        }
+
+        // --- Insert pose / velocity / bias seeds ---
+        for (std::size_t i = 0; i < num_epochs; ++i) {
+            // body-in-nav translation: antenna at the DD position, offset back
+            // through the (dead-reckoned) attitude's lever arm.
+            const Point3 body_nav = antenna_nav[i] - attitude_seed[i] * lever_arm_body;
+            initial.insert(positionKey(i), Pose3(attitude_seed[i], body_nav));
+
+            Vector3d vel = problem.imu.init_velocity_nav;
+            if (num_epochs >= 2) {
+                const std::size_t a = (i + 1 < num_epochs) ? i : i - 1;
+                const double dt = problem.epochs[a + 1].time - problem.epochs[a].time;
+                if (dt > 1e-3) {
+                    vel = (antenna_nav[a + 1] - antenna_nav[a]) / dt;
+                }
+            }
+            initial.insert(velocityKey(i), gtsam::Vector3(vel));
+            initial.insert(biasKey(i), init_bias);
+        }
+
+        // --- First-state priors (replace the 2a per-epoch rotation pin): they
+        // anchor the IMU integration chain and resolve the gauge. Attitude is
+        // now observable (gravity fixes roll/pitch; motion fixes yaw), so no
+        // per-pose rotation pin is needed. Position stays fully DD-driven. ---
+        gtsam::Vector6 pose_prior_sigmas;
+        pose_prior_sigmas << problem.imu.init_attitude_sigma_roll_pitch_rad,
+            problem.imu.init_attitude_sigma_roll_pitch_rad,
+            problem.imu.init_attitude_sigma_yaw_rad,
+            1e6, 1e6, 1e6;  // translation left free (DD constrains it)
+        graph.addPrior(positionKey(0), initial.at<Pose3>(positionKey(0)),
+                       gtsam::noiseModel::Diagonal::Sigmas(pose_prior_sigmas));
+        graph.addPrior(velocityKey(0), gtsam::Vector3(problem.imu.init_velocity_nav),
+                       gtsam::noiseModel::Isotropic::Sigma(3, problem.imu.init_velocity_sigma_mps));
+        gtsam::Vector6 bias_prior_sigmas;
+        bias_prior_sigmas << problem.imu.init_accel_bias_sigma, problem.imu.init_accel_bias_sigma,
+            problem.imu.init_accel_bias_sigma, problem.imu.init_gyro_bias_sigma,
+            problem.imu.init_gyro_bias_sigma, problem.imu.init_gyro_bias_sigma;
+        graph.addPrior(biasKey(0), init_bias,
+                       gtsam::noiseModel::Diagonal::Sigmas(bias_prior_sigmas));
+
+        // --- Add the CombinedImuFactors (or a loose velocity/bias continuity
+        // across an IMU dropout) ---
+        for (std::size_t i = 0; i + 1 < num_epochs; ++i) {
+            if (pim_valid[i]) {
+                graph.emplace_shared<gtsam::CombinedImuFactor>(
+                    positionKey(i), velocityKey(i), positionKey(i + 1), velocityKey(i + 1),
+                    biasKey(i), biasKey(i + 1), pims[i]);
+            } else {
+                graph.emplace_shared<gtsam::BetweenFactor<gtsam::Vector3>>(
+                    velocityKey(i), velocityKey(i + 1), gtsam::Vector3::Zero(),
+                    gtsam::noiseModel::Isotropic::Sigma(3, 10.0));
+                graph.emplace_shared<gtsam::BetweenFactor<gtsam::imuBias::ConstantBias>>(
+                    biasKey(i), biasKey(i + 1), gtsam::imuBias::ConstantBias(),
+                    gtsam::noiseModel::Isotropic::Sigma(6, 1.0));
+            }
+        }
+        result.diagnostics.imu_intervals = imu_intervals;
+    } else if (use_pose3) {
+        // 2a rotation-only gauge pin (no IMU): resolves the exact rotational
+        // null space left by lever-arm-only position observations, without
+        // perturbing the estimated antenna position beyond kRotationPinSigmaRad
+        // * |lever_arm| (~0.06 mm at 1e-4 rad and the tokyo ~0.62 m lever arm).
+        constexpr double kRotationPinSigmaRad = 1e-4;
+        const auto rotation_noise = gtsam::noiseModel::Isotropic::Sigma(3, kRotationPinSigmaRad);
+        for (std::size_t i = 0; i < num_epochs; ++i) {
+            graph.emplace_shared<Pose3RotationPrior>(positionKey(i), Rot3(), rotation_noise);
+        }
+    }
+
+    // Undifferenced factors need a per-epoch base receiver clock [s] plus, for
+    // every non-GPS constellation, ONE global (time-constant) inter-system bias
+    // node shared across all epochs -- matching the native backend's per-epoch
+    // clock + per-constellation bias columns.
+    const bool need_clock_states =
+        !problem.pseudorange_factors.empty() || !problem.carrier_phase_factors.empty();
+    std::set<gtsam::Key> inserted_clock_keys;
+    std::set<int> inserted_isb_ordinals;
+    auto ensureBaseClock = [&](std::size_t epoch) -> gtsam::Key {
+        const gtsam::Key key = clockKey(epoch);
+        if (inserted_clock_keys.insert(key).second) {
+            initial.insert(key, epoch < num_epochs
+                                    ? problem.epochs[epoch].receiver_clock_bias_m /
+                                          constants::SPEED_OF_LIGHT
+                                    : 0.0);
+        }
+        return key;
+    };
+    // Returns the ISB ordinal for a system: 0 means GPS/base (no ISB node),
+    // >0 means a global ISB node was ensured for that constellation.
+    auto ensureIsb = [&](GNSSSystem system) -> int {
+        const int ordinal =
+            clockGroupOrdinal(clockBiasGroup(system), config.use_inter_system_biases);
+        if (ordinal != 0 && inserted_isb_ordinals.insert(ordinal).second) {
+            initial.insert(isbKey(ordinal), 0.0);
+        }
+        return ordinal;
+    };
+
+    // Ambiguity nodes: one per AmbiguityState, in the units that state's
+    // consuming factor expects (cycles for DD, meters for undifferenced).
+    for (std::size_t i = 0; i < problem.ambiguity_states.size(); ++i) {
+        const auto& ambiguity = problem.ambiguity_states[i];
+        const double value =
+            ambiguity.is_double_difference && ambiguity.wavelength_m > 0.0
+                ? ambiguity.initial_ambiguity_m / ambiguity.wavelength_m
+                : ambiguity.initial_ambiguity_m;
+        initial.insert(ambiguityKey(i), value);
+    }
+    const bool need_dummy_ambiguity =
+        std::any_of(problem.ambiguity_states.begin(), problem.ambiguity_states.end(),
+                    [](const FGOProcessor::AmbiguityState& a) { return a.is_double_difference; });
+    if (need_dummy_ambiguity) {
+        initial.insert(dummyAmbiguityKey(), 0.0);
+        // Pin the shared dummy ambiguity at 0 so the lumped libgnss DD ambiguity
+        // lives entirely in ambRef (the estimate is then simply ambRef). The
+        // dummy is shared across every DD carrier factor, which introduces a
+        // common-mode null space (shift dummy + every ambRef by the same delta
+        // leaves all carrier residuals unchanged); only this prior constrains
+        // it. A near-zero sigma (e.g. 1e-6) pins it but makes the prior's
+        // Hessian block ~1e12 against position blocks ~1e2, i.e. condition
+        // number ~1e10 -> Cholesky returns a garbage step, every LM trial
+        // diverges to inf error, and LM gives up at iteration 0. 1e-3 cycles
+        // (~0.2 mm of range) is still "fixed" physically but keeps the system
+        // well conditioned (~1e4).
+        constexpr double kDummyAmbiguityPinSigmaCycles = 1e-3;
+        graph.addPrior(dummyAmbiguityKey(), 0.0,
+                       gtsam::noiseModel::Isotropic::Sigma(1, kDummyAmbiguityPinSigmaCycles));
+    }
+
+    // --- Undifferenced pseudorange / carrier-phase factors ---
+    for (const auto& factor : problem.pseudorange_factors) {
+        const gtsam::Key base_clock = ensureBaseClock(factor.epoch_index);
+        const int ordinal = ensureIsb(factor.satellite.system);
+        const auto noise = makeNoise(factor.sigma_m, config.use_robust_loss,
+                                     config.pseudorange_huber_threshold_sigma);
+        if (use_pose3) {
+            if (ordinal == 0) {
+                graph.emplace_shared<PseudorangeFactorPlainArm>(
+                    positionKey(factor.epoch_index), base_clock,
+                    factor.corrected_pseudorange_m, Point3(factor.satellite_position_ecef),
+                    gnss_lever_arm, noise);
+            } else {
+                graph.emplace_shared<PseudorangeFactorISBArm>(
+                    positionKey(factor.epoch_index), base_clock, isbKey(ordinal),
+                    factor.corrected_pseudorange_m, Point3(factor.satellite_position_ecef),
+                    gnss_lever_arm, noise);
+            }
+        } else if (ordinal == 0) {
+            graph.emplace_shared<PseudorangeFactorPlain>(
+                positionKey(factor.epoch_index), base_clock,
+                factor.corrected_pseudorange_m, Point3(factor.satellite_position_ecef),
+                noise);
+        } else {
+            graph.emplace_shared<PseudorangeFactorISB>(
+                positionKey(factor.epoch_index), base_clock, isbKey(ordinal),
+                factor.corrected_pseudorange_m, Point3(factor.satellite_position_ecef),
+                noise);
+        }
+    }
+    // Undifferenced carrier phase (rare here: use_carrier_phase_factors is off
+    // in the DD RTK config) uses only the base clock; the ISB affects code and
+    // phase identically and cancels in the DD path, so this is adequate for the
+    // SPP-seed carrier path and can gain its own ISB term if PPP-RTK needs it.
+    // Not yet ported to Pose3 (milestone 2a targets the pure-DD RTK path,
+    // where use_carrier_phase_factors is off); skip with a warning rather
+    // than silently mixing a Point3 factor into a Pose3 graph.
+    for (const auto& factor : problem.carrier_phase_factors) {
+        if (factor.ambiguity_index >= problem.ambiguity_states.size()) {
+            continue;
+        }
+        if (use_pose3) {
+            std::fprintf(stderr,
+                         "[fgo_gtsam_backend] WARNING: undifferenced carrier_phase_factors are "
+                         "not yet supported with use_pose3_state; skipping %zu factor(s).\n",
+                         problem.carrier_phase_factors.size());
+            break;
+        }
+        const gtsam::Key base_clock = ensureBaseClock(factor.epoch_index);
+        const auto noise = makeNoise(factor.sigma_m, config.use_robust_loss,
+                                     config.carrier_phase_huber_threshold_sigma);
+        graph.emplace_shared<gtsam::CarrierPhaseFactor>(
+            positionKey(factor.epoch_index), base_clock,
+            ambiguityKey(factor.ambiguity_index), factor.corrected_carrier_m,
+            Point3(factor.satellite_position_ecef), 0.0, noise);
+    }
+
+    // --- Double-difference pseudorange factors ---
+    for (const auto& factor : problem.double_difference_pseudorange_factors) {
+        const gtsam::gnss::DoubleDifferenceData dd{
+            factor.rover_satellite_model.corrected_pseudorange_m,
+            factor.base_satellite_model.corrected_pseudorange_m,
+            factor.rover_reference_model.corrected_pseudorange_m,
+            factor.base_reference_model.corrected_pseudorange_m,
+            Point3(factor.rover_satellite_position_ecef),
+            Point3(factor.rover_reference_position_ecef),
+            Point3(factor.base_satellite_position_ecef),
+            Point3(factor.base_reference_position_ecef),
+            Point3(factor.base_position_ecef),
+        };
+        checkObservedDdMatches(dd.observed(), factor.observed_dd_pseudorange_m,
+                              "DD pseudorange");
+
+        const auto noise = makeNoise(factor.sigma_m, config.use_robust_loss,
+                                     config.pseudorange_huber_threshold_sigma);
+        if (use_imu) {
+            // 2b: pose is body-in-nav (ENU) -> feed ecef_T_nav so the factor
+            // reconstructs the antenna ECEF from the nav-frame pose.
+            graph.emplace_shared<gtsam::DoubleDifferencePseudorangeFactorArm>(
+                positionKey(factor.epoch_index),
+                dd.rovRef, dd.baseRef, dd.rovTarget, dd.baseTarget,
+                dd.satRefRov, dd.satTargetRov, dd.satRefBase, dd.satTargetBase,
+                dd.basePos, lever_arm_body, ecef_T_nav, noise);
+        } else if (use_pose3) {
+            // 2a: pose expressed directly in ECEF (no ecef_T_nav).
+            graph.emplace_shared<gtsam::DoubleDifferencePseudorangeFactorArm>(
+                positionKey(factor.epoch_index),
+                dd.rovRef, dd.baseRef, dd.rovTarget, dd.baseTarget,
+                dd.satRefRov, dd.satTargetRov, dd.satRefBase, dd.satTargetBase,
+                dd.basePos, lever_arm_body, noise);
+        } else {
+            graph.emplace_shared<gtsam::DoubleDifferencePseudorangeFactor>(
+                positionKey(factor.epoch_index),
+                dd.rovRef, dd.baseRef, dd.rovTarget, dd.baseTarget,
+                dd.satRefRov, dd.satTargetRov, dd.satRefBase, dd.satTargetBase,
+                dd.basePos, noise);
+        }
+    }
+
+    // --- Double-difference carrier-phase factors ---
+    for (const auto& factor : problem.double_difference_carrier_factors) {
+        if (factor.ambiguity_index >= problem.ambiguity_states.size()) {
+            continue;
+        }
+        const auto& ambiguity = problem.ambiguity_states[factor.ambiguity_index];
+        const gtsam::gnss::DoubleDifferenceData dd{
+            factor.rover_satellite_model.corrected_carrier_m,
+            factor.base_satellite_model.corrected_carrier_m,
+            factor.rover_reference_model.corrected_carrier_m,
+            factor.base_reference_model.corrected_carrier_m,
+            Point3(factor.rover_satellite_position_ecef),
+            Point3(factor.rover_reference_position_ecef),
+            Point3(factor.base_satellite_position_ecef),
+            Point3(factor.base_reference_position_ecef),
+            Point3(factor.base_position_ecef),
+        };
+        checkObservedDdMatches(dd.observed(), factor.observed_dd_carrier_m, "DD carrier");
+
+        const auto noise = makeNoise(factor.sigma_m, config.use_robust_loss,
+                                     config.carrier_phase_huber_threshold_sigma);
+        if (use_imu) {
+            graph.emplace_shared<gtsam::DoubleDifferenceCarrierPhaseFactorArm>(
+                positionKey(factor.epoch_index),
+                ambiguityKey(factor.ambiguity_index),  // ambRef <- real DD ambiguity node
+                dummyAmbiguityKey(),                   // ambTarget <- pinned at 0
+                dd.rovRef, dd.baseRef, dd.rovTarget, dd.baseTarget,
+                dd.satRefRov, dd.satTargetRov, dd.satRefBase, dd.satTargetBase,
+                dd.basePos, ambiguity.wavelength_m, lever_arm_body, ecef_T_nav, noise);
+        } else if (use_pose3) {
+            graph.emplace_shared<gtsam::DoubleDifferenceCarrierPhaseFactorArm>(
+                positionKey(factor.epoch_index),
+                ambiguityKey(factor.ambiguity_index),  // ambRef <- real DD ambiguity node
+                dummyAmbiguityKey(),                   // ambTarget <- pinned at 0
+                dd.rovRef, dd.baseRef, dd.rovTarget, dd.baseTarget,
+                dd.satRefRov, dd.satTargetRov, dd.satRefBase, dd.satTargetBase,
+                dd.basePos, ambiguity.wavelength_m, lever_arm_body, noise);
+        } else {
+            graph.emplace_shared<gtsam::DoubleDifferenceCarrierPhaseFactor>(
+                positionKey(factor.epoch_index),
+                ambiguityKey(factor.ambiguity_index),  // ambRef <- real DD ambiguity node
+                dummyAmbiguityKey(),                   // ambTarget <- pinned at 0
+                dd.rovRef, dd.baseRef, dd.rovTarget, dd.baseTarget,
+                dd.satRefRov, dd.satTargetRov, dd.satRefBase, dd.satTargetBase,
+                dd.basePos, ambiguity.wavelength_m, noise);
+        }
+    }
+
+    // --- Ambiguity priors ---
+    if (config.use_ambiguity_priors && config.ambiguity_prior_sigma_m > 0.0) {
+        for (std::size_t i = 0; i < problem.ambiguity_states.size(); ++i) {
+            const auto& ambiguity = problem.ambiguity_states[i];
+            if (ambiguity.is_double_difference && ambiguity.wavelength_m > 0.0) {
+                const double mean = ambiguity.initial_ambiguity_m / ambiguity.wavelength_m;
+                const double sigma = config.ambiguity_prior_sigma_m / ambiguity.wavelength_m;
+                graph.addPrior(ambiguityKey(i), mean, gtsam::noiseModel::Isotropic::Sigma(1, sigma));
+            } else {
+                graph.addPrior(ambiguityKey(i), ambiguity.initial_ambiguity_m,
+                               gtsam::noiseModel::Isotropic::Sigma(1, config.ambiguity_prior_sigma_m));
+            }
+        }
+    }
+
+    // --- Ambiguity continuity (BetweenFactor<double>) ---
+    for (const auto& factor : problem.ambiguity_between_factors) {
+        if (factor.previous_ambiguity_index >= problem.ambiguity_states.size() ||
+            factor.current_ambiguity_index >= problem.ambiguity_states.size()) {
+            continue;
+        }
+        const auto& ambiguity = problem.ambiguity_states[factor.current_ambiguity_index];
+        const double wavelength = ambiguity.wavelength_m;
+        const double sigma_cycles = wavelength > 0.0 ? factor.sigma_m / wavelength : factor.sigma_m;
+        graph.emplace_shared<gtsam::BetweenFactor<double>>(
+            ambiguityKey(factor.previous_ambiguity_index),
+            ambiguityKey(factor.current_ambiguity_index), 0.0,
+            gtsam::noiseModel::Isotropic::Sigma(1, std::max(1e-9, sigma_cycles)));
+    }
+
+    // --- Position motion (random-walk) factors between consecutive epochs ---
+    if (config.use_motion_factors && config.use_position_motion_factors &&
+        config.motion_sigma_m > 0.0) {
+        if (use_pose3) {
+            // Pose3 analog of the Point3 zero-motion BetweenFactor below: same
+            // loose translation sigma (motion_sigma_m, e.g. 100 m -- a
+            // near-no-op regularizer at DD noise levels), and an even looser
+            // rotation sigma so it never competes with the dedicated
+            // Pose3RotationPrior gauge pin above.
+            constexpr double kLooseRotationSigmaRad = 10.0;
+            gtsam::Vector6 sigmas;
+            sigmas << kLooseRotationSigmaRad, kLooseRotationSigmaRad, kLooseRotationSigmaRad,
+                config.motion_sigma_m, config.motion_sigma_m, config.motion_sigma_m;
+            const auto noise = gtsam::noiseModel::Diagonal::Sigmas(sigmas);
+            for (std::size_t i = 1; i < num_epochs; ++i) {
+                graph.emplace_shared<gtsam::BetweenFactor<Pose3>>(
+                    positionKey(i - 1), positionKey(i), Pose3(Rot3(), Point3(0.0, 0.0, 0.0)),
+                    noise);
+            }
+        } else {
+            const auto noise = gtsam::noiseModel::Isotropic::Sigma(3, config.motion_sigma_m);
+            for (std::size_t i = 1; i < num_epochs; ++i) {
+                graph.emplace_shared<gtsam::BetweenFactor<Point3>>(
+                    positionKey(i - 1), positionKey(i), Point3(0.0, 0.0, 0.0), noise);
+            }
+        }
+    }
+
+    // --- Optional absolute priors (disabled by default: sigma <= 0) ---
+    if (config.position_prior_sigma_m > 0.0) {
+        if (use_pose3) {
+            constexpr double kLooseRotationSigmaRad = 1e6;
+            gtsam::Vector6 sigmas;
+            sigmas << kLooseRotationSigmaRad, kLooseRotationSigmaRad, kLooseRotationSigmaRad,
+                config.position_prior_sigma_m, config.position_prior_sigma_m,
+                config.position_prior_sigma_m;
+            const auto noise = gtsam::noiseModel::Diagonal::Sigmas(sigmas);
+            for (std::size_t i = 0; i < num_epochs; ++i) {
+                graph.addPrior(positionKey(i),
+                               Pose3(Rot3(), Point3(problem.epochs[i].position_ecef) - lever_arm_body),
+                               noise);
+            }
+        } else {
+            const auto noise = gtsam::noiseModel::Isotropic::Sigma(3, config.position_prior_sigma_m);
+            for (std::size_t i = 0; i < num_epochs; ++i) {
+                graph.addPrior(positionKey(i), Point3(problem.epochs[i].position_ecef), noise);
+            }
+        }
+    }
+    if (need_clock_states && config.clock_prior_sigma_m > 0.0) {
+        const auto noise = gtsam::noiseModel::Isotropic::Sigma(
+            1, config.clock_prior_sigma_m / constants::SPEED_OF_LIGHT);
+        for (const gtsam::Key key : inserted_clock_keys) {
+            graph.addPrior(key, initial.at<double>(key), noise);
+        }
+    }
+
+    result.diagnostics.graph_factors = graph.size();
+    result.diagnostics.graph_values = initial.size();
+
+    // --- Solve ---
+    gtsam::LevenbergMarquardtParams params;
+    if (std::getenv("GNSSPP_GTSAM_LM_VERBOSE") != nullptr) {
+        params.setVerbosityLM("SUMMARY");
+    }
+    params.setMaxIterations(std::max(1, config.max_iterations));
+    params.setAbsoluteErrorTol(config.absolute_cost_convergence_threshold > 0.0
+                                   ? config.absolute_cost_convergence_threshold
+                                   : 1e-10);
+    params.setRelativeErrorTol(config.relative_cost_convergence_threshold > 0.0
+                                   ? config.relative_cost_convergence_threshold
+                                   : 1e-8);
+
+    const double initial_cost = graph.error(initial);
+    gtsam::LevenbergMarquardtOptimizer optimizer(graph, initial, params);
+    gtsam::Values optimized;
+    bool solved = true;
+    try {
+        optimized = optimizer.optimize();
+    } catch (const std::exception& e) {
+        std::fprintf(stderr, "[fgo_gtsam_backend] LM optimize() threw: %s\n", e.what());
+        solved = false;
+        optimized = initial;
+    }
+    const double final_cost = graph.error(optimized);
+
+    result.diagnostics.iterations = static_cast<int>(optimizer.iterations());
+    result.diagnostics.converged = solved;
+    result.diagnostics.initial_cost = initial_cost;
+    result.diagnostics.final_cost = final_cost;
+
+    // --- Per-epoch / partial LAMBDA integer fixing ---
+    // Mirrors the native backend's per-epoch LAMBDA path (fgo.cpp
+    // process_epoch_lambda_work): group each epoch's DD ambiguities, take their
+    // joint marginal covariance (here via gtsam::Marginals over the whole
+    // graph), run the SAME libgnss::lambdaSearch with the same ratio test, and
+    // -- when use_epoch_lambda_fixed_output is set -- snap that epoch's position
+    // to the fixed solution via the position/ambiguity cross-covariance. GTSAM
+    // ambiguity nodes are already in cycles, so no wavelength scaling is needed.
+    std::map<std::size_t, int> fixed_cycles_by_index;      // amb index -> integer cycles
+    std::map<std::size_t, double> fixed_residual_by_index;  // amb index -> float-int residual
+    std::vector<bool> epoch_fixed(num_epochs, false);
+    std::vector<int> epoch_fixed_count(num_epochs, 0);
+    std::vector<double> epoch_ratio(num_epochs, 0.0);
+    std::vector<Point3> epoch_output_position(num_epochs, Point3(0, 0, 0));
+    for (std::size_t i = 0; i < num_epochs; ++i) {
+        epoch_output_position[i] = antennaPositionOf(optimized, i);
+    }
+    std::size_t total_fixed_ambiguities = 0;
+    std::size_t covariance_failures = 0;
+    double best_ratio = 0.0;
+
+    const bool do_fix =
+        solved && config.use_lambda_ambiguity_fix &&
+        !problem.double_difference_carrier_factors.empty();
+    if (do_fix) {
+        // DD ambiguity indices present at each epoch.
+        std::map<std::size_t, std::set<std::size_t>> ambiguity_indices_by_epoch;
+        for (const auto& factor : problem.double_difference_carrier_factors) {
+            if (factor.epoch_index < num_epochs &&
+                factor.ambiguity_index < problem.ambiguity_states.size()) {
+                ambiguity_indices_by_epoch[factor.epoch_index].insert(factor.ambiguity_index);
+            }
+        }
+        // Same minimum-candidate gate as the native per-epoch path.
+        const int min_candidates =
+            std::max(6, std::max(1, config.min_fixed_ambiguities + 1));
+
+        gtsam::Marginals marginals;
+        bool have_marginals = false;
+        try {
+            marginals = gtsam::Marginals(graph, optimized, gtsam::Marginals::CHOLESKY);
+            have_marginals = true;
+        } catch (const std::exception& e) {
+            std::fprintf(stderr, "[fgo_gtsam_backend] Marginals failed, no fixing: %s\n",
+                         e.what());
+        }
+
+        for (auto it = ambiguity_indices_by_epoch.begin();
+             have_marginals && it != ambiguity_indices_by_epoch.end(); ++it) {
+            const std::size_t epoch_index = it->first;
+            if (static_cast<int>(it->second.size()) < min_candidates) {
+                continue;
+            }
+            // Deterministic candidate order (satellite/reference), matching the
+            // native path's sort.
+            std::vector<std::size_t> candidates(it->second.begin(), it->second.end());
+            std::sort(candidates.begin(), candidates.end(),
+                      [&](std::size_t a, std::size_t b) {
+                          const auto& sa = problem.ambiguity_states[a];
+                          const auto& sb = problem.ambiguity_states[b];
+                          return std::tie(sa.satellite, sa.reference_satellite, sa.signal, a) <
+                                 std::tie(sb.satellite, sb.reference_satellite, sb.signal, b);
+                      });
+            const int n = static_cast<int>(candidates.size());
+
+            gtsam::KeyVector keys;
+            keys.reserve(candidates.size() + 1);
+            keys.push_back(positionKey(epoch_index));
+            for (std::size_t idx : candidates) {
+                keys.push_back(ambiguityKey(idx));
+            }
+
+            Eigen::VectorXd float_amb(n);
+            Eigen::MatrixXd q_amb(n, n);
+            Eigen::MatrixXd pos_amb(3, n);  // Cov(antenna_position, ambiguity_row)
+            bool ok = true;
+            try {
+                const gtsam::JointMarginal joint = marginals.jointMarginalCovariance(keys);
+                const gtsam::Key pos_key = positionKey(epoch_index);
+                // Pose3 mode: the joint marginal gives Cov(pose_tangent, amb),
+                // a 6x1 block; propagate it through the antenna Jacobian
+                // (3x6, constant for this epoch/optimized-value) to get
+                // Cov(antenna_position, amb), matching the Point3 case's
+                // native 3x1 block below.
+                gtsam::Matrix36 H_antenna_pose;
+                if (use_pose3) {
+                    gtsam::gnss::LeverArm::PoseFrame frame;
+                    gnss_lever_arm.antennaPosition(optimized.at<Pose3>(pos_key), &frame);
+                    for (int r3 = 0; r3 < 3; ++r3) {
+                        gtsam::Matrix13 unit = gtsam::Matrix13::Zero();
+                        unit(0, r3) = 1.0;
+                        H_antenna_pose.row(r3) = gnss_lever_arm.antennaPoseJacobian(unit, frame);
+                    }
+                }
+                for (int r = 0; r < n && ok; ++r) {
+                    const gtsam::Key rk = ambiguityKey(candidates[r]);
+                    float_amb(r) = optimized.at<double>(rk);
+                    const gtsam::Matrix pr = joint(pos_key, rk);  // 6x1 (Pose3) or 3x1 (Point3)
+                    const Eigen::Vector3d pr3 = use_pose3 ? Eigen::Vector3d(H_antenna_pose * pr)
+                                                          : Eigen::Vector3d(pr.col(0));
+                    pos_amb(0, r) = pr3(0);
+                    pos_amb(1, r) = pr3(1);
+                    pos_amb(2, r) = pr3(2);
+                    for (int c = 0; c < n; ++c) {
+                        q_amb(r, c) = joint(rk, ambiguityKey(candidates[c]))(0, 0);
+                    }
+                }
+            } catch (const std::exception&) {
+                ok = false;
+            }
+            if (!ok || !float_amb.allFinite() || !q_amb.allFinite()) {
+                ++covariance_failures;
+                continue;
+            }
+
+            q_amb = 0.5 * (q_amb + q_amb.transpose());
+            for (int i = 0; i < n; ++i) {
+                q_amb(i, i) += std::max(1e-12, std::abs(q_amb(i, i)) * 1e-9);
+            }
+
+            Eigen::VectorXd fixed_amb;
+            double ratio = 0.0;
+            ++result.diagnostics.lambda_ambiguity_attempts;
+            result.diagnostics.lambda_ambiguity_candidates += static_cast<std::size_t>(n);
+            const bool solved_lambda = lambdaSearch(float_amb, q_amb, fixed_amb, ratio);
+            if (!solved_lambda) {
+                continue;
+            }
+            result.diagnostics.lambda_ambiguity_fix_solved = true;
+            best_ratio = std::max(best_ratio, ratio);
+            epoch_ratio[epoch_index] = ratio;
+            const bool fixed_epoch =
+                std::isfinite(ratio) &&
+                (config.lambda_ratio_threshold <= 0.0 || ratio > config.lambda_ratio_threshold) &&
+                fixed_amb.size() == n;
+            if (!fixed_epoch) {
+                continue;
+            }
+
+            epoch_fixed[epoch_index] = true;
+            epoch_fixed_count[epoch_index] = n;
+            total_fixed_ambiguities += static_cast<std::size_t>(n);
+            result.diagnostics.lambda_ambiguity_fix_used = true;
+            result.diagnostics.lambda_ambiguity_used_candidates += static_cast<std::size_t>(n);
+            for (int r = 0; r < n; ++r) {
+                const int fixed_int = static_cast<int>(std::lround(fixed_amb(r)));
+                fixed_cycles_by_index[candidates[r]] = fixed_int;
+                fixed_residual_by_index[candidates[r]] = float_amb(r) - static_cast<double>(fixed_int);
+            }
+
+            // Position snap to the fixed ambiguities (only when requested):
+            //   x_fixed = x_float - Cov(x,N) Cov(N,N)^-1 (N_float - N_fixed)
+            if (config.use_epoch_lambda_fixed_output) {
+                const Eigen::VectorXd delta = float_amb - fixed_amb;
+                const Eigen::LDLT<Eigen::MatrixXd> ldlt(q_amb);
+                if (ldlt.info() == Eigen::Success) {
+                    const Eigen::VectorXd correction = ldlt.solve(delta);
+                    if (correction.allFinite()) {
+                        const Eigen::Vector3d pos_delta = pos_amb * correction;
+                        if (pos_delta.allFinite()) {
+                            epoch_output_position[epoch_index] =
+                                antennaPositionOf(optimized, epoch_index) - Point3(pos_delta);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    const bool any_fixed = total_fixed_ambiguities > 0;
+    result.diagnostics.lambda_ambiguity_ratio = best_ratio;
+    result.diagnostics.fixed_solution = any_fixed;
+    result.diagnostics.fixed_ambiguities = total_fixed_ambiguities;
+    if (covariance_failures > 0) {
+        std::fprintf(stderr,
+                     "[fgo_gtsam_backend] %zu epoch(s) skipped: non-PSD / marginal failure\n",
+                     covariance_failures);
+    }
+
+    // --- Map ambiguity estimates ---
+    result.ambiguity_estimates.reserve(problem.ambiguity_states.size());
+    for (std::size_t i = 0; i < problem.ambiguity_states.size(); ++i) {
+        const auto& ambiguity = problem.ambiguity_states[i];
+        FGOProcessor::AmbiguityEstimate estimate;
+        estimate.satellite = ambiguity.satellite;
+        estimate.signal = ambiguity.signal;
+        estimate.segment_index = ambiguity.segment_index;
+        estimate.wavelength_m = ambiguity.wavelength_m;
+        const double value = optimized.at<double>(ambiguityKey(i));
+        if (ambiguity.is_double_difference && ambiguity.wavelength_m > 0.0) {
+            estimate.ambiguity_cycles = value;
+            estimate.ambiguity_m = value * ambiguity.wavelength_m;
+        } else {
+            estimate.ambiguity_m = value;
+            estimate.ambiguity_cycles =
+                ambiguity.wavelength_m > 0.0 ? value / ambiguity.wavelength_m : 0.0;
+        }
+        const auto fixed_it = fixed_cycles_by_index.find(i);
+        if (fixed_it != fixed_cycles_by_index.end()) {
+            estimate.is_fixed = true;
+            estimate.fixed_by_lambda = true;
+            estimate.fixed_cycles = fixed_it->second;
+            estimate.fixed_ambiguity_m = fixed_it->second * ambiguity.wavelength_m;
+            estimate.fix_residual_cycles = fixed_residual_by_index.at(i);
+        }
+        result.ambiguity_estimates.push_back(estimate);
+    }
+
+    // --- Map per-epoch solutions ---
+    const bool have_ambiguities = !problem.ambiguity_states.empty();
+    for (std::size_t i = 0; i < num_epochs; ++i) {
+        PositionSolution solution;
+        solution.time = problem.epochs[i].time;
+        if (epoch_fixed[i]) {
+            solution.status = SolutionStatus::FIXED;
+        } else if (have_ambiguities) {
+            solution.status = SolutionStatus::FLOAT;
+        } else {
+            solution.status = SolutionStatus::SPP;
+        }
+        // Fixed position snap only takes effect when use_epoch_lambda_fixed_output
+        // is set; otherwise epoch_output_position holds the float position.
+        solution.position_ecef = epoch_output_position[i];
+        if (need_clock_states && optimized.exists(clockKey(i))) {
+            solution.receiver_clock_bias = optimized.at<double>(clockKey(i));
+        }
+        solution.num_frequencies = 1;
+        solution.ratio = epoch_ratio[i];
+        solution.num_fixed_ambiguities = epoch_fixed_count[i];
+        solution.iterations = result.diagnostics.iterations;
+
+        double lat = 0.0;
+        double lon = 0.0;
+        double height = 0.0;
+        ecef2geodetic(solution.position_ecef, lat, lon, height);
+        solution.position_geodetic = GeodeticCoord(lat, lon, height);
+
+        result.solution.addSolution(solution);
+    }
+
+    // --- Milestone 2b: export estimated attitude (roll/pitch/heading, deg)
+    // and ENU velocity so callers can confirm attitude is now observable. ---
+    if (use_imu) {
+        result.epoch_attitude_rpy_deg.resize(num_epochs);
+        result.epoch_velocity_nav_mps.resize(num_epochs);
+        constexpr double kRadToDeg = 180.0 / 3.14159265358979323846;
+        for (std::size_t i = 0; i < num_epochs; ++i) {
+            const Rot3 R_body_to_nav = optimized.at<Pose3>(positionKey(i)).rotation();
+            const gtsam::Matrix3 R = R_body_to_nav.matrix();
+            const Eigen::Vector3d fwd = R.col(0);   // body forward in ENU
+            const Eigen::Vector3d left = R.col(1);  // body left in ENU
+            // heading: clockwise from North (atan2(E, N)); pitch: nose-up from
+            // the forward axis Up component; roll: from the left axis Up
+            // component. Matches the reference.csv Roll/Pitch/Heading convention.
+            double heading = std::atan2(fwd.x(), fwd.y()) * kRadToDeg;
+            if (heading < 0.0) heading += 360.0;
+            const double pitch =
+                std::asin(std::max(-1.0, std::min(1.0, fwd.z()))) * kRadToDeg;
+            const double roll = std::atan2(left.z(), R.col(2).z()) * kRadToDeg;
+            result.epoch_attitude_rpy_deg[i] = Vector3d(roll, pitch, heading);
+            result.epoch_velocity_nav_mps[i] =
+                Vector3d(optimized.at<gtsam::Vector3>(velocityKey(i)));
+        }
+    }
+
+    // --- Residual RMS diagnostics (recomputed from the optimized state so
+    // they are directly comparable with the native backend's fields) ---
+    auto accumulate_rms = [](double sum, std::size_t count) {
+        return count > 0 ? std::sqrt(sum / static_cast<double>(count)) : 0.0;
+    };
+
+    {
+        double sum = 0.0;
+        std::size_t count = 0;
+        for (const auto& factor : problem.double_difference_pseudorange_factors) {
+            const Point3 position = antennaPositionOf(optimized, factor.epoch_index);
+            const gtsam::gnss::DoubleDifferenceData dd{
+                factor.rover_satellite_model.corrected_pseudorange_m,
+                factor.base_satellite_model.corrected_pseudorange_m,
+                factor.rover_reference_model.corrected_pseudorange_m,
+                factor.base_reference_model.corrected_pseudorange_m,
+                Point3(factor.rover_satellite_position_ecef),
+                Point3(factor.rover_reference_position_ecef),
+                Point3(factor.base_satellite_position_ecef),
+                Point3(factor.base_reference_position_ecef),
+                Point3(factor.base_position_ecef),
+            };
+            const double residual = dd.observed() - dd.model(position);
+            sum += residual * residual;
+            ++count;
+        }
+        result.diagnostics.double_difference_pseudorange_residual_rms_m =
+            accumulate_rms(sum, count);
+    }
+    {
+        double sum = 0.0;
+        std::size_t count = 0;
+        for (const auto& factor : problem.double_difference_carrier_factors) {
+            if (factor.ambiguity_index >= problem.ambiguity_states.size()) {
+                continue;
+            }
+            const auto& ambiguity = problem.ambiguity_states[factor.ambiguity_index];
+            const Point3 position = antennaPositionOf(optimized, factor.epoch_index);
+            const double amb_cycles = optimized.at<double>(ambiguityKey(factor.ambiguity_index));
+            const gtsam::gnss::DoubleDifferenceData dd{
+                factor.rover_satellite_model.corrected_carrier_m,
+                factor.base_satellite_model.corrected_carrier_m,
+                factor.rover_reference_model.corrected_carrier_m,
+                factor.base_reference_model.corrected_carrier_m,
+                Point3(factor.rover_satellite_position_ecef),
+                Point3(factor.rover_reference_position_ecef),
+                Point3(factor.base_satellite_position_ecef),
+                Point3(factor.base_reference_position_ecef),
+                Point3(factor.base_position_ecef),
+            };
+            const double residual =
+                dd.observed() - (dd.model(position) + ambiguity.wavelength_m * amb_cycles);
+            sum += residual * residual;
+            ++count;
+        }
+        result.diagnostics.double_difference_carrier_residual_rms_m = accumulate_rms(sum, count);
+    }
+    {
+        double sum = 0.0;
+        std::size_t count = 0;
+        for (const auto& factor : problem.pseudorange_factors) {
+            const Point3 position = antennaPositionOf(optimized, factor.epoch_index);
+            const int ordinal = clockGroupOrdinal(
+                clockBiasGroup(factor.satellite.system), config.use_inter_system_biases);
+            double clock_s = optimized.at<double>(clockKey(factor.epoch_index));
+            if (ordinal != 0 && optimized.exists(isbKey(ordinal))) {
+                clock_s += optimized.at<double>(isbKey(ordinal));
+            }
+            // Plain Euclidean range to match the native backend and the factor
+            // model above (satellite positions are already earth-rotation
+            // corrected; no additional Sagnac term).
+            const double range =
+                (Point3(factor.satellite_position_ecef) - position).norm();
+            const double predicted = range + constants::SPEED_OF_LIGHT * clock_s;
+            const double residual = factor.corrected_pseudorange_m - predicted;
+            sum += residual * residual;
+            ++count;
+        }
+        result.diagnostics.residual_rms_m = accumulate_rms(sum, count);
+    }
+
+    const auto end_time = std::chrono::high_resolution_clock::now();
+    result.diagnostics.processing_time_ms =
+        std::chrono::duration_cast<std::chrono::duration<double, std::milli>>(end_time -
+                                                                               start_time)
+            .count();
+    result.diagnostics.total_processing_time_ms = result.diagnostics.processing_time_ms;
+
+    return result;
+}
+
+}  // namespace libgnss

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -28,6 +28,8 @@
 #include <libgnss++/algorithms/lambda.hpp>
 #include <libgnss++/core/constants.hpp>
 #include <libgnss++/core/coordinates.hpp>
+#include <libgnss++/core/signal_policy.hpp>
+#include <libgnss++/core/signals.hpp>
 
 #include <gtsam/geometry/Point3.h>
 #include <gtsam/geometry/Pose3.h>
@@ -71,6 +73,56 @@ using gtsam::Pose3;
 using gtsam::Rot3;
 using gtsam::Symbol;
 using SharedNoise = gtsam::SharedNoiseModel;
+
+// MF-AR step 1: restrict a per-epoch LAMBDA candidate set to independent
+// satellites -- keep at most one ambiguity per satellite (primary band
+// preferred, else the longest-wavelength secondary; ties broken by index for
+// determinism). Multiple frequency bands of one satellite share the same
+// line-of-sight, so they contribute little to the DD geometry but do inflate
+// the all-or-nothing integer ratio test and lower the ratio. The dropped
+// bands' DD factors remain in the graph and still constrain the float; they
+// are simply not forced into the integer search. No-op for single-frequency
+// DD (each satellite already has a single band). Input indices are assumed
+// unique (one DD carrier factor per (sat,signal) per epoch).
+std::vector<std::size_t> selectOneBandPerSatellite(
+    const std::vector<std::size_t>& indices,
+    const FGOProcessor::FGOProblem& problem) {
+    std::map<SatelliteId, std::size_t> best_by_satellite;
+    for (std::size_t idx : indices) {
+        if (idx >= problem.ambiguity_states.size()) {
+            continue;
+        }
+        const auto& amb = problem.ambiguity_states[idx];
+        const auto it = best_by_satellite.find(amb.satellite);
+        if (it == best_by_satellite.end()) {
+            best_by_satellite.emplace(amb.satellite, idx);
+            continue;
+        }
+        const auto& cur = problem.ambiguity_states[it->second];
+        const bool amb_primary =
+            signal_policy::isPrimarySignal(amb.satellite.system, amb.signal);
+        const bool cur_primary =
+            signal_policy::isPrimarySignal(cur.satellite.system, cur.signal);
+        bool replace = false;
+        if (amb_primary != cur_primary) {
+            replace = amb_primary;  // prefer the primary band
+        } else if (amb.wavelength_m != cur.wavelength_m) {
+            replace = amb.wavelength_m > cur.wavelength_m;  // longer wavelength: easier to fix
+        } else {
+            replace = idx < it->second;  // deterministic
+        }
+        if (replace) {
+            it->second = idx;
+        }
+    }
+    std::vector<std::size_t> selected;
+    selected.reserve(best_by_satellite.size());
+    for (const auto& [sat, idx] : best_by_satellite) {
+        (void)sat;
+        selected.push_back(idx);
+    }
+    return selected;
+}
 
 // Mirror of fgo.cpp's clockBiasGroup(): which receiver-clock group a system
 // belongs to. GPS+QZSS share one clock; every other constellation gets its own
@@ -772,6 +824,26 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
         }
         if (dummy_created) ts[dummyAmbiguityKey()] = te;  // dummy persists (re-stamped every epoch)
 
+        // MF-AR step 1: the DD carrier factors for every band stay in the graph
+        // (added above) and constrain the float, but the per-epoch LAMBDA
+        // integer ratio test below is restricted to one band per satellite so
+        // correlated multi-frequency bands don't weaken the all-or-nothing fix.
+        if (config.double_difference_lambda_one_band_per_satellite &&
+            epoch_amb_indices.size() > 1) {
+            epoch_amb_indices = selectOneBandPerSatellite(epoch_amb_indices, problem);
+        }
+        // MF-AR step 2 (gated): keep Galileo arcs out of the integer search /
+        // fix-and-hold entirely -- their DD factors still shape the float.
+        if (config.exclude_galileo_ambiguity_fixing) {
+            epoch_amb_indices.erase(
+                std::remove_if(epoch_amb_indices.begin(), epoch_amb_indices.end(),
+                               [&](std::size_t idx) {
+                                   return problem.ambiguity_states[idx].satellite.system ==
+                                          GNSSSystem::Galileo;
+                               }),
+                epoch_amb_indices.end());
+        }
+
         // --- Milestone 2d: NHC + ZUPT pseudo-measurements (gated per epoch) ---
         const ImuWindowStats wstats =
             (config.use_nhc || config.use_zupt)
@@ -938,12 +1010,68 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                     for (int k = 0; k < n; ++k) {
                         q_amb(k, k) += std::max(1e-12, std::abs(q_amb(k, k)) * 1e-9);
                     }
-                    Eigen::VectorXd fixed_amb;
-                    double ratio = 0.0;
-                    ++lambda_attempts;
-                    ++result.diagnostics.lambda_ambiguity_attempts;
-                    result.diagnostics.lambda_ambiguity_candidates += static_cast<std::size_t>(n);
-                    if (lambdaSearch(float_amb, q_amb, fixed_amb, ratio)) {
+
+                    // --- MF-AR step 2: partial AR (port of the Eigen path's
+                    // use_partial_lambda_ambiguity_fix). Candidate order:
+                    // identity (= the deterministic sat/ref/signal sort above)
+                    // for the legacy all-or-nothing path; best-first by
+                    // (fractional cycles, variance) with a
+                    // max_lambda_ambiguities cap when partial AR is enabled.
+                    // The loop below runs exactly ONCE at full size when
+                    // partial AR is off -- bit-identical legacy behaviour. ---
+                    std::vector<int> order(n);
+                    std::iota(order.begin(), order.end(), 0);
+                    int attempt_n = n;
+                    int min_subset = n;  // all-or-nothing: single attempt
+                    if (config.use_fixed_lag_partial_lambda) {
+                        std::stable_sort(
+                            order.begin(), order.end(), [&](int a, int b) {
+                                const double fa = std::abs(
+                                    float_amb(a) - std::round(float_amb(a)));
+                                const double fb = std::abs(
+                                    float_amb(b) - std::round(float_amb(b)));
+                                if (fa == fb) {
+                                    return q_amb(a, a) < q_amb(b, b);
+                                }
+                                return fa < fb;
+                            });
+                        attempt_n = config.max_lambda_ambiguities > 0
+                                        ? std::min(n, config.max_lambda_ambiguities)
+                                        : n;
+                        min_subset = std::max(1, config.min_fixed_ambiguities);
+                        // Subset floor: drop a few outliers, never the
+                        // majority (see fixed_lag_partial_lambda_min_fraction).
+                        const double fraction = std::min(
+                            1.0, std::max(0.0,
+                                          config.fixed_lag_partial_lambda_min_fraction));
+                        min_subset = std::max(
+                            min_subset,
+                            static_cast<int>(std::ceil(fraction * attempt_n)));
+                    }
+
+                    bool float_cycles_recorded = false;
+                    for (int subset = attempt_n; subset >= min_subset; --subset) {
+                        Eigen::VectorXd sub_float(subset);
+                        Eigen::MatrixXd sub_q(subset, subset);
+                        Eigen::MatrixXd sub_pos(3, subset);
+                        for (int r = 0; r < subset; ++r) {
+                            sub_float(r) = float_amb(order[r]);
+                            sub_pos.col(r) = pos_amb.col(order[r]);
+                            for (int c = 0; c < subset; ++c) {
+                                sub_q(r, c) = q_amb(order[r], order[c]);
+                            }
+                        }
+
+                        Eigen::VectorXd fixed_amb;
+                        double ratio = 0.0;
+                        ++lambda_attempts;
+                        ++result.diagnostics.lambda_ambiguity_attempts;
+                        result.diagnostics.lambda_ambiguity_candidates +=
+                            static_cast<std::size_t>(subset);
+                        if (!lambdaSearch(sub_float, sub_q, fixed_amb, ratio)) {
+                            if (!config.use_fixed_lag_partial_lambda) break;
+                            continue;
+                        }
                         result.diagnostics.lambda_ambiguity_fix_solved = true;
                         best_ratio = std::max(best_ratio, ratio);
                         epoch_ratio[i] = ratio;
@@ -951,76 +1079,95 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                             std::isfinite(ratio) &&
                             (config.lambda_ratio_threshold <= 0.0 ||
                              ratio > config.lambda_ratio_threshold) &&
-                            fixed_amb.size() == n;
-                        // Record float ambiguity values for the result mapping.
-                        for (int r = 0; r < n; ++r) {
-                            amb_float_cycles[epoch_amb_indices[r]] = float_amb(r);
-                        }
-                        if (fixed_epoch) {
-                            epoch_fixed[i] = true;
-                            epoch_fixed_count[i] = n;
-                            total_fixed_ambiguities += static_cast<std::size_t>(n);
-                            result.diagnostics.lambda_ambiguity_fix_used = true;
-                            result.diagnostics.lambda_ambiguity_used_candidates +=
-                                static_cast<std::size_t>(n);
+                            fixed_amb.size() == subset;
+                        // Record float ambiguity values for the result mapping
+                        // (full candidate set, once).
+                        if (!float_cycles_recorded) {
                             for (int r = 0; r < n; ++r) {
-                                const int fi = static_cast<int>(std::lround(fixed_amb(r)));
-                                amb_fixed_cycles[epoch_amb_indices[r]] = fi;
-                                amb_fixed_residual[epoch_amb_indices[r]] =
-                                    float_amb(r) - static_cast<double>(fi);
+                                amb_float_cycles[epoch_amb_indices[r]] = float_amb(r);
                             }
-                            if (config.use_epoch_lambda_fixed_output) {
-                                const Eigen::VectorXd delta = float_amb - fixed_amb;
-                                const Eigen::LDLT<Eigen::MatrixXd> ldlt(q_amb);
-                                if (ldlt.info() == Eigen::Success) {
-                                    const Eigen::VectorXd corr = ldlt.solve(delta);
-                                    if (corr.allFinite()) {
-                                        const Eigen::Vector3d pd = pos_amb * corr;
-                                        if (pd.allFinite()) {
-                                            epoch_fixed_position[i] = antennaOf(pose_i) - Point3(pd);
-                                            epoch_has_fixed[i] = true;
-                                        }
-                                    }
-                                }
-                            }
+                            float_cycles_recorded = true;
+                        }
+                        if (!fixed_epoch) {
+                            if (!config.use_fixed_lag_partial_lambda) break;
+                            continue;
+                        }
 
-                            // --- 2e fix-and-hold: pin newly-validated arcs at
-                            // their integer so they persist for the rest of the
-                            // arc. Stricter ratio gate than "mark FIXED". ---
-                            if (config.use_ambiguity_hold &&
-                                ratio > config.ambiguity_hold_ratio_threshold &&
-                                n >= config.ambiguity_hold_min_fixed) {
-                                gtsam::NonlinearFactorGraph hold_factors;
-                                const auto hold_noise = gtsam::noiseModel::Isotropic::Sigma(
-                                    1, config.ambiguity_hold_sigma_cycles);
-                                for (int r = 0; r < n; ++r) {
-                                    const std::size_t idx = epoch_amb_indices[r];
-                                    if (pinned_ambiguities.count(idx)) continue;
-                                    const int fi = static_cast<int>(std::lround(fixed_amb(r)));
-                                    hold_factors.addPrior(ambiguityKey(idx),
-                                                          static_cast<double>(fi), hold_noise);
-                                    pinned_ambiguities.insert(idx);
-                                }
-                                if (hold_factors.size() > 0) {
-                                    try {
-                                        smoother.update(hold_factors, gtsam::Values(),
-                                                        gtsam::FixedLagSmoother::KeyTimestampMap());
-                                        ++result.diagnostics.smoother_updates;
-                                        // Re-read epoch i now that holds pin it.
-                                        pose_i = smoother.calculateEstimate<Pose3>(positionKey(i));
-                                        vel_i = smoother.calculateEstimate<gtsam::Vector3>(
-                                            velocityKey(i));
-                                        prev_nav = gtsam::NavState(pose_i, vel_i);
-                                        epoch_float_position[i] = antennaOf(pose_i);
-                                    } catch (const std::exception& e) {
-                                        std::fprintf(stderr,
-                                                     "[fgo_gtsam_backend] hold update epoch %zu "
-                                                     "threw: %s\n",
-                                                     i, e.what());
+                        epoch_fixed[i] = true;
+                        epoch_fixed_count[i] = subset;
+                        total_fixed_ambiguities += static_cast<std::size_t>(subset);
+                        result.diagnostics.lambda_ambiguity_fix_used = true;
+                        result.diagnostics.lambda_ambiguity_used_candidates +=
+                            static_cast<std::size_t>(subset);
+                        if (subset < attempt_n) {
+                            result.diagnostics.partial_lambda_ambiguity_fix_used = true;
+                        }
+                        for (int r = 0; r < subset; ++r) {
+                            const std::size_t idx = epoch_amb_indices[order[r]];
+                            const int fi = static_cast<int>(std::lround(fixed_amb(r)));
+                            amb_fixed_cycles[idx] = fi;
+                            amb_fixed_residual[idx] =
+                                sub_float(r) - static_cast<double>(fi);
+                        }
+                        if (config.use_epoch_lambda_fixed_output) {
+                            const Eigen::VectorXd delta = sub_float - fixed_amb;
+                            const Eigen::LDLT<Eigen::MatrixXd> ldlt(sub_q);
+                            if (ldlt.info() == Eigen::Success) {
+                                const Eigen::VectorXd corr = ldlt.solve(delta);
+                                if (corr.allFinite()) {
+                                    const Eigen::Vector3d pd = sub_pos * corr;
+                                    if (pd.allFinite()) {
+                                        epoch_fixed_position[i] = antennaOf(pose_i) - Point3(pd);
+                                        epoch_has_fixed[i] = true;
                                     }
                                 }
                             }
                         }
+
+                        // --- 2e fix-and-hold: pin newly-validated arcs at
+                        // their integer so they persist for the rest of the
+                        // arc. Stricter ratio gate than "mark FIXED". With
+                        // partial AR, only a FULL-set validation may hold:
+                        // a shrunken subset that squeaked past the ratio test
+                        // is enough to label this epoch FIXED, but pinning its
+                        // integers would poison the arc for its whole
+                        // remaining lifetime if any are wrong (measured on
+                        // tokyo1 full-run deep urban: FIXED rms 6.2 m). ---
+                        if (config.use_ambiguity_hold &&
+                            subset == attempt_n &&
+                            ratio > config.ambiguity_hold_ratio_threshold &&
+                            subset >= config.ambiguity_hold_min_fixed) {
+                            gtsam::NonlinearFactorGraph hold_factors;
+                            const auto hold_noise = gtsam::noiseModel::Isotropic::Sigma(
+                                1, config.ambiguity_hold_sigma_cycles);
+                            for (int r = 0; r < subset; ++r) {
+                                const std::size_t idx = epoch_amb_indices[order[r]];
+                                if (pinned_ambiguities.count(idx)) continue;
+                                const int fi = static_cast<int>(std::lround(fixed_amb(r)));
+                                hold_factors.addPrior(ambiguityKey(idx),
+                                                      static_cast<double>(fi), hold_noise);
+                                pinned_ambiguities.insert(idx);
+                            }
+                            if (hold_factors.size() > 0) {
+                                try {
+                                    smoother.update(hold_factors, gtsam::Values(),
+                                                    gtsam::FixedLagSmoother::KeyTimestampMap());
+                                    ++result.diagnostics.smoother_updates;
+                                    // Re-read epoch i now that holds pin it.
+                                    pose_i = smoother.calculateEstimate<Pose3>(positionKey(i));
+                                    vel_i = smoother.calculateEstimate<gtsam::Vector3>(
+                                        velocityKey(i));
+                                    prev_nav = gtsam::NavState(pose_i, vel_i);
+                                    epoch_float_position[i] = antennaOf(pose_i);
+                                } catch (const std::exception& e) {
+                                    std::fprintf(stderr,
+                                                 "[fgo_gtsam_backend] hold update epoch %zu "
+                                                 "threw: %s\n",
+                                                 i, e.what());
+                                }
+                            }
+                        }
+                        break;  // validated subset found
                     }
                 } else {
                     ++marginals_failures;
@@ -1738,6 +1885,11 @@ FGOProcessor::FGOResult optimizeProblemWithGtsam(
             // Deterministic candidate order (satellite/reference), matching the
             // native path's sort.
             std::vector<std::size_t> candidates(it->second.begin(), it->second.end());
+            // MF-AR step 1: one band per satellite for the integer ratio test.
+            if (config.double_difference_lambda_one_band_per_satellite &&
+                candidates.size() > 1) {
+                candidates = selectOneBandPerSatellite(candidates, problem);
+            }
             std::sort(candidates.begin(), candidates.end(),
                       [&](std::size_t a, std::size_t b) {
                           const auto& sa = problem.ambiguity_states[a];

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -659,6 +659,11 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
 
     const bool robust = config.use_robust_loss;
 
+    // Quality gates: satellites whose post-fit DDPR residual exceeded
+    // gate_per_sat_res_max_m LAST epoch (reference: prefit
+    // apply_per_sat_residual_gate keeps them out of the LAMBDA tree).
+    std::set<SatelliteId> gate_bad_sats;
+
     for (std::size_t i = 0; i < num_epochs; ++i) {
         gtsam::NonlinearFactorGraph new_factors;
         gtsam::Values new_values;
@@ -956,8 +961,104 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             epoch_vel_nav[j] = Vector3d(vj);
         }
 
+        // --- Per-epoch quality gates (port of the reference's gate.py /
+        // postfit.py fixing policy; see FGOConfig::use_epoch_quality_gates).
+        // Computed at the smoothed antenna position AFTER the update, so the
+        // DDPR residuals are post-fit like the reference's. Gated epochs keep
+        // their factors but attempt no LAMBDA, add no holds, and are never
+        // labelled FIXED via held integers. ---
+        bool fix_allowed = true;
+        if (config.use_epoch_quality_gates) {
+            const Point3 ant_p = antennaOf(pose_i);
+            const Vector3d ant(ant_p.x(), ant_p.y(), ant_p.z());
+
+            // (a) GDOP / nsat over this epoch's DD satellites.
+            std::map<SatelliteId, Vector3d> sat_positions;
+            for (const auto* fp : pr_by_epoch[i]) {
+                sat_positions.emplace(fp->satellite, fp->rover_satellite_position_ecef);
+                sat_positions.emplace(fp->reference_satellite,
+                                      fp->rover_reference_position_ecef);
+            }
+            const int nsat = static_cast<int>(sat_positions.size());
+            double gdop = std::numeric_limits<double>::infinity();
+            if (nsat >= 4) {
+                Eigen::MatrixXd H(nsat, 4);
+                int row = 0;
+                for (const auto& [sid, sp] : sat_positions) {
+                    (void)sid;
+                    const Vector3d d = sp - ant;
+                    const double rng = d.norm();
+                    if (rng > 0.0) {
+                        H.block<1, 3>(row, 0) = (-d / rng).transpose();
+                    } else {
+                        H.block<1, 3>(row, 0).setZero();
+                    }
+                    H(row, 3) = 1.0;
+                    ++row;
+                }
+                const Eigen::Matrix4d Ninv = (H.transpose() * H).inverse();
+                if (Ninv.allFinite()) {
+                    gdop = std::sqrt(std::max(0.0, Ninv.trace()));
+                }
+            }
+
+            // (b) post-fit DD-pseudorange residuals at the smoothed antenna
+            // (reference: postfit.main_ddpr_residuals -- epoch RMS + per-sat
+            // max, charged to both the target and the reference satellite).
+            double res_sq_sum = 0.0;
+            std::size_t res_n = 0;
+            std::map<SatelliteId, double> per_sat_res;
+            for (const auto* fp : pr_by_epoch[i]) {
+                const double geom =
+                    ((fp->rover_satellite_position_ecef - ant).norm() -
+                     (fp->base_satellite_position_ecef - fp->base_position_ecef).norm()) -
+                    ((fp->rover_reference_position_ecef - ant).norm() -
+                     (fp->base_reference_position_ecef - fp->base_position_ecef).norm());
+                const double res = std::abs(fp->observed_dd_pseudorange_m - geom);
+                res_sq_sum += res * res;
+                ++res_n;
+                double& worst = per_sat_res[fp->satellite];
+                worst = std::max(worst, res);
+                double& worst_ref = per_sat_res[fp->reference_satellite];
+                worst_ref = std::max(worst_ref, res);
+            }
+            const double ddpr_rms =
+                res_n > 0 ? std::sqrt(res_sq_sum / static_cast<double>(res_n)) : 0.0;
+
+            if (nsat < config.gate_min_satellites ||
+                gdop > config.gate_gdop_max ||
+                (config.gate_ddpr_res_max_m > 0.0 &&
+                 ddpr_rms > config.gate_ddpr_res_max_m)) {
+                fix_allowed = false;
+                ++result.diagnostics.quality_gated_epochs;
+            }
+
+            // (c) satellites flagged by LAST epoch's post-fit residuals stay
+            // out of this epoch's LAMBDA candidate set (their factors and
+            // held pins are untouched).
+            if (!gate_bad_sats.empty() && !epoch_amb_indices.empty()) {
+                epoch_amb_indices.erase(
+                    std::remove_if(
+                        epoch_amb_indices.begin(), epoch_amb_indices.end(),
+                        [&](std::size_t idx) {
+                            const auto& amb = problem.ambiguity_states[idx];
+                            return gate_bad_sats.count(amb.satellite) > 0 ||
+                                   gate_bad_sats.count(amb.reference_satellite) > 0;
+                        }),
+                    epoch_amb_indices.end());
+            }
+            gate_bad_sats.clear();
+            if (config.gate_per_sat_res_max_m > 0.0) {
+                for (const auto& [sid, r] : per_sat_res) {
+                    if (r > config.gate_per_sat_res_max_m) {
+                        gate_bad_sats.insert(sid);
+                    }
+                }
+            }
+        }
+
         // --- Per-epoch LAMBDA off the bounded windowed marginals ---
-        if (config.use_lambda_ambiguity_fix && !epoch_amb_indices.empty()) {
+        if (fix_allowed && config.use_lambda_ambiguity_fix && !epoch_amb_indices.empty()) {
             std::sort(epoch_amb_indices.begin(), epoch_amb_indices.end(),
                       [&](std::size_t a, std::size_t b) {
                           const auto& sa = problem.ambiguity_states[a];
@@ -1178,8 +1279,10 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
         // --- 2e fix-and-hold: an epoch whose arcs are (mostly) already held is
         // FIXED regardless of the fresh per-epoch LAMBDA -- the integers are
         // known and the smoother position (with the held priors active) is the
-        // fixed solution. This is the main fix-rate lever. ---
-        if (config.use_ambiguity_hold && !epoch_fixed[i]) {
+        // fixed solution. This is the main fix-rate lever. Quality-gated
+        // epochs are never labelled FIXED this way (reference: no fixing on a
+        // corrupt epoch). ---
+        if (fix_allowed && config.use_ambiguity_hold && !epoch_fixed[i]) {
             int held_here = 0;
             for (std::size_t idx : epoch_amb_indices) {
                 if (pinned_ambiguities.count(idx)) ++held_here;

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -794,14 +794,35 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
     // Deviation (see fgo.hpp): substitute for the reference's unported
     // CP-vs-PR innovation-consistency reject counter (rejc_cp_pr). Persistent
     // per-(satellite, signal) count of THIS backend's own FDE carrier
-    // rejections; never reset (no analogue of the reference's unported
-    // cp_pr_rejc_max wipe). Structurally empty/0 whenever use_fde is off.
-    std::map<std::pair<SatelliteId, SignalType>, int> sb_fde_cp_reject_count;
+    // rejections.
+    //
+    // CLAMPED-variant deviation (fgo.hpp sat_badness_cppr_decay): unlike the
+    // faithful port (which never reset this and let it grow forever), this
+    // is now a decayed float -- cppr[s,sig] = decay*prev + this_epoch_rejects
+    // -- applied once per epoch by runFde() below (decay=1.0 reproduces the
+    // old ever-growing-counter behaviour exactly). Structurally empty/0
+    // whenever use_fde is off.
+    std::map<std::pair<SatelliteId, SignalType>, double> sb_fde_cp_reject_count;
+
+    // CLAMPED-variant helper (fgo.hpp sat_badness_residual_clamp_m): caps a
+    // per-satellite post-fit DDPR residual before it feeds any badness term.
+    // Applied only at badness's OWN reads/snapshots of per_sat_res (see the
+    // per-epoch state-update block below) -- never to the shared per_sat_res
+    // map itself, which use_epoch_quality_gates/use_cp_hold_recovery also
+    // consume raw and which must stay numerically untouched by this knob.
+    // 0 = no clamp = faithful (returns r unchanged).
+    auto sbClampResidual = [&](double r) -> double {
+        return config.sat_badness_residual_clamp_m > 0.0
+                   ? std::min(r, config.sat_badness_residual_clamp_m)
+                   : r;
+    };
 
     // Continuous per-(reference, target, signal) badness score (0 when the
     // master switch is off). `ref_sat` non-null adds the directional-pair
     // term (only when sat_badness_alpha_recent_pair > 0 -- see fgo.hpp
-    // deviation 5). Mirrors SatQualityState.sat_badness() term-for-term.
+    // deviation 5). Mirrors SatQualityState.sat_badness() term-for-term, then
+    // (CLAMPED-variant deviation, fgo.hpp sat_badness_score_cap) caps the
+    // total before returning it -- 0 = no cap = faithful.
     auto satBadness = [&](SatelliteId sat_id, SignalType freq,
                           const SatelliteId* ref_sat) -> double {
         if (!config.use_sat_badness_downweight) return 0.0;
@@ -831,8 +852,8 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
         }
         {
             const auto it = sb_fde_cp_reject_count.find(std::make_pair(sat_id, freq));
-            const int cppr = it != sb_fde_cp_reject_count.end() ? it->second : 0;
-            if (cppr > 0) score += alpha_cppr * (static_cast<double>(cppr) / cppr_thr);
+            const double cppr = it != sb_fde_cp_reject_count.end() ? it->second : 0.0;
+            if (cppr > 0.0) score += alpha_cppr * (cppr / cppr_thr);
         }
         {
             const auto it = sb_recent_cppr.find(sat_id);
@@ -878,7 +899,11 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             const double penalty = std::max(0.0, std::min(1.0, (snr_ref_dbhz - snr) / snr_span_db));
             score += alpha_snr * penalty;
         }
-        return std::max(0.0, score);
+        score = std::max(0.0, score);
+        if (config.sat_badness_score_cap > 0.0) {
+            score = std::min(score, config.sat_badness_score_cap);
+        }
+        return score;
     };
 
     // --- CP-hold / sanity FSM state (use_cp_hold_recovery) ---
@@ -1045,6 +1070,26 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
         const bool iterative = max_iter > 1;
         std::size_t total_rejected = 0;
 
+        // CLAMPED-variant deviation (fgo.hpp sat_badness_cppr_decay): this
+        // call's rejects, by (satellite, signal), accumulated across every
+        // FDE round below and folded into sb_fde_cp_reject_count's decay
+        // exactly once (at applyCpprDecay()'s call sites, one per return
+        // path) before this lambda returns.
+        std::map<std::pair<SatelliteId, SignalType>, int> sb_cppr_delta_this_call;
+        auto applyCpprDecay = [&]() {
+            const double decay = std::min(1.0, std::max(0.0, config.sat_badness_cppr_decay));
+            std::set<std::pair<SatelliteId, SignalType>> keys;
+            for (const auto& kv : sb_fde_cp_reject_count) keys.insert(kv.first);
+            for (const auto& kv : sb_cppr_delta_this_call) keys.insert(kv.first);
+            for (const auto& k : keys) {
+                const double prev = sb_fde_cp_reject_count.count(k) ? sb_fde_cp_reject_count[k] : 0.0;
+                const double add = sb_cppr_delta_this_call.count(k)
+                                        ? static_cast<double>(sb_cppr_delta_this_call.at(k))
+                                        : 0.0;
+                sb_fde_cp_reject_count[k] = decay * prev + add;
+            }
+        };
+
         struct FdeEntry {
             std::size_t graph_idx;
             bool is_carrier;
@@ -1189,6 +1234,7 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                         cp_hold_release_streak = 0;
                         ++result.diagnostics.cp_hold_triggers;
                     }
+                    applyCpprDecay();
                     return total_rejected;  // 0: FDE skipped entirely this epoch
                 }
             }
@@ -1222,7 +1268,7 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 // when config.use_sat_badness_downweight is true.
                 if (amb_idx < problem.ambiguity_states.size()) {
                     const auto& amb = problem.ambiguity_states[amb_idx];
-                    ++sb_fde_cp_reject_count[std::make_pair(amb.satellite, amb.signal)];
+                    ++sb_cppr_delta_this_call[std::make_pair(amb.satellite, amb.signal)];
                 }
             }
 
@@ -1252,9 +1298,11 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             total_rejected += reject_entries.size();
 
             if (!iterative) {
+                applyCpprDecay();
                 return total_rejected;  // single removal batch, done
             }
         }
+        applyCpprDecay();
         return total_rejected;
     };
 
@@ -1974,7 +2022,10 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 for (SatelliteId r : active_refs) {
                     const double prev = sb_recent_ref_bad.count(r) ? sb_recent_ref_bad[r] : 0.0;
                     const auto it = per_sat_res.find(r);
-                    const double res = it != per_sat_res.end() ? it->second : 0.0;
+                    // CLAMPED-variant deviation (fgo.hpp sat_badness_residual_
+                    // clamp_m): clamp upstream of the reference's own existing
+                    // min(2,.) increment limit below (left unchanged).
+                    const double res = it != per_sat_res.end() ? sbClampResidual(it->second) : 0.0;
                     const double incr = res > 0.0 ? std::min(2.0, res / thr) : 0.0;
                     sb_recent_ref_bad[r] = decay * prev + incr;
                 }
@@ -1997,9 +2048,19 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 double worst_val = -1.0;
                 for (const auto& [sid, rmax] : per_sat_res) {
                     seen.insert(sid);
+                    // CLAMPED-variant deviation (fgo.hpp sat_badness_residual_
+                    // clamp_m): clamp the residual before it feeds the EWMA
+                    // input or the bad-streak comparison -- both direct
+                    // badness inputs. The "worst satellite" argmax just below
+                    // deliberately keeps the RAW rmax: clamping is monotonic
+                    // (order-preserving), so it cannot change which satellite
+                    // is identified as worst, and per_sat_res itself (read by
+                    // use_epoch_quality_gates/use_cp_hold_recovery elsewhere)
+                    // is never touched.
+                    const double rmax_c = sbClampResidual(rmax);
                     const double prev = sb_obsq_ewma.count(sid) ? sb_obsq_ewma[sid] : 0.0;
-                    sb_obsq_ewma[sid] = prev <= 0.0 ? rmax : ((1.0 - alpha) * prev + alpha * rmax);
-                    if (rmax > thr_obsq) {
+                    sb_obsq_ewma[sid] = prev <= 0.0 ? rmax_c : ((1.0 - alpha) * prev + alpha * rmax_c);
+                    if (rmax_c > thr_obsq) {
                         sb_obsq_bad_streak[sid] = (sb_obsq_bad_streak.count(sid) ? sb_obsq_bad_streak[sid] : 0) + 1;
                     } else {
                         sb_obsq_bad_streak[sid] = 0;
@@ -2025,7 +2086,7 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 std::map<SatelliteId, double> cppr_this_epoch;
                 for (const auto& [key, cnt] : sb_fde_cp_reject_count) {
                     double& v = cppr_this_epoch[key.first];
-                    v = std::max(v, static_cast<double>(cnt));
+                    v = std::max(v, cnt);
                 }
 
                 std::set<SatelliteId> active_sats(seen);
@@ -2075,7 +2136,10 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                     const auto key = std::make_tuple(ref, sat, freq);
                     seen_pairs.insert(key);
                     const double prev = sb_recent_pair_bad.count(key) ? sb_recent_pair_bad[key] : 0.0;
-                    const double incr = res > 0.0 ? std::min(2.0, res / thr) : 0.0;
+                    // CLAMPED-variant deviation (fgo.hpp sat_badness_residual_
+                    // clamp_m): same upstream clamp as recent_ref_bad above,
+                    // ahead of the reference's own existing min(2,.) limit.
+                    const double incr = res > 0.0 ? std::min(2.0, sbClampResidual(res) / thr) : 0.0;
                     sb_recent_pair_bad[key] = decay * prev + incr;
                 }
                 for (auto& [key, v] : sb_recent_pair_bad) {
@@ -2086,7 +2150,14 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             // (d) Snapshot THIS epoch's (pre-FDE) per_sat_res as "last epoch"
             // for the NEXT epoch's res_s term (reference: tc._mres_signals.
             // per_sat, set from this same pre-FDE per_sat_res pass).
-            sb_last_ddpr_per_sat = per_sat_res;
+            // CLAMPED-variant deviation (fgo.hpp sat_badness_residual_clamp_m):
+            // the snapshot itself is clamped -- this is the direct res_s term
+            // satBadness() reads next epoch -- while per_sat_res (the shared
+            // map other features also read) stays raw.
+            sb_last_ddpr_per_sat.clear();
+            for (const auto& [sid, r] : per_sat_res) {
+                sb_last_ddpr_per_sat[sid] = sbClampResidual(r);
+            }
         }
 
         // --- Per-epoch quality gates (port of the reference's gate.py /

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -713,7 +713,13 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
     const auto sq = [](double s) { return s * s; };
     imu_params->setAccelerometerCovariance(gtsam::I_3x3 * sq(problem.imu.noise.accel_noise_sigma));
     imu_params->setGyroscopeCovariance(gtsam::I_3x3 * sq(problem.imu.noise.gyro_noise_sigma));
-    imu_params->setIntegrationCovariance(gtsam::I_3x3 * sq(problem.imu.noise.integration_sigma));
+    // Reference parity (FGOConfig::imu_integration_covariance, fgo.hpp):
+    // imu_integration_covariance IS the covariance directly (reference
+    // imu_integ_cov value semantics -- no squaring), replacing the
+    // sq(integration_sigma) computation for this fixed-lag path. Default
+    // 1e-6 reproduces the harness's hardcoded integration_sigma=1e-3 squared,
+    // so this is bit-identical unless the new knob is overridden.
+    imu_params->setIntegrationCovariance(gtsam::I_3x3 * config.imu_integration_covariance);
     imu_params->setBiasAccCovariance(gtsam::I_3x3 * sq(problem.imu.noise.accel_bias_rw_sigma));
     imu_params->setBiasOmegaCovariance(gtsam::I_3x3 * sq(problem.imu.noise.gyro_bias_rw_sigma));
     const auto& imu_samples = problem.imu.samples_body_flu;
@@ -960,6 +966,12 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
     int cp_hold_release_streak = 0;  ///< consecutive clean epochs while held (reference _recov_cp_release_streak)
     int ddpr_bad_count = 0;          ///< consecutive bad epochs (reference _ddpr_bad_count)
     double last_ddpr_rms = 0.0;      ///< previous epoch's post-fit DDPR RMS (reference _last_main_ddpr_res)
+    // Epoch index at which last_ddpr_rms was last written (reference
+    // _last_main_ddpr_epoch / _mres_signals.epoch); sentinel far in the past
+    // so the very first epochs are always treated as stale (reference inits
+    // to -10**9). Feeds the imu_integration_covariance_inflation staleness
+    // test below.
+    long long last_ddpr_rms_epoch = -1000000000LL;
     bool pim_discontinuity = false;  ///< one-shot: break the IMU chain at the NEXT epoch (reference _pim_discontinuity)
     // DDPR-anchor bootstrap re-seed countdown (use_ddpr_anchor; reference
     // tc._tc_bootstrap_ddpr_epochs). While > 0, every epoch gets a
@@ -1406,6 +1418,28 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 ++sample_cursor;
             }
             win_begin = sample_cursor;
+            // Reference parity: residual-driven per-epoch integration-
+            // covariance inflation (FGOConfig::
+            // use_imu_integration_covariance_inflation; port of
+            // imu_preintegration.py's _apply_mres_integ_cov_override). Mutate
+            // the SHARED imu_params in place immediately before this epoch's
+            // PIM is constructed -- integrateMeasurement() below bakes the
+            // covariance in at integration time, so this affects only the
+            // PIM about to be built, never any already-linearized factor.
+            if (config.use_imu_integration_covariance_inflation) {
+                const int stale_max = config.imu_integration_covariance_stale_epochs;
+                const bool is_stale = stale_max > 0 &&
+                    (static_cast<long long>(i) - last_ddpr_rms_epoch) > stale_max;
+                const double default_cov = config.imu_integration_covariance;
+                double integ_eff = default_cov;
+                if (!is_stale) {
+                    const double dt_epoch = std::max(t1 - t0, 1e-3);
+                    integ_eff = std::max(default_cov, sq(last_ddpr_rms) / dt_epoch);
+                    const double cap = config.imu_integration_covariance_max;
+                    if (cap > 0.0) integ_eff = std::min(integ_eff, cap);
+                }
+                imu_params->setIntegrationCovariance(gtsam::I_3x3 * integ_eff);
+            }
             gtsam::PreintegratedCombinedMeasurements pim(imu_params, prev_bias);
             std::size_t j = sample_cursor;
             GNSSTime prev_time = t0;
@@ -1931,7 +1965,8 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
         // knobs but share this one (possibly expensive) residual pass. ---
         const bool need_ddpr_residuals =
             config.use_epoch_quality_gates || config.use_cp_hold_recovery ||
-            config.use_sat_badness_downweight;
+            config.use_sat_badness_downweight ||
+            config.use_imu_integration_covariance_inflation;
         int nsat = 0;
         double gdop = std::numeric_limits<double>::infinity();
         double ddpr_rms = 0.0;
@@ -2671,6 +2706,7 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 ddpr_bad_count = 0;
             }
             last_ddpr_rms = ddpr_rms;
+            last_ddpr_rms_epoch = static_cast<long long>(i);
         }
     }
     result.diagnostics.partial_lambda_ambiguity_fix_used = held_epoch_count > 0;

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -585,6 +585,12 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
     std::map<std::size_t, int> amb_fixed_cycles;
     std::map<std::size_t, double> amb_fixed_residual;
 
+    // 2e fix-and-hold: arcs whose DD ambiguity has been validated-fixed and
+    // pinned in the graph at its integer (reset automatically when the arc ends
+    // and the builder issues a fresh ambiguity index).
+    std::set<std::size_t> pinned_ambiguities;
+    std::size_t held_epoch_count = 0;
+
     std::set<std::size_t> ambiguity_created;
     bool dummy_created = false;
     constexpr double kDummyPinSigmaCycles = 1e-3;
@@ -805,6 +811,35 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             }
         }
 
+        // --- Preemptive regularization ---
+        // Weak-geometry urban epochs (few DD sats + near-stationary IMU) can
+        // leave a DOF (typically yaw, or velocity/bias) unobservable, so the
+        // incremental Cholesky throws IndeterminantLinearSystemException. That
+        // is unrecoverable here: iSAM2 partially commits the new values before
+        // throwing, and skipping the epoch orphans X(i)/V(i)/B(i) so every later
+        // IMU factor references a missing key ("invalid map key") and the whole
+        // tail cascades. A very loose per-epoch prior on pose/velocity/bias
+        // (anchored to the seed) regularizes the Hessian so it is always
+        // positive-definite. Sigmas are far looser than the real measurements
+        // (rot 10 rad, trans 1000 m, vel 100 m/s, bias 10), so the effect on
+        // the DD-cm solution is negligible -- they only fill rank in the null
+        // space that would otherwise be unobservable.
+        {
+            // Sigmas loose vs the real measurements (DD ~cm, IMU) but tight
+            // enough to keep the Hessian well-conditioned even when an epoch's
+            // measurement info on some DOF is ~0 (few DD sats / IMU dropout):
+            // rot 1 rad, trans 100 m, vel 10 m/s, bias 1.
+            gtsam::Vector6 reg_pose;
+            reg_pose << 1.0, 1.0, 1.0, 100.0, 100.0, 100.0;
+            new_factors.addPrior(positionKey(i), pose_seed,
+                                 gtsam::noiseModel::Diagonal::Sigmas(reg_pose));
+            const gtsam::Vector3 v_reg = vel_seed;
+            new_factors.addPrior<gtsam::Vector3>(velocityKey(i), v_reg,
+                                                 gtsam::noiseModel::Isotropic::Sigma(3, 10.0));
+            new_factors.addPrior(biasKey(i), prev_bias,
+                                 gtsam::noiseModel::Isotropic::Sigma(6, 1.0));
+        }
+
         // --- Smoother update ---
         bool update_ok = true;
         try {
@@ -813,6 +848,7 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             std::fprintf(stderr, "[fgo_gtsam_backend] smoother.update() epoch %zu threw: %s\n", i,
                          e.what());
             update_ok = false;
+            ++result.diagnostics.smoother_recovery_epochs;
         }
         ++result.diagnostics.smoother_updates;
         if (!update_ok) {
@@ -947,6 +983,43 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                                     }
                                 }
                             }
+
+                            // --- 2e fix-and-hold: pin newly-validated arcs at
+                            // their integer so they persist for the rest of the
+                            // arc. Stricter ratio gate than "mark FIXED". ---
+                            if (config.use_ambiguity_hold &&
+                                ratio > config.ambiguity_hold_ratio_threshold &&
+                                n >= config.ambiguity_hold_min_fixed) {
+                                gtsam::NonlinearFactorGraph hold_factors;
+                                const auto hold_noise = gtsam::noiseModel::Isotropic::Sigma(
+                                    1, config.ambiguity_hold_sigma_cycles);
+                                for (int r = 0; r < n; ++r) {
+                                    const std::size_t idx = epoch_amb_indices[r];
+                                    if (pinned_ambiguities.count(idx)) continue;
+                                    const int fi = static_cast<int>(std::lround(fixed_amb(r)));
+                                    hold_factors.addPrior(ambiguityKey(idx),
+                                                          static_cast<double>(fi), hold_noise);
+                                    pinned_ambiguities.insert(idx);
+                                }
+                                if (hold_factors.size() > 0) {
+                                    try {
+                                        smoother.update(hold_factors, gtsam::Values(),
+                                                        gtsam::FixedLagSmoother::KeyTimestampMap());
+                                        ++result.diagnostics.smoother_updates;
+                                        // Re-read epoch i now that holds pin it.
+                                        pose_i = smoother.calculateEstimate<Pose3>(positionKey(i));
+                                        vel_i = smoother.calculateEstimate<gtsam::Vector3>(
+                                            velocityKey(i));
+                                        prev_nav = gtsam::NavState(pose_i, vel_i);
+                                        epoch_float_position[i] = antennaOf(pose_i);
+                                    } catch (const std::exception& e) {
+                                        std::fprintf(stderr,
+                                                     "[fgo_gtsam_backend] hold update epoch %zu "
+                                                     "threw: %s\n",
+                                                     i, e.what());
+                                    }
+                                }
+                            }
                         }
                     }
                 } else {
@@ -954,7 +1027,35 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 }
             }
         }
+
+        // --- 2e fix-and-hold: an epoch whose arcs are (mostly) already held is
+        // FIXED regardless of the fresh per-epoch LAMBDA -- the integers are
+        // known and the smoother position (with the held priors active) is the
+        // fixed solution. This is the main fix-rate lever. ---
+        if (config.use_ambiguity_hold && !epoch_fixed[i]) {
+            int held_here = 0;
+            for (std::size_t idx : epoch_amb_indices) {
+                if (pinned_ambiguities.count(idx)) ++held_here;
+            }
+            if (held_here >= config.ambiguity_hold_min_fixed) {
+                epoch_fixed[i] = true;
+                epoch_fixed_count[i] = held_here;
+                epoch_has_fixed[i] = true;
+                epoch_fixed_position[i] = antennaOf(pose_i);
+                ++held_epoch_count;
+                for (std::size_t idx : epoch_amb_indices) {
+                    if (pinned_ambiguities.count(idx) && !amb_fixed_cycles.count(idx)) {
+                        // Record the held integer (rounded from the current estimate).
+                        const double v = smoother.calculateEstimate<double>(ambiguityKey(idx));
+                        amb_fixed_cycles[idx] = static_cast<int>(std::lround(v));
+                    }
+                }
+            }
+        }
     }
+    result.diagnostics.partial_lambda_ambiguity_fix_used = held_epoch_count > 0;
+    result.diagnostics.ambiguity_hold_epochs = held_epoch_count;
+    result.diagnostics.ambiguity_hold_arcs = pinned_ambiguities.size();
 
     // --- Diagnostics ---
     result.diagnostics.converged = true;

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -522,6 +522,20 @@ SharedNoise makeNoise(double sigma_m, bool robust, double huber_threshold_sigma)
     return base;
 }
 
+
+// Result of the mini DDPR-only LS anchor solve (FGOConfig::use_ddpr_anchor;
+// port of the inuex35 reference's utils/ls_solvers.py ddpr_only_position).
+// `pose` is a body-in-nav-ENU Pose3, the SAME convention as the main graph's
+// positionKey(i) -- i.e. translation() is the body position in nav-ENU, NOT
+// the antenna position (apply the caller's antennaOf()/lever-arm convention
+// to get the antenna ECEF, exactly like the main loop does for pose_i).
+struct DdprAnchorResult {
+    bool ok = false;
+    Pose3 pose;
+    int n_active = 0;
+    double res_rms = std::numeric_limits<double>::infinity();
+};
+
 // Cross-checks that gtsam::gnss::DoubleDifferenceData::observed() reproduces
 // libgnss's precomputed observed DD value for the mapping used below. Cheap
 // (a handful of subtractions) so it is left active in all builds rather than
@@ -603,6 +617,94 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
         }
     }
 
+    // --- DDPR-LS anchor solve (FGOConfig::use_ddpr_anchor; port of the
+    // reference's ddpr_only_position / _ddpr_build_specs / _ddpr_solve_with_fde).
+    // Reuses the SAME DoubleDifferencePseudorangeFactorArm construction the
+    // main loop uses (see the "DD pseudorange factors at epoch i" block
+    // below) against a dedicated, throwaway Pose3 key ('y', 0) so the mini
+    // solve never touches the smoother's key space. Plain (non-robust) noise
+    // throughout, matching the reference's huber_pr=0 default -- the same
+    // noise model is reused for both the LM solve and the FDE residual
+    // evaluation (the reference rebuilds a second "non-robust" graph for
+    // eval only because ITS default solve pass may be robust; ours already
+    // isn't, so one graph suffices for both).
+    auto solveDdprAnchor = [&](std::size_t epoch_idx, const Pose3& pose_init) -> DdprAnchorResult {
+        DdprAnchorResult out;
+        std::vector<const FGOProcessor::DoubleDifferencePseudorangeFactor*> active(
+            pr_by_epoch[epoch_idx].begin(), pr_by_epoch[epoch_idx].end());
+        if (active.size() < static_cast<std::size_t>(std::max(1, config.ddpr_anchor_min_factors))) {
+            return out;
+        }
+        const gtsam::Key anchor_key = Symbol('y', 0);
+        gtsam::Vector6 prior_sigmas;
+        prior_sigmas << 0.05, 0.05, 0.1, 50.0, 50.0, 50.0;
+        const auto prior_noise = gtsam::noiseModel::Diagonal::Sigmas(prior_sigmas);
+
+        gtsam::Values est;
+        double res_rms = std::numeric_limits<double>::infinity();
+        bool have_est = false;
+
+        for (int fde_iter = 0; fde_iter < 3; ++fde_iter) {
+            gtsam::NonlinearFactorGraph g;
+            gtsam::Values v;
+            v.insert(anchor_key, pose_init);
+            g.addPrior(anchor_key, pose_init, prior_noise);
+            for (const auto* fp : active) {
+                const gtsam::gnss::DoubleDifferenceData dd{
+                    fp->rover_satellite_model.corrected_pseudorange_m,
+                    fp->base_satellite_model.corrected_pseudorange_m,
+                    fp->rover_reference_model.corrected_pseudorange_m,
+                    fp->base_reference_model.corrected_pseudorange_m,
+                    Point3(fp->rover_satellite_position_ecef),
+                    Point3(fp->rover_reference_position_ecef),
+                    Point3(fp->base_satellite_position_ecef),
+                    Point3(fp->base_reference_position_ecef),
+                    Point3(fp->base_position_ecef)};
+                g.emplace_shared<gtsam::DoubleDifferencePseudorangeFactorArm>(
+                    anchor_key, dd.rovRef, dd.baseRef, dd.rovTarget, dd.baseTarget, dd.satRefRov,
+                    dd.satTargetRov, dd.satRefBase, dd.satTargetBase, dd.basePos, lever_arm_body,
+                    ecef_T_nav, makeNoise(fp->sigma_m, /*robust=*/false, 0.0));
+            }
+            gtsam::Values cur_est;
+            try {
+                gtsam::LevenbergMarquardtParams lm_params;
+                lm_params.setMaxIterations(10);
+                cur_est = gtsam::LevenbergMarquardtOptimizer(g, v, lm_params).optimize();
+            } catch (const std::exception&) {
+                return out;  // solve failed -> not ok
+            }
+            est = cur_est;
+            have_est = true;
+
+            std::vector<const FGOProcessor::DoubleDifferencePseudorangeFactor*> kept;
+            kept.reserve(active.size());
+            double sq_sum = 0.0;
+            std::size_t dropped = 0;
+            for (std::size_t k = 0; k < active.size(); ++k) {
+                const double err = g.at(1 + k)->error(est);  // factor 0 is the pose prior
+                const double res_m = std::sqrt(std::max(0.0, err) * 2.0) * active[k]->sigma_m;
+                if (res_m > config.ddpr_anchor_fde_threshold_m &&
+                    (active.size() - dropped) > static_cast<std::size_t>(std::max(1, config.ddpr_anchor_min_factors))) {
+                    ++dropped;
+                    continue;
+                }
+                kept.push_back(active[k]);
+                sq_sum += res_m * res_m;
+            }
+            res_rms = kept.empty() ? 0.0 : std::sqrt(sq_sum / static_cast<double>(kept.size()));
+            active = kept;
+            if (dropped == 0) break;
+        }
+        if (!have_est || active.size() < static_cast<std::size_t>(std::max(1, config.ddpr_anchor_min_factors))) {
+            return out;
+        }
+        out.ok = true;
+        out.pose = est.at<Pose3>(anchor_key);
+        out.n_active = static_cast<int>(active.size());
+        out.res_rms = res_rms;
+        return out;
+    };
+
     // IMU preintegration params (ENU / Z-up; gravity -Z).
     auto imu_params = gtsam::PreintegrationCombinedParams::MakeSharedU(problem.imu.noise.gravity_mps2);
     const auto sq = [](double s) { return s * s; };
@@ -664,6 +766,443 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
     // apply_per_sat_residual_gate keeps them out of the LAMBDA tree).
     std::set<SatelliteId> gate_bad_sats;
 
+    // --- CP-hold / sanity FSM state (use_cp_hold_recovery) ---
+    //
+    // Arc-regeneration overlay: our front-end (fgo.cpp) statically assigns one
+    // ambiguity_index per continuous carrier arc for the WHOLE dataset before
+    // this backend ever runs, so it cannot react to a backend-only decision
+    // (bad post-fit residuals) to invalidate an arc mid-stream. `amb_generation`
+    // adds that reactive layer: bumping an index's generation makes
+    // ambSymbolId() mint a brand-new backend-local graph symbol the next time
+    // that ambiguity_index is observed, which the existing "ambiguity_created"
+    // fresh-arc bookkeeping below (seed value + prior, no held integer) then
+    // treats exactly like a genuinely new arc. Generation-0 resolves to the
+    // identity (symbol id == ambiguity_index), so this whole mechanism is a
+    // no-op -- and the backend bit-identical to pre-port -- whenever
+    // use_cp_hold_recovery is false.
+    std::map<std::size_t, int> amb_generation;
+    std::map<std::pair<std::size_t, int>, std::size_t> amb_symbol_id;
+    std::size_t next_free_amb_symbol_id = problem.ambiguity_states.size();
+    // Ambiguity indices with a symbol currently live in the graph (added under
+    // their CURRENT generation); mass reset removes exactly these factors and
+    // then clears the set (see reset_ambiguities_with_cp_hold below).
+    std::set<std::size_t> live_ambiguity_indices;
+    // Reverse of ambSymbolId(): backend graph symbol id -> the caller-facing
+    // ambiguity_index it currently resolves for. Populated on every
+    // ambSymbolId() call (cheap; at most one entry per (index, generation)
+    // ever observed). Used by FDE's iterative mode, which discovers rejected
+    // carrier factors by scanning the live graph rather than iterating
+    // problem.ambiguity_states, so it needs to map a factor's ambiguityKey
+    // symbol back to the ambiguity_index whose hold/generation it must
+    // update.
+    std::map<std::size_t, std::size_t> sym_to_ambiguity_index;
+    auto ambSymbolId = [&](std::size_t idx) -> std::size_t {
+        std::size_t sid = idx;
+        if (config.use_cp_hold_recovery) {
+            const auto git = amb_generation.find(idx);
+            const int gen = (git == amb_generation.end()) ? 0 : git->second;
+            if (gen != 0) {
+                const auto key = std::make_pair(idx, gen);
+                const auto it = amb_symbol_id.find(key);
+                if (it != amb_symbol_id.end()) {
+                    sid = it->second;
+                } else {
+                    sid = next_free_amb_symbol_id++;
+                    amb_symbol_id.emplace(key, sid);
+                }
+            }
+        }
+        sym_to_ambiguity_index[sid] = idx;
+        return sid;
+    };
+
+    int cp_hold_counter = 0;         ///< remaining epochs with carrier suppressed (reference _recov_cp_hold)
+    int cp_hold_release_streak = 0;  ///< consecutive clean epochs while held (reference _recov_cp_release_streak)
+    int ddpr_bad_count = 0;          ///< consecutive bad epochs (reference _ddpr_bad_count)
+    double last_ddpr_rms = 0.0;      ///< previous epoch's post-fit DDPR RMS (reference _last_main_ddpr_res)
+    bool pim_discontinuity = false;  ///< one-shot: break the IMU chain at the NEXT epoch (reference _pim_discontinuity)
+    // DDPR-anchor bootstrap re-seed countdown (use_ddpr_anchor; reference
+    // tc._tc_bootstrap_ddpr_epochs). While > 0, every epoch gets a
+    // translation-only anchor prior (see the bootstrap block in the main
+    // loop) and CP-hold is forced to 0 via effectiveCpHoldEpochs() below
+    // (reference state.effective_cp_hold_epochs: bootstrap wins).
+    int ddpr_bootstrap_epochs_remaining = 0;
+
+    // Reference state.effective_cp_hold_epochs(): the configured CP-hold
+    // length, suppressed to 0 while the DDPR-anchor bootstrap countdown is
+    // active. A no-op (always returns config.cp_hold_epochs) whenever
+    // use_ddpr_anchor is false, so use_cp_hold_recovery's behaviour is
+    // unaffected unless the anchor is also enabled.
+    auto effectiveCpHoldEpochs = [&]() -> int {
+        if (config.use_ddpr_anchor && ddpr_bootstrap_epochs_remaining > 0) return 0;
+        return config.cp_hold_epochs;
+    };
+
+    // Mass reset shared by the persist path and the catastrophic fast path
+    // (reference _apply_sanity_reset / reset_ambiguities_with_cp_hold): collect
+    // every live ambiguity's CURRENT-generation factor indices out of the live
+    // ISAM2 graph, remove them via a smoother update, bump every generation
+    // (forcing fresh arcs), clear the pinned/live bookkeeping, and (re)engage
+    // CP-hold at full strength. Returns the number of factors removed.
+    auto resetAmbiguitiesWithCpHold = [&]() -> std::size_t {
+        gtsam::FactorIndices remove_indices;
+        if (!live_ambiguity_indices.empty()) {
+            std::set<gtsam::Key> live_keys;
+            for (std::size_t idx : live_ambiguity_indices) {
+                live_keys.insert(ambiguityKey(ambSymbolId(idx)));
+            }
+            const auto& factors = smoother.getISAM2().getFactorsUnsafe();
+            for (std::size_t fi = 0; fi < factors.size(); ++fi) {
+                const auto& f = factors[fi];
+                if (!f) continue;
+                for (gtsam::Key k : f->keys()) {
+                    if (live_keys.count(k)) {
+                        remove_indices.push_back(fi);
+                        break;
+                    }
+                }
+            }
+        }
+        for (std::size_t idx : live_ambiguity_indices) {
+            const std::size_t old_sid = ambSymbolId(idx);  // resolve BEFORE bumping
+            ++amb_generation[idx];
+            ++result.diagnostics.ambiguity_generation_bumps;
+            pinned_ambiguities.erase(old_sid);
+        }
+        live_ambiguity_indices.clear();
+        if (!remove_indices.empty()) {
+            try {
+                smoother.update(gtsam::NonlinearFactorGraph(), gtsam::Values(),
+                                gtsam::FixedLagSmoother::KeyTimestampMap(), remove_indices);
+                ++result.diagnostics.smoother_updates;
+            } catch (const std::exception& e) {
+                std::fprintf(stderr,
+                             "[fgo_gtsam_backend] cp-hold factor removal threw: %s\n", e.what());
+            }
+        }
+        // Our adaptation of the reference's bootstrap arming (see
+        // FGOConfig::use_ddpr_anchor's deviation note): opt-in re-seed after
+        // a mass/fast ambiguity reset, not just after a full warm reset.
+        // Armed BEFORE the hold length is computed below, so that -- per the
+        // reference's state.effective_cp_hold_epochs (bootstrap and global
+        // CP-hold are mutually exclusive; bootstrap wins) -- the reset that
+        // arms the bootstrap engages NO carrier hold: the bootstrap needs
+        // the fresh carrier arcs + anchor translation priors flowing
+        // immediately to pull the float back.
+        if (config.use_ddpr_anchor && config.cp_hold_bootstrap_after_mass_reset) {
+            ddpr_bootstrap_epochs_remaining = config.ddpr_anchor_bootstrap_epochs;
+        }
+        cp_hold_counter = effectiveCpHoldEpochs();
+        cp_hold_release_streak = 0;
+        ddpr_bad_count = 0;
+        if (config.cp_hold_break_imu_chain) pim_discontinuity = true;
+        ++result.diagnostics.cp_hold_triggers;
+        return remove_indices.size();
+    };
+
+    // --- FDE (GICI-style Fault Detection and Exclusion; FGOConfig::use_fde).
+    // See use_fde's comment in fgo.hpp for the full design rationale
+    // (ordering vs. the sanity FSM / LAMBDA, residual reconstruction
+    // arithmetic, single-pass vs. iterative). Called from the per-epoch
+    // loop AFTER the shared post-fit DDPR diagnostics pass (so the sanity
+    // FSM below still sees PRE-FDE residuals) but BEFORE per-epoch LAMBDA.
+    //
+    // `local_indices_for_epoch` / `new_indices_for_epoch` identify THIS
+    // epoch's own DD PR/CP factors precisely (local index within the
+    // graph just passed to smoother.update(), and that update's
+    // ISAM2Result::newFactorsIndices to resolve them to live graph
+    // indices) -- used only in single-pass mode. Iterative mode ignores
+    // them and scans the whole live graph by factor type instead.
+    //
+    // On any rejected CP factor, the caller-visible ambiguity_index is
+    // written into `*rejected_ambiguity_indices` so the caller can drop it
+    // from this epoch's still-pending LAMBDA candidate list (the factor
+    // backing that candidate no longer exists in the graph).
+    //
+    // Returns the number of factors actually removed (0 = no-op /
+    // safeguarded / evaluation or removal failed).
+    auto runFde = [&](std::size_t epoch_idx,
+                      const std::vector<std::size_t>& local_indices_for_epoch,
+                      const gtsam::FactorIndices& new_indices_for_epoch,
+                      std::set<std::size_t>* rejected_ambiguity_indices) -> std::size_t {
+        if (!config.use_fde) return 0;
+        const int max_iter = std::max(1, config.fde_max_iterations);
+        const bool iterative = max_iter > 1;
+        std::size_t total_rejected = 0;
+
+        struct FdeEntry {
+            std::size_t graph_idx;
+            bool is_carrier;
+            double res_m;
+        };
+
+        for (int fde_iter = 0; fde_iter < max_iter; ++fde_iter) {
+            const auto& factors = smoother.getISAM2().getFactorsUnsafe();
+            std::vector<std::size_t> candidate_graph_indices;
+            if (iterative) {
+                // Whole live graph, re-scanned fresh every round so a prior
+                // round's removal never leaves a stale index dangling.
+                candidate_graph_indices.reserve(factors.size());
+                for (std::size_t fi = 0; fi < factors.size(); ++fi) {
+                    if (factors[fi]) candidate_graph_indices.push_back(fi);
+                }
+            } else {
+                candidate_graph_indices.reserve(local_indices_for_epoch.size());
+                for (std::size_t li : local_indices_for_epoch) {
+                    if (li < new_indices_for_epoch.size()) {
+                        candidate_graph_indices.push_back(new_indices_for_epoch[li]);
+                    }
+                }
+            }
+            if (candidate_graph_indices.empty()) break;
+
+            gtsam::Values estimate;
+            try {
+                estimate = smoother.calculateEstimate();
+            } catch (const std::exception&) {
+                break;  // cannot evaluate residuals -- abandon FDE, keep current estimate
+            }
+
+            // Residual in meters: evaluateError() directly, NOT factor->error()
+            // (see the design-note above runFde -- error() runs the noise
+            // model's loss(), which for a Robust/Huber-wrapped factor
+            // returns the DOWN-WEIGHTED loss, not the raw chi-squared
+            // distance, silently weakening outlier detection exactly for
+            // the large residuals FDE exists to catch). evaluateError()
+            // bypasses the noise model entirely and returns the 1-D raw
+            // (unwhitened) residual directly in meters, so no sigma
+            // reconstruction is needed at all -- correct whether or not
+            // config.use_robust_loss is set.
+            std::vector<FdeEntry> pr_entries, cp_entries;
+            for (std::size_t gi : candidate_graph_indices) {
+                if (gi >= factors.size() || !factors[gi]) continue;
+                const auto& f = factors[gi];
+                const auto* pr_f =
+                    dynamic_cast<const gtsam::DoubleDifferencePseudorangeFactorArm*>(f.get());
+                const auto* cp_f =
+                    pr_f ? nullptr
+                         : dynamic_cast<const gtsam::DoubleDifferenceCarrierPhaseFactorArm*>(
+                               f.get());
+                if (!pr_f && !cp_f) continue;
+                try {
+                    if (pr_f) {
+                        const Pose3 pose = estimate.at<Pose3>(f->keys()[0]);
+                        const double res_m = std::abs(pr_f->evaluateError(pose)(0));
+                        pr_entries.push_back({gi, false, res_m});
+                    } else {
+                        const Pose3 pose = estimate.at<Pose3>(f->keys()[0]);
+                        const double amb_ref = estimate.at<double>(f->keys()[1]);
+                        const double amb_target = estimate.at<double>(f->keys()[2]);
+                        const double res_m =
+                            std::abs(cp_f->evaluateError(pose, amb_ref, amb_target)(0));
+                        cp_entries.push_back({gi, true, res_m});
+                    }
+                } catch (const std::exception&) {
+                    continue;
+                }
+            }
+
+            double pr_median = 0.0, cp_median = 0.0;
+            if (config.fde_median_subtraction) {
+                auto medianOf = [](const std::vector<FdeEntry>& v) {
+                    if (v.empty()) return 0.0;
+                    std::vector<double> r;
+                    r.reserve(v.size());
+                    for (const auto& e : v) r.push_back(e.res_m);
+                    std::sort(r.begin(), r.end());
+                    return r[r.size() / 2];
+                };
+                pr_median = medianOf(pr_entries);
+                cp_median = medianOf(cp_entries);
+            }
+
+            std::vector<FdeEntry> reject_entries;
+            if (iterative) {
+                // Single worst |res - median| exceeder across PR and CP
+                // combined (reference _fde_pick_rejects_iterative); ties
+                // favor whichever group is scanned first (PR), matching the
+                // reference's strict '>' override in the CP loop.
+                double best_d = 0.0;
+                int best_pr = -1, best_cp = -1;
+                for (std::size_t k = 0; k < pr_entries.size(); ++k) {
+                    const double d = std::abs(pr_entries[k].res_m - pr_median);
+                    if (d > config.fde_pseudorange_threshold_m && d > best_d) {
+                        best_d = d;
+                        best_pr = static_cast<int>(k);
+                        best_cp = -1;
+                    }
+                }
+                for (std::size_t k = 0; k < cp_entries.size(); ++k) {
+                    const double d = std::abs(cp_entries[k].res_m - cp_median);
+                    if (d > config.fde_carrier_threshold_m && d > best_d) {
+                        best_d = d;
+                        best_cp = static_cast<int>(k);
+                        best_pr = -1;
+                    }
+                }
+                if (best_pr < 0 && best_cp < 0) break;  // no outlier this round -- done
+                reject_entries.push_back(best_pr >= 0 ? pr_entries[static_cast<std::size_t>(best_pr)]
+                                                       : cp_entries[static_cast<std::size_t>(best_cp)]);
+            } else {
+                for (const auto& e : pr_entries) {
+                    if (std::abs(e.res_m - pr_median) > config.fde_pseudorange_threshold_m) {
+                        reject_entries.push_back(e);
+                    }
+                }
+                for (const auto& e : cp_entries) {
+                    if (std::abs(e.res_m - cp_median) > config.fde_carrier_threshold_m) {
+                        reject_entries.push_back(e);
+                    }
+                }
+                if (reject_entries.empty()) break;  // no-op: nothing exceeded threshold
+                // Safeguard (single-pass only, matching the reference): a
+                // runaway reject fraction likely means the FLOAT itself is
+                // wrong (not the measurements), so excluding that many
+                // factors would just poison the graph further -- abandon
+                // FDE for the epoch and hand off to CP-hold instead.
+                const std::size_t nv = pr_entries.size() + cp_entries.size();
+                const double frac_limit = config.fde_max_rejected_fraction *
+                                          static_cast<double>(std::max<std::size_t>(1, nv));
+                if (static_cast<double>(reject_entries.size()) > frac_limit) {
+                    ++result.diagnostics.fde_safeguard_skips;
+                    // Reference trigger_cp_hold(..., skip_if_active=True):
+                    // engage the hold at full strength unless already
+                    // active. With use_cp_hold_recovery off there is no
+                    // hold to engage -- FDE simply skips this epoch.
+                    if (config.use_cp_hold_recovery && cp_hold_counter <= 0) {
+                        cp_hold_counter = effectiveCpHoldEpochs();
+                        cp_hold_release_streak = 0;
+                        ++result.diagnostics.cp_hold_triggers;
+                    }
+                    return total_rejected;  // 0: FDE skipped entirely this epoch
+                }
+            }
+
+            // Cycle-slip bookkeeping for rejected CP factors (reference
+            // _fde_reset_rejected_amb): release the fix-and-hold pin and
+            // bump the generation. Applied BEFORE the removal update below
+            // is attempted, mirroring the reference's own ordering (which
+            // does this even though the isam2 removal could still fail).
+            for (const auto& e : reject_entries) {
+                if (!e.is_carrier) continue;
+                const auto& f = factors[e.graph_idx];
+                if (!f || f->keys().size() < 2) continue;
+                // Key 1 is ambRef = ambiguityKey(sym_idx) by construction
+                // (see the DoubleDifferenceCarrierPhaseFactorArm emplace
+                // site above: position, ambRef, ambTarget=dummy).
+                const gtsam::Symbol sym(f->keys()[1]);
+                const std::size_t sym_idx = sym.index();
+                const auto it = sym_to_ambiguity_index.find(sym_idx);
+                if (it == sym_to_ambiguity_index.end()) continue;
+                const std::size_t amb_idx = it->second;
+                pinned_ambiguities.erase(sym_idx);
+                ++amb_generation[amb_idx];
+                ++result.diagnostics.ambiguity_generation_bumps;
+                live_ambiguity_indices.erase(amb_idx);
+                if (rejected_ambiguity_indices) rejected_ambiguity_indices->insert(amb_idx);
+            }
+
+            gtsam::FactorIndices remove_indices;
+            remove_indices.reserve(reject_entries.size());
+            std::size_t pr_rejected = 0, cp_rejected = 0;
+            for (const auto& e : reject_entries) {
+                remove_indices.push_back(e.graph_idx);
+                if (e.is_carrier) {
+                    ++cp_rejected;
+                } else {
+                    ++pr_rejected;
+                }
+            }
+            try {
+                smoother.update(gtsam::NonlinearFactorGraph(), gtsam::Values(),
+                                gtsam::FixedLagSmoother::KeyTimestampMap(), remove_indices);
+                ++result.diagnostics.smoother_updates;
+            } catch (const std::exception& e) {
+                std::fprintf(stderr,
+                             "[fgo_gtsam_backend] FDE factor removal epoch %zu threw: %s\n",
+                             epoch_idx, e.what());
+                break;  // abandon FDE; keep the estimate as it stood before this attempt
+            }
+            result.diagnostics.fde_pseudorange_rejections += pr_rejected;
+            result.diagnostics.fde_carrier_rejections += cp_rejected;
+            total_rejected += reject_entries.size();
+
+            if (!iterative) {
+                return total_rejected;  // single removal batch, done
+            }
+        }
+        return total_rejected;
+    };
+
+    // --- Exception recovery (use_solve_exception_recovery): full warm reset
+    // (reference recovery.warm_reset_phase2), the fallback for REPEATED
+    // smoother.update() failures. Destroys and recreates the smoother from
+    // scratch and re-anchors epoch `epoch_idx` at (seed_pose, zero velocity,
+    // seed_bias) with loose-but-finite priors, matching the reference's
+    // rot/pos/vel/bias sigmas. Unlike the Python reference (which restarts
+    // its own relative epoch counter at 0), this keeps the SAME epoch index
+    // i / key space -- there is nothing special about our key numbering to
+    // reset, so re-anchoring in place is the direct equivalent. Also bumps
+    // every live ambiguity's generation (the fresh smoother has none of
+    // their factors any more) and engages CP-hold. Throws on failure (the
+    // caller decides whether to give up on the epoch).
+    auto performFullWarmReset = [&](std::size_t epoch_idx, const Pose3& seed_pose,
+                                    const gtsam::imuBias::ConstantBias& seed_bias) {
+        smoother = gtsam::IncrementalFixedLagSmoother(config.fixed_lag_smoother_lag_s, isam_params);
+        dummy_created = false;
+        ambiguity_created.clear();
+        pinned_ambiguities.clear();
+        for (std::size_t idx : live_ambiguity_indices) {
+            ++amb_generation[idx];
+            ++result.diagnostics.ambiguity_generation_bumps;
+        }
+        live_ambiguity_indices.clear();
+
+        constexpr double kDegToRad = 3.14159265358979323846 / 180.0;
+        const double rot_sigma = config.cp_hold_warm_reset_rotation_sigma_deg * kDegToRad;
+        gtsam::Vector6 pose_sigmas;
+        pose_sigmas << rot_sigma, rot_sigma, rot_sigma, 2.0, 2.0, 3.0;
+        const gtsam::Vector3 zero_vel = gtsam::Vector3::Zero();
+
+        gtsam::NonlinearFactorGraph reset_factors;
+        gtsam::Values reset_values;
+        gtsam::FixedLagSmoother::KeyTimestampMap reset_ts;
+        reset_values.insert(positionKey(epoch_idx), seed_pose);
+        reset_values.insert(velocityKey(epoch_idx), zero_vel);
+        reset_values.insert(biasKey(epoch_idx), seed_bias);
+        reset_factors.addPrior(positionKey(epoch_idx), seed_pose,
+                               gtsam::noiseModel::Diagonal::Sigmas(pose_sigmas));
+        reset_factors.addPrior<gtsam::Vector3>(
+            velocityKey(epoch_idx), zero_vel, gtsam::noiseModel::Isotropic::Sigma(3, 3.0));
+        reset_factors.addPrior(biasKey(epoch_idx), seed_bias,
+                               gtsam::noiseModel::Isotropic::Sigma(6, 0.01));
+        const double te_reset = stampOf(epoch_idx);
+        reset_ts[positionKey(epoch_idx)] = te_reset;
+        reset_ts[velocityKey(epoch_idx)] = te_reset;
+        reset_ts[biasKey(epoch_idx)] = te_reset;
+        smoother.update(reset_factors, reset_values, reset_ts);
+        ++result.diagnostics.smoother_updates;
+
+        prev_nav = gtsam::NavState(seed_pose, zero_vel);
+        prev_bias = seed_bias;
+        // Bootstrap re-seed: reference arms this once at Phase-2 init; this
+        // port arms it after EVERY full warm reset instead (see
+        // FGOConfig::use_ddpr_anchor's deviation note) -- unconditional
+        // (unlike the mass/fast-reset arming in resetAmbiguitiesWithCpHold,
+        // which is opt-in via cp_hold_bootstrap_after_mass_reset) because a
+        // full warm reset always throws away the smoother's linearization
+        // entirely. Armed BEFORE the hold computation below so the
+        // reference's bootstrap-suppresses-CP-hold rule
+        // (state.effective_cp_hold_epochs) applies to this very reset.
+        if (config.use_ddpr_anchor) {
+            ddpr_bootstrap_epochs_remaining = config.ddpr_anchor_bootstrap_epochs;
+        }
+        if (config.use_cp_hold_recovery) {
+            cp_hold_counter = effectiveCpHoldEpochs();
+            cp_hold_release_streak = 0;
+        }
+    };
+
     for (std::size_t i = 0; i < num_epochs; ++i) {
         gtsam::NonlinearFactorGraph new_factors;
         gtsam::Values new_values;
@@ -719,9 +1258,30 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 const gtsam::NavState pred = pim.predict(prev_nav, prev_bias);
                 pose_seed = pred.pose();
                 vel_seed = pred.velocity();
-                new_factors.emplace_shared<gtsam::CombinedImuFactor>(
-                    positionKey(i - 1), velocityKey(i - 1), positionKey(i), velocityKey(i),
-                    biasKey(i - 1), biasKey(i), pim);
+                // CP-hold / sanity FSM: break the IMU chain the epoch after a
+                // mass/fast reset (reference add_imu_chain's discontinuity
+                // path). The seed is still the IMU prediction (dead-reckoned
+                // from the pre-reset state, same as normal), but NO
+                // CombinedImuFactor links epoch i back to epoch i-1 -- instead
+                // a loose PriorPose3/PriorVector anchors epoch i at the seed so
+                // a wrong pre-reset pose cannot drag the post-reset solution
+                // back through the IMU factor.
+                if (config.use_cp_hold_recovery && pim_discontinuity) {
+                    gtsam::Vector6 break_sigmas;
+                    const double trans_sig = config.cp_hold_imu_break_translation_sigma_m;
+                    break_sigmas << 0.1, 0.1, 0.3, trans_sig, trans_sig, trans_sig;
+                    new_factors.addPrior(positionKey(i), pose_seed,
+                                         gtsam::noiseModel::Diagonal::Sigmas(break_sigmas));
+                    new_factors.addPrior<gtsam::Vector3>(
+                        velocityKey(i), vel_seed, gtsam::noiseModel::Isotropic::Sigma(3, 2.0));
+                    new_factors.addPrior(biasKey(i), prev_bias,
+                                         gtsam::noiseModel::Isotropic::Sigma(6, 0.01));
+                    pim_discontinuity = false;
+                } else {
+                    new_factors.emplace_shared<gtsam::CombinedImuFactor>(
+                        positionKey(i - 1), velocityKey(i - 1), positionKey(i), velocityKey(i),
+                        biasKey(i - 1), biasKey(i), pim);
+                }
             } else {
                 // IMU dropout: hold pose at the DD antenna seed, loose continuity.
                 const Vector3d antenna_nav = navAntenna(problem.epochs[i].position_ecef);
@@ -763,6 +1323,12 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
         }
 
         // --- DD pseudorange factors at epoch i ---
+        // fde_local_indices: local index (within new_factors) of every DD
+        // PR/CP factor added THIS epoch, only tracked when FGOConfig::use_fde
+        // is set (see runFde()'s single-pass mode, which resolves these to
+        // live graph indices via this epoch's ISAM2Result::newFactorsIndices
+        // right after the smoother update below).
+        std::vector<std::size_t> fde_local_indices;
         for (const auto* fp : pr_by_epoch[i]) {
             const auto& factor = *fp;
             const gtsam::gnss::DoubleDifferenceData dd{
@@ -777,32 +1343,80 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 Point3(factor.base_position_ecef)};
             const auto noise = makeNoise(factor.sigma_m, robust,
                                          config.pseudorange_huber_threshold_sigma);
+            const std::size_t local_idx = new_factors.size();
             new_factors.emplace_shared<gtsam::DoubleDifferencePseudorangeFactorArm>(
                 positionKey(i), dd.rovRef, dd.baseRef, dd.rovTarget, dd.baseTarget, dd.satRefRov,
                 dd.satTargetRov, dd.satRefBase, dd.satTargetBase, dd.basePos, lever_arm_body,
                 ecef_T_nav, noise);
+            if (config.use_fde) fde_local_indices.push_back(local_idx);
+        }
+
+        // --- CP-hold / sanity FSM: release hysteresis + carrier suppression
+        // decision for epoch i (reference preprocess/gate.py lines ~113-128).
+        // Decided BEFORE building this epoch's DD carrier factors so the
+        // suppression takes effect immediately. last_ddpr_rms is the PREVIOUS
+        // epoch's post-fit DDPR RMS; this epoch's own RMS is computed after
+        // its solve (below) and feeds the FSM trigger for the epoch AFTER.
+        bool skip_cp_now = false;
+        if (config.use_cp_hold_recovery) {
+            skip_cp_now = cp_hold_counter > 0;
+            if (skip_cp_now) {
+                --cp_hold_counter;
+                ++result.diagnostics.cp_hold_epochs_held;
+                const double release_thr = config.cp_hold_release_threshold_m;
+                if (release_thr > 0.0) {
+                    if (last_ddpr_rms > 0.0 && last_ddpr_rms <= release_thr) {
+                        ++cp_hold_release_streak;
+                    } else {
+                        cp_hold_release_streak = 0;
+                    }
+                    // Release hysteresis: don't let the hold counter reach 0
+                    // until residuals have proven clean for
+                    // cp_hold_release_count consecutive epochs -- extend by one
+                    // more epoch at a time otherwise (reference: tc._recov_cp_hold = 1).
+                    if (cp_hold_counter <= 0 && cp_hold_release_streak < config.cp_hold_release_count) {
+                        cp_hold_counter = 1;
+                    }
+                }
+            }
         }
 
         // --- DD carrier factors + ambiguity nodes at epoch i ---
         std::vector<std::size_t> epoch_amb_indices;
         for (const auto* fp : cp_by_epoch[i]) {
             const auto& factor = *fp;
+            if (config.use_cp_hold_recovery && skip_cp_now) {
+                // Carrier suppressed for the duration of the hold: DD
+                // pseudorange keeps flowing (added above, unaffected) but no
+                // carrier factor/symbol is added here, and (mirroring
+                // _carry_prev_amb) the arc's generation bumps every held
+                // epoch so there is no carrier continuity across the hold
+                // once it releases.
+                const std::size_t idx = factor.ambiguity_index;
+                const std::size_t old_sid = ambSymbolId(idx);
+                ++amb_generation[idx];
+                ++result.diagnostics.ambiguity_generation_bumps;
+                pinned_ambiguities.erase(old_sid);
+                live_ambiguity_indices.erase(idx);
+                continue;
+            }
             const auto& ambiguity = problem.ambiguity_states[factor.ambiguity_index];
+            const std::size_t sym_idx = ambSymbolId(factor.ambiguity_index);
             if (!dummy_created) {
                 new_values.insert(dummyAmbiguityKey(), 0.0);
                 new_factors.addPrior(dummyAmbiguityKey(), 0.0,
                                      gtsam::noiseModel::Isotropic::Sigma(1, kDummyPinSigmaCycles));
                 dummy_created = true;
             }
-            if (ambiguity_created.insert(factor.ambiguity_index).second) {
+            if (ambiguity_created.insert(sym_idx).second) {
                 const double seed_cycles = ambiguity.wavelength_m > 0.0
                                                ? ambiguity.initial_ambiguity_m / ambiguity.wavelength_m
                                                : ambiguity.initial_ambiguity_m;
-                new_values.insert(ambiguityKey(factor.ambiguity_index), seed_cycles);
+                new_values.insert(ambiguityKey(sym_idx), seed_cycles);
                 if (config.use_ambiguity_priors && config.ambiguity_prior_sigma_m > 0.0 &&
                     ambiguity.wavelength_m > 0.0) {
                     new_factors.addPrior(
-                        ambiguityKey(factor.ambiguity_index), seed_cycles,
+                        ambiguityKey(sym_idx), seed_cycles,
                         gtsam::noiseModel::Isotropic::Sigma(
                             1, config.ambiguity_prior_sigma_m / ambiguity.wavelength_m));
                 }
@@ -819,15 +1433,54 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 Point3(factor.base_position_ecef)};
             const auto noise = makeNoise(factor.sigma_m, robust,
                                          config.carrier_phase_huber_threshold_sigma);
+            const std::size_t cp_local_idx = new_factors.size();
             new_factors.emplace_shared<gtsam::DoubleDifferenceCarrierPhaseFactorArm>(
-                positionKey(i), ambiguityKey(factor.ambiguity_index), dummyAmbiguityKey(),
+                positionKey(i), ambiguityKey(sym_idx), dummyAmbiguityKey(),
                 dd.rovRef, dd.baseRef, dd.rovTarget, dd.baseTarget, dd.satRefRov, dd.satTargetRov,
                 dd.satRefBase, dd.satTargetBase, dd.basePos, ambiguity.wavelength_m, lever_arm_body,
                 ecef_T_nav, noise);
-            ts[ambiguityKey(factor.ambiguity_index)] = te;  // re-stamp: keep in-window while active
+            if (config.use_fde) fde_local_indices.push_back(cp_local_idx);
+            ts[ambiguityKey(sym_idx)] = te;  // re-stamp: keep in-window while active
             epoch_amb_indices.push_back(factor.ambiguity_index);
+            if (config.use_cp_hold_recovery) live_ambiguity_indices.insert(factor.ambiguity_index);
         }
         if (dummy_created) ts[dummyAmbiguityKey()] = te;  // dummy persists (re-stamped every epoch)
+
+        // --- DDPR-anchor bootstrap re-seed (use_ddpr_anchor; port of
+        // optimize/stage.py's BOOT_DDPR_EPOCHS translation-only re-seed).
+        // While the countdown (armed after a warm/mass reset -- see
+        // resetAmbiguitiesWithCpHold / performFullWarmReset) is running,
+        // every epoch gets an anchor-only translation prior alongside the
+        // normal graph: rotation unconstrained (sigma 1e6, taken from the
+        // IMU-predicted pose so it does not fight attitude), translation
+        // pulled toward THIS epoch's independent DDPR-LS position (sigma
+        // ddpr_anchor_bootstrap_sigma_m). This is the primary lever against
+        // the CP-hold FSM's known FLOAT-degradation cost: a pull-back
+        // channel to truth that does not depend on carrier/AR recovering
+        // first. The countdown decrements every armed epoch regardless of
+        // whether this epoch's anchor solve succeeds (reference: stage.py
+        // decrements outside the try/except).
+        if (config.use_ddpr_anchor && ddpr_bootstrap_epochs_remaining > 0) {
+            ++result.diagnostics.ddpr_anchor_solves;
+            const DdprAnchorResult boot_anchor = solveDdprAnchor(i, pose_seed);
+            if (boot_anchor.ok && boot_anchor.n_active >= config.ddpr_anchor_min_factors) {
+                // "successes" counts TRUSTED solves (res gate included) for
+                // diagnostic consistency with the other two call sites; the
+                // prior itself is added on the reference's weaker condition
+                // (solve ok, n >= 4 -- stage.py has no residual gate here).
+                if (boot_anchor.res_rms <= config.ddpr_anchor_max_residual_m) {
+                    ++result.diagnostics.ddpr_anchor_successes;
+                }
+                gtsam::Vector6 boot_sigmas;
+                const double bs = config.ddpr_anchor_bootstrap_sigma_m;
+                boot_sigmas << 1e6, 1e6, 1e6, bs, bs, bs;
+                const Pose3 boot_pose(pose_seed.rotation(), boot_anchor.pose.translation());
+                new_factors.addPrior(positionKey(i), boot_pose,
+                                     gtsam::noiseModel::Diagonal::Sigmas(boot_sigmas));
+                ++result.diagnostics.ddpr_anchor_bootstrap_prior_epochs;
+            }
+            --ddpr_bootstrap_epochs_remaining;
+        }
 
         // MF-AR step 1: the DD carrier factors for every band stay in the graph
         // (added above) and constrain the float, but the per-epoch LAMBDA
@@ -919,13 +1572,114 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
 
         // --- Smoother update ---
         bool update_ok = true;
+        // FDE (use_fde): resolved only on the PRIMARY (non-exception) path,
+        // since exception recovery below (loose-prior retry / warm reset)
+        // never actually adds this epoch's own DD PR/CP factors to the
+        // graph -- there would be nothing for FDE to evaluate this epoch in
+        // that case (see runFde's call site further down for the gating).
+        gtsam::FactorIndices fde_new_indices;
+        bool fde_indices_valid = false;
         try {
             smoother.update(new_factors, new_values, ts);
+            if (config.use_fde) {
+                fde_new_indices = smoother.getISAM2Result().newFactorsIndices;
+                fde_indices_valid = true;
+            }
         } catch (const std::exception& e) {
             std::fprintf(stderr, "[fgo_gtsam_backend] smoother.update() epoch %zu threw: %s\n", i,
                          e.what());
             update_ok = false;
             ++result.diagnostics.smoother_recovery_epochs;
+            // --- Exception recovery (use_solve_exception_recovery; reference
+            // recovery.handle_solve_exception). Targets the known
+            // IndeterminantLinearSystemException tail failure (tokyo run2,
+            // ~epoch 6390): without this, the epoch is skipped (`continue`
+            // below) and the run keeps going in a degraded state, but a
+            // SECOND failure while the graph is still poisoned would repeat
+            // forever with no recovery. ---
+            if (config.use_solve_exception_recovery) {
+                // Stage 0 (use_ddpr_anchor only; reference
+                // handle_solve_exception's ACTUAL first choice --
+                // try_ddpr_reset before the loose-prior fallback): warm-reset
+                // the smoother seeded at (this epoch's DDPR-LS anchor
+                // translation, IMU-predicted rotation, zero velocity) when
+                // the anchor is trusted. Falls through to stage 1 otherwise.
+                bool anchor_recovered = false;
+                if (config.use_ddpr_anchor) {
+                    ++result.diagnostics.ddpr_anchor_solves;
+                    const DdprAnchorResult anchor = solveDdprAnchor(i, pose_seed);
+                    if (anchor.ok && anchor.n_active >= config.ddpr_anchor_min_factors &&
+                        anchor.res_rms <= config.ddpr_anchor_max_residual_m) {
+                        ++result.diagnostics.ddpr_anchor_successes;
+                        try {
+                            const Pose3 anchor_seed_pose(pose_seed.rotation(),
+                                                         anchor.pose.translation());
+                            performFullWarmReset(i, anchor_seed_pose, prev_bias);
+                            update_ok = true;
+                            anchor_recovered = true;
+                            ++result.diagnostics.ddpr_anchored_warm_resets;
+                        } catch (const std::exception& e_anchor) {
+                            std::fprintf(stderr,
+                                         "[fgo_gtsam_backend] ddpr-anchored warm reset epoch %zu "
+                                         "threw: %s -- falling back\n",
+                                         i, e_anchor.what());
+                        }
+                    }
+                }
+                if (!anchor_recovered) {
+                // Stage 1: retry with ONLY loose re-seed priors at the
+                // IMU-predicted state, discarding this epoch's GNSS/IMU
+                // factors entirely.
+                gtsam::NonlinearFactorGraph retry_factors;
+                gtsam::Values retry_values;
+                gtsam::FixedLagSmoother::KeyTimestampMap retry_ts;
+                retry_values.insert(positionKey(i), pose_seed);
+                retry_values.insert(velocityKey(i), vel_seed);
+                retry_values.insert(biasKey(i), prev_bias);
+                retry_factors.addPrior(
+                    positionKey(i), pose_seed,
+                    gtsam::noiseModel::Isotropic::Sigma(6, config.solve_exception_pose_sigma_m));
+                retry_factors.addPrior<gtsam::Vector3>(
+                    velocityKey(i), vel_seed,
+                    gtsam::noiseModel::Isotropic::Sigma(3, config.solve_exception_velocity_sigma_mps));
+                retry_factors.addPrior(
+                    biasKey(i), prev_bias,
+                    gtsam::noiseModel::Isotropic::Sigma(6, config.solve_exception_bias_sigma));
+                retry_ts[positionKey(i)] = te;
+                retry_ts[velocityKey(i)] = te;
+                retry_ts[biasKey(i)] = te;
+                bool retry_ok = true;
+                try {
+                    smoother.update(retry_factors, retry_values, retry_ts);
+                    ++result.diagnostics.smoother_updates;
+                } catch (const std::exception& e2) {
+                    std::fprintf(stderr,
+                                 "[fgo_gtsam_backend] loose-prior retry epoch %zu ALSO threw: %s "
+                                 "-- performing full warm reset\n",
+                                 i, e2.what());
+                    retry_ok = false;
+                }
+                if (retry_ok) {
+                    update_ok = true;
+                    ++result.diagnostics.solve_exception_recoveries;
+                } else {
+                    // Stage 2: repeated failure -- full warm reset (reference
+                    // warm_reset_phase2), seeded at the IMU prediction (the
+                    // DDPR anchor was untrusted or use_ddpr_anchor is off).
+                    try {
+                        performFullWarmReset(i, pose_seed, prev_bias);
+                        update_ok = true;
+                        ++result.diagnostics.solve_exception_warm_resets;
+                    } catch (const std::exception& e3) {
+                        std::fprintf(stderr,
+                                     "[fgo_gtsam_backend] full warm reset epoch %zu threw: %s -- "
+                                     "epoch skipped\n",
+                                     i, e3.what());
+                        update_ok = false;
+                    }
+                }
+                }  // !anchor_recovered
+            }
         }
         ++result.diagnostics.smoother_updates;
         if (!update_ok) {
@@ -961,14 +1715,21 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             epoch_vel_nav[j] = Vector3d(vj);
         }
 
-        // --- Per-epoch quality gates (port of the reference's gate.py /
-        // postfit.py fixing policy; see FGOConfig::use_epoch_quality_gates).
-        // Computed at the smoothed antenna position AFTER the update, so the
-        // DDPR residuals are post-fit like the reference's. Gated epochs keep
-        // their factors but attempt no LAMBDA, add no holds, and are never
-        // labelled FIXED via held integers. ---
-        bool fix_allowed = true;
-        if (config.use_epoch_quality_gates) {
+        // --- Shared post-fit DDPR residual / GDOP computation (reference:
+        // postfit.main_ddpr_residuals -- epoch RMS + per-sat max, charged to
+        // both the target and the reference satellite -- and gate.py's
+        // GDOP/nsat gate). Computed ONCE at the smoothed antenna position
+        // AFTER the update and reused by BOTH the per-epoch quality gates
+        // (use_epoch_quality_gates) and the CP-hold/sanity FSM
+        // (use_cp_hold_recovery) below -- the two features are independent
+        // knobs but share this one (possibly expensive) residual pass. ---
+        const bool need_ddpr_residuals =
+            config.use_epoch_quality_gates || config.use_cp_hold_recovery;
+        int nsat = 0;
+        double gdop = std::numeric_limits<double>::infinity();
+        double ddpr_rms = 0.0;
+        std::map<SatelliteId, double> per_sat_res;
+        if (need_ddpr_residuals) {
             const Point3 ant_p = antennaOf(pose_i);
             const Vector3d ant(ant_p.x(), ant_p.y(), ant_p.z());
 
@@ -979,8 +1740,7 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 sat_positions.emplace(fp->reference_satellite,
                                       fp->rover_reference_position_ecef);
             }
-            const int nsat = static_cast<int>(sat_positions.size());
-            double gdop = std::numeric_limits<double>::infinity();
+            nsat = static_cast<int>(sat_positions.size());
             if (nsat >= 4) {
                 Eigen::MatrixXd H(nsat, 4);
                 int row = 0;
@@ -1002,12 +1762,9 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 }
             }
 
-            // (b) post-fit DD-pseudorange residuals at the smoothed antenna
-            // (reference: postfit.main_ddpr_residuals -- epoch RMS + per-sat
-            // max, charged to both the target and the reference satellite).
+            // (b) post-fit DD-pseudorange residuals at the smoothed antenna.
             double res_sq_sum = 0.0;
             std::size_t res_n = 0;
-            std::map<SatelliteId, double> per_sat_res;
             for (const auto* fp : pr_by_epoch[i]) {
                 const double geom =
                     ((fp->rover_satellite_position_ecef - ant).norm() -
@@ -1022,9 +1779,15 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 double& worst_ref = per_sat_res[fp->reference_satellite];
                 worst_ref = std::max(worst_ref, res);
             }
-            const double ddpr_rms =
-                res_n > 0 ? std::sqrt(res_sq_sum / static_cast<double>(res_n)) : 0.0;
+            ddpr_rms = res_n > 0 ? std::sqrt(res_sq_sum / static_cast<double>(res_n)) : 0.0;
+        }
 
+        // --- Per-epoch quality gates (port of the reference's gate.py /
+        // postfit.py fixing policy; see FGOConfig::use_epoch_quality_gates).
+        // Gated epochs keep their factors but attempt no LAMBDA, add no
+        // holds, and are never labelled FIXED via held integers. ---
+        bool fix_allowed = true;
+        if (config.use_epoch_quality_gates) {
             if (nsat < config.gate_min_satellites ||
                 gdop > config.gate_gdop_max ||
                 (config.gate_ddpr_res_max_m > 0.0 &&
@@ -1057,6 +1820,59 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             }
         }
 
+        // --- FDE (use_fde): runs AFTER the shared post-fit DDPR diagnostics
+        // pass above (nsat/gdop/ddpr_rms/per_sat_res, already computed at
+        // the post-solve pre-FDE estimate -- the CP-hold/sanity FSM further
+        // below reuses THOSE pre-FDE numbers unchanged, exactly mirroring
+        // the reference's stage.py ordering: main_ddpr_residuals runs
+        // before apply_fde, so the sanity trigger sees pre-FDE residuals)
+        // but BEFORE per-epoch LAMBDA/fix-and-hold, so ambiguity resolution
+        // sees the float already cleaned of gross outliers. Gated on the
+        // PRIMARY smoother.update having succeeded without exception (see
+        // fde_indices_valid's declaration above).
+        if (config.use_fde && fde_indices_valid) {
+            std::set<std::size_t> fde_rejected_amb;
+            const std::size_t fde_removed =
+                runFde(i, fde_local_indices, fde_new_indices, &fde_rejected_amb);
+            if (fde_removed > 0) {
+                ++result.diagnostics.fde_epochs;
+                // A rejected CP factor's ambiguity_index may still be
+                // sitting in this epoch's still-pending LAMBDA candidate
+                // list (built before FDE ran) -- its factor no longer
+                // exists, so drop it (mirrors the cp-hold suppression
+                // branch above, which never adds a suppressed arc to
+                // epoch_amb_indices in the first place).
+                if (!fde_rejected_amb.empty()) {
+                    epoch_amb_indices.erase(
+                        std::remove_if(epoch_amb_indices.begin(), epoch_amb_indices.end(),
+                                       [&](std::size_t idx) {
+                                           return fde_rejected_amb.count(idx) > 0;
+                                       }),
+                        epoch_amb_indices.end());
+                }
+                // Refresh the post-FDE estimate: downstream LAMBDA/fix-and-
+                // hold and the REPORTED pose for this epoch must see the
+                // cleaned float (reference: the pose snapshot in stage.py's
+                // _compute_postfit_diagnostics happens AFTER apply_fde).
+                pose_i = smoother.calculateEstimate<Pose3>(positionKey(i));
+                vel_i = smoother.calculateEstimate<gtsam::Vector3>(velocityKey(i));
+                prev_bias = smoother.calculateEstimate<gtsam::imuBias::ConstantBias>(biasKey(i));
+                prev_nav = gtsam::NavState(pose_i, vel_i);
+                epoch_float_position[i] = antennaOf(pose_i);
+                const gtsam::Matrix3 R_fde = pose_i.rotation().matrix();
+                const Eigen::Vector3d fwd_fde = R_fde.col(0);
+                const Eigen::Vector3d left_fde = R_fde.col(1);
+                constexpr double kRadToDegFde = 180.0 / 3.14159265358979323846;
+                double heading_fde = std::atan2(fwd_fde.x(), fwd_fde.y()) * kRadToDegFde;
+                if (heading_fde < 0.0) heading_fde += 360.0;
+                const double pitch_fde =
+                    std::asin(std::max(-1.0, std::min(1.0, fwd_fde.z()))) * kRadToDegFde;
+                const double roll_fde = std::atan2(left_fde.z(), R_fde.col(2).z()) * kRadToDegFde;
+                epoch_rpy_deg[i] = Vector3d(roll_fde, pitch_fde, heading_fde);
+                epoch_vel_nav[i] = Vector3d(vel_i);
+            }
+        }
+
         // --- Per-epoch LAMBDA off the bounded windowed marginals ---
         if (fix_allowed && config.use_lambda_ambiguity_fix && !epoch_amb_indices.empty()) {
             std::sort(epoch_amb_indices.begin(), epoch_amb_indices.end(),
@@ -1071,7 +1887,7 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 gtsam::KeyVector keys;
                 keys.reserve(n + 1);
                 keys.push_back(positionKey(i));
-                for (std::size_t idx : epoch_amb_indices) keys.push_back(ambiguityKey(idx));
+                for (std::size_t idx : epoch_amb_indices) keys.push_back(ambiguityKey(ambSymbolId(idx)));
 
                 Eigen::VectorXd float_amb(n);
                 Eigen::MatrixXd q_amb(n, n);
@@ -1092,7 +1908,7 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                         }
                     }
                     for (int r = 0; r < n && ok; ++r) {
-                        const gtsam::Key rk = ambiguityKey(epoch_amb_indices[r]);
+                        const gtsam::Key rk = ambiguityKey(ambSymbolId(epoch_amb_indices[r]));
                         float_amb(r) = smoother.calculateEstimate<double>(rk);
                         const gtsam::Matrix pr = joint(positionKey(i), rk);  // 6x1
                         const Eigen::Vector3d pr3 = H_antenna_pose * pr;
@@ -1100,7 +1916,7 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                         pos_amb(1, r) = pr3(1);
                         pos_amb(2, r) = pr3(2);
                         for (int c = 0; c < n; ++c) {
-                            q_amb(r, c) = joint(rk, ambiguityKey(epoch_amb_indices[c]))(0, 0);
+                            q_amb(r, c) = joint(rk, ambiguityKey(ambSymbolId(epoch_amb_indices[c])))(0, 0);
                         }
                     }
                 } catch (const std::exception&) {
@@ -1243,11 +2059,12 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                                 1, config.ambiguity_hold_sigma_cycles);
                             for (int r = 0; r < subset; ++r) {
                                 const std::size_t idx = epoch_amb_indices[order[r]];
-                                if (pinned_ambiguities.count(idx)) continue;
+                                const std::size_t sym_idx = ambSymbolId(idx);
+                                if (pinned_ambiguities.count(sym_idx)) continue;
                                 const int fi = static_cast<int>(std::lround(fixed_amb(r)));
-                                hold_factors.addPrior(ambiguityKey(idx),
+                                hold_factors.addPrior(ambiguityKey(sym_idx),
                                                       static_cast<double>(fi), hold_noise);
-                                pinned_ambiguities.insert(idx);
+                                pinned_ambiguities.insert(sym_idx);
                             }
                             if (hold_factors.size() > 0) {
                                 try {
@@ -1285,7 +2102,7 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
         if (fix_allowed && config.use_ambiguity_hold && !epoch_fixed[i]) {
             int held_here = 0;
             for (std::size_t idx : epoch_amb_indices) {
-                if (pinned_ambiguities.count(idx)) ++held_here;
+                if (pinned_ambiguities.count(ambSymbolId(idx))) ++held_here;
             }
             if (held_here >= config.ambiguity_hold_min_fixed) {
                 epoch_fixed[i] = true;
@@ -1294,13 +2111,188 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 epoch_fixed_position[i] = antennaOf(pose_i);
                 ++held_epoch_count;
                 for (std::size_t idx : epoch_amb_indices) {
-                    if (pinned_ambiguities.count(idx) && !amb_fixed_cycles.count(idx)) {
+                    const std::size_t sym_idx = ambSymbolId(idx);
+                    if (pinned_ambiguities.count(sym_idx) && !amb_fixed_cycles.count(idx)) {
                         // Record the held integer (rounded from the current estimate).
-                        const double v = smoother.calculateEstimate<double>(ambiguityKey(idx));
+                        const double v = smoother.calculateEstimate<double>(ambiguityKey(sym_idx));
                         amb_fixed_cycles[idx] = static_cast<int>(std::lround(v));
                     }
                 }
             }
+        }
+
+        // --- CP-hold / sanity FSM (use_cp_hold_recovery). Runs LAST, after
+        // this epoch's LAMBDA/fix-and-hold, because the catastrophic fast
+        // path needs "no fixed solution this epoch" (nb == 0) exactly like
+        // the reference's postfit.run_ddpr_sanity(..., nb=...), which the
+        // runner calls from validation/postprocess.py AFTER AR for the
+        // epoch (see validation/postfit.py's trigger -> multipath-skip ->
+        // fast-path -> persist -> gdop-skip -> anchor stages -> apply-reset
+        // pipeline; the DDPR-LS anchor stages are ported inside the persist
+        // path below, gated by FGOConfig::use_ddpr_anchor). ---
+        if (config.use_cp_hold_recovery) {
+            const int nb = epoch_fixed[i] ? epoch_fixed_count[i] : 0;
+            bool did_reset = false;
+            double pred_res = 0.0;
+            if (ddpr_rms > config.cp_hold_main_residual_threshold_m) {
+                // Stage: multipath-dominated skip -- one dominant multipath
+                // satellite is not a wrong basin (reference
+                // _ddpr_multipath_dominated). Bad-count/CP-hold are frozen
+                // (not reset, not incremented) on this path, matching the
+                // reference: the skip returns before _ddpr_sanity_persist.
+                bool multipath_dominated = false;
+                if (config.cp_hold_multipath_median_ratio > 0.0 &&
+                    static_cast<int>(per_sat_res.size()) >= config.cp_hold_multipath_min_satellites) {
+                    std::vector<double> vals;
+                    vals.reserve(per_sat_res.size());
+                    for (const auto& [sid, r] : per_sat_res) {
+                        (void)sid;
+                        vals.push_back(r);
+                    }
+                    std::sort(vals.begin(), vals.end());
+                    const double median = vals[vals.size() / 2];
+                    const double max_v = vals.back();
+                    if (median > 1e-3 && (max_v / median) > config.cp_hold_multipath_median_ratio) {
+                        multipath_dominated = true;
+                        ++result.diagnostics.sanity_multipath_skips;
+                    }
+                }
+                if (!multipath_dominated) {
+                    // DDPR residual evaluated at the IMU-predicted pose
+                    // (pose_seed, this epoch's pre-solve seed) -- reference
+                    // _compute_res_at_pred. Feeds the fast path AND the pose
+                    // replacement decision below.
+                    {
+                        const Point3 pred_ant_p = antennaOf(pose_seed);
+                        const Vector3d pred_ant(pred_ant_p.x(), pred_ant_p.y(), pred_ant_p.z());
+                        double sq_sum = 0.0;
+                        std::size_t n = 0;
+                        for (const auto* fp : pr_by_epoch[i]) {
+                            const double geom =
+                                ((fp->rover_satellite_position_ecef - pred_ant).norm() -
+                                 (fp->base_satellite_position_ecef - fp->base_position_ecef).norm()) -
+                                ((fp->rover_reference_position_ecef - pred_ant).norm() -
+                                 (fp->base_reference_position_ecef - fp->base_position_ecef).norm());
+                            const double res = std::abs(fp->observed_dd_pseudorange_m - geom);
+                            sq_sum += res * res;
+                            ++n;
+                        }
+                        pred_res = n > 0 ? std::sqrt(sq_sum / static_cast<double>(n)) : 0.0;
+                    }
+
+                    // Stage: catastrophic fast path. Fires immediately
+                    // (bypassing persist) when residuals are catastrophic,
+                    // no fixed solution this epoch, and the worst
+                    // per-satellite residual clears the fast-path floor
+                    // (reference _ddpr_sanity_fast_path).
+                    double worst_sat_res = 0.0;
+                    for (const auto& [sid, r] : per_sat_res) {
+                        (void)sid;
+                        worst_sat_res = std::max(worst_sat_res, r);
+                    }
+                    const bool fast_eligible =
+                        ddpr_rms > config.cp_hold_catastrophic_threshold_m && nb == 0 &&
+                        worst_sat_res >= config.cp_hold_fast_worst_satellite_min_m;
+                    if (fast_eligible) {
+                        resetAmbiguitiesWithCpHold();
+                        ++result.diagnostics.sanity_fast_resets;
+                        did_reset = true;
+                    } else {
+                        // Stage: persist. Every bad epoch (re)engages
+                        // CP-hold at full strength; the mass reset itself
+                        // only fires once cp_hold_persist_epochs consecutive
+                        // bad epochs have accumulated (reference
+                        // _ddpr_sanity_persist / trigger_cp_hold).
+                        ++ddpr_bad_count;
+                        cp_hold_counter = std::max(cp_hold_counter, effectiveCpHoldEpochs());
+                        cp_hold_release_streak = 0;
+                        ++result.diagnostics.cp_hold_triggers;
+                        if (ddpr_bad_count >= config.cp_hold_persist_epochs) {
+                            // Stage: GDOP gate -- abort the reset (CP-hold
+                            // stays engaged) when geometry is too weak to
+                            // trust the residual signal (reference
+                            // _ddpr_sanity_gdop_ok).
+                            if (config.cp_hold_max_gdop <= 0.0 || gdop <= config.cp_hold_max_gdop) {
+                                // Stage: DDPR-LS anchor fetch + anchor-vs-IMU
+                                // gap (use_ddpr_anchor; reference
+                                // _ddpr_sanity_fetch_anchor / _anchor_vs_imu).
+                                // DIAGNOSTIC ONLY here: the reference's own
+                                // control flow converges on the exact same
+                                // _apply_sanity_reset() call whether the
+                                // anchor is untrusted, disagrees with the IMU
+                                // prediction, or agrees -- see
+                                // FGOConfig::use_ddpr_anchor's comment. So
+                                // this records whether the gate WOULD have
+                                // skipped/allowed the reset without actually
+                                // gating it, faithfully matching the
+                                // reference.
+                                if (config.use_ddpr_anchor) {
+                                    ++result.diagnostics.ddpr_anchor_solves;
+                                    const DdprAnchorResult anchor = solveDdprAnchor(i, pose_seed);
+                                    const bool anchor_trusted =
+                                        anchor.ok && anchor.n_active >= config.ddpr_anchor_min_factors &&
+                                        anchor.res_rms <= config.ddpr_anchor_max_residual_m;
+                                    if (anchor_trusted) {
+                                        ++result.diagnostics.ddpr_anchor_successes;
+                                        const Point3 anchor_ant = antennaOf(anchor.pose);
+                                        const Point3 pred_ant = antennaOf(pose_seed);
+                                        const double gap = (anchor_ant - pred_ant).norm();
+                                        const bool clean_anchor =
+                                            anchor.res_rms < config.ddpr_anchor_clean_residual_m &&
+                                            ddpr_rms > config.ddpr_anchor_clean_main_residual_m;
+                                        const bool catastrophic_res =
+                                            ddpr_rms > config.cp_hold_catastrophic_threshold_m;
+                                        const bool persistent_bad =
+                                            ddpr_bad_count >= config.ddpr_anchor_persist_override &&
+                                            anchor.res_rms < config.ddpr_anchor_clean_residual_m;
+                                        const bool hard_reject =
+                                            gap > config.ddpr_anchor_imu_hard_max_m && !clean_anchor;
+                                        const bool soft_reject =
+                                            gap > config.ddpr_anchor_imu_max_gap_m &&
+                                            !catastrophic_res && !persistent_bad;
+                                        if (hard_reject || soft_reject) {
+                                            ++result.diagnostics.ddpr_anchor_gated_resets_skipped;
+                                        } else {
+                                            ++result.diagnostics.ddpr_anchor_gated_resets_allowed;
+                                        }
+                                    } else {
+                                        ++result.diagnostics.ddpr_anchor_gated_resets_skipped;
+                                    }
+                                }
+                                resetAmbiguitiesWithCpHold();
+                                ++result.diagnostics.sanity_mass_resets;
+                                did_reset = true;
+                            } else {
+                                ++result.diagnostics.sanity_gdop_skips;
+                            }
+                        }
+                    }
+
+                    // Stage: pose replacement for the REPORTED solution only
+                    // (reference _sanity_report_translation /
+                    // _apply_sanity_reset always reports 'FLT' after a
+                    // reset). The graph values (pose_i, prev_nav, the
+                    // smoother's linearization point) are untouched.
+                    if (did_reset) {
+                        epoch_fixed[i] = false;
+                        const double thr = config.cp_hold_pose_replace_threshold_m;
+                        const Point3 graph_ant_pose = antennaOf(pose_i);
+                        Point3 report_ant = graph_ant_pose;
+                        if (thr > 0.0 && pred_res <= thr) {
+                            const Point3 pred_ant_pose = antennaOf(pose_seed);
+                            const double gap = (graph_ant_pose - pred_ant_pose).norm();
+                            if (gap > thr) {
+                                report_ant = pred_ant_pose;
+                                ++result.diagnostics.sanity_pose_replacements;
+                            }
+                        }
+                        epoch_float_position[i] = report_ant;
+                    }
+                }
+            } else {
+                ddpr_bad_count = 0;
+            }
+            last_ddpr_rms = ddpr_rms;
         }
     }
     result.diagnostics.partial_lambda_ambiguity_fix_used = held_epoch_count > 0;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,6 +67,14 @@ if(GTest_FOUND)
         target_sources(gnss_run_tests PRIVATE test_rtk_legacy.cpp)
     endif()
 
+    # GTSAM FGO backend parity tests (guarded at both CMake and #ifdef level:
+    # the source itself is a no-op TU when GNSSPP_HAS_GTSAM isn't defined, but
+    # we still only add it to the build when GTSAM was actually found so a
+    # GTSAM-less build doesn't pay for an always-empty translation unit).
+    if(GTSAM_FOUND)
+        target_sources(gnss_run_tests PRIVATE test_fgo_gtsam_backend.cpp)
+    endif()
+
     set_target_properties(gnss_run_tests PROPERTIES OUTPUT_NAME run_tests)
     # Backward-compatible alias for CI/scripts that build --target run_tests.
     # Skipped for Visual Studio generators, where the name collides with

--- a/tests/test_fgo.cpp
+++ b/tests/test_fgo.cpp
@@ -4,6 +4,7 @@
 
 #include <array>
 #include <cmath>
+#include <limits>
 #include <map>
 #include <vector>
 
@@ -413,6 +414,120 @@ FGOProcessor::FGOProblem makeSyntheticInterSystemBiasProblem() {
     problem.diagnostics.input_epochs = true_positions.size();
     problem.diagnostics.seeded_epochs = true_positions.size();
     return problem;
+}
+
+// --- CMC (Code-Minus-Carrier) screening test helper ---
+//
+// Builds a fixed-position, two-satellite (GPS PRN1/PRN2) epoch stream where
+// the per-satellite, per-epoch carrier bias is fully controlled. Reusing
+// makeSyntheticGpsL1Observation's construction (carrier_phase = (pseudorange
+// + carrier_bias_m) / wavelength) means the receiver's own geometric
+// pseudorange term cancels exactly out of the single-difference CMC, so for
+// a satellite tracked at both receivers:
+//   CMC = (PR_rover - PR_base) - (CP_rover - CP_base) * wavelength
+//       = carrier_bias_base_m - carrier_bias_rover_m
+// exactly (no residual geometry term), regardless of the rover/base
+// baseline. The same bias sequence is applied identically to BOTH
+// satellites so the test does not need to predict which one
+// select_reference() will pick as the DD reference (elevation-driven, not
+// controlled here); whichever one is NOT selected is the one the CMC
+// screening actually gates for that (system, signal) group, and it is
+// identified after the fact from the built problem.
+std::vector<ObservationData> makeCmcObservationEpochs(
+    const NavigationData& nav,
+    const Vector3d& receiver_position,
+    const std::vector<std::array<double, 2>>& carrier_bias_m,
+    double dt_s,
+    const std::vector<bool>& loss_of_lock_epochs = {}) {
+    std::vector<ObservationData> epochs;
+    for (std::size_t epoch_index = 0; epoch_index < carrier_bias_m.size();
+         ++epoch_index) {
+        ObservationData epoch(
+            GNSSTime(2300, 100100.0 + dt_s * static_cast<double>(epoch_index)));
+        epoch.receiver_position = receiver_position;
+        for (std::size_t sat_index = 0; sat_index < 2; ++sat_index) {
+            Observation observation;
+            const uint8_t prn = static_cast<uint8_t>(sat_index + 1);
+            if (makeSyntheticGpsL1Observation(nav,
+                                              SatelliteId(GNSSSystem::GPS, prn),
+                                              epoch.time,
+                                              receiver_position,
+                                              carrier_bias_m[epoch_index][sat_index],
+                                              observation)) {
+                if (epoch_index < loss_of_lock_epochs.size() &&
+                    loss_of_lock_epochs[epoch_index]) {
+                    observation.loss_of_lock = true;
+                }
+                epoch.addObservation(observation);
+            }
+        }
+        epochs.push_back(epoch);
+    }
+    return epochs;
+}
+
+// Common config for CMC integration tests: minimal DD-only problem, all
+// satellites pass (no elevation/SNR gating gets in the way of a controlled
+// synthetic scenario), matching the style of
+// BuiltSingleDifferenceTdcpFactorsUseCurrentEpochLos above.
+FGOProcessor::FGOConfig makeCmcTestConfig() {
+    FGOProcessor::FGOConfig config;
+    config.use_spp_seed = false;
+    config.use_pseudorange_factors = false;
+    config.use_motion_factors = false;
+    config.use_tdcp_factors = false;
+    config.use_double_difference_factors = true;
+    config.use_ionosphere_model = false;
+    config.use_troposphere_model = false;
+    config.min_elevation_deg = -90.0;
+    config.min_satellites_per_epoch = 2;
+    config.max_tdcp_gap_s = 10.0;
+    config.use_code_minus_carrier_screening = true;
+    config.code_minus_carrier_jump_threshold_m = 1.0;
+    config.code_minus_carrier_level_threshold_m = 0.0;  // off unless a test opts in
+    return config;
+}
+
+// Identifies, from a built DD problem, the (satellite, signal) that the CMC
+// screening actually gates -- i.e. whichever of PRN1/PRN2 was NOT picked as
+// the per-epoch DD reference -- and returns its ambiguity_index (or
+// SIZE_MAX if absent) plus whether a DD carrier/pseudorange factor exists,
+// for every requested epoch index.
+struct TrackedSatelliteRow {
+    bool has_carrier_factor = false;
+    bool has_pseudorange_factor = false;
+    std::size_t ambiguity_index = std::numeric_limits<std::size_t>::max();
+};
+
+std::map<std::size_t, TrackedSatelliteRow> trackedSatelliteRowsByEpoch(
+    const FGOProcessor::FGOProblem& problem,
+    SatelliteId* out_tracked_satellite = nullptr) {
+    SatelliteId tracked;
+    bool found_tracked = false;
+    for (const auto& factor : problem.double_difference_carrier_factors) {
+        tracked = factor.satellite;
+        found_tracked = true;
+        break;
+    }
+    std::map<std::size_t, TrackedSatelliteRow> rows;
+    if (!found_tracked) {
+        return rows;
+    }
+    for (const auto& factor : problem.double_difference_carrier_factors) {
+        if (factor.satellite == tracked) {
+            rows[factor.epoch_index].has_carrier_factor = true;
+            rows[factor.epoch_index].ambiguity_index = factor.ambiguity_index;
+        }
+    }
+    for (const auto& factor : problem.double_difference_pseudorange_factors) {
+        if (factor.satellite == tracked) {
+            rows[factor.epoch_index].has_pseudorange_factor = true;
+        }
+    }
+    if (out_tracked_satellite != nullptr) {
+        *out_tracked_satellite = tracked;
+    }
+    return rows;
 }
 
 }  // namespace
@@ -1023,4 +1138,249 @@ TEST(FGOTest, PropagatesTdcpQualityDiagnostics) {
     EXPECT_EQ(result.diagnostics.tdcp_rejected_missing_previous, 3u);
     EXPECT_EQ(result.diagnostics.tdcp_rejected_loss_of_lock, 4u);
     EXPECT_EQ(result.diagnostics.tdcp_rejected_code_phase_jump, 5u);
+}
+
+TEST(FGOTest, CmcJumpForcesAmbiguityArcBreak) {
+    const NavigationData nav = makeSyntheticGpsNavigation(2);
+    const Vector3d rover_position(1113194.0, -4841695.0, 3985350.0);
+    const Vector3d base_position = rover_position + Vector3d(-320.0, 180.0, 45.0);
+
+    // Both satellites: rover bias jumps by 5 m at epoch 2 (base bias stays
+    // at 0), so single-difference CMC jumps by -5 m there -- well past the
+    // 1.0 m test threshold. No jump before or after.
+    const std::vector<std::array<double, 2>> rover_bias = {
+        {0.0, 0.0}, {0.0, 0.0}, {5.0, 5.0}, {5.0, 5.0},
+    };
+    const std::vector<std::array<double, 2>> base_bias = {
+        {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0},
+    };
+    const auto rover_epochs =
+        makeCmcObservationEpochs(nav, rover_position, rover_bias, 1.0);
+    const auto base_epochs =
+        makeCmcObservationEpochs(nav, base_position, base_bias, 1.0);
+
+    FGOProcessor processor(makeCmcTestConfig());
+    const auto problem = processor.buildDoubleDifferenceProblem(
+        rover_epochs, base_epochs, nav, base_position);
+
+    const auto rows = trackedSatelliteRowsByEpoch(problem);
+    ASSERT_EQ(rows.size(), 4u);
+    for (const auto& [epoch_index, row] : rows) {
+        EXPECT_TRUE(row.has_carrier_factor) << "epoch " << epoch_index;
+        EXPECT_TRUE(row.has_pseudorange_factor) << "epoch " << epoch_index;
+    }
+
+    // No break between epoch 0 and 1 (no CMC change).
+    EXPECT_EQ(rows.at(0).ambiguity_index, rows.at(1).ambiguity_index);
+    // The jump at epoch 2 forces a NEW ambiguity for the tracked satellite.
+    EXPECT_NE(rows.at(1).ambiguity_index, rows.at(2).ambiguity_index);
+    // No further break at epoch 3 (bias held steady after the jump).
+    EXPECT_EQ(rows.at(2).ambiguity_index, rows.at(3).ambiguity_index);
+
+    // Both PRN1 and PRN2 are screened every epoch (only one of them is the
+    // DD reference and gates factor emission, but the CMC pre-pass runs over
+    // every tracked satellite), so the shared jump at epoch 2 is detected
+    // twice.
+    EXPECT_EQ(problem.diagnostics.code_minus_carrier_jump_resets, 2u);
+    EXPECT_EQ(problem.diagnostics.code_minus_carrier_level_exclusions, 0u);
+}
+
+TEST(FGOTest, CmcScreeningDefaultOffIsNoOp) {
+    const NavigationData nav = makeSyntheticGpsNavigation(2);
+    const Vector3d rover_position(1113194.0, -4841695.0, 3985350.0);
+    const Vector3d base_position = rover_position + Vector3d(-320.0, 180.0, 45.0);
+
+    const std::vector<std::array<double, 2>> rover_bias = {
+        {0.0, 0.0}, {0.0, 0.0}, {5.0, 5.0}, {5.0, 5.0},
+    };
+    const std::vector<std::array<double, 2>> base_bias = {
+        {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0},
+    };
+    const auto rover_epochs =
+        makeCmcObservationEpochs(nav, rover_position, rover_bias, 1.0);
+    const auto base_epochs =
+        makeCmcObservationEpochs(nav, base_position, base_bias, 1.0);
+
+    FGOProcessor::FGOConfig config = makeCmcTestConfig();
+    config.use_code_minus_carrier_screening = false;  // default
+    FGOProcessor processor(config);
+    const auto problem = processor.buildDoubleDifferenceProblem(
+        rover_epochs, base_epochs, nav, base_position);
+
+    const auto rows = trackedSatelliteRowsByEpoch(problem);
+    ASSERT_EQ(rows.size(), 4u);
+    for (const auto& [epoch_index, row] : rows) {
+        EXPECT_TRUE(row.has_carrier_factor) << "epoch " << epoch_index;
+        EXPECT_TRUE(row.has_pseudorange_factor) << "epoch " << epoch_index;
+    }
+    // With screening off, the same CMC jump that broke the arc in
+    // CmcJumpForcesAmbiguityArcBreak must NOT break it here: every epoch
+    // keeps the same ambiguity_index.
+    EXPECT_EQ(rows.at(0).ambiguity_index, rows.at(1).ambiguity_index);
+    EXPECT_EQ(rows.at(1).ambiguity_index, rows.at(2).ambiguity_index);
+    EXPECT_EQ(rows.at(2).ambiguity_index, rows.at(3).ambiguity_index);
+
+    EXPECT_EQ(problem.diagnostics.code_minus_carrier_jump_resets, 0u);
+    EXPECT_EQ(problem.diagnostics.code_minus_carrier_level_exclusions, 0u);
+}
+
+TEST(FGOTest, CmcLevelExclusionSkipsBothFactorsWithoutUpdatingBaseline) {
+    const NavigationData nav = makeSyntheticGpsNavigation(2);
+    const Vector3d rover_position(1113194.0, -4841695.0, 3985350.0);
+    const Vector3d base_position = rover_position + Vector3d(-320.0, 180.0, 45.0);
+
+    // Warmup = 3: epochs 0,1,2 seed/average the baseline to
+    // (0 + 2 - 1) / 3 = 1/3 (CMC = base_bias - rover_bias). Epoch 3 and 4
+    // both deviate by the SAME amount (baseline + threshold + margin) so
+    // that IF the baseline had been updated after epoch 3's exclusion,
+    // epoch 4 would no longer be excluded -- it must still be excluded,
+    // proving the baseline was left untouched.
+    FGOProcessor::FGOConfig config = makeCmcTestConfig();
+    config.code_minus_carrier_jump_threshold_m = 1000.0;  // isolate the level check
+    config.code_minus_carrier_level_threshold_m = 0.4;
+    config.code_minus_carrier_warmup_epochs = 3;
+    config.code_minus_carrier_baseline_alpha = 0.5;
+
+    // CMC[e] = base_bias[e] - rover_bias[e]:
+    //   e0: 0 - 0 = 0
+    //   e1: 2 - 0 = 2   (rover=0, base=2)
+    //   e2: -1 - 0 = -1 (rover=0, base=-1)
+    //   baseline after warmup = (0 + 2 - 1) / 3 = 1/3
+    //   e3, e4: cmc = 1/3 + 0.4 + 0.2 = 0.9333... -> |delta| = 0.6 > 0.4: excluded both times
+    const double baseline_after_warmup = (0.0 + 2.0 - 1.0) / 3.0;
+    const double excluded_cmc = baseline_after_warmup + 0.4 + 0.2;
+    const std::vector<std::array<double, 2>> base_bias = {
+        {0.0, 0.0}, {2.0, 2.0}, {-1.0, -1.0},
+        {excluded_cmc, excluded_cmc}, {excluded_cmc, excluded_cmc},
+    };
+    const std::vector<std::array<double, 2>> rover_bias = {
+        {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0},
+    };
+    const auto rover_epochs =
+        makeCmcObservationEpochs(nav, rover_position, rover_bias, 1.0);
+    const auto base_epochs =
+        makeCmcObservationEpochs(nav, base_position, base_bias, 1.0);
+
+    FGOProcessor processor(config);
+    const auto problem = processor.buildDoubleDifferenceProblem(
+        rover_epochs, base_epochs, nav, base_position);
+
+    const auto rows = trackedSatelliteRowsByEpoch(problem);
+    // Epochs 0, 1, 2 (seeding/warmup) always emit factors.
+    EXPECT_TRUE(rows.at(0).has_carrier_factor);
+    EXPECT_TRUE(rows.at(1).has_carrier_factor);
+    EXPECT_TRUE(rows.at(2).has_carrier_factor);
+    // Epochs 3 and 4 are BOTH excluded -- if the baseline had moved after
+    // epoch 3, epoch 4 (identical deviation) would no longer exceed the
+    // threshold and would NOT be excluded.
+    EXPECT_EQ(rows.find(3), rows.end());
+    EXPECT_EQ(rows.find(4), rows.end());
+
+    // No ambiguity arc break: only the level check is active here.
+    EXPECT_EQ(problem.diagnostics.code_minus_carrier_jump_resets, 0u);
+    // Both PRN1 and PRN2 are screened -> each excluded epoch counts twice.
+    EXPECT_EQ(problem.diagnostics.code_minus_carrier_level_exclusions, 4u);
+}
+
+TEST(FGOTest, CmcBaselineEwmaUpdatesInSteadyState) {
+    const NavigationData nav = makeSyntheticGpsNavigation(2);
+    const Vector3d rover_position(1113194.0, -4841695.0, 3985350.0);
+    const Vector3d base_position = rover_position + Vector3d(-320.0, 180.0, 45.0);
+
+    // Warmup = 1: epoch 0 seeds the baseline directly (count=1==warmup), so
+    // epoch 1 onward is already steady-state.
+    FGOProcessor::FGOConfig config = makeCmcTestConfig();
+    config.code_minus_carrier_jump_threshold_m = 1000.0;  // isolate the level check
+    config.code_minus_carrier_level_threshold_m = 0.5;
+    config.code_minus_carrier_warmup_epochs = 1;
+    config.code_minus_carrier_baseline_alpha = 0.5;
+
+    // baseline0 = cmc0 = 0.
+    // e1: cmc1 = 0.4 (within 0.5 of baseline0=0) -> NOT excluded;
+    //     baseline1 = 0.5*0 + 0.5*0.4 = 0.2.
+    // e2: cmc2 = 0.65 (within 0.5 of baseline1=0.2, would be EXCLUDED if
+    //     compared against the stale baseline0=0: |0.65-0|=0.65>0.5) ->
+    //     proves the baseline moved. NOT excluded;
+    //     baseline2 = 0.5*0.2 + 0.5*0.65 = 0.425.
+    // e3: cmc3 = 0.9 (within 0.5 of baseline2=0.425: |0.9-0.425|=0.475<=0.5,
+    //     but would be EXCLUDED against baseline1=0.2: |0.9-0.2|=0.7>0.5) ->
+    //     proves the second EWMA update also took effect. NOT excluded.
+    const std::vector<std::array<double, 2>> base_bias = {
+        {0.0, 0.0}, {0.4, 0.4}, {0.65, 0.65}, {0.9, 0.9},
+    };
+    const std::vector<std::array<double, 2>> rover_bias = {
+        {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0},
+    };
+    const auto rover_epochs =
+        makeCmcObservationEpochs(nav, rover_position, rover_bias, 1.0);
+    const auto base_epochs =
+        makeCmcObservationEpochs(nav, base_position, base_bias, 1.0);
+
+    FGOProcessor processor(config);
+    const auto problem = processor.buildDoubleDifferenceProblem(
+        rover_epochs, base_epochs, nav, base_position);
+
+    const auto rows = trackedSatelliteRowsByEpoch(problem);
+    ASSERT_EQ(rows.size(), 4u);
+    for (const auto& [epoch_index, row] : rows) {
+        EXPECT_TRUE(row.has_carrier_factor) << "epoch " << epoch_index;
+    }
+    EXPECT_EQ(problem.diagnostics.code_minus_carrier_level_exclusions, 0u);
+}
+
+TEST(FGOTest, CmcArcResetAlsoResetsBaseline) {
+    const NavigationData nav = makeSyntheticGpsNavigation(2);
+    const Vector3d rover_position(1113194.0, -4841695.0, 3985350.0);
+    const Vector3d base_position = rover_position + Vector3d(-320.0, 180.0, 45.0);
+
+    // Warmup = 2, level threshold = 1.0: epochs 0-1 establish a baseline of
+    // 0. At epoch 2 a loss-of-lock is injected on BOTH satellites (forcing
+    // the pre-existing rover-side arc-break machinery to start a new
+    // carrier arc) at the SAME epoch the CMC value jumps by 50 m -- an
+    // enormous deviation that would clearly exceed the level threshold
+    // against the OLD baseline. Because this port resets the CMC
+    // baseline/prev/warmup state whenever the rover-side arc restarts (the
+    // deliberate deviation from the reference, documented on
+    // FGOConfig::use_code_minus_carrier_screening), epoch 2 must be treated
+    // as a fresh baseline seed -- NOT excluded.
+    FGOProcessor::FGOConfig config = makeCmcTestConfig();
+    config.code_minus_carrier_jump_threshold_m = 1000.0;  // isolate the level check
+    config.code_minus_carrier_level_threshold_m = 1.0;
+    config.code_minus_carrier_warmup_epochs = 2;
+    config.code_minus_carrier_baseline_alpha = 0.5;
+
+    const std::vector<std::array<double, 2>> base_bias = {
+        {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0}, {0.0, 0.0},
+    };
+    // CMC = base_bias - rover_bias, so a rover bias of -50 at/after epoch 2
+    // makes CMC jump to +50.
+    const std::vector<std::array<double, 2>> rover_bias = {
+        {0.0, 0.0}, {0.0, 0.0}, {-50.0, -50.0}, {-50.0, -50.0}, {-50.0, -50.0},
+    };
+    const std::vector<bool> loss_of_lock_epochs = {false, false, true, false, false};
+    const auto rover_epochs = makeCmcObservationEpochs(
+        nav, rover_position, rover_bias, 1.0, loss_of_lock_epochs);
+    const auto base_epochs = makeCmcObservationEpochs(
+        nav, base_position, base_bias, 1.0, loss_of_lock_epochs);
+
+    FGOProcessor processor(config);
+    const auto problem = processor.buildDoubleDifferenceProblem(
+        rover_epochs, base_epochs, nav, base_position);
+
+    const auto rows = trackedSatelliteRowsByEpoch(problem);
+    ASSERT_EQ(rows.size(), 5u);
+    // Epoch 2's huge CMC deviation is NOT excluded: the arc reset (from
+    // loss-of-lock) also reset the baseline, so epoch 2 just reseeds it.
+    EXPECT_TRUE(rows.at(2).has_carrier_factor);
+    EXPECT_TRUE(rows.at(2).has_pseudorange_factor);
+    // The loss-of-lock itself still breaks the ambiguity arc as before.
+    EXPECT_NE(rows.at(1).ambiguity_index, rows.at(2).ambiguity_index);
+    // Epochs 3, 4 continue the new arc with the reseeded baseline (stable
+    // value, count still ramping through warmup) -- also not excluded.
+    EXPECT_TRUE(rows.at(3).has_carrier_factor);
+    EXPECT_TRUE(rows.at(4).has_carrier_factor);
+    EXPECT_EQ(rows.at(2).ambiguity_index, rows.at(3).ambiguity_index);
+    EXPECT_EQ(rows.at(3).ambiguity_index, rows.at(4).ambiguity_index);
+
+    EXPECT_EQ(problem.diagnostics.code_minus_carrier_level_exclusions, 0u);
 }

--- a/tests/test_fgo.cpp
+++ b/tests/test_fgo.cpp
@@ -1384,3 +1384,148 @@ TEST(FGOTest, CmcArcResetAlsoResetsBaseline) {
 
     EXPECT_EQ(problem.diagnostics.code_minus_carrier_level_exclusions, 0u);
 }
+
+// --- Elevation-dependent DD sigma ("varerr", FGOConfig::use_elevation_
+// dependent_sigma) -- port of the inuex35 reference's preprocess/prefit.py
+// varerr_dd_sigma / buildfactor/factors.py pair_sigma. See the knob's doc
+// comment in fgo.hpp for the full formula and dt_s/undifferenced-PR
+// decisions.
+
+TEST(FGOTest, ElevationDependentSigmaDefaultOffMatchesFlatFormula) {
+    const NavigationData nav = makeSyntheticGpsNavigation(2);
+    const Vector3d rover_position(1113194.0, -4841695.0, 3985350.0);
+    const Vector3d base_position = rover_position + Vector3d(-320.0, 180.0, 45.0);
+
+    const std::vector<std::array<double, 2>> bias = {{0.0, 0.0}, {0.0, 0.0}};
+    const auto rover_epochs = makeCmcObservationEpochs(nav, rover_position, bias, 0.5);
+    const auto base_epochs = makeCmcObservationEpochs(nav, base_position, bias, 0.5);
+
+    FGOProcessor::FGOConfig config = makeCmcTestConfig();
+    config.use_code_minus_carrier_screening = false;
+    ASSERT_FALSE(config.use_elevation_dependent_sigma);  // default OFF
+
+    FGOProcessor processor(config);
+    const auto problem = processor.buildDoubleDifferenceProblem(
+        rover_epochs, base_epochs, nav, base_position);
+
+    // With the knob off, DD PR/CP sigma must be bit-for-bit the pre-existing
+    // flat/elevation-power formula: band_scale(=1, single-freq GPS L1CA) *
+    // sigma_m / sqrt(max(0.1, sin(own elevation))).
+    ASSERT_FALSE(problem.double_difference_pseudorange_factors.empty());
+    ASSERT_FALSE(problem.double_difference_carrier_factors.empty());
+    for (const auto& f : problem.double_difference_pseudorange_factors) {
+        const double sin_el = std::max(0.1, std::sin(f.elevation_rad));
+        const double expected =
+            std::max(1e-3, config.double_difference_pseudorange_sigma_m) /
+            std::sqrt(sin_el);
+        EXPECT_DOUBLE_EQ(f.sigma_m, expected) << "epoch " << f.epoch_index;
+    }
+    for (const auto& f : problem.double_difference_carrier_factors) {
+        const double sin_el = std::max(0.1, std::sin(f.elevation_rad));
+        const double expected =
+            std::max(1e-4, config.double_difference_carrier_sigma_m) /
+            std::sqrt(sin_el);
+        EXPECT_DOUBLE_EQ(f.sigma_m, expected) << "epoch " << f.epoch_index;
+    }
+}
+
+TEST(FGOTest, ElevationDependentSigmaMatchesPortedVarerrFormula) {
+    const NavigationData nav = makeSyntheticGpsNavigation(2);
+    const Vector3d rover_position(1113194.0, -4841695.0, 3985350.0);
+    const Vector3d base_position = rover_position + Vector3d(-320.0, 180.0, 45.0);
+
+    // dt_s = 0.5 s (deliberately different from the 0.2 s epoch-0 fallback)
+    // so epoch 1's clock term proves the ACTUAL measured rover epoch spacing
+    // is used, not just the fallback default.
+    constexpr double kDtS = 0.5;
+    const std::vector<std::array<double, 2>> bias = {{0.0, 0.0}, {0.0, 0.0}};
+    const auto rover_epochs = makeCmcObservationEpochs(nav, rover_position, bias, kDtS);
+    const auto base_epochs = makeCmcObservationEpochs(nav, base_position, bias, kDtS);
+
+    FGOProcessor::FGOConfig config = makeCmcTestConfig();
+    config.use_code_minus_carrier_screening = false;
+    config.use_elevation_dependent_sigma = true;
+    // Reference defaults (config.py): these ran DEFAULT-ON in every
+    // reference benchmark.
+    config.elevation_sigma_err_a_m = 0.001;
+    config.elevation_sigma_err_b_m = 0.001;
+    config.elevation_sigma_pseudorange_ratio = 100.0;
+    config.elevation_sigma_clock_stability = 5e-12;
+
+    FGOProcessor processor(config);
+    const auto problem = processor.buildDoubleDifferenceProblem(
+        rover_epochs, base_epochs, nav, base_position);
+
+    ASSERT_FALSE(problem.double_difference_pseudorange_factors.empty());
+    ASSERT_FALSE(problem.double_difference_carrier_factors.empty());
+
+    const double el_min_rad = M_PI / 180.0 * std::max(1.0, config.min_elevation_deg);
+    constexpr double kSpeedOfLightMps = 299792458.0;
+
+    // Independent oracle re-implementing the exact ported formula (fgo.hpp's
+    // use_elevation_dependent_sigma doc comment / varerrDdSigma in fgo.cpp),
+    // so this test would catch a broken port even if it coincidentally
+    // matched at one particular elevation.
+    auto expectedSigma = [&](bool is_pseudorange, double el_pair_rad, double epoch_dt_s) {
+        const double fact = is_pseudorange ? config.elevation_sigma_pseudorange_ratio : 1.0;
+        const double a = fact * config.elevation_sigma_err_a_m;
+        const double b = fact * config.elevation_sigma_err_b_m;
+        const double d = kSpeedOfLightMps * config.elevation_sigma_clock_stability * epoch_dt_s;
+        const double sinel = std::max(std::sin(el_pair_rad), 0.05);
+        const double var_sd = 2.0 * (a * a + b * b / (sinel * sinel)) + d * d;
+        return std::sqrt(2.0 * var_sd);
+    };
+
+    auto findReferenceElevationRad = [&](std::size_t epoch_index,
+                                         const SatelliteId& reference_satellite,
+                                         SignalType signal) {
+        for (const auto& reference_observation :
+             problem.double_difference_reference_observations) {
+            if (reference_observation.epoch_index == epoch_index &&
+                reference_observation.satellite == reference_satellite &&
+                reference_observation.signal == signal) {
+                return reference_observation.elevation_rad;
+            }
+        }
+        ADD_FAILURE() << "no matching reference observation for epoch "
+                      << epoch_index;
+        return 0.0;
+    };
+
+    // Epoch 0 has no preceding epoch, so the port's epoch_dt_s is still at
+    // its initial 0.2 s default (see the fgo.hpp doc comment); epoch 1's
+    // measured spacing is exactly kDtS.
+    for (const auto& f : problem.double_difference_pseudorange_factors) {
+        const double epoch_dt_s = (f.epoch_index == 0) ? 0.2 : kDtS;
+        const double reference_el_rad = findReferenceElevationRad(
+            f.epoch_index, f.reference_satellite, f.signal);
+        const double el_pair_rad =
+            std::max(std::min(reference_el_rad, f.elevation_rad), el_min_rad);
+        const double expected = expectedSigma(/*is_pseudorange=*/true, el_pair_rad, epoch_dt_s);
+        EXPECT_NEAR(f.sigma_m, expected, 1e-9 * std::max(1.0, expected))
+            << "PR epoch " << f.epoch_index;
+    }
+    double pr_sigma_at_epoch0 = 0.0;
+    double cp_sigma_at_epoch0 = 0.0;
+    for (const auto& f : problem.double_difference_carrier_factors) {
+        const double epoch_dt_s = (f.epoch_index == 0) ? 0.2 : kDtS;
+        const double reference_el_rad = findReferenceElevationRad(
+            f.epoch_index, f.reference_satellite, f.signal);
+        const double el_pair_rad =
+            std::max(std::min(reference_el_rad, f.elevation_rad), el_min_rad);
+        const double expected = expectedSigma(/*is_pseudorange=*/false, el_pair_rad, epoch_dt_s);
+        EXPECT_NEAR(f.sigma_m, expected, 1e-9 * std::max(1.0, expected))
+            << "CP epoch " << f.epoch_index;
+        if (f.epoch_index == 0) cp_sigma_at_epoch0 = f.sigma_m;
+    }
+    for (const auto& f : problem.double_difference_pseudorange_factors) {
+        if (f.epoch_index == 0) pr_sigma_at_epoch0 = f.sigma_m;
+    }
+    // PR is roughly eratio_pr (100x) the CP sigma at the same pair-elevation
+    // -- not exactly 100x, because the additive clock term d^2 does NOT
+    // scale by eratio_pr in the reference formula (see fgo.hpp's doc
+    // comment); at these defaults d^2 is a small correction, so the ratio is
+    // close to but not exactly 100.
+    ASSERT_GT(cp_sigma_at_epoch0, 0.0);
+    EXPECT_NEAR(pr_sigma_at_epoch0 / cp_sigma_at_epoch0, 100.0, 1.0);
+}

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -3,11 +3,14 @@
 #include <gtest/gtest.h>
 #include <libgnss++/algorithms/fgo.hpp>
 #include <libgnss++/core/constants.hpp>
+#include <libgnss++/core/coordinates.hpp>
+#include <libgnss++/io/imu.hpp>
 
 #include <algorithm>
 #include <array>
 #include <cmath>
 #include <cstdio>
+#include <set>
 #include <vector>
 
 // Parity harness for Phase 1 of the GTSAM backend (docs/gtsam_backend_design.md):
@@ -242,6 +245,970 @@ TEST(FGOGtsamBackendTest, GtsamBackendRecoversFloatAmbiguitiesNearIntegers) {
         EXPECT_LT(std::abs(cycles - nearest_integer), 0.05)
             << "ambiguity index " << i << " float cycles=" << cycles;
     }
+}
+
+// ============================================================================
+// CP-hold / sanity FSM (FGOConfig::use_cp_hold_recovery) -- fixed-lag path.
+//
+// Builds a stationary, IMU-coupled, multi-epoch DD RTK problem (6 satellites,
+// 1 reference + 5 targets) and corrupts specific epochs' DD CARRIER
+// observation for satellite index 1 (ambiguity_index 0) by a large integer-
+// cycle offset -- a "wrong basin" carrier lock the front-end never flags as a
+// new arc (no cycle-slip marker), which the FSM must catch from post-fit DD
+// PSEUDORANGE residuals alone. Corrupting carrier (very tight sigma) rather
+// than pseudorange drags the GRAPH pose away from the true/IMU-predicted
+// (stationary) position without the degenerate "uniform PR bias looks like a
+// position shift" ambiguity a pseudorange-only corruption would have.
+// ============================================================================
+namespace {
+
+struct CpHoldTestOptions {
+    std::size_t num_epochs = 25;
+    double epoch_dt_s = 1.0;
+    // "Wrong basin" corruption: in the listed epochs, EVERY DD carrier
+    // observation (reference AND all targets) is generated as if the rover
+    // were actually at (true_position + carrier_corrupt_offset_ecef) instead
+    // of true_position -- a self-consistent alternate hypothesis, exactly
+    // like a real wrong-integer AR fix the front-end never flagged as a new
+    // arc. Carrier sigma (0.02 m) is far tighter than pseudorange (0.5 m),
+    // so this drags the GRAPH POSE to the wrong position; pseudorange is
+    // ALWAYS generated from the true (stationary) position, so post-fit DD
+    // pseudorange residuals at the dragged pose light up on every satellite
+    // uniformly -- the intended "wrong basin", not single-satellite
+    // multipath (see pr_corrupt_epochs below for that scenario).
+    std::set<std::size_t> carrier_corrupt_epochs;
+    Vector3d carrier_corrupt_offset_ecef = Vector3d(20.0, 0.0, 0.0);
+    // Pseudorange-only corruption (carriers stay clean/consistent with
+    // true_position, so the tight carrier constraints keep the graph pose
+    // pinned at truth and any injected PR bias shows up almost entirely as
+    // PER-SATELLITE residual) -- used to engineer a genuine "one dominant
+    // multipath satellite among a noisy-but-small baseline" scenario for the
+    // multipath-skip test.
+    std::set<std::size_t> pr_corrupt_epochs;
+    double pr_baseline_bias_m = 0.0;       ///< applied to every target satellite
+    double pr_dominant_extra_bias_m = 0.0;  ///< additional bias, satellite index 1 only
+};
+
+FGOProcessor::FGOProblem makeCpHoldFixedLagProblem(const CpHoldTestOptions& opt) {
+    FGOProcessor::FGOProblem problem;
+    const auto satellites = gtsamParitySatelliteGeometry();
+    const double wavelength = constants::GPS_L1_WAVELENGTH;
+
+    const Vector3d true_position(1113194.0, -4841695.0, 3985350.0);
+    const Vector3d base_position = true_position + Vector3d(-320.0, 180.0, 45.0);
+    const double base_clock_bias_m = 11.0;
+    const double rover_clock_bias_m = 42.0;
+
+    double lat = 0.0, lon = 0.0, h = 0.0;
+    ecef2geodetic(true_position, lat, lon, h);
+    problem.imu.valid = true;
+    problem.imu.nav_origin_ecef = true_position;
+    problem.imu.nav_origin_lat_rad = lat;
+    problem.imu.nav_origin_lon_rad = lon;
+    problem.imu.init_attitude_body_to_nav = Matrix3d::Identity();
+    problem.imu.init_velocity_nav = Vector3d::Zero();
+    problem.imu.init_accel_bias = Vector3d::Zero();
+    problem.imu.init_gyro_bias = Vector3d::Zero();
+
+    // Ambiguity per non-reference satellite, held constant for the whole run
+    // (no front-end arc break -- the corruption below is a mid-arc anomaly
+    // only the backend FSM can react to).
+    for (std::size_t sat = 1; sat < satellites.size(); ++sat) {
+        FGOProcessor::AmbiguityState ambiguity;
+        ambiguity.satellite = SatelliteId(GNSSSystem::GPS, static_cast<uint8_t>(sat + 1));
+        ambiguity.reference_satellite = SatelliteId(GNSSSystem::GPS, 1);
+        ambiguity.signal = SignalType::GPS_L1CA;
+        ambiguity.wavelength_m = wavelength;
+        ambiguity.is_double_difference = true;
+        const int true_dd_cycles = 100 + static_cast<int>(sat);
+        ambiguity.initial_ambiguity_m = static_cast<double>(true_dd_cycles) * wavelength;
+        problem.ambiguity_states.push_back(ambiguity);
+    }
+
+    const GNSSTime t0(2300, 100000.0);
+    for (std::size_t epoch = 0; epoch < opt.num_epochs; ++epoch) {
+        FGOProcessor::EpochSeed seed;
+        seed.time = t0 + static_cast<double>(epoch) * opt.epoch_dt_s;
+        seed.position_ecef = true_position;  // stationary rover
+        seed.receiver_clock_bias_m = rover_clock_bias_m;
+        problem.epochs.push_back(seed);
+
+        const bool corrupt = opt.carrier_corrupt_epochs.count(epoch) > 0;
+        const bool pr_corrupt = opt.pr_corrupt_epochs.count(epoch) > 0;
+        // Carriers are generated from carrier_pos (the wrong-basin hypothesis
+        // when corrupt); pseudorange is ALWAYS generated from true_position.
+        const Vector3d carrier_pos =
+            corrupt ? true_position + opt.carrier_corrupt_offset_ecef : true_position;
+
+        const double rover_ref_range_pr = (satellites[0] - true_position).norm();
+        const double rover_ref_range_cp = (satellites[0] - carrier_pos).norm();
+        const double base_ref_range = (satellites[0] - base_position).norm();
+        FGOProcessor::ObservationModelDebug rover_ref_model;
+        rover_ref_model.corrected_pseudorange_m = rover_ref_range_pr + rover_clock_bias_m;
+        rover_ref_model.corrected_carrier_m = rover_ref_range_cp + rover_clock_bias_m;
+        FGOProcessor::ObservationModelDebug base_ref_model;
+        base_ref_model.corrected_pseudorange_m = base_ref_range + base_clock_bias_m;
+        base_ref_model.corrected_carrier_m = base_ref_range + base_clock_bias_m;
+
+        for (std::size_t sat = 1; sat < satellites.size(); ++sat) {
+            const double rover_target_range_pr = (satellites[sat] - true_position).norm();
+            const double rover_target_range_cp = (satellites[sat] - carrier_pos).norm();
+            const double base_target_range = (satellites[sat] - base_position).norm();
+            const int true_dd_cycles = 100 + static_cast<int>(sat);
+
+            FGOProcessor::ObservationModelDebug rover_target_model;
+            rover_target_model.corrected_pseudorange_m = rover_target_range_pr + rover_clock_bias_m;
+            rover_target_model.corrected_carrier_m =
+                rover_target_range_cp + rover_clock_bias_m +
+                static_cast<double>(true_dd_cycles) * wavelength;
+            if (pr_corrupt) {
+                rover_target_model.corrected_pseudorange_m += opt.pr_baseline_bias_m;
+                if (sat == 1) {
+                    rover_target_model.corrected_pseudorange_m += opt.pr_dominant_extra_bias_m;
+                }
+            }
+
+            FGOProcessor::ObservationModelDebug base_target_model;
+            base_target_model.corrected_pseudorange_m = base_target_range + base_clock_bias_m;
+            base_target_model.corrected_carrier_m = base_target_range + base_clock_bias_m;
+
+            FGOProcessor::DoubleDifferencePseudorangeFactor pr_factor;
+            pr_factor.epoch_index = epoch;
+            pr_factor.satellite = SatelliteId(GNSSSystem::GPS, static_cast<uint8_t>(sat + 1));
+            pr_factor.reference_satellite = SatelliteId(GNSSSystem::GPS, 1);
+            pr_factor.signal = SignalType::GPS_L1CA;
+            pr_factor.rover_satellite_position_ecef = satellites[sat];
+            pr_factor.rover_reference_position_ecef = satellites[0];
+            pr_factor.base_satellite_position_ecef = satellites[sat];
+            pr_factor.base_reference_position_ecef = satellites[0];
+            pr_factor.base_position_ecef = base_position;
+            pr_factor.rover_satellite_model = rover_target_model;
+            pr_factor.rover_reference_model = rover_ref_model;
+            pr_factor.base_satellite_model = base_target_model;
+            pr_factor.base_reference_model = base_ref_model;
+            // The backend's post-fit DDPR residual / quality-gate code reads
+            // this field DIRECTLY (unlike the factor construction itself,
+            // which reconstructs from the 4 raw model fields) -- it must be
+            // populated for the CP-hold FSM / quality-gate tests to see
+            // meaningful residuals.
+            pr_factor.observed_dd_pseudorange_m =
+                (rover_target_model.corrected_pseudorange_m -
+                 base_target_model.corrected_pseudorange_m) -
+                (rover_ref_model.corrected_pseudorange_m -
+                 base_ref_model.corrected_pseudorange_m);
+            pr_factor.sigma_m = 0.5;
+            pr_factor.elevation_rad = 0.7;
+            problem.double_difference_pseudorange_factors.push_back(pr_factor);
+
+            FGOProcessor::DoubleDifferenceCarrierFactor cp_factor;
+            cp_factor.epoch_index = epoch;
+            cp_factor.ambiguity_index = sat - 1;
+            cp_factor.use_ambiguity_difference = false;
+            cp_factor.satellite = pr_factor.satellite;
+            cp_factor.reference_satellite = pr_factor.reference_satellite;
+            cp_factor.signal = SignalType::GPS_L1CA;
+            cp_factor.rover_satellite_position_ecef = satellites[sat];
+            cp_factor.rover_reference_position_ecef = satellites[0];
+            cp_factor.base_satellite_position_ecef = satellites[sat];
+            cp_factor.base_reference_position_ecef = satellites[0];
+            cp_factor.base_position_ecef = base_position;
+            cp_factor.rover_satellite_model = rover_target_model;
+            cp_factor.rover_reference_model = rover_ref_model;
+            cp_factor.base_satellite_model = base_target_model;
+            cp_factor.base_reference_model = base_ref_model;
+            cp_factor.observed_dd_carrier_m =
+                (rover_target_model.corrected_carrier_m - base_target_model.corrected_carrier_m) -
+                (rover_ref_model.corrected_carrier_m - base_ref_model.corrected_carrier_m);
+            cp_factor.sigma_m = 0.02;
+            cp_factor.elevation_rad = 0.7;
+            problem.double_difference_carrier_factors.push_back(cp_factor);
+        }
+    }
+
+    // Synthetic stationary IMU at 10 Hz: identity attitude, zero velocity ->
+    // accel = (0, 0, +g) in body, zero gyro.
+    const double g = problem.imu.noise.gravity_mps2;
+    const double total_s = static_cast<double>(opt.num_epochs) * opt.epoch_dt_s + 1.0;
+    for (double t = 0.0; t <= total_s; t += 0.1) {
+        ImuSample s;
+        s.time = t0 + t;
+        s.accel_raw = Vector3d(0.0, 0.0, g);
+        s.gyro_raw_radps = Vector3d::Zero();
+        problem.imu.samples_body_flu.push_back(s);
+    }
+
+    problem.diagnostics.input_epochs = opt.num_epochs;
+    problem.diagnostics.seeded_epochs = opt.num_epochs;
+    return problem;
+}
+
+FGOProcessor::FGOConfig makeCpHoldBaseConfig() {
+    FGOProcessor::FGOConfig config;
+    config.backend = FGOBackend::GTSAM;
+    config.use_pose3_state = true;
+    config.use_imu = true;
+    config.use_fixed_lag_smoother = true;
+    config.fixed_lag_smoother_lag_s = 6.0;
+    config.use_double_difference_factors = true;
+    config.use_carrier_phase_factors = false;
+    config.use_pseudorange_factors = false;
+    config.use_tdcp_factors = false;
+    config.use_single_difference_doppler_factors = false;
+    config.use_single_difference_tdcp_factors = false;
+    config.use_ambiguity_priors = true;
+    config.ambiguity_prior_sigma_m = 50.0;
+    // No LAMBDA fixing in these tests: keeps nb == 0 always, so the
+    // catastrophic fast path's "no fixed solution this epoch" gate is
+    // trivially satisfied and unrelated to fix-and-hold behaviour.
+    config.use_lambda_ambiguity_fix = false;
+    config.use_ambiguity_hold = false;
+    return config;
+}
+
+}  // namespace
+
+TEST(FGOCpHoldFsmTest, DefaultOffIsNoOp) {
+    CpHoldTestOptions opt;
+    opt.carrier_corrupt_epochs = {5, 6, 7, 8, 9, 10, 11, 12};
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
+    ASSERT_FALSE(config.use_cp_hold_recovery);
+    ASSERT_FALSE(config.use_solve_exception_recovery);
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(problem);
+
+    EXPECT_EQ(result.diagnostics.cp_hold_triggers, 0u);
+    EXPECT_EQ(result.diagnostics.cp_hold_epochs_held, 0u);
+    EXPECT_EQ(result.diagnostics.sanity_mass_resets, 0u);
+    EXPECT_EQ(result.diagnostics.sanity_fast_resets, 0u);
+    EXPECT_EQ(result.diagnostics.sanity_pose_replacements, 0u);
+    EXPECT_EQ(result.diagnostics.ambiguity_generation_bumps, 0u);
+    EXPECT_EQ(result.diagnostics.solve_exception_recoveries, 0u);
+    EXPECT_EQ(result.diagnostics.solve_exception_warm_resets, 0u);
+    EXPECT_EQ(result.solution.solutions.size(), problem.epochs.size());
+}
+
+TEST(FGOCpHoldFsmTest, HoldEngagesOnPersistAndSuppressesCarrier) {
+    CpHoldTestOptions opt;
+    // A long corrupt stretch: bad epochs 5..14 (10 consecutive), well past
+    // the persist threshold (3), so the reset should fire around epoch 7 and
+    // (with the fast path disabled below) stay held for a while afterward.
+    for (std::size_t e = 5; e <= 14; ++e) opt.carrier_corrupt_epochs.insert(e);
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
+    config.use_cp_hold_recovery = true;
+    config.cp_hold_main_residual_threshold_m = 3.0;
+    config.cp_hold_persist_epochs = 3;
+    config.cp_hold_catastrophic_threshold_m = 1.0e6;  // never take the fast path here
+    config.cp_hold_epochs = 5;
+    config.cp_hold_release_threshold_m = 2.0;
+    config.cp_hold_release_count = 3;
+    config.cp_hold_max_gdop = 0.0;  // no GDOP gate in this synthetic geometry
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(problem);
+
+    EXPECT_GT(result.diagnostics.cp_hold_triggers, 0u);
+    EXPECT_GT(result.diagnostics.sanity_mass_resets, 0u)
+        << "10 consecutive bad epochs should cross the persist threshold and reset";
+    EXPECT_EQ(result.diagnostics.sanity_fast_resets, 0u)
+        << "catastrophic threshold is disabled; only the persist path may fire";
+    EXPECT_GT(result.diagnostics.cp_hold_epochs_held, 0u);
+    EXPECT_GT(result.diagnostics.ambiguity_generation_bumps, 0u)
+        << "the reset and/or held epochs should bump the corrupted arc's generation";
+    for (const auto& sol : result.solution.solutions) {
+        EXPECT_TRUE(sol.position_ecef.allFinite());
+    }
+}
+
+TEST(FGOCpHoldFsmTest, ReleaseHysteresisExtendsHoldPastNominalLength) {
+    CpHoldTestOptions opt;
+    opt.num_epochs = 30;
+    for (std::size_t e = 5; e <= 8; ++e) opt.carrier_corrupt_epochs.insert(e);  // 4 bad epochs
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
+    config.use_cp_hold_recovery = true;
+    config.cp_hold_main_residual_threshold_m = 3.0;
+    config.cp_hold_persist_epochs = 3;
+    config.cp_hold_catastrophic_threshold_m = 1.0e6;
+    // Nominal hold is short (3 epochs), but the release count (8) is longer
+    // than that -- once carrier is suppressed the (now PR-only, clean)
+    // residual should read as "clean" every held epoch, so the ONLY way to
+    // reach release_count consecutive clean epochs is for the hold to keep
+    // extending itself past cp_hold_epochs. This isolates the hysteresis
+    // extension logic from the exact corruption magnitude.
+    config.cp_hold_epochs = 3;
+    config.cp_hold_release_threshold_m = 2.0;
+    config.cp_hold_release_count = 8;
+    config.cp_hold_max_gdop = 0.0;
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(problem);
+
+    EXPECT_GT(result.diagnostics.sanity_mass_resets, 0u);
+    EXPECT_GE(result.diagnostics.cp_hold_epochs_held, 8u)
+        << "hold must be extended by the release hysteresis past the nominal "
+           "cp_hold_epochs=3 to reach the release_count=8 clean streak";
+}
+
+TEST(FGOCpHoldFsmTest, CatastrophicEpochTakesFastPath) {
+    CpHoldTestOptions opt;
+    opt.carrier_corrupt_epochs = {10};  // single isolated catastrophic epoch
+    opt.carrier_corrupt_offset_ecef = Vector3d(150.0, 0.0, 0.0);  // unambiguously catastrophic
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
+    config.use_cp_hold_recovery = true;
+    config.cp_hold_main_residual_threshold_m = 3.0;
+    config.cp_hold_persist_epochs = 1000;  // never reachable within this run
+    config.cp_hold_catastrophic_threshold_m = 5.0;
+    config.cp_hold_fast_worst_satellite_min_m = 1.0;
+    config.cp_hold_max_gdop = 0.0;
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(problem);
+
+    EXPECT_GT(result.diagnostics.sanity_fast_resets, 0u);
+    EXPECT_EQ(result.diagnostics.sanity_mass_resets, 0u)
+        << "persist_epochs is unreachable in this run; only the fast path may fire";
+}
+
+TEST(FGOCpHoldFsmTest, PoseReplacementOnlyAffectsReportedSolution) {
+    // Pose replacement needs the IMU-predicted pose to be CLEAN at the reset
+    // epoch: it is dead-reckoned from the PREVIOUS epoch's solved state, so
+    // an isolated single-epoch corruption (like the fast-path scenario)
+    // keeps pose_seed near truth right up to the bad epoch, while the graph
+    // pose for that one epoch gets dragged to the wrong basin -- exactly the
+    // "replace the reported position with the clean IMU prediction" case. A
+    // run of several CONSECUTIVE corrupt epochs (as in the persist-path
+    // tests above) would already have dragged the previous epoch's solved
+    // state into the wrong basin by the time persist fires, so the IMU
+    // prediction would be wrong too and the gap/pred_res gates correctly
+    // decline to replace -- that is exercised implicitly by
+    // HoldEngagesOnPersistAndSuppressesCarrier's absence of replacements.
+    CpHoldTestOptions opt;
+    opt.carrier_corrupt_epochs = {10};
+    opt.carrier_corrupt_offset_ecef = Vector3d(150.0, 0.0, 0.0);
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
+    config.use_cp_hold_recovery = true;
+    config.cp_hold_main_residual_threshold_m = 3.0;
+    config.cp_hold_persist_epochs = 1000;  // isolate the fast path
+    config.cp_hold_catastrophic_threshold_m = 5.0;
+    config.cp_hold_fast_worst_satellite_min_m = 1.0;
+    config.cp_hold_max_gdop = 0.0;
+    config.cp_hold_pose_replace_threshold_m = 5.0;
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(problem);
+
+    ASSERT_GT(result.diagnostics.sanity_fast_resets, 0u);
+    EXPECT_GT(result.diagnostics.sanity_pose_replacements, 0u)
+        << "the corrupted (wrong-basin) graph pose should be far enough from "
+           "the clean, stationary IMU-predicted pose to trigger a swap of the "
+           "REPORTED position on the reset epoch";
+    // The reset epoch(s) must be reported FLOAT (never FIXED via a wrong hold).
+    for (const auto& sol : result.solution.solutions) {
+        if (sol.status == SolutionStatus::FIXED) {
+            // With use_ambiguity_hold/use_lambda_ambiguity_fix both off in
+            // this config, no epoch should ever be labelled FIXED.
+            FAIL() << "no epoch should be FIXED with fixing disabled";
+        }
+    }
+}
+
+TEST(FGOCpHoldFsmTest, MultipathDominatedEpochIsSkipped) {
+    // A SINGLE dominant bad satellite among >=6 tracked satellites should be
+    // read as multipath, not a wrong basin -- skip the reset entirely
+    // (reference _ddpr_multipath_dominated). Corrupt PSEUDORANGE (not
+    // carrier) here: with every satellite's carrier left clean, the tight
+    // (0.02 m) carrier constraints pin the graph pose at truth regardless of
+    // the loose (0.5 m) pseudorange, so the injected PR bias shows up almost
+    // entirely as PER-SATELLITE residual rather than a shared position
+    // error -- a small common baseline on every target plus one dominant
+    // outlier on satellite index 1 gives the classic "one bad satellite"
+    // shape (reference: max/median ratio far above threshold with >= 6
+    // tracked satellites, this problem's exact floor: 5 targets + 1
+    // reference).
+    CpHoldTestOptions opt;
+    opt.num_epochs = 30;
+    for (std::size_t e = 5; e <= 19; ++e) opt.pr_corrupt_epochs.insert(e);
+    opt.pr_baseline_bias_m = 0.3;         // small noise-like baseline, all targets
+    opt.pr_dominant_extra_bias_m = 10.0;  // dominant outlier, satellite index 1 only
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
+    config.use_cp_hold_recovery = true;
+    // NOTE: keep this at a realistic level (reference default 3.0), not an
+    // artificially tiny threshold: the fixed-lag window takes several
+    // epochs to fully forget the corruption after it ends (marginals decay,
+    // not an instant drop to 0), and an unrealistically small threshold
+    // turns that ordinary decay tail into a spurious multi-epoch "bad but
+    // no longer single-satellite-shaped" streak that isn't the scenario
+    // under test.
+    config.cp_hold_main_residual_threshold_m = 3.0;
+    config.cp_hold_persist_epochs = 3;
+    config.cp_hold_catastrophic_threshold_m = 1.0e6;
+    config.cp_hold_multipath_median_ratio = 1.5;  // easily cleared by one bad sat among 6
+    config.cp_hold_multipath_min_satellites = 6;
+    config.cp_hold_max_gdop = 0.0;
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(problem);
+
+    EXPECT_GT(result.diagnostics.sanity_multipath_skips, 0u);
+    EXPECT_EQ(result.diagnostics.sanity_mass_resets, 0u)
+        << "the multipath skip must prevent the persist path from ever resetting";
+}
+
+// ============================================================================
+// DDPR-LS anchor (FGOConfig::use_ddpr_anchor) -- the anchor stages of the
+// reference's postfit.py/recovery.py/optimize-stage.py that the CP-hold FSM
+// port above deliberately skipped. Reuses makeCpHoldFixedLagProblem/
+// makeCpHoldBaseConfig from the CP-hold FSM tests above.
+// ============================================================================
+
+TEST(FGODdprAnchorTest, DefaultOffIsNoOpEvenWithFsmOn) {
+    CpHoldTestOptions opt;
+    for (std::size_t e = 5; e <= 14; ++e) opt.carrier_corrupt_epochs.insert(e);
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
+    config.use_cp_hold_recovery = true;
+    config.cp_hold_persist_epochs = 3;
+    config.cp_hold_catastrophic_threshold_m = 1.0e6;
+    config.cp_hold_max_gdop = 0.0;
+    config.use_solve_exception_recovery = true;
+    ASSERT_FALSE(config.use_ddpr_anchor);
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(problem);
+
+    EXPECT_GT(result.diagnostics.sanity_mass_resets, 0u)
+        << "sanity check: the FSM itself must still fire in this scenario";
+    EXPECT_EQ(result.diagnostics.ddpr_anchor_solves, 0u);
+    EXPECT_EQ(result.diagnostics.ddpr_anchor_successes, 0u);
+    EXPECT_EQ(result.diagnostics.ddpr_anchor_gated_resets_skipped, 0u);
+    EXPECT_EQ(result.diagnostics.ddpr_anchor_gated_resets_allowed, 0u);
+    EXPECT_EQ(result.diagnostics.ddpr_anchored_warm_resets, 0u);
+    EXPECT_EQ(result.diagnostics.ddpr_anchor_bootstrap_prior_epochs, 0u);
+}
+
+TEST(FGODdprAnchorTest, OffMatchesFsmOnlyBaselineBitIdentical) {
+    // use_ddpr_anchor=false must be a true no-op: setting it (and every new
+    // anchor knob) to deliberately weird non-default values must not change
+    // a single bit of the FSM-only result, since every new code path is
+    // gated behind config.use_ddpr_anchor.
+    CpHoldTestOptions opt;
+    for (std::size_t e = 5; e <= 14; ++e) opt.carrier_corrupt_epochs.insert(e);
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig base_config = makeCpHoldBaseConfig();
+    base_config.use_cp_hold_recovery = true;
+    base_config.cp_hold_persist_epochs = 3;
+    base_config.cp_hold_catastrophic_threshold_m = 1.0e6;
+    base_config.cp_hold_max_gdop = 0.0;
+    base_config.use_solve_exception_recovery = true;
+
+    FGOProcessor::FGOConfig anchor_off_config = base_config;
+    anchor_off_config.use_ddpr_anchor = false;  // explicit, still default
+    anchor_off_config.ddpr_anchor_max_residual_m = 999.0;
+    anchor_off_config.ddpr_anchor_fde_threshold_m = 0.001;
+    anchor_off_config.ddpr_anchor_min_factors = 1;
+    anchor_off_config.ddpr_anchor_bootstrap_epochs = 1000;
+    anchor_off_config.ddpr_anchor_bootstrap_sigma_m = 1e-6;
+    anchor_off_config.cp_hold_bootstrap_after_mass_reset = false;
+
+    FGOProcessor base_processor(base_config);
+    const auto base_result = base_processor.optimizeProblem(problem);
+    FGOProcessor anchor_off_processor(anchor_off_config);
+    const auto anchor_off_result = anchor_off_processor.optimizeProblem(problem);
+
+    ASSERT_EQ(base_result.solution.solutions.size(), anchor_off_result.solution.solutions.size());
+    for (std::size_t i = 0; i < base_result.solution.solutions.size(); ++i) {
+        const auto& a = base_result.solution.solutions[i];
+        const auto& b = anchor_off_result.solution.solutions[i];
+        EXPECT_EQ(a.status, b.status) << "epoch " << i;
+        EXPECT_TRUE(a.position_ecef.isApprox(b.position_ecef, 0.0) || a.position_ecef == b.position_ecef)
+            << "epoch " << i << " position diverged with use_ddpr_anchor=false";
+    }
+    EXPECT_EQ(base_result.diagnostics.sanity_mass_resets, anchor_off_result.diagnostics.sanity_mass_resets);
+    EXPECT_EQ(base_result.diagnostics.cp_hold_triggers, anchor_off_result.diagnostics.cp_hold_triggers);
+    EXPECT_EQ(base_result.diagnostics.ambiguity_generation_bumps,
+              anchor_off_result.diagnostics.ambiguity_generation_bumps);
+    EXPECT_EQ(anchor_off_result.diagnostics.ddpr_anchor_solves, 0u);
+}
+
+TEST(FGODdprAnchorTest, BootstrapRecoversPositionAndRejectsFdeOutlier) {
+    // Epochs 5-7: carrier-corrupted -> persist-path mass reset fires (~epoch
+    // 7) and (with cp_hold_bootstrap_after_mass_reset explicitly enabled
+    // below -- shipped default is false, see fgo.hpp) arms the bootstrap
+    // countdown. Epochs 10-12 (inside the bootstrap window, well
+    // after carrier corruption has ended): a small common PR bias (0.3 m,
+    // noise-like) on every target plus a dominant 25 m outlier on satellite
+    // index 1 -- the mini DDPR-LS anchor's FDE (threshold 4.0 m default)
+    // must drop that one satellite (5 targets -> 4 remain, exactly the
+    // min-factors floor). We prove FDE worked by comparing this run against
+    // an otherwise-identical CLEAN run (no PR outlier): if FDE is doing its
+    // job, the outlier run keeps the same res-gated success count and its
+    // bootstrap-anchored position stays near truth.
+    auto run = [](bool inject_outlier) {
+        CpHoldTestOptions opt;
+        opt.num_epochs = 40;
+        for (std::size_t e = 5; e <= 7; ++e) opt.carrier_corrupt_epochs.insert(e);
+        opt.carrier_corrupt_offset_ecef = Vector3d(30.0, 0.0, 0.0);
+        if (inject_outlier) {
+            for (std::size_t e = 10; e <= 12; ++e) opt.pr_corrupt_epochs.insert(e);
+            opt.pr_baseline_bias_m = 0.3;
+            // Large enough that the 5-factor LS fit cannot absorb it below
+            // the 4.0 m FDE threshold by shifting position (an ~8 m outlier
+            // among only 5 DD factors CAN be mostly absorbed -- measured).
+            opt.pr_dominant_extra_bias_m = 25.0;
+        }
+        const auto problem = makeCpHoldFixedLagProblem(opt);
+
+        FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
+        config.use_cp_hold_recovery = true;
+        config.cp_hold_persist_epochs = 3;
+        config.cp_hold_catastrophic_threshold_m = 1.0e6;
+        config.cp_hold_max_gdop = 0.0;
+        config.cp_hold_epochs = 3;
+        config.use_ddpr_anchor = true;
+        config.ddpr_anchor_bootstrap_epochs = 15;
+        config.ddpr_anchor_bootstrap_sigma_m = 0.5;
+        config.cp_hold_bootstrap_after_mass_reset = true;
+
+        FGOProcessor processor(config);
+        return processor.optimizeProblem(problem);
+    };
+
+    const auto clean_result = run(/*inject_outlier=*/false);
+    const auto outlier_result = run(/*inject_outlier=*/true);
+
+    ASSERT_GT(outlier_result.diagnostics.sanity_mass_resets, 0u);
+    EXPECT_GT(outlier_result.diagnostics.ddpr_anchor_solves, 0u);
+    EXPECT_GT(outlier_result.diagnostics.ddpr_anchor_bootstrap_prior_epochs, 0u)
+        << "bootstrap must be armed after the mass reset and add anchor priors";
+
+    // FDE proof: ddpr_anchor_successes counts RES-GATED (res_rms <=
+    // ddpr_anchor_max_residual_m = 2.0 m) trusted solves. On the outlier
+    // epochs the anchor sees a dominant 8 m residual on satellite 1; only
+    // if FDE drops that factor can the post-FDE res_rms come back under
+    // 2.0 m and the epoch still count as a success. So a working FDE makes
+    // the outlier run's success count track the clean run's; a broken FDE
+    // loses (at least) the 3 outlier epochs.
+    EXPECT_GT(outlier_result.diagnostics.ddpr_anchor_successes, 0u);
+    EXPECT_GE(outlier_result.diagnostics.ddpr_anchor_successes + 1,
+              clean_result.diagnostics.ddpr_anchor_successes)
+        << "FDE should keep the 3 outlier epochs trusted (res-gated) -- a broken FDE "
+           "would lose them (clean=" << clean_result.diagnostics.ddpr_anchor_successes
+        << " outlier=" << outlier_result.diagnostics.ddpr_anchor_successes << ")";
+    EXPECT_GE(outlier_result.diagnostics.ddpr_anchor_bootstrap_prior_epochs,
+              clean_result.diagnostics.ddpr_anchor_bootstrap_prior_epochs - 1);
+
+    // Position recovery: with noise-free synthetic pseudorange the DDPR-LS
+    // anchor is exact, so the bootstrap-anchored post-reset float must pull
+    // back to truth within the bootstrap window (the reset happened ~epoch
+    // 7; by epoch 10 the anchor priors dominate). The outlier run must land
+    // in the same place -- FDE'd anchors are computed from the 4 clean
+    // factors only. (The main graph's own PR factors for the corrupted
+    // epochs are NOT FDE'd -- only the standalone anchor solve is -- so
+    // allow a wider tolerance there.)
+    const Vector3d true_position(1113194.0, -4841695.0, 3985350.0);
+    ASSERT_EQ(clean_result.solution.solutions.size(), outlier_result.solution.solutions.size());
+    for (std::size_t e = 10; e <= 14; ++e) {
+        const double clean_err =
+            (clean_result.solution.solutions[e].position_ecef - true_position).norm();
+        EXPECT_LT(clean_err, 0.5)
+            << "epoch " << e << ": clean bootstrap-anchored float should be pinned at truth "
+               "(err=" << clean_err << " m)";
+        const double outlier_err =
+            (outlier_result.solution.solutions[e].position_ecef - true_position).norm();
+        EXPECT_LT(outlier_err, 3.0)
+            << "epoch " << e << ": FDE'd anchor should keep the outlier run near truth "
+               "(err=" << outlier_err << " m)";
+    }
+}
+
+TEST(FGODdprAnchorTest, GatingDiagnosticsAllowsWhenAnchorAgreesWithImu) {
+    // A single ISOLATED corrupt epoch (persist_epochs=1 so it fires
+    // immediately on that one bad epoch, mirroring the existing
+    // PoseReplacementOnlyAffectsReportedSolution / CatastrophicEpochTakesFastPath
+    // fast-path fixtures' rationale): the IMU-predicted pose_seed is dead-
+    // reckoned from the PREVIOUS (clean) epoch, so it stays at truth, while
+    // the anchor -- solved from this epoch's uncorrupted DD PSEUDORANGE
+    // alone -- also converges to truth. Anchor-vs-IMU gap should be ~0, well
+    // under ddpr_anchor_imu_max_gap_m (20 m default): the gate agrees.
+    CpHoldTestOptions opt;
+    opt.carrier_corrupt_epochs = {10};
+    opt.carrier_corrupt_offset_ecef = Vector3d(25.0, 0.0, 0.0);
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
+    config.use_cp_hold_recovery = true;
+    config.cp_hold_persist_epochs = 1;  // fire on the very first (isolated) bad epoch
+    config.cp_hold_catastrophic_threshold_m = 1.0e6;  // disable the fast path
+    config.cp_hold_max_gdop = 0.0;
+    config.use_ddpr_anchor = true;
+    config.cp_hold_bootstrap_after_mass_reset = false;  // isolate the gating diagnostics
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(problem);
+
+    ASSERT_GT(result.diagnostics.sanity_mass_resets, 0u);
+    EXPECT_GT(result.diagnostics.ddpr_anchor_gated_resets_allowed, 0u);
+    EXPECT_EQ(result.diagnostics.ddpr_anchor_gated_resets_skipped, 0u);
+}
+
+TEST(FGODdprAnchorTest, GatingDiagnosticsSkipsWhenAnchorDisagreesWithImu) {
+    // The multi-epoch persist scenario (carrier-corrupted for several
+    // CONSECUTIVE epochs before the reset fires): by the time persist
+    // triggers, the IMU-predicted pose_seed has ITSELF been dragged into the
+    // wrong basin by the accumulated corrupt carrier evidence over several
+    // epochs, while the anchor (recomputed fresh from this epoch's clean DD
+    // pseudorange) still lands near truth -- their gap comfortably exceeds
+    // ddpr_anchor_imu_max_gap_m (20 m default): the gate would reject.
+    CpHoldTestOptions opt;
+    for (std::size_t e = 5; e <= 9; ++e) opt.carrier_corrupt_epochs.insert(e);
+    opt.carrier_corrupt_offset_ecef = Vector3d(20.0, 0.0, 0.0);
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
+    config.use_cp_hold_recovery = true;
+    config.cp_hold_persist_epochs = 3;
+    config.cp_hold_catastrophic_threshold_m = 1.0e6;  // disable the catastrophic override
+    config.cp_hold_max_gdop = 0.0;
+    config.use_ddpr_anchor = true;
+    config.cp_hold_bootstrap_after_mass_reset = false;  // isolate the gating diagnostics
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(problem);
+
+    ASSERT_GT(result.diagnostics.sanity_mass_resets, 0u);
+    EXPECT_GT(result.diagnostics.ddpr_anchor_gated_resets_skipped, 0u);
+}
+
+// ============================================================================
+// FDE: GICI-style Fault Detection and Exclusion (FGOConfig::use_fde) -- port
+// of the reference's validation/postfit.py apply_fde. Uses two dedicated
+// fixtures: a PR-only fixed-lag problem (no carrier/ambiguity at all, so an
+// injected pseudorange outlier's effect on the FLOAT POSITION is not masked
+// by a tight, clean carrier pin) for the pseudorange-side tests, and the
+// existing makeCpHoldFixedLagProblem (which does carry carrier/ambiguities)
+// for the carrier-side test.
+// ============================================================================
+namespace {
+
+// Stationary, IMU-coupled, DD-PSEUDORANGE-ONLY fixed-lag problem (no carrier
+// factors, no ambiguities): the float position is driven purely by DD PR
+// residuals, so an injected outlier's effect on the reported position is
+// directly attributable to FDE (not masked by a tight carrier constraint).
+// Always clean; tests mutate specific (epoch, satellite) factors afterward.
+FGOProcessor::FGOProblem makeFdeDdPrOnlyProblem(std::size_t num_epochs) {
+    FGOProcessor::FGOProblem problem;
+    const auto satellites = gtsamParitySatelliteGeometry();
+
+    const Vector3d true_position(1113194.0, -4841695.0, 3985350.0);
+    const Vector3d base_position = true_position + Vector3d(-320.0, 180.0, 45.0);
+    const double base_clock_bias_m = 11.0;
+    const double rover_clock_bias_m = 42.0;
+
+    double lat = 0.0, lon = 0.0, h = 0.0;
+    ecef2geodetic(true_position, lat, lon, h);
+    problem.imu.valid = true;
+    problem.imu.nav_origin_ecef = true_position;
+    problem.imu.nav_origin_lat_rad = lat;
+    problem.imu.nav_origin_lon_rad = lon;
+    problem.imu.init_attitude_body_to_nav = Matrix3d::Identity();
+    problem.imu.init_velocity_nav = Vector3d::Zero();
+    problem.imu.init_accel_bias = Vector3d::Zero();
+    problem.imu.init_gyro_bias = Vector3d::Zero();
+
+    const GNSSTime t0(2300, 100000.0);
+    for (std::size_t epoch = 0; epoch < num_epochs; ++epoch) {
+        FGOProcessor::EpochSeed seed;
+        seed.time = t0 + static_cast<double>(epoch);
+        seed.position_ecef = true_position;  // stationary rover
+        seed.receiver_clock_bias_m = rover_clock_bias_m;
+        problem.epochs.push_back(seed);
+
+        const double rover_ref_range = (satellites[0] - true_position).norm();
+        const double base_ref_range = (satellites[0] - base_position).norm();
+        FGOProcessor::ObservationModelDebug rover_ref_model;
+        rover_ref_model.corrected_pseudorange_m = rover_ref_range + rover_clock_bias_m;
+        FGOProcessor::ObservationModelDebug base_ref_model;
+        base_ref_model.corrected_pseudorange_m = base_ref_range + base_clock_bias_m;
+
+        for (std::size_t sat = 1; sat < satellites.size(); ++sat) {
+            const double rover_target_range = (satellites[sat] - true_position).norm();
+            const double base_target_range = (satellites[sat] - base_position).norm();
+
+            FGOProcessor::ObservationModelDebug rover_target_model;
+            rover_target_model.corrected_pseudorange_m = rover_target_range + rover_clock_bias_m;
+            FGOProcessor::ObservationModelDebug base_target_model;
+            base_target_model.corrected_pseudorange_m = base_target_range + base_clock_bias_m;
+
+            FGOProcessor::DoubleDifferencePseudorangeFactor pr_factor;
+            pr_factor.epoch_index = epoch;
+            pr_factor.satellite = SatelliteId(GNSSSystem::GPS, static_cast<uint8_t>(sat + 1));
+            pr_factor.reference_satellite = SatelliteId(GNSSSystem::GPS, 1);
+            pr_factor.signal = SignalType::GPS_L1CA;
+            pr_factor.rover_satellite_position_ecef = satellites[sat];
+            pr_factor.rover_reference_position_ecef = satellites[0];
+            pr_factor.base_satellite_position_ecef = satellites[sat];
+            pr_factor.base_reference_position_ecef = satellites[0];
+            pr_factor.base_position_ecef = base_position;
+            pr_factor.rover_satellite_model = rover_target_model;
+            pr_factor.rover_reference_model = rover_ref_model;
+            pr_factor.base_satellite_model = base_target_model;
+            pr_factor.base_reference_model = base_ref_model;
+            pr_factor.observed_dd_pseudorange_m =
+                (rover_target_model.corrected_pseudorange_m -
+                 base_target_model.corrected_pseudorange_m) -
+                (rover_ref_model.corrected_pseudorange_m - base_ref_model.corrected_pseudorange_m);
+            pr_factor.sigma_m = 0.5;
+            pr_factor.elevation_rad = 0.7;
+            problem.double_difference_pseudorange_factors.push_back(pr_factor);
+        }
+    }
+
+    const double g = problem.imu.noise.gravity_mps2;
+    const double total_s = static_cast<double>(num_epochs) + 1.0;
+    for (double t = 0.0; t <= total_s; t += 0.1) {
+        ImuSample s;
+        s.time = t0 + t;
+        s.accel_raw = Vector3d(0.0, 0.0, g);
+        s.gyro_raw_radps = Vector3d::Zero();
+        problem.imu.samples_body_flu.push_back(s);
+    }
+
+    problem.diagnostics.input_epochs = num_epochs;
+    problem.diagnostics.seeded_epochs = num_epochs;
+    return problem;
+}
+
+FGOProcessor::FGOConfig makeFdeBaseConfig() {
+    FGOProcessor::FGOConfig config;
+    config.backend = FGOBackend::GTSAM;
+    config.use_pose3_state = true;
+    config.use_imu = true;
+    config.use_fixed_lag_smoother = true;
+    config.fixed_lag_smoother_lag_s = 6.0;
+    config.use_double_difference_factors = true;
+    config.use_carrier_phase_factors = false;
+    config.use_pseudorange_factors = false;
+    config.use_tdcp_factors = false;
+    config.use_single_difference_doppler_factors = false;
+    config.use_single_difference_tdcp_factors = false;
+    config.use_lambda_ambiguity_fix = false;
+    config.use_ambiguity_hold = false;
+    // Isolate FDE's own effect from Huber down-weighting, which would
+    // otherwise already suppress a large outlier's influence before FDE
+    // ever gets a chance to remove it outright.
+    config.use_robust_loss = false;
+    return config;
+}
+
+// Injects a raw pseudorange bias into ONE (epoch, satellite)'s DD PR factor,
+// mutating the same raw model field (rover_satellite_model.corrected_
+// pseudorange_m) the GTSAM factor is actually built from AND observed_dd_
+// pseudorange_m (which the post-fit diagnostics/quality-gate code reads
+// directly), mirroring how makeCpHoldFixedLagProblem's own pr_corrupt
+// mechanism keeps both in sync.
+void injectPseudorangeOutlier(FGOProcessor::FGOProblem& problem, std::size_t epoch_index,
+                              uint8_t satellite_prn, double bias_m) {
+    for (auto& pr : problem.double_difference_pseudorange_factors) {
+        if (pr.epoch_index != epoch_index || pr.satellite.prn != satellite_prn) continue;
+        pr.rover_satellite_model.corrected_pseudorange_m += bias_m;
+        pr.observed_dd_pseudorange_m += bias_m;
+    }
+}
+
+}  // namespace
+
+TEST(FGOFdeTest, DefaultOffIsNoOp) {
+    auto problem = makeFdeDdPrOnlyProblem(20);
+    injectPseudorangeOutlier(problem, /*epoch=*/10, /*prn=*/2, /*bias_m=*/20.0);
+
+    FGOProcessor::FGOConfig config = makeFdeBaseConfig();
+    ASSERT_FALSE(config.use_fde);
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(problem);
+
+    EXPECT_EQ(result.diagnostics.fde_pseudorange_rejections, 0u);
+    EXPECT_EQ(result.diagnostics.fde_carrier_rejections, 0u);
+    EXPECT_EQ(result.diagnostics.fde_safeguard_skips, 0u);
+    EXPECT_EQ(result.diagnostics.fde_epochs, 0u);
+    EXPECT_EQ(result.solution.solutions.size(), problem.epochs.size());
+}
+
+TEST(FGOFdeTest, PseudorangeOutlierIsRemovedAndFloatRecovers) {
+    constexpr std::size_t kOutlierEpoch = 10;
+    constexpr double kOutlierBiasM = 20.0;  // well above fde_pseudorange_threshold_m default (4.0)
+    const Vector3d true_position(1113194.0, -4841695.0, 3985350.0);
+
+    auto problem = makeFdeDdPrOnlyProblem(20);
+    injectPseudorangeOutlier(problem, kOutlierEpoch, /*prn=*/2, kOutlierBiasM);
+
+    FGOProcessor::FGOConfig off_config = makeFdeBaseConfig();
+    ASSERT_FALSE(off_config.use_fde);
+    FGOProcessor off_processor(off_config);
+    const auto off_result = off_processor.optimizeProblem(problem);
+
+    FGOProcessor::FGOConfig on_config = makeFdeBaseConfig();
+    on_config.use_fde = true;
+    FGOProcessor on_processor(on_config);
+    const auto on_result = on_processor.optimizeProblem(problem);
+
+    ASSERT_GT(on_result.diagnostics.fde_pseudorange_rejections, 0u);
+    ASSERT_GT(on_result.diagnostics.fde_epochs, 0u);
+    EXPECT_EQ(on_result.diagnostics.fde_carrier_rejections, 0u);
+    EXPECT_EQ(on_result.diagnostics.fde_safeguard_skips, 0u);
+
+    ASSERT_EQ(off_result.solution.solutions.size(), on_result.solution.solutions.size());
+    const double off_err =
+        (off_result.solution.solutions[kOutlierEpoch].position_ecef - true_position).norm();
+    const double on_err =
+        (on_result.solution.solutions[kOutlierEpoch].position_ecef - true_position).norm();
+    EXPECT_GT(off_err, 1.0) << "without FDE the outlier should visibly bias the float (err="
+                            << off_err << " m)";
+    EXPECT_LT(on_err, 0.5) << "with FDE the outlier factor should be excluded and the float "
+                              "recover near truth (err=" << on_err << " m)";
+}
+
+TEST(FGOFdeTest, CarrierOutlierReleasesHoldAndBumpsGeneration) {
+    // Fix-and-hold needs several clean epochs to validate and pin an arc
+    // before the outlier can test its release.
+    CpHoldTestOptions opt;
+    opt.num_epochs = 30;
+    auto problem = makeCpHoldFixedLagProblem(opt);
+
+    // Single-satellite, single-epoch carrier-only outlier (ambiguity_index 0,
+    // i.e. satellite PRN 2): mutate the same raw model field the GTSAM
+    // carrier factor is built from, well past where fix-and-hold should have
+    // pinned this arc (noise-free synthetic geometry converges in a handful
+    // of epochs).
+    constexpr std::size_t kOutlierEpoch = 15;
+    constexpr double kOutlierBiasM = 5.0;  // >> fde_carrier_threshold_m (0.5)
+    for (auto& cp : problem.double_difference_carrier_factors) {
+        if (cp.epoch_index != kOutlierEpoch || cp.ambiguity_index != 0) continue;
+        cp.rover_satellite_model.corrected_carrier_m += kOutlierBiasM;
+        cp.observed_dd_carrier_m += kOutlierBiasM;
+    }
+
+    FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
+    config.use_lambda_ambiguity_fix = true;
+    config.use_ambiguity_hold = true;
+    config.lambda_ratio_threshold = 1.5;      // easily cleared by this noise-free synthetic data
+    config.ambiguity_hold_ratio_threshold = 1.5;
+    config.ambiguity_hold_min_fixed = 4;
+    config.min_fixed_ambiguities = 5;  // all 5 ambiguities
+
+    FGOProcessor::FGOConfig off_config = config;
+    ASSERT_FALSE(off_config.use_fde);
+    FGOProcessor off_processor(off_config);
+    const auto off_result = off_processor.optimizeProblem(problem);
+
+    FGOProcessor::FGOConfig on_config = config;
+    on_config.use_fde = true;
+    FGOProcessor on_processor(on_config);
+    const auto on_result = on_processor.optimizeProblem(problem);
+
+    // With no other reset mechanism enabled (cp-hold FSM / solve-exception
+    // recovery both off), the generation must never bump without FDE.
+    EXPECT_EQ(off_result.diagnostics.ambiguity_generation_bumps, 0u);
+
+    ASSERT_GT(on_result.diagnostics.fde_carrier_rejections, 0u);
+    EXPECT_EQ(on_result.diagnostics.fde_pseudorange_rejections, 0u);
+    EXPECT_GT(on_result.diagnostics.ambiguity_generation_bumps, 0u)
+        << "the rejected carrier factor's arc should get a fresh generation, "
+           "i.e. be treated as a cycle slip";
+    for (const auto& sol : on_result.solution.solutions) {
+        EXPECT_TRUE(sol.position_ecef.allFinite());
+    }
+}
+
+TEST(FGOFdeTest, SafeguardSkipsWhenMajorityOfEpochRejected) {
+    // 5 DD PR factors this epoch (ref PRN1 + 5 targets PRN2..6); corrupt 4 of
+    // the 5 (PRNs 2-5) by a huge bias so the reject fraction (4/5 = 0.8)
+    // exceeds the default fde_max_rejected_fraction (0.5) safeguard, leaving
+    // only PRN6 clean. The corruption is placed on the LAST epoch of a short
+    // run: since the safeguard leaves epoch kBadEpoch's factors un-cleaned
+    // (that is the point of this test), the resulting wrong position estimate
+    // would otherwise cascade into later epochs via the fixed-lag window and
+    // create genuine (if unwanted) residual spikes there too -- placing it
+    // last means there is no "later epoch" for that cascade to reach.
+    constexpr std::size_t kBadEpoch = 9;
+    auto problem = makeFdeDdPrOnlyProblem(kBadEpoch + 1);
+    for (uint8_t prn = 2; prn <= 5; ++prn) {
+        injectPseudorangeOutlier(problem, kBadEpoch, prn, 50.0);
+    }
+
+    // use_cp_hold_recovery OFF: the safeguard has no hold to engage, it must
+    // simply skip FDE for the epoch with no other side effect.
+    {
+        FGOProcessor::FGOConfig config = makeFdeBaseConfig();
+        config.use_fde = true;
+        ASSERT_FALSE(config.use_cp_hold_recovery);
+        FGOProcessor processor(config);
+        const auto result = processor.optimizeProblem(problem);
+
+        EXPECT_GT(result.diagnostics.fde_safeguard_skips, 0u);
+        EXPECT_EQ(result.diagnostics.fde_pseudorange_rejections, 0u)
+            << "the safeguard must abandon FDE entirely for the epoch -- no partial removal";
+        EXPECT_EQ(result.diagnostics.cp_hold_triggers, 0u)
+            << "with the FSM off there is no hold to engage";
+    }
+    // use_cp_hold_recovery ON: the safeguard should engage CP-hold (reference
+    // trigger_cp_hold(..., skip_if_active=True)).
+    {
+        FGOProcessor::FGOConfig config = makeFdeBaseConfig();
+        config.use_fde = true;
+        config.use_cp_hold_recovery = true;
+        config.cp_hold_epochs = 5;
+        FGOProcessor processor(config);
+        const auto result = processor.optimizeProblem(problem);
+
+        EXPECT_GT(result.diagnostics.fde_safeguard_skips, 0u);
+        EXPECT_EQ(result.diagnostics.fde_pseudorange_rejections, 0u);
+        EXPECT_GT(result.diagnostics.cp_hold_triggers, 0u)
+            << "the safeguard should engage CP-hold when the FSM is enabled";
+    }
+}
+
+TEST(FGOFdeTest, SanityTriggerSeesPreFdeResidualNotPostFde) {
+    // A single injected outlier that FDE fully cleans up this SAME epoch
+    // must still have been visible to the CP-hold/sanity FSM's residual
+    // input (reference: stage.py's main_ddpr_residuals -- which feeds the
+    // FSM trigger -- runs BEFORE apply_fde). If the FSM instead read the
+    // POST-FDE (cleaned) residual, it would never trigger here.
+    constexpr std::size_t kOutlierEpoch = 10;
+    constexpr double kOutlierBiasM = 20.0;
+    auto problem = makeFdeDdPrOnlyProblem(20);
+    injectPseudorangeOutlier(problem, kOutlierEpoch, /*prn=*/2, kOutlierBiasM);
+
+    FGOProcessor::FGOConfig config = makeFdeBaseConfig();
+    config.use_fde = true;
+    config.use_cp_hold_recovery = true;
+    config.cp_hold_persist_epochs = 1;  // fire on the very first bad epoch
+    config.cp_hold_catastrophic_threshold_m = 1.0e6;  // isolate the persist path
+    config.cp_hold_main_residual_threshold_m = 3.0;
+    config.cp_hold_max_gdop = 0.0;
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(problem);
+
+    ASSERT_GT(result.diagnostics.fde_pseudorange_rejections, 0u)
+        << "sanity check: FDE must actually clean this epoch";
+    EXPECT_GT(result.diagnostics.cp_hold_triggers, 0u)
+        << "the sanity FSM must still react to the PRE-FDE (dirty) residual even though "
+           "FDE cleaned the SAME epoch";
 }
 
 #endif  // GNSSPP_HAS_GTSAM

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -1211,4 +1211,209 @@ TEST(FGOFdeTest, SanityTriggerSeesPreFdeResidualNotPostFde) {
            "FDE cleaned the SAME epoch";
 }
 
+// ============================================================================
+// Sat-badness EWMA down-weighting (FGOConfig::use_sat_badness_downweight) --
+// port of the inuex35 reference's preprocess/sat_quality.py SatQualityState.
+// Reuses makeCpHoldFixedLagProblem/makeCpHoldBaseConfig (defined above): its
+// pr_corrupt_epochs/pr_dominant_extra_bias_m knobs inject a per-satellite DD
+// PSEUDORANGE bias (satellite index 1, i.e. PRN 2) while leaving carrier
+// clean, which is exactly the "chronically bad satellite" pattern the
+// backend's post-fit per-sat DDPR residual (per_sat_res) is meant to detect
+// -- without corrupting the carrier data that the CP-sigma-inflation test
+// needs to stay trustworthy.
+// ============================================================================
+namespace {
+
+// Removes every DD PR/CP factor for one (epoch, satellite PRN) pair,
+// simulating that satellite being untracked/absent for that single epoch --
+// used to exercise the reference's "sats not seen this epoch hard-reset
+// their EWMA/streak to 0" semantics.
+void dropSatelliteAtEpoch(FGOProcessor::FGOProblem& problem, std::size_t epoch_index,
+                          uint8_t satellite_prn) {
+    auto& prs = problem.double_difference_pseudorange_factors;
+    prs.erase(std::remove_if(prs.begin(), prs.end(),
+                             [&](const auto& f) {
+                                 return f.epoch_index == epoch_index &&
+                                        f.satellite.prn == satellite_prn;
+                             }),
+             prs.end());
+    auto& cps = problem.double_difference_carrier_factors;
+    cps.erase(std::remove_if(cps.begin(), cps.end(),
+                             [&](const auto& f) {
+                                 return f.epoch_index == epoch_index &&
+                                        f.satellite.prn == satellite_prn;
+                             }),
+             cps.end());
+}
+
+}  // namespace
+
+TEST(FGOSatBadnessTest, DefaultOffIsNoOp) {
+    CpHoldTestOptions opt;
+    opt.num_epochs = 25;
+    opt.pr_corrupt_epochs = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
+    opt.pr_dominant_extra_bias_m = 3.0;
+    auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
+    ASSERT_FALSE(config.use_sat_badness_downweight);
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(problem);
+
+    EXPECT_EQ(result.diagnostics.sat_badness_downweighted_factors, 0u);
+    EXPECT_EQ(result.diagnostics.sat_badness_max_score_seen, 0.0);
+    EXPECT_EQ(result.solution.solutions.size(), problem.epochs.size());
+    for (const auto& sol : result.solution.solutions) {
+        EXPECT_TRUE(sol.position_ecef.allFinite());
+    }
+}
+
+TEST(FGOSatBadnessTest, ChronicallyBadSatelliteScoresHigherThanCleanRun) {
+    CpHoldTestOptions bad_opt;
+    bad_opt.num_epochs = 25;
+    bad_opt.pr_corrupt_epochs = {10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
+    bad_opt.pr_dominant_extra_bias_m = 3.0;
+    auto bad_problem = makeCpHoldFixedLagProblem(bad_opt);
+
+    CpHoldTestOptions clean_opt;
+    clean_opt.num_epochs = 25;
+    auto clean_problem = makeCpHoldFixedLagProblem(clean_opt);
+
+    FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
+    config.use_sat_badness_downweight = true;
+
+    FGOProcessor bad_processor(config);
+    const auto bad_result = bad_processor.optimizeProblem(bad_problem);
+    FGOProcessor clean_processor(config);
+    const auto clean_result = clean_processor.optimizeProblem(clean_problem);
+
+    EXPECT_GT(bad_result.diagnostics.sat_badness_downweighted_factors, 0u)
+        << "the chronically-bad satellite's DD pairs must get inflated";
+    EXPECT_GT(bad_result.diagnostics.sat_badness_max_score_seen,
+              clean_result.diagnostics.sat_badness_max_score_seen)
+        << "a chronically bad satellite's score must clearly exceed a clean run's "
+           "(bad=" << bad_result.diagnostics.sat_badness_max_score_seen
+        << ", clean=" << clean_result.diagnostics.sat_badness_max_score_seen << ")";
+    for (const auto& sol : bad_result.solution.solutions) {
+        EXPECT_TRUE(sol.position_ecef.allFinite());
+    }
+}
+
+TEST(FGOSatBadnessTest, SigmaInflationAffectsCarrierNotPseudorangeAtDefaults) {
+    // Carrier stays clean/true in this fixture; only the DD pseudorange for
+    // satellite PRN 2 carries a bias. Truth is recoverable primarily through
+    // the (unbiased) tight carrier constraint, so this isolates each sigma
+    // knob's effect on the float position at the corrupted epoch.
+    constexpr std::size_t kCorruptEpoch = 19;
+    const Vector3d true_position(1113194.0, -4841695.0, 3985350.0);
+
+    CpHoldTestOptions opt;
+    opt.num_epochs = 25;
+    for (std::size_t e = 10; e <= kCorruptEpoch; ++e) opt.pr_corrupt_epochs.insert(e);
+    opt.pr_dominant_extra_bias_m = 3.0;
+    auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig base_config = makeCpHoldBaseConfig();
+
+    FGOProcessor::FGOConfig off_config = base_config;
+    ASSERT_FALSE(off_config.use_sat_badness_downweight);
+    FGOProcessor off_processor(off_config);
+    const auto off_result = off_processor.optimizeProblem(problem);
+    const double off_err =
+        (off_result.solution.solutions[kCorruptEpoch].position_ecef - true_position).norm();
+
+    // Defaults: carrier_sigma_scale=1.5, pseudorange_sigma_scale=0.0. Carrier
+    // is already far tighter than pseudorange in this fixture (0.02 m vs
+    // 0.5 m), so inflating ONLY its sigma by a realistic factor barely moves
+    // the relative PR/CP weighting -- the float position should stay close
+    // to the badness-off baseline.
+    FGOProcessor::FGOConfig cp_config = base_config;
+    cp_config.use_sat_badness_downweight = true;
+    ASSERT_GT(cp_config.sat_badness_carrier_sigma_scale, 0.0);
+    ASSERT_EQ(cp_config.sat_badness_pseudorange_sigma_scale, 0.0);
+    FGOProcessor cp_processor(cp_config);
+    const auto cp_result = cp_processor.optimizeProblem(problem);
+    const double cp_err =
+        (cp_result.solution.solutions[kCorruptEpoch].position_ecef - true_position).norm();
+    EXPECT_NEAR(cp_err, off_err, std::max(0.05, 0.2 * off_err))
+        << "at defaults (pr_scale=0) the float position should be little-changed by CP-only "
+           "sigma inflation (off_err=" << off_err << " m, cp_err=" << cp_err << " m)";
+
+    // Enabling the pseudorange scale on the SAME bad pair should visibly pull
+    // the float back toward truth (down-weighting the biased PR observation
+    // in favour of the clean carrier).
+    FGOProcessor::FGOConfig pr_config = base_config;
+    pr_config.use_sat_badness_downweight = true;
+    pr_config.sat_badness_carrier_sigma_scale = 0.0;
+    pr_config.sat_badness_pseudorange_sigma_scale = 3.0;
+    FGOProcessor pr_processor(pr_config);
+    const auto pr_result = pr_processor.optimizeProblem(problem);
+    const double pr_err =
+        (pr_result.solution.solutions[kCorruptEpoch].position_ecef - true_position).norm();
+    EXPECT_GT(pr_result.diagnostics.sat_badness_downweighted_factors, 0u);
+    EXPECT_LT(pr_err, off_err)
+        << "down-weighting the biased pseudorange should reduce float error vs the "
+           "badness-off baseline (off_err=" << off_err << " m, pr_err=" << pr_err << " m)";
+}
+
+TEST(FGOSatBadnessTest, NotSeenThisEpochHardResetsBeatsContinuousAccumulation) {
+    // Same 10-epoch chronic corruption (epochs 10..19) on satellite PRN 2 in
+    // both variants; the "dropout" variant additionally removes PRN 2's DD
+    // factors ENTIRELY (as if untracked) for one epoch in the middle of that
+    // run. The reference hard-resets (not decays) a not-seen satellite's
+    // EWMA/streak to 0, so the dropout variant's cumulative score should
+    // fall clearly short of the uninterrupted run's peak.
+    CpHoldTestOptions opt;
+    opt.num_epochs = 25;
+    for (std::size_t e = 10; e <= 19; ++e) opt.pr_corrupt_epochs.insert(e);
+    opt.pr_dominant_extra_bias_m = 3.0;
+
+    auto continuous_problem = makeCpHoldFixedLagProblem(opt);
+    auto dropout_problem = makeCpHoldFixedLagProblem(opt);
+    dropSatelliteAtEpoch(dropout_problem, /*epoch_index=*/15, /*satellite_prn=*/2);
+
+    FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
+    config.use_sat_badness_downweight = true;
+
+    FGOProcessor continuous_processor(config);
+    const auto continuous_result = continuous_processor.optimizeProblem(continuous_problem);
+    FGOProcessor dropout_processor(config);
+    const auto dropout_result = dropout_processor.optimizeProblem(dropout_problem);
+
+    EXPECT_GT(continuous_result.diagnostics.sat_badness_max_score_seen,
+              dropout_result.diagnostics.sat_badness_max_score_seen)
+        << "an uninterrupted 10-epoch bad streak must accumulate a higher score than the same "
+           "streak with a one-epoch absence resetting EWMA/streak mid-way (continuous="
+        << continuous_result.diagnostics.sat_badness_max_score_seen
+        << ", dropout=" << dropout_result.diagnostics.sat_badness_max_score_seen << ")";
+}
+
+TEST(FGOSatBadnessTest, RecentPairAlphaGatesPairMemoryContribution) {
+    // alpha_recent_pair defaults to 0.0 (reference profile: the pair term is
+    // provably inert). Raising it on the SAME chronically-bad-pair fixture
+    // must be able to increase the observed score/down-weighting -- i.e. the
+    // term is actually wired, just gated off by default.
+    CpHoldTestOptions opt;
+    opt.num_epochs = 25;
+    for (std::size_t e = 10; e <= 19; ++e) opt.pr_corrupt_epochs.insert(e);
+    opt.pr_dominant_extra_bias_m = 3.0;
+    auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig off_config = makeCpHoldBaseConfig();
+    off_config.use_sat_badness_downweight = true;
+    ASSERT_EQ(off_config.sat_badness_alpha_recent_pair, 0.0);
+    FGOProcessor off_processor(off_config);
+    const auto off_result = off_processor.optimizeProblem(problem);
+
+    FGOProcessor::FGOConfig pair_config = off_config;
+    pair_config.sat_badness_alpha_recent_pair = 5.0;
+    FGOProcessor pair_processor(pair_config);
+    const auto pair_result = pair_processor.optimizeProblem(problem);
+
+    EXPECT_GT(pair_result.diagnostics.sat_badness_max_score_seen,
+              off_result.diagnostics.sat_badness_max_score_seen)
+        << "raising alpha_recent_pair from its inert default must raise the observed score";
+}
+
 #endif  // GNSSPP_HAS_GTSAM

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -1,0 +1,247 @@
+#ifdef GNSSPP_HAS_GTSAM
+
+#include <gtest/gtest.h>
+#include <libgnss++/algorithms/fgo.hpp>
+#include <libgnss++/core/constants.hpp>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+// Parity harness for Phase 1 of the GTSAM backend (docs/gtsam_backend_design.md):
+// builds one synthetic double-difference RTK FGOProblem with fully populated
+// raw (undifferenced) observation debug fields -- required because the GTSAM
+// DD factors are built from the 4 raw rover/base x ref/target observations,
+// not from the precomputed observed_dd_*_m scalar alone -- and runs it
+// through both FGOProcessor backends, asserting the float ECEF solutions and
+// DD residual RMS agree to well within the sub-cm target.
+
+using namespace libgnss;
+
+namespace {
+
+std::vector<Vector3d> gtsamParitySatelliteGeometry() {
+    return {
+        Vector3d(15600000.0, 7540000.0, 20140000.0),
+        Vector3d(-18760000.0, 2750000.0, 18610000.0),
+        Vector3d(17610000.0, -14630000.0, 13480000.0),
+        Vector3d(19170000.0, 610000.0, -18390000.0),
+        Vector3d(-13480000.0, -15600000.0, 17760000.0),
+        Vector3d(21700000.0, 13000000.0, 9000000.0),
+    };
+}
+
+// Builds a two-epoch, single-reference-satellite DD RTK problem where every
+// raw ObservationModelDebug field is populated consistently with how
+// FGOProcessor::buildDoubleDifferenceProblem fills them in production, so
+// the GTSAM backend's 4-raw-observation reconstruction of the DD factors has
+// something real to reconstruct from (see the observed-DD assertion in
+// fgo_gtsam_backend.cpp).
+FGOProcessor::FGOProblem makeGtsamParityDoubleDifferenceProblem() {
+    FGOProcessor::FGOProblem problem;
+    const auto satellites = gtsamParitySatelliteGeometry();
+    const double wavelength = constants::GPS_L1_WAVELENGTH;
+
+    const std::array<Vector3d, 2> true_positions = {
+        Vector3d(1113194.0, -4841695.0, 3985350.0),
+        Vector3d(1113196.8, -4841692.5, 3985351.1),
+    };
+    const std::array<double, 2> rover_clock_bias_m = {42.0, 43.7};
+    const double base_clock_bias_m = 11.0;
+    const Vector3d base_position = true_positions[0] + Vector3d(-320.0, 180.0, 45.0);
+
+    // One DD ambiguity state per non-reference satellite (index sat - 1),
+    // held constant across both epochs (no cycle slip in this synthetic set).
+    for (std::size_t sat = 1; sat < satellites.size(); ++sat) {
+        FGOProcessor::AmbiguityState ambiguity;
+        ambiguity.satellite = SatelliteId(GNSSSystem::GPS, static_cast<uint8_t>(sat + 1));
+        ambiguity.reference_satellite = SatelliteId(GNSSSystem::GPS, 1);
+        ambiguity.signal = SignalType::GPS_L1CA;
+        ambiguity.wavelength_m = wavelength;
+        ambiguity.is_double_difference = true;
+        const int true_dd_cycles = 100 + static_cast<int>(sat);
+        // Seed off the true value so the float solve has real work to do.
+        ambiguity.initial_ambiguity_m = (static_cast<double>(true_dd_cycles) - 0.6) * wavelength;
+        problem.ambiguity_states.push_back(ambiguity);
+    }
+
+    for (std::size_t epoch = 0; epoch < true_positions.size(); ++epoch) {
+        FGOProcessor::EpochSeed seed;
+        seed.time = GNSSTime(2300, 100000.0 + static_cast<double>(epoch));
+        seed.position_ecef = true_positions[epoch] + Vector3d(12.0, -7.0, 5.0);
+        seed.receiver_clock_bias_m = rover_clock_bias_m[epoch];
+        problem.epochs.push_back(seed);
+
+        const Vector3d& rover_pos = true_positions[epoch];
+        const double rover_ref_range = (satellites[0] - rover_pos).norm();
+        const double base_ref_range = (satellites[0] - base_position).norm();
+
+        FGOProcessor::ObservationModelDebug rover_ref_model;
+        rover_ref_model.corrected_pseudorange_m = rover_ref_range + rover_clock_bias_m[epoch];
+        rover_ref_model.corrected_carrier_m = rover_ref_range + rover_clock_bias_m[epoch];
+
+        FGOProcessor::ObservationModelDebug base_ref_model;
+        base_ref_model.corrected_pseudorange_m = base_ref_range + base_clock_bias_m;
+        base_ref_model.corrected_carrier_m = base_ref_range + base_clock_bias_m;
+
+        for (std::size_t sat = 1; sat < satellites.size(); ++sat) {
+            const double rover_target_range = (satellites[sat] - rover_pos).norm();
+            const double base_target_range = (satellites[sat] - base_position).norm();
+            const int true_dd_cycles = 100 + static_cast<int>(sat);
+
+            FGOProcessor::ObservationModelDebug rover_target_model;
+            rover_target_model.corrected_pseudorange_m =
+                rover_target_range + rover_clock_bias_m[epoch];
+            rover_target_model.corrected_carrier_m =
+                rover_target_range + rover_clock_bias_m[epoch] +
+                static_cast<double>(true_dd_cycles) * wavelength;
+
+            FGOProcessor::ObservationModelDebug base_target_model;
+            base_target_model.corrected_pseudorange_m = base_target_range + base_clock_bias_m;
+            base_target_model.corrected_carrier_m = base_target_range + base_clock_bias_m;
+
+            FGOProcessor::DoubleDifferencePseudorangeFactor pr_factor;
+            pr_factor.epoch_index = epoch;
+            pr_factor.satellite = SatelliteId(GNSSSystem::GPS, static_cast<uint8_t>(sat + 1));
+            pr_factor.reference_satellite = SatelliteId(GNSSSystem::GPS, 1);
+            pr_factor.signal = SignalType::GPS_L1CA;
+            pr_factor.rover_satellite_position_ecef = satellites[sat];
+            pr_factor.rover_reference_position_ecef = satellites[0];
+            pr_factor.base_satellite_position_ecef = satellites[sat];
+            pr_factor.base_reference_position_ecef = satellites[0];
+            pr_factor.base_position_ecef = base_position;
+            pr_factor.rover_satellite_model = rover_target_model;
+            pr_factor.rover_reference_model = rover_ref_model;
+            pr_factor.base_satellite_model = base_target_model;
+            pr_factor.base_reference_model = base_ref_model;
+            pr_factor.observed_dd_pseudorange_m =
+                (rover_target_model.corrected_pseudorange_m -
+                 base_target_model.corrected_pseudorange_m) -
+                (rover_ref_model.corrected_pseudorange_m -
+                 base_ref_model.corrected_pseudorange_m);
+            pr_factor.sigma_m = 0.5;
+            pr_factor.elevation_rad = 0.7;
+            problem.double_difference_pseudorange_factors.push_back(pr_factor);
+
+            FGOProcessor::DoubleDifferenceCarrierFactor cp_factor;
+            cp_factor.epoch_index = epoch;
+            cp_factor.ambiguity_index = sat - 1;
+            cp_factor.use_ambiguity_difference = false;
+            cp_factor.satellite = pr_factor.satellite;
+            cp_factor.reference_satellite = pr_factor.reference_satellite;
+            cp_factor.signal = SignalType::GPS_L1CA;
+            cp_factor.rover_satellite_position_ecef = satellites[sat];
+            cp_factor.rover_reference_position_ecef = satellites[0];
+            cp_factor.base_satellite_position_ecef = satellites[sat];
+            cp_factor.base_reference_position_ecef = satellites[0];
+            cp_factor.base_position_ecef = base_position;
+            cp_factor.rover_satellite_model = rover_target_model;
+            cp_factor.rover_reference_model = rover_ref_model;
+            cp_factor.base_satellite_model = base_target_model;
+            cp_factor.base_reference_model = base_ref_model;
+            cp_factor.observed_dd_carrier_m =
+                (rover_target_model.corrected_carrier_m -
+                 base_target_model.corrected_carrier_m) -
+                (rover_ref_model.corrected_carrier_m - base_ref_model.corrected_carrier_m);
+            cp_factor.sigma_m = 0.01;
+            cp_factor.elevation_rad = 0.7;
+            problem.double_difference_carrier_factors.push_back(cp_factor);
+        }
+    }
+
+    problem.diagnostics.input_epochs = true_positions.size();
+    problem.diagnostics.seeded_epochs = true_positions.size();
+    problem.diagnostics.double_difference_matched_base_epochs = true_positions.size();
+    problem.diagnostics.double_difference_candidate_pairs =
+        problem.double_difference_carrier_factors.size();
+    return problem;
+}
+
+FGOProcessor::FGOConfig makeParityBaseConfig() {
+    FGOProcessor::FGOConfig config;
+    config.use_double_difference_factors = true;
+    config.use_carrier_phase_factors = false;
+    config.use_pseudorange_factors = false;  // no undifferenced factors in this problem
+    config.use_tdcp_factors = false;
+    config.use_single_difference_doppler_factors = false;
+    config.use_single_difference_tdcp_factors = false;
+    config.use_ambiguity_priors = true;
+    config.ambiguity_prior_sigma_m = 50.0;
+    config.fix_ambiguities = false;
+    config.use_lambda_ambiguity_fix = false;
+    config.max_iterations = 15;
+    return config;
+}
+
+}  // namespace
+
+TEST(FGOGtsamBackendTest, FloatSolutionMatchesEigenBackendOnDoubleDifferenceProblem) {
+    const FGOProcessor::FGOProblem problem = makeGtsamParityDoubleDifferenceProblem();
+
+    FGOProcessor::FGOConfig eigen_config = makeParityBaseConfig();
+    eigen_config.backend = FGOBackend::Eigen;
+
+    FGOProcessor::FGOConfig gtsam_config = makeParityBaseConfig();
+    gtsam_config.backend = FGOBackend::GTSAM;
+
+    FGOProcessor eigen_processor(eigen_config);
+    FGOProcessor gtsam_processor(gtsam_config);
+
+    const FGOProcessor::FGOResult eigen_result = eigen_processor.optimizeProblem(problem);
+    const FGOProcessor::FGOResult gtsam_result = gtsam_processor.optimizeProblem(problem);
+
+    ASSERT_EQ(eigen_result.solution.size(), problem.epochs.size());
+    ASSERT_EQ(gtsam_result.solution.size(), problem.epochs.size());
+
+    double max_delta_m = 0.0;
+    double sum_sq_delta = 0.0;
+    for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
+        const Vector3d eigen_pos = eigen_result.solution.solutions[i].position_ecef;
+        const Vector3d gtsam_pos = gtsam_result.solution.solutions[i].position_ecef;
+        const double delta = (eigen_pos - gtsam_pos).norm();
+        max_delta_m = std::max(max_delta_m, delta);
+        sum_sq_delta += delta * delta;
+    }
+    const double rms_delta_m =
+        std::sqrt(sum_sq_delta / static_cast<double>(problem.epochs.size()));
+
+    // Emit the parity numbers so the harness output carries the deliverable
+    // metric (max/RMS per-epoch ECEF delta between the two float solutions).
+    std::fprintf(stderr,
+                 "[parity] Eigen-vs-GTSAM float ECEF delta: max=%.6g m rms=%.6g m "
+                 "(epochs=%zu)\n",
+                 max_delta_m, rms_delta_m, problem.epochs.size());
+
+    EXPECT_LT(max_delta_m, 0.01) << "max ECEF delta between backends should be sub-cm (m)";
+    EXPECT_LT(rms_delta_m, 0.01) << "RMS ECEF delta between backends should be sub-cm (m)";
+
+    EXPECT_NEAR(eigen_result.diagnostics.double_difference_pseudorange_residual_rms_m,
+                gtsam_result.diagnostics.double_difference_pseudorange_residual_rms_m, 1e-3)
+        << "eigen=" << eigen_result.diagnostics.double_difference_pseudorange_residual_rms_m
+        << " gtsam=" << gtsam_result.diagnostics.double_difference_pseudorange_residual_rms_m;
+    EXPECT_NEAR(eigen_result.diagnostics.double_difference_carrier_residual_rms_m,
+                gtsam_result.diagnostics.double_difference_carrier_residual_rms_m, 1e-3)
+        << "eigen=" << eigen_result.diagnostics.double_difference_carrier_residual_rms_m
+        << " gtsam=" << gtsam_result.diagnostics.double_difference_carrier_residual_rms_m;
+}
+
+TEST(FGOGtsamBackendTest, GtsamBackendRecoversFloatAmbiguitiesNearIntegers) {
+    const FGOProcessor::FGOProblem problem = makeGtsamParityDoubleDifferenceProblem();
+    FGOProcessor::FGOConfig config = makeParityBaseConfig();
+    config.backend = FGOBackend::GTSAM;
+
+    FGOProcessor processor(config);
+    const FGOProcessor::FGOResult result = processor.optimizeProblem(problem);
+
+    ASSERT_EQ(result.ambiguity_estimates.size(), problem.ambiguity_states.size());
+    for (std::size_t i = 0; i < result.ambiguity_estimates.size(); ++i) {
+        const double cycles = result.ambiguity_estimates[i].ambiguity_cycles;
+        const double nearest_integer = std::round(cycles);
+        EXPECT_LT(std::abs(cycles - nearest_integer), 0.05)
+            << "ambiguity index " << i << " float cycles=" << cycles;
+    }
+}
+
+#endif  // GNSSPP_HAS_GTSAM

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -1619,4 +1619,148 @@ TEST(FGOSatBadnessClampedTest, FaithfulEscapeHatchReproducesUnboundedScoring) {
         << ", default(bounded)=" << default_result.diagnostics.sat_badness_max_score_seen << ")";
 }
 
+// --- IMU preintegration-covariance value semantics + per-epoch inflation
+// (port of the inuex35 reference's buildfactor/imu_preintegration.py's
+// _apply_mres_integ_cov_override + config.py's imu_integ_cov /
+// imu_integ_cov_max -- see FGOConfig::imu_integration_covariance's comment
+// in fgo.hpp for the full mapping). ---
+
+TEST(FGOImuIntegrationCovarianceTest, DefaultsMatchPortedReferenceMapping) {
+    const FGOProcessor::FGOConfig config;
+    // 1e-6 == sq(1e-3), the harness's hardcoded (pre-port) effective
+    // covariance -- this default alone must not change any existing run.
+    EXPECT_DOUBLE_EQ(config.imu_integration_covariance, 1e-6);
+    EXPECT_FALSE(config.use_imu_integration_covariance_inflation);
+    EXPECT_DOUBLE_EQ(config.imu_integration_covariance_max, 0.5);   // reference imu_integ_cov_max
+    EXPECT_EQ(config.imu_integration_covariance_stale_epochs, 2);
+}
+
+namespace {
+// Pure reimplementation of the exact formula documented on
+// FGOConfig::use_imu_integration_covariance_inflation (and applied in
+// fgo_gtsam_backend.cpp's optimizeProblemFixedLag immediately before each
+// epoch's PIM is constructed), so this test can check hand-computed values
+// without depending on gtsam internals or a full nonlinear solve.
+double expectedIntegEff(double default_cov, double cap, int stale_epochs,
+                        long long epoch, long long last_mres_epoch,
+                        double last_mres, double dt) {
+    const bool is_stale =
+        stale_epochs > 0 && (epoch - last_mres_epoch) > stale_epochs;
+    if (is_stale) return default_cov;
+    double integ_eff = std::max(default_cov, (last_mres * last_mres) / std::max(dt, 1e-3));
+    if (cap > 0.0) integ_eff = std::min(integ_eff, cap);
+    return integ_eff;
+}
+}  // namespace
+
+TEST(FGOImuIntegrationCovarianceTest, InflationFormulaMaxCapAndStalenessHandComputed) {
+    const double default_cov = 1e-3;  // reference imu_integ_cov value
+    const double cap = 0.5;           // reference imu_integ_cov_max default
+
+    // (a) Clean residual (mres=0): floor wins regardless of dt.
+    EXPECT_DOUBLE_EQ(expectedIntegEff(default_cov, cap, 2, 10, 9, 0.0, 1.0), default_cov);
+
+    // (b) Small residual that doesn't clear the floor: mres=0.02 m, dt=1.0 s
+    // -> mres^2/dt = 4e-4 < default_cov (1e-3), so the floor still wins.
+    EXPECT_DOUBLE_EQ(expectedIntegEff(default_cov, cap, 2, 10, 9, 0.02, 1.0), default_cov);
+
+    // (c) Moderate residual that clears the floor but stays under the cap:
+    // mres=0.1 m, dt=1.0 s -> mres^2/dt = 0.01, between 1e-3 and 0.5.
+    EXPECT_DOUBLE_EQ(expectedIntegEff(default_cov, cap, 2, 10, 9, 0.1, 1.0), 0.01);
+
+    // (d) Large residual that would blow past the cap: mres=5.0 m, dt=1.0 s
+    // -> mres^2/dt = 25.0, clamped down to imu_integ_cov_max (0.5).
+    EXPECT_DOUBLE_EQ(expectedIntegEff(default_cov, cap, 2, 10, 9, 5.0, 1.0), cap);
+
+    // (e) Same large residual but a shorter dt makes it even larger pre-cap
+    // (mres^2/dt = 25.0/0.2 = 125.0) -- still clamped to the same cap.
+    EXPECT_DOUBLE_EQ(expectedIntegEff(default_cov, cap, 2, 10, 9, 5.0, 0.2), cap);
+
+    // (f) Staleness: the same large residual as (d), but recorded 5 epochs
+    // ago with stale_epochs=2 (5 > 2) -- the signal is stale, so the
+    // inflation is skipped entirely and the static floor is used, even
+    // though mres^2/dt alone would blow past both the floor and the cap.
+    EXPECT_DOUBLE_EQ(expectedIntegEff(default_cov, cap, 2, 10, 5, 5.0, 1.0), default_cov);
+
+    // (g) Exactly at the staleness boundary (epoch - last_mres_epoch ==
+    // stale_epochs) is NOT stale (reference: `> stale_max`, strict): the
+    // inflation still applies.
+    EXPECT_DOUBLE_EQ(expectedIntegEff(default_cov, cap, 2, 10, 8, 5.0, 1.0), cap);
+
+    // (h) stale_epochs<=0 disables the staleness check entirely (reference:
+    // `stale_max > 0 and ...`) -- inflation applies no matter how old the
+    // residual is.
+    EXPECT_DOUBLE_EQ(expectedIntegEff(default_cov, cap, 0, 10, -1000000, 0.1, 1.0), 0.01);
+
+    // (i) cap<=0 disables the cap entirely (reference: `if cap > 0`).
+    EXPECT_DOUBLE_EQ(expectedIntegEff(default_cov, 0.0, 2, 10, 9, 5.0, 1.0), 25.0);
+}
+
+TEST(FGOImuIntegrationCovarianceTest, InflationIsNoOpOnCleanResidualsRegardlessOfSwitch) {
+    // With no injected corruption, the post-fit DDPR RMS stays effectively
+    // zero every epoch, so the inflation formula's max(default_cov, mres^2/dt)
+    // collapses to default_cov on every epoch -- turning the switch on must
+    // not perturb a clean run at all (wiring sanity + "default-off unchanged"
+    // companion: this shows the ON path degenerates to the OFF path when the
+    // residual signal has nothing to say).
+    CpHoldTestOptions opt;
+    opt.num_epochs = 25;  // clean, stationary, no corruption
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig off_config = makeCpHoldBaseConfig();
+    off_config.imu_integration_covariance = 1e-3;
+    ASSERT_FALSE(off_config.use_imu_integration_covariance_inflation);
+    FGOProcessor off_processor(off_config);
+    const auto off_result = off_processor.optimizeProblem(problem);
+
+    FGOProcessor::FGOConfig on_config = off_config;
+    on_config.use_imu_integration_covariance_inflation = true;
+    FGOProcessor on_processor(on_config);
+    const auto on_result = on_processor.optimizeProblem(problem);
+
+    ASSERT_EQ(off_result.solution.solutions.size(), on_result.solution.solutions.size());
+    for (std::size_t i = 0; i < off_result.solution.solutions.size(); ++i) {
+        const auto& a = off_result.solution.solutions[i];
+        const auto& b = on_result.solution.solutions[i];
+        EXPECT_TRUE(a.position_ecef.isApprox(b.position_ecef, 0.0) || a.position_ecef == b.position_ecef)
+            << "epoch " << i << " position diverged with a clean (zero-residual) run";
+    }
+}
+
+TEST(FGOImuIntegrationCovarianceTest, ValuePassthroughNotSquaredAffectsDragResistance) {
+    // Reuses the CP-hold FSM's "wrong basin" fixture: a self-consistent
+    // erroneous carrier-phase hypothesis drags the graph pose away from the
+    // (stationary) true position during the corrupt window. A TIGHTER
+    // integration covariance makes the IMU chain stiffer (more resistant to
+    // being dragged by the erroneous carrier pull); a LOOSER one lets the
+    // carrier win more easily. If the backend still squared this field
+    // internally (the pre-port bug), configuring 1e-3 would silently become
+    // a covariance of 1e-6 -- identical to the "tight" run below -- so this
+    // comparison would collapse to no difference and the test would fail.
+    CpHoldTestOptions opt;
+    opt.carrier_corrupt_epochs = {5, 6, 7, 8, 9, 10, 11, 12};
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+    const Vector3d true_position(1113194.0, -4841695.0, 3985350.0);
+    constexpr std::size_t kProbeEpoch = 9;
+
+    FGOProcessor::FGOConfig tight_config = makeCpHoldBaseConfig();
+    tight_config.imu_integration_covariance = 1e-6;  // shipped default
+    FGOProcessor tight_processor(tight_config);
+    const auto tight_result = tight_processor.optimizeProblem(problem);
+    const double tight_dev =
+        (tight_result.solution.solutions[kProbeEpoch].position_ecef - true_position).norm();
+
+    FGOProcessor::FGOConfig loose_config = makeCpHoldBaseConfig();
+    loose_config.imu_integration_covariance = 1e-3;  // reference imu_integ_cov, applied directly
+    FGOProcessor loose_processor(loose_config);
+    const auto loose_result = loose_processor.optimizeProblem(problem);
+    const double loose_dev =
+        (loose_result.solution.solutions[kProbeEpoch].position_ecef - true_position).norm();
+
+    EXPECT_GT(loose_dev, tight_dev)
+        << "a 1000x-looser integration covariance (applied directly, not squared) must let the "
+           "erroneous carrier pull drag the pose further from truth than the tight default "
+           "(tight_dev=" << tight_dev << " m, loose_dev=" << loose_dev << " m)";
+}
+
 #endif  // GNSSPP_HAS_GTSAM

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -1246,6 +1246,21 @@ void dropSatelliteAtEpoch(FGOProcessor::FGOProblem& problem, std::size_t epoch_i
              cps.end());
 }
 
+// Injects a raw carrier bias into ONE (epoch, satellite)'s DD carrier factor,
+// mutating the same raw model field the GTSAM factor is built from AND
+// observed_dd_carrier_m -- the carrier analogue of injectPseudorangeOutlier
+// above. Used (with config.use_fde on) to engineer genuine single-satellite
+// carrier outliers for FDE to reject, which is what populates
+// sb_fde_cp_reject_count (the CLAMPED variant's decayed cppr substitute).
+void injectCarrierOutlier(FGOProcessor::FGOProblem& problem, std::size_t epoch_index,
+                          uint8_t satellite_prn, double bias_m) {
+    for (auto& cp : problem.double_difference_carrier_factors) {
+        if (cp.epoch_index != epoch_index || cp.satellite.prn != satellite_prn) continue;
+        cp.rover_satellite_model.corrected_carrier_m += bias_m;
+        cp.observed_dd_carrier_m += bias_m;
+    }
+}
+
 }  // namespace
 
 TEST(FGOSatBadnessTest, DefaultOffIsNoOp) {
@@ -1282,6 +1297,11 @@ TEST(FGOSatBadnessTest, ChronicallyBadSatelliteScoresHigherThanCleanRun) {
 
     FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
     config.use_sat_badness_downweight = true;
+    // CLAMPED-variant deviation: this test's invariant is about the score's
+    // ORDERING (chronic vs clean), not about the cap -- disable it so the
+    // new default sat_badness_score_cap (3.0) can't flatten both sides to
+    // the same capped value and make the comparison vacuous.
+    config.sat_badness_score_cap = 0.0;
 
     FGOProcessor bad_processor(config);
     const auto bad_result = bad_processor.optimizeProblem(bad_problem);
@@ -1375,6 +1395,10 @@ TEST(FGOSatBadnessTest, NotSeenThisEpochHardResetsBeatsContinuousAccumulation) {
 
     FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
     config.use_sat_badness_downweight = true;
+    // CLAMPED-variant deviation: disable the new default score cap so it
+    // can't flatten both sides to the same capped value (see the analogous
+    // note in ChronicallyBadSatelliteScoresHigherThanCleanRun above).
+    config.sat_badness_score_cap = 0.0;
 
     FGOProcessor continuous_processor(config);
     const auto continuous_result = continuous_processor.optimizeProblem(continuous_problem);
@@ -1403,6 +1427,10 @@ TEST(FGOSatBadnessTest, RecentPairAlphaGatesPairMemoryContribution) {
     FGOProcessor::FGOConfig off_config = makeCpHoldBaseConfig();
     off_config.use_sat_badness_downweight = true;
     ASSERT_EQ(off_config.sat_badness_alpha_recent_pair, 0.0);
+    // CLAMPED-variant deviation: disable the new default score cap so it
+    // can't flatten both sides to the same capped value (see the analogous
+    // note in ChronicallyBadSatelliteScoresHigherThanCleanRun above).
+    off_config.sat_badness_score_cap = 0.0;
     FGOProcessor off_processor(off_config);
     const auto off_result = off_processor.optimizeProblem(problem);
 
@@ -1414,6 +1442,181 @@ TEST(FGOSatBadnessTest, RecentPairAlphaGatesPairMemoryContribution) {
     EXPECT_GT(pair_result.diagnostics.sat_badness_max_score_seen,
               off_result.diagnostics.sat_badness_max_score_seen)
         << "raising alpha_recent_pair from its inert default must raise the observed score";
+}
+
+// ============================================================================
+// CLAMPED variant (fgo.hpp: sat_badness_residual_clamp_m / sat_badness_
+// score_cap / sat_badness_cppr_decay) -- deliberate DEVIATION from the
+// reference bounding the faithful port's feedback loop. See fgo.hpp's
+// comment on these three knobs for the mechanistic rationale (the reference
+// port is harmless in the reference's own ~1-2 m FLOAT regime but explodes
+// on this codebase's 100s-of-meters deep-urban FLOAT excursions).
+// ============================================================================
+
+TEST(FGOSatBadnessClampedTest, ResidualClampMakesHugeResidualBehaveLikeTheClampValue) {
+    // Two configs sharing the SAME clamp (15 m, the shipped default) but with
+    // wildly different raw biases (100 m vs 10000 m) on the same corrupted
+    // satellite/epochs. Both raw residuals land far above the clamp, so
+    // EVERY badness term that reads the per-satellite residual (obsq EWMA,
+    // obsq bad-streak, the next-epoch res_s snapshot, recent_ref_bad's
+    // upstream input) must see the SAME hard-clamped-to-15 value in both --
+    // i.e. a 100 m residual "behaves as" a 15 m one, regardless of how much
+    // further it overshoots. (Comparing against a genuine, unclamped 15 m
+    // bias instead is NOT a valid equivalence: the graph's Huber-robustified
+    // least-squares absorbs a small fraction of ANY bias into the state, and
+    // that absorbed fraction is itself bias-size-dependent near the Huber
+    // knee -- so a real 15 m case and a clamped-from-100 m case are not
+    // expected to match bit-for-bit. Two biases that both clamp is the clean
+    // invariant.) Score cap disabled in both so it can't hide a mismatch.
+    CpHoldTestOptions huge_opt;
+    huge_opt.num_epochs = 25;
+    for (std::size_t e = 10; e <= 19; ++e) huge_opt.pr_corrupt_epochs.insert(e);
+    huge_opt.pr_dominant_extra_bias_m = 100.0;
+    auto huge_problem = makeCpHoldFixedLagProblem(huge_opt);
+
+    CpHoldTestOptions astronomical_opt;
+    astronomical_opt.num_epochs = 25;
+    for (std::size_t e = 10; e <= 19; ++e) astronomical_opt.pr_corrupt_epochs.insert(e);
+    astronomical_opt.pr_dominant_extra_bias_m = 10000.0;
+    auto astronomical_problem = makeCpHoldFixedLagProblem(astronomical_opt);
+
+    FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
+    config.use_sat_badness_downweight = true;
+    ASSERT_EQ(config.sat_badness_residual_clamp_m, 15.0)
+        << "test assumes the shipped default clamp";
+    config.sat_badness_score_cap = 0.0;  // isolate the clamp from the cap
+
+    FGOProcessor huge_processor(config);
+    const auto huge_result = huge_processor.optimizeProblem(huge_problem);
+    FGOProcessor astronomical_processor(config);
+    const auto astronomical_result = astronomical_processor.optimizeProblem(astronomical_problem);
+
+    EXPECT_NEAR(huge_result.diagnostics.sat_badness_max_score_seen,
+                astronomical_result.diagnostics.sat_badness_max_score_seen, 1e-6)
+        << "once the raw residual clears the clamp, growing it further (100m -> 10000m) must not "
+           "change the score at all -- both must behave as exactly the clamp value (100m="
+        << huge_result.diagnostics.sat_badness_max_score_seen
+        << ", 10000m=" << astronomical_result.diagnostics.sat_badness_max_score_seen << ")";
+    EXPECT_GT(huge_result.diagnostics.sat_badness_max_score_seen, 0.0)
+        << "sanity: the corrupted satellite must actually register a nonzero score";
+}
+
+TEST(FGOSatBadnessClampedTest, ScoreCapBoundsTheFinalScore) {
+    // An extreme 100 m bias with the clamp at its default (15 m) still lets
+    // several additive terms in satBadness() accumulate substantially; the
+    // score cap must nonetheless bound the value actually consumed for sigma
+    // inflation. Compare against the SAME fixture with the cap disabled to
+    // prove the cap is doing real work here, not just trivially satisfied.
+    CpHoldTestOptions opt;
+    opt.num_epochs = 25;
+    for (std::size_t e = 5; e <= 19; ++e) opt.pr_corrupt_epochs.insert(e);
+    opt.pr_dominant_extra_bias_m = 100.0;
+    auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig capped_config = makeCpHoldBaseConfig();
+    capped_config.use_sat_badness_downweight = true;
+    ASSERT_EQ(capped_config.sat_badness_score_cap, 3.0) << "test assumes the shipped default cap";
+    FGOProcessor capped_processor(capped_config);
+    const auto capped_result = capped_processor.optimizeProblem(problem);
+
+    FGOProcessor::FGOConfig uncapped_config = capped_config;
+    uncapped_config.sat_badness_score_cap = 0.0;  // 0 = no cap = faithful
+    FGOProcessor uncapped_processor(uncapped_config);
+    const auto uncapped_result = uncapped_processor.optimizeProblem(problem);
+
+    EXPECT_LE(capped_result.diagnostics.sat_badness_max_score_seen,
+              capped_config.sat_badness_score_cap + 1e-9)
+        << "the capped run's score must never exceed sat_badness_score_cap (observed="
+        << capped_result.diagnostics.sat_badness_max_score_seen << ")";
+    EXPECT_GT(uncapped_result.diagnostics.sat_badness_max_score_seen,
+              capped_config.sat_badness_score_cap)
+        << "sanity: on this fixture the uncapped score must actually exceed the cap, otherwise "
+           "the cap assertion above is vacuous (uncapped="
+        << uncapped_result.diagnostics.sat_badness_max_score_seen << ")";
+}
+
+TEST(FGOSatBadnessClampedTest, CpprDecayFadesAfterFdeRejectsStop) {
+    // Two well-separated bursts of genuine single-satellite carrier outliers
+    // (PRN 2), each big enough that FDE (config.use_fde) rejects that DD
+    // carrier factor outright, feeding sb_fde_cp_reject_count. With
+    // sat_badness_cppr_decay=1.0 (never decays, the old faithful-port
+    // behaviour) the SECOND burst's score carries the FIRST burst's count
+    // forward undiminished; with the default 0.8 decay, ~25 clean epochs in
+    // between decay that carry-over most of the way to zero. Every other
+    // badness knob is identical between the two runs (same fixture, same
+    // everything else), so any score difference is attributable to this one
+    // knob.
+    constexpr uint8_t kPrn = 2;
+    constexpr double kBiasM = 5.0;  // >> fde_carrier_threshold_m default (0.5 m)
+    CpHoldTestOptions opt;
+    opt.num_epochs = 40;
+    auto problem = makeCpHoldFixedLagProblem(opt);
+    for (std::size_t e = 5; e <= 7; ++e) injectCarrierOutlier(problem, e, kPrn, kBiasM);
+    for (std::size_t e = 30; e <= 32; ++e) injectCarrierOutlier(problem, e, kPrn, kBiasM);
+
+    FGOProcessor::FGOConfig base_config = makeCpHoldBaseConfig();
+    base_config.use_fde = true;
+    base_config.use_sat_badness_downweight = true;
+    base_config.sat_badness_score_cap = 0.0;  // isolate the decay: don't let the cap flatten it
+
+    FGOProcessor::FGOConfig never_decay_config = base_config;
+    never_decay_config.sat_badness_cppr_decay = 1.0;  // faithful: never decays
+    FGOProcessor never_decay_processor(never_decay_config);
+    const auto never_decay_result = never_decay_processor.optimizeProblem(problem);
+
+    FGOProcessor::FGOConfig decay_config = base_config;
+    ASSERT_EQ(decay_config.sat_badness_cppr_decay, 0.8) << "test assumes the shipped default decay";
+    FGOProcessor decay_processor(decay_config);
+    const auto decay_result = decay_processor.optimizeProblem(problem);
+
+    ASSERT_GT(never_decay_result.diagnostics.fde_carrier_rejections, 0u)
+        << "sanity: the injected outliers must actually get FDE-rejected in both bursts";
+    ASSERT_GT(decay_result.diagnostics.fde_carrier_rejections, 0u);
+
+    EXPECT_GT(never_decay_result.diagnostics.sat_badness_max_score_seen,
+              decay_result.diagnostics.sat_badness_max_score_seen)
+        << "an ever-growing (never-decaying) reject counter must score higher at the second "
+           "burst than one that decayed away in between (never_decay="
+        << never_decay_result.diagnostics.sat_badness_max_score_seen
+        << ", decay=0.8=" << decay_result.diagnostics.sat_badness_max_score_seen << ")";
+}
+
+TEST(FGOSatBadnessClampedTest, FaithfulEscapeHatchReproducesUnboundedScoring) {
+    // clamp=0, cap=0, cppr_decay=1.0 together must disable all three CLAMPED-
+    // variant bounds at once, reproducing the original faithful port's
+    // unbounded scoring exactly. Demonstrated here by contrast: on an extreme
+    // 100 m bias fixture, the escape-hatch config's score must blow well past
+    // both the shipped clamp (15 m) and cap (3.0) -- if any bound were still
+    // silently active, the score could not grow this large.
+    CpHoldTestOptions opt;
+    opt.num_epochs = 25;
+    for (std::size_t e = 5; e <= 19; ++e) opt.pr_corrupt_epochs.insert(e);
+    opt.pr_dominant_extra_bias_m = 100.0;
+    auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig default_config = makeCpHoldBaseConfig();
+    default_config.use_sat_badness_downweight = true;
+    ASSERT_EQ(default_config.sat_badness_residual_clamp_m, 15.0);
+    ASSERT_EQ(default_config.sat_badness_score_cap, 3.0);
+    ASSERT_EQ(default_config.sat_badness_cppr_decay, 0.8);
+    FGOProcessor default_processor(default_config);
+    const auto default_result = default_processor.optimizeProblem(problem);
+
+    FGOProcessor::FGOConfig escape_config = default_config;
+    escape_config.sat_badness_residual_clamp_m = 0.0;  // no clamp
+    escape_config.sat_badness_score_cap = 0.0;         // no cap
+    escape_config.sat_badness_cppr_decay = 1.0;        // never decays
+    FGOProcessor escape_processor(escape_config);
+    const auto escape_result = escape_processor.optimizeProblem(problem);
+
+    EXPECT_LE(default_result.diagnostics.sat_badness_max_score_seen,
+              default_config.sat_badness_score_cap + 1e-9)
+        << "sanity: the default (bounded) run must respect its own cap";
+    EXPECT_GT(escape_result.diagnostics.sat_badness_max_score_seen,
+              default_config.sat_badness_score_cap * 2.0)
+        << "the escape hatch must let the score run well past the shipped cap (escape="
+        << escape_result.diagnostics.sat_badness_max_score_seen
+        << ", default(bounded)=" << default_result.diagnostics.sat_badness_max_score_seen << ")";
 }
 
 #endif  // GNSSPP_HAS_GTSAM


### PR DESCRIPTION
## Summary

Adds an optional GTSAM-based backend behind the existing `FGOProblem` interface, with tightly-coupled GNSS/IMU RTK via `IncrementalFixedLagSmoother`, and ports the urban-robustness machinery from [inuex35/tightly-coupled-gnss-imu-fgo](https://github.com/inuex35/tightly-coupled-gnss-imu-fgo) (CMC screening, CP-hold/sanity recovery, DDPR-LS anchor, GICI-style FDE). Everything is opt-in: with GTSAM absent or all knobs at defaults, the library builds and behaves exactly as before (verified bit-identical at full scale at every stage).

## What's included (7 commits)

1. **GTSAM backend (Phase 1 + IMU phases 2a-2d)** — `FGOBackend::GTSAM` maps DD pseudorange/carrier factors to `gtsam::navigation` DD factors (lever-arm variants share a `Pose3` with `CombinedImuFactor`), per-epoch LAMBDA via windowed joint marginals, NHC/ZUPT custom factors, fixed-lag smoothing at full-dataset scale. Float parity vs the native Eigen backend: sub-cm on strong geometry.
2. **Fix-and-hold + urban robustness** — arc-level integer pinning after ratio-test validation; per-epoch regularization priors.
3. **Multi-frequency DD, secondary-code alignment, partial AR** — RTKLIB-style code-priority selection fixing a real per-satellite code-mixing issue in secondary bands; partial LAMBDA on ranked prefixes.
4. **Per-epoch quality gates** — GDOP/nsat fixing gates, post-fit per-satellite DD residual exclusion.
5. **CMC (code-minus-carrier) multipath screening** — jump detection (arc break) + sustained-level exclusion vs an EWMA baseline, per (satellite, signal).
6. **CP-hold/sanity recovery, DDPR-LS anchor, solve-exception recovery, GICI-style FDE** — post-fit-residual-driven mass ambiguity resets with carrier hold and release hysteresis; per-epoch DD-PR-only LS anchor; warm restarts on numerical failure (removes a crash-tail failure mode); per-epoch fault detection and exclusion from the live graph.

## Validation (Tokyo PPC dataset, full runs)

Recommended config (multi-freq + partial AR + fix-and-hold + elev mask 20 + IMU + fixed-lag 5 s + CMC + recovery + FDE):

| Run | FIXED RMS | <50 cm | Fix rate | Unsolved epochs |
|---|---|---|---|---|
| run1 | 0.71 m | 27.1% | 34.3% | 0 |
| run2 | 0.58 m | 52.3% | 62.2% | 0 |
| run3 | 0.56 m | 51.7% | 65.3% | 0 |

Fix rates on run2/run3 exceed the reference implementation's published benchmarks (60.8/59.4%); FIXED-epoch accuracy is sub-meter on all runs. Remaining gap to the reference is deep-urban FLOAT quality (<50 cm on run1).

## Build

`-DGTSAM_DIR=<install>/CMake` enables the backend (`GNSSPP_HAS_GTSAM`); without GTSAM nothing changes. MSVC needs `/FORCE:MULTIPLE` for shared-GTSAM STL duplicate symbols (wired under `if(MSVC)`).

## Tests

401 pass / 0 fail (16 new backend tests this final commit; full series adds ~40). Default-off paths verified bit-identical against the pre-series baseline at full scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QQrVvteSAJ1Lg7QDeu4CR2