### PR TITLE
Add satellite-count RTK ratio experiment

### DIFF
--- a/apps/gnss_ppc_coverage_matrix.py
+++ b/apps/gnss_ppc_coverage_matrix.py
@@ -148,6 +148,11 @@ def parse_args() -> argparse.Namespace:
         help="Optional RTK ambiguity ratio threshold passed to each ppc-demo run.",
     )
     parser.add_argument(
+        "--sat-count-ratio",
+        action="store_true",
+        help="Use experimental satellite-count-aware RTK Ratio thresholds.",
+    )
+    parser.add_argument(
         "--max-subset-ar-drop-steps",
         type=int,
         default=None,
@@ -417,6 +422,8 @@ def build_ppc_demo_command(
         command.extend(["--iono", args.iono])
     if getattr(args, "ratio", None) is not None:
         command.extend(["--ratio", str(args.ratio)])
+    if getattr(args, "sat_count_ratio", False):
+        command.extend(["--ratio", "sat-count"])
     if getattr(args, "max_subset_ar_drop_steps", None) is not None:
         command.extend(["--max-subset-ar-drop-steps", str(args.max_subset_ar_drop_steps)])
     if getattr(args, "max_hold_div", None) is not None:

--- a/apps/gnss_ppc_demo.py
+++ b/apps/gnss_ppc_demo.py
@@ -245,6 +245,11 @@ def parse_args() -> argparse.Namespace:
         help="Optional RTK ambiguity ratio threshold passed through to gnss solve when --solver rtk.",
     )
     parser.add_argument(
+        "--sat-count-ratio",
+        action="store_true",
+        help="Use experimental satellite-count-aware RTK Ratio thresholds.",
+    )
+    parser.add_argument(
         "--max-subset-ar-drop-steps",
         type=int,
         default=None,
@@ -1209,6 +1214,8 @@ def run_solver(
             command.extend(["--iono", args.iono])
         if getattr(args, "ratio", None) is not None:
             command.extend(["--ratio", str(args.ratio)])
+        if getattr(args, "sat_count_ratio", False):
+            command.extend(["--ratio", "sat-count"])
         if getattr(args, "max_subset_ar_drop_steps", None) is not None:
             command.extend(
                 ["--max-subset-ar-drop-steps", str(args.max_subset_ar_drop_steps)]
@@ -1650,6 +1657,9 @@ def build_summary_payload(
         "receiver_observation_provenance": ppc_receiver_observation_provenance(args._dataset_city),
         "rtk_iono": getattr(args, "iono", None) if args.solver == "rtk" else None,
         "rtk_ratio_threshold": getattr(args, "ratio", None) if args.solver == "rtk" else None,
+        "rtk_satellite_count_ratio": (
+            bool(getattr(args, "sat_count_ratio", False)) if args.solver == "rtk" else False
+        ),
         "rtk_max_subset_ar_drop_steps": (
             getattr(args, "max_subset_ar_drop_steps", None)
             if args.solver == "rtk"

--- a/apps/gnss_solve.cpp
+++ b/apps/gnss_solve.cpp
@@ -99,6 +99,7 @@ struct SolveConfig {
     std::string diagnostics_csv_path;
     double rtk_update_outlier_threshold = 0.0;
     double ratio_threshold = 3.0;
+    bool enable_satellite_count_ratio_threshold = false;
     bool enable_ar_filter = false;
     bool has_ar_filter_override = false;
     double ar_filter_margin = 0.25;
@@ -563,7 +564,7 @@ public:
         }
         file_ << "gps_week,tow,status,num_sats,ratio,baseline_m,"
               << "ar_attempted,input_pair_count,pair_count,max_ambiguity_variance,"
-              << "effective_ratio_threshold,min_subset_pair_count,min_full_ratio_for_subset_ar,"
+              << "effective_ratio_threshold,ratio_satellite_count,min_subset_pair_count,min_full_ratio_for_subset_ar,"
               << "subset_candidates_evaluated,subset_candidates_rejected_by_full_ratio,"
               << "subset_candidates_rejected_by_diversity,"
               << "bsr_guided_candidates_evaluated,bsr_guided_candidates_accepted,"
@@ -607,6 +608,7 @@ public:
         writeNumber(telemetry.max_ambiguity_variance);
         file_ << ",";
         writeNumber(telemetry.effective_ratio_threshold);
+        file_ << ',' << telemetry.ratio_satellite_count;
         file_ << ","
               << telemetry.min_subset_pair_count << ","
               << telemetry.min_full_ratio_for_subset_ar << ","
@@ -696,7 +698,7 @@ void printUsage(const char* program_name) {
         << "  --mode <auto|kinematic|static|moving-base>\n"
         << "                             Position mode (default: auto)\n"
         << "  --iono <auto|off|iflc|est> Ionosphere option (default: auto)\n"
-        << "  --ratio <value>            Ambiguity ratio threshold (default: 3.0)\n"
+        << "  --ratio <value|sat-count>  Fixed or satellite-count-aware Ratio threshold\n"
         << "  --preset <survey|low-cost|moving-base|odaiba>\n"
         << "                             Apply a named RTK tuning preset\n"
         << "  --arfilter                 Require extra ratio margin for subset AR fixes\n"
@@ -1155,7 +1157,11 @@ SolveConfig parseArguments(int argc, char* argv[]) {
         } else if (arg == "--iono" && i + 1 < argc) {
             config.iono = parseIonoChoice(argv[++i], argv[0]);
         } else if (arg == "--ratio" && i + 1 < argc) {
-            config.ratio_threshold = std::stod(argv[++i]);
+            const std::string ratio_value = argv[++i];
+            config.enable_satellite_count_ratio_threshold = ratio_value == "sat-count";
+            config.ratio_threshold = config.enable_satellite_count_ratio_threshold
+                ? 3.0
+                : std::stod(ratio_value);
             config.ratio_threshold_set = true;
         } else if (arg == "--preset" && i + 1 < argc) {
             config.preset = parseRTKTuningPreset(argv[++i], argv[0]);
@@ -1840,6 +1846,8 @@ int main(int argc, char* argv[]) {
         rtk_config.ar_mode = libgnss::RTKProcessor::RTKConfig::AmbiguityResolutionMode::CONTINUOUS;
         rtk_config.ratio_threshold = config.ratio_threshold;
         rtk_config.ambiguity_ratio_threshold = config.ratio_threshold;
+        rtk_config.enable_satellite_count_ratio_threshold =
+            config.enable_satellite_count_ratio_threshold;
         rtk_config.hold_ambiguity_ratio_threshold = config.hold_ratio_threshold;
         rtk_config.enable_ar_filter = config.enable_ar_filter;
         rtk_config.ar_filter_margin = config.ar_filter_margin;

--- a/include/libgnss++/algorithms/rtk.hpp
+++ b/include/libgnss++/algorithms/rtk.hpp
@@ -53,6 +53,7 @@ public:
 
         double ratio_threshold = 3.0;
         double ambiguity_ratio_threshold = 3.0;
+        bool enable_satellite_count_ratio_threshold = false;
         double validation_threshold = 0.15;
         bool enable_ar_filter = false;
         double ar_filter_margin = 0.25;
@@ -432,6 +433,7 @@ public:
         int pair_count = 0;
         double max_ambiguity_variance = std::numeric_limits<double>::quiet_NaN();
         double effective_ratio_threshold = std::numeric_limits<double>::quiet_NaN();
+        int ratio_satellite_count = 0;
         int min_subset_pair_count = 0;
         double min_full_ratio_for_subset_ar = std::numeric_limits<double>::quiet_NaN();
         int subset_candidates_evaluated = 0;

--- a/src/algorithms/rtk.cpp
+++ b/src/algorithms/rtk.cpp
@@ -2580,6 +2580,24 @@ bool RTKProcessor::resolveAmbiguities(std::vector<DDPair> dd_pairs) {
 
     // Use lower ratio threshold when holdamb is active (more confidence in solution)
     double effective_ratio_threshold = rtk_config_.ambiguity_ratio_threshold;
+    if (rtk_config_.enable_satellite_count_ratio_threshold) {
+        std::set<SatelliteId> ratio_satellites;
+        for (const auto& pair : dd_pairs) {
+            ratio_satellites.insert(pair.ref_sat);
+            ratio_satellites.insert(pair.sat);
+        }
+        const int satellite_count = static_cast<int>(ratio_satellites.size());
+        debug_telemetry_.ratio_satellite_count = satellite_count;
+        if (satellite_count >= 20) {
+            effective_ratio_threshold = 1.5;
+        } else if (satellite_count >= 15) {
+            effective_ratio_threshold = 2.0;
+        } else if (satellite_count >= 10) {
+            effective_ratio_threshold = 2.5;
+        } else {
+            effective_ratio_threshold = 3.0;
+        }
+    }
     if (rtk_config_.ar_policy != RTKConfig::ARPolicy::DEMO5_CONTINUOUS) {
         if (consecutive_fix_count_ >= rtk_config_.min_hold_count && has_last_fixed_position_) {
             // WP7 dead-knob fix: honor the configured hold-ambiguity ratio


### PR DESCRIPTION
## What changed

- add an opt-in satellite-count-aware RTK Ratio policy based on the supplied TUMSAT/GNSStutor study
- use thresholds 1.5 (20+ satellites), 2.0 (15-19), 2.5 (10-14), and 3.0 (<10)
- expose the effective threshold and contributing satellite count in RTK diagnostics CSV
- pass the experiment through ppc-demo and the six-run PPC coverage matrix
- record the selected policy in PPC summary JSON

## Safety

The policy is opt-in via --sat-count-ratio. Existing fixed Ratio behavior and defaults remain unchanged. Evaluation must prioritize 50 cm official score and wrong-Fix rate rather than Fix rate alone.

Closes part of #299.

## Validation

- Python modules compile
- PPCCoverageMatrixTest: 5 passed
- RTK core library compiled locally
- Windows gnss_solve rebuild hits the pre-existing MSVC C1061 nesting limit in the monolithic parser; Linux/macOS CI will validate the full CLI target