### PR TITLE
Add Doppler-propagated RTK float seed

### DIFF
--- a/apps/gnss_ppc_coverage_matrix.py
+++ b/apps/gnss_ppc_coverage_matrix.py
@@ -297,6 +297,8 @@ def parse_args() -> argparse.Namespace:
         help="Optional RTK ambiguity reset after N consecutive non-FIX epochs.",
     )
     parser.add_argument("--max-postfix-rms", type=float, default=None)
+    parser.add_argument("--doppler-float-seed", action="store_true")
+    parser.add_argument("--doppler-float-seed-max-age", type=float, default=None)
     parser.add_argument("--enable-wide-lane-ar", action="store_true")
     parser.add_argument("--wide-lane-threshold", type=float, default=None)
     parser.add_argument("--enable-wlnl-fallback", action="store_true")
@@ -633,6 +635,12 @@ def build_ppc_demo_command(
         command.extend(["--max-consec-nonfix-reset", str(args.max_consec_nonfix_reset)])
     if getattr(args, "max_postfix_rms", None) is not None:
         command.extend(["--max-postfix-rms", str(args.max_postfix_rms)])
+    if getattr(args, "doppler_float_seed", False):
+        command.append("--doppler-float-seed")
+    if getattr(args, "doppler_float_seed_max_age", None) is not None:
+        command.extend(
+            ["--doppler-float-seed-max-age", str(args.doppler_float_seed_max_age)]
+        )
     if getattr(args, "enable_wide_lane_ar", False):
         command.append("--enable-wide-lane-ar")
     if getattr(args, "wide_lane_threshold", None) is not None:
@@ -978,6 +986,10 @@ def build_matrix_payload(args: argparse.Namespace, runs: list[dict[str, object]]
         "max_consec_float_reset": getattr(args, "max_consec_float_reset", None),
         "max_consec_nonfix_reset": getattr(args, "max_consec_nonfix_reset", None),
         "max_postfix_rms": getattr(args, "max_postfix_rms", None),
+        "doppler_float_seed": bool(getattr(args, "doppler_float_seed", False)),
+        "doppler_float_seed_max_age_s": getattr(
+            args, "doppler_float_seed_max_age", None
+        ),
         "enable_wide_lane_ar": getattr(args, "enable_wide_lane_ar", False),
         "wide_lane_threshold": getattr(args, "wide_lane_threshold", None),
         "enable_wlnl_fallback": getattr(args, "enable_wlnl_fallback", False),

--- a/apps/gnss_ppc_demo.py
+++ b/apps/gnss_ppc_demo.py
@@ -481,6 +481,8 @@ def parse_args() -> argparse.Namespace:
         default=None,
         help="Optional RTK post-fix residual RMS rejection threshold in meters.",
     )
+    parser.add_argument("--doppler-float-seed", action="store_true")
+    parser.add_argument("--doppler-float-seed-max-age", type=float, default=None)
     parser.add_argument(
         "--enable-wide-lane-ar",
         action="store_true",
@@ -1429,6 +1431,12 @@ def run_solver(
             command.extend(["--max-consec-nonfix-reset", str(args.max_consec_nonfix_reset)])
         if getattr(args, "max_postfix_rms", None) is not None:
             command.extend(["--max-postfix-rms", str(args.max_postfix_rms)])
+        if getattr(args, "doppler_float_seed", False):
+            command.append("--doppler-float-seed")
+        if getattr(args, "doppler_float_seed_max_age", None) is not None:
+            command.extend(
+                ["--doppler-float-seed-max-age", str(args.doppler_float_seed_max_age)]
+            )
         if getattr(args, "enable_wide_lane_ar", False):
             command.append("--enable-wide-lane-ar")
         if getattr(args, "wide_lane_threshold", None) is not None:
@@ -1826,6 +1834,14 @@ def build_summary_payload(
         ),
         "rtk_max_postfix_residual_rms_m": (
             getattr(args, "max_postfix_rms", None) if args.solver == "rtk" else None
+        ),
+        "rtk_doppler_float_seed": (
+            bool(getattr(args, "doppler_float_seed", False)) if args.solver == "rtk" else False
+        ),
+        "rtk_doppler_float_seed_max_age_s": (
+            getattr(args, "doppler_float_seed_max_age", None)
+            if args.solver == "rtk"
+            else None
         ),
         "rtk_wide_lane_ar_enabled": bool(
             args.solver == "rtk" and getattr(args, "enable_wide_lane_ar", False)

--- a/apps/gnss_solve.cpp
+++ b/apps/gnss_solve.cpp
@@ -95,6 +95,8 @@ struct SolveConfig {
     libgnss::io::SolutionWriter::Format output_format = libgnss::io::SolutionWriter::Format::POS;
     double max_baseline_length_m = 20000.0;
     bool prefer_trusted_seed = false;
+    bool use_doppler_float_seed = false;
+    double doppler_float_seed_max_age_s = 6.0;
     std::string rover_seed_pos_path;
     std::string diagnostics_csv_path;
     double rtk_update_outlier_threshold = 0.0;
@@ -980,6 +982,10 @@ void printUsage(const char* program_name) {
         << "  --max-epochs <n>           Stop after n rover epochs\n"
         << "  --debug-epoch-log <csv>    Write per-epoch AR/debug telemetry CSV\n"
         << "  --prefer-trusted-seed      Prefer recent trusted/fixed solution as seed\n"
+        << "  --doppler-float-seed       Propagate trusted position with Doppler velocity\n"
+        << "                             during short FLOAT gaps (default: off)\n"
+        << "  --doppler-float-seed-max-age <s>\n"
+        << "                             Maximum trusted-anchor age (default: 6)\n"
         << "  --rover-seed-pos <file>    Inject ECEF seed positions from .pos file per epoch\n"
         << "  --diagnostics-csv <file>   Write per-epoch RTK candidate diagnostics CSV (PPC pipeline format)\n"
         << "  --rtk-update-outlier-threshold <v>\n"
@@ -1436,6 +1442,10 @@ SolveConfig parseArguments(int argc, char* argv[]) {
             config.debug_epoch_log_path = argv[++i];
         } else if (arg == "--prefer-trusted-seed") {
             config.prefer_trusted_seed = true;
+        } else if (arg == "--doppler-float-seed") {
+            config.use_doppler_float_seed = true;
+        } else if (arg == "--doppler-float-seed-max-age" && i + 1 < argc) {
+            config.doppler_float_seed_max_age_s = std::stod(argv[++i]);
         } else if (arg == "--rover-seed-pos" && i + 1 < argc) {
             config.rover_seed_pos_path = argv[++i];
         } else if (arg == "--diagnostics-csv" && i + 1 < argc) {
@@ -1697,6 +1707,10 @@ SolveConfig parseArguments(int argc, char* argv[]) {
     if (config.skip_epochs < 0) {
         argumentError("--skip-epochs must be >= 0", argv[0]);
     }
+    if (!std::isfinite(config.doppler_float_seed_max_age_s) ||
+        config.doppler_float_seed_max_age_s <= 0.0) {
+        argumentError("--doppler-float-seed-max-age must be > 0", argv[0]);
+    }
 
     return config;
 }
@@ -1837,6 +1851,8 @@ int main(int argc, char* argv[]) {
         libgnss::SPPProcessor spp_processor;
         libgnss::RTKProcessor::RTKConfig rtk_config;
         rtk_config.prefer_trusted_position_seed = config.prefer_trusted_seed;
+        rtk_config.use_doppler_float_seed = config.use_doppler_float_seed;
+        rtk_config.doppler_float_seed_max_age_s = config.doppler_float_seed_max_age_s;
         rtk_config.prefer_rover_position_seed =
             config.prefer_trusted_seed || !rover_seed_positions.empty();
         if (config.rtk_update_outlier_threshold > 0.0) {

--- a/include/libgnss++/algorithms/rtk.hpp
+++ b/include/libgnss++/algorithms/rtk.hpp
@@ -86,6 +86,13 @@ public:
         bool prefer_trusted_position_seed = false;
         bool prefer_rover_position_seed = false;
 
+        /// Propagate the latest trusted position with the most recent
+        /// Doppler-derived rover velocity when reseeding a kinematic epoch.
+        /// This mirrors the short FLOAT-gap strategy in Fredeluces et al.
+        /// false (default) preserves the existing seed policy.
+        bool use_doppler_float_seed = false;
+        double doppler_float_seed_max_age_s = 6.0;
+
         // Kalman filter parameters
         double process_noise_position = 1e-4;       // m^2/s for static baseline
         double process_noise_ambiguity = 1e-8;    // cycles^2/s (very small - ambiguities are constant)
@@ -567,6 +574,9 @@ private:
     SPPProcessor spp_processor_;
     EpochDebugTelemetry debug_telemetry_;
     double doppler_velocity_sigma_mps_ = 0.5;
+    Vector3d last_doppler_velocity_ecef_ = Vector3d::Zero();
+    GNSSTime last_doppler_velocity_time_;
+    bool has_last_doppler_velocity_ = false;
 
     /**
      * @brief The original processRTKEpoch() body (DD-RTK float/fixed solve).

--- a/src/algorithms/rtk.cpp
+++ b/src/algorithms/rtk.cpp
@@ -328,6 +328,7 @@ void RTKProcessor::reset() {
     has_last_epoch_ = false;
     has_last_trusted_time_ = false;
     has_prev_trusted_position_ = false;
+    has_last_doppler_velocity_ = false;
     current_epoch_nlos_fraction_ = std::numeric_limits<double>::quiet_NaN();
     current_sat_data_.clear();
     gf_l1l2_history_.clear();
@@ -1502,7 +1503,23 @@ void RTKProcessor::resetPositionToSPP(const ObservationData& rover_obs, const Na
         }
     } else {
         bool seeded = false;
-        if (rtk_config_.prefer_trusted_position_seed &&
+        if (rtk_config_.use_doppler_float_seed &&
+            has_last_trusted_position_ && has_last_trusted_time_ &&
+            has_last_doppler_velocity_) {
+            const double anchor_age = rover_obs.time - last_trusted_time_;
+            const double velocity_age = rover_obs.time - last_doppler_velocity_time_;
+            if (std::isfinite(anchor_age) && anchor_age >= 0.0 &&
+                anchor_age <= rtk_config_.doppler_float_seed_max_age_s &&
+                std::isfinite(velocity_age) && velocity_age >= 0.0 &&
+                velocity_age <= 1.0 && last_doppler_velocity_ecef_.allFinite()) {
+                rover_pos = last_trusted_position_ +
+                            last_doppler_velocity_ecef_ * anchor_age;
+                var_pos = std::max(25.0,
+                    std::pow(doppler_velocity_sigma_mps_ * std::max(anchor_age, 0.2), 2.0));
+                seeded = true;
+            }
+        }
+        if (!seeded && rtk_config_.prefer_trusted_position_seed &&
             has_last_trusted_position_ && has_last_trusted_time_) {
             const double dt = rover_obs.time - last_trusted_time_;
             if (std::isfinite(dt) && dt >= 0.0 && dt <= 1.0) {
@@ -1649,6 +1666,12 @@ PositionSolution RTKProcessor::processRTKEpoch(const ObservationData& rover_obs,
             solution.has_velocity = true;
             solution.receiver_clock_drift = velocity_result.receiver_clock_drift;
         }
+    }
+
+    if (solution.isValid() && solution.has_velocity && solution.velocity_ecef.allFinite()) {
+        last_doppler_velocity_ecef_ = solution.velocity_ecef;
+        last_doppler_velocity_time_ = rover_obs.time;
+        has_last_doppler_velocity_ = true;
     }
 
     return solution;

--- a/tests/test_rtk_legacy.cpp
+++ b/tests/test_rtk_legacy.cpp
@@ -576,6 +576,19 @@ TEST(RTKLegacyCompatibilityStandaloneTest, MaxPostfixResidualRmsDefaultDisabled)
     EXPECT_DOUBLE_EQ(processor.getRTKConfig().max_postfix_residual_rms, 0.0);
 }
 
+TEST(RTKLegacyCompatibilityStandaloneTest, DopplerFloatSeedDefaultDisabled) {
+    RTKProcessor processor;
+    EXPECT_FALSE(processor.getRTKConfig().use_doppler_float_seed);
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().doppler_float_seed_max_age_s, 6.0);
+
+    auto config = processor.getRTKConfig();
+    config.use_doppler_float_seed = true;
+    config.doppler_float_seed_max_age_s = 3.0;
+    processor.setRTKConfig(config);
+    EXPECT_TRUE(processor.getRTKConfig().use_doppler_float_seed);
+    EXPECT_DOUBLE_EQ(processor.getRTKConfig().doppler_float_seed_max_age_s, 3.0);
+}
+
 TEST(RTKLegacyCompatibilityStandaloneTest, MaxPostfixResidualRmsConfigurable) {
     RTKProcessor processor;
 


### PR DESCRIPTION
## Summary

- add an opt-in RTK seed that propagates the latest trusted position with fresh Doppler velocity
- cap propagation age at a configurable 6 seconds and fall back to existing seed policies when gates fail
- expose the option through solve, PPC demo, and coverage-matrix workflows
- record experiment configuration in JSON summaries

## Why

The referenced Modified RTK-GNSS work uses short-term velocity propagation to improve float positioning in urban gaps. This adapts that approach without sacrificing satellites and keeps it disabled by default because one course showed fix-rate/P95 tradeoffs.

## Validation

- Clang/Ninja gnss_solve build passed
- Python PPC scripts compile passed
- 1200-epoch x 6 PPC matrix: weighted official score 7.955377% -> 8.015351%
- Nagoya run3 official score 20.330521% -> 21.006173%; H P95 5.688678 m -> 2.041913 m
- default-off/configuration regression test added

Closes part of #299.