### PR TITLE
Add MADOCA L6D PPP shadow diagnostics

### DIFF
--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -1,4 +1,6 @@
 #include <algorithm>
+#include <chrono>
+#include <ctime>
 #include <exception>
 #include <filesystem>
 #include <fstream>
@@ -25,6 +27,7 @@ struct Options {
     std::string ssr_path;
     std::string ssr_rtcm_path;
     std::vector<std::string> madoca_l6_paths;
+    std::vector<std::string> madoca_l6d_shadow_paths;
     std::string madoca_materialization_dump_path;
     bool madoca_materialization_dump_only = false;
     std::string ionex_path;
@@ -94,6 +97,9 @@ void printUsage(const char* program_name) {
         << "                          RTCM SSR source converted/read for PPP use\n"
         << "  --madoca-l6 <file>       Native MADOCA L6E SSR channel (repeatable,\n"
         << "                          e.g. PRN 204 and 206); requires --nav\n"
+        << "  --madoca-l6d-shadow <file>\n"
+        << "                          Native L6D ionosphere shadow input (repeatable);\n"
+        << "                          reports lookup diagnostics without changing PPP\n"
         << "  --madoca-materialization-dump <csv>\n"
         << "                          Dump native MADOCA L6E SSRProducts materialization\n"
         << "                          rows before PPP processing\n"
@@ -253,6 +259,8 @@ Options parseArguments(int argc, char* argv[]) {
             options.ssr_rtcm_path = argv[++i];
         } else if (arg == "--madoca-l6" && i + 1 < argc) {
             options.madoca_l6_paths.push_back(argv[++i]);
+        } else if (arg == "--madoca-l6d-shadow" && i + 1 < argc) {
+            options.madoca_l6d_shadow_paths.push_back(argv[++i]);
         } else if (arg == "--madoca-materialization-dump" && i + 1 < argc) {
             options.madoca_materialization_dump_path = argv[++i];
         } else if (arg == "--madoca-materialization-dump-only") {
@@ -1041,6 +1049,41 @@ int main(int argc, char* argv[]) {
             std::cerr << "Error: failed to load MADOCA L6E corrections\n";
             return 1;
         }
+        if (!options.madoca_l6d_shadow_paths.empty()) {
+            if (obs_header.first_obs.week <= 0 ||
+                obs_header.approximate_position.norm() <= 1e3) {
+                std::cerr << "Error: --madoca-l6d-shadow requires RINEX first-observation "
+                             "time and approximate receiver position\n";
+                return 1;
+            }
+            const auto reference_tp = obs_header.first_obs.toSystemTime();
+            const std::time_t reference_time =
+                std::chrono::system_clock::to_time_t(reference_tp);
+            std::tm reference_tm{};
+#if defined(_WIN32)
+            gmtime_s(&reference_tm, &reference_time);
+#else
+            gmtime_r(&reference_time, &reference_tm);
+#endif
+            const double reference_epoch[6] = {
+                static_cast<double>(reference_tm.tm_year + 1900),
+                static_cast<double>(reference_tm.tm_mon + 1),
+                static_cast<double>(reference_tm.tm_mday),
+                static_cast<double>(reference_tm.tm_hour),
+                static_cast<double>(reference_tm.tm_min),
+                static_cast<double>(reference_tm.tm_sec),
+            };
+            const double receiver_ecef[3] = {
+                obs_header.approximate_position.x(),
+                obs_header.approximate_position.y(),
+                obs_header.approximate_position.z(),
+            };
+            if (!processor.loadMadocaL6dProducts(
+                    options.madoca_l6d_shadow_paths, reference_epoch, receiver_ecef)) {
+                std::cerr << "Error: failed to load MADOCA L6D shadow corrections\n";
+                return 1;
+            }
+        }
 
         libgnss::Solution solutions;
         libgnss::ObservationData observation_data;
@@ -1054,6 +1097,12 @@ int main(int argc, char* argv[]) {
         int ionex_corrections = 0;
         int dcb_corrections = 0;
         int clas_hybrid_fallback_epochs = 0;
+        int madoca_l6d_shadow_snapshot_epochs = 0;
+        int madoca_l6d_shadow_stale_epochs = 0;
+        int madoca_l6d_shadow_matched_satellites = 0;
+        double madoca_l6d_shadow_max_age_s = 0.0;
+        int madoca_l6d_shadow_last_region = -1;
+        int madoca_l6d_shadow_last_area = 0;
         std::map<std::string, int> clas_hybrid_fallback_reasons;
         double atmospheric_trop_meters = 0.0;
         double atmospheric_iono_meters = 0.0;
@@ -1078,6 +1127,17 @@ int main(int argc, char* argv[]) {
                 processor.getLastAppliedAtmosphericIonosphereMeters();
             ionex_meters += processor.getLastAppliedIonexMeters();
             dcb_meters += processor.getLastAppliedDcbMeters();
+            const auto& l6d_shadow = processor.getLastMadocaL6dShadowStatus();
+            if (l6d_shadow.snapshot_available) {
+                ++madoca_l6d_shadow_snapshot_epochs;
+                madoca_l6d_shadow_matched_satellites += l6d_shadow.matched_satellites;
+                madoca_l6d_shadow_max_age_s =
+                    std::max(madoca_l6d_shadow_max_age_s, l6d_shadow.age_s);
+                madoca_l6d_shadow_last_region = l6d_shadow.region_id;
+                madoca_l6d_shadow_last_area = l6d_shadow.area_number;
+            } else if (l6d_shadow.stale) {
+                ++madoca_l6d_shadow_stale_epochs;
+            }
             if (processor.getLastClasHybridFallbackUsed()) {
                 ++clas_hybrid_fallback_epochs;
                 ++clas_hybrid_fallback_reasons[processor.getLastClasHybridFallbackReason()];
@@ -1199,6 +1259,20 @@ int main(int argc, char* argv[]) {
                     << "  \"dcb_entries\": " << processor.getLoadedDCBEntryCount() << ",\n"
                     << "  \"dcb_corrections\": " << dcb_corrections << ",\n"
                     << "  \"dcb_meters\": " << dcb_meters << ",\n"
+                    << "  \"madoca_l6d_shadow_loaded\": "
+                    << (processor.hasLoadedMadocaL6dProducts() ? "true" : "false") << ",\n"
+                    << "  \"madoca_l6d_shadow_snapshot_epochs\": "
+                    << madoca_l6d_shadow_snapshot_epochs << ",\n"
+                    << "  \"madoca_l6d_shadow_stale_epochs\": "
+                    << madoca_l6d_shadow_stale_epochs << ",\n"
+                    << "  \"madoca_l6d_shadow_matched_satellites\": "
+                    << madoca_l6d_shadow_matched_satellites << ",\n"
+                    << "  \"madoca_l6d_shadow_max_age_s\": "
+                    << madoca_l6d_shadow_max_age_s << ",\n"
+                    << "  \"madoca_l6d_shadow_last_region\": "
+                    << madoca_l6d_shadow_last_region << ",\n"
+                    << "  \"madoca_l6d_shadow_last_area\": "
+                    << madoca_l6d_shadow_last_area << ",\n"
                     << "  \"clas_hybrid_fallback_reasons\": {";
             bool first_reason = true;
             for (const auto& [reason, count] : clas_hybrid_fallback_reasons) {
@@ -1250,6 +1324,14 @@ int main(int argc, char* argv[]) {
             if (!options.madoca_materialization_dump_path.empty()) {
                 std::cout << "  MADOCA materialization dump: "
                           << options.madoca_materialization_dump_path << "\n";
+            }
+            if (processor.hasLoadedMadocaL6dProducts()) {
+                std::cout << "  MADOCA L6D shadow snapshot epochs: "
+                          << madoca_l6d_shadow_snapshot_epochs << "\n";
+                std::cout << "  MADOCA L6D shadow stale epochs: "
+                          << madoca_l6d_shadow_stale_epochs << "\n";
+                std::cout << "  MADOCA L6D shadow matched satellites: "
+                          << madoca_l6d_shadow_matched_satellites << "\n";
             }
             if (atmospheric_trop_corrections > 0 || atmospheric_iono_corrections > 0) {
                 std::cout << "  atmospheric trop corrections: "

--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -55,6 +55,13 @@ CSV schema is
 `madoca_materialization_snapshot.v1` and records satellite key, system/PRN,
 correction epoch, orbit/clock reference epochs, IODE/SSR IOD, RAC orbit,
 clock, code-bias ids/values, phase-bias ids/values, and discontinuity counters.
+
+For measurement-neutral L6D coverage inspection, repeat
+`--madoca-l6d-shadow <file>` for the PRN 200/201 inputs. The PPP summary JSON
+records loaded state, causal/fresh snapshot epochs, stale epochs, matched
+satellites, maximum age, and the last selected region/area without modifying
+code, phase, ionosphere states, or the position solution.
+
 This is the M3 boundary between decoded L6E content and solver row construction:
 use it before residual or state/covariance tuning so decoder-vs-materializer
 identity/time/IOD mistakes are visible as artifacts.  The option changes no

--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -798,6 +798,9 @@ Phase 5, PPP application:
 
 - Wire MADOCA correction products into the existing PPP pipeline only after the
   correction objects are independently testable.
+- Start with measurement-neutral L6D shadow lookup: select only causal/fresh
+  snapshots and report matched satellites plus region, area, and age before
+  enabling any code/phase or STEC-state update.
 - Keep CLAS and MADOCA profiles explicit.
 - Add runtime knobs as narrow, documented options, not broad solver rewrites.
 - Compare sample `exec_ppp` and `exec_pppar` windows against MADOCALIB output.

--- a/include/libgnss++/algorithms/madoca_core.hpp
+++ b/include/libgnss++/algorithms/madoca_core.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <libgnss++/core/types.hpp>
+#include <libgnss++/io/madoca_l6.hpp>
 
 #include <cstdint>
 #include <optional>
@@ -49,6 +50,11 @@ std::vector<int> compactSsrSignalCodes(int compact_ssr_system_id, std::uint16_t 
 
 // RTCM/MADOCA SSR URA indicator to one-sigma standard deviation in meters.
 double ssrUraIndicatorToSigmaMeters(int ura_index);
+
+// Convert libgnss++ time/satellite identities to the RTKLIB-compatible forms
+// used by the native L6D correction arrays. Invalid inputs return zero.
+io::MadocaGtime madocaGtimeFromGpsTime(const GNSSTime& time);
+int rtklibSatelliteNumber(const SatelliteId& satellite);
 
 // MADOCA-PPP code/phase-bias code selection. The system argument uses the
 // RTKLIB SYS_* bit constants mirrored in madoca_parity.hpp.

--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -10,6 +10,7 @@
 #include "ppp_shared.hpp"
 #include "ppp_clas_sd.hpp"
 #include "ppp_osr_types.hpp"
+#include "../io/madoca_l6d.hpp"
 #include "spp.hpp"
 #include "../iers/eop_table.hpp"
 #include "../iers/tides.hpp"
@@ -39,6 +40,15 @@ struct ReceiverPcvGrid {
     double zen2_deg = 90.0;
     double dzen_deg = 5.0;
     std::vector<double> noazi_m;  // PCV at each zenith node (metres)
+};
+
+struct MadocaL6dShadowStatus {
+    bool snapshot_available = false;
+    bool stale = false;
+    double age_s = 0.0;
+    int region_id = -1;
+    int area_number = 0;
+    int matched_satellites = 0;
 };
 
 /**
@@ -96,6 +106,23 @@ public:
      * were produced. Distinct from loadL6Products (CLAS-oriented decoder).
      */
     bool loadMadocaL6Products(const std::vector<std::string>& l6_files);
+
+    // Load receiver-specific L6D ionosphere snapshots for diagnostic shadow
+    // lookup. This does not change PPP measurements or filter state.
+    bool loadMadocaL6dProducts(const std::vector<std::string>& l6d_files,
+                               const double reference_epoch[6],
+                               const double receiver_ecef[3]);
+    void setMadocaIonoProductsForShadow(const io::MadocaIonoProducts& products) {
+        madoca_iono_products_ = products;
+    }
+    MadocaL6dShadowStatus inspectMadocaL6dShadow(
+        const std::vector<SatelliteId>& satellites,
+        const GNSSTime& time,
+        double max_age_s = 300.0) const;
+    const MadocaL6dShadowStatus& getLastMadocaL6dShadowStatus() const {
+        return last_madoca_l6d_shadow_status_;
+    }
+    bool hasLoadedMadocaL6dProducts() const { return !madoca_iono_products_.empty(); }
 
     /**
      * @brief Load IONEX ionosphere products for future PPP hooks.
@@ -228,6 +255,7 @@ private:
     SSRProducts ssr_products_;
     IONEXProducts ionex_products_;
     DCBProducts dcb_products_;
+    io::MadocaIonoProducts madoca_iono_products_;
     
     PPPState filter_state_;
     bool filter_initialized_ = false;
@@ -278,6 +306,7 @@ private:
     int last_applied_dcb_corrections_ = 0;
     double last_applied_ionex_m_ = 0.0;
     double last_applied_dcb_m_ = 0.0;
+    MadocaL6dShadowStatus last_madoca_l6d_shadow_status_;
     bool last_clas_hybrid_fallback_used_ = false;
     std::string last_clas_hybrid_fallback_reason_;
     

--- a/src/algorithms/madoca_core.cpp
+++ b/src/algorithms/madoca_core.cpp
@@ -159,6 +159,39 @@ double ssrUraIndicatorToSigmaMeters(int ura_index) {
            1e-3;
 }
 
+io::MadocaGtime madocaGtimeFromGpsTime(const GNSSTime& time) {
+    constexpr std::int64_t kGpsEpochUnixSeconds = 315964800;
+    constexpr double kWeekSeconds = 604800.0;
+    if (time.week < 0 || !std::isfinite(time.tow) ||
+        time.tow < 0.0 || time.tow >= kWeekSeconds) {
+        return {};
+    }
+    const double whole_tow = std::floor(time.tow);
+    io::MadocaGtime converted;
+    converted.time = kGpsEpochUnixSeconds +
+        static_cast<std::int64_t>(time.week) * 604800 +
+        static_cast<std::int64_t>(whole_tow);
+    converted.sec = time.tow - whole_tow;
+    return converted;
+}
+
+int rtklibSatelliteNumber(const SatelliteId& satellite) {
+    int system = 0;
+    int prn = satellite.prn;
+    switch (satellite.system) {
+        case GNSSSystem::GPS: system = madoca_parity::kSysGps; break;
+        case GNSSSystem::GLONASS: system = madoca_parity::kSysGlo; break;
+        case GNSSSystem::Galileo: system = madoca_parity::kSysGal; break;
+        case GNSSSystem::BeiDou: system = madoca_parity::kSysCmp; break;
+        case GNSSSystem::QZSS:
+            system = madoca_parity::kSysQzs;
+            prn += 192;
+            break;
+        default: return 0;
+    }
+    return madoca_parity::satno(system, prn);
+}
+
 int selectBiasCode(int rtklib_system, int rtklib_code) {
     return madoca_parity::mcssrSelBiascode(rtklib_system, rtklib_code);
 }

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -510,6 +510,7 @@ PositionSolution PPPProcessor::processEpochStandard(
     last_applied_dcb_corrections_ = 0;
     last_applied_ionex_m_ = 0.0;
     last_applied_dcb_m_ = 0.0;
+    last_madoca_l6d_shadow_status_ = {};
     if (require_coherent_ssr_ && ssr_products_loaded_ &&
         !hasEnoughCoherentSsrObservations(obs, nav)) {
         return finalizeSolution(solution);
@@ -748,6 +749,7 @@ void PPPProcessor::reset() {
     last_applied_dcb_corrections_ = 0;
     last_applied_ionex_m_ = 0.0;
     last_applied_dcb_m_ = 0.0;
+    last_madoca_l6d_shadow_status_ = {};
 
     std::lock_guard<std::mutex> lock(stats_mutex_);
     total_epochs_processed_ = 0;

--- a/src/algorithms/ppp_corrections.cpp
+++ b/src/algorithms/ppp_corrections.cpp
@@ -1,6 +1,7 @@
 #include "ppp_internal.hpp"
 
 #include <libgnss++/algorithms/ppp_correction_contract.hpp>
+#include <libgnss++/algorithms/madoca_core.hpp>
 
 #include <libgnss++/algorithms/ppp_bias_identity.hpp>
 #include <libgnss++/algorithms/ppp_atmosphere.hpp>
@@ -32,6 +33,44 @@
 namespace libgnss {
 
 using namespace ppp_internal;
+
+MadocaL6dShadowStatus PPPProcessor::inspectMadocaL6dShadow(
+    const std::vector<SatelliteId>& satellites,
+    const GNSSTime& time,
+    double max_age_s) const {
+    MadocaL6dShadowStatus status;
+    const auto query_time = algorithms::madoca_core::madocaGtimeFromGpsTime(time);
+    if (query_time.time == 0 || madoca_iono_products_.empty()) {
+        return status;
+    }
+    const auto* causal = madoca_iono_products_.latestAtOrBefore(query_time);
+    if (causal == nullptr) {
+        return status;
+    }
+    const auto* snapshot = madoca_iono_products_.latestAtOrBefore(query_time, max_age_s);
+    if (snapshot == nullptr) {
+        status.stale = true;
+        return status;
+    }
+    status.snapshot_available = true;
+    status.age_s = static_cast<double>(query_time.time - snapshot->decode_time.time) +
+        query_time.sec - snapshot->decode_time.sec;
+    status.region_id = snapshot->correction.rid;
+    status.area_number = snapshot->correction.anum;
+    for (const auto& satellite : satellites) {
+        const int sat = algorithms::madoca_core::rtklibSatelliteNumber(satellite);
+        if (sat <= 0 || sat > io::MadocaIonoCorr::kMaxSat) {
+            continue;
+        }
+        const int index = sat - 1;
+        if (snapshot->correction.t0[index].time != 0 &&
+            std::isfinite(snapshot->correction.dly[index]) &&
+            std::isfinite(snapshot->correction.std[index])) {
+            ++status.matched_satellites;
+        }
+    }
+    return status;
+}
 
 namespace {
 
@@ -778,6 +817,16 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
     const Vector3d receiver_marker_position = applyGeophysicalCorrections(
         filter_state_.state.segment(filter_state_.pos_index, 3), time);
     const double elevation_mask = config_.elevation_mask * kDegreesToRadians;
+
+    std::vector<SatelliteId> shadow_satellites;
+    shadow_satellites.reserve(observations.size());
+    for (const auto& observation : observations) {
+        if (observation.valid) {
+            shadow_satellites.push_back(observation.satellite);
+        }
+    }
+    last_madoca_l6d_shadow_status_ =
+        inspectMadocaL6dShadow(shadow_satellites, time);
 
     // Pre-fetch epoch-wide atmosphere tokens from any satellite that has them.
     // CLAS atmosphere corrections are network-wide, not per-satellite, so we

--- a/src/algorithms/ppp_products.cpp
+++ b/src/algorithms/ppp_products.cpp
@@ -220,6 +220,25 @@ bool PPPProcessor::loadMadocaL6Products(const std::vector<std::string>& l6_files
     return ssr_products_loaded_;
 }
 
+bool PPPProcessor::loadMadocaL6dProducts(const std::vector<std::string>& l6d_files,
+                                         const double reference_epoch[6],
+                                         const double receiver_ecef[3]) {
+    madoca_iono_products_.clear();
+    if (l6d_files.empty()) {
+        return false;
+    }
+    for (const auto& file : l6d_files) {
+        std::vector<io::MadocaIonoSnapshot> snapshots;
+        if (!io::decodeMadocaL6dFileToSnapshots(
+                file, reference_epoch, receiver_ecef, snapshots)) {
+            madoca_iono_products_.clear();
+            return false;
+        }
+        madoca_iono_products_.addSnapshots(snapshots);
+    }
+    return !madoca_iono_products_.empty();
+}
+
 bool PPPProcessor::loadIONEXProducts(const std::string& ionex_file) {
     ionex_products_.clear();
     if (ionex_file.empty()) {

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -4031,6 +4031,7 @@ class CLIToolsTest(unittest.TestCase):
         self.assertIn("--madocalib-bridge", result.stdout)
         self.assertIn("--madocalib-l6", result.stdout)
         self.assertIn("--madocalib-mdciono", result.stdout)
+        self.assertIn("--madoca-l6d-shadow", result.stdout)
         self.assertIn("--madoca-materialization-dump", result.stdout)
         self.assertIn("--madoca-materialization-dump-only", result.stdout)
 

--- a/tests/test_madoca_core.cpp
+++ b/tests/test_madoca_core.cpp
@@ -87,4 +87,16 @@ TEST(MadocaCore, SelectsBiasCodesThroughParityHelper) {
     EXPECT_EQ(core::selectBiasCode(mp::kSysSbs, mp::kCodeL1C), mp::kCodeNone);
 }
 
+TEST(MadocaCore, ConvertsGpsTimeAndSatelliteIdentityForL6d) {
+    const auto time = core::madocaGtimeFromGpsTime(libgnss::GNSSTime(1, 2.25));
+    EXPECT_EQ(time.time, 315964800 + 604800 + 2);
+    EXPECT_DOUBLE_EQ(time.sec, 0.25);
+    EXPECT_EQ(core::rtklibSatelliteNumber(
+                  libgnss::SatelliteId(libgnss::GNSSSystem::GPS, 1)), 1);
+    EXPECT_GT(core::rtklibSatelliteNumber(
+                  libgnss::SatelliteId(libgnss::GNSSSystem::QZSS, 1)), 0);
+    EXPECT_EQ(core::rtklibSatelliteNumber(
+                  libgnss::SatelliteId(libgnss::GNSSSystem::UNKNOWN, 1)), 0);
+}
+
 }  // namespace

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -1,6 +1,7 @@
 #include <gtest/gtest.h>
 
 #include <libgnss++/algorithms/ppp.hpp>
+#include <libgnss++/algorithms/madoca_core.hpp>
 #include <libgnss++/core/coordinates.hpp>
 #include <libgnss++/models/troposphere.hpp>
 
@@ -1608,6 +1609,45 @@ TEST(PPPTest, ProcessorLoadsRtcmSsrCodeBiasFromFile) {
     EXPECT_DOUBLE_EQ(ura_sigma_m, 0.0);
 
     std::filesystem::remove(rtcm_path);
+}
+
+TEST(PPPTest, MadocaL6dShadowSelectsFreshCausalSatelliteCorrections) {
+    const GNSSTime epoch(2414, 345600.0);
+    io::MadocaIonoSnapshot snapshot;
+    snapshot.decode_time = algorithms::madoca_core::madocaGtimeFromGpsTime(epoch);
+    snapshot.updated_region_id = 7;
+    snapshot.correction.rid = 7;
+    snapshot.correction.anum = 3;
+    const int gps1 = algorithms::madoca_core::rtklibSatelliteNumber(
+        SatelliteId(GNSSSystem::GPS, 1));
+    ASSERT_GT(gps1, 0);
+    snapshot.correction.t0[gps1 - 1] = snapshot.decode_time;
+    snapshot.correction.dly[gps1 - 1] = 1.25;
+    snapshot.correction.std[gps1 - 1] = 0.15;
+
+    io::MadocaIonoProducts products;
+    ASSERT_TRUE(products.addSnapshot(snapshot));
+    PPPProcessor processor;
+    processor.setMadocaIonoProductsForShadow(products);
+
+    const auto fresh = processor.inspectMadocaL6dShadow(
+        {SatelliteId(GNSSSystem::GPS, 1), SatelliteId(GNSSSystem::GPS, 2)},
+        epoch + 5.0, 10.0);
+    EXPECT_TRUE(fresh.snapshot_available);
+    EXPECT_FALSE(fresh.stale);
+    EXPECT_DOUBLE_EQ(fresh.age_s, 5.0);
+    EXPECT_EQ(fresh.region_id, 7);
+    EXPECT_EQ(fresh.area_number, 3);
+    EXPECT_EQ(fresh.matched_satellites, 1);
+
+    const auto stale = processor.inspectMadocaL6dShadow(
+        {SatelliteId(GNSSSystem::GPS, 1)}, epoch + 11.0, 10.0);
+    EXPECT_FALSE(stale.snapshot_available);
+    EXPECT_TRUE(stale.stale);
+    const auto before = processor.inspectMadocaL6dShadow(
+        {SatelliteId(GNSSSystem::GPS, 1)}, epoch - 1.0, 10.0);
+    EXPECT_FALSE(before.snapshot_available);
+    EXPECT_FALSE(before.stale);
 }
 
 TEST(PPPTest, ProcessorProducesConvergedFloatSolutionWithSyntheticPreciseProducts) {


### PR DESCRIPTION
## Summary

- load receiver-specific native MADOCA L6D products into `PPPProcessor`
- convert libgnss++ GPST and satellite identities to MADOCALIB-compatible forms
- perform causal, freshness-gated L6D lookup for each PPP epoch
- report matched satellites, region, area, and correction age without changing measurements
- expose repeatable `--madoca-l6d-shadow` input and stable summary JSON metrics

## Why

Native L6D decoding and time-series products were independently tested, but PPP
had no measurement-neutral integration point. This shadow path makes real-data
coverage and MADOCALIB row parity observable before any STEC-state or
code/phase correction is enabled.

## Impact

The default solution, observations, and filter state are unchanged. L6D data is
only loaded when explicitly requested, and shadow lookup records diagnostics.

## Validation

- MSVC Release builds of `gnss_lib`, `gnss_run_tests`, and `gnss_ppp`
- 96 PPP/MADOCA/atmosphere/OSR tests passed
- CLI help regression passed
- Python compile passed
- `git diff --check`

Refs #148
