### PR TITLE
Add time-indexed MADOCA ionosphere products

### DIFF
--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -786,6 +786,9 @@ Phase 4, L6D ionosphere foundation:
 - Materialize completed region updates as receiver-specific, timestamped
   `MadocaIonoSnapshot` rows; this is the tested product boundary for later PPP
   ingestion and keeps raw file replay out of the solver.
+- Merge snapshots from replay sources through `MadocaIonoProducts`, which owns
+  chronological ordering, duplicate replacement, causal lookup, and the
+  explicit correction-age gate used by later PPP ingestion.
 - Add sample-driven tests for PRNs 200 and 201.
 - Keep PRN 197 only where it is needed for compatibility or fixture coverage.
 - Do not feed L6D products into PPP until decoder-level values match the oracle

--- a/include/libgnss++/io/madoca_l6d.hpp
+++ b/include/libgnss++/io/madoca_l6d.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <map>
 #include <string>
@@ -158,6 +159,30 @@ struct MadocaIonoSnapshot {
     MadocaGtime decode_time;
     int updated_region_id = -1;
     MadocaIonoCorr correction;
+};
+
+// Time-indexed receiver-specific L6D products. This container owns ordering,
+// duplicate replacement, causal lookup, and freshness policy so PPP consumers
+// do not need to know how raw files were replayed. Returned lookup pointers stay
+// valid until the next mutating call.
+class MadocaIonoProducts {
+public:
+    bool addSnapshot(const MadocaIonoSnapshot& snapshot);
+    std::size_t addSnapshots(const std::vector<MadocaIonoSnapshot>& snapshots);
+
+    // Latest snapshot whose decode time is not later than query_time. A
+    // negative max_age_s disables the freshness gate; otherwise snapshots
+    // older than max_age_s are rejected.
+    const MadocaIonoSnapshot* latestAtOrBefore(
+        const MadocaGtime& query_time, double max_age_s = -1.0) const;
+
+    bool empty() const { return snapshots_.empty(); }
+    std::size_t size() const { return snapshots_.size(); }
+    const std::vector<MadocaIonoSnapshot>& snapshots() const { return snapshots_; }
+    void clear() { snapshots_.clear(); }
+
+private:
+    std::vector<MadocaIonoSnapshot> snapshots_;
 };
 
 // Materialize the current persistent L6D store for one receiver. This is the

--- a/src/io/madoca_l6d.cpp
+++ b/src/io/madoca_l6d.cpp
@@ -2,8 +2,10 @@
 
 #include <libgnss++/algorithms/madoca_parity.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <fstream>
+#include <iterator>
 #include <memory>
 
 namespace libgnss::io {
@@ -549,6 +551,85 @@ bool appendMadocaIonoSnapshot(const MadocaIonoStore& store,
     }
     snapshots.push_back(snapshot);
     return true;
+}
+
+namespace {
+
+bool ionoSnapshotTimeLess(const MadocaGtime& lhs, const MadocaGtime& rhs) {
+    return lhs.time < rhs.time ||
+        (lhs.time == rhs.time && lhs.sec < rhs.sec);
+}
+
+bool ionoSnapshotTimeEqual(const MadocaGtime& lhs, const MadocaGtime& rhs) {
+    return lhs.time == rhs.time && lhs.sec == rhs.sec;
+}
+
+double ionoSnapshotAgeSeconds(const MadocaGtime& newer,
+                              const MadocaGtime& older) {
+    return static_cast<double>(newer.time - older.time) + newer.sec - older.sec;
+}
+
+}  // namespace
+
+bool MadocaIonoProducts::addSnapshot(const MadocaIonoSnapshot& snapshot) {
+    if (snapshot.decode_time.time == 0 || !std::isfinite(snapshot.decode_time.sec) ||
+        snapshot.decode_time.sec < 0.0 || snapshot.decode_time.sec >= 1.0 ||
+        snapshot.updated_region_id < 0 ||
+        snapshot.updated_region_id >= MadocaIonoStore::kMaxRid) {
+        return false;
+    }
+
+    const auto duplicate = std::find_if(
+        snapshots_.begin(), snapshots_.end(), [&](const MadocaIonoSnapshot& existing) {
+            return ionoSnapshotTimeEqual(existing.decode_time, snapshot.decode_time) &&
+                existing.updated_region_id == snapshot.updated_region_id;
+        });
+    if (duplicate != snapshots_.end()) {
+        *duplicate = snapshot;
+        return true;
+    }
+
+    const auto insertion = std::upper_bound(
+        snapshots_.begin(), snapshots_.end(), snapshot.decode_time,
+        [](const MadocaGtime& time, const MadocaIonoSnapshot& existing) {
+            return ionoSnapshotTimeLess(time, existing.decode_time);
+        });
+    snapshots_.insert(insertion, snapshot);
+    return true;
+}
+
+std::size_t MadocaIonoProducts::addSnapshots(
+    const std::vector<MadocaIonoSnapshot>& snapshots) {
+    std::size_t accepted = 0;
+    for (const auto& snapshot : snapshots) {
+        if (addSnapshot(snapshot)) {
+            ++accepted;
+        }
+    }
+    return accepted;
+}
+
+const MadocaIonoSnapshot* MadocaIonoProducts::latestAtOrBefore(
+    const MadocaGtime& query_time, double max_age_s) const {
+    if (snapshots_.empty() || query_time.time == 0 ||
+        !std::isfinite(query_time.sec) || query_time.sec < 0.0 ||
+        query_time.sec >= 1.0 || !std::isfinite(max_age_s)) {
+        return nullptr;
+    }
+    const auto after = std::upper_bound(
+        snapshots_.begin(), snapshots_.end(), query_time,
+        [](const MadocaGtime& time, const MadocaIonoSnapshot& snapshot) {
+            return ionoSnapshotTimeLess(time, snapshot.decode_time);
+        });
+    if (after == snapshots_.begin()) {
+        return nullptr;
+    }
+    const auto& selected = *std::prev(after);
+    const double age_s = ionoSnapshotAgeSeconds(query_time, selected.decode_time);
+    if (age_s < 0.0 || (max_age_s >= 0.0 && age_s > max_age_s)) {
+        return nullptr;
+    }
+    return &selected;
 }
 
 bool decodeMadocaL6dFileToSnapshots(

--- a/tests/test_madoca_l6d_snapshots.cpp
+++ b/tests/test_madoca_l6d_snapshots.cpp
@@ -69,3 +69,61 @@ TEST(MadocaL6dSnapshotTest, RejectsMissingAndIncompleteFiles) {
     EXPECT_NE(error.find("no complete L6D messages"), std::string::npos);
     std::filesystem::remove(path);
 }
+
+namespace {
+
+MadocaIonoSnapshot makeSnapshot(std::int64_t time, double sec, int region,
+                                double delay) {
+    MadocaIonoSnapshot snapshot;
+    snapshot.decode_time = {time, sec};
+    snapshot.updated_region_id = region;
+    snapshot.correction.rid = region;
+    snapshot.correction.dly[0] = delay;
+    return snapshot;
+}
+
+}  // namespace
+
+TEST(MadocaIonoProductsTest, OrdersMultipleSourcesAndNeverSelectsFuture) {
+    MadocaIonoProducts products;
+    const std::vector<MadocaIonoSnapshot> second_source = {
+        makeSnapshot(1'700'000'030, 0.0, 8, 3.0),
+        makeSnapshot(1'700'000'010, 0.0, 8, 1.0),
+    };
+    const std::vector<MadocaIonoSnapshot> first_source = {
+        makeSnapshot(1'700'000'020, 0.0, 7, 2.0),
+    };
+    EXPECT_EQ(products.addSnapshots(second_source), 2u);
+    EXPECT_EQ(products.addSnapshots(first_source), 1u);
+    ASSERT_EQ(products.size(), 3u);
+    EXPECT_EQ(products.snapshots()[0].decode_time.time, 1'700'000'010);
+    EXPECT_EQ(products.snapshots()[1].decode_time.time, 1'700'000'020);
+    EXPECT_EQ(products.snapshots()[2].decode_time.time, 1'700'000'030);
+
+    EXPECT_EQ(products.latestAtOrBefore({1'700'000'009, 0.9}), nullptr);
+    const auto* selected = products.latestAtOrBefore({1'700'000'025, 0.0});
+    ASSERT_NE(selected, nullptr);
+    EXPECT_DOUBLE_EQ(selected->correction.dly[0], 2.0);
+}
+
+TEST(MadocaIonoProductsTest, ReplacesDuplicateAndAppliesFreshnessGate) {
+    MadocaIonoProducts products;
+    ASSERT_TRUE(products.addSnapshot(makeSnapshot(1'700'000'000, 0.5, 7, 1.0)));
+    ASSERT_TRUE(products.addSnapshot(makeSnapshot(1'700'000'000, 0.5, 7, 4.0)));
+    EXPECT_EQ(products.size(), 1u);
+
+    const auto* fresh = products.latestAtOrBefore({1'700'000'005, 0.5}, 5.0);
+    ASSERT_NE(fresh, nullptr);
+    EXPECT_DOUBLE_EQ(fresh->correction.dly[0], 4.0);
+    EXPECT_EQ(products.latestAtOrBefore({1'700'000'005, 0.6}, 5.0), nullptr);
+    EXPECT_NE(products.latestAtOrBefore({1'700'100'000, 0.0}), nullptr);
+}
+
+TEST(MadocaIonoProductsTest, RejectsInvalidSnapshotKeysAndQueries) {
+    MadocaIonoProducts products;
+    EXPECT_FALSE(products.addSnapshot(makeSnapshot(0, 0.0, 7, 1.0)));
+    EXPECT_FALSE(products.addSnapshot(makeSnapshot(1'700'000'000, 1.0, 7, 1.0)));
+    EXPECT_FALSE(products.addSnapshot(makeSnapshot(1'700'000'000, 0.0, -1, 1.0)));
+    EXPECT_TRUE(products.empty());
+    EXPECT_EQ(products.latestAtOrBefore({1'700'000'000, 0.0}), nullptr);
+}


### PR DESCRIPTION
## Summary

- add `MadocaIonoProducts` as the time-series boundary for native L6D corrections
- merge snapshots from multiple replay sources in chronological order
- replace duplicate epoch/region updates deterministically
- select only corrections at or before the observation epoch
- reject stale corrections through an explicit maximum-age gate
- document the product-store boundary in the MADOCA port plan

## Why

The native L6D snapshot API established in #289 still left sorting, duplicate
handling, causal lookup, and freshness policy to each future consumer. PPP
ingestion needs these rules in a reusable product container so the solver does
not own raw replay or time-series policy.

## Impact

Future PPP wiring can request one causal, fresh L6D correction snapshot for an
observation epoch. This change does not enable L6D correction application in
the default PPP runtime.

## Validation

- MSVC Release build of `gnss_lib`
- MSVC Release build of `gnss_run_tests` with already-built project references
- 17 MADOCA-related tests passed
- `git diff --check`

Closes #290
