### PR TITLE
Add MADOCALIB PPP-AR profile smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -570,7 +570,24 @@ jobs:
         rows="$(awk '$0 !~ /^%/ && NF > 0 {n++} END {print n+0}' madocalib_bridge_smoke.pos)"
         test "$rows" -eq 118
         non_q6="$(awk '$0 !~ /^%/ && NF > 0 && $6 != 6 {n++} END {print n+0}' madocalib_bridge_smoke.pos)"
-        test "$non_q6" -eq 0
+          test "$non_q6" -eq 0
+          ./apps/gnss_ppp \
+            --madocalib-bridge \
+            --madocalib-profile pppar \
+            --obs "$ROOT/sample_data/data/rinex/MIZU00JPN_R_20250910000_01D_30S_MO.rnx" \
+            --nav "$ROOT/sample_data/data/rinex/BRDM00DLR_S_20250910000_01D_MN.rnx" \
+            --madocalib-l6 "$ROOT/sample_data/data/l6_is-qzss-mdc-004/2025/091/2025091A.204.l6" \
+            --madocalib-l6 "$ROOT/sample_data/data/l6_is-qzss-mdc-004/2025/091/2025091A.206.l6" \
+            --antex "$ROOT/sample_data/data/igs20.atx" \
+            --madocalib-start "2025/04/01 00:00:00" \
+            --madocalib-end "2025/04/01 00:59:30" \
+            --madocalib-ti 30 \
+            --out madocalib_pppar_smoke.pos \
+            --summary-json madocalib_pppar_smoke.json \
+            --quiet
+          grep -q '"madocalib_profile": "pppar"' madocalib_pppar_smoke.json
+          fixed="$(awk '$0 !~ /^%/ && NF > 0 && $6 == 1 {n++} END {print n+0}' madocalib_pppar_smoke.pos)"
+          test "$fixed" -gt 0
 
     - name: Upload MadocaParity diagnostics
       if: failure()
@@ -584,6 +601,8 @@ jobs:
           build-madoca-parity/CMakeFiles/CMakeConfigureLog.yaml
           build-madoca-parity/madocalib_bridge_smoke.pos
           build-madoca-parity/madocalib_bridge_smoke.json
+          build-madoca-parity/madocalib_pppar_smoke.pos
+          build-madoca-parity/madocalib_pppar_smoke.json
         if-no-files-found: ignore
 
   static-analysis:

--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -59,6 +59,7 @@ struct Options {
     double clas_atmos_stale_after_seconds = 15.0;
     bool madocalib_bridge = false;
     std::string madocalib_config_path;
+    std::string madocalib_profile = "ppp";
     std::vector<std::string> madocalib_l6_paths;
     std::vector<std::string> madocalib_mdciono_paths;
     std::string madocalib_start_time;
@@ -156,6 +157,8 @@ void printUsage(const char* program_name) {
         << "                          Extra MADOCA L6D ionosphere file; repeat up to three\n"
         << "  --madocalib-config <file>\n"
         << "                          MADOCALIB rnx2rtkp config (default: sample.conf)\n"
+        << "  --madocalib-profile <ppp|pppar|pppar-ion>\n"
+        << "                          Select a bundled MADOCALIB sample config (default: ppp)\n"
         << "  --madocalib-start <time>\n"
         << "                          MADOCALIB start time, e.g. '2025/04/01 00:00:00'\n"
         << "  --madocalib-end <time>  MADOCALIB end time, e.g. '2025/04/01 00:59:30'\n"
@@ -325,6 +328,8 @@ Options parseArguments(int argc, char* argv[]) {
             options.madocalib_mdciono_paths.push_back(argv[++i]);
         } else if (arg == "--madocalib-config" && i + 1 < argc) {
             options.madocalib_config_path = argv[++i];
+        } else if (arg == "--madocalib-profile" && i + 1 < argc) {
+            options.madocalib_profile = argv[++i];
         } else if (arg == "--madocalib-start" && i + 1 < argc) {
             options.madocalib_start_time = argv[++i];
         } else if (arg == "--madocalib-end" && i + 1 < argc) {
@@ -441,6 +446,17 @@ Options parseArguments(int argc, char* argv[]) {
     }
     if (options.madocalib_trace_level < 0) {
         argumentError("--madocalib-trace must be non-negative", argv[0]);
+    }
+    if (options.madocalib_profile != "ppp" &&
+        options.madocalib_profile != "pppar" &&
+        options.madocalib_profile != "pppar-ion") {
+        argumentError("--madocalib-profile must be one of: ppp, pppar, pppar-ion", argv[0]);
+    }
+    if (!options.madocalib_config_path.empty() && options.madocalib_profile != "ppp") {
+        argumentError("--madocalib-config cannot be combined with a non-default --madocalib-profile", argv[0]);
+    }
+    if (options.madocalib_profile == "pppar-ion" && options.madocalib_mdciono_paths.empty()) {
+        argumentError("--madocalib-profile pppar-ion requires --madocalib-mdciono", argv[0]);
     }
     if (options.clas_epoch_policy != "strict-osr" &&
         options.clas_epoch_policy != "hybrid-standard-ppp") {
@@ -693,6 +709,15 @@ int main(int argc, char* argv[]) {
             bridge_options.nav_path = options.nav_path;
             bridge_options.out_path = options.out_path;
             bridge_options.config_path = options.madocalib_config_path;
+            if (bridge_options.config_path.empty() && options.madocalib_profile != "ppp") {
+                const std::string filename =
+                    options.madocalib_profile == "pppar"
+                        ? "sample_pppar.conf"
+                        : "sample_pppar_iono.conf";
+                bridge_options.config_path =
+                    (std::filesystem::path(madocalib::defaultRootDir()) /
+                     "app/consapp/rnx2rtkp/gcc_mingw" / filename).string();
+            }
             bridge_options.antenna_path = options.antex_path;
             bridge_options.start_time = options.madocalib_start_time;
             bridge_options.end_time = options.madocalib_end_time;
@@ -767,6 +792,8 @@ int main(int argc, char* argv[]) {
                         << "  \"out\": \"" << jsonEscape(options.out_path) << "\",\n"
                         << "  \"madocalib_bridge\": true,\n"
                         << "  \"madocalib_bridge_status\": " << bridge_status << ",\n"
+                        << "  \"madocalib_profile\": \""
+                        << jsonEscape(options.madocalib_profile) << "\",\n"
                         << "  \"madocalib_config\": "
                         << (options.madocalib_config_path.empty() ?
                                 "null" :

--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -444,6 +444,11 @@ Batch examples show the intended scenarios:
 - `exec_pppar_ion.bat`: PPP-AR plus L6D ionosphere with PRNs 200 and 201.
 - `exec_cssr2ssr.bat`: `cssr2ssr` conversion from L6E to RTCM3/debug text.
 
+The bridge CLI exposes these bundled configurations through
+`--madocalib-profile ppp`, `pppar`, and `pppar-ion`.  The MADOCA parity CI runs
+the one-hour `pppar` profile and requires at least one fixed solution, preventing
+an AR comparison from silently falling back to the default float-PPP config.
+
 These sample files should become the first whole-run oracle candidates after
 helper parity exists.
 

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -4031,9 +4031,26 @@ class CLIToolsTest(unittest.TestCase):
         self.assertIn("--madocalib-bridge", result.stdout)
         self.assertIn("--madocalib-l6", result.stdout)
         self.assertIn("--madocalib-mdciono", result.stdout)
+        self.assertIn("--madocalib-profile", result.stdout)
         self.assertIn("--madoca-l6d-shadow", result.stdout)
         self.assertIn("--madoca-materialization-dump", result.stdout)
         self.assertIn("--madoca-materialization-dump-only", result.stdout)
+
+    def test_ppp_cli_rejects_unknown_madocalib_profile(self) -> None:
+        result = self.run_gnss(
+            "ppp",
+            "--obs",
+            "missing.obs",
+            "--nav",
+            "missing.nav",
+            "--out",
+            "unused.pos",
+            "--madocalib-bridge",
+            "--madocalib-profile",
+            "unknown",
+        )
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("--madocalib-profile must be one of", result.stderr)
 
     def test_ppp_cli_rejects_madoca_materialization_dump_only_without_dump_path(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ppp_madoca_materialization_dump_only_cli_") as temp_dir:


### PR DESCRIPTION
## What changed
- add `--madocalib-profile ppp|pppar|pppar-ion` to select the pinned bundled MADOCALIB configs
- reject ambiguous explicit-config/profile combinations and missing L6D inputs for `pppar-ion`
- extend the MADOCA parity lane with the official one-hour `exec_pppar` scenario and require at least one fixed solution
- record the selected profile in bridge summary JSON and document the workflow

## Why
The bridge previously ignored native `--enable-ar`; without an explicit config path an intended PPP-AR oracle run silently used `sample.conf` and produced only float PPP. The named profile makes the oracle mode explicit and machine-verifiable.

## Validation
- targeted CLI help and invalid-profile tests
- Release `gnss_ppp` build
- `git diff --check`

The real one-hour MADOCALIB PPP-AR smoke is intentionally validated by the Linux parity lane.

Advances #148.