### PR TITLE
Record native MADOCA PPP-AR baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -588,6 +588,45 @@ jobs:
           grep -q '"madocalib_profile": "pppar"' madocalib_pppar_smoke.json
           fixed="$(awk '$0 !~ /^%/ && NF > 0 && $6 == 1 {n++} END {print n+0}' madocalib_pppar_smoke.pos)"
           test "$fixed" -gt 0
+          ./apps/gnss_ppp \
+            --kinematic \
+            --enable-ar \
+            --ar-method per-freq \
+            --ar-ratio-threshold 1.5 \
+            --obs "$ROOT/sample_data/data/rinex/MIZU00JPN_R_20250910000_01D_30S_MO.rnx" \
+            --nav "$ROOT/sample_data/data/rinex/BRDM00DLR_S_20250910000_01D_MN.rnx" \
+            --madoca-l6 "$ROOT/sample_data/data/l6_is-qzss-mdc-004/2025/091/2025091A.204.l6" \
+            --madoca-l6 "$ROOT/sample_data/data/l6_is-qzss-mdc-004/2025/091/2025091A.206.l6" \
+            --antex "$ROOT/sample_data/data/igs20.atx" \
+            --max-epochs 120 \
+            --emit-epoch-time \
+            --out native_pppar_smoke.pos \
+            --summary-json native_pppar_smoke.json \
+            --quiet
+          grep -q '"ambiguity_resolution_enabled": true' native_pppar_smoke.json
+          grep -q '"ar_method": "per-freq"' native_pppar_smoke.json
+          python3 "${GITHUB_WORKSPACE}/scripts/analysis/madoca_solution_diff.py" \
+            madocalib_pppar_smoke.pos \
+            native_pppar_smoke.pos \
+            --reference-ecef -3857167.6484 3108694.9138 4004041.6876 \
+            --base-label bridge-pppar \
+            --candidate-label native-per-freq \
+            --json-out madoca_pppar_solution_diff.json \
+            --match-csv madoca_pppar_solution_matches.csv
+
+    - name: Upload MADOCA PPP-AR baseline
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: madoca-pppar-baseline
+        path: |
+          build-madoca-parity/madocalib_pppar_smoke.pos
+          build-madoca-parity/madocalib_pppar_smoke.json
+          build-madoca-parity/native_pppar_smoke.pos
+          build-madoca-parity/native_pppar_smoke.json
+          build-madoca-parity/madoca_pppar_solution_diff.json
+          build-madoca-parity/madoca_pppar_solution_matches.csv
+        if-no-files-found: warn
 
     - name: Upload MadocaParity diagnostics
       if: failure()
@@ -603,6 +642,10 @@ jobs:
           build-madoca-parity/madocalib_bridge_smoke.json
           build-madoca-parity/madocalib_pppar_smoke.pos
           build-madoca-parity/madocalib_pppar_smoke.json
+          build-madoca-parity/native_pppar_smoke.pos
+          build-madoca-parity/native_pppar_smoke.json
+          build-madoca-parity/madoca_pppar_solution_diff.json
+          build-madoca-parity/madoca_pppar_solution_matches.csv
         if-no-files-found: ignore
 
   static-analysis:

--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -1263,6 +1263,7 @@ int main(int argc, char* argv[]) {
                     << "  \"clas_atmos_selection\": \"" << jsonEscape(options.clas_atmos_selection) << "\",\n"
                     << "  \"clas_atmos_stale_after_seconds\": " << options.clas_atmos_stale_after_seconds << ",\n"
                     << "  \"ambiguity_resolution_enabled\": " << (options.enable_ar ? "true" : "false") << ",\n"
+                    << "  \"ar_method\": \"" << jsonEscape(options.ar_method) << "\",\n"
                     << "  \"ar_ratio_threshold\": " << options.ar_ratio_threshold << ",\n"
                     << "  \"processed_epochs\": " << processed_epochs << ",\n"
                     << "  \"valid_solutions\": " << valid_solutions << ",\n"

--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -448,6 +448,12 @@ The bridge CLI exposes these bundled configurations through
 `--madocalib-profile ppp`, `pppar`, and `pppar-ion`.  The MADOCA parity CI runs
 the one-hour `pppar` profile and requires at least one fixed solution, preventing
 an AR comparison from silently falling back to the default float-PPP config.
+The same lane runs native `--enable-ar --ar-method per-freq` for the first 120
+MIZU epochs, records the selected AR method and native fixed/float counts in its
+summary JSON, and generates `madoca_pppar_solution_diff.json` plus a matched-row
+CSV against the oracle trajectory.  This initial baseline requires successful
+execution and common epochs but deliberately does not impose an accuracy or
+native-fix-rate threshold until the measured artifact has been reviewed.
 
 These sample files should become the first whole-run oracle candidates after
 helper parity exists.

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -4706,6 +4706,7 @@ class CLIToolsTest(unittest.TestCase):
             temp_root = Path(temp_dir)
             obs_path, sp3_path, clk_path, _ = build_synthetic_ppp_inputs(temp_root)
             out_path = temp_root / "ppp_ar_solution.pos"
+            summary_path = temp_root / "ppp_ar_summary.json"
 
             result = self.run_gnss(
                 "ppp",
@@ -4724,12 +4725,16 @@ class CLIToolsTest(unittest.TestCase):
                 "--no-estimate-troposphere",
                 "--out",
                 str(out_path),
+                "--summary-json",
+                str(summary_path),
                 "--max-epochs",
                 "8",
             )
 
             self.assertEqual(result.returncode, 0, msg=result.stderr)
             self.assertIn("ambiguity resolution: on", result.stdout)
+            summary = json.loads(summary_path.read_text(encoding="utf-8"))
+            self.assertEqual(summary["ar_method"], "iflc")
             self.assertIn("PPP fixed solutions:", result.stdout)
             records = self.read_pos_records(out_path)
             self.assertEqual(len(records), 8)


### PR DESCRIPTION
## What changed
- run native MADOCA `--enable-ar --ar-method per-freq` over the same 120-epoch MIZU window as the MADOCALIB PPP-AR oracle
- generate solution-diff JSON and matched-epoch CSV artifacts on every parity run
- record `ar_method` in native summary JSON and test the contract
- document the baseline as observational, without premature accuracy/fix-rate thresholds

## Why
PR #295 established that the oracle PPP-AR profile produces fixed solutions. The next step is a reproducible native/oracle baseline. Local real-data execution produced 118 valid native solutions, all float and zero fixed, so future work should focus on AR candidate/fix admission rather than run plumbing.

## Validation
- Release `gnss_ppp` build
- targeted CLI summary and MADOCA solution-diff tests
- local 120-epoch MIZU native per-frequency run
- workflow YAML parse and `git diff --check`

Advances #148.