### PR TITLE
Define MADOCA correction contract and L6D snapshots

### DIFF
--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -783,6 +783,9 @@ Phase 4, L6D ionosphere foundation:
 
 - Implement coverage and correction message parsing separately from L6E.
 - Implement area selection and STEC delay/std calculation.
+- Materialize completed region updates as receiver-specific, timestamped
+  `MadocaIonoSnapshot` rows; this is the tested product boundary for later PPP
+  ingestion and keeps raw file replay out of the solver.
 - Add sample-driven tests for PRNs 200 and 201.
 - Keep PRN 197 only where it is needed for compatibility or fixture coverage.
 - Do not feed L6D products into PPP until decoder-level values match the oracle

--- a/docs/references/madocalib-gap.md
+++ b/docs/references/madocalib-gap.md
@@ -50,10 +50,10 @@ Relevant code entrypoints today:
 | Gap | Current libgnss++ state | Why it matters |
 |---|---|---|
 | Native in-core `L6E/L6D -> correction object` path | Current CLAS/MADOCA transport still depends on Python-side preprocessing in `gnss_clas_ppp.py` / `gnss_qzss_l6_info.py` before the C++ PPP core sees sampled corrections | A first-class C++ path would make correction handling easier to test, replay, and profile |
-| First-class `IONEX / DCB` workflow | No in-tree `IONEX` or `DCB` loader is present today | `MADOCALIB`-style PPP studies often assume a fuller product pipeline than `SP3/CLK` alone |
+| First-class `IONEX / DCB` workflow | Native loaders and PPP hooks are implemented; production workflow and sign-off coverage remain narrower than SP3/CLK | `MADOCALIB`-style PPP studies need these products to be reproducible across normal CLI and validation workflows |
 | Explicit multi-frequency PPP beyond the current IF-centric path | Current solver structure is centered on ionosphere-free combinations and PPP ambiguity state handling in `ppp.cpp` | A wider multi-frequency story needs to be explicit before claiming parity with richer PPP references |
 | Broader PPP-AR reference matrix | Current real-data sign-off is useful but still relatively narrow compared with a dedicated upstream PPP reference stack | `PPP-AR` robustness needs more dataset coverage before it can be considered mature |
-| Correction ordering audit against upstream reference behavior | The current code works, but the exact correction-application order has not yet been documented as a deliberate compatibility target | This is the kind of subtle mismatch that creates hard-to-debug centimeter-level differences |
+| Correction ordering audit against upstream reference behavior | The native order is now an explicit, tested contract in `ppp_correction_contract.hpp`; whole-run parity still guards numerical behavior | Future reordering is reviewable because it changes a named contract rather than incidental control flow |
 
 ## What should *not* be copied directly
 
@@ -76,8 +76,10 @@ and **not** a direct code transplant.
 
 ## Immediate work items derived from this gap
 
-1. Document the current PPP correction-application order inside `ppp.cpp`.
-2. Decide whether `IONEX` and `DCB` belong in the first product expansion wave.
+1. Keep the correction-order contract and its MADOCALIB sign conventions covered
+   when adding new correction sources.
+2. Finish integrating the existing `IONEX` and `DCB` loaders across production
+   workflows and sign-off datasets.
 3. Move more `CLAS/MADOCA` transport handling from Python preprocessing toward
    native C++ product ingestion.
 4. Widen PPP-AR sign-off datasets and keep the results as checked artifacts.

--- a/include/libgnss++/algorithms/ppp_correction_contract.hpp
+++ b/include/libgnss++/algorithms/ppp_correction_contract.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+namespace libgnss::algorithms::ppp_correction_contract {
+
+// Stable ordering contract for corrections materialized by
+// PPPProcessor::applyPreciseCorrections(). Keep this list synchronized with
+// that function: changing the order is a measurement-model change and must be
+// reviewed against the MADOCA/CLAS parity gates.
+enum class Stage {
+    ReceiverGeophysics,
+    SatelliteOrbitClock,
+    SsrMeasurementBias,
+    SsrAtmosphere,
+    SatelliteAntenna,
+    DcbFallback,
+    IonexFallback,
+    ReceiverAntenna,
+    PhaseWindup,
+};
+
+inline constexpr std::array<Stage, 9> kApplicationOrder = {
+    Stage::ReceiverGeophysics,
+    Stage::SatelliteOrbitClock,
+    Stage::SsrMeasurementBias,
+    Stage::SsrAtmosphere,
+    Stage::SatelliteAntenna,
+    Stage::DcbFallback,
+    Stage::IonexFallback,
+    Stage::ReceiverAntenna,
+    Stage::PhaseWindup,
+};
+
+constexpr std::size_t orderOf(Stage stage) {
+    for (std::size_t index = 0; index < kApplicationOrder.size(); ++index) {
+        if (kApplicationOrder[index] == stage) {
+            return index;
+        }
+    }
+    return kApplicationOrder.size();
+}
+
+constexpr const char* name(Stage stage) {
+    switch (stage) {
+        case Stage::ReceiverGeophysics: return "receiver_geophysics";
+        case Stage::SatelliteOrbitClock: return "satellite_orbit_clock";
+        case Stage::SsrMeasurementBias: return "ssr_measurement_bias";
+        case Stage::SsrAtmosphere: return "ssr_atmosphere";
+        case Stage::SatelliteAntenna: return "satellite_antenna";
+        case Stage::DcbFallback: return "dcb_fallback";
+        case Stage::IonexFallback: return "ionex_fallback";
+        case Stage::ReceiverAntenna: return "receiver_antenna";
+        case Stage::PhaseWindup: return "phase_windup";
+    }
+    return "unknown";
+}
+
+// MADOCA follows MADOCALIB ppp.c and adds SSR code/phase biases to the
+// observables. Other SSR inputs retain libgnss++'s historical subtraction.
+constexpr double ssrMeasurementBiasSign(bool madoca_convention) {
+    return madoca_convention ? 1.0 : -1.0;
+}
+
+// Neutral atmosphere delays are removed from code and phase alike, while the
+// first-order ionosphere is dispersive: remove it from code, add it to phase.
+constexpr double measurementCorrectionSign(bool carrier_phase, bool dispersive) {
+    return carrier_phase && dispersive ? 1.0 : -1.0;
+}
+
+}  // namespace libgnss::algorithms::ppp_correction_contract

--- a/include/libgnss++/io/madoca_l6d.hpp
+++ b/include/libgnss++/io/madoca_l6d.hpp
@@ -2,6 +2,8 @@
 
 #include <cstdint>
 #include <map>
+#include <string>
+#include <vector>
 
 #include <libgnss++/io/madoca_l6.hpp>  // MadocaGtime
 
@@ -147,5 +149,37 @@ private:
 
     std::map<int, MadocaIonoRegion> re_;  // sparse pppiono.re[MIONO_MAX_RID]
 };
+
+// Receiver-specific correction view emitted after one complete L6D region
+// update. updated_region_id identifies the message that triggered the snapshot;
+// correction.rid/anum identify the nearest area selected from the persistent
+// store (which may belong to an earlier region update).
+struct MadocaIonoSnapshot {
+    MadocaGtime decode_time;
+    int updated_region_id = -1;
+    MadocaIonoCorr correction;
+};
+
+// Materialize the current persistent L6D store for one receiver. This is the
+// reusable boundary shared by file replay and future streaming PPP ingestion.
+// Returns true when a receiver area was selected and a snapshot was appended.
+bool appendMadocaIonoSnapshot(const MadocaIonoStore& store,
+                              const double receiver_ecef[3],
+                              const MadocaGtime& decode_time,
+                              int updated_region_id,
+                              std::vector<MadocaIonoSnapshot>& snapshots,
+                              const double* gloFreqHz = nullptr);
+
+// Decode one raw QZSS L6D file and materialize a snapshot after every complete
+// region update. The reference epoch seeds GPS-week reconstruction. Returns
+// false for invalid arguments, unreadable input, decoder errors, or a file with
+// no complete L6D messages; error_message is optional.
+bool decodeMadocaL6dFileToSnapshots(
+    const std::string& path,
+    const double reference_epoch[6],
+    const double receiver_ecef[3],
+    std::vector<MadocaIonoSnapshot>& snapshots,
+    std::string* error_message = nullptr,
+    const double* gloFreqHz = nullptr);
 
 }  // namespace libgnss::io

--- a/src/algorithms/ppp_corrections.cpp
+++ b/src/algorithms/ppp_corrections.cpp
@@ -1,5 +1,7 @@
 #include "ppp_internal.hpp"
 
+#include <libgnss++/algorithms/ppp_correction_contract.hpp>
+
 #include <libgnss++/algorithms/ppp_bias_identity.hpp>
 #include <libgnss++/algorithms/ppp_atmosphere.hpp>
 #include <libgnss++/algorithms/ppp_osr.hpp>
@@ -767,6 +769,12 @@ void PPPProcessor::materializeClasReceiverAntennaCorrections(
 void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& observations,
                                            const NavigationData& nav,
                                            const GNSSTime& time) {
+    // Correction-order contract (see ppp_correction_contract.hpp):
+    // receiver geophysics -> satellite orbit/clock -> SSR biases -> SSR
+    // atmosphere -> satellite antenna -> DCB/IONEX fallbacks -> receiver
+    // antenna -> phase wind-up. Reordering these stages changes the geometry
+    // or observable on which later corrections operate and therefore requires
+    // MADOCALIB/CLAS parity evidence.
     const Vector3d receiver_marker_position = applyGeophysicalCorrections(
         filter_state_.state.segment(filter_state_.pos_index, 3), time);
     const double elevation_mask = config_.elevation_mask * kDegreesToRadians;
@@ -1016,9 +1024,8 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                 // GNSS_PPP_MADOCA_BIAS_SUBTRACT restores the legacy subtraction
                 // for diagnostics. Non-MADOCA SSR paths keep subtracting.
                 const double ssr_bias_sign =
-                    (require_coherent_ssr_ && !env_overrides_.madoca_bias_subtract)
-                        ? +1.0
-                        : -1.0;
+                    algorithms::ppp_correction_contract::ssrMeasurementBiasSign(
+                        require_coherent_ssr_ && !env_overrides_.madoca_bias_subtract);
                 observation.pseudorange_if += ssr_bias_sign * code_bias;
                 observation.pseudorange_code_bias_m = code_bias;
                 applied_ssr_code_bias = std::abs(code_bias) > 0.0;
@@ -1123,9 +1130,13 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                         ppp_config_.clas_subtype12_value_construction_policy,
                         ppp_config_.clas_expanded_residual_sampling_policy);
                 if (std::isfinite(trop_correction_m) && std::abs(trop_correction_m) > 0.0) {
-                    observation.pseudorange_if -= trop_correction_m;
+                    observation.pseudorange_if +=
+                        algorithms::ppp_correction_contract::measurementCorrectionSign(false, false) *
+                        trop_correction_m;
                     if (observation.has_carrier_phase) {
-                        observation.carrier_phase_if -= trop_correction_m;
+                        observation.carrier_phase_if +=
+                            algorithms::ppp_correction_contract::measurementCorrectionSign(true, false) *
+                            trop_correction_m;
                     }
                     observation.atmospheric_trop_correction_m = trop_correction_m;
                     ++last_applied_atmos_trop_corrections_;
@@ -1180,9 +1191,13 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                 } else if (std::isfinite(ionosphere_correction_m) &&
                     std::abs(ionosphere_correction_m) > 0.0) {
                     // Direct observation correction (non-estimation mode)
-                    observation.pseudorange_if -= ionosphere_correction_m;
+                    observation.pseudorange_if +=
+                        algorithms::ppp_correction_contract::measurementCorrectionSign(false, true) *
+                        ionosphere_correction_m;
                     if (observation.has_carrier_phase) {
-                        observation.carrier_phase_if += ionosphere_correction_m;
+                        observation.carrier_phase_if +=
+                            algorithms::ppp_correction_contract::measurementCorrectionSign(true, true) *
+                            ionosphere_correction_m;
                     }
                     observation.atmospheric_iono_correction_m = ionosphere_correction_m;
                     ++last_applied_atmos_iono_corrections_;
@@ -1257,7 +1272,9 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                 observation.primary_code_bias_coeff,
                 observation.secondary_code_bias_coeff);
             if (std::isfinite(dcb_bias_m) && std::abs(dcb_bias_m) > 0.0) {
-                observation.pseudorange_if -= dcb_bias_m;
+                observation.pseudorange_if +=
+                    algorithms::ppp_correction_contract::measurementCorrectionSign(false, false) *
+                    dcb_bias_m;
                 observation.pseudorange_code_bias_m += dcb_bias_m;
                 ++last_applied_dcb_corrections_;
                 last_applied_dcb_m_ += std::abs(dcb_bias_m);
@@ -1301,9 +1318,13 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                     observation.secondary_code_bias_coeff);
                 if (std::isfinite(ionosphere_correction_m) &&
                     std::abs(ionosphere_correction_m) > 0.0) {
-                    observation.pseudorange_if -= ionosphere_correction_m;
+                    observation.pseudorange_if +=
+                        algorithms::ppp_correction_contract::measurementCorrectionSign(false, true) *
+                        ionosphere_correction_m;
                     if (observation.has_carrier_phase) {
-                        observation.carrier_phase_if += ionosphere_correction_m;
+                        observation.carrier_phase_if +=
+                            algorithms::ppp_correction_contract::measurementCorrectionSign(true, true) *
+                            ionosphere_correction_m;
                     }
                     observation.atmospheric_iono_correction_m += ionosphere_correction_m;
                     ++last_applied_atmos_iono_corrections_;

--- a/src/io/madoca_l6d.cpp
+++ b/src/io/madoca_l6d.cpp
@@ -3,6 +3,8 @@
 #include <libgnss++/algorithms/madoca_parity.hpp>
 
 #include <cmath>
+#include <fstream>
+#include <memory>
 
 namespace libgnss::io {
 namespace {
@@ -527,6 +529,99 @@ int MadocaIonoStore::getCorr(const double rr[3], const MadocaGtime& decode_time,
         out.std[i] = stecUraStd(area->sat[i].sqi);
     }
     return 1;
+}
+
+bool appendMadocaIonoSnapshot(const MadocaIonoStore& store,
+                              const double receiver_ecef[3],
+                              const MadocaGtime& decode_time,
+                              int updated_region_id,
+                              std::vector<MadocaIonoSnapshot>& snapshots,
+                              const double* gloFreqHz) {
+    if (receiver_ecef == nullptr || decode_time.time == 0 ||
+        updated_region_id < 0 || updated_region_id >= MadocaIonoStore::kMaxRid) {
+        return false;
+    }
+    MadocaIonoSnapshot snapshot;
+    snapshot.decode_time = decode_time;
+    snapshot.updated_region_id = updated_region_id;
+    if (store.getCorr(receiver_ecef, decode_time, snapshot.correction, gloFreqHz) == 0) {
+        return false;
+    }
+    snapshots.push_back(snapshot);
+    return true;
+}
+
+bool decodeMadocaL6dFileToSnapshots(
+    const std::string& path,
+    const double reference_epoch[6],
+    const double receiver_ecef[3],
+    std::vector<MadocaIonoSnapshot>& snapshots,
+    std::string* error_message,
+    const double* gloFreqHz) {
+    snapshots.clear();
+    const auto fail = [error_message](const std::string& message) {
+        if (error_message != nullptr) {
+            *error_message = message;
+        }
+        return false;
+    };
+    if (error_message != nullptr) {
+        error_message->clear();
+    }
+    if (path.empty() || reference_epoch == nullptr || receiver_ecef == nullptr) {
+        return fail("invalid L6D snapshot input");
+    }
+    for (int i = 0; i < 6; ++i) {
+        if (!std::isfinite(reference_epoch[i])) {
+            return fail("invalid L6D reference epoch");
+        }
+    }
+    double receiver_norm_sq = 0.0;
+    for (int i = 0; i < 3; ++i) {
+        if (!std::isfinite(receiver_ecef[i])) {
+            return fail("invalid L6D receiver position");
+        }
+        receiver_norm_sq += receiver_ecef[i] * receiver_ecef[i];
+    }
+    if (receiver_norm_sq == 0.0) {
+        return fail("invalid L6D receiver position");
+    }
+
+    std::ifstream input(path, std::ios::binary);
+    if (!input.is_open()) {
+        return fail("failed to open L6D file: " + path);
+    }
+
+    // Decoder scratch regions and the persistent 256-region store are large;
+    // keep them off the caller's stack (notably the 1 MiB default on Windows).
+    auto decoder = std::make_unique<MadocaL6dDecoder>();
+    decoder->setReferenceEpoch(reference_epoch);
+    auto store = std::make_unique<MadocaIonoStore>();
+    std::size_t completed_messages = 0;
+    char byte = 0;
+    while (input.get(byte)) {
+        const int result = decoder->inputByte(static_cast<std::uint8_t>(byte));
+        if (result < 0) {
+            snapshots.clear();
+            return fail("invalid L6D message in file: " + path);
+        }
+        if (result != 10) {
+            continue;
+        }
+        ++completed_messages;
+        store->update(decoder->regionId(), decoder->region());
+        appendMadocaIonoSnapshot(*store, receiver_ecef, decoder->decodeTime(),
+                                 decoder->regionId(), snapshots, gloFreqHz);
+        decoder->clearRegionAfterUse();
+    }
+    if (input.bad()) {
+        snapshots.clear();
+        return fail("failed while reading L6D file: " + path);
+    }
+    if (completed_messages == 0) {
+        return fail("no complete L6D messages in file: " + path);
+    }
+    return true;
 }
 
 }  // namespace libgnss::io

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,6 +44,7 @@ if(GTest_FOUND)
         test_ppp.cpp
         test_rinex_writer.cpp
         test_madoca_core.cpp
+        test_madoca_l6d_snapshots.cpp
         test_madoca_parity.cpp
         test_spp.cpp
         test_spp_velocity.cpp

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,6 +26,7 @@ if(GTest_FOUND)
         test_ppp_osr.cpp
         test_ppp_ar.cpp
         test_ppp_atmosphere.cpp
+        test_ppp_correction_contract.cpp
         test_rtk_ar_evaluation.cpp
         test_rtk_ar_selection.cpp
         test_nlos_weights.cpp

--- a/tests/test_madoca_l6d_snapshots.cpp
+++ b/tests/test_madoca_l6d_snapshots.cpp
@@ -1,0 +1,71 @@
+#include <gtest/gtest.h>
+
+#include <libgnss++/io/madoca_l6d.hpp>
+
+#include <cmath>
+#include <filesystem>
+#include <fstream>
+#include <memory>
+#include <string>
+#include <vector>
+
+using namespace libgnss::io;
+
+TEST(MadocaL6dSnapshotTest, MaterializesPersistentStoreForReceiver) {
+    auto region = std::make_unique<MadocaIonoRegion>();
+    region->rvalid = 1;
+    region->narea = 1;
+    auto& area = region->area[3];
+    area.avalid = 1;
+    area.sid = 1;
+    area.type = 0;
+    area.ref[0] = 35.0;
+    area.ref[1] = 139.0;
+    area.span[0] = 1000.0;
+    area.sat[0].t0.time = 1'700'000'000;
+    area.sat[0].coef[0] = 10.0;
+    area.sat[0].sqi = 1;
+
+    auto store = std::make_unique<MadocaIonoStore>();
+    store->update(7, *region);
+    const double receiver_ecef[3] = {-3'947'450.0, 3'431'468.0, 3'636'866.0};
+    const MadocaGtime decode_time{1'700'000'000, 0.0};
+    std::vector<MadocaIonoSnapshot> snapshots;
+
+    ASSERT_TRUE(appendMadocaIonoSnapshot(
+        *store, receiver_ecef, decode_time, 7, snapshots));
+    ASSERT_EQ(snapshots.size(), 1u);
+    EXPECT_EQ(snapshots[0].decode_time.time, decode_time.time);
+    EXPECT_EQ(snapshots[0].updated_region_id, 7);
+    EXPECT_EQ(snapshots[0].correction.rid, 7);
+    EXPECT_EQ(snapshots[0].correction.anum, 3);
+    EXPECT_EQ(snapshots[0].correction.t0[0].time, area.sat[0].t0.time);
+    EXPECT_TRUE(std::isfinite(snapshots[0].correction.dly[0]));
+    EXPECT_GT(snapshots[0].correction.dly[0], 0.0);
+    EXPECT_GT(snapshots[0].correction.std[0], 0.0);
+}
+
+TEST(MadocaL6dSnapshotTest, RejectsMissingAndIncompleteFiles) {
+    const double reference_epoch[6] = {2025, 4, 1, 0, 0, 0};
+    const double receiver_ecef[3] = {-3'947'450.0, 3'431'468.0, 3'636'866.0};
+    std::vector<MadocaIonoSnapshot> snapshots;
+    std::string error;
+
+    EXPECT_FALSE(decodeMadocaL6dFileToSnapshots(
+        "missing-madoca-l6d-file.l6", reference_epoch, receiver_ecef,
+        snapshots, &error));
+    EXPECT_NE(error.find("failed to open"), std::string::npos);
+
+    const auto path = std::filesystem::temp_directory_path() /
+        "gnsspp_incomplete_madoca_l6d.l6";
+    {
+        std::ofstream output(path, std::ios::binary);
+        const unsigned char bytes[] = {0x1A, 0xCF, 0xFC, 0x1D, 0x00};
+        output.write(reinterpret_cast<const char*>(bytes), sizeof(bytes));
+    }
+    error.clear();
+    EXPECT_FALSE(decodeMadocaL6dFileToSnapshots(
+        path.string(), reference_epoch, receiver_ecef, snapshots, &error));
+    EXPECT_NE(error.find("no complete L6D messages"), std::string::npos);
+    std::filesystem::remove(path);
+}

--- a/tests/test_ppp_correction_contract.cpp
+++ b/tests/test_ppp_correction_contract.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+
+#include <libgnss++/algorithms/ppp_correction_contract.hpp>
+
+#include <set>
+#include <string>
+
+namespace contract = libgnss::algorithms::ppp_correction_contract;
+
+TEST(PPPCorrectionContractTest, ApplicationStagesAreUniqueAndOrdered) {
+    std::set<contract::Stage> stages;
+    std::set<std::string> names;
+    for (std::size_t index = 0; index < contract::kApplicationOrder.size(); ++index) {
+        const auto stage = contract::kApplicationOrder[index];
+        EXPECT_TRUE(stages.insert(stage).second);
+        EXPECT_TRUE(names.insert(contract::name(stage)).second);
+        EXPECT_EQ(contract::orderOf(stage), index);
+    }
+
+    EXPECT_LT(contract::orderOf(contract::Stage::SatelliteOrbitClock),
+              contract::orderOf(contract::Stage::SsrMeasurementBias));
+    EXPECT_LT(contract::orderOf(contract::Stage::SsrAtmosphere),
+              contract::orderOf(contract::Stage::DcbFallback));
+    EXPECT_LT(contract::orderOf(contract::Stage::IonexFallback),
+              contract::orderOf(contract::Stage::PhaseWindup));
+}
+
+TEST(PPPCorrectionContractTest, MadocaBiasConventionAddsMeasurementBiases) {
+    EXPECT_DOUBLE_EQ(contract::ssrMeasurementBiasSign(true), 1.0);
+    EXPECT_DOUBLE_EQ(contract::ssrMeasurementBiasSign(false), -1.0);
+}
+
+TEST(PPPCorrectionContractTest, AtmosphereSignsMatchCodeAndPhasePhysics) {
+    EXPECT_DOUBLE_EQ(contract::measurementCorrectionSign(false, false), -1.0);
+    EXPECT_DOUBLE_EQ(contract::measurementCorrectionSign(true, false), -1.0);
+    EXPECT_DOUBLE_EQ(contract::measurementCorrectionSign(false, true), -1.0);
+    EXPECT_DOUBLE_EQ(contract::measurementCorrectionSign(true, true), 1.0);
+}


### PR DESCRIPTION
## Summary

- define a stable, testable MADOCA PPP correction-application order
- centralize MADOCALIB-compatible SSR bias and atmospheric sign conventions
- add receiver-specific, timestamped native L6D ionosphere snapshots
- reject unreadable, incomplete, and malformed L6D replay inputs explicitly
- keep large L6D decoder/store state off the Windows stack
- update the MADOCALIB gap analysis and port plan

## Why

Correction ordering and sign differences can create subtle centimetre-level
divergence from MADOCALIB. The native L6D decoder also lacked a reusable product
boundary between raw bytes and corrections suitable for later PPP ingestion.
This PR makes both boundaries explicit without enabling L6D in the default PPP
runtime.

## Impact

Maintainers can review future correction-order changes as an API contract.
Future streaming and file-based PPP ingestion can consume the same
`MadocaIonoSnapshot` representation instead of coupling the solver to raw L6D
replay.

## Validation

- MSVC Release build of `gnss_lib`
- MSVC Release build of `gnss_run_tests` with already-built project references
- 80 focused PPP/atmosphere/OSR/contract tests passed
- 14 MADOCA-related tests passed
- `git diff --check`

The aggregate MSVC dependency build still encounters the pre-existing
`gnss_solve.cpp` C1061 compiler nesting limit; the changed library and test
executable build successfully.

Closes #287
Closes #288
