### PR TITLE
Fix satellite-count ratio forwarding

### DIFF
--- a/apps/gnss_ppc_coverage_matrix.py
+++ b/apps/gnss_ppc_coverage_matrix.py
@@ -423,7 +423,7 @@ def build_ppc_demo_command(
     if getattr(args, "ratio", None) is not None:
         command.extend(["--ratio", str(args.ratio)])
     if getattr(args, "sat_count_ratio", False):
-        command.extend(["--ratio", "sat-count"])
+        command.append("--sat-count-ratio")
     if getattr(args, "max_subset_ar_drop_steps", None) is not None:
         command.extend(["--max-subset-ar-drop-steps", str(args.max_subset_ar_drop_steps)])
     if getattr(args, "max_hold_div", None) is not None:


### PR DESCRIPTION
## What changed

Forward --sat-count-ratio from the PPC coverage matrix to ppc-demo as its dedicated flag. ppc-demo then translates it to the native solver's --ratio sat-count form.

## Root cause

The matrix previously sent --ratio sat-count directly to ppc-demo, whose --ratio parser accepts only floats, so six-run experiments stopped before the solver.

## Validation

- PPCCoverageMatrixTest: 5 passed
- six PPC runs x 120 epochs completed with the corrected forwarding path
- fixed 2.4 and satellite-count policies produced identical initial-window Fix rates and official scores

Relates to #299.