### PR TITLE
Expose PPP convergence gate telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,6 +607,8 @@ jobs:
           grep -q '"ar_method": "per-freq"' native_pppar_smoke.json
           grep -q '"estimate_ionosphere": true' native_pppar_smoke.json
           grep -q '"use_ionosphere_free": false' native_pppar_smoke.json
+          grep -q '"convergence_gate_reason":' native_pppar_smoke.json
+          grep -q '"convergence_max_position_deviation_m":' native_pppar_smoke.json
           python3 "${GITHUB_WORKSPACE}/scripts/analysis/madoca_solution_diff.py" \
             madocalib_pppar_smoke.pos \
             native_pppar_smoke.pos \

--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -1200,6 +1200,7 @@ int main(int argc, char* argv[]) {
         }
 
         const auto stats = processor.getStats();
+        const auto& convergence = processor.getConvergenceTelemetry();
         const double ppp_solution_rate =
             valid_solutions > 0 ?
                 100.0 * static_cast<double>(ppp_float_solutions + ppp_fixed_solutions) /
@@ -1319,6 +1320,19 @@ int main(int argc, char* argv[]) {
             summary << "},\n"
                     << "  \"converged\": " << (processor.hasConverged() ? "true" : "false") << ",\n"
                     << "  \"convergence_time_s\": " << processor.getConvergenceTime() << ",\n"
+                    << "  \"convergence_gate_reason\": \"" << jsonEscape(convergence.gate_reason) << "\",\n"
+                    << "  \"convergence_evaluated_epochs\": " << convergence.evaluated_epochs << ",\n"
+                    << "  \"convergence_insufficient_history_epochs\": "
+                    << convergence.insufficient_history_epochs << ",\n"
+                    << "  \"convergence_unstable_position_epochs\": "
+                    << convergence.unstable_position_epochs << ",\n"
+                    << "  \"convergence_window_epochs\": " << convergence.window_epochs << ",\n"
+                    << "  \"convergence_required_window_epochs\": "
+                    << convergence.required_window_epochs << ",\n"
+                    << "  \"convergence_max_position_deviation_m\": "
+                    << convergence.max_position_deviation_m << ",\n"
+                    << "  \"convergence_position_deviation_threshold_m\": "
+                    << convergence.position_deviation_threshold_m << ",\n"
                     << "  \"average_processing_time_ms\": " << stats.average_processing_time_ms << "\n"
                     << "}\n";
         }

--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -51,6 +51,17 @@ struct MadocaL6dShadowStatus {
     int matched_satellites = 0;
 };
 
+struct PPPConvergenceTelemetry {
+    size_t evaluated_epochs = 0;
+    size_t insufficient_history_epochs = 0;
+    size_t unstable_position_epochs = 0;
+    size_t window_epochs = 0;
+    size_t required_window_epochs = 0;
+    double max_position_deviation_m = 0.0;
+    double position_deviation_threshold_m = 0.0;
+    std::string gate_reason = "not_evaluated";
+};
+
 /**
  * @brief Precise Point Positioning (PPP) processor
  *
@@ -244,6 +255,9 @@ public:
      * @brief Get convergence time
      */
     double getConvergenceTime() const { return convergence_time_; }
+    const PPPConvergenceTelemetry& getConvergenceTelemetry() const {
+        return convergence_telemetry_;
+    }
 
 private:
     void applyEnvironmentOverridesToPPPConfig();
@@ -298,6 +312,7 @@ private:
     bool has_static_anchor_position_ = false;
     double last_ar_ratio_ = 0.0;
     int last_fixed_ambiguities_ = 0;
+    PPPConvergenceTelemetry convergence_telemetry_;
     int last_applied_atmos_trop_corrections_ = 0;
     int last_applied_atmos_iono_corrections_ = 0;
     double last_applied_atmos_trop_m_ = 0.0;

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -737,6 +737,7 @@ void PPPProcessor::reset() {
     has_static_anchor_position_ = false;
     last_ar_ratio_ = 0.0;
     last_fixed_ambiguities_ = 0;
+    convergence_telemetry_ = {};
     ppp_ar::clearWlnlHoldState(clas_wlnl_hold_);
     last_clas_constrained_fixed_state_valid_ = false;
     clas_kinematic_fix_candidate_streak_ = 0;

--- a/src/algorithms/ppp_measurement.cpp
+++ b/src/algorithms/ppp_measurement.cpp
@@ -478,12 +478,21 @@ void PPPProcessor::checkConvergence(const GNSSTime& current_time) {
         return;
     }
 
+    ++convergence_telemetry_.evaluated_epochs;
+    convergence_telemetry_.required_window_epochs =
+        static_cast<size_t>(ppp_config_.convergence_min_epochs);
+    convergence_telemetry_.position_deviation_threshold_m =
+        ppp_config_.convergence_threshold_horizontal;
+
     recent_positions_.push_back(filter_state_.state.segment(filter_state_.pos_index, 3));
     if (recent_positions_.size() > static_cast<size_t>(ppp_config_.convergence_min_epochs)) {
         recent_positions_.erase(recent_positions_.begin());
     }
+    convergence_telemetry_.window_epochs = recent_positions_.size();
 
     if (recent_positions_.size() < static_cast<size_t>(ppp_config_.convergence_min_epochs)) {
+        ++convergence_telemetry_.insufficient_history_epochs;
+        convergence_telemetry_.gate_reason = "insufficient_history";
         return;
     }
 
@@ -497,10 +506,15 @@ void PPPProcessor::checkConvergence(const GNSSTime& current_time) {
     for (const auto& position : recent_positions_) {
         max_deviation = std::max(max_deviation, (position - mean).norm());
     }
+    convergence_telemetry_.max_position_deviation_m = max_deviation;
 
     if (max_deviation < ppp_config_.convergence_threshold_horizontal) {
         converged_ = true;
         convergence_time_ = current_time - convergence_start_time_;
+        convergence_telemetry_.gate_reason = "converged";
+    } else {
+        ++convergence_telemetry_.unstable_position_epochs;
+        convergence_telemetry_.gate_reason = "position_deviation";
     }
 }
 

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -1918,6 +1918,11 @@ TEST(PPPTest, ProcessorFixesSyntheticAmbiguitiesWithPreciseProducts) {
     EXPECT_LT((last_solution.position_ecef - true_receiver_position).norm(), 1.0);
     EXPECT_GE(last_solution.ratio, 0.0);
     EXPECT_GE(last_solution.num_fixed_ambiguities, 0);
+    const auto& convergence = processor.getConvergenceTelemetry();
+    EXPECT_GE(convergence.evaluated_epochs, 4u);
+    EXPECT_EQ(convergence.required_window_epochs, 4u);
+    EXPECT_EQ(convergence.position_deviation_threshold_m, 0.2);
+    EXPECT_NE(convergence.gate_reason, "not_evaluated");
     if (saw_fixed_solution) {
         EXPECT_GE(best_fixed_ambiguities, 1);
         EXPECT_GT(best_ratio, 2.0);


### PR DESCRIPTION
## What changed

- expose structured PPP convergence-gate telemetry through the processor API and gnss_ppp summary JSON
- report history-window counts, position-deviation rejects, the current window deviation, and configured threshold
- assert the telemetry contract in the MADOCA PPP-AR CI lane

## Why

Native MADOCA per-frequency PPP-AR never reaches LAMBDA because the shared convergence gate remains closed. The one-hour MIZU replay now identifies the blocker directly: 19 warm-up epochs and 99 position-deviation rejects, with a final 1.17008 m window deviation against a 0.1 m threshold.

This makes the next fix measurable and supports parameter sweeps inspired by the supplied Tokyo University of Marine Science and Technology / GNSStutor material without weakening ambiguity validation blindly.

## Validation

- gnss_ppp Release target builds successfully
- core C++ run_tests passed
- local 120-epoch MIZU MADOCA replay emitted the expected telemetry
- full local CTest reached 92%; unrelated Windows file-lock and optional docs/web/packaging failures remain