### PR TITLE
Guard deep Partial AR after full-set fixes

### DIFF
--- a/include/libgnss++/algorithms/rtk_ar_evaluation.hpp
+++ b/include/libgnss++/algorithms/rtk_ar_evaluation.hpp
@@ -25,6 +25,7 @@ struct SubsetMatrices {
 
 bool shouldSearchPreferredSubsets(bool fixed, double ratio, double threshold);
 bool shouldSearchDropSubsets(bool fixed, double ratio, double threshold, double max_variance);
+int progressiveDropStepLimit(int configured_steps, bool full_set_fixed);
 bool passesArFilter(bool enabled, double candidate_ratio, double threshold, double margin);
 
 SubsetMatrices extractSubset(const Eigen::VectorXd& full_dd_float,

--- a/src/algorithms/rtk.cpp
+++ b/src/algorithms/rtk.cpp
@@ -3198,11 +3198,20 @@ bool RTKProcessor::resolveAmbiguities(std::vector<DDPair> dd_pairs) {
         }
 
         if (search_drop_subsets) {
+            // A full-set fix already passed the Ratio/AR-filter gates. Keep the
+            // legacy six-step refinement ceiling in that case so an opt-in
+            // deeper search cannot replace a healthy solution with a much
+            // smaller, higher-Ratio subset and perturb subsequent filter
+            // states. Deeper Partial AR remains available when the full set
+            // failed, which is the recovery case the wider search targets.
+            const int max_progressive_drop_steps =
+                rtk_ar_evaluation::progressiveDropStepLimit(
+                    rtk_config_.max_subset_drop_steps_for_ar, fixed);
             const auto progressive_subsets =
                 rtk_ar_selection::buildProgressiveVarianceDropSubsets(
                     descriptors,
                     min_subset_pairs_for_ar,
-                    std::max(0, rtk_config_.max_subset_drop_steps_for_ar));
+                    max_progressive_drop_steps);
             for (const auto& subset : progressive_subsets) {
                 try_subset(subset);
             }

--- a/src/algorithms/rtk_ar_evaluation.cpp
+++ b/src/algorithms/rtk_ar_evaluation.cpp
@@ -13,6 +13,11 @@ bool shouldSearchDropSubsets(bool fixed, double ratio, double threshold, double 
     return !fixed || ratio < threshold + 0.8 || max_variance > 0.20;
 }
 
+int progressiveDropStepLimit(int configured_steps, bool full_set_fixed) {
+    const int nonnegative_steps = std::max(0, configured_steps);
+    return full_set_fixed ? std::min(nonnegative_steps, 6) : nonnegative_steps;
+}
+
 bool passesArFilter(bool enabled, double candidate_ratio, double threshold, double margin) {
     if (!enabled) {
         return true;

--- a/tests/test_rtk_ar_evaluation.cpp
+++ b/tests/test_rtk_ar_evaluation.cpp
@@ -16,6 +16,13 @@ TEST(RTKArEvaluationTest, SearchPoliciesTrackRatioAndVarianceThresholds) {
     EXPECT_FALSE(rtk_ar_evaluation::shouldSearchDropSubsets(true, 4.0, 3.0, 0.05));
 }
 
+TEST(RTKArEvaluationTest, DeepProgressiveDropsOnlyRecoverFailedFullSet) {
+    EXPECT_EQ(rtk_ar_evaluation::progressiveDropStepLimit(18, false), 18);
+    EXPECT_EQ(rtk_ar_evaluation::progressiveDropStepLimit(18, true), 6);
+    EXPECT_EQ(rtk_ar_evaluation::progressiveDropStepLimit(4, true), 4);
+    EXPECT_EQ(rtk_ar_evaluation::progressiveDropStepLimit(-3, false), 0);
+}
+
 TEST(RTKArEvaluationTest, ArFilterRequiresExtraRatioMarginOnlyWhenEnabled) {
     EXPECT_TRUE(rtk_ar_evaluation::passesArFilter(false, 3.05, 3.0, 0.25));
     EXPECT_FALSE(rtk_ar_evaluation::passesArFilter(true, 3.05, 3.0, 0.25));


### PR DESCRIPTION
## What changed

- allow configured deep progressive Partial AR when the full ambiguity set fails
- cap refinement at the legacy six drops after a full-set fix already passes
- add a pure policy helper and unit coverage

## Root cause

An 18-step search helped Nagoya run3 recover an 11-pair subset after a full-set Ratio failure, but on Tokyo run2 it replaced already-healthy full-set fixes with much smaller high-Ratio subsets and perturbed later filter states.

The guard uses only solver state; reference truth is not used at runtime.

## Validation

- C++ core tests passed, including the new policy test
- 1,200 epochs x six PPC runs: weighted official score 7.842371% → 7.955377% (+0.113006 pp)
- Tokyo run2 official score 12.18% → 12.21%, Fix 75.48% → 86.15%
- Nagoya run3 official score 18.80% → 20.33%, Fix 61.29% → 74.02%
- minimum realtime factor remained above 2.5x
- unrelated Windows Python CLI file-lock failures remain in the full local CTest run

Relates to #299.