### PR TITLE
Phase 18 L5/N5 widelane AR state + WP9-10 float trust policy / NLOS weights / RTK knob wiring

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,6 +115,8 @@ set(GNSS_SOURCES
 set(GNSS_SOURCES_NO_OPTIMIZATION
     src/algorithms/rtk_ar_selection.cpp
     src/algorithms/rtk_ar_evaluation.cpp
+    src/algorithms/nlos_weights.cpp
+    src/algorithms/float_trust_policy.cpp
     src/algorithms/rtk_measurement.cpp
     src/algorithms/rtk_selection.cpp
     src/algorithms/rtk_update.cpp

--- a/apps/gnss_solve.cpp
+++ b/apps/gnss_solve.cpp
@@ -7,10 +7,13 @@
 #include <iostream>
 #include <limits>
 #include <map>
+#include <memory>
 #include <sstream>
 #include <string>
 #include <vector>
 
+#include <libgnss++/algorithms/nlos_weights.hpp>
+#include <libgnss++/algorithms/float_trust_policy.hpp>
 #include <libgnss++/algorithms/rtk.hpp>
 #include <libgnss++/algorithms/rtk_validation.hpp>
 #include <libgnss++/algorithms/spp.hpp>
@@ -218,6 +221,32 @@ struct SolveConfig {
     bool enable_bsr_guided_decimation = false;
     int bsr_guided_worst_axes = 3;
     int bsr_guided_max_drop_steps = 6;
+    // WP7: NLOS/multipath measurement weighting. Empty path / OFF mode
+    // (both defaults) mean the feature is entirely inert.
+    std::string nlos_weights_csv_path;
+    libgnss::nlos_weights::NlosWeightMode nlos_weight_mode =
+        libgnss::nlos_weights::NlosWeightMode::OFF;
+    double nlos_two_tier_los_threshold = 0.5;
+    double nlos_two_tier_sigma_inflation = 3.0;
+    double nlos_continuous_los_prob_floor = 0.05;
+    double nlos_tow_tolerance_s = 0.05;
+    // WP8: hard exclusion mode threshold/safety-guard. No effect unless
+    // --nlos-weight-mode exclude.
+    double nlos_exclude_threshold = 0.5;
+    int nlos_min_sats = 5;
+    // WP9: float-filter trust/reset policy. LEGACY (default) is
+    // bit-identical to pre-WP9 behavior.
+    libgnss::float_trust_policy::FloatTrustPolicy float_trust_policy =
+        libgnss::float_trust_policy::FloatTrustPolicy::LEGACY;
+    double trust_lapse_qpos_m2_per_s = 10.0;
+    bool trust_gate_nlos_relax = false;
+    // WP10: lapse-gated trust policy + optional NLOS-fraction trigger.
+    // No effect unless --float-trust-policy lapse-gated.
+    double trust_lapse_gate_s = 5.0;
+    double trust_lapse_gate_nlos_frac = -1.0;
+    // WP10 (WP8 rec 2): AR-acceptance-only min-LOS-satellites gate.
+    // <= 0 (default) disables it; requires --nlos-weights.
+    int nlos_min_los_sats = 0;
 };
 
 using libgnss_apps::timeDiffSeconds;
@@ -551,7 +580,11 @@ public:
               << "selected_fixed_ambiguities,selected_used_subset,"
               << "used_wlnl_fallback,validation_attempted,validation_passed,"
               << "postfix_residual_rms,fixed_float_jump_m,post_validation_rejected,"
-              << "final_fixed_applied,reject_reason,ar_skip_reason\n";
+              << "final_fixed_applied,reject_reason,ar_skip_reason,"
+              << "float_update_observation_count,float_update_prefit_residual_rms_m,"
+              << "float_update_post_suppression_residual_rms_m,"
+              << "float_update_nis_per_observation,float_update_suppressed_outliers,"
+              << "float_position_covariance_trace_m2\n";
         return true;
     }
 
@@ -624,7 +657,17 @@ public:
               << telemetry.post_validation_rejected << ","
               << telemetry.final_fixed_applied << ","
               << telemetry.reject_reason << ","
-              << libgnss::RTKProcessor::arSkipReasonToString(telemetry.ar_skip_reason) << "\n";
+              << libgnss::RTKProcessor::arSkipReasonToString(telemetry.ar_skip_reason) << ","
+              << telemetry.float_update_observation_count << ",";
+        writeNumber(telemetry.float_update_prefit_residual_rms_m);
+        file_ << ",";
+        writeNumber(telemetry.float_update_post_suppression_residual_rms_m);
+        file_ << ",";
+        writeNumber(telemetry.float_update_nis_per_observation);
+        file_ << ","
+              << telemetry.float_update_suppressed_outliers << ",";
+        writeNumber(telemetry.float_position_covariance_trace_m2);
+        file_ << "\n";
         file_.flush();
     }
 
@@ -804,6 +847,78 @@ void printUsage(const char* program_name) {
         << "                             per-pair loadings against (default: 3)\n"
         << "  --bsr-max-drops <n>        Max pairs to drop progressively in BSR-guided\n"
         << "                             decimation (default: 6)\n"
+        << "  --nlos-weights <csv>       WP7: per-epoch per-satellite LOS/NLOS weight CSV\n"
+        << "                             (columns: tow,sat,los_prob; also accepts the\n"
+        << "                             tow,epoch_idx,prn,is_los,... contract emitted by\n"
+        << "                             build_per_epoch_nlos_csv.py). Requires\n"
+        << "                             --nlos-weight-mode to have any effect.\n"
+        << "  --nlos-weight-mode <off|two-tier|continuous|exclude>\n"
+        << "                             Sigma-inflation (or WP8 hard exclusion) mapping for\n"
+        << "                             NLOS satellites (default: off — bit-identical to no\n"
+        << "                             NLOS weighting)\n"
+        << "  --nlos-two-tier-threshold <v>\n"
+        << "                             los_prob below this is treated as NLOS in\n"
+        << "                             two-tier mode (default: 0.5)\n"
+        << "  --nlos-two-tier-inflation <v>\n"
+        << "                             Sigma multiplier for NLOS satellites in two-tier\n"
+        << "                             mode (default: 3.0)\n"
+        << "  --nlos-continuous-floor <v>\n"
+        << "                             Floor on los_prob before the 1/sqrt(...) sigma\n"
+        << "                             mapping in continuous mode (default: 0.05)\n"
+        << "  --nlos-tow-tolerance <s>   Tow-matching tolerance for the NLOS weight CSV\n"
+        << "                             (default: 0.05)\n"
+        << "  --nlos-exclude-threshold <v>\n"
+        << "                             WP8: los_prob below this is dropped from DD\n"
+        << "                             formation entirely in exclude mode (default: 0.5)\n"
+        << "  --nlos-min-sats <n>        WP8: exclude-mode safety guard -- skip exclusion for\n"
+        << "                             an epoch (keep all satellites) if it would leave\n"
+        << "                             fewer than this many in the candidate set (default: 5)\n"
+        << "  --float-trust-policy <legacy|cv-predict|scaled-reset|lapse-gated>\n"
+        << "                             WP9/WP10: policy for resetPositionToSPP() once the\n"
+        << "                             previous epoch failed to refresh position trust.\n"
+        << "                             legacy (default): unconditional wide reset to\n"
+        << "                             900 m^2/axis, reseeded from SPP -- bit-identical to\n"
+        << "                             pre-WP9 behavior. cv-predict: propagate the previous\n"
+        << "                             position with a constant-velocity predict and grow\n"
+        << "                             covariance at --trust-lapse-qpos instead of jumping\n"
+        << "                             to 900. scaled-reset: keep the SPP reseed but scale\n"
+        << "                             the reset variance with time-since-trust instead of\n"
+        << "                             using a flat 900 (from the very first lapsed epoch).\n"
+        << "                             lapse-gated (WP10): scaled-reset's law, but only once\n"
+        << "                             the *continuous* trust lapse exceeds --trust-lapse-\n"
+        << "                             gate-s seconds (or --trust-lapse-gate-nlos-frac\n"
+        << "                             triggers) -- below the gate, behaves exactly like\n"
+        << "                             legacy (bit-identical), fixing scaled-reset's WP9\n"
+        << "                             regression on short/benign lapses. All non-legacy\n"
+        << "                             policies are capped at 900 m^2/axis (converge to\n"
+        << "                             legacy under a long drought)\n"
+        << "  --trust-lapse-qpos <v>     WP9/WP10: process-noise rate (m^2/s) used by\n"
+        << "                             cv-predict (linear growth per second) and\n"
+        << "                             scaled-reset/lapse-gated (quadratic growth in\n"
+        << "                             time-since-trust). No effect when --float-trust-policy\n"
+        << "                             legacy (default: 10.0; WP9/WP10's run1 winner is 0.1)\n"
+        << "  --trust-lapse-gate-s <s>   WP10: seconds of continuous trust lapse required\n"
+        << "                             before --float-trust-policy lapse-gated switches from\n"
+        << "                             legacy to the scaled-reset law (default: 5.0). No\n"
+        << "                             effect unless --float-trust-policy lapse-gated\n"
+        << "  --trust-lapse-gate-nlos-frac <f>\n"
+        << "                             WP10 optional second trigger for lapse-gated: when\n"
+        << "                             set (>= 0) and --nlos-weights is loaded, ALSO switch\n"
+        << "                             to the scaled-reset law (regardless of lapse length)\n"
+        << "                             on epochs whose NLOS-flagged satellite fraction\n"
+        << "                             exceeds this value (one-epoch-lagged; default: off/\n"
+        << "                             disabled). No effect unless --float-trust-policy\n"
+        << "                             lapse-gated\n"
+        << "  --trust-gate-nlos-relax    WP9 optional lever: relax rememberSolution()'s FLOAT\n"
+        << "                             trust-refresh jump gate 2x when >50% of this epoch's\n"
+        << "                             tracked satellites are NLOS-flagged per --nlos-weights\n"
+        << "                             (default: off; also requires --nlos-weights to have\n"
+        << "                             any effect, independent of --nlos-weight-mode)\n"
+        << "  --nlos-min-los-sats <n>    WP10: AR-acceptance-only gate (never touches the\n"
+        << "                             float-KF update) -- require at least n LOS-flagged\n"
+        << "                             satellites (per --nlos-weights) among the AR\n"
+        << "                             candidate set before attempting/accepting a fix\n"
+        << "                             (default: 0, disabled). Requires --nlos-weights\n"
         << "  --max-consec-float-reset <n>\n"
         << "                             Reset ambiguity state after n consecutive float epochs\n"
         << "                             (default: 0, disabled; e.g. 10 for aggressive urban reconvergence)\n"
@@ -900,6 +1015,24 @@ GlonassARChoice parseGlonassARChoice(const std::string& value, const char* progr
     if (value == "on") return GlonassARChoice::ON;
     if (value == "autocal") return GlonassARChoice::AUTOCAL;
     argumentError("unsupported --glonass-ar value: " + value, program_name);
+}
+
+libgnss::nlos_weights::NlosWeightMode parseNlosWeightMode(const std::string& value,
+                                                           const char* program_name) {
+    if (value == "off") return libgnss::nlos_weights::NlosWeightMode::OFF;
+    if (value == "two-tier") return libgnss::nlos_weights::NlosWeightMode::TWO_TIER;
+    if (value == "continuous") return libgnss::nlos_weights::NlosWeightMode::CONTINUOUS;
+    if (value == "exclude") return libgnss::nlos_weights::NlosWeightMode::EXCLUDE;
+    argumentError("unsupported --nlos-weight-mode value: " + value, program_name);
+}
+
+libgnss::float_trust_policy::FloatTrustPolicy parseFloatTrustPolicy(const std::string& value,
+                                                                     const char* program_name) {
+    if (value == "legacy") return libgnss::float_trust_policy::FloatTrustPolicy::LEGACY;
+    if (value == "cv-predict") return libgnss::float_trust_policy::FloatTrustPolicy::CV_PREDICT;
+    if (value == "scaled-reset") return libgnss::float_trust_policy::FloatTrustPolicy::SCALED_RESET;
+    if (value == "lapse-gated") return libgnss::float_trust_policy::FloatTrustPolicy::LAPSE_GATED;
+    argumentError("unsupported --float-trust-policy value: " + value, program_name);
 }
 
 RTKTuningPreset parseRTKTuningPreset(const std::string& value, const char* program_name) {
@@ -1205,6 +1338,34 @@ SolveConfig parseArguments(int argc, char* argv[]) {
             config.bsr_guided_worst_axes = std::stoi(argv[++i]);
         } else if (arg == "--bsr-max-drops" && i + 1 < argc) {
             config.bsr_guided_max_drop_steps = std::stoi(argv[++i]);
+        } else if (arg == "--nlos-weights" && i + 1 < argc) {
+            config.nlos_weights_csv_path = argv[++i];
+        } else if (arg == "--nlos-weight-mode" && i + 1 < argc) {
+            config.nlos_weight_mode = parseNlosWeightMode(argv[++i], argv[0]);
+        } else if (arg == "--nlos-two-tier-threshold" && i + 1 < argc) {
+            config.nlos_two_tier_los_threshold = std::stod(argv[++i]);
+        } else if (arg == "--nlos-two-tier-inflation" && i + 1 < argc) {
+            config.nlos_two_tier_sigma_inflation = std::stod(argv[++i]);
+        } else if (arg == "--nlos-continuous-floor" && i + 1 < argc) {
+            config.nlos_continuous_los_prob_floor = std::stod(argv[++i]);
+        } else if (arg == "--nlos-tow-tolerance" && i + 1 < argc) {
+            config.nlos_tow_tolerance_s = std::stod(argv[++i]);
+        } else if (arg == "--nlos-exclude-threshold" && i + 1 < argc) {
+            config.nlos_exclude_threshold = std::stod(argv[++i]);
+        } else if (arg == "--nlos-min-sats" && i + 1 < argc) {
+            config.nlos_min_sats = std::stoi(argv[++i]);
+        } else if (arg == "--float-trust-policy" && i + 1 < argc) {
+            config.float_trust_policy = parseFloatTrustPolicy(argv[++i], argv[0]);
+        } else if (arg == "--trust-lapse-qpos" && i + 1 < argc) {
+            config.trust_lapse_qpos_m2_per_s = std::stod(argv[++i]);
+        } else if (arg == "--trust-lapse-gate-s" && i + 1 < argc) {
+            config.trust_lapse_gate_s = std::stod(argv[++i]);
+        } else if (arg == "--trust-lapse-gate-nlos-frac" && i + 1 < argc) {
+            config.trust_lapse_gate_nlos_frac = std::stod(argv[++i]);
+        } else if (arg == "--trust-gate-nlos-relax") {
+            config.trust_gate_nlos_relax = true;
+        } else if (arg == "--nlos-min-los-sats" && i + 1 < argc) {
+            config.nlos_min_los_sats = std::stoi(argv[++i]);
         } else if (arg == "--max-consec-float-reset" && i + 1 < argc) {
             config.max_consecutive_float_for_reset = std::stoi(argv[++i]);
         } else if (arg == "--max-consec-nonfix-reset" && i + 1 < argc) {
@@ -1323,6 +1484,40 @@ SolveConfig parseArguments(int argc, char* argv[]) {
     }
     if (config.ar_filter_margin < 0.0) {
         argumentError("--arfilter-margin must be >= 0", argv[0]);
+    }
+    if (config.nlos_weight_mode != libgnss::nlos_weights::NlosWeightMode::OFF &&
+        config.nlos_weights_csv_path.empty()) {
+        argumentError("--nlos-weight-mode requires --nlos-weights <csv>", argv[0]);
+    }
+    if (config.nlos_two_tier_los_threshold < 0.0 || config.nlos_two_tier_los_threshold > 1.0) {
+        argumentError("--nlos-two-tier-threshold must be in [0, 1]", argv[0]);
+    }
+    if (config.nlos_two_tier_sigma_inflation < 1.0) {
+        argumentError("--nlos-two-tier-inflation must be >= 1", argv[0]);
+    }
+    if (config.nlos_continuous_los_prob_floor <= 0.0 || config.nlos_continuous_los_prob_floor > 1.0) {
+        argumentError("--nlos-continuous-floor must be in (0, 1]", argv[0]);
+    }
+    if (config.nlos_tow_tolerance_s < 0.0) {
+        argumentError("--nlos-tow-tolerance must be >= 0", argv[0]);
+    }
+    if (config.nlos_exclude_threshold < 0.0 || config.nlos_exclude_threshold > 1.0) {
+        argumentError("--nlos-exclude-threshold must be in [0, 1]", argv[0]);
+    }
+    if (config.nlos_min_sats < 0) {
+        argumentError("--nlos-min-sats must be >= 0", argv[0]);
+    }
+    if (config.trust_lapse_qpos_m2_per_s < 0.0) {
+        argumentError("--trust-lapse-qpos must be >= 0", argv[0]);
+    }
+    if (config.trust_lapse_gate_s < 0.0) {
+        argumentError("--trust-lapse-gate-s must be >= 0", argv[0]);
+    }
+    if (config.trust_lapse_gate_nlos_frac > 1.0) {
+        argumentError("--trust-lapse-gate-nlos-frac must be <= 1 (or negative to disable)", argv[0]);
+    }
+    if (config.nlos_min_los_sats < 0) {
+        argumentError("--nlos-min-los-sats must be >= 0", argv[0]);
     }
     if (config.min_hold_count < 0) {
         argumentError("--min-hold-count must be >= 0", argv[0]);
@@ -1648,6 +1843,19 @@ int main(int argc, char* argv[]) {
         rtk_config.hold_ambiguity_ratio_threshold = config.hold_ratio_threshold;
         rtk_config.enable_ar_filter = config.enable_ar_filter;
         rtk_config.ar_filter_margin = config.ar_filter_margin;
+        rtk_config.nlos_weight_mode = config.nlos_weight_mode;
+        rtk_config.nlos_two_tier_los_threshold = config.nlos_two_tier_los_threshold;
+        rtk_config.nlos_two_tier_sigma_inflation = config.nlos_two_tier_sigma_inflation;
+        rtk_config.nlos_continuous_los_prob_floor = config.nlos_continuous_los_prob_floor;
+        rtk_config.nlos_tow_tolerance_s = config.nlos_tow_tolerance_s;
+        rtk_config.nlos_exclude_threshold = config.nlos_exclude_threshold;
+        rtk_config.nlos_min_sats = config.nlos_min_sats;
+        rtk_config.float_trust_policy = config.float_trust_policy;
+        rtk_config.trust_lapse_qpos_m2_per_s = config.trust_lapse_qpos_m2_per_s;
+        rtk_config.trust_gate_nlos_relax = config.trust_gate_nlos_relax;
+        rtk_config.trust_lapse_gate_s = config.trust_lapse_gate_s;
+        rtk_config.trust_lapse_gate_nlos_frac = config.trust_lapse_gate_nlos_frac;
+        rtk_config.nlos_min_los_sats = config.nlos_min_los_sats;
         rtk_config.min_satellites_for_ar = config.min_satellites_for_ar;
         rtk_config.min_subset_pairs_for_ar = config.min_subset_pairs_for_ar;
         rtk_config.max_subset_drop_steps_for_ar = config.max_subset_drop_steps_for_ar;
@@ -1745,6 +1953,13 @@ int main(int argc, char* argv[]) {
         rtk_config.enable_bsr_guided_decimation = config.enable_bsr_guided_decimation;
         rtk_config.bsr_guided_worst_axes = config.bsr_guided_worst_axes;
         rtk_config.bsr_guided_max_drop_steps = config.bsr_guided_max_drop_steps;
+        if (!config.nlos_weights_csv_path.empty()) {
+            auto table = std::make_shared<libgnss::nlos_weights::NlosWeightTable>(
+                libgnss::nlos_weights::loadNlosWeightsCsv(config.nlos_weights_csv_path));
+            std::cout << "Loaded NLOS weights: " << config.nlos_weights_csv_path
+                      << " (" << table->by_tow.size() << " distinct epochs)" << std::endl;
+            rtk_processor.setNlosWeightTable(std::move(table));
+        }
         rtk_processor.setRTKConfig(rtk_config);
         libgnss::SPPProcessor::SPPConfig spp_config;
         spp_config.use_multi_constellation = true;

--- a/apps/gnss_solve.cpp
+++ b/apps/gnss_solve.cpp
@@ -7,6 +7,7 @@
 #include <iostream>
 #include <limits>
 #include <map>
+#include <sstream>
 #include <string>
 #include <vector>
 
@@ -90,6 +91,10 @@ struct SolveConfig {
     IonoChoice iono = IonoChoice::AUTO;
     libgnss::io::SolutionWriter::Format output_format = libgnss::io::SolutionWriter::Format::POS;
     double max_baseline_length_m = 20000.0;
+    bool prefer_trusted_seed = false;
+    std::string rover_seed_pos_path;
+    std::string diagnostics_csv_path;
+    double rtk_update_outlier_threshold = 0.0;
     double ratio_threshold = 3.0;
     bool enable_ar_filter = false;
     bool has_ar_filter_override = false;
@@ -126,6 +131,7 @@ struct SolveConfig {
     bool carrier_phase_sigma_set = false;
     bool enable_glonass = true;
     bool enable_beidou = true;
+    bool enable_l5 = false;  // Phase 18 Step 3: opt-in L5 measurement collection
     GlonassARChoice glonass_ar = GlonassARChoice::OFF;
     double glonass_icb_l1_m_per_mhz = 0.0;
     double glonass_icb_l2_m_per_mhz = 0.0;
@@ -320,6 +326,200 @@ std::string outputFormatString(libgnss::io::SolutionWriter::Format format) {
             return "xyz";
     }
     return "pos";
+}
+
+// PPC pipeline 互換の診断 CSV ライター。 my-branch と同じ列構成を維持し、
+// develop に存在しないフィールド (alt_lambda_*, glonass_icb_*, cascade_*) は
+// 0/NaN/空でスタブ出力 (forward-compat: cascade branch では実値が入る)。
+struct EpochDiagnostics {
+    int epoch_index = 0;
+    int gps_week = 0;
+    double tow = 0.0;
+    bool exact_base = false;
+    bool interpolated_base = false;
+    bool initial_valid = false;
+    int initial_status = 0;
+    int initial_sats = 0;
+    double initial_ratio = 0.0;
+    double initial_pdop = 999.9;
+    double initial_baseline_m = 0.0;
+    double initial_residual_rms = 0.0;
+    double initial_residual_abs_max = 0.0;
+    int initial_update_rows = 0;
+    int initial_suppressed_outliers = 0;
+    bool final_valid = false;
+    int final_status = 0;
+    int final_sats = 0;
+    double final_ratio = 0.0;
+    double final_pdop = 999.9;
+    double final_baseline_m = 0.0;
+    double final_residual_rms = 0.0;
+    double final_residual_abs_max = 0.0;
+    int final_update_rows = 0;
+    int final_suppressed_outliers = 0;
+    bool spp_valid = false;
+    int spp_sats = 0;
+    double spp_pdop = 999.9;
+    double candidate_vs_spp_m = std::numeric_limits<double>::quiet_NaN();
+    double candidate_jump_m = std::numeric_limits<double>::quiet_NaN();
+    double last_output_dt_s = std::numeric_limits<double>::quiet_NaN();
+    double nonfixed_jump_guard_m = std::numeric_limits<double>::quiet_NaN();
+    double drift_from_fixed_m = std::numeric_limits<double>::quiet_NaN();
+    double height_from_fixed_m = std::numeric_limits<double>::quiet_NaN();
+    double dt_since_fixed_s = std::numeric_limits<double>::quiet_NaN();
+    double fixed_drift_guard_m = std::numeric_limits<double>::quiet_NaN();
+    double fixed_height_guard_m = std::numeric_limits<double>::quiet_NaN();
+    bool spp_replacement_used = false;
+    bool output_added = false;
+    std::string rejection_reason = "none";
+    // cascade fields (develop port: stub. cascade branch では PositionSolution
+    // から populate される。 PPC pipeline の 70-col schema に対する forward-compat 拡張。)
+    bool initial_cascade_used = false;
+    int initial_cascade_wl_attempted = 0;
+    int initial_cascade_wl_fixed = 0;
+    int initial_cascade_n1_fixed = 0;
+    double initial_cascade_wl_acceptance_rate = std::numeric_limits<double>::quiet_NaN();
+    int initial_cascade_l5_pairs_attempted = 0;
+    int initial_cascade_l5_pairs_fixed = 0;
+    int initial_cascade_l5_cross_validation_rejects = 0;
+    bool final_cascade_used = false;
+    int final_cascade_wl_attempted = 0;
+    int final_cascade_wl_fixed = 0;
+    int final_cascade_n1_fixed = 0;
+    double final_cascade_wl_acceptance_rate = std::numeric_limits<double>::quiet_NaN();
+    int final_cascade_l5_pairs_attempted = 0;
+    int final_cascade_l5_pairs_fixed = 0;
+    int final_cascade_l5_cross_validation_rejects = 0;
+};
+
+void writeDiagnosticsHeader(std::ostream& out) {
+    out << "epoch_index,gps_week,tow,exact_base,interpolated_base,"
+        << "initial_valid,initial_status,initial_sats,initial_ratio,initial_pdop,"
+        << "initial_baseline_m,initial_residual_rms,initial_residual_abs_max,"
+        << "initial_update_rows,initial_suppressed_outliers,"
+        << "initial_has_glonass_icb_diag,initial_glonass_icb_l1,initial_glonass_icb_l2,"
+        << "initial_glonass_icb_l1_sigma,initial_glonass_icb_l2_sigma,"
+        << "initial_glonass_icb_l1_rows,initial_glonass_icb_l2_rows,"
+        << "initial_has_alt_lambda,initial_alt_lambda_rank,initial_alt_lambda_cost_ratio,"
+        << "initial_alt_lambda_x,initial_alt_lambda_y,initial_alt_lambda_z,"
+        << "initial_alt_lambda_dx,initial_alt_lambda_dy,initial_alt_lambda_dz,"
+        << "initial_alt_lambda_dnorm,initial_alt_lambda_candidates,"
+        << "initial_cascade_used,initial_cascade_wl_attempted,initial_cascade_wl_fixed,"
+        << "initial_cascade_n1_fixed,initial_cascade_wl_acceptance_rate,"
+        << "initial_cascade_l5_pairs_attempted,initial_cascade_l5_pairs_fixed,"
+        << "initial_cascade_l5_cross_validation_rejects,"
+        << "final_valid,final_status,final_sats,final_ratio,final_pdop,"
+        << "final_baseline_m,final_residual_rms,final_residual_abs_max,"
+        << "final_update_rows,final_suppressed_outliers,"
+        << "final_has_glonass_icb_diag,final_glonass_icb_l1,final_glonass_icb_l2,"
+        << "final_glonass_icb_l1_sigma,final_glonass_icb_l2_sigma,"
+        << "final_glonass_icb_l1_rows,final_glonass_icb_l2_rows,"
+        << "final_has_alt_lambda,final_alt_lambda_rank,final_alt_lambda_cost_ratio,"
+        << "final_alt_lambda_x,final_alt_lambda_y,final_alt_lambda_z,"
+        << "final_alt_lambda_dx,final_alt_lambda_dy,final_alt_lambda_dz,"
+        << "final_alt_lambda_dnorm,final_alt_lambda_candidates,"
+        << "final_cascade_used,final_cascade_wl_attempted,final_cascade_wl_fixed,"
+        << "final_cascade_n1_fixed,final_cascade_wl_acceptance_rate,"
+        << "final_cascade_l5_pairs_attempted,final_cascade_l5_pairs_fixed,"
+        << "final_cascade_l5_cross_validation_rejects,"
+        << "spp_valid,spp_sats,spp_pdop,candidate_vs_spp_m,candidate_jump_m,"
+        << "last_output_dt_s,nonfixed_jump_guard_m,drift_from_fixed_m,"
+        << "height_from_fixed_m,dt_since_fixed_s,fixed_drift_guard_m,"
+        << "fixed_height_guard_m,spp_replacement_used,output_added,rejection_reason\n";
+}
+
+// develop 用 fill: alt_lambda / glonass_icb は develop に存在せずスタブ
+void fillSolutionDiagnostics(const libgnss::PositionSolution& solution,
+                             bool& valid, int& status, int& sats,
+                             double& ratio, double& pdop, double& baseline_m,
+                             double& residual_rms, double& residual_abs_max,
+                             int& update_rows, int& suppressed_outliers) {
+    valid = solution.isValid();
+    status = static_cast<int>(solution.status);
+    sats = solution.num_satellites;
+    ratio = solution.ratio;
+    pdop = solution.pdop;
+    baseline_m = solution.baseline_length;
+    residual_rms = solution.rtk_update_post_suppression_residual_rms_m > 0.0
+                       ? solution.rtk_update_post_suppression_residual_rms_m
+                       : solution.residual_rms;
+    residual_abs_max = solution.rtk_update_post_suppression_residual_max_m;
+    update_rows = solution.rtk_update_observations;
+    suppressed_outliers = solution.rtk_update_suppressed_outliers;
+}
+
+void writeDiagnosticsRow(std::ostream& out, const EpochDiagnostics& d) {
+    const char* nan_str = "nan";
+    out << d.epoch_index << ','
+        << d.gps_week << ','
+        << std::fixed << std::setprecision(3) << d.tow << ','
+        << (d.exact_base ? 1 : 0) << ','
+        << (d.interpolated_base ? 1 : 0) << ','
+        << (d.initial_valid ? 1 : 0) << ','
+        << d.initial_status << ','
+        << d.initial_sats << ','
+        << std::setprecision(6) << d.initial_ratio << ','
+        << d.initial_pdop << ','
+        << d.initial_baseline_m << ','
+        << d.initial_residual_rms << ','
+        << d.initial_residual_abs_max << ','
+        << d.initial_update_rows << ','
+        << d.initial_suppressed_outliers << ','
+        // initial glonass_icb (stub: develop に無い)
+        << "0," << nan_str << "," << nan_str << "," << nan_str << "," << nan_str
+        << ",0,0,"
+        // initial alt_lambda (stub)
+        << "0,0," << nan_str << "," << nan_str << "," << nan_str << "," << nan_str
+        << "," << nan_str << "," << nan_str << "," << nan_str << "," << nan_str << ",,"
+        // initial cascade
+        << (d.initial_cascade_used ? 1 : 0) << ','
+        << d.initial_cascade_wl_attempted << ','
+        << d.initial_cascade_wl_fixed << ','
+        << d.initial_cascade_n1_fixed << ','
+        << d.initial_cascade_wl_acceptance_rate << ','
+        << d.initial_cascade_l5_pairs_attempted << ','
+        << d.initial_cascade_l5_pairs_fixed << ','
+        << d.initial_cascade_l5_cross_validation_rejects << ','
+        << (d.final_valid ? 1 : 0) << ','
+        << d.final_status << ','
+        << d.final_sats << ','
+        << d.final_ratio << ','
+        << d.final_pdop << ','
+        << d.final_baseline_m << ','
+        << d.final_residual_rms << ','
+        << d.final_residual_abs_max << ','
+        << d.final_update_rows << ','
+        << d.final_suppressed_outliers << ','
+        // final glonass_icb (stub)
+        << "0," << nan_str << "," << nan_str << "," << nan_str << "," << nan_str
+        << ",0,0,"
+        // final alt_lambda (stub)
+        << "0,0," << nan_str << "," << nan_str << "," << nan_str << "," << nan_str
+        << "," << nan_str << "," << nan_str << "," << nan_str << "," << nan_str << ",,"
+        // final cascade
+        << (d.final_cascade_used ? 1 : 0) << ','
+        << d.final_cascade_wl_attempted << ','
+        << d.final_cascade_wl_fixed << ','
+        << d.final_cascade_n1_fixed << ','
+        << d.final_cascade_wl_acceptance_rate << ','
+        << d.final_cascade_l5_pairs_attempted << ','
+        << d.final_cascade_l5_pairs_fixed << ','
+        << d.final_cascade_l5_cross_validation_rejects << ','
+        << (d.spp_valid ? 1 : 0) << ','
+        << d.spp_sats << ','
+        << d.spp_pdop << ','
+        << d.candidate_vs_spp_m << ','
+        << d.candidate_jump_m << ','
+        << d.last_output_dt_s << ','
+        << d.nonfixed_jump_guard_m << ','
+        << d.drift_from_fixed_m << ','
+        << d.height_from_fixed_m << ','
+        << d.dt_since_fixed_s << ','
+        << d.fixed_drift_guard_m << ','
+        << d.fixed_height_guard_m << ','
+        << (d.spp_replacement_used ? 1 : 0) << ','
+        << (d.output_added ? 1 : 0) << ','
+        << d.rejection_reason << '\n';
 }
 
 class EpochDebugWriter {
@@ -662,6 +862,11 @@ void printUsage(const char* program_name) {
         << "  --skip-epochs <n>          Skip the first n rover epochs before solving\n"
         << "  --max-epochs <n>           Stop after n rover epochs\n"
         << "  --debug-epoch-log <csv>    Write per-epoch AR/debug telemetry CSV\n"
+        << "  --prefer-trusted-seed      Prefer recent trusted/fixed solution as seed\n"
+        << "  --rover-seed-pos <file>    Inject ECEF seed positions from .pos file per epoch\n"
+        << "  --diagnostics-csv <file>   Write per-epoch RTK candidate diagnostics CSV (PPC pipeline format)\n"
+        << "  --rtk-update-outlier-threshold <v>\n"
+        << "                             Outlier rejection threshold for RTK measurement update (default: 30.0)\n"
         << "  --no-kinematic-post-filter Disable the kinematic output post-filter\n"
         << "  --no-base-interp           Require exact rover/base epoch alignment\n"
         << "  --verbose                  Print per-epoch progress summary\n"
@@ -898,6 +1103,13 @@ SolveConfig parseArguments(int argc, char* argv[]) {
             config.enable_glonass = false;
         } else if (arg == "--no-beidou") {
             config.enable_beidou = false;
+        } else if (arg == "--enable-l5") {
+            // Phase 18 Step 3: opt-in L5 measurement collection. Default off — when off,
+            // L5 obs are still placed in the L2 slot (legacy fallback for L5-only receivers).
+            // When on, L5-class obs are collected into a dedicated SatelliteData.l5_* slot
+            // and the L2 slot only carries true L2 signals. Step 4+ will add filter
+            // measurement updates / cycle slip handling for L5.
+            config.enable_l5 = true;
         } else if (arg == "--glonass-ar" && i + 1 < argc) {
             config.glonass_ar = parseGlonassARChoice(argv[++i], argv[0]);
         } else if (arg == "--glonass-icb-l1" && i + 1 < argc) {
@@ -1055,6 +1267,14 @@ SolveConfig parseArguments(int argc, char* argv[]) {
             config.max_epochs = std::stoi(argv[++i]);
         } else if (arg == "--debug-epoch-log" && i + 1 < argc) {
             config.debug_epoch_log_path = argv[++i];
+        } else if (arg == "--prefer-trusted-seed") {
+            config.prefer_trusted_seed = true;
+        } else if (arg == "--rover-seed-pos" && i + 1 < argc) {
+            config.rover_seed_pos_path = argv[++i];
+        } else if (arg == "--diagnostics-csv" && i + 1 < argc) {
+            config.diagnostics_csv_path = argv[++i];
+        } else if (arg == "--rtk-update-outlier-threshold" && i + 1 < argc) {
+            config.rtk_update_outlier_threshold = std::stod(argv[++i]);
         } else if (arg == "--no-kinematic-post-filter") {
             config.enable_kinematic_post_filter = false;
         } else if (arg == "--no-base-interp") {
@@ -1370,15 +1590,57 @@ bool writeSolutions(const SolveConfig& config, const libgnss::Solution& solution
     return true;
 }
 
+double roundedTowKey(double tow) {
+    return std::round(tow * 10.0) / 10.0;
+}
+
+std::map<double, Eigen::Vector3d> loadSeedPositions(const std::string& path) {
+    std::ifstream input(path);
+    if (!input.is_open()) {
+        throw std::runtime_error("failed to open rover seed .pos: " + path);
+    }
+    std::map<double, Eigen::Vector3d> out;
+    std::string line;
+    while (std::getline(input, line)) {
+        if (line.empty() || line[0] == '%') continue;
+        std::istringstream iss(line);
+        double week = 0.0;
+        double tow = 0.0;
+        double x = 0.0;
+        double y = 0.0;
+        double z = 0.0;
+        if (!(iss >> week >> tow >> x >> y >> z)) continue;
+        Eigen::Vector3d pos(x, y, z);
+        if (std::isfinite(tow) && pos.allFinite() && pos.norm() > 1e6) {
+            out[roundedTowKey(tow)] = pos;
+        }
+    }
+    if (out.empty()) {
+        throw std::runtime_error("rover seed .pos contained no usable ECEF rows: " + path);
+    }
+    return out;
+}
+
 }  // namespace
 
 int main(int argc, char* argv[]) {
     try {
         const SolveConfig config = parseArguments(argc, argv);
 
+        const std::map<double, Eigen::Vector3d> rover_seed_positions =
+            config.rover_seed_pos_path.empty()
+                ? std::map<double, Eigen::Vector3d>{}
+                : loadSeedPositions(config.rover_seed_pos_path);
+
         libgnss::RTKProcessor rtk_processor;
         libgnss::SPPProcessor spp_processor;
         libgnss::RTKProcessor::RTKConfig rtk_config;
+        rtk_config.prefer_trusted_position_seed = config.prefer_trusted_seed;
+        rtk_config.prefer_rover_position_seed =
+            config.prefer_trusted_seed || !rover_seed_positions.empty();
+        if (config.rtk_update_outlier_threshold > 0.0) {
+            rtk_config.outlier_threshold = config.rtk_update_outlier_threshold;
+        }
         rtk_config.max_baseline_length = config.max_baseline_length_m;
         rtk_config.ar_mode = libgnss::RTKProcessor::RTKConfig::AmbiguityResolutionMode::CONTINUOUS;
         rtk_config.ratio_threshold = config.ratio_threshold;
@@ -1427,6 +1689,7 @@ int main(int argc, char* argv[]) {
         rtk_config.ionoopt = resolveIonoOpt(config, rtk_config.position_mode);
         rtk_config.enable_glonass = config.enable_glonass;
         rtk_config.enable_beidou = config.enable_beidou;
+        rtk_config.enable_l5 = config.enable_l5;  // Phase 18 Step 3
         rtk_config.glonass_ar_mode =
             config.glonass_ar == GlonassARChoice::AUTOCAL
                 ? libgnss::RTKProcessor::RTKConfig::GlonassARMode::AUTOCAL
@@ -1495,6 +1758,17 @@ int main(int argc, char* argv[]) {
             return 1;
         }
 
+        std::ofstream diagnostics_csv;
+        if (!config.diagnostics_csv_path.empty()) {
+            diagnostics_csv.open(config.diagnostics_csv_path);
+            if (!diagnostics_csv.is_open()) {
+                std::cerr << "Error: failed to open diagnostics CSV: "
+                          << config.diagnostics_csv_path << std::endl;
+                return 1;
+            }
+            writeDiagnosticsHeader(diagnostics_csv);
+        }
+
         std::cout << "libgnss++ post-process solver" << std::endl;
         std::cout << "  rover: " << config.rover_obs_path << std::endl;
         std::cout << "  base: " << config.base_obs_path << std::endl;
@@ -1510,7 +1784,8 @@ int main(int argc, char* argv[]) {
                   << " (requested " << ionoChoiceString(config.iono) << ")" << std::endl;
         std::cout << "  carrier constellations: GLONASS "
                   << (rtk_config.enable_glonass ? "on" : "off")
-                  << ", BeiDou " << (rtk_config.enable_beidou ? "on" : "off") << std::endl;
+                  << ", BeiDou " << (rtk_config.enable_beidou ? "on" : "off")
+                  << ", L5 " << (rtk_config.enable_l5 ? "on" : "off") << std::endl;
         std::cout << "  GLONASS AR: " << glonassARChoiceString(config.glonass_ar)
                   << " (L1 ICB " << config.glonass_icb_l1_m_per_mhz
                   << " m/MHz, L2 ICB " << config.glonass_icb_l2_m_per_mhz << " m/MHz)"
@@ -1680,6 +1955,14 @@ int main(int argc, char* argv[]) {
                 continue;
             }
 
+            if (!rover_seed_positions.empty()) {
+                const auto seed_it =
+                    rover_seed_positions.find(roundedTowKey(rover_obs.time.tow));
+                if (seed_it != rover_seed_positions.end()) {
+                    rover_obs.receiver_position = seed_it->second;
+                }
+            }
+
             auto pos_solution = rtk_processor.processRTKEpoch(rover_obs, aligned_base_obs, nav_data);
             const libgnss::PositionSolution* last_output = solution.getLastSolution();
             const bool have_last_output = last_output != nullptr && last_output->isValid();
@@ -1756,6 +2039,27 @@ int main(int argc, char* argv[]) {
             }
 
             debug_writer.write(pos_solution, rtk_processor.getLastDebugTelemetry());
+
+            if (diagnostics_csv.is_open()) {
+                EpochDiagnostics diag;
+                diag.epoch_index = static_cast<int>(processed_rover_epochs);
+                diag.gps_week = rover_obs.time.week;
+                diag.tow = rover_obs.time.tow;
+                diag.exact_base = !used_interpolated_base;
+                diag.interpolated_base = used_interpolated_base;
+                fillSolutionDiagnostics(pos_solution,
+                    diag.initial_valid, diag.initial_status, diag.initial_sats,
+                    diag.initial_ratio, diag.initial_pdop, diag.initial_baseline_m,
+                    diag.initial_residual_rms, diag.initial_residual_abs_max,
+                    diag.initial_update_rows, diag.initial_suppressed_outliers);
+                fillSolutionDiagnostics(pos_solution,
+                    diag.final_valid, diag.final_status, diag.final_sats,
+                    diag.final_ratio, diag.final_pdop, diag.final_baseline_m,
+                    diag.final_residual_rms, diag.final_residual_abs_max,
+                    diag.final_update_rows, diag.final_suppressed_outliers);
+                diag.output_added = pos_solution.isValid();
+                writeDiagnosticsRow(diagnostics_csv, diag);
+            }
 
             if (pos_solution.isValid()) {
                 solution.addSolution(pos_solution);

--- a/include/libgnss++/algorithms/float_trust_policy.hpp
+++ b/include/libgnss++/algorithms/float_trust_policy.hpp
@@ -1,0 +1,139 @@
+#pragma once
+
+// WP9: graceful degradation of the RTK float filter's per-epoch
+// position-trust/reseed policy (see RTKProcessor::resetPositionToSPP() /
+// rememberSolution() in rtk.cpp). WP8's canyon forensics found the
+// root cause of the ~119 m float divergence in urban canyons: every
+// epoch that fails to "refresh trust" (rtk.cpp:3747-3762 -- FIXED, or
+// FLOAT with >=5 sats and a small jump vs the last trusted position)
+// gets its position covariance reset to a wide 900 m^2/axis prior and
+// reseeded from a fresh, possibly NLOS-corrupted SPP fix.
+//
+// This header holds the pure, unit-testable math for two opt-in
+// alternatives to that unconditional wide reset, selected via
+// RTKConfig::float_trust_policy (default LEGACY, bit-identical to
+// pre-WP9 behavior):
+//
+// - CV_PREDICT: propagate the previous position with a constant-velocity
+//   predict instead of reseeding from SPP, and grow the position
+//   covariance by a process-noise rate (trust_lapse_qpos_m2_per_s)
+//   instead of jumping straight to 900 m^2/axis.
+// - SCALED_RESET: keep the SPP reseed, but scale the reset variance with
+//   how long trust has been lapsed instead of using a flat 900.
+// - LAPSE_GATED (WP10): the SCALED_RESET law regressed run2/run3 because
+//   its dt=0 variance (25 m^2) is tighter than legacy's 900 m^2 for
+//   *every* lapse, however short/benign. LAPSE_GATED makes this
+//   conditional: while the continuous trust lapse is shorter than
+//   trust_lapse_gate_s, behave EXACTLY like LEGACY (falls through to the
+//   unmodified wide-reset branch in resetPositionToSPP() -- bit-identical
+//   below the gate by construction, not just numerically close); once the
+//   lapse's duration exceeds the gate, switch to the SCALED_RESET law.
+//   The lapse duration is "time since the position last refreshed trust"
+//   (dt_since_trust in resetPositionToSPP()), which is naturally reset to
+//   ~0 every time rememberSolution() refreshes last_trusted_time_ -- no
+//   separate clock/counter state is needed. See lapseGateExceeded() below.
+//
+// All three non-LEGACY policies are capped at the legacy 900 m^2/axis
+// value once engaged, so behavior is bounded-divergent from legacy by
+// construction under a long enough trust drought, and all are strict
+// no-ops (LEGACY code path taken unconditionally) whenever the previous
+// epoch actually refreshed trust -- i.e. on every epoch of a healthy
+// segment, matching WP8's own framing that this should only engage
+// during a trust drought. LAPSE_GATED goes one step further: it is also
+// a strict no-op (LEGACY path) for any *short* trust lapse below its
+// gate, which is exactly the WP10 fix for SCALED_RESET's run2/run3
+// regression (see WP10_REPORT.md).
+//
+// Everything here is a free function over plain doubles/Eigen vectors --
+// no RTK-specific types (GNSSTime, SatelliteId, ...) -- mirroring
+// nlos_weights.hpp's separation of pure math from RTKProcessor wiring.
+
+#include <Eigen/Dense>
+
+namespace libgnss {
+namespace float_trust_policy {
+
+/// Selects which policy resetPositionToSPP() uses once trust has lapsed.
+/// LEGACY (default) never consults any of the functions below --
+/// RTKProcessor's existing unconditional wide-reset code path runs
+/// unchanged, so this is bit-identical to pre-WP9 behavior.
+enum class FloatTrustPolicy {
+    LEGACY = 0,
+    CV_PREDICT = 1,
+    SCALED_RESET = 2,
+    /// WP10: SCALED_RESET, but only once a continuous trust lapse exceeds
+    /// a configured gate (RTKConfig::trust_lapse_gate_s); below the gate,
+    /// behaves exactly like LEGACY. See lapseGateExceeded().
+    LAPSE_GATED = 3,
+};
+
+/// True when "trust" has lapsed, i.e. graceful degradation should engage
+/// instead of the legacy unconditional wide reset.
+///
+/// ``has_last_trusted`` is whether any trusted position/time has ever
+/// been recorded at all (false only very early in a run, before the
+/// first FIXED/good-FLOAT solution). ``trust_refreshed_last_epoch`` is
+/// whether the immediately preceding *processed* epoch specifically
+/// refreshed trust (i.e. the caller's own last_trusted_time_ equals its
+/// last_epoch_time_) -- trust "lapses" the moment one epoch fails to
+/// refresh it, matching WP8's framing of a self-reinforcing drought that
+/// starts as soon as trust-refresh opportunities dry up.
+bool hasTrustLapsed(bool has_last_trusted, bool trust_refreshed_last_epoch);
+
+/// CV_PREDICT: grows a previous per-axis position variance by a
+/// process-noise rate (``qpos_m2_per_s``, m^2/s) integrated over ``dt_s``
+/// seconds, capped at ``legacy_var_m2`` (900 by construction) so a long
+/// enough trust drought converges to the same wide prior legacy always
+/// uses. Non-finite/negative inputs are clamped defensively (previous
+/// variance defaults to the legacy cap; qpos/dt default to 0, i.e. no
+/// growth) rather than propagating NaN into the filter.
+double growPositionVarianceCvPredict(double previous_var_m2,
+                                      double qpos_m2_per_s,
+                                      double dt_s,
+                                      double legacy_var_m2);
+
+/// SCALED_RESET: reset variance that grows *quadratically* with how long
+/// trust has been lapsed (``dt_since_trust_s``), starting from a tight
+/// ``base_var_m2`` (25 m^2/axis, matching the existing trusted-seed tight
+/// variance) and capped at ``legacy_var_m2``. Matches the task-specified
+/// formula ``var_pos = min(900, base + qpos * dt^2)``.
+double scaledResetPositionVariance(double base_var_m2,
+                                    double qpos_m2_per_s,
+                                    double dt_since_trust_s,
+                                    double legacy_var_m2);
+
+/// Two-point finite-difference ECEF velocity estimate from the last two
+/// *trusted* position samples (the task's "last N trusted deltas" source,
+/// N=2 here -- documented in WP9_REPORT.md). Returns zero velocity
+/// (caller should then just hold position) when ``dt_s`` is non-finite,
+/// non-positive, or implausibly large (> ``max_dt_s``, i.e. the two
+/// trusted samples are too far apart in time to give a meaningful
+/// instantaneous-velocity estimate), or either position is non-finite.
+Eigen::Vector3d estimateVelocityFromTrustedDeltas(const Eigen::Vector3d& newer_position,
+                                                   const Eigen::Vector3d& older_position,
+                                                   double dt_s,
+                                                   double max_dt_s);
+
+/// Constant-velocity position predict: propagates ``previous_position``
+/// by ``velocity_mps`` (ECEF, m/s) over ``dt_s`` seconds. Falls back to
+/// holding ``previous_position`` unchanged (zero-velocity CV predict) if
+/// either input is non-finite.
+Eigen::Vector3d predictPositionConstantVelocity(const Eigen::Vector3d& previous_position,
+                                                 const Eigen::Vector3d& velocity_mps,
+                                                 double dt_s);
+
+/// WP10 LAPSE_GATED boundary test: true once a continuous trust lapse of
+/// ``dt_since_trust_s`` seconds has reached or exceeded ``gate_s``
+/// seconds, i.e. the caller should switch from LEGACY's flat 900 m^2/axis
+/// reset to the SCALED_RESET law for this epoch. The boundary is
+/// inclusive (``dt_since_trust_s == gate_s`` returns true) so a gate of
+/// exactly 0 s means "always use the scaled law once trust has lapsed at
+/// all", the natural degenerate case swept at the low end of a gate grid.
+/// Non-finite/negative inputs are clamped to 0 (a non-finite/negative
+/// elapsed lapse duration is defensively treated as "no lapse yet" and a
+/// non-finite/negative gate as "trigger immediately"), matching this
+/// module's existing defensive-clamping convention.
+bool lapseGateExceeded(double dt_since_trust_s, double gate_s);
+
+}  // namespace float_trust_policy
+}  // namespace libgnss

--- a/include/libgnss++/algorithms/nlos_weights.hpp
+++ b/include/libgnss++/algorithms/nlos_weights.hpp
@@ -1,0 +1,130 @@
+#pragma once
+
+// WP7: optional per-epoch, per-satellite LOS/NLOS soft-weighting for the RTK
+// measurement update. The weight source is external (e.g. a PLATEAU 3D-mesh
+// BVH ray-trace mask, see experiments/build_per_epoch_nlos_csv.py in the
+// parent gnss_gpu repo) and is loaded from a small CSV contract:
+//
+//   tow,sat,los_prob
+//   187470.000,G01,1.0
+//   187470.000,G14,0.0
+//
+// ``los_prob`` in [0, 1]: 1.0 = confident line-of-sight, 0.0 = confident
+// non-line-of-sight (NLOS/multipath). Missing (tow, sat) pairs default to
+// los_prob = 1.0 (LOS, no inflation) so a partial mask never *hides*
+// satellites, it only ever down-weights the ones it has evidence for.
+//
+// Everything here is a free function / value type — no file I/O happens
+// inside RTKProcessor itself, so RTKConfig (copied by value all over the
+// existing CLI apps) stays POD-simple. Callers (apps/gnss_solve.cpp) load
+// the table once via loadNlosWeightsCsv() and hand a shared_ptr to
+// RTKProcessor::setNlosWeightTable().
+
+#include <map>
+#include <string>
+
+namespace libgnss {
+namespace nlos_weights {
+
+/// Sigma-inflation mapping applied to a per-satellite LOS probability.
+/// OFF (default) is always a no-op, independent of whether a weight table
+/// is loaded — this is what keeps the feature bit-identical when unused.
+enum class NlosWeightMode {
+    OFF = 0,
+    TWO_TIER = 1,
+    CONTINUOUS = 2,
+    /// WP8: hard exclusion. Satellites with los_prob below
+    /// nlos_exclude_threshold are dropped from DD formation entirely
+    /// (rather than down-weighted) — see nlosShouldExclude() /
+    /// nlosExclusionGuardAllows() and RTKProcessor::buildSelectionSnapshot(),
+    /// the single function both the float KF (buildMeasurementBlocks()) and
+    /// the AR candidate set (buildDoubleDifferencePairs()) call, so
+    /// filtering there applies identically to both consumers.
+    EXCLUDE = 3,
+};
+
+/// Per-epoch, per-satellite LOS-probability table.
+///
+/// Keyed by ``tow`` (seconds, ascending) -> {satellite id string -> los_prob}.
+/// Lookup tolerates small tow mismatches (receiver logging jitter) via
+/// ``lookupLosProb``'s tolerance parameter, mirroring
+/// ``gnss_gpu.nlos_mask.lookup_nlos_sets`` in the Python asset-generation
+/// pipeline this table is usually built from.
+struct NlosWeightTable {
+    std::map<double, std::map<std::string, double>> by_tow;
+
+    bool empty() const { return by_tow.empty(); }
+};
+
+/// Parses a ``tow,sat,los_prob`` (or the equivalent ``tow,epoch_idx,prn,
+/// is_los,...`` extended contract emitted by build_per_epoch_nlos_csv.py)
+/// CSV file. Column matching is header-driven and case-insensitive; extra
+/// columns are ignored. Throws std::runtime_error if the file cannot be
+/// opened or the header is missing a usable satellite/tow/probability
+/// column triple.
+NlosWeightTable loadNlosWeightsCsv(const std::string& path);
+
+/// Resolves the LOS probability for one (tow, satellite) pair.
+/// Returns 1.0 (LOS, no inflation) when the table is empty or no entry is
+/// found within ``tow_tolerance_s`` of ``tow`` for ``sat_id``.
+double lookupLosProb(const NlosWeightTable& table,
+                      double tow,
+                      const std::string& sat_id,
+                      double tow_tolerance_s);
+
+/// Maps a LOS probability to a measurement *variance* (sigma^2) multiplier
+/// (always >= 1.0; 1.0 = no-op).
+///
+/// - OFF: always 1.0, regardless of los_prob.
+/// - TWO_TIER: los_prob < two_tier_los_threshold -> two_tier_inflation^2,
+///   else 1.0. Simple binary classification, matching the existing
+///   LOS/NLOS mask contract (is_los in {0, 1}).
+/// - CONTINUOUS: 1 / max(los_prob, floor), i.e. sigma *= 1 / sqrt(max(los_prob,
+///   floor)) (the mapping suggested by the WP7 task spec). Degrades to a
+///   TWO_TIER-like step for binary los_prob inputs when floor is small.
+double nlosVarianceInflationFactor(double los_prob,
+                                    NlosWeightMode mode,
+                                    double continuous_floor,
+                                    double two_tier_los_threshold,
+                                    double two_tier_sigma_inflation);
+
+/// WP8 hard-exclusion per-satellite decision: true when ``mode ==
+/// EXCLUDE`` and ``los_prob`` is strictly below ``exclude_threshold``.
+/// Always false for every other mode (OFF/TWO_TIER/CONTINUOUS never
+/// exclude, only inflate-or-not) and false for a non-finite ``los_prob``
+/// (missing/unclassified satellites are never excluded, mirroring
+/// lookupLosProb()'s "default to LOS" behavior). This is a pure,
+/// per-satellite building block — the two epoch-level safety guards
+/// (minimum surviving satellite count, never dropping a system's last
+/// reference-satellite candidate) are applied by the caller; see
+/// nlosExclusionGuardAllows() for the first guard and
+/// RTKProcessor::buildSelectionSnapshot() (rtk.cpp) for both, plugged in
+/// upstream of both DD-formation consumers.
+bool nlosShouldExclude(double los_prob, NlosWeightMode mode, double exclude_threshold);
+
+/// WP8 exclusion safety guard ("--nlos-min-sats"): given how many
+/// satellites are in the epoch's full candidate set (``total_sats``) and
+/// how many the per-satellite threshold test (nlosShouldExclude) marked
+/// for exclusion (``excluded_count``), returns whether exclusion should
+/// actually be applied this epoch. Returns false (guard trips, caller
+/// keeps every satellite, i.e. exclusion is skipped for that epoch) when
+/// nothing was marked for exclusion, or when excluding would leave fewer
+/// than ``min_sats`` satellites remaining — never degrade geometry below
+/// solvability for the sake of dropping NLOS satellites.
+bool nlosExclusionGuardAllows(int total_sats, int excluded_count, int min_sats);
+
+/// WP10 (WP8 recommendation 2, "--nlos-min-los-sats"): AR-acceptance-side
+/// gate, independent of and orthogonal to EXCLUDE mode -- this never
+/// removes satellites from the float-KF measurement update, it only
+/// vetoes *attempting/accepting* an ambiguity-resolution fix for the
+/// epoch when too few of the AR candidate set's satellites are
+/// LOS-flagged. Returns true (AR may proceed) when ``min_los_sats <= 0``
+/// (disabled, the default) or when ``los_sat_count >= min_los_sats``.
+/// The caller (RTKProcessor::resolveAmbiguities()) is responsible for
+/// counting ``los_sat_count`` over the unique satellites already present
+/// in the AR candidate set's DD pairs -- this function is the pure,
+/// unit-testable threshold comparison only.
+bool nlosMinLosSatsGateAllows(int los_sat_count, int min_los_sats);
+
+}  // namespace nlos_weights
+}  // namespace libgnss

--- a/include/libgnss++/algorithms/rtk.hpp
+++ b/include/libgnss++/algorithms/rtk.hpp
@@ -74,6 +74,14 @@ public:
         };
         PositionMode position_mode = PositionMode::KINEMATIC;
 
+        // Initial-position seed sources (default off preserves legacy SPP-only seed).
+        // When prefer_trusted_position_seed is set, kinematic re-seeds prefer the
+        // most recent trusted/fixed solution (within a 1s window) over an SPP fix.
+        // When prefer_rover_position_seed is set, the rover RINEX header position
+        // (if magnitude > 1e6 m, i.e. real ECEF) is used before SPP.
+        bool prefer_trusted_position_seed = false;
+        bool prefer_rover_position_seed = false;
+
         // Kalman filter parameters
         double process_noise_position = 1e-4;       // m^2/s for static baseline
         double process_noise_ambiguity = 1e-8;    // cycles^2/s (very small - ambiguities are constant)
@@ -110,6 +118,12 @@ public:
         bool enable_beidou = true;
         double glonass_icb_l1_m_per_mhz = 0.0;
         double glonass_icb_l2_m_per_mhz = 0.0;
+
+        // Phase 18 Step 3: enable L5 measurement collection.
+        // When false (default), collectSatelliteData populates only L1/L2 — L5 obs are ignored.
+        // When true, L5-class obs (GPS_L5/QZS_L5/GAL_E5A/BDS_B2A) are populated into
+        // SatelliteData.l5_* fields. Step 4+ will add residual/Jacobian/cycle-slip handling.
+        bool enable_l5 = false;
 
         /// AR policy gate.
         /// EXTENDED (default): all hold/subset/fallback/regularization extras active.
@@ -337,12 +351,17 @@ public:
         int gf_slip_count = 0;
         int doppler_slip_l1_count = 0;
         int doppler_slip_l2_count = 0;
+        int doppler_slip_l5_count = 0;  // Phase 18 Step 5
         int code_slip_l1_count = 0;
         int code_slip_l2_count = 0;
+        int code_slip_l5_count = 0;  // Phase 18 Step 5
         int lli_slip_l1_count = 0;
         int lli_slip_l2_count = 0;
+        int lli_slip_l5_count = 0;  // Phase 18 Step 5
         int ambiguity_reset_l1_count = 0;
         int ambiguity_reset_l2_count = 0;
+        int ambiguity_reset_l5_count = 0;  // Phase 18 Step 5
+        int gf_slip_l1l5_count = 0;       // Phase 18 Step 5: GF combination L1-L5
         bool adaptive_dynamic_slip_active = false;
         int consecutive_nonfix_before_bias_update = 0;
         int adaptive_dynamic_slip_hold_remaining = 0;
@@ -435,7 +454,10 @@ private:
     Vector3d base_position_;
     bool base_position_known_ = false;
 
-    // Fixed-size state: [pos(3), glo_hw_bias(2), iono(MAXSAT), N1(MAXSAT), N2(MAXSAT)]
+    // Fixed-size state: [pos(3), glo_hw_bias(2), iono(MAXSAT), N1(MAXSAT), N2(MAXSAT), N5(MAXSAT)]
+    // Phase 18 Step 2 (2026-05-09): N5 freq slot reserved (IB(sat, freq=2)).
+    // Currently N5 entries stay 0 / unconfirmed; populated by Steps 3+ when L5 enabled.
+    // Existing L1/L2-only path is unchanged: N5 slots default to 0 with zero covariance.
     // Satellite slots are system-aware so G01/E01/Q01 do not collide.
     static constexpr int BASE_STATES = 3;
     static constexpr int GLO_HWBIAS_STATES = 2;
@@ -444,7 +466,8 @@ private:
     static constexpr int MAXSAT = SATS_PER_SYSTEM * SUPPORTED_SYSTEM_BLOCKS;
     static constexpr int REAL_STATES = BASE_STATES + GLO_HWBIAS_STATES;
     static constexpr int IONO_STATES = MAXSAT;
-    static constexpr int NX = REAL_STATES + IONO_STATES + MAXSAT * 2;  // total state size
+    static constexpr int FREQ_SLOTS = 3;  // L1, L2, L5 (Phase 18 Step 2)
+    static constexpr int NX = REAL_STATES + IONO_STATES + MAXSAT * FREQ_SLOTS;  // total state size
 
     static int systemSlotBase(GNSSSystem system) {
         switch (system) {
@@ -484,6 +507,9 @@ private:
         std::map<SatelliteId, int> iono_indices;
         std::map<SatelliteId, int> n1_indices;
         std::map<SatelliteId, int> n2_indices;
+        // Phase 18 Step 2: N5 ambiguity index map (parallel to n1/n2_indices).
+        // Populated only when L5 measurements present (Step 3+); remains empty for L1/L2-only path.
+        std::map<SatelliteId, int> n5_indices;
         int next_state_idx = BASE_STATES;
     };
 
@@ -493,6 +519,8 @@ private:
     // Lock count per satellite per frequency (for AR eligibility)
     std::map<SatelliteId, int> lock_count_l1_;
     std::map<SatelliteId, int> lock_count_l2_;
+    // Phase 18 Step 2: L5 lock count (parallel to L1/L2). Stays empty in L1/L2-only path.
+    std::map<SatelliteId, int> lock_count_l5_;
 
     // Reference satellite tracking
     SatelliteId current_ref_satellite_;
@@ -590,10 +618,13 @@ private:
         SatelliteId satellite;
         SignalType l1_signal = SignalType::GPS_L1CA;
         SignalType l2_signal = SignalType::GPS_L2C;
+        SignalType l5_signal = SignalType::GPS_L5;
         double l1_wavelength = 0.0;
         double l2_wavelength = 0.0;
+        double l5_wavelength = 0.0;
         double l1_frequency_hz = 0.0;
         double l2_frequency_hz = 0.0;
+        double l5_frequency_hz = 0.0;
         // L1
         double rover_l1_phase = 0.0;  // cycles
         double rover_l1_code = 0.0;   // meters
@@ -618,6 +649,18 @@ private:
         bool has_l2 = false;
         bool has_l2_doppler = false;
         int l2_lli = 0;
+        // L5 (Phase 18 — populated when --enable-l5 set; default off, no effect on L1/L2 path)
+        double rover_l5_phase = 0.0;
+        double rover_l5_code = 0.0;
+        double rover_l5_doppler = 0.0;
+        double rover_l5_snr = 0.0;
+        double base_l5_phase = 0.0;
+        double base_l5_code = 0.0;
+        double base_l5_doppler = 0.0;
+        double base_l5_snr = 0.0;
+        bool has_l5 = false;
+        bool has_l5_doppler = false;
+        int l5_lli = 0;
         // Geometry
         Vector3d sat_pos;          // satellite position for rover (RTKLIB satposs from rover PR)
         Vector3d sat_pos_base;     // satellite position for base (RTKLIB satposs from base PR)
@@ -629,10 +672,13 @@ private:
     // Current epoch satellite data (cached for use across functions)
     std::map<SatelliteId, SatelliteData> current_sat_data_;
     std::map<SatelliteId, double> gf_l1l2_history_;
+    std::map<SatelliteId, double> gf_l1l5_history_;  // Phase 18 Step 5: GF L1-L5 combination
     std::map<SatelliteId, double> doppler_phase_history_l1_m_;
     std::map<SatelliteId, double> doppler_phase_history_l2_m_;
+    std::map<SatelliteId, double> doppler_phase_history_l5_m_;  // Phase 18 Step 5
     std::map<SatelliteId, double> code_phase_history_l1_m_;
     std::map<SatelliteId, double> code_phase_history_l2_m_;
+    std::map<SatelliteId, double> code_phase_history_l5_m_;  // Phase 18 Step 5
 
     /**
      * Collect all satellite data for an epoch (L1+L2 for rover and base)
@@ -755,6 +801,7 @@ private:
      */
     int getOrCreateN1Index(const SatelliteId& sat, double initial_value);
     int getOrCreateN2Index(const SatelliteId& sat, double initial_value);
+    int getOrCreateN5Index(const SatelliteId& sat, double initial_value);  // Phase 18 Step 4
     int getOrCreateIonoIndex(const SatelliteId& sat, double initial_value);
 
     bool selectSystemReferenceSatellite(const std::map<SatelliteId, SatelliteData>& sat_data,

--- a/include/libgnss++/algorithms/rtk.hpp
+++ b/include/libgnss++/algorithms/rtk.hpp
@@ -4,6 +4,8 @@
 #include "../core/observation.hpp"
 #include "../core/navigation.hpp"
 #include "../core/solution.hpp"
+#include "nlos_weights.hpp"
+#include "float_trust_policy.hpp"
 #include "rtk_measurement.hpp"
 #include "rtk_selection.hpp"
 #include "rtk_slip_detection.hpp"
@@ -11,6 +13,7 @@
 #include "spp.hpp"
 #include <Eigen/Dense>
 #include <limits>
+#include <memory>
 #include <mutex>
 #include <set>
 #include <string>
@@ -296,6 +299,99 @@ public:
 
         /// Max pairs to drop progressively in BSR-guided decimation.
         int bsr_guided_max_drop_steps = 6;
+
+        /// WP7: NLOS/multipath measurement-weighting sigma-inflation mapping.
+        /// OFF (default) preserves pre-WP7 behavior bit-for-bit — the lookup
+        /// table injected via setNlosWeightTable() is never consulted, even
+        /// if one is set. Enable with --nlos-weight-mode {two-tier,continuous}
+        /// in gnss_solve (requires --nlos-weights <csv>).
+        nlos_weights::NlosWeightMode nlos_weight_mode = nlos_weights::NlosWeightMode::OFF;
+
+        /// TWO_TIER: satellites with los_prob below this are treated as NLOS
+        /// and get nlos_two_tier_sigma_inflation applied to sigma.
+        double nlos_two_tier_los_threshold = 0.5;
+
+        /// TWO_TIER: sigma multiplier applied to NLOS-classified satellites
+        /// (variance multiplier is this value squared). >= 1.0.
+        double nlos_two_tier_sigma_inflation = 3.0;
+
+        /// CONTINUOUS: floor applied to los_prob before the 1/sqrt(...) sigma
+        /// mapping, so a satellite with los_prob == 0 still gets a finite
+        /// (if large) sigma inflation instead of infinite.
+        double nlos_continuous_los_prob_floor = 0.05;
+
+        /// Tolerance (seconds) used when matching the current epoch's tow
+        /// against the NLOS weight table's tow keys.
+        double nlos_tow_tolerance_s = 0.05;
+
+        /// WP8: EXCLUDE mode threshold — satellites with los_prob strictly
+        /// below this are dropped from DD formation entirely (both the
+        /// float KF and the AR candidate set), instead of just having their
+        /// sigma inflated. No effect unless nlos_weight_mode == EXCLUDE.
+        double nlos_exclude_threshold = 0.5;
+
+        /// WP8: EXCLUDE mode safety guard — if excluding NLOS satellites
+        /// this epoch would leave fewer than this many satellites in the
+        /// candidate set, skip exclusion for the epoch entirely (keep every
+        /// satellite) rather than degrade geometry below solvability.
+        int nlos_min_sats = 5;
+
+        /// WP9: float-filter trust/reset policy. LEGACY (default) preserves
+        /// resetPositionToSPP()'s pre-WP9 unconditional wide-reset-unless-
+        /// trusted behavior bit-for-bit. See float_trust_policy.hpp for the
+        /// CV_PREDICT/SCALED_RESET math and rtk.cpp's resetPositionToSPP()
+        /// for the wiring; both alternate policies only ever engage once
+        /// trust has lapsed (float_trust_policy::hasTrustLapsed()), so they
+        /// are a strict no-op on every epoch of a healthy segment.
+        float_trust_policy::FloatTrustPolicy float_trust_policy =
+            float_trust_policy::FloatTrustPolicy::LEGACY;
+
+        /// WP9: process-noise rate (m^2/s) used by both CV_PREDICT (linear
+        /// covariance growth per second of elapsed dt) and SCALED_RESET
+        /// (quadratic growth in time-since-trust). No effect when
+        /// float_trust_policy == LEGACY.
+        double trust_lapse_qpos_m2_per_s = 10.0;
+
+        /// WP9 optional lever: relax rememberSolution()'s FLOAT trust-
+        /// refresh jump gate (rtk.cpp, "refresh_trusted = trusted_jump <=
+        /// max(3.0, 6.0*dt)") by 2x when more than half of this epoch's
+        /// tracked satellites are NLOS-flagged per the loaded NLOS weight
+        /// table. false (default) is a no-op; also has no effect unless a
+        /// weight table has been injected via setNlosWeightTable(),
+        /// independent of nlos_weight_mode (this lever only reads the
+        /// table's LOS/NLOS classification, it does not require sigma
+        /// inflation/exclusion to also be enabled).
+        bool trust_gate_nlos_relax = false;
+
+        /// WP10: gate (seconds) used by float_trust_policy == LAPSE_GATED.
+        /// Below this many seconds of continuous trust lapse, resetPositionToSPP()
+        /// behaves exactly like LEGACY; at or beyond it, SCALED_RESET's law
+        /// (base 25 m^2 + trust_lapse_qpos_m2_per_s * dt_since_trust^2,
+        /// capped at 900) takes over. No effect unless float_trust_policy
+        /// == LAPSE_GATED. See float_trust_policy::lapseGateExceeded().
+        double trust_lapse_gate_s = 5.0;
+
+        /// WP10 optional second trigger (own flag, default off via the
+        /// negative sentinel): when >= 0 and a NLOS weight table is
+        /// loaded, ALSO switch LAPSE_GATED to the SCALED_RESET law
+        /// (regardless of how long the lapse has been continuous) on any
+        /// epoch whose NLOS-flagged satellite fraction exceeds this
+        /// value. Read from current_epoch_nlos_fraction_, which carries a
+        /// one-epoch lag here (see rtk.cpp resetPositionToSPP()'s WP10
+        /// comment) since resetPositionToSPP() runs before this epoch's
+        /// own satellite set is collected. No effect unless
+        /// float_trust_policy == LAPSE_GATED.
+        double trust_lapse_gate_nlos_frac = -1.0;
+
+        /// WP10 (WP8 recommendation 2): AR-acceptance-side gate, entirely
+        /// independent of nlos_weight_mode/EXCLUDE -- never touches the
+        /// float-KF measurement update (buildMeasurementBlocks()), only
+        /// vetoes attempting/accepting an ambiguity-resolution fix for an
+        /// epoch when fewer than this many of the AR candidate set's
+        /// satellites are LOS-flagged per the loaded NLOS weight table.
+        /// <= 0 (default) disables the gate. No effect without
+        /// --nlos-weights (a loaded weight table).
+        int nlos_min_los_sats = 0;
     };
 
     /// Reason why AR was silently skipped or failed in resolveAmbiguities().
@@ -308,6 +404,11 @@ public:
         DD_PAIRS_LT_4_AFTER_VAR_FILTER,
         LAMBDA_FAILED,
         RATIO_COMPUTATION_FAILED,
+        /// WP10: --nlos-min-los-sats vetoed this epoch's AR attempt --
+        /// fewer than nlos_min_los_sats of the AR candidate set's
+        /// satellites are LOS-flagged. Never set unless nlos_min_los_sats
+        /// > 0 and --nlos-weights is loaded.
+        TOO_FEW_LOS_SATS,
     };
 
     /// Convert ARSkipReason to a short ASCII string suitable for CSV output.
@@ -320,6 +421,7 @@ public:
             case ARSkipReason::DD_PAIRS_LT_4_AFTER_VAR_FILTER:  return "dd_lt4_after_var";
             case ARSkipReason::LAMBDA_FAILED:                  return "lambda_failed";
             case ARSkipReason::RATIO_COMPUTATION_FAILED:       return "ratio_computation_failed";
+            case ARSkipReason::TOO_FEW_LOS_SATS:               return "too_few_los_sats";
             default:                                           return "unknown";
         }
     }
@@ -387,6 +489,24 @@ public:
         bool final_fixed_applied = false;
         std::string reject_reason;
         ARSkipReason ar_skip_reason{ARSkipReason::NONE};
+
+        // WP8 canyon forensics: mirrors RTKProcessor::RTKUpdateDiagnostics
+        // (private, updateFilter()-local) into the public per-epoch debug
+        // log so --debug-epoch-log can distinguish "wide float covariance
+        // absorbing a large residual" from "tight/overconfident covariance
+        // rejecting or barely budging against it" without needing a
+        // separate instrumentation pass.
+        int float_update_observation_count = 0;
+        double float_update_prefit_residual_rms_m = std::numeric_limits<double>::quiet_NaN();
+        double float_update_post_suppression_residual_rms_m =
+            std::numeric_limits<double>::quiet_NaN();
+        double float_update_nis_per_observation = std::numeric_limits<double>::quiet_NaN();
+        int float_update_suppressed_outliers = 0;
+        // Trace (sum of diagonal) of the float filter's 3x3 ECEF position
+        // covariance block, sampled just after this epoch's measurement
+        // update -- a direct, model-based answer to "is the float position
+        // covariance collapsing (overconfident)".
+        double float_position_covariance_trace_m2 = std::numeric_limits<double>::quiet_NaN();
     };
 
     RTKProcessor();
@@ -422,6 +542,14 @@ public:
     void setRTKConfig(const RTKConfig& config);
     const RTKConfig& getRTKConfig() const { return rtk_config_; }
     const EpochDebugTelemetry& getLastDebugTelemetry() const { return debug_telemetry_; }
+
+    /// WP7: inject an optional per-epoch per-satellite NLOS weight table.
+    /// A null/empty table (the default) is equivalent to not calling this
+    /// at all; the table is only consulted when rtk_config_.nlos_weight_mode
+    /// != OFF.
+    void setNlosWeightTable(std::shared_ptr<const nlos_weights::NlosWeightTable> table) {
+        nlos_weight_table_ = std::move(table);
+    }
 
 public:
     bool lambdaMethod(const VectorXd& float_ambiguities,
@@ -590,6 +718,20 @@ private:
     bool has_last_epoch_ = false;
     GNSSTime last_trusted_time_;
     bool has_last_trusted_time_ = false;
+    // WP9: the trusted position/time recorded just *before* the current
+    // last_trusted_position_/last_trusted_time_ (i.e. the previous trust
+    // refresh). Used only by float_trust_policy::CV_PREDICT to derive a
+    // constant-velocity estimate from the last two trusted deltas; unused
+    // (and never read) when float_trust_policy == LEGACY.
+    Vector3d prev_trusted_position_ = Vector3d::Zero();
+    GNSSTime prev_trusted_time_;
+    bool has_prev_trusted_position_ = false;
+    // WP9 optional lever: fraction of this epoch's tracked satellites
+    // classified NLOS (los_prob < 0.5), computed in processRTKEpoch (where
+    // sat_data is available) and cached for rememberSolution() to read.
+    // NaN unless trust_gate_nlos_relax is enabled and a weight table is
+    // loaded, so std::isfinite() gates every use of this field.
+    double current_epoch_nlos_fraction_ = std::numeric_limits<double>::quiet_NaN();
 
     // Statistics
     mutable std::mutex stats_mutex_;
@@ -668,6 +810,12 @@ private:
         double base_elevation = 0.0;   // elevation from base position
         bool has_ephemeris = false;
     };
+
+    // WP7: current epoch's time (tow), used to look up the NLOS weight
+    // table from buildMeasurementBlocks() (a const method with no direct
+    // access to rover_obs). Set at the top of processRTKEpoch/processEpoch.
+    GNSSTime current_epoch_time_;
+    std::shared_ptr<const nlos_weights::NlosWeightTable> nlos_weight_table_;
 
     // Current epoch satellite data (cached for use across functions)
     std::map<SatelliteId, SatelliteData> current_sat_data_;

--- a/include/libgnss++/algorithms/rtk_selection.hpp
+++ b/include/libgnss++/algorithms/rtk_selection.hpp
@@ -11,13 +11,17 @@ struct SatelliteSelectionData {
     SatelliteId satellite;
     bool has_l1 = false;
     bool has_l2 = false;
+    bool has_l5 = false;  // Phase 18 Step 4
     double l1_wavelength = 0.0;
     double l2_wavelength = 0.0;
+    double l5_wavelength = 0.0;  // Phase 18 Step 4
     double elevation = 0.0;
     bool n1_active = false;
     bool n2_active = false;
+    bool n5_active = false;  // Phase 18 Step 4
     int lock_count_l1 = 0;
     int lock_count_l2 = 0;
+    int lock_count_l5 = 0;  // Phase 18 Step 4
 };
 
 struct SelectionPair {

--- a/include/libgnss++/core/signal_policy.hpp
+++ b/include/libgnss++/core/signal_policy.hpp
@@ -148,6 +148,27 @@ inline bool isSecondarySignal(GNSSSystem system, SignalType signal) {
     }
 }
 
+// Phase 18 Step 3: tertiary (L5-class) signal slot.
+// L5 (1176.45 MHz) and equivalents (GAL E5a, BDS B2a, QZS L5, NavIC L5).
+// Distinct from isSecondarySignal so that L5 can be tracked in its own filter slot
+// without competing with L2-class signals.
+inline bool isL5Signal(GNSSSystem system, SignalType signal) {
+    switch (system) {
+        case GNSSSystem::GPS:
+            return signal == SignalType::GPS_L5;
+        case GNSSSystem::Galileo:
+            return signal == SignalType::GAL_E5A;
+        case GNSSSystem::BeiDou:
+            return signal == SignalType::BDS_B2A;
+        case GNSSSystem::QZSS:
+            return signal == SignalType::QZS_L5;
+        case GNSSSystem::NavIC:
+            return signal == SignalType::GPS_L5;
+        default:
+            return false;
+    }
+}
+
 inline int signalPriority(GNSSSystem system, SignalType signal, bool primary) {
     if (primary) {
         switch (system) {

--- a/src/algorithms/float_trust_policy.cpp
+++ b/src/algorithms/float_trust_policy.cpp
@@ -1,0 +1,66 @@
+#include "libgnss++/algorithms/float_trust_policy.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace libgnss {
+namespace float_trust_policy {
+
+bool hasTrustLapsed(bool has_last_trusted, bool trust_refreshed_last_epoch) {
+    return !has_last_trusted || !trust_refreshed_last_epoch;
+}
+
+double growPositionVarianceCvPredict(double previous_var_m2,
+                                      double qpos_m2_per_s,
+                                      double dt_s,
+                                      double legacy_var_m2) {
+    const double safe_legacy = std::isfinite(legacy_var_m2) ? std::max(legacy_var_m2, 0.0) : 900.0;
+    const double safe_prev = std::isfinite(previous_var_m2)
+        ? std::max(previous_var_m2, 0.0)
+        : safe_legacy;
+    const double safe_qpos = std::isfinite(qpos_m2_per_s) ? std::max(qpos_m2_per_s, 0.0) : 0.0;
+    const double safe_dt = std::isfinite(dt_s) ? std::max(dt_s, 0.0) : 0.0;
+    const double grown = safe_prev + safe_qpos * safe_dt;
+    return std::min(grown, safe_legacy);
+}
+
+double scaledResetPositionVariance(double base_var_m2,
+                                    double qpos_m2_per_s,
+                                    double dt_since_trust_s,
+                                    double legacy_var_m2) {
+    const double safe_legacy = std::isfinite(legacy_var_m2) ? std::max(legacy_var_m2, 0.0) : 900.0;
+    const double safe_base = std::isfinite(base_var_m2) ? std::max(base_var_m2, 0.0) : 0.0;
+    const double safe_qpos = std::isfinite(qpos_m2_per_s) ? std::max(qpos_m2_per_s, 0.0) : 0.0;
+    const double safe_dt = std::isfinite(dt_since_trust_s) ? std::max(dt_since_trust_s, 0.0) : 0.0;
+    const double grown = safe_base + safe_qpos * safe_dt * safe_dt;
+    return std::min(grown, safe_legacy);
+}
+
+Eigen::Vector3d estimateVelocityFromTrustedDeltas(const Eigen::Vector3d& newer_position,
+                                                   const Eigen::Vector3d& older_position,
+                                                   double dt_s,
+                                                   double max_dt_s) {
+    if (!std::isfinite(dt_s) || dt_s <= 0.0 || dt_s > max_dt_s ||
+        !newer_position.allFinite() || !older_position.allFinite()) {
+        return Eigen::Vector3d::Zero();
+    }
+    return (newer_position - older_position) / dt_s;
+}
+
+Eigen::Vector3d predictPositionConstantVelocity(const Eigen::Vector3d& previous_position,
+                                                 const Eigen::Vector3d& velocity_mps,
+                                                 double dt_s) {
+    if (!previous_position.allFinite() || !velocity_mps.allFinite() || !std::isfinite(dt_s)) {
+        return previous_position;
+    }
+    return previous_position + velocity_mps * dt_s;
+}
+
+bool lapseGateExceeded(double dt_since_trust_s, double gate_s) {
+    const double safe_dt = std::isfinite(dt_since_trust_s) ? std::max(dt_since_trust_s, 0.0) : 0.0;
+    const double safe_gate = std::isfinite(gate_s) ? std::max(gate_s, 0.0) : 0.0;
+    return safe_dt >= safe_gate;
+}
+
+}  // namespace float_trust_policy
+}  // namespace libgnss

--- a/src/algorithms/nlos_weights.cpp
+++ b/src/algorithms/nlos_weights.cpp
@@ -1,0 +1,204 @@
+#include <libgnss++/algorithms/nlos_weights.hpp>
+
+#include <algorithm>
+#include <cctype>
+#include <cmath>
+#include <fstream>
+#include <iterator>
+#include <sstream>
+#include <stdexcept>
+#include <vector>
+
+namespace libgnss {
+namespace nlos_weights {
+
+namespace {
+
+std::string toLower(const std::string& s) {
+    std::string out = s;
+    std::transform(out.begin(), out.end(), out.begin(),
+                    [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return out;
+}
+
+std::string trim(const std::string& s) {
+    const auto begin = s.find_first_not_of(" \t\r\n");
+    if (begin == std::string::npos) return "";
+    const auto end = s.find_last_not_of(" \t\r\n");
+    return s.substr(begin, end - begin + 1);
+}
+
+std::vector<std::string> splitCsvLine(const std::string& line) {
+    std::vector<std::string> out;
+    std::stringstream ss(line);
+    std::string cell;
+    while (std::getline(ss, cell, ',')) {
+        out.push_back(trim(cell));
+    }
+    return out;
+}
+
+int findColumn(const std::vector<std::string>& header,
+               const std::vector<std::string>& candidate_names) {
+    for (const auto& name : candidate_names) {
+        for (size_t i = 0; i < header.size(); ++i) {
+            if (toLower(header[i]) == name) {
+                return static_cast<int>(i);
+            }
+        }
+    }
+    return -1;
+}
+
+}  // namespace
+
+NlosWeightTable loadNlosWeightsCsv(const std::string& path) {
+    std::ifstream input(path);
+    if (!input.is_open()) {
+        throw std::runtime_error("failed to open NLOS weights CSV: " + path);
+    }
+
+    std::string header_line;
+    if (!std::getline(input, header_line)) {
+        throw std::runtime_error("NLOS weights CSV is empty: " + path);
+    }
+    const auto header = splitCsvLine(header_line);
+
+    const int tow_col = findColumn(header, {"tow"});
+    const int sat_col = findColumn(header, {"sat", "prn", "satellite"});
+    // "los_prob" (this module's native contract) takes precedence; fall
+    // back to the boolean "is_los" contract emitted by
+    // build_per_epoch_nlos_csv.py (0/1 -> 0.0/1.0).
+    int prob_col = findColumn(header, {"los_prob"});
+    bool prob_is_boolean_is_los = false;
+    if (prob_col < 0) {
+        prob_col = findColumn(header, {"is_los"});
+        prob_is_boolean_is_los = prob_col >= 0;
+    }
+
+    if (tow_col < 0 || sat_col < 0 || prob_col < 0) {
+        throw std::runtime_error(
+            "NLOS weights CSV missing required columns (need tow + sat/prn + "
+            "los_prob/is_los): " + path);
+    }
+
+    NlosWeightTable table;
+    std::string line;
+    while (std::getline(input, line)) {
+        if (line.empty()) continue;
+        const auto cells = splitCsvLine(line);
+        const size_t max_needed =
+            static_cast<size_t>(std::max({tow_col, sat_col, prob_col})) + 1;
+        if (cells.size() < max_needed) continue;
+
+        double tow = 0.0;
+        double prob_raw = 0.0;
+        try {
+            tow = std::stod(cells[static_cast<size_t>(tow_col)]);
+            prob_raw = std::stod(cells[static_cast<size_t>(prob_col)]);
+        } catch (const std::exception&) {
+            continue;
+        }
+        const std::string sat_id = trim(cells[static_cast<size_t>(sat_col)]);
+        if (sat_id.empty() || !std::isfinite(tow) || !std::isfinite(prob_raw)) continue;
+
+        const double los_prob =
+            prob_is_boolean_is_los ? (prob_raw != 0.0 ? 1.0 : 0.0)
+                                    : std::clamp(prob_raw, 0.0, 1.0);
+
+        table.by_tow[tow][sat_id] = los_prob;
+    }
+
+    return table;
+}
+
+double lookupLosProb(const NlosWeightTable& table,
+                      double tow,
+                      const std::string& sat_id,
+                      double tow_tolerance_s) {
+    if (table.empty() || sat_id.empty()) {
+        return 1.0;
+    }
+
+    const double tolerance = std::isfinite(tow_tolerance_s) ? std::max(0.0, tow_tolerance_s) : 0.0;
+
+    // Nearest-tow lookup (like Python's bisect_left in gnss_gpu.nlos_mask):
+    // check the first key >= tow and the key just before it, pick whichever
+    // is within tolerance and closer.
+    auto it = table.by_tow.lower_bound(tow);
+    const double* best_prob = nullptr;
+    double best_delta = tolerance + 1.0;
+
+    auto consider = [&](const std::map<double, std::map<std::string, double>>::const_iterator& candidate) {
+        if (candidate == table.by_tow.end()) return;
+        const double delta = std::abs(candidate->first - tow);
+        if (delta > tolerance || delta >= best_delta) return;
+        const auto sat_it = candidate->second.find(sat_id);
+        if (sat_it == candidate->second.end()) return;
+        best_prob = &sat_it->second;
+        best_delta = delta;
+    };
+
+    consider(it);
+    if (it != table.by_tow.begin()) {
+        consider(std::prev(it));
+    }
+
+    return best_prob != nullptr ? *best_prob : 1.0;
+}
+
+double nlosVarianceInflationFactor(double los_prob,
+                                    NlosWeightMode mode,
+                                    double continuous_floor,
+                                    double two_tier_los_threshold,
+                                    double two_tier_sigma_inflation) {
+    if (mode == NlosWeightMode::OFF || mode == NlosWeightMode::EXCLUDE) {
+        // EXCLUDE drops flagged satellites from DD formation entirely
+        // (nlosShouldExclude / RTKProcessor::buildSelectionSnapshot); any
+        // satellite that survives that filter gets no sigma inflation on
+        // top, so this mapping is a no-op for EXCLUDE, same as OFF.
+        return 1.0;
+    }
+    if (!std::isfinite(los_prob)) {
+        return 1.0;
+    }
+    const double prob = std::clamp(los_prob, 0.0, 1.0);
+
+    if (mode == NlosWeightMode::TWO_TIER) {
+        if (prob >= two_tier_los_threshold) {
+            return 1.0;
+        }
+        const double inflation = std::isfinite(two_tier_sigma_inflation)
+                                      ? std::max(1.0, two_tier_sigma_inflation)
+                                      : 1.0;
+        return inflation * inflation;
+    }
+
+    // CONTINUOUS
+    const double floor = std::isfinite(continuous_floor)
+                              ? std::clamp(continuous_floor, 1e-6, 1.0)
+                              : 1e-3;
+    return 1.0 / std::max(prob, floor);
+}
+
+bool nlosShouldExclude(double los_prob, NlosWeightMode mode, double exclude_threshold) {
+    if (mode != NlosWeightMode::EXCLUDE) return false;
+    if (!std::isfinite(los_prob)) return false;
+    const double threshold = std::isfinite(exclude_threshold) ? exclude_threshold : 0.5;
+    return los_prob < threshold;
+}
+
+bool nlosExclusionGuardAllows(int total_sats, int excluded_count, int min_sats) {
+    if (excluded_count <= 0) return false;
+    const int floor = std::max(0, min_sats);
+    const int surviving = total_sats - excluded_count;
+    return surviving >= floor;
+}
+
+bool nlosMinLosSatsGateAllows(int los_sat_count, int min_los_sats) {
+    if (min_los_sats <= 0) return true;
+    return los_sat_count >= min_los_sats;
+}
+
+}  // namespace nlos_weights
+}  // namespace libgnss

--- a/src/algorithms/rtk.cpp
+++ b/src/algorithms/rtk.cpp
@@ -327,6 +327,8 @@ void RTKProcessor::reset() {
     has_ref_satellite_ = false;
     has_last_epoch_ = false;
     has_last_trusted_time_ = false;
+    has_prev_trusted_position_ = false;
+    current_epoch_nlos_fraction_ = std::numeric_limits<double>::quiet_NaN();
     current_sat_data_.clear();
     gf_l1l2_history_.clear();
     doppler_phase_history_l1_m_.clear();
@@ -761,6 +763,61 @@ std::vector<rtk_selection::SatelliteSelectionData> RTKProcessor::buildSelectionS
         item.lock_count_l5 = l5_it != lock_count_l5_.end() ? l5_it->second : 0;
         snapshot.push_back(item);
     }
+
+    // WP8: hard NLOS exclusion. Both buildMeasurementBlocks() (float KF)
+    // and buildDoubleDifferencePairs() (AR/LAMBDA candidate set) call this
+    // one shared function to get their satellite candidate list, so
+    // filtering it here applies identically to both consumers. No-op
+    // (bit-identical) unless nlos_weight_mode == EXCLUDE and a weight
+    // table is loaded, exactly mirroring the WP7 sigma-inflation hook's own
+    // absent-flag guard.
+    if (rtk_config_.nlos_weight_mode == nlos_weights::NlosWeightMode::EXCLUDE &&
+        nlos_weight_table_ && !nlos_weight_table_->empty()) {
+        std::set<SatelliteId> excluded;
+        for (const auto& item : snapshot) {
+            const double los_prob = nlos_weights::lookupLosProb(
+                *nlos_weight_table_, current_epoch_time_.tow, item.satellite.toString(),
+                rtk_config_.nlos_tow_tolerance_s);
+            if (nlos_weights::nlosShouldExclude(
+                    los_prob, rtk_config_.nlos_weight_mode, rtk_config_.nlos_exclude_threshold)) {
+                excluded.insert(item.satellite);
+            }
+        }
+        const bool guard_allows = nlos_weights::nlosExclusionGuardAllows(
+            static_cast<int>(snapshot.size()), static_cast<int>(excluded.size()),
+            rtk_config_.nlos_min_sats);
+        if (guard_allows) {
+            // Second guard: never exclude a system's *last* remaining
+            // reference-satellite candidate -- that would zero out the
+            // whole system's DD set rather than just shrinking it, even if
+            // the epoch-wide min-sats floor above was satisfied.
+            for (GNSSSystem system : kRTKSupportedSystems) {
+                SatelliteId full_ref;
+                if (!rtk_selection::selectSystemReferenceSatellite(snapshot, system, 0, full_ref)) {
+                    continue;  // no reference candidate at all pre-exclusion; nothing to protect
+                }
+                if (excluded.count(full_ref) == 0) continue;
+                std::vector<rtk_selection::SatelliteSelectionData> trial;
+                trial.reserve(snapshot.size());
+                for (const auto& item : snapshot) {
+                    if (excluded.count(item.satellite) == 0) trial.push_back(item);
+                }
+                SatelliteId trial_ref;
+                if (!rtk_selection::selectSystemReferenceSatellite(trial, system, 0, trial_ref)) {
+                    excluded.erase(full_ref);
+                }
+            }
+            if (!excluded.empty()) {
+                std::vector<rtk_selection::SatelliteSelectionData> filtered;
+                filtered.reserve(snapshot.size());
+                for (auto& item : snapshot) {
+                    if (excluded.count(item.satellite) == 0) filtered.push_back(std::move(item));
+                }
+                snapshot = std::move(filtered);
+            }
+        }
+    }
+
     return snapshot;
 }
 
@@ -1454,7 +1511,91 @@ void RTKProcessor::resetPositionToSPP(const ObservationData& rover_obs, const Na
                 seeded = true;
             }
         }
-        if (!seeded) {
+
+        // WP9: float-trust-policy graceful degradation. Only ever consulted
+        // once trust has lapsed (the previous processed epoch did not
+        // refresh trust) -- on every epoch of a healthy segment this block
+        // is skipped entirely and the pre-WP9 legacy branch below runs
+        // unchanged, matching WP8's finding that the wide reset should only
+        // need softening during an actual trust drought. LEGACY (the
+        // default) never enters this block at all.
+        bool wp9_seeded = false;
+        if (!seeded &&
+            rtk_config_.float_trust_policy != float_trust_policy::FloatTrustPolicy::LEGACY) {
+            const bool trust_refreshed_last_epoch =
+                has_last_trusted_time_ && has_last_epoch_ &&
+                (last_trusted_time_ == last_epoch_time_);
+            const bool trust_lapsed = float_trust_policy::hasTrustLapsed(
+                has_last_trusted_position_ && has_last_trusted_time_,
+                trust_refreshed_last_epoch);
+            if (trust_lapsed) {
+                double dt_epoch = has_last_epoch_ ? (rover_obs.time - last_epoch_time_) : 0.2;
+                if (!std::isfinite(dt_epoch) || dt_epoch <= 0.0) dt_epoch = 0.2;
+
+                if (rtk_config_.float_trust_policy ==
+                        float_trust_policy::FloatTrustPolicy::CV_PREDICT &&
+                    has_last_solution_position_) {
+                    Vector3d velocity = Vector3d::Zero();
+                    if (has_prev_trusted_position_ && has_last_trusted_position_ &&
+                        has_last_trusted_time_) {
+                        velocity = float_trust_policy::estimateVelocityFromTrustedDeltas(
+                            last_trusted_position_, prev_trusted_position_,
+                            last_trusted_time_ - prev_trusted_time_, 10.0);
+                    }
+                    rover_pos = float_trust_policy::predictPositionConstantVelocity(
+                        last_solution_position_, velocity, dt_epoch);
+                    const double previous_var_pos = filter_state_.covariance(0, 0);
+                    var_pos = float_trust_policy::growPositionVarianceCvPredict(
+                        previous_var_pos, rtk_config_.trust_lapse_qpos_m2_per_s, dt_epoch, 900.0);
+                    wp9_seeded = true;
+                } else if (rtk_config_.float_trust_policy ==
+                               float_trust_policy::FloatTrustPolicy::SCALED_RESET &&
+                           spp.isValid()) {
+                    const double dt_since_trust = has_last_trusted_time_
+                        ? std::max(rover_obs.time - last_trusted_time_, 0.0)
+                        : 1.0e6;  // never trusted yet -> effectively at the legacy cap
+                    rover_pos = spp.position_ecef;
+                    var_pos = float_trust_policy::scaledResetPositionVariance(
+                        25.0, rtk_config_.trust_lapse_qpos_m2_per_s, dt_since_trust, 900.0);
+                    wp9_seeded = true;
+                } else if (rtk_config_.float_trust_policy ==
+                               float_trust_policy::FloatTrustPolicy::LAPSE_GATED &&
+                           spp.isValid()) {
+                    // WP10: only switch off the LEGACY path once the
+                    // *continuous* trust lapse exceeds the configured
+                    // gate (or, optionally, on a sufficiently NLOS-heavy
+                    // epoch regardless of lapse length). Below the gate
+                    // (and with the optional NLOS trigger off/unmet),
+                    // wp9_seeded is deliberately left false so this falls
+                    // straight through to the unmodified legacy fallback
+                    // branch below -- bit-identical to LEGACY for short
+                    // lapses by construction, not just numerically close.
+                    const double dt_since_trust = has_last_trusted_time_
+                        ? std::max(rover_obs.time - last_trusted_time_, 0.0)
+                        : 1.0e6;  // never trusted yet -> effectively at the legacy cap
+                    // current_epoch_nlos_fraction_ still holds the *previous*
+                    // epoch's value here (this epoch's own value isn't
+                    // computed until collectSatelliteData() runs, later in
+                    // processRTKEpoch()) -- a one-epoch-lagged proxy, cheap
+                    // and adequate for the multi-second-to-minute NLOS-heavy
+                    // dwells (e.g. the canyon) this trigger targets.
+                    const bool nlos_frac_trigger =
+                        rtk_config_.trust_lapse_gate_nlos_frac >= 0.0 &&
+                        std::isfinite(current_epoch_nlos_fraction_) &&
+                        current_epoch_nlos_fraction_ > rtk_config_.trust_lapse_gate_nlos_frac;
+                    if (float_trust_policy::lapseGateExceeded(
+                            dt_since_trust, rtk_config_.trust_lapse_gate_s) ||
+                        nlos_frac_trigger) {
+                        rover_pos = spp.position_ecef;
+                        var_pos = float_trust_policy::scaledResetPositionVariance(
+                            25.0, rtk_config_.trust_lapse_qpos_m2_per_s, dt_since_trust, 900.0);
+                        wp9_seeded = true;
+                    }
+                }
+            }
+        }
+
+        if (!seeded && !wp9_seeded) {
             if (rtk_config_.prefer_rover_position_seed &&
                 rover_obs.receiver_position.norm() > 1e6) {
                 rover_pos = rover_obs.receiver_position;
@@ -1520,6 +1661,8 @@ PositionSolution RTKProcessor::processRTKEpochInternal(const ObservationData& ro
     solution.time = rover_obs.time;
     solution.status = SolutionStatus::NONE;
     current_update_diagnostics_ = RTKUpdateDiagnostics{};
+    // WP7: record current tow for buildMeasurementBlocks()'s NLOS weight lookup.
+    current_epoch_time_ = rover_obs.time;
 
     try {
         const bool moving_base_mode = isMovingBasePositionMode(rtk_config_);
@@ -1597,6 +1740,31 @@ PositionSolution RTKProcessor::processRTKEpochInternal(const ObservationData& ro
         auto sat_data = collectSatelliteData(rover_obs, base_obs, nav);
         if (sat_data.size() < 4) {
             return fallback_spp();
+        }
+
+        // WP9/WP10: cache this epoch's NLOS fraction (sat_data is only
+        // available locally here) for two downstream readers: WP9's
+        // rememberSolution() jump-gate relax check (same epoch), and
+        // WP10's LAPSE_GATED --trust-lapse-gate-nlos-frac trigger, which
+        // reads it (necessarily one-epoch-lagged) from the *next*
+        // epoch's resetPositionToSPP(), called before this recomputation.
+        // NaN unless one of the two levers is on and a table is loaded --
+        // std::isfinite() at every read site gates this to a strict no-op
+        // otherwise.
+        current_epoch_nlos_fraction_ = std::numeric_limits<double>::quiet_NaN();
+        if ((rtk_config_.trust_gate_nlos_relax ||
+             rtk_config_.trust_lapse_gate_nlos_frac >= 0.0) &&
+            nlos_weight_table_ && !nlos_weight_table_->empty()) {
+            int total = 0;
+            int nlos = 0;
+            for (const auto& kv : sat_data) {
+                ++total;
+                const double los_prob = nlos_weights::lookupLosProb(
+                    *nlos_weight_table_, current_epoch_time_.tow, kv.first.toString(),
+                    rtk_config_.nlos_tow_tolerance_s);
+                if (los_prob < 0.5) ++nlos;
+            }
+            current_epoch_nlos_fraction_ = total > 0 ? static_cast<double>(nlos) / total : 0.0;
         }
 
         double state_dt = 1.0;
@@ -1980,6 +2148,25 @@ std::vector<rtk_measurement::MeasurementBlock> RTKProcessor::buildMeasurementBlo
     const auto selection_snapshot = buildSelectionSnapshot(sat_data);
     std::vector<rtk_measurement::MeasurementBlock> blocks;
 
+    // WP7: NLOS/multipath sigma inflation. Returns 1.0 (no-op) whenever the
+    // feature is off or no table/entry is available, so this is bit-identical
+    // to pre-WP7 behavior by construction when nlos_weight_mode == OFF.
+    const bool nlos_weighting_active =
+        rtk_config_.nlos_weight_mode != nlos_weights::NlosWeightMode::OFF &&
+        nlos_weight_table_ && !nlos_weight_table_->empty();
+    auto nlos_variance_factor = [&](const SatelliteId& sat) -> double {
+        if (!nlos_weighting_active) return 1.0;
+        const double los_prob = nlos_weights::lookupLosProb(
+            *nlos_weight_table_, current_epoch_time_.tow, sat.toString(),
+            rtk_config_.nlos_tow_tolerance_s);
+        return nlos_weights::nlosVarianceInflationFactor(
+            los_prob,
+            rtk_config_.nlos_weight_mode,
+            rtk_config_.nlos_continuous_los_prob_floor,
+            rtk_config_.nlos_two_tier_los_threshold,
+            rtk_config_.nlos_two_tier_sigma_inflation);
+    };
+
     for (GNSSSystem system : kRTKSupportedSystems) {
         if (!isEnabledRTKSystem(rtk_config_, system)) continue;
         SatelliteId ref_sat;
@@ -2063,8 +2250,9 @@ std::vector<rtk_measurement::MeasurementBlock> RTKProcessor::buildMeasurementBlo
                 return;
             }
             const double ref_snr = signal_snr_dbhz(ref_sd, freq);
-            const double ref_phase_variance = varerr(ref_sd.elevation, true, ref_snr);
-            const double ref_code_variance = varerr(ref_sd.elevation, false, ref_snr);
+            const double ref_nlos_factor = nlos_variance_factor(ref_sat);
+            const double ref_phase_variance = varerr(ref_sd.elevation, true, ref_snr) * ref_nlos_factor;
+            const double ref_code_variance = varerr(ref_sd.elevation, false, ref_snr) * ref_nlos_factor;
 
             for (const auto& pair : system_pairs) {
                 if (pair.freq != freq) continue;
@@ -2081,8 +2269,9 @@ std::vector<rtk_measurement::MeasurementBlock> RTKProcessor::buildMeasurementBlo
                 const double sat_wavelength = freq_wavelength_local(sd, freq);
                 if (sat_wavelength <= 0.0) continue;
                 const double sat_snr = signal_snr_dbhz(sd, freq);
-                const double sat_phase_variance = varerr(sd.elevation, true, sat_snr);
-                const double sat_code_variance = varerr(sd.elevation, false, sat_snr);
+                const double sat_nlos_factor = nlos_variance_factor(sat);
+                const double sat_phase_variance = varerr(sd.elevation, true, sat_snr) * sat_nlos_factor;
+                const double sat_code_variance = varerr(sd.elevation, false, sat_snr) * sat_nlos_factor;
                 const int sat_iono_idx = estimate_iono ? II(sat) : -1;
                 const double sat_iono_scale =
                     estimate_iono
@@ -2219,6 +2408,22 @@ bool RTKProcessor::updateFilter(const std::map<SatelliteId, SatelliteData>& sat_
         update_result.normalized_innovation_squared_per_observation;
     current_update_diagnostics_.rejected_by_innovation_gate =
         update_result.rejected_by_innovation_gate;
+
+    // WP8 canyon forensics: mirror into the public per-epoch debug
+    // telemetry (see EpochDebugTelemetry's float_update_* fields).
+    debug_telemetry_.float_update_observation_count = update_result.observation_count;
+    debug_telemetry_.float_update_prefit_residual_rms_m = update_result.prefit_residual_rms_m;
+    debug_telemetry_.float_update_post_suppression_residual_rms_m =
+        update_result.post_suppression_residual_rms_m;
+    debug_telemetry_.float_update_nis_per_observation =
+        update_result.normalized_innovation_squared_per_observation;
+    debug_telemetry_.float_update_suppressed_outliers = update_result.suppressed_outliers;
+    debug_telemetry_.float_position_covariance_trace_m2 =
+        filter_state_.covariance.rows() >= 3 && filter_state_.covariance.cols() >= 3
+            ? filter_state_.covariance(0, 0) + filter_state_.covariance(1, 1) +
+                  filter_state_.covariance(2, 2)
+            : std::numeric_limits<double>::quiet_NaN();
+
     return update_result.ok;
 }
 
@@ -2270,6 +2475,33 @@ bool RTKProcessor::resolveAmbiguities(std::vector<DDPair> dd_pairs) {
         debug_telemetry_.reject_reason = "too_few_pairs";
         debug_telemetry_.ar_skip_reason = ARSkipReason::DD_PAIRS_LT_4_BEFORE_VAR_FILTER;
         return false;
+    }
+
+    // WP10 (WP8 recommendation 2): --nlos-min-los-sats AR-acceptance gate.
+    // Gates AR only -- it never touches buildSelectionSnapshot()/
+    // buildMeasurementBlocks(), so the float-KF update for this epoch is
+    // completely unaffected either way. No-op unless nlos_min_los_sats > 0
+    // and a weight table is loaded (mirrors WP8 EXCLUDE's own absent-flag
+    // guard style).
+    if (rtk_config_.nlos_min_los_sats > 0 && nlos_weight_table_ &&
+        !nlos_weight_table_->empty()) {
+        std::set<SatelliteId> candidate_sats;
+        for (const auto& pair : dd_pairs) {
+            candidate_sats.insert(pair.ref_sat);
+            candidate_sats.insert(pair.sat);
+        }
+        int los_count = 0;
+        for (const auto& sat : candidate_sats) {
+            const double los_prob = nlos_weights::lookupLosProb(
+                *nlos_weight_table_, current_epoch_time_.tow, sat.toString(),
+                rtk_config_.nlos_tow_tolerance_s);
+            if (los_prob >= 0.5) ++los_count;
+        }
+        if (!nlos_weights::nlosMinLosSatsGateAllows(los_count, rtk_config_.nlos_min_los_sats)) {
+            debug_telemetry_.reject_reason = "too_few_los_sats";
+            debug_telemetry_.ar_skip_reason = ARSkipReason::TOO_FEW_LOS_SATS;
+            return false;
+        }
     }
 
     std::vector<rtk_measurement::AmbiguityDifference> differences;
@@ -2350,7 +2582,15 @@ bool RTKProcessor::resolveAmbiguities(std::vector<DDPair> dd_pairs) {
     double effective_ratio_threshold = rtk_config_.ambiguity_ratio_threshold;
     if (rtk_config_.ar_policy != RTKConfig::ARPolicy::DEMO5_CONTINUOUS) {
         if (consecutive_fix_count_ >= rtk_config_.min_hold_count && has_last_fixed_position_) {
-            effective_ratio_threshold = 2.0;
+            // WP7 dead-knob fix: honor the configured hold-ambiguity ratio
+            // threshold (--hold-ratio-threshold) instead of a hardcoded 2.0.
+            // Default hold_ambiguity_ratio_threshold is 2.0 (rtk.hpp), so this
+            // is bit-identical unless a caller explicitly overrides the flag.
+            effective_ratio_threshold =
+                std::isfinite(rtk_config_.hold_ambiguity_ratio_threshold) &&
+                rtk_config_.hold_ambiguity_ratio_threshold > 0.0
+                    ? rtk_config_.hold_ambiguity_ratio_threshold
+                    : 2.0;
         }
     }
     debug_telemetry_.effective_ratio_threshold = effective_ratio_threshold;
@@ -2679,7 +2919,13 @@ bool RTKProcessor::resolveAmbiguities(std::vector<DDPair> dd_pairs) {
         debug_telemetry_.full_lambda_solved = full_solved;
         if (full_solved) {
             debug_telemetry_.full_ratio = ratio;
-            if (ratio >= effective_ratio_threshold) {
+            // WP7 dead-knob fix: passesArFilter is a no-op AND term when
+            // enable_ar_filter is false (its default), so this preserves the
+            // exact base ratio >= threshold gate unless --arfilter is set.
+            if (ratio >= effective_ratio_threshold &&
+                rtk_ar_evaluation::passesArFilter(
+                    rtk_config_.enable_ar_filter, ratio, effective_ratio_threshold,
+                    rtk_config_.ar_filter_margin)) {
                 fixed = true;
 
                 // WL-NL cross-validation: verify LAMBDA integers match WL-NL
@@ -2888,6 +3134,11 @@ bool RTKProcessor::resolveAmbiguities(std::vector<DDPair> dd_pairs) {
                 return false;
             }
             if (sub_ratio < effective_ratio_threshold) {
+                return false;
+            }
+            if (!rtk_ar_evaluation::passesArFilter(
+                    rtk_config_.enable_ar_filter, sub_ratio, effective_ratio_threshold,
+                    rtk_config_.ar_filter_margin)) {
                 return false;
             }
 
@@ -3673,10 +3924,29 @@ void RTKProcessor::rememberSolution(const PositionSolution& solution) {
             }
             const double trusted_jump =
                 (solution.position_ecef - last_trusted_position_).norm();
-            refresh_trusted = trusted_jump <= std::max(3.0, 6.0 * dt);
+            // WP9 optional lever: relax the jump gate 2x when a majority of
+            // this epoch's tracked satellites are NLOS-flagged (per the
+            // loaded weight table). No-op (multiplier stays 1.0) unless
+            // both --trust-gate-nlos-relax is set and current_epoch_nlos_
+            // fraction_ was actually computed this epoch (finite).
+            double jump_gate_multiplier = 1.0;
+            if (rtk_config_.trust_gate_nlos_relax &&
+                std::isfinite(current_epoch_nlos_fraction_) &&
+                current_epoch_nlos_fraction_ > 0.5) {
+                jump_gate_multiplier = 2.0;
+            }
+            refresh_trusted = trusted_jump <= std::max(3.0, 6.0 * dt) * jump_gate_multiplier;
         }
     }
     if (refresh_trusted) {
+        // WP9: remember the trust sample being replaced so CV_PREDICT can
+        // derive a two-point constant-velocity estimate from the last two
+        // trusted deltas. No effect on any exported solution.
+        if (has_last_trusted_position_ && has_last_trusted_time_) {
+            prev_trusted_position_ = last_trusted_position_;
+            prev_trusted_time_ = last_trusted_time_;
+            has_prev_trusted_position_ = true;
+        }
         last_trusted_position_ = solution.position_ecef;
         has_last_trusted_position_ = true;
         last_trusted_time_ = solution.time;

--- a/src/algorithms/rtk.cpp
+++ b/src/algorithms/rtk.cpp
@@ -110,6 +110,11 @@ bool isSecondaryRTKSignal(GNSSSystem system, SignalType signal) {
     return signal_policy::isSecondarySignal(system, signal);
 }
 
+// Phase 18 Step 3: L5-class signal slot, distinct from L2 secondary.
+bool isL5RTKSignal(GNSSSystem system, SignalType signal) {
+    return signal_policy::isL5Signal(system, signal);
+}
+
 int signalSelectionPriority(GNSSSystem system, SignalType signal, bool primary) {
     return signal_policy::signalPriority(system, signal, primary);
 }
@@ -312,6 +317,7 @@ void RTKProcessor::reset() {
     ambiguity_states_.clear();
     lock_count_l1_.clear();
     lock_count_l2_.clear();
+    lock_count_l5_.clear();  // Phase 18 Step 2: clear L5 lock counts on reset
     has_fixed_solution_ = false;
     has_last_fixed_position_ = false;
     has_last_fixed_time_ = false;
@@ -434,6 +440,24 @@ int RTKProcessor::getOrCreateN2Index(const SatelliteId& sat, double initial_valu
     return idx;
 }
 
+// Phase 18 Step 4: parallel to N1/N2 index creators.
+// IB(sat, 2) maps into the L5 slot of the state vector (FREQ_SLOTS=3 reserved by Step 2).
+int RTKProcessor::getOrCreateN5Index(const SatelliteId& sat, double initial_value) {
+    int idx = IB(sat, 2);
+    if (filter_state_.state(idx) != 0.0) {
+        filter_state_.n5_indices[sat] = idx;
+        return idx;
+    }
+    filter_state_.n5_indices[sat] = idx;
+    filter_state_.state(idx) = initial_value;
+    for (int j = 0; j < NX; ++j) {
+        filter_state_.covariance(idx, j) = 0.0;
+        filter_state_.covariance(j, idx) = 0.0;
+    }
+    filter_state_.covariance(idx, idx) = 900.0;
+    return idx;
+}
+
 int RTKProcessor::getOrCreateIonoIndex(const SatelliteId& sat, double initial_value) {
     int idx = II(sat);
     if (filter_state_.covariance(idx, idx) > 0.0) {
@@ -482,6 +506,17 @@ void RTKProcessor::removeSatelliteFromState(const SatelliteId& sat) {
         }
         filter_state_.n2_indices.erase(it2);
     }
+    // Phase 18 Step 2: erase L5 ambiguity slot if present (no-op until Step 3+ populates n5_indices).
+    auto it5 = filter_state_.n5_indices.find(sat);
+    if (it5 != filter_state_.n5_indices.end()) {
+        int idx = it5->second;
+        filter_state_.state(idx) = 0.0;
+        for (int j = 0; j < NX; ++j) {
+            filter_state_.covariance(idx, j) = 0.0;
+            filter_state_.covariance(j, idx) = 0.0;
+        }
+        filter_state_.n5_indices.erase(it5);
+    }
 }
 
 // ============================================================
@@ -491,6 +526,9 @@ std::map<SatelliteId, RTKProcessor::SatelliteData> RTKProcessor::collectSatellit
     const ObservationData& rover_obs, const ObservationData& base_obs, const NavigationData& nav) {
     std::map<SatelliteId, SatelliteData> result;
     std::map<SatelliteId, std::vector<const Observation*>> rover_l1, rover_l2, base_l1, base_l2;
+    // Phase 18 Step 3: L5 collection (only populated when enable_l5=true).
+    std::map<SatelliteId, std::vector<const Observation*>> rover_l5, base_l5;
+    const bool l5_enabled = rtk_config_.enable_l5;
     for (const auto& obs : rover_obs.observations) {
         if (!isEnabledRTKSystem(rtk_config_, obs.satellite.system)) continue;
         if (!isUsableRTKSatellite(obs.satellite)) continue;
@@ -500,7 +538,13 @@ std::map<SatelliteId, RTKProcessor::SatelliteData> RTKProcessor::collectSatellit
         }
         if (isSecondaryRTKSignal(obs.satellite.system, obs.signal) &&
             obs.has_carrier_phase && obs.has_pseudorange) {
-            rover_l2[obs.satellite].push_back(&obs);
+            // When L5 enabled, exclude L5-class obs from L2 slot so they don't
+            // displace true L2C signals or pollute the L2 wavelength.
+            if (l5_enabled && isL5RTKSignal(obs.satellite.system, obs.signal)) {
+                rover_l5[obs.satellite].push_back(&obs);
+            } else {
+                rover_l2[obs.satellite].push_back(&obs);
+            }
         }
     }
     for (const auto& obs : base_obs.observations) {
@@ -512,7 +556,11 @@ std::map<SatelliteId, RTKProcessor::SatelliteData> RTKProcessor::collectSatellit
         }
         if (isSecondaryRTKSignal(obs.satellite.system, obs.signal) &&
             obs.has_carrier_phase && obs.has_pseudorange) {
-            base_l2[obs.satellite].push_back(&obs);
+            if (l5_enabled && isL5RTKSignal(obs.satellite.system, obs.signal)) {
+                base_l5[obs.satellite].push_back(&obs);
+            } else {
+                base_l2[obs.satellite].push_back(&obs);
+            }
         }
     }
     Vector3d rover_pos_for_clk = rover_obs.receiver_position;
@@ -611,6 +659,36 @@ std::map<SatelliteId, RTKProcessor::SatelliteData> RTKProcessor::collectSatellit
                 sd.has_l2_doppler = r_l2_obs->has_doppler && b_l2_obs->has_doppler;
             }
         }
+        // Phase 18 Step 3: L5 pairing (no-op until rtk_config_.enable_l5 is set).
+        if (l5_enabled) {
+            auto r_l5 = rover_l5.find(sat); auto b_l5 = base_l5.find(sat);
+            if (r_l5 != rover_l5.end() && b_l5 != base_l5.end()) {
+                const Observation* r_l5_obs = nullptr;
+                const Observation* b_l5_obs = nullptr;
+                // Both rover/base L5 candidate lists contain only L5-class signals,
+                // so selectMatchedObservationPair with primary=false picks the highest-
+                // priority L5 variant common to both (e.g. matched GPS_L5 / GAL_E5A).
+                if (selectMatchedObservationPair(
+                        sat.system, r_l5->second, b_l5->second, false, r_l5_obs, b_l5_obs)) {
+                    sd.l5_signal = r_l5_obs->signal;
+                    sd.l5_frequency_hz = signalFrequencyHz(sd.l5_signal, eph);
+                    sd.l5_wavelength = signalWavelengthMeters(sd.l5_signal, eph);
+                    if (sd.l5_wavelength > 0.0) {
+                        sd.rover_l5_phase = r_l5_obs->carrier_phase;
+                        sd.rover_l5_code = r_l5_obs->pseudorange;
+                        sd.base_l5_phase = b_l5_obs->carrier_phase;
+                        sd.base_l5_code = b_l5_obs->pseudorange;
+                        sd.rover_l5_doppler = r_l5_obs->doppler;
+                        sd.base_l5_doppler = b_l5_obs->doppler;
+                        sd.rover_l5_snr = r_l5_obs->snr;
+                        sd.base_l5_snr = b_l5_obs->snr;
+                        sd.has_l5 = true;
+                        sd.l5_lli = r_l5_obs->lli | b_l5_obs->lli;
+                        sd.has_l5_doppler = r_l5_obs->has_doppler && b_l5_obs->has_doppler;
+                    }
+                }
+            }
+        }
         result[sat] = sd;
     }
     return result;
@@ -661,8 +739,10 @@ std::vector<rtk_selection::SatelliteSelectionData> RTKProcessor::buildSelectionS
         item.satellite = sat;
         item.has_l1 = sd.has_l1;
         item.has_l2 = sd.has_l2;
+        item.has_l5 = sd.has_l5;  // Phase 18 Step 4
         item.l1_wavelength = sd.l1_wavelength;
         item.l2_wavelength = sd.l2_wavelength;
+        item.l5_wavelength = sd.l5_wavelength;  // Phase 18 Step 4
         item.elevation = sd.elevation;
         auto n1_it = filter_state_.n1_indices.find(sat);
         item.n1_active = n1_it != filter_state_.n1_indices.end() &&
@@ -670,10 +750,15 @@ std::vector<rtk_selection::SatelliteSelectionData> RTKProcessor::buildSelectionS
         auto n2_it = filter_state_.n2_indices.find(sat);
         item.n2_active = n2_it != filter_state_.n2_indices.end() &&
                          filter_state_.state(n2_it->second) != 0.0;
+        auto n5_it = filter_state_.n5_indices.find(sat);
+        item.n5_active = n5_it != filter_state_.n5_indices.end() &&
+                         filter_state_.state(n5_it->second) != 0.0;
         auto l1_it = lock_count_l1_.find(sat);
         item.lock_count_l1 = l1_it != lock_count_l1_.end() ? l1_it->second : 0;
         auto l2_it = lock_count_l2_.find(sat);
         item.lock_count_l2 = l2_it != lock_count_l2_.end() ? l2_it->second : 0;
+        auto l5_it = lock_count_l5_.find(sat);
+        item.lock_count_l5 = l5_it != lock_count_l5_.end() ? l5_it->second : 0;
         snapshot.push_back(item);
     }
     return snapshot;
@@ -693,21 +778,15 @@ std::vector<RTKProcessor::DDPair> RTKProcessor::buildDoubleDifferencePairs(
             min_lock_count,
             requiresMatchedCarrierWavelength(rtk_config_, system));
         for (const auto& pair : system_pairs) {
-            if (pair.freq == 0) {
-                auto ref_idx = filter_state_.n1_indices.find(pair.ref_sat);
-                auto sat_idx = filter_state_.n1_indices.find(pair.sat);
-                if (ref_idx == filter_state_.n1_indices.end() || sat_idx == filter_state_.n1_indices.end()) {
-                    continue;
-                }
-                dd_pairs.push_back({pair.ref_sat, ref_idx->second, sat_idx->second, pair.sat, pair.freq});
-            } else {
-                auto ref_idx = filter_state_.n2_indices.find(pair.ref_sat);
-                auto sat_idx = filter_state_.n2_indices.find(pair.sat);
-                if (ref_idx == filter_state_.n2_indices.end() || sat_idx == filter_state_.n2_indices.end()) {
-                    continue;
-                }
-                dd_pairs.push_back({pair.ref_sat, ref_idx->second, sat_idx->second, pair.sat, pair.freq});
+            const auto& indices = (pair.freq == 0) ? filter_state_.n1_indices :
+                                  (pair.freq == 1) ? filter_state_.n2_indices :
+                                                     filter_state_.n5_indices;  // Phase 18 Step 4
+            auto ref_idx = indices.find(pair.ref_sat);
+            auto sat_idx = indices.find(pair.sat);
+            if (ref_idx == indices.end() || sat_idx == indices.end()) {
+                continue;
             }
+            dd_pairs.push_back({pair.ref_sat, ref_idx->second, sat_idx->second, pair.sat, pair.freq});
         }
     }
 
@@ -725,11 +804,14 @@ bool RTKProcessor::initializeFilter(const ObservationData& rover_obs,
     filter_state_.iono_indices.clear();
     filter_state_.n1_indices.clear();
     filter_state_.n2_indices.clear();
+    filter_state_.n5_indices.clear();  // Phase 18 Step 2: clear L5 index map on filter init
     filter_state_.next_state_idx = REAL_STATES + IONO_STATES;
 
     auto spp = spp_processor_.processEpoch(rover_obs, nav);
     Vector3d rover_pos;
-    if (spp.isValid()) {
+    if (rtk_config_.prefer_rover_position_seed && rover_obs.receiver_position.norm() > 1e6) {
+        rover_pos = rover_obs.receiver_position;
+    } else if (spp.isValid()) {
         rover_pos = spp.position_ecef;
     } else if (rover_obs.receiver_position.norm() > 1e6) {
         rover_pos = rover_obs.receiver_position;
@@ -784,11 +866,15 @@ void RTKProcessor::updateBias(const std::map<SatelliteId, SatelliteData>& sat_da
         removeSatelliteFromState(sat);
         lock_count_l1_.erase(sat);
         lock_count_l2_.erase(sat);
+        lock_count_l5_.erase(sat);  // Phase 18 Step 2: erase L5 lock count when sat dropped
         gf_l1l2_history_.erase(sat);
+        gf_l1l5_history_.erase(sat);  // Phase 18 Step 5
         doppler_phase_history_l1_m_.erase(sat);
         doppler_phase_history_l2_m_.erase(sat);
+        doppler_phase_history_l5_m_.erase(sat);  // Phase 18 Step 5
         code_phase_history_l1_m_.erase(sat);
         code_phase_history_l2_m_.erase(sat);
+        code_phase_history_l5_m_.erase(sat);  // Phase 18 Step 5
     }
 
     const bool dynamic_slip_floor_candidate =
@@ -818,6 +904,7 @@ void RTKProcessor::updateBias(const std::map<SatelliteId, SatelliteData>& sat_da
     }
 
     std::set<SatelliteId> gf_slips;
+    std::set<SatelliteId> gf_slips_l1l5;  // Phase 18 Step 5
     if (rtk_config_.enable_cycle_slip_detection) {
         const double gf_slip_threshold =
             apply_dynamic_slip_floor
@@ -834,11 +921,29 @@ void RTKProcessor::updateBias(const std::map<SatelliteId, SatelliteData>& sat_da
             }
             gf_l1l2_history_[sat] = gf;
         }
+        if (rtk_config_.enable_l5) {
+            // Phase 18 Step 5: parallel GF L1-L5 detector. Same threshold as L1-L2 since both
+            // are dual-carrier ionosphere-free residuals — slip on either L1 or L5 carrier
+            // appears as a multi-cycle jump in the GF combination.
+            for (const auto& [sat, sd] : sat_data) {
+                if (!sd.has_l1 || !sd.has_l5 || sd.l1_wavelength <= 0.0 || sd.l5_wavelength <= 0.0) continue;
+                double gf15 = (sd.rover_l1_phase - sd.base_l1_phase) * sd.l1_wavelength -
+                              (sd.rover_l5_phase - sd.base_l5_phase) * sd.l5_wavelength;
+                auto prev_it = gf_l1l5_history_.find(sat);
+                if (prev_it != gf_l1l5_history_.end() &&
+                    std::abs(gf15 - prev_it->second) > gf_slip_threshold) {
+                    gf_slips_l1l5.insert(sat);
+                }
+                gf_l1l5_history_[sat] = gf15;
+            }
+        }
     }
     debug_telemetry_.gf_slip_count = static_cast<int>(gf_slips.size());
+    debug_telemetry_.gf_slip_l1l5_count = static_cast<int>(gf_slips_l1l5.size());
 
     std::set<SatelliteId> doppler_slips_l1;
     std::set<SatelliteId> doppler_slips_l2;
+    std::set<SatelliteId> doppler_slips_l5;  // Phase 18 Step 5
     if (rtk_config_.enable_doppler_slip_detection &&
         std::isfinite(dt_s) &&
         dt_s > 0.0 &&
@@ -884,13 +989,35 @@ void RTKProcessor::updateBias(const std::map<SatelliteId, SatelliteData>& sat_da
                 }
                 doppler_phase_history_l2_m_[sat] = sd_phase_m;
             }
+            // Phase 18 Step 5: doppler-based slip detection on L5.
+            if (rtk_config_.enable_l5 &&
+                sd.has_l5 && sd.has_l5_doppler && sd.l5_wavelength > 0.0) {
+                const double sd_phase_m =
+                    (sd.rover_l5_phase - sd.base_l5_phase) * sd.l5_wavelength;
+                const double sd_range_rate_mps =
+                    rtk_slip_detection::singleDifferenceRangeRateMps(
+                        sd.rover_l5_doppler, sd.base_l5_doppler, sd.l5_wavelength);
+                auto previous = doppler_phase_history_l5_m_.find(sat);
+                if (previous != doppler_phase_history_l5_m_.end() &&
+                    rtk_slip_detection::detectDopplerSlip(
+                        previous->second,
+                        sd_phase_m,
+                        sd_range_rate_mps,
+                        dt_s,
+                        doppler_slip_threshold)) {
+                    doppler_slips_l5.insert(sat);
+                }
+                doppler_phase_history_l5_m_[sat] = sd_phase_m;
+            }
         }
     }
     debug_telemetry_.doppler_slip_l1_count = static_cast<int>(doppler_slips_l1.size());
     debug_telemetry_.doppler_slip_l2_count = static_cast<int>(doppler_slips_l2.size());
+    debug_telemetry_.doppler_slip_l5_count = static_cast<int>(doppler_slips_l5.size());
 
     std::set<SatelliteId> code_slips_l1;
     std::set<SatelliteId> code_slips_l2;
+    std::set<SatelliteId> code_slips_l5;  // Phase 18 Step 5
     if (rtk_config_.enable_code_slip_detection) {
         const double code_slip_threshold =
             apply_dynamic_slip_floor
@@ -933,32 +1060,88 @@ void RTKProcessor::updateBias(const std::map<SatelliteId, SatelliteData>& sat_da
                 }
                 code_phase_history_l2_m_[sat] = code_minus_phase_m;
             }
+            // Phase 18 Step 5: code-minus-phase slip detection on L5.
+            if (rtk_config_.enable_l5 && sd.has_l5 && sd.l5_wavelength > 0.0) {
+                const double code_minus_phase_m =
+                    rtk_slip_detection::singleDifferenceCodeMinusPhaseM(
+                        sd.rover_l5_code,
+                        sd.base_l5_code,
+                        sd.rover_l5_phase,
+                        sd.base_l5_phase,
+                        sd.l5_wavelength);
+                auto previous = code_phase_history_l5_m_.find(sat);
+                if (previous != code_phase_history_l5_m_.end() &&
+                    rtk_slip_detection::detectCodeSlip(
+                        previous->second,
+                        code_minus_phase_m,
+                        code_slip_threshold)) {
+                    code_slips_l5.insert(sat);
+                }
+                code_phase_history_l5_m_[sat] = code_minus_phase_m;
+            }
         }
     }
     debug_telemetry_.code_slip_l1_count = static_cast<int>(code_slips_l1.size());
     debug_telemetry_.code_slip_l2_count = static_cast<int>(code_slips_l2.size());
+    debug_telemetry_.code_slip_l5_count = static_cast<int>(code_slips_l5.size());
 
-    for (int freq = 0; freq < 2; ++freq) {
-        auto& indices = (freq == 0) ? filter_state_.n1_indices : filter_state_.n2_indices;
-        auto& lock_counts = (freq == 0) ? lock_count_l1_ : lock_count_l2_;
+    // Phase 18 Step 4: extend freq loop from {L1, L2} to {L1, L2, L5} when enable_l5.
+    // Per-frequency accessors abstract over the SatelliteData layout differences.
+    auto has_freq_signal = [](const SatelliteData& sd, int freq) -> bool {
+        return freq == 0 ? sd.has_l1 : (freq == 1 ? sd.has_l2 : sd.has_l5);
+    };
+    auto freq_lli = [](const SatelliteData& sd, int freq) -> int {
+        return freq == 0 ? sd.l1_lli : (freq == 1 ? sd.l2_lli : sd.l5_lli);
+    };
+    auto freq_wavelength = [](const SatelliteData& sd, int freq) -> double {
+        return freq == 0 ? sd.l1_wavelength : (freq == 1 ? sd.l2_wavelength : sd.l5_wavelength);
+    };
+    auto freq_phase_diff = [](const SatelliteData& sd, int freq) -> double {
+        if (freq == 0) return sd.rover_l1_phase - sd.base_l1_phase;
+        if (freq == 1) return sd.rover_l2_phase - sd.base_l2_phase;
+        return sd.rover_l5_phase - sd.base_l5_phase;
+    };
+    auto freq_code_diff = [](const SatelliteData& sd, int freq) -> double {
+        if (freq == 0) return sd.rover_l1_code - sd.base_l1_code;
+        if (freq == 1) return sd.rover_l2_code - sd.base_l2_code;
+        return sd.rover_l5_code - sd.base_l5_code;
+    };
+    const int max_freq = rtk_config_.enable_l5 ? 3 : 2;
+    for (int freq = 0; freq < max_freq; ++freq) {
+        auto& indices = (freq == 0) ? filter_state_.n1_indices :
+                        (freq == 1) ? filter_state_.n2_indices : filter_state_.n5_indices;
+        auto& lock_counts = (freq == 0) ? lock_count_l1_ :
+                            (freq == 1) ? lock_count_l2_ : lock_count_l5_;
         int lli_slip_count = 0;
         int ambiguity_reset_count = 0;
 
         // Detect cycle slips and reset
         for (const auto& [sat, sd] : sat_data) {
-            bool has_freq = (freq == 0) ? sd.has_l1 : sd.has_l2;
-            if (!has_freq) continue;
-            int lli = (freq == 0) ? sd.l1_lli : sd.l2_lli;
+            if (!has_freq_signal(sd, freq)) continue;
+            int lli = freq_lli(sd, freq);
             const bool lli_slip = (lli & 0x01) != 0;
             if (lli_slip) {
                 lli_slip_count++;
             }
-            bool slip = lli_slip ||
-                        gf_slips.find(sat) != gf_slips.end() ||
-                        (freq == 0 ? code_slips_l1.find(sat) != code_slips_l1.end()
-                                   : code_slips_l2.find(sat) != code_slips_l2.end()) ||
-                        (freq == 0 ? doppler_slips_l1.find(sat) != doppler_slips_l1.end()
-                                   : doppler_slips_l2.find(sat) != doppler_slips_l2.end());
+            // Phase 18 Step 5: L5 now participates in GF (L1-L5) / doppler-L5 / code-L5 slip checks.
+            bool slip = lli_slip;
+            if (freq == 0) {
+                slip = slip ||
+                       gf_slips.find(sat) != gf_slips.end() ||
+                       gf_slips_l1l5.find(sat) != gf_slips_l1l5.end() ||
+                       code_slips_l1.find(sat) != code_slips_l1.end() ||
+                       doppler_slips_l1.find(sat) != doppler_slips_l1.end();
+            } else if (freq == 1) {
+                slip = slip ||
+                       gf_slips.find(sat) != gf_slips.end() ||
+                       code_slips_l2.find(sat) != code_slips_l2.end() ||
+                       doppler_slips_l2.find(sat) != doppler_slips_l2.end();
+            } else {  // freq == 2 (L5)
+                slip = slip ||
+                       gf_slips_l1l5.find(sat) != gf_slips_l1l5.end() ||
+                       code_slips_l5.find(sat) != code_slips_l5.end() ||
+                       doppler_slips_l5.find(sat) != doppler_slips_l5.end();
+            }
             auto idx_it = indices.find(sat);
             if (idx_it != indices.end() && slip) {
                 ambiguity_reset_count++;
@@ -989,9 +1172,12 @@ void RTKProcessor::updateBias(const std::map<SatelliteId, SatelliteData>& sat_da
         if (freq == 0) {
             debug_telemetry_.lli_slip_l1_count = lli_slip_count;
             debug_telemetry_.ambiguity_reset_l1_count = ambiguity_reset_count;
-        } else {
+        } else if (freq == 1) {
             debug_telemetry_.lli_slip_l2_count = lli_slip_count;
             debug_telemetry_.ambiguity_reset_l2_count = ambiguity_reset_count;
+        } else {  // freq == 2 (Phase 18 Step 5)
+            debug_telemetry_.lli_slip_l5_count = lli_slip_count;
+            debug_telemetry_.ambiguity_reset_l5_count = ambiguity_reset_count;
         }
 
         for (GNSSSystem system : kRTKSupportedSystems) {
@@ -1002,17 +1188,11 @@ void RTKProcessor::updateBias(const std::map<SatelliteId, SatelliteData>& sat_da
 
             for (const auto& [sat, sd] : sat_data) {
                 if (sat.system != system) continue;
-                bool has_freq = (freq == 0) ? sd.has_l1 : sd.has_l2;
-                const double wavelength = (freq == 0) ? sd.l1_wavelength : sd.l2_wavelength;
-                if (!has_freq || wavelength <= 0.0) continue;
-                double cp, pr;
-                if (freq == 0) {
-                    cp = sd.rover_l1_phase - sd.base_l1_phase;
-                    pr = sd.rover_l1_code - sd.base_l1_code;
-                } else {
-                    cp = sd.rover_l2_phase - sd.base_l2_phase;
-                    pr = sd.rover_l2_code - sd.base_l2_code;
-                }
+                if (!has_freq_signal(sd, freq)) continue;
+                const double wavelength = freq_wavelength(sd, freq);
+                if (wavelength <= 0.0) continue;
+                const double cp = freq_phase_diff(sd, freq);
+                const double pr = freq_code_diff(sd, freq);
                 double b = cp - pr / wavelength;
                 bias[sat] = b;
                 auto idx_it = indices.find(sat);
@@ -1035,7 +1215,8 @@ void RTKProcessor::updateBias(const std::map<SatelliteId, SatelliteData>& sat_da
                 auto idx_it = indices.find(sat);
                 if (idx_it != indices.end() && filter_state_.state(idx_it->second) != 0.0) continue;
                 if (freq == 0) getOrCreateN1Index(sat, b);
-                else getOrCreateN2Index(sat, b);
+                else if (freq == 1) getOrCreateN2Index(sat, b);
+                else getOrCreateN5Index(sat, b);
                 lock_counts[sat] = 0;
             }
         }
@@ -1078,6 +1259,7 @@ void RTKProcessor::incrementLockCounts(const std::map<SatelliteId, SatelliteData
     for (const auto& [sat, sd] : sat_data) {
         if (sd.has_l1) lock_count_l1_[sat]++;
         if (sd.has_l2) lock_count_l2_[sat]++;
+        if (sd.has_l5) lock_count_l5_[sat]++;  // Phase 18 Step 4: only set when enable_l5 populated has_l5
     }
 }
 
@@ -1112,6 +1294,11 @@ void RTKProcessor::resetAmbiguityStatesForReacquisition(const ObservationData& r
         filter_state_.covariance(idx, idx) = 900.0;
     }
     for (auto& [sat, idx] : filter_state_.n2_indices) {
+        filter_state_.state(idx) = 0.0;
+        filter_state_.covariance(idx, idx) = 900.0;
+    }
+    // Phase 18 Step 2: reset N5 ambiguities (no-op until n5_indices populated).
+    for (auto& [sat, idx] : filter_state_.n5_indices) {
         filter_state_.state(idx) = 0.0;
         filter_state_.covariance(idx, idx) = 900.0;
     }
@@ -1257,16 +1444,31 @@ void RTKProcessor::resetPositionToSPP(const ObservationData& rover_obs, const Na
             rover_pos = base_position_;
         }
     } else {
-        if (spp.isValid()) {
-            rover_pos = spp.position_ecef;
-        } else if (has_last_fixed_position_) {
-            rover_pos = last_fixed_position_;
-        } else if (rover_obs.receiver_position.norm() > 1e6) {
-            rover_pos = rover_obs.receiver_position;
-        } else if (has_last_solution_position_) {
-            rover_pos = last_solution_position_;
-        } else {
-            rover_pos = base_position_;
+        bool seeded = false;
+        if (rtk_config_.prefer_trusted_position_seed &&
+            has_last_trusted_position_ && has_last_trusted_time_) {
+            const double dt = rover_obs.time - last_trusted_time_;
+            if (std::isfinite(dt) && dt >= 0.0 && dt <= 1.0) {
+                rover_pos = last_trusted_position_;
+                var_pos = std::max(25.0, std::pow(3.0 * std::max(dt, 0.2), 2.0));
+                seeded = true;
+            }
+        }
+        if (!seeded) {
+            if (rtk_config_.prefer_rover_position_seed &&
+                rover_obs.receiver_position.norm() > 1e6) {
+                rover_pos = rover_obs.receiver_position;
+            } else if (spp.isValid()) {
+                rover_pos = spp.position_ecef;
+            } else if (has_last_fixed_position_) {
+                rover_pos = last_fixed_position_;
+            } else if (rover_obs.receiver_position.norm() > 1e6) {
+                rover_pos = rover_obs.receiver_position;
+            } else if (has_last_solution_position_) {
+                rover_pos = last_solution_position_;
+            } else {
+                rover_pos = base_position_;
+            }
         }
     }
     Vector3d baseline = rover_pos - base_position_;
@@ -1797,9 +1999,30 @@ std::vector<rtk_measurement::MeasurementBlock> RTKProcessor::buildMeasurementBlo
                               tropModel(base_position_, ref_sd.base_elevation);
         const Vector3d los_ref = (ref_sd.sat_pos - rover_pos).normalized();
         auto signal_snr_dbhz = [](const SatelliteData& sd, int freq) {
-            return freq == 0
-                ? combinedSnrDbHz(sd.rover_l1_snr, sd.base_l1_snr)
-                : combinedSnrDbHz(sd.rover_l2_snr, sd.base_l2_snr);
+            if (freq == 0) return combinedSnrDbHz(sd.rover_l1_snr, sd.base_l1_snr);
+            if (freq == 1) return combinedSnrDbHz(sd.rover_l2_snr, sd.base_l2_snr);
+            return combinedSnrDbHz(sd.rover_l5_snr, sd.base_l5_snr);  // Phase 18 Step 4
+        };
+        // Phase 18 Step 4: per-frequency accessors (parallel to updateBias). freq=2 returns L5.
+        auto freq_wavelength_local = [](const SatelliteData& sd, int freq) -> double {
+            if (freq == 0) return sd.l1_wavelength;
+            if (freq == 1) return sd.l2_wavelength;
+            return sd.l5_wavelength;
+        };
+        auto freq_frequency_hz_local = [](const SatelliteData& sd, int freq) -> double {
+            if (freq == 0) return sd.l1_frequency_hz;
+            if (freq == 1) return sd.l2_frequency_hz;
+            return sd.l5_frequency_hz;
+        };
+        auto freq_phase_diff_local = [](const SatelliteData& sd, int freq) -> double {
+            if (freq == 0) return sd.rover_l1_phase - sd.base_l1_phase;
+            if (freq == 1) return sd.rover_l2_phase - sd.base_l2_phase;
+            return sd.rover_l5_phase - sd.base_l5_phase;
+        };
+        auto freq_code_diff_local = [](const SatelliteData& sd, int freq) -> double {
+            if (freq == 0) return sd.rover_l1_code - sd.base_l1_code;
+            if (freq == 1) return sd.rover_l2_code - sd.base_l2_code;
+            return sd.rover_l5_code - sd.base_l5_code;
         };
 
         auto append_frequency_blocks = [&](int freq) {
@@ -1809,7 +2032,9 @@ std::vector<rtk_measurement::MeasurementBlock> RTKProcessor::buildMeasurementBlo
             rtk_measurement::MeasurementBlock code_block;
             code_block.kind = rtk_measurement::MeasurementKind::CODE;
             code_block.frequency_index = freq;
-            const auto& ref_indices = (freq == 0) ? filter_state_.n1_indices : filter_state_.n2_indices;
+            const auto& ref_indices = (freq == 0) ? filter_state_.n1_indices :
+                                      (freq == 1) ? filter_state_.n2_indices :
+                                                    filter_state_.n5_indices;
             auto ref_state_it = ref_indices.find(ref_sat);
             if (ref_state_it == ref_indices.end()) {
                 blocks.push_back(std::move(phase_block));
@@ -1817,7 +2042,7 @@ std::vector<rtk_measurement::MeasurementBlock> RTKProcessor::buildMeasurementBlo
                 return;
             }
 
-            const double ref_wavelength = (freq == 0) ? ref_sd.l1_wavelength : ref_sd.l2_wavelength;
+            const double ref_wavelength = freq_wavelength_local(ref_sd, freq);
             if (ref_wavelength <= 0.0) {
                 blocks.push_back(std::move(phase_block));
                 blocks.push_back(std::move(code_block));
@@ -1830,7 +2055,7 @@ std::vector<rtk_measurement::MeasurementBlock> RTKProcessor::buildMeasurementBlo
                     ? ionoFrequencyScale(
                           freq,
                           ref_sd.l1_frequency_hz,
-                          (freq == 0) ? ref_sd.l1_frequency_hz : ref_sd.l2_frequency_hz)
+                          freq_frequency_hz_local(ref_sd, freq))
                     : 0.0;
             if (estimate_iono && filter_state_.covariance(ref_iono_idx, ref_iono_idx) <= 0.0) {
                 blocks.push_back(std::move(phase_block));
@@ -1847,11 +2072,13 @@ std::vector<rtk_measurement::MeasurementBlock> RTKProcessor::buildMeasurementBlo
                 if (sat_it == sat_data.end()) continue;
                 const auto& sat = pair.sat;
                 const auto& sd = sat_it->second;
-                const auto& sat_indices = (freq == 0) ? filter_state_.n1_indices : filter_state_.n2_indices;
+                const auto& sat_indices = (freq == 0) ? filter_state_.n1_indices :
+                                          (freq == 1) ? filter_state_.n2_indices :
+                                                        filter_state_.n5_indices;
                 auto sat_state_it = sat_indices.find(sat);
                 if (sat_state_it == sat_indices.end()) continue;
 
-                const double sat_wavelength = (freq == 0) ? sd.l1_wavelength : sd.l2_wavelength;
+                const double sat_wavelength = freq_wavelength_local(sd, freq);
                 if (sat_wavelength <= 0.0) continue;
                 const double sat_snr = signal_snr_dbhz(sd, freq);
                 const double sat_phase_variance = varerr(sd.elevation, true, sat_snr);
@@ -1862,7 +2089,7 @@ std::vector<rtk_measurement::MeasurementBlock> RTKProcessor::buildMeasurementBlo
                         ? ionoFrequencyScale(
                               freq,
                               sd.l1_frequency_hz,
-                              (freq == 0) ? sd.l1_frequency_hz : sd.l2_frequency_hz)
+                              freq_frequency_hz_local(sd, freq))
                         : 0.0;
                 if (estimate_iono &&
                     filter_state_.covariance(sat_iono_idx, sat_iono_idx) <= 0.0) {
@@ -1878,14 +2105,11 @@ std::vector<rtk_measurement::MeasurementBlock> RTKProcessor::buildMeasurementBlo
                     estimate_iono ? filter_state_.state(ref_iono_idx) : 0.0;
                 const double sat_iono_state =
                     estimate_iono ? filter_state_.state(sat_iono_idx) : 0.0;
-                const double ref_phase = (freq == 0) ? ref_sd.rover_l1_phase - ref_sd.base_l1_phase
-                                                     : ref_sd.rover_l2_phase - ref_sd.base_l2_phase;
-                const double sat_phase = (freq == 0) ? sd.rover_l1_phase - sd.base_l1_phase
-                                                     : sd.rover_l2_phase - sd.base_l2_phase;
-                const double ref_code = (freq == 0) ? ref_sd.rover_l1_code - ref_sd.base_l1_code
-                                                    : ref_sd.rover_l2_code - ref_sd.base_l2_code;
-                const double sat_code = (freq == 0) ? sd.rover_l1_code - sd.base_l1_code
-                                                    : sd.rover_l2_code - sd.base_l2_code;
+                const double ref_phase = freq_phase_diff_local(ref_sd, freq);
+                const double sat_phase = freq_phase_diff_local(sd, freq);
+                const double ref_code = freq_code_diff_local(ref_sd, freq);
+                const double sat_code = freq_code_diff_local(sd, freq);
+                // Glonass autocal/ICB only meaningful on L1/L2 (no GLO L5 path); freq==2 → false.
                 const bool autocal_glonass =
                     usesGlonassAutocal(rtk_config_) &&
                     ref_sd.satellite.system == GNSSSystem::GLONASS &&
@@ -1893,16 +2117,16 @@ std::vector<rtk_measurement::MeasurementBlock> RTKProcessor::buildMeasurementBlo
                     freq < GLO_HWBIAS_STATES;
                 const double df_mhz =
                     autocal_glonass
-                        ? (((freq == 0) ? ref_sd.l1_frequency_hz : ref_sd.l2_frequency_hz) -
-                           ((freq == 0) ? sd.l1_frequency_hz : sd.l2_frequency_hz)) / 1e6
+                        ? (freq_frequency_hz_local(ref_sd, freq) -
+                           freq_frequency_hz_local(sd, freq)) / 1e6
                         : 0.0;
                 const double glonass_icb =
                     glonassInterChannelBiasMeters(
                         rtk_config_,
                         ref_sd.satellite.system,
                         sd.satellite.system,
-                        (freq == 0) ? ref_sd.l1_frequency_hz : ref_sd.l2_frequency_hz,
-                        (freq == 0) ? sd.l1_frequency_hz : sd.l2_frequency_hz,
+                        freq_frequency_hz_local(ref_sd, freq),
+                        freq_frequency_hz_local(sd, freq),
                         freq);
                 const double phase_iono_term =
                     estimate_iono ?
@@ -1951,6 +2175,9 @@ std::vector<rtk_measurement::MeasurementBlock> RTKProcessor::buildMeasurementBlo
 
         append_frequency_blocks(0);
         append_frequency_blocks(1);
+        if (rtk_config_.enable_l5) {
+            append_frequency_blocks(2);  // Phase 18 Step 4: L5 phase + code DD measurement rows
+        }
     }
 
     return blocks;
@@ -1966,7 +2193,9 @@ bool RTKProcessor::updateFilter(const std::map<SatelliteId, SatelliteData>& sat_
     const auto update_result = rtk_update::applyMeasurementUpdate(filter_state_.state,
                                                                   filter_state_.covariance,
                                                                   measurement_system,
-                                                                  30.0,
+                                                                  rtk_config_.outlier_threshold > 0.0
+                                                                      ? rtk_config_.outlier_threshold
+                                                                      : 30.0,
                                                                   6,
                                                                   rtk_config_.max_update_nis_per_observation);
     current_update_diagnostics_.observation_count = update_result.observation_count;
@@ -2253,6 +2482,48 @@ bool RTKProcessor::resolveAmbiguities(std::vector<DDPair> dd_pairs) {
         return std::isfinite(wide_lane_float);
     };
 
+    // Phase 18 Step 6: L1-L5 wide-lane Melbourne-Wübbena combination.
+    // Parallel to the L1-L2 path; uses the dd_pairs entry with freq==2 as the L5 leg.
+    auto compute_wide_lane_l5_float = [&](int l1_index, int l5_index, double& wide_lane_float) {
+        if (l1_index < 0 || l5_index < 0 ||
+            l1_index >= nb || l5_index >= nb ||
+            dd_pairs[l1_index].freq != 0 || dd_pairs[l5_index].freq != 2) {
+            return false;
+        }
+        const auto ref_it = sat_data.find(dd_pairs[l1_index].ref_sat);
+        const auto sat_it = sat_data.find(dd_pairs[l1_index].sat);
+        if (ref_it == sat_data.end() || sat_it == sat_data.end()) {
+            return false;
+        }
+        const auto& ref_sd = ref_it->second;
+        const auto& sd = sat_it->second;
+        if (!ref_sd.has_l1 || !ref_sd.has_l5 || !sd.has_l1 || !sd.has_l5) {
+            return false;
+        }
+
+        const double f1 = ref_sd.l1_frequency_hz;
+        const double f5 = ref_sd.l5_frequency_hz;
+        const double lambda_wl_m = wideLaneWavelength(f1, f5);  // ~0.751 m for GPS L1-L5
+        if (f1 <= 0.0 || f5 <= 0.0 || lambda_wl_m <= 0.0) {
+            return false;
+        }
+
+        auto single_difference_wide_lane_l5 = [&](const SatelliteData& data) {
+            const double phi1_m =
+                (data.rover_l1_phase - data.base_l1_phase) * data.l1_wavelength;
+            const double phi5_m =
+                (data.rover_l5_phase - data.base_l5_phase) * data.l5_wavelength;
+            const double code_term =
+                (f1 * (data.rover_l1_code - data.base_l1_code) +
+                 f5 * (data.rover_l5_code - data.base_l5_code)) / (f1 + f5);
+            return ((f1 * phi1_m - f5 * phi5_m) / (f1 - f5) - code_term) / lambda_wl_m;
+        };
+
+        wide_lane_float = single_difference_wide_lane_l5(ref_sd) -
+                          single_difference_wide_lane_l5(sd);
+        return std::isfinite(wide_lane_float);
+    };
+
     if (rtk_config_.enable_wide_lane_ar) {
         const double wide_lane_threshold =
             std::max(0.0, rtk_config_.wide_lane_acceptance_threshold);
@@ -2289,6 +2560,45 @@ bool RTKProcessor::resolveAmbiguities(std::vector<DDPair> dd_pairs) {
 
             wide_lane_constraints.push_back({i, l2_pair, fixed_integer});
             wide_lane_fixed++;
+        }
+        // Phase 18 Step 6: parallel L1-L5 wide-lane fixing for sats lacking an L1-L2
+        // pair (or in addition to it). Constraint structure is identical — l2_index
+        // simply now points at a freq=2 dd_pair instead of freq=1.
+        if (rtk_config_.enable_l5) {
+            for (int i = 0; i < nb; ++i) {
+                if (dd_pairs[i].freq != 0 || dd_pairs[i].ref_sat.system == GNSSSystem::GLONASS) {
+                    continue;
+                }
+                int l5_pair = -1;
+                for (int j = 0; j < nb; ++j) {
+                    if (dd_pairs[j].freq == 2 &&
+                        dd_pairs[j].sat == dd_pairs[i].sat &&
+                        dd_pairs[j].ref_sat == dd_pairs[i].ref_sat) {
+                        l5_pair = j;
+                        break;
+                    }
+                }
+                if (l5_pair < 0) {
+                    continue;
+                }
+
+                wide_lane_total++;
+                double wide_lane_float = 0.0;
+                if (!compute_wide_lane_l5_float(i, l5_pair, wide_lane_float)) {
+                    continue;
+                }
+                const double fixed_integer = std::round(wide_lane_float);
+                const double wl_distance = distanceToNearestInteger(wide_lane_float);
+                wide_lane_min_distance = std::min(wide_lane_min_distance, wl_distance);
+                wide_lane_max_distance = std::max(wide_lane_max_distance, wl_distance);
+                if (wl_distance >= wide_lane_threshold) {
+                    wide_lane_rejected++;
+                    continue;
+                }
+
+                wide_lane_constraints.push_back({i, l5_pair, fixed_integer});
+                wide_lane_fixed++;
+            }
         }
         if (wide_lane_total > 0) {
             std::clog << "[RTK-AR] WL fixed " << wide_lane_fixed

--- a/src/algorithms/rtk_selection.cpp
+++ b/src/algorithms/rtk_selection.cpp
@@ -111,6 +111,28 @@ std::vector<SelectionPair> buildDoubleDifferencePairsForSystem(
         }
     }
 
+    // Phase 18 Step 4: emit L5 (freq=2) pairs when ref sat carries an active L5 ambiguity.
+    // Backward-compat: when L5 collection is disabled (Step 3 default), has_l5/n5_active stay
+    // false on every snapshot entry, so this block is a no-op.
+    if (ref_data->has_l5 && ref_data->n5_active) {
+        for (const auto& satellite : satellites) {
+            if (satellite.satellite.system != system || satellite.satellite == ref_sat) {
+                continue;
+            }
+            if (!satellite.has_l5 || !satellite.n5_active) {
+                continue;
+            }
+            if (min_lock_count > 0 && satellite.lock_count_l5 < min_lock_count) {
+                continue;
+            }
+            if (require_matched_carrier_wavelength &&
+                std::abs(satellite.l5_wavelength - ref_data->l5_wavelength) > 1e-6) {
+                continue;
+            }
+            pairs.push_back({ref_sat, satellite.satellite, 2});
+        }
+    }
+
     return pairs;
 }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,8 @@ if(GTest_FOUND)
         test_ppp_atmosphere.cpp
         test_rtk_ar_evaluation.cpp
         test_rtk_ar_selection.cpp
+        test_nlos_weights.cpp
+        test_float_trust_policy.cpp
         test_rtk_slip_detection.cpp
         test_rtk_measurement.cpp
         test_rtk_update.cpp

--- a/tests/test_float_trust_policy.cpp
+++ b/tests/test_float_trust_policy.cpp
@@ -1,0 +1,226 @@
+#include <gtest/gtest.h>
+
+#include <libgnss++/algorithms/float_trust_policy.hpp>
+
+#include <cmath>
+#include <limits>
+
+namespace libgnss {
+namespace float_trust_policy {
+namespace {
+
+constexpr double kLegacyVar = 900.0;
+
+// --------------------------------------------------------------------------
+// hasTrustLapsed
+// --------------------------------------------------------------------------
+
+TEST(FloatTrustPolicyTest, LapsedWhenNeverTrusted) {
+    EXPECT_TRUE(hasTrustLapsed(/*has_last_trusted=*/false, /*trust_refreshed_last_epoch=*/false));
+    // has_last_trusted false should still report lapsed even if the second
+    // flag is (nonsensically) true -- "never trusted" always wins.
+    EXPECT_TRUE(hasTrustLapsed(false, true));
+}
+
+TEST(FloatTrustPolicyTest, LapsedWhenPreviousEpochDidNotRefresh) {
+    EXPECT_TRUE(hasTrustLapsed(/*has_last_trusted=*/true, /*trust_refreshed_last_epoch=*/false));
+}
+
+TEST(FloatTrustPolicyTest, NotLapsedWhenPreviousEpochRefreshed) {
+    EXPECT_FALSE(hasTrustLapsed(/*has_last_trusted=*/true, /*trust_refreshed_last_epoch=*/true));
+}
+
+// --------------------------------------------------------------------------
+// growPositionVarianceCvPredict (CV_PREDICT)
+// --------------------------------------------------------------------------
+
+TEST(FloatTrustPolicyTest, CvPredictGrowsLinearlyWithDt) {
+    // prev=10, qpos=5 m^2/s, dt=0.2s -> 10 + 5*0.2 = 11
+    EXPECT_NEAR(growPositionVarianceCvPredict(10.0, 5.0, 0.2, kLegacyVar), 11.0, 1e-9);
+}
+
+TEST(FloatTrustPolicyTest, CvPredictZeroQposMeansNoGrowth) {
+    EXPECT_NEAR(growPositionVarianceCvPredict(42.0, 0.0, 5.0, kLegacyVar), 42.0, 1e-9);
+}
+
+TEST(FloatTrustPolicyTest, CvPredictCapsAtLegacyValue) {
+    // Large qpos/dt should saturate at the legacy cap, not exceed it.
+    EXPECT_DOUBLE_EQ(growPositionVarianceCvPredict(100.0, 1000.0, 100.0, kLegacyVar), kLegacyVar);
+}
+
+TEST(FloatTrustPolicyTest, CvPredictConvergesToLegacyUnderLongDrought) {
+    // Repeated application (simulating consecutive lapsed epochs) must
+    // monotonically approach, and eventually sit at, the legacy cap --
+    // i.e. bounded divergence from legacy by construction.
+    double var = 1.0;
+    for (int i = 0; i < 1000; ++i) {
+        const double next = growPositionVarianceCvPredict(var, 50.0, 0.2, kLegacyVar);
+        EXPECT_GE(next, var - 1e-9);  // monotonically non-decreasing
+        EXPECT_LE(next, kLegacyVar + 1e-9);
+        var = next;
+    }
+    EXPECT_NEAR(var, kLegacyVar, 1e-6);
+}
+
+TEST(FloatTrustPolicyTest, CvPredictClampsNegativeAndNonFiniteInputsDefensively) {
+    // Negative previous variance treated as 0.
+    EXPECT_NEAR(growPositionVarianceCvPredict(-5.0, 5.0, 1.0, kLegacyVar), 5.0, 1e-9);
+    // Negative qpos treated as 0 (no growth).
+    EXPECT_NEAR(growPositionVarianceCvPredict(20.0, -5.0, 1.0, kLegacyVar), 20.0, 1e-9);
+    // Negative dt treated as 0.
+    EXPECT_NEAR(growPositionVarianceCvPredict(20.0, 5.0, -1.0, kLegacyVar), 20.0, 1e-9);
+    // Non-finite previous variance falls back to the legacy cap (safe default).
+    const double nan_prev = std::numeric_limits<double>::quiet_NaN();
+    EXPECT_DOUBLE_EQ(growPositionVarianceCvPredict(nan_prev, 5.0, 1.0, kLegacyVar), kLegacyVar);
+}
+
+// --------------------------------------------------------------------------
+// scaledResetPositionVariance (SCALED_RESET)
+// --------------------------------------------------------------------------
+
+TEST(FloatTrustPolicyTest, ScaledResetIsBaseAtZeroTrustAge) {
+    EXPECT_NEAR(scaledResetPositionVariance(25.0, 10.0, 0.0, kLegacyVar), 25.0, 1e-9);
+}
+
+TEST(FloatTrustPolicyTest, ScaledResetGrowsQuadraticallyWithTrustAge) {
+    // var = min(900, 25 + 10 * 2^2) = min(900, 65) = 65
+    EXPECT_NEAR(scaledResetPositionVariance(25.0, 10.0, 2.0, kLegacyVar), 65.0, 1e-9);
+    // Doubling dt should more than double the growth term (quadratic, not linear).
+    const double growth_at_2s = scaledResetPositionVariance(25.0, 10.0, 2.0, kLegacyVar) - 25.0;
+    const double growth_at_4s = scaledResetPositionVariance(25.0, 10.0, 4.0, kLegacyVar) - 25.0;
+    EXPECT_NEAR(growth_at_4s, growth_at_2s * 4.0, 1e-9);
+}
+
+TEST(FloatTrustPolicyTest, ScaledResetCapsAtLegacyValue) {
+    EXPECT_DOUBLE_EQ(scaledResetPositionVariance(25.0, 10.0, 1000.0, kLegacyVar), kLegacyVar);
+}
+
+TEST(FloatTrustPolicyTest, ScaledResetClampsNegativeInputsDefensively) {
+    EXPECT_NEAR(scaledResetPositionVariance(-5.0, 10.0, 1.0, kLegacyVar), 10.0, 1e-9);
+    EXPECT_NEAR(scaledResetPositionVariance(25.0, -10.0, 1.0, kLegacyVar), 25.0, 1e-9);
+    EXPECT_NEAR(scaledResetPositionVariance(25.0, 10.0, -1.0, kLegacyVar), 25.0, 1e-9);
+}
+
+// --------------------------------------------------------------------------
+// estimateVelocityFromTrustedDeltas
+// --------------------------------------------------------------------------
+
+TEST(FloatTrustPolicyTest, VelocityFromTrustedDeltasBasicCase) {
+    const Eigen::Vector3d newer(10.0, 0.0, 0.0);
+    const Eigen::Vector3d older(0.0, 0.0, 0.0);
+    const Eigen::Vector3d v = estimateVelocityFromTrustedDeltas(newer, older, 2.0, 10.0);
+    EXPECT_NEAR(v.x(), 5.0, 1e-9);
+    EXPECT_NEAR(v.y(), 0.0, 1e-9);
+    EXPECT_NEAR(v.z(), 0.0, 1e-9);
+}
+
+TEST(FloatTrustPolicyTest, VelocityIsZeroForNonPositiveDt) {
+    const Eigen::Vector3d newer(10.0, 0.0, 0.0), older(0.0, 0.0, 0.0);
+    EXPECT_TRUE(estimateVelocityFromTrustedDeltas(newer, older, 0.0, 10.0).isZero());
+    EXPECT_TRUE(estimateVelocityFromTrustedDeltas(newer, older, -1.0, 10.0).isZero());
+}
+
+TEST(FloatTrustPolicyTest, VelocityIsZeroWhenDeltaTooOld) {
+    const Eigen::Vector3d newer(10.0, 0.0, 0.0), older(0.0, 0.0, 0.0);
+    // dt=20s > max_dt_s=10s -> samples too far apart, don't trust the delta.
+    EXPECT_TRUE(estimateVelocityFromTrustedDeltas(newer, older, 20.0, 10.0).isZero());
+}
+
+TEST(FloatTrustPolicyTest, VelocityIsZeroForNonFinitePositions) {
+    const Eigen::Vector3d bad(std::numeric_limits<double>::quiet_NaN(), 0.0, 0.0);
+    const Eigen::Vector3d ok(0.0, 0.0, 0.0);
+    EXPECT_TRUE(estimateVelocityFromTrustedDeltas(bad, ok, 1.0, 10.0).isZero());
+    EXPECT_TRUE(estimateVelocityFromTrustedDeltas(ok, bad, 1.0, 10.0).isZero());
+}
+
+// --------------------------------------------------------------------------
+// predictPositionConstantVelocity
+// --------------------------------------------------------------------------
+
+TEST(FloatTrustPolicyTest, PredictAdvancesPositionByVelocityTimesDt) {
+    const Eigen::Vector3d pos(100.0, 200.0, 300.0);
+    const Eigen::Vector3d vel(1.0, -2.0, 0.5);
+    const Eigen::Vector3d predicted = predictPositionConstantVelocity(pos, vel, 0.2);
+    EXPECT_NEAR(predicted.x(), 100.2, 1e-9);
+    EXPECT_NEAR(predicted.y(), 199.6, 1e-9);
+    EXPECT_NEAR(predicted.z(), 300.1, 1e-9);
+}
+
+TEST(FloatTrustPolicyTest, PredictWithZeroVelocityHoldsPosition) {
+    const Eigen::Vector3d pos(1.0, 2.0, 3.0);
+    const Eigen::Vector3d predicted = predictPositionConstantVelocity(pos, Eigen::Vector3d::Zero(), 5.0);
+    EXPECT_TRUE(predicted.isApprox(pos));
+}
+
+TEST(FloatTrustPolicyTest, PredictHoldsPositionOnNonFiniteVelocity) {
+    const Eigen::Vector3d pos(1.0, 2.0, 3.0);
+    const Eigen::Vector3d bad_vel(std::numeric_limits<double>::quiet_NaN(), 0.0, 0.0);
+    const Eigen::Vector3d predicted = predictPositionConstantVelocity(pos, bad_vel, 1.0);
+    EXPECT_TRUE(predicted.isApprox(pos));
+}
+
+// --------------------------------------------------------------------------
+// lapseGateExceeded (WP10: LAPSE_GATED)
+// --------------------------------------------------------------------------
+
+TEST(FloatTrustPolicyTest, LapseGateBelowGateStaysLegacy) {
+    // A 3s lapse against a 5s gate must NOT yet trigger the scaled law.
+    EXPECT_FALSE(lapseGateExceeded(3.0, 5.0));
+    EXPECT_FALSE(lapseGateExceeded(4.999, 5.0));
+}
+
+TEST(FloatTrustPolicyTest, LapseGateBoundaryIsInclusive) {
+    // Exactly at the gate: "exceeds" is treated as >=, i.e. the scaled law
+    // engages the instant the lapse reaches the configured duration.
+    EXPECT_TRUE(lapseGateExceeded(5.0, 5.0));
+}
+
+TEST(FloatTrustPolicyTest, LapseGateAboveGateSwitchesToScaledLaw) {
+    EXPECT_TRUE(lapseGateExceeded(5.001, 5.0));
+    EXPECT_TRUE(lapseGateExceeded(92.0, 5.0));  // the canyon's ~92s drought
+}
+
+TEST(FloatTrustPolicyTest, LapseGateZeroMeansAlwaysUseScaledLaw) {
+    // gate=0 is the degenerate "always scaled, never legacy, once lapsed"
+    // case -- useful as a sanity endpoint of a gate sweep.
+    EXPECT_TRUE(lapseGateExceeded(0.0, 0.0));
+    EXPECT_TRUE(lapseGateExceeded(0.001, 0.0));
+}
+
+TEST(FloatTrustPolicyTest, LapseGateVeryLargeGateNeverTriggersOnRealisticLapses) {
+    // This is the bit-identity check's mechanism: a gate value larger than
+    // any lapse that actually occurs in a run means lapseGateExceeded()
+    // never returns true, so resetPositionToSPP()'s caller never takes the
+    // scaled-reset branch -- every epoch falls through to the unmodified
+    // legacy fallback code path.
+    EXPECT_FALSE(lapseGateExceeded(92.0, 1.0e6));
+}
+
+TEST(FloatTrustPolicyTest, LapseGateClampsNegativeAndNonFiniteInputsDefensively) {
+    // Negative/non-finite lapse duration clamped to 0 (treated as "no
+    // lapse yet"); combined with any non-negative gate, that means "not
+    // exceeded" unless the gate is also clamped to <= 0.
+    EXPECT_FALSE(lapseGateExceeded(-1.0, 5.0));
+    EXPECT_FALSE(lapseGateExceeded(std::numeric_limits<double>::quiet_NaN(), 5.0));
+    // Negative/non-finite gate clamped to 0 -> "trigger immediately" once
+    // dt_since_trust is itself clamped to >= 0.
+    EXPECT_TRUE(lapseGateExceeded(0.5, -1.0));
+    EXPECT_TRUE(lapseGateExceeded(0.5, std::numeric_limits<double>::quiet_NaN()));
+}
+
+TEST(FloatTrustPolicyTest, LapseGateComposesWithScaledResetLawAboveGate) {
+    // Once the gate is exceeded, the resulting variance must match
+    // scaledResetPositionVariance()'s formula exactly (this is how
+    // resetPositionToSPP() wires the two functions together).
+    const double dt = 10.0;
+    const double gate = 5.0;
+    const double qpos = 0.1;
+    ASSERT_TRUE(lapseGateExceeded(dt, gate));
+    const double var = scaledResetPositionVariance(25.0, qpos, dt, kLegacyVar);
+    // 25 + 0.1 * 10^2 = 35
+    EXPECT_NEAR(var, 35.0, 1e-9);
+}
+
+}  // namespace
+}  // namespace float_trust_policy
+}  // namespace libgnss

--- a/tests/test_nlos_weights.cpp
+++ b/tests/test_nlos_weights.cpp
@@ -1,0 +1,248 @@
+#include <gtest/gtest.h>
+
+#include <libgnss++/algorithms/nlos_weights.hpp>
+
+#include <cmath>
+#include <cstdio>
+#include <filesystem>
+#include <fstream>
+#include <string>
+
+namespace libgnss {
+namespace nlos_weights {
+namespace {
+
+std::string writeTempCsv(const std::string& contents, const std::string& suffix) {
+    const auto path = std::filesystem::temp_directory_path() /
+        ("nlos_weights_test_" + suffix + ".csv");
+    std::ofstream out(path);
+    out << contents;
+    out.close();
+    return path.string();
+}
+
+// --------------------------------------------------------------------------
+// loadNlosWeightsCsv
+// --------------------------------------------------------------------------
+
+TEST(NlosWeightsTest, LoadsNativeTowSatLosProbContract) {
+    const std::string path = writeTempCsv(
+        "tow,sat,los_prob\n"
+        "100.000,G01,1.0\n"
+        "100.000,G02,0.0\n"
+        "100.500,G01,0.25\n",
+        "native");
+
+    const auto table = loadNlosWeightsCsv(path);
+    ASSERT_FALSE(table.empty());
+    EXPECT_DOUBLE_EQ(lookupLosProb(table, 100.0, "G01", 0.1), 1.0);
+    EXPECT_DOUBLE_EQ(lookupLosProb(table, 100.0, "G02", 0.1), 0.0);
+    EXPECT_DOUBLE_EQ(lookupLosProb(table, 100.5, "G01", 0.1), 0.25);
+
+    std::filesystem::remove(path);
+}
+
+TEST(NlosWeightsTest, LoadsExtendedIsLosBooleanContract) {
+    // Matches build_per_epoch_nlos_csv.py's actual header/row shape.
+    const std::string path = writeTempCsv(
+        "tow,epoch_idx,prn,is_los,system,svid,elevation_deg,receiver_source,receiver_time_delta_s\n"
+        "187470.000,0,C11,1,C,11,50.777,reference,0.000\n"
+        "187470.000,0,C21,0,C,21,15.475,reference,0.000\n",
+        "extended");
+
+    const auto table = loadNlosWeightsCsv(path);
+    ASSERT_FALSE(table.empty());
+    EXPECT_DOUBLE_EQ(lookupLosProb(table, 187470.0, "C11", 0.01), 1.0);
+    EXPECT_DOUBLE_EQ(lookupLosProb(table, 187470.0, "C21", 0.01), 0.0);
+
+    std::filesystem::remove(path);
+}
+
+TEST(NlosWeightsTest, MissingFileThrows) {
+    EXPECT_THROW(loadNlosWeightsCsv("/no/such/path/nlos_weights.csv"), std::runtime_error);
+}
+
+TEST(NlosWeightsTest, MissingRequiredColumnsThrows) {
+    const std::string path = writeTempCsv("a,b,c\n1,2,3\n", "bad_header");
+    EXPECT_THROW(loadNlosWeightsCsv(path), std::runtime_error);
+    std::filesystem::remove(path);
+}
+
+TEST(NlosWeightsTest, MalformedRowsAreSkippedNotFatal) {
+    const std::string path = writeTempCsv(
+        "tow,sat,los_prob\n"
+        "not_a_number,G01,1.0\n"
+        "100.0,G02,not_a_number\n"
+        "100.0,G03,0.5\n",
+        "malformed");
+    const auto table = loadNlosWeightsCsv(path);
+    EXPECT_DOUBLE_EQ(lookupLosProb(table, 100.0, "G03", 0.1), 0.5);
+    // Rows that failed to parse leave that (tow, sat) absent -> default 1.0.
+    EXPECT_DOUBLE_EQ(lookupLosProb(table, 100.0, "G02", 0.1), 1.0);
+    std::filesystem::remove(path);
+}
+
+// --------------------------------------------------------------------------
+// lookupLosProb
+// --------------------------------------------------------------------------
+
+TEST(NlosWeightsTest, EmptyTableAlwaysReturnsLos) {
+    NlosWeightTable table;
+    EXPECT_DOUBLE_EQ(lookupLosProb(table, 123.0, "G01", 0.1), 1.0);
+}
+
+TEST(NlosWeightsTest, UnknownSatelliteDefaultsToLos) {
+    NlosWeightTable table;
+    table.by_tow[100.0]["G01"] = 0.0;
+    EXPECT_DOUBLE_EQ(lookupLosProb(table, 100.0, "G99", 0.1), 1.0);
+}
+
+TEST(NlosWeightsTest, ToleranceRejectsFarTow) {
+    NlosWeightTable table;
+    table.by_tow[100.0]["G01"] = 0.0;
+    EXPECT_DOUBLE_EQ(lookupLosProb(table, 100.5, "G01", 0.1), 1.0);
+    EXPECT_DOUBLE_EQ(lookupLosProb(table, 100.05, "G01", 0.1), 0.0);
+}
+
+TEST(NlosWeightsTest, PicksNearestTowAmongCandidates) {
+    NlosWeightTable table;
+    table.by_tow[100.0]["G01"] = 0.1;
+    table.by_tow[100.2]["G01"] = 0.9;
+    // 100.11 is closer to 100.2 than to 100.0.
+    EXPECT_DOUBLE_EQ(lookupLosProb(table, 100.11, "G01", 0.5), 0.9);
+    // 100.05 is closer to 100.0.
+    EXPECT_DOUBLE_EQ(lookupLosProb(table, 100.05, "G01", 0.5), 0.1);
+}
+
+// --------------------------------------------------------------------------
+// nlosVarianceInflationFactor
+// --------------------------------------------------------------------------
+
+TEST(NlosWeightsTest, OffModeIsAlwaysNoOp) {
+    EXPECT_DOUBLE_EQ(
+        nlosVarianceInflationFactor(0.0, NlosWeightMode::OFF, 0.05, 0.5, 3.0), 1.0);
+    EXPECT_DOUBLE_EQ(
+        nlosVarianceInflationFactor(1.0, NlosWeightMode::OFF, 0.05, 0.5, 3.0), 1.0);
+    EXPECT_DOUBLE_EQ(
+        nlosVarianceInflationFactor(std::nan(""), NlosWeightMode::OFF, 0.05, 0.5, 3.0), 1.0);
+}
+
+TEST(NlosWeightsTest, TwoTierInflatesOnlyBelowThreshold) {
+    EXPECT_DOUBLE_EQ(
+        nlosVarianceInflationFactor(1.0, NlosWeightMode::TWO_TIER, 0.05, 0.5, 3.0), 1.0);
+    EXPECT_DOUBLE_EQ(
+        nlosVarianceInflationFactor(0.5, NlosWeightMode::TWO_TIER, 0.05, 0.5, 3.0), 1.0);
+    EXPECT_DOUBLE_EQ(
+        nlosVarianceInflationFactor(0.0, NlosWeightMode::TWO_TIER, 0.05, 0.5, 3.0), 9.0);
+    EXPECT_DOUBLE_EQ(
+        nlosVarianceInflationFactor(0.49, NlosWeightMode::TWO_TIER, 0.05, 0.5, 5.0), 25.0);
+}
+
+TEST(NlosWeightsTest, TwoTierClampsSubUnitInflationToOne) {
+    EXPECT_DOUBLE_EQ(
+        nlosVarianceInflationFactor(0.0, NlosWeightMode::TWO_TIER, 0.05, 0.5, 0.5), 1.0);
+}
+
+TEST(NlosWeightsTest, ContinuousMatchesOneOverMaxLosProbFloor) {
+    EXPECT_NEAR(
+        nlosVarianceInflationFactor(1.0, NlosWeightMode::CONTINUOUS, 0.05, 0.5, 3.0), 1.0, 1e-12);
+    EXPECT_NEAR(
+        nlosVarianceInflationFactor(0.0, NlosWeightMode::CONTINUOUS, 0.05, 0.5, 3.0), 20.0, 1e-9);
+    EXPECT_NEAR(
+        nlosVarianceInflationFactor(0.5, NlosWeightMode::CONTINUOUS, 0.05, 0.5, 3.0), 2.0, 1e-9);
+}
+
+TEST(NlosWeightsTest, ContinuousFloorClampedToSaneRange) {
+    // A non-finite / out-of-range floor should fall back to a safe default
+    // rather than dividing by zero or a negative number.
+    const double factor =
+        nlosVarianceInflationFactor(0.0, NlosWeightMode::CONTINUOUS, std::nan(""), 0.5, 3.0);
+    EXPECT_TRUE(std::isfinite(factor));
+    EXPECT_GT(factor, 1.0);
+}
+
+TEST(NlosWeightsTest, ExcludeModeIsAlwaysNoOpForInflationFactor) {
+    // EXCLUDE mode drops satellites entirely (nlosShouldExclude), it never
+    // inflates sigma -- nlosVarianceInflationFactor should treat it exactly
+    // like OFF for any surviving (non-excluded) satellite.
+    EXPECT_DOUBLE_EQ(
+        nlosVarianceInflationFactor(0.0, NlosWeightMode::EXCLUDE, 0.05, 0.5, 3.0), 1.0);
+    EXPECT_DOUBLE_EQ(
+        nlosVarianceInflationFactor(1.0, NlosWeightMode::EXCLUDE, 0.05, 0.5, 3.0), 1.0);
+}
+
+// --------------------------------------------------------------------------
+// nlosShouldExclude (WP8)
+// --------------------------------------------------------------------------
+
+TEST(NlosWeightsTest, ExcludeModeDropsBelowThreshold) {
+    EXPECT_TRUE(nlosShouldExclude(0.3, NlosWeightMode::EXCLUDE, 0.5));
+    EXPECT_FALSE(nlosShouldExclude(0.5, NlosWeightMode::EXCLUDE, 0.5));  // >= threshold kept
+    EXPECT_FALSE(nlosShouldExclude(0.7, NlosWeightMode::EXCLUDE, 0.5));
+    EXPECT_TRUE(nlosShouldExclude(0.0, NlosWeightMode::EXCLUDE, 0.5));
+}
+
+TEST(NlosWeightsTest, NonExcludeModesNeverExclude) {
+    EXPECT_FALSE(nlosShouldExclude(0.0, NlosWeightMode::OFF, 0.5));
+    EXPECT_FALSE(nlosShouldExclude(0.0, NlosWeightMode::TWO_TIER, 0.5));
+    EXPECT_FALSE(nlosShouldExclude(0.0, NlosWeightMode::CONTINUOUS, 0.5));
+}
+
+TEST(NlosWeightsTest, NonFiniteLosProbIsNeverExcluded) {
+    EXPECT_FALSE(nlosShouldExclude(std::nan(""), NlosWeightMode::EXCLUDE, 0.5));
+}
+
+TEST(NlosWeightsTest, NonFiniteExcludeThresholdFallsBackToHalf) {
+    EXPECT_TRUE(nlosShouldExclude(0.3, NlosWeightMode::EXCLUDE, std::nan("")));
+    EXPECT_FALSE(nlosShouldExclude(0.7, NlosWeightMode::EXCLUDE, std::nan("")));
+}
+
+// --------------------------------------------------------------------------
+// nlosExclusionGuardAllows (WP8 --nlos-min-sats safety guard)
+// --------------------------------------------------------------------------
+
+TEST(NlosWeightsTest, GuardAllowsExclusionWhenEnoughSatellitesSurvive) {
+    // 10 total, 3 excluded -> 7 survive, floor is 5 -> allowed.
+    EXPECT_TRUE(nlosExclusionGuardAllows(10, 3, 5));
+}
+
+TEST(NlosWeightsTest, GuardBlocksExclusionWhenTooFewWouldSurvive) {
+    // 8 total, 4 excluded -> 4 survive, floor is 5 -> blocked (keep all).
+    EXPECT_FALSE(nlosExclusionGuardAllows(8, 4, 5));
+}
+
+TEST(NlosWeightsTest, GuardAllowsExactlyAtTheFloor) {
+    // 10 total, 5 excluded -> exactly 5 survive, floor is 5 -> allowed.
+    EXPECT_TRUE(nlosExclusionGuardAllows(10, 5, 5));
+}
+
+TEST(NlosWeightsTest, GuardIsNoOpWhenNothingWouldBeExcluded) {
+    EXPECT_FALSE(nlosExclusionGuardAllows(10, 0, 5));
+}
+
+TEST(NlosWeightsTest, GuardTreatsNegativeMinSatsAsZero) {
+    // Even excluding everyone is allowed once min_sats itself is clamped to 0.
+    EXPECT_TRUE(nlosExclusionGuardAllows(5, 5, -3));
+}
+
+// --------------------------------------------------------------------------
+// nlosMinLosSatsGateAllows (WP10, WP8 recommendation 2 --nlos-min-los-sats)
+// --------------------------------------------------------------------------
+
+TEST(NlosWeightsTest, MinLosSatsGateDisabledAtZeroOrNegative) {
+    EXPECT_TRUE(nlosMinLosSatsGateAllows(0, 0));
+    EXPECT_TRUE(nlosMinLosSatsGateAllows(0, -1));
+}
+
+TEST(NlosWeightsTest, MinLosSatsGateBlocksBelowThreshold) {
+    EXPECT_FALSE(nlosMinLosSatsGateAllows(3, 4));
+}
+
+TEST(NlosWeightsTest, MinLosSatsGateAllowsAtOrAboveThreshold) {
+    EXPECT_TRUE(nlosMinLosSatsGateAllows(4, 4));
+    EXPECT_TRUE(nlosMinLosSatsGateAllows(6, 4));
+}
+
+}  // namespace
+}  // namespace nlos_weights
+}  // namespace libgnss

--- a/tests/test_rtk_smoke.cpp
+++ b/tests/test_rtk_smoke.cpp
@@ -3,6 +3,7 @@
 #include <libgnss++/io/rinex.hpp>
 
 #include <filesystem>
+#include <memory>
 #include <string>
 
 using namespace libgnss;
@@ -202,6 +203,429 @@ TEST_F(RTKSmokeTest, MovingBaseModeProducesValidSolutionsOnBundledKinematicData)
     EXPECT_GE(summary.valid_solutions, 8);
     EXPECT_TRUE(summary.first_valid_solution.isValid());
     EXPECT_GE(summary.first_valid_solution.num_satellites, 5);
+}
+
+// ============================================================================
+// WP7: dead-knob wiring regression tests.
+//
+// WP6 found --arfilter/--arfilter-margin and --hold-ratio-threshold were
+// parsed into RTKConfig but never read by rtk.cpp (rtk_ar_evaluation::
+// passesArFilter() was only ever called from its own unit test; the
+// fix-and-hold ratio relaxation used a hardcoded literal 2.0 instead of
+// RTKConfig::hold_ambiguity_ratio_threshold). These tests exercise the
+// wiring end-to-end on the bundled kinematic fixture, not just the pure
+// helper functions in test_rtk_ar_evaluation.cpp.
+// ============================================================================
+
+TEST_F(RTKSmokeTest, ArFilterDisabledByDefaultMatchesPreWiringBehavior) {
+    RTKProcessor::RTKConfig off_config;
+    off_config.position_mode = RTKProcessor::RTKConfig::PositionMode::KINEMATIC;
+    off_config.ar_mode = RTKProcessor::RTKConfig::AmbiguityResolutionMode::CONTINUOUS;
+    off_config.min_satellites_for_ar = 5;
+    off_config.ratio_threshold = 3.0;
+    ASSERT_FALSE(off_config.enable_ar_filter);
+
+    auto explicit_zero_margin_config = off_config;
+    explicit_zero_margin_config.enable_ar_filter = true;
+    explicit_zero_margin_config.ar_filter_margin = 0.0;
+
+    const auto off_summary = runEpochs(30, off_config);
+
+    rover_reader_.close();
+    base_reader_.close();
+    nav_reader_.close();
+    SetUp();
+
+    const auto zero_margin_summary = runEpochs(30, explicit_zero_margin_config);
+
+    // enable_ar_filter=true with margin=0 imposes ratio >= threshold + 0,
+    // identical to the always-on base gate, so the two runs must match
+    // exactly (bit-identical wiring, not just "close").
+    EXPECT_EQ(off_summary.epochs_processed, zero_margin_summary.epochs_processed);
+    EXPECT_EQ(off_summary.valid_solutions, zero_margin_summary.valid_solutions);
+    EXPECT_EQ(off_summary.fixed_solutions, zero_margin_summary.fixed_solutions);
+}
+
+TEST_F(RTKSmokeTest, ArFilterWithLargeMarginSuppressesFixesOnceEnabled) {
+    RTKProcessor::RTKConfig off_config;
+    off_config.position_mode = RTKProcessor::RTKConfig::PositionMode::KINEMATIC;
+    off_config.ar_mode = RTKProcessor::RTKConfig::AmbiguityResolutionMode::CONTINUOUS;
+    off_config.min_satellites_for_ar = 5;
+    off_config.ratio_threshold = 3.0;
+
+    auto strict_config = off_config;
+    strict_config.enable_ar_filter = true;
+    strict_config.ar_filter_margin = 1000.0;  // effectively unreachable ratio margin
+
+    const auto baseline_summary = runEpochs(30, off_config);
+
+    rover_reader_.close();
+    base_reader_.close();
+    nav_reader_.close();
+    SetUp();
+
+    const auto strict_summary = runEpochs(30, strict_config);
+
+    EXPECT_GE(baseline_summary.fixed_solutions, 1);
+    EXPECT_EQ(strict_summary.fixed_solutions, 0);
+    // The AR filter only guards ambiguity acceptance, not the SPP/float path.
+    EXPECT_EQ(baseline_summary.valid_solutions, strict_summary.valid_solutions);
+}
+
+TEST_F(RTKSmokeTest, HoldAmbiguityRatioThresholdIsHonoredNotHardcodedTwo) {
+    // min_hold_count=2 makes the hold-fix regime reachable within the
+    // bundled fixture's early, easy fix streak (AchievesEarlyFixedSolution*
+    // above shows fixed_solutions >= 1 well within 20 epochs).
+    RTKProcessor::RTKConfig config;
+    config.position_mode = RTKProcessor::RTKConfig::PositionMode::KINEMATIC;
+    config.ar_mode = RTKProcessor::RTKConfig::AmbiguityResolutionMode::CONTINUOUS;
+    config.min_satellites_for_ar = 5;
+    config.ratio_threshold = 3.0;
+    config.ambiguity_ratio_threshold = 3.0;
+    config.min_hold_count = 2;
+    config.hold_ambiguity_ratio_threshold = 7.25;  // distinct from both 3.0 and the old hardcoded 2.0
+
+    RTKProcessor processor;
+    processor.setRTKConfig(config);
+    processor.setBasePosition(base_header_.approximate_position);
+
+    ObservationData rover_obs;
+    ObservationData base_obs;
+    ASSERT_TRUE(rover_reader_.readObservationEpoch(rover_obs));
+    ASSERT_TRUE(base_reader_.readObservationEpoch(base_obs));
+    rover_obs.receiver_position = rover_header_.approximate_position;
+
+    bool observed_hold_regime = false;
+    for (int i = 0; i < 60; ++i) {
+        double time_diff = (rover_obs.time.week - base_obs.time.week) * 604800.0 +
+                            (rover_obs.time.tow - base_obs.time.tow);
+        bool rover_ok = true;
+        bool base_ok = true;
+        while (std::abs(time_diff) > 0.5) {
+            if (time_diff < 0.0) {
+                const Vector3d saved_position = rover_obs.receiver_position;
+                rover_ok = rover_reader_.readObservationEpoch(rover_obs);
+                if (rover_ok) rover_obs.receiver_position = saved_position;
+            } else {
+                base_ok = base_reader_.readObservationEpoch(base_obs);
+            }
+            if (!rover_ok || !base_ok) break;
+            time_diff = (rover_obs.time.week - base_obs.time.week) * 604800.0 +
+                        (rover_obs.time.tow - base_obs.time.tow);
+        }
+        if (!rover_ok || !base_ok) break;
+
+        const auto solution = processor.processRTKEpoch(rover_obs, base_obs, nav_data_);
+        const auto& telemetry = processor.getLastDebugTelemetry();
+        if (telemetry.ar_attempted && std::isfinite(telemetry.effective_ratio_threshold) &&
+            std::abs(telemetry.effective_ratio_threshold - config.ratio_threshold) > 1e-9) {
+            // The hold regime kicked in (effective threshold deviated from
+            // the base ratio_threshold): it must equal the *configured*
+            // hold_ambiguity_ratio_threshold, not a hardcoded 2.0.
+            observed_hold_regime = true;
+            EXPECT_DOUBLE_EQ(telemetry.effective_ratio_threshold, config.hold_ambiguity_ratio_threshold);
+        }
+
+        const Vector3d fallback_position = rover_obs.receiver_position;
+        rover_ok = rover_reader_.readObservationEpoch(rover_obs);
+        base_ok = base_reader_.readObservationEpoch(base_obs);
+        if (!rover_ok || !base_ok) break;
+        const bool trusted_seed =
+            solution.isFixed() || (solution.status == SolutionStatus::SPP && solution.num_satellites >= 7);
+        rover_obs.receiver_position = trusted_seed ? solution.position_ecef : fallback_position;
+    }
+
+    EXPECT_TRUE(observed_hold_regime)
+        << "bundled kinematic fixture never reached the hold-fix regime within 60 epochs";
+}
+
+TEST_F(RTKSmokeTest, HoldAmbiguityRatioThresholdDefaultMatchesLegacyHardcodedValue) {
+    // Default hold_ambiguity_ratio_threshold is 2.0 (rtk.hpp), matching the
+    // value that used to be hardcoded at the fix-and-hold call site — this
+    // is the bit-identical-by-default half of the WP7 dead-knob fix.
+    RTKProcessor::RTKConfig config;
+    config.position_mode = RTKProcessor::RTKConfig::PositionMode::KINEMATIC;
+    config.ar_mode = RTKProcessor::RTKConfig::AmbiguityResolutionMode::CONTINUOUS;
+    config.min_satellites_for_ar = 5;
+    config.ratio_threshold = 3.0;
+    config.ambiguity_ratio_threshold = 3.0;
+    config.min_hold_count = 2;
+    EXPECT_DOUBLE_EQ(config.hold_ambiguity_ratio_threshold, 2.0);
+
+    const auto summary = runEpochs(30, config);
+    EXPECT_GE(summary.fixed_solutions, 1);
+}
+
+// --------------------------------------------------------------------------
+// WP8: hard NLOS exclusion (--nlos-weight-mode exclude)
+// --------------------------------------------------------------------------
+
+TEST_F(RTKSmokeTest, NlosExcludeModeAbsentTableIsBitIdenticalToDefault) {
+    RTKProcessor::RTKConfig config;
+    config.position_mode = RTKProcessor::RTKConfig::PositionMode::KINEMATIC;
+    config.ar_mode = RTKProcessor::RTKConfig::AmbiguityResolutionMode::CONTINUOUS;
+    config.min_satellites_for_ar = 5;
+    config.ratio_threshold = 3.0;
+
+    const auto baseline_summary = runEpochs(30, config);
+
+    rover_reader_.close();
+    base_reader_.close();
+    nav_reader_.close();
+    SetUp();
+
+    // Mode set to EXCLUDE but setNlosWeightTable() is never called -- must
+    // stay a no-op, mirroring the WP7 sigma-inflation modes' own
+    // absent-table guard (buildSelectionSnapshot() checks
+    // `nlos_weight_table_ && !nlos_weight_table_->empty()` before doing
+    // anything).
+    auto exclude_config = config;
+    exclude_config.nlos_weight_mode = nlos_weights::NlosWeightMode::EXCLUDE;
+    exclude_config.nlos_exclude_threshold = 0.9;  // would exclude almost everyone if it fired
+    exclude_config.nlos_min_sats = 0;
+    const auto exclude_summary = runEpochs(30, exclude_config);
+
+    EXPECT_EQ(baseline_summary.epochs_processed, exclude_summary.epochs_processed);
+    EXPECT_EQ(baseline_summary.valid_solutions, exclude_summary.valid_solutions);
+    EXPECT_EQ(baseline_summary.fixed_solutions, exclude_summary.fixed_solutions);
+}
+
+namespace {
+// Every plausible satellite ID across all five constellations, marked NLOS
+// (los_prob=0.0) at a single tow key with an enormous tolerance so the
+// nearest-tow lookup always matches regardless of the fixture's real
+// observation times -- exercises the exclusion *mechanism* without needing
+// to know the bundled fixture's exact tracked PRNs.
+std::shared_ptr<nlos_weights::NlosWeightTable> allSatellitesFlaggedNlosTable() {
+    auto table = std::make_shared<nlos_weights::NlosWeightTable>();
+    auto& row = table->by_tow[0.0];
+    for (int prn = 1; prn <= 32; ++prn) row[SatelliteId(GNSSSystem::GPS, prn).toString()] = 0.0;
+    for (int prn = 1; prn <= 36; ++prn) row[SatelliteId(GNSSSystem::Galileo, prn).toString()] = 0.0;
+    for (int prn = 1; prn <= 24; ++prn) row[SatelliteId(GNSSSystem::GLONASS, prn).toString()] = 0.0;
+    for (int prn = 1; prn <= 46; ++prn) row[SatelliteId(GNSSSystem::BeiDou, prn).toString()] = 0.0;
+    for (int prn = 1; prn <= 7; ++prn) row[SatelliteId(GNSSSystem::QZSS, prn).toString()] = 0.0;
+    return table;
+}
+
+int countFixedSolutionsWithTable(
+    io::RINEXReader& rover_reader, io::RINEXReader& base_reader,
+    const NavigationData& nav_data, const Vector3d& base_position,
+    const Vector3d& rover_seed_position, const RTKProcessor::RTKConfig& config,
+    std::shared_ptr<const nlos_weights::NlosWeightTable> table, int max_epochs) {
+    RTKProcessor processor;
+    processor.setRTKConfig(config);
+    processor.setBasePosition(base_position);
+    if (table) processor.setNlosWeightTable(std::move(table));
+
+    ObservationData rover_obs;
+    ObservationData base_obs;
+    bool rover_ok = rover_reader.readObservationEpoch(rover_obs);
+    bool base_ok = base_reader.readObservationEpoch(base_obs);
+    if (rover_ok) rover_obs.receiver_position = rover_seed_position;
+
+    int fixed_solutions = 0;
+    int epochs_processed = 0;
+    while (rover_ok && base_ok && epochs_processed < max_epochs) {
+        double time_diff = (rover_obs.time.week - base_obs.time.week) * 604800.0 +
+                            (rover_obs.time.tow - base_obs.time.tow);
+        while (rover_ok && base_ok && std::abs(time_diff) > 0.5) {
+            if (time_diff < 0.0) {
+                const Vector3d saved_position = rover_obs.receiver_position;
+                rover_ok = rover_reader.readObservationEpoch(rover_obs);
+                if (rover_ok) rover_obs.receiver_position = saved_position;
+            } else {
+                base_ok = base_reader.readObservationEpoch(base_obs);
+            }
+            if (!rover_ok || !base_ok) break;
+            time_diff = (rover_obs.time.week - base_obs.time.week) * 604800.0 +
+                        (rover_obs.time.tow - base_obs.time.tow);
+        }
+        if (!rover_ok || !base_ok) break;
+
+        const auto solution = processor.processRTKEpoch(rover_obs, base_obs, nav_data);
+        epochs_processed++;
+        if (solution.isFixed()) fixed_solutions++;
+
+        const Vector3d fallback_position = rover_obs.receiver_position;
+        rover_ok = rover_reader.readObservationEpoch(rover_obs);
+        base_ok = base_reader.readObservationEpoch(base_obs);
+        if (!rover_ok || !base_ok) break;
+        rover_obs.receiver_position = solution.isValid() ? solution.position_ecef : fallback_position;
+    }
+    return fixed_solutions;
+}
+}  // namespace
+
+TEST_F(RTKSmokeTest, NlosExcludeModeWithMinSatsZeroCollapsesFixedSolutions) {
+    RTKProcessor::RTKConfig config;
+    config.position_mode = RTKProcessor::RTKConfig::PositionMode::KINEMATIC;
+    config.ar_mode = RTKProcessor::RTKConfig::AmbiguityResolutionMode::CONTINUOUS;
+    config.min_satellites_for_ar = 5;
+    config.ratio_threshold = 3.0;
+    config.nlos_weight_mode = nlos_weights::NlosWeightMode::EXCLUDE;
+    config.nlos_exclude_threshold = 0.5;
+    config.nlos_min_sats = 0;   // guard disabled -- exclusion always fires
+    config.nlos_tow_tolerance_s = 1e9;
+
+    const int fixed_solutions = countFixedSolutionsWithTable(
+        rover_reader_, base_reader_, nav_data_, base_header_.approximate_position,
+        rover_header_.approximate_position, config, allSatellitesFlaggedNlosTable(), 30);
+
+    // Every candidate satellite is flagged NLOS, so (down to at most one
+    // protected reference per system, per the "never drop the last
+    // reference-satellite candidate" guard) each system's DD pair set
+    // collapses to ~0 pairs -- AR can never gather enough redundancy to
+    // fix. This is the exclusion mechanism itself, not a tuned threshold.
+    EXPECT_EQ(fixed_solutions, 0);
+}
+
+TEST_F(RTKSmokeTest, NlosExcludeModeMinSatsGuardKeepsAllSatellitesWhenTooFewWouldSurvive) {
+    RTKProcessor::RTKConfig baseline_config;
+    baseline_config.position_mode = RTKProcessor::RTKConfig::PositionMode::KINEMATIC;
+    baseline_config.ar_mode = RTKProcessor::RTKConfig::AmbiguityResolutionMode::CONTINUOUS;
+    baseline_config.min_satellites_for_ar = 5;
+    baseline_config.ratio_threshold = 3.0;
+
+    const int baseline_fixed = countFixedSolutionsWithTable(
+        rover_reader_, base_reader_, nav_data_, base_header_.approximate_position,
+        rover_header_.approximate_position, baseline_config, nullptr, 30);
+    ASSERT_GE(baseline_fixed, 1)
+        << "bundled fixture expected to fix within 30 epochs (see other tests in this file)";
+
+    rover_reader_.close();
+    base_reader_.close();
+    nav_reader_.close();
+    SetUp();
+
+    // Same "exclude everyone" table as the mechanism test above, but with
+    // an unreachably high --nlos-min-sats floor -- the guard must trip
+    // every epoch and keep every satellite, reproducing the baseline
+    // fixed-solution count exactly (the guard's whole point: never degrade
+    // geometry below solvability).
+    auto guarded_config = baseline_config;
+    guarded_config.nlos_weight_mode = nlos_weights::NlosWeightMode::EXCLUDE;
+    guarded_config.nlos_exclude_threshold = 0.5;
+    guarded_config.nlos_min_sats = 999;
+    guarded_config.nlos_tow_tolerance_s = 1e9;
+
+    const int guarded_fixed = countFixedSolutionsWithTable(
+        rover_reader_, base_reader_, nav_data_, base_header_.approximate_position,
+        rover_header_.approximate_position, guarded_config, allSatellitesFlaggedNlosTable(), 30);
+
+    EXPECT_EQ(guarded_fixed, baseline_fixed);
+}
+
+TEST_F(RTKSmokeTest, FloatTrustPolicyDefaultLegacyIsBitIdenticalToPreWp9) {
+    RTKProcessor::RTKConfig config;
+    config.position_mode = RTKProcessor::RTKConfig::PositionMode::KINEMATIC;
+    config.ar_mode = RTKProcessor::RTKConfig::AmbiguityResolutionMode::CONTINUOUS;
+    config.min_satellites_for_ar = 5;
+    config.ratio_threshold = 3.0;
+
+    const auto baseline_summary = runEpochs(30, config);
+
+    rover_reader_.close();
+    base_reader_.close();
+    nav_reader_.close();
+    SetUp();
+
+    // float_trust_policy left at its LEGACY default explicitly -- must be a
+    // no-op, mirroring the absent-flag guarantee required for every other
+    // WP9 flag.
+    auto explicit_legacy_config = config;
+    explicit_legacy_config.float_trust_policy = float_trust_policy::FloatTrustPolicy::LEGACY;
+    explicit_legacy_config.trust_lapse_qpos_m2_per_s = 999.0;  // must be ignored under LEGACY
+    const auto explicit_legacy_summary = runEpochs(30, explicit_legacy_config);
+
+    EXPECT_EQ(baseline_summary.epochs_processed, explicit_legacy_summary.epochs_processed);
+    EXPECT_EQ(baseline_summary.valid_solutions, explicit_legacy_summary.valid_solutions);
+    EXPECT_EQ(baseline_summary.fixed_solutions, explicit_legacy_summary.fixed_solutions);
+}
+
+TEST_F(RTKSmokeTest, FloatTrustPolicyCvPredictAndScaledResetDoNotCrashAndRemainValid) {
+    // Not a numerical-equivalence test (that's float_trust_policy.hpp's own
+    // unit tests) -- this is an integration smoke test that both new
+    // policies wire in cleanly against real data: no crashes, solutions
+    // stay finite/valid, and fixed-solution count never exceeds the legacy
+    // baseline's on this short, easy bundled fixture (both policies only
+    // ever engage once trust has lapsed, so on an easy fixture where trust
+    // rarely lapses they should track the baseline closely).
+    RTKProcessor::RTKConfig baseline_config;
+    baseline_config.position_mode = RTKProcessor::RTKConfig::PositionMode::KINEMATIC;
+    baseline_config.ar_mode = RTKProcessor::RTKConfig::AmbiguityResolutionMode::CONTINUOUS;
+    baseline_config.min_satellites_for_ar = 5;
+    baseline_config.ratio_threshold = 3.0;
+    const auto baseline_summary = runEpochs(60, baseline_config);
+    ASSERT_GT(baseline_summary.valid_solutions, 0);
+
+    for (const auto policy : {float_trust_policy::FloatTrustPolicy::CV_PREDICT,
+                              float_trust_policy::FloatTrustPolicy::SCALED_RESET}) {
+        rover_reader_.close();
+        base_reader_.close();
+        nav_reader_.close();
+        SetUp();
+
+        auto config = baseline_config;
+        config.float_trust_policy = policy;
+        config.trust_lapse_qpos_m2_per_s = 10.0;
+        const auto summary = runEpochs(60, config);
+
+        EXPECT_EQ(summary.epochs_processed, baseline_summary.epochs_processed);
+        EXPECT_GT(summary.valid_solutions, 0);
+        if (summary.first_valid_solution.isValid()) {
+            EXPECT_TRUE(summary.first_valid_solution.position_ecef.allFinite());
+        }
+    }
+}
+
+TEST_F(RTKSmokeTest, FloatTrustPolicyLapseGatedWithHugeGateIsBitIdenticalToLegacy) {
+    // WP10's core bit-identity claim: at a gate value far larger than any
+    // lapse that can occur on this short fixture, lapse-gated must never
+    // take the scaled-reset branch -- every epoch falls through to the
+    // unmodified legacy fallback path, reproducing the plain-LEGACY
+    // baseline's fixed/valid counts exactly.
+    RTKProcessor::RTKConfig config;
+    config.position_mode = RTKProcessor::RTKConfig::PositionMode::KINEMATIC;
+    config.ar_mode = RTKProcessor::RTKConfig::AmbiguityResolutionMode::CONTINUOUS;
+    config.min_satellites_for_ar = 5;
+    config.ratio_threshold = 3.0;
+    const auto baseline_summary = runEpochs(60, config);
+    ASSERT_GT(baseline_summary.valid_solutions, 0);
+
+    rover_reader_.close();
+    base_reader_.close();
+    nav_reader_.close();
+    SetUp();
+
+    auto gated_config = config;
+    gated_config.float_trust_policy = float_trust_policy::FloatTrustPolicy::LAPSE_GATED;
+    gated_config.trust_lapse_gate_s = 1.0e6;
+    gated_config.trust_lapse_qpos_m2_per_s = 0.1;
+    const auto gated_summary = runEpochs(60, gated_config);
+
+    EXPECT_EQ(gated_summary.epochs_processed, baseline_summary.epochs_processed);
+    EXPECT_EQ(gated_summary.valid_solutions, baseline_summary.valid_solutions);
+    EXPECT_EQ(gated_summary.fixed_solutions, baseline_summary.fixed_solutions);
+}
+
+TEST_F(RTKSmokeTest, FloatTrustPolicyLapseGatedAtZeroGateDoesNotCrash) {
+    // The opposite endpoint of the gate sweep (0s -- "always scaled, never
+    // legacy, once lapsed") should behave like SCALED_RESET: no crashes,
+    // solutions stay finite/valid.
+    RTKProcessor::RTKConfig config;
+    config.position_mode = RTKProcessor::RTKConfig::PositionMode::KINEMATIC;
+    config.ar_mode = RTKProcessor::RTKConfig::AmbiguityResolutionMode::CONTINUOUS;
+    config.min_satellites_for_ar = 5;
+    config.ratio_threshold = 3.0;
+    config.float_trust_policy = float_trust_policy::FloatTrustPolicy::LAPSE_GATED;
+    config.trust_lapse_gate_s = 0.0;
+    config.trust_lapse_qpos_m2_per_s = 0.1;
+
+    const auto summary = runEpochs(60, config);
+    EXPECT_GT(summary.valid_solutions, 0);
+    if (summary.first_valid_solution.isValid()) {
+        EXPECT_TRUE(summary.first_valid_solution.position_ecef.allFinite());
+    }
 }
 
 TEST(RTKStateIndexTest, SeparatesConstellationsInAmbiguityStateLayout) {


### PR DESCRIPTION
Two commits carried locally in the gnss_gpu submodule during the inuex35 TC-FGO benchmark campaign, rebased cleanly onto develop@09fec9a:

- **Phase 18**: L5 N5 filter state with L1/L5 cascade widelane AR
- **WP9-WP10**: float trust policy (lapse-gated scaled-reset), NLOS variance weights, dead RTK knob wiring (`--no-arfilter`, `--hold-ratio-threshold` etc.)

Both are opt-in / default-off; the WP14 verification (gnss_gpu `results/wp14/WP14_REPORT.md`) confirmed the GTSAM TC-FGO parity numbers reproduce byte-identically with these commits present (features off). Bit-identity of the pre-existing behavior was verified during the campaign (WP6 winner `.pos` byte-for-byte with knobs pinned).

Context: these were previously stranded on a shallow submodule checkout; 103 of the 110 local commits were already upstream by patch-id, these 2 (plus 5 obsolete April-era commits intentionally dropped, preserved locally on `wp9-10-local-backup`) were the only unique ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TSBXwM1A4npuVXm1VAhCqG
