### PR TITLE
Audit MADOCA GLONASS phase residuals

### DIFF
--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -43,6 +43,14 @@ and GLONASS code carries large FDMA inter-frequency biases too.  MADOCA SSR
 provides no GLONASS phase-bias product, so default GLONASS-phase-off is correct
 (matches MADOCALIB excluding GLO from the precise phase/AR solution).
 
+Generate the evidence with `GNSS_PPP_MADOCA_GLONASS_PHASE=1` and
+`GNSS_PPP_MADOCA_POSTFIT_SHADOW=<csv>`, then run
+`scripts/analysis/madoca_glonass_phase_audit.py <csv> --json-out <json>`.
+The `madoca_glonass_phase_audit.v1` report records per-satellite raw and
+demeaned RMS, residual span, duration, and residual/elevation correlation.
+The shadow CSV header includes the signal-family, RINEX-code, and RTKLIB-code
+columns emitted by each data row so these residual fields remain aligned.
+
 Open MADOCA levers (measured, none yet a default win): PPP-AR parity
 (`exec_pppar` window); QZSS atmosphere row-set.
 

--- a/scripts/analysis/madoca_glonass_phase_audit.py
+++ b/scripts/analysis/madoca_glonass_phase_audit.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Audit time-varying GLONASS phase residuals in a MADOCA postfit shadow CSV."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from collections import defaultdict
+from pathlib import Path
+from typing import Sequence
+
+
+SCHEMA = "madoca_glonass_phase_audit.v1"
+REQUIRED_COLUMNS = {"record", "tow", "sat", "system", "obs_type", "residual_m", "elevation_deg"}
+
+
+def _finite(value: str) -> float | None:
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if math.isfinite(parsed) else None
+
+
+def _correlation(xs: list[float], ys: list[float]) -> float | None:
+    if len(xs) < 2:
+        return None
+    mx, my = sum(xs) / len(xs), sum(ys) / len(ys)
+    dx = [value - mx for value in xs]
+    dy = [value - my for value in ys]
+    denom = math.sqrt(sum(value * value for value in dx) * sum(value * value for value in dy))
+    return sum(x * y for x, y in zip(dx, dy)) / denom if denom > 0.0 else None
+
+
+def audit_rows(rows: list[dict[str, str]]) -> dict[str, object]:
+    grouped: dict[str, list[tuple[float, float, float]]] = defaultdict(list)
+    for row in rows:
+        if row.get("record") != "row" or row.get("system") != "GLO" or row.get("obs_type") != "phase":
+            continue
+        tow = _finite(row.get("tow", ""))
+        residual = _finite(row.get("residual_m", ""))
+        elevation = _finite(row.get("elevation_deg", ""))
+        if tow is not None and residual is not None and elevation is not None and row.get("sat"):
+            grouped[row["sat"]].append((tow, residual, elevation))
+
+    satellites: dict[str, object] = {}
+    for sat, samples in sorted(grouped.items()):
+        samples.sort()
+        residuals = [sample[1] for sample in samples]
+        elevations = [sample[2] for sample in samples]
+        mean = sum(residuals) / len(residuals)
+        demeaned_rms = math.sqrt(sum((value - mean) ** 2 for value in residuals) / len(residuals))
+        satellites[sat] = {
+            "rows": len(samples),
+            "duration_s": samples[-1][0] - samples[0][0],
+            "mean_residual_m": mean,
+            "rms_residual_m": math.sqrt(sum(value * value for value in residuals) / len(residuals)),
+            "demeaned_rms_m": demeaned_rms,
+            "residual_span_m": max(residuals) - min(residuals),
+            "residual_elevation_correlation": _correlation(elevations, residuals),
+        }
+    return {
+        "schema": SCHEMA,
+        "status": "passed" if satellites else "failed",
+        "glonass_phase_rows": sum(item["rows"] for item in satellites.values()),
+        "satellites": satellites,
+        "failures": [] if satellites else ["no valid GLONASS phase rows"],
+    }
+
+
+def audit_file(path: Path) -> dict[str, object]:
+    with path.open(newline="", encoding="utf-8") as handle:
+        reader = csv.DictReader(handle)
+        columns = set(reader.fieldnames or [])
+        missing = sorted(REQUIRED_COLUMNS - columns)
+        if missing:
+            return {"schema": SCHEMA, "status": "failed", "failures": [f"missing columns: {', '.join(missing)}"]}
+        return audit_rows(list(reader))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("shadow_csv", type=Path)
+    parser.add_argument("--json-out", type=Path)
+    args = parser.parse_args(argv)
+    report = audit_file(args.shadow_csv)
+    if args.json_out:
+        args.json_out.parent.mkdir(parents=True, exist_ok=True)
+        args.json_out.write_text(json.dumps(report, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"madoca_glonass_phase_audit: {report['status']}")
+    print(f"  GLONASS phase rows: {report.get('glonass_phase_rows', 0)}")
+    return 0 if report["status"] == "passed" else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -92,7 +92,8 @@ public:
         }
         if (!header_written_) {
             out_ << "record,week,tow,iteration_count,row,row_count,"
-                    "sat,system,signal_type,signal_band,obs_type,"
+                    "sat,system,signal_type,signal_band,signal_family,"
+                    "rinex_code,rtklib_code,obs_type,"
                     "residual_m,variance_m2,sigma_m,abs_norm,elevation_deg,"
                     "azimuth_deg,glonass_fcn,primary_frequency_hz,"
                     "secondary_frequency_hz,primary_if_coeff,secondary_if_coeff,"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -154,6 +154,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_madoca_residual_component_summary.py
     )
     add_test(
+        NAME python_madoca_glonass_phase_audit_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_madoca_glonass_phase_audit.py
+    )
+    add_test(
         NAME python_madoca_materialization_diff_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_madoca_materialization_diff.py
     )

--- a/tests/test_madoca_glonass_phase_audit.py
+++ b/tests/test_madoca_glonass_phase_audit.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SCRIPT = ROOT / "scripts" / "analysis" / "madoca_glonass_phase_audit.py"
+spec = importlib.util.spec_from_file_location("madoca_glonass_phase_audit", SCRIPT)
+module = importlib.util.module_from_spec(spec)
+assert spec and spec.loader
+spec.loader.exec_module(module)
+
+
+class MadocaGlonassPhaseAuditTest(unittest.TestCase):
+    def test_reports_demeaned_variation_and_elevation_shape(self) -> None:
+        rows = [
+            {"record": "row", "tow": "0", "sat": "R09", "system": "GLO", "obs_type": "phase", "residual_m": "-1", "elevation_deg": "10"},
+            {"record": "row", "tow": "30", "sat": "R09", "system": "GLO", "obs_type": "phase", "residual_m": "0", "elevation_deg": "30"},
+            {"record": "row", "tow": "60", "sat": "R09", "system": "GLO", "obs_type": "phase", "residual_m": "1", "elevation_deg": "50"},
+            {"record": "row", "tow": "60", "sat": "G01", "system": "GPS", "obs_type": "phase", "residual_m": "9", "elevation_deg": "50"},
+        ]
+        report = module.audit_rows(rows)
+        sat = report["satellites"]["R09"]
+        self.assertEqual(report["glonass_phase_rows"], 3)
+        self.assertAlmostEqual(sat["demeaned_rms_m"], (2 / 3) ** 0.5)
+        self.assertAlmostEqual(sat["residual_elevation_correlation"], 1.0)
+        self.assertEqual(sat["residual_span_m"], 2.0)
+
+    def test_cli_rejects_shifted_legacy_header(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            source = Path(temp_dir) / "shadow.csv"
+            output = Path(temp_dir) / "report.json"
+            source.write_text("record,tow,sat,system,residual_m,elevation_deg\n", encoding="utf-8")
+            result = subprocess.run([sys.executable, str(SCRIPT), str(source), "--json-out", str(output)], capture_output=True, text=True)
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("obs_type", json.loads(output.read_text(encoding="utf-8"))["failures"][0])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed
- fix the MADOCA postfit shadow CSV header so signal family, RINEX code, and RTKLIB code align with emitted row values
- add a GLONASS phase residual audit that reports per-satellite raw/demeaned RMS, span, duration, and elevation correlation
- document the reproducible audit workflow and add Python regression coverage

## Why
Issue #148 still listed the GLONASS time-varying phase residual as an open isolation task, but the shadow header shifted `obs_type`, residual, and elevation fields by three columns. Correctly aligned artifacts are required before the R09/R21 evidence can be regenerated reliably.

## Validation
- `python tests/test_madoca_glonass_phase_audit.py`
- focused CTest residual-summary and GLONASS-audit tests
- `cmake --build build --config Release --target gnss_lib -- /m:1`
- `git diff --check`

Closes the GLONASS phase-isolation subtask in #148; the overall tracker remains open.