### PR TITLE
Expose RTK elevation mask in PPC sweeps

### DIFF
--- a/apps/gnss_ppc_coverage_matrix.py
+++ b/apps/gnss_ppc_coverage_matrix.py
@@ -148,6 +148,12 @@ def parse_args() -> argparse.Namespace:
         help="Optional RTK ambiguity ratio threshold passed to each ppc-demo run.",
     )
     parser.add_argument(
+        "--elevation-mask-deg",
+        type=float,
+        default=None,
+        help="Optional RTK elevation mask in degrees passed to every run.",
+    )
+    parser.add_argument(
         "--sat-count-ratio",
         action="store_true",
         help="Use experimental satellite-count-aware RTK Ratio thresholds.",
@@ -425,6 +431,8 @@ def build_ppc_demo_command(
         command.extend(["--iono", args.iono])
     if getattr(args, "ratio", None) is not None:
         command.extend(["--ratio", str(args.ratio)])
+    if getattr(args, "elevation_mask_deg", None) is not None:
+        command.extend(["--elevation-mask-deg", str(args.elevation_mask_deg)])
     if getattr(args, "sat_count_ratio", False):
         command.append("--sat-count-ratio")
     if getattr(args, "max_subset_ar_drop_steps", None) is not None:
@@ -903,6 +911,7 @@ def build_matrix_payload(args: argparse.Namespace, runs: list[dict[str, object]]
         "preset": args.preset,
         "iono": getattr(args, "iono", None),
         "ratio": getattr(args, "ratio", None),
+        "elevation_mask_deg": getattr(args, "elevation_mask_deg", None),
         "max_subset_ar_drop_steps": getattr(args, "max_subset_ar_drop_steps", None),
         "max_hold_div": getattr(args, "max_hold_div", None),
         "max_pos_jump": getattr(args, "max_pos_jump", None),

--- a/apps/gnss_ppc_demo.py
+++ b/apps/gnss_ppc_demo.py
@@ -245,6 +245,12 @@ def parse_args() -> argparse.Namespace:
         help="Optional RTK ambiguity ratio threshold passed through to gnss solve when --solver rtk.",
     )
     parser.add_argument(
+        "--elevation-mask-deg",
+        type=float,
+        default=None,
+        help="Optional RTK elevation mask in degrees.",
+    )
+    parser.add_argument(
         "--sat-count-ratio",
         action="store_true",
         help="Use experimental satellite-count-aware RTK Ratio thresholds.",
@@ -1214,6 +1220,8 @@ def run_solver(
             command.extend(["--iono", args.iono])
         if getattr(args, "ratio", None) is not None:
             command.extend(["--ratio", str(args.ratio)])
+        if getattr(args, "elevation_mask_deg", None) is not None:
+            command.extend(["--elevation-mask-deg", str(args.elevation_mask_deg)])
         if getattr(args, "sat_count_ratio", False):
             command.extend(["--ratio", "sat-count"])
         if getattr(args, "max_subset_ar_drop_steps", None) is not None:
@@ -1657,6 +1665,9 @@ def build_summary_payload(
         "receiver_observation_provenance": ppc_receiver_observation_provenance(args._dataset_city),
         "rtk_iono": getattr(args, "iono", None) if args.solver == "rtk" else None,
         "rtk_ratio_threshold": getattr(args, "ratio", None) if args.solver == "rtk" else None,
+        "rtk_elevation_mask_deg": (
+            getattr(args, "elevation_mask_deg", None) if args.solver == "rtk" else None
+        ),
         "rtk_satellite_count_ratio": (
             bool(getattr(args, "sat_count_ratio", False)) if args.solver == "rtk" else False
         ),

--- a/tests/test_benchmark_scripts.py
+++ b/tests/test_benchmark_scripts.py
@@ -1032,6 +1032,7 @@ class PPCCoverageMatrixTest(unittest.TestCase):
                 preset="low-cost",
                 iono="iflc",
                 ratio=2.4,
+                elevation_mask_deg=22.5,
                 max_subset_ar_drop_steps=18,
                 max_hold_div=5.0,
                 max_pos_jump=20.0,
@@ -1110,6 +1111,8 @@ class PPCCoverageMatrixTest(unittest.TestCase):
             self.assertIn("--iono", command)
             self.assertIn("iflc", command)
             self.assertIn("--ratio", command)
+            self.assertIn("--elevation-mask-deg", command)
+            self.assertIn("22.5", command)
             self.assertIn("2.4", command)
             self.assertIn("--max-subset-ar-drop-steps", command)
             self.assertIn("18", command)


### PR DESCRIPTION
## What changed

- add --elevation-mask-deg to ppc-demo and the six-run coverage matrix
- forward the setting to the native RTK solver
- record the selected mask in per-run and matrix summaries
- test command propagation

## Why

The supplied TUMSAT/GNSStutor work reports course-dependent gains from elevation-mask and signal-strength sweeps. This adds the missing benchmark plumbing so masks can be compared across all six PPC runs without changing the solver default.

## Validation

- PPCCoverageMatrixTest: 6 passed
- Python compile checks passed

Relates to #299.