### PR TITLE
Enable guarded Partial AR in PPC coverage

### DIFF
--- a/apps/gnss_ppc_coverage_matrix.py
+++ b/apps/gnss_ppc_coverage_matrix.py
@@ -155,8 +155,11 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--max-subset-ar-drop-steps",
         type=int,
-        default=None,
-        help="Optional max worst-variance DD pairs dropped by RTK subset AR.",
+        default=18,
+        help=(
+            "Max worst-variance DD pairs dropped by RTK subset AR "
+            "(default: 18; deep drops run only after full-set failure)."
+        ),
     )
     parser.add_argument(
         "--max-hold-div",

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -21,7 +21,9 @@ runtime solver/coverage profile below.
 All runs below use `--mode kinematic --preset low-cost --match-tolerance-s 0.25`.
 The coverage profile additionally uses `--no-arfilter` plus the default
 low-speed non-FIX drift guard, SPP height-step guard, and FLOAT bridge-tail
-guard, with `--ratio 2.4`. The kinematic post-filter cascade was removed in
+guard, with `--ratio 2.4`. It permits up to 18 progressive Partial AR drops
+only when the full ambiguity set fails; after a full-set fix, refinement stays
+at the legacy six-drop ceiling. The kinematic post-filter cascade was removed in
 PR #36 (single-epoch height-step drop only), so `--no-kinematic-post-filter`
 is no longer required for coverage parity with the default profile.
 

--- a/tests/test_benchmark_scripts.py
+++ b/tests/test_benchmark_scripts.py
@@ -898,6 +898,16 @@ class PPCRTKSignoffHelpersTest(unittest.TestCase):
 
 
 class PPCCoverageMatrixTest(unittest.TestCase):
+    def test_default_profile_uses_guarded_deep_partial_ar(self) -> None:
+        with mock.patch.object(
+            sys,
+            "argv",
+            ["gnss_ppc_coverage_matrix.py", "--dataset-root", "data/PPC-Dataset"],
+        ):
+            args = ppc_coverage_matrix.parse_args()
+
+        self.assertEqual(args.max_subset_ar_drop_steps, 18)
+
     def test_parse_args_loads_config_toml_profile_and_allows_cli_overrides(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ppc_coverage_config_") as temp_dir:
             temp_root = Path(temp_dir)


### PR DESCRIPTION
## What changed

- make the PPC six-run coverage matrix request 18 progressive Partial AR drops by default
- document that deep drops run only after full-set failure
- add parser-default coverage

The RTK solver default remains six drops. This changes only the PPC coverage benchmark profile, where the full-set guard from #302 is active.

## Evidence

Six runs x 1,200 epochs improved weighted official score 7.842371%→7.955377%. Full-run checks also improved:

- Nagoya run3: official 49.73%→52.64%, Fix 58.17%→64.97%
- Tokyo run2: official 82.96%→83.30%, Fix 82.66%→84.31%
- positioning and horizontal P95 did not regress materially

## Validation

- PPCCoverageMatrixTest: 6 passed
- Python compile check passed

Relates to #299.