### PR TITLE
Select state model for per-frequency AR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -605,6 +605,8 @@ jobs:
             --quiet
           grep -q '"ambiguity_resolution_enabled": true' native_pppar_smoke.json
           grep -q '"ar_method": "per-freq"' native_pppar_smoke.json
+          grep -q '"estimate_ionosphere": true' native_pppar_smoke.json
+          grep -q '"use_ionosphere_free": false' native_pppar_smoke.json
           python3 "${GITHUB_WORKSPACE}/scripts/analysis/madoca_solution_diff.py" \
             madocalib_pppar_smoke.pos \
             native_pppar_smoke.pos \

--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -180,7 +180,8 @@ void printUsage(const char* program_name) {
         << "  --disable-ar            Disable PPP ambiguity fixing (default)\n"
         << "  --ar-ratio-threshold <value>\n"
         << "                          Ratio threshold for PPP ambiguity fixing (default: 3.0)\n"
-        << "  --ar-method <name>      AR method: iflc, wlnl, per-freq (default: iflc)\n"
+        << "  --ar-method <name>      AR method: iflc, wlnl, per-freq (default: iflc);\n"
+        << "                          per-freq enables uncombined estimated-STEC states\n"
         << "  --process-noise-iono <v>\n"
         << "                          KF process noise for per-satellite ionosphere states,\n"
         << "                          m^2/s (default: 1e-4 for MADOCA per-frequency mode,\n"
@@ -886,8 +887,9 @@ int main(int argc, char* argv[]) {
         ppp_config.antex_file_path = options.antex_path;
         ppp_config.ocean_loading_file_path = options.blq_path;
         ppp_config.estimate_troposphere = options.estimate_troposphere;
-        ppp_config.estimate_ionosphere = options.estimate_ionosphere;
-        ppp_config.use_ionosphere_free = options.use_ionosphere_free;
+        const bool per_frequency_ar = options.ar_method == "per-freq";
+        ppp_config.estimate_ionosphere = options.estimate_ionosphere || per_frequency_ar;
+        ppp_config.use_ionosphere_free = options.use_ionosphere_free && !per_frequency_ar;
         ppp_config.use_clas_osr_filter = options.use_clas_osr_filter;
         ppp_config.clas_epoch_policy =
             parseClasEpochPolicy(options.clas_epoch_policy);
@@ -1264,6 +1266,10 @@ int main(int argc, char* argv[]) {
                     << "  \"clas_atmos_stale_after_seconds\": " << options.clas_atmos_stale_after_seconds << ",\n"
                     << "  \"ambiguity_resolution_enabled\": " << (options.enable_ar ? "true" : "false") << ",\n"
                     << "  \"ar_method\": \"" << jsonEscape(options.ar_method) << "\",\n"
+                    << "  \"estimate_ionosphere\": "
+                    << (ppp_config.estimate_ionosphere ? "true" : "false") << ",\n"
+                    << "  \"use_ionosphere_free\": "
+                    << (ppp_config.use_ionosphere_free ? "true" : "false") << ",\n"
                     << "  \"ar_ratio_threshold\": " << options.ar_ratio_threshold << ",\n"
                     << "  \"processed_epochs\": " << processed_epochs << ",\n"
                     << "  \"valid_solutions\": " << valid_solutions << ",\n"

--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -454,6 +454,10 @@ summary JSON, and generates `madoca_pppar_solution_diff.json` plus a matched-row
 CSV against the oracle trajectory.  This initial baseline requires successful
 execution and common epochs but deliberately does not impose an accuracy or
 native-fix-rate threshold until the measured artifact has been reviewed.
+Selecting native `--ar-method per-freq` also selects the state model required
+by that algorithm: uncombined observations with estimated per-satellite STEC.
+Previously the CLI changed only the AR enum, so the dedicated per-frequency
+resolver was unreachable unless two extra ionosphere flags were supplied.
 
 These sample files should become the first whole-run oracle candidates after
 helper parity exists.

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -4712,6 +4712,8 @@ class CLIToolsTest(unittest.TestCase):
                 "ppp",
                 "--kinematic",
                 "--enable-ar",
+                "--ar-method",
+                "per-freq",
                 "--convergence-min-epochs",
                 "4",
                 "--ar-ratio-threshold",
@@ -4734,7 +4736,9 @@ class CLIToolsTest(unittest.TestCase):
             self.assertEqual(result.returncode, 0, msg=result.stderr)
             self.assertIn("ambiguity resolution: on", result.stdout)
             summary = json.loads(summary_path.read_text(encoding="utf-8"))
-            self.assertEqual(summary["ar_method"], "iflc")
+            self.assertEqual(summary["ar_method"], "per-freq")
+            self.assertTrue(summary["estimate_ionosphere"])
+            self.assertFalse(summary["use_ionosphere_free"])
             self.assertIn("PPP fixed solutions:", result.stdout)
             records = self.read_pos_records(out_path)
             self.assertEqual(len(records), 8)


### PR DESCRIPTION
## What changed
- make `--ar-method per-freq` select uncombined observations with estimated per-satellite STEC
- expose the effective ionosphere state model in native summary JSON
- assert that state model in both CLI regression coverage and the real MADOCA parity lane
- document the previously unreachable dedicated resolver

## Root cause
The CLI changed only the AR enum. `resolveAmbiguitiesPerFreq()` requires `use_ionosphere_free=false` and `estimate_ionosphere=true`, so the baseline silently fell through to generic DD AR and returned ratio 1 at every epoch.

## Validation
- Release `gnss_ppp` build
- synthetic CLI per-frequency state-contract test
- local 120-epoch MIZU run: 118 valid solutions, effective uncombined/estimated-STEC state confirmed
- debug replay confirmed the next blocker is the per-frequency resolver's `converged_` gate; fixed solutions remain zero in this slice
- `git diff --check`

Advances #148.