### PR TITLE
Add paper constellation AR fallback

### DIFF
--- a/include/libgnss++/algorithms/rtk.hpp
+++ b/include/libgnss++/algorithms/rtk.hpp
@@ -151,6 +151,9 @@ public:
         /// Maximum number of worst-variance DD pairs to drop while searching
         /// progressive subset AR candidates. 6 preserves existing behavior.
         int max_subset_drop_steps_for_ar = 6;
+        /// Try the paper's GQEBR -> GQEB -> GQER -> GQE -> GQB -> GQ
+        /// constellation sequence after a full-set AR failure.
+        bool enable_paper_constellation_fallback_ar = false;
 
         /// Minimum distinct non-reference satellites required for subset AR.
         /// 0 (default) disables the gate and preserves existing subset behavior.

--- a/include/libgnss++/algorithms/rtk_ar_selection.hpp
+++ b/include/libgnss++/algorithms/rtk_ar_selection.hpp
@@ -20,6 +20,11 @@ std::vector<int> filterPairsByRelativeVariance(const std::vector<PairDescriptor>
 
 std::vector<std::vector<int>> buildPreferredSubsets(const std::vector<PairDescriptor>& pairs);
 
+// Okada/Sasaki/Ando constellation fallback after the full GQEBR set:
+// GQEB -> GQER -> GQE -> GQB -> GQ. QZSS is retained with GPS.
+std::vector<std::vector<int>> buildPaperConstellationFallbackSubsets(
+    const std::vector<PairDescriptor>& pairs);
+
 std::vector<std::vector<int>> buildProgressiveVarianceDropSubsets(
     const std::vector<PairDescriptor>& pairs,
     int minimum_pairs = 4,

--- a/src/algorithms/rtk.cpp
+++ b/src/algorithms/rtk.cpp
@@ -3203,8 +3203,11 @@ bool RTKProcessor::resolveAmbiguities(std::vector<DDPair> dd_pairs) {
         }
 
         const std::vector<std::vector<int>> preferred_subsets =
-            rtk_ar_selection::buildPreferredSubsets(descriptors);
+            rtk_config_.enable_paper_constellation_fallback_ar
+                ? rtk_ar_selection::buildPaperConstellationFallbackSubsets(descriptors)
+                : rtk_ar_selection::buildPreferredSubsets(descriptors);
         const bool compare_preferred_subsets =
+            rtk_config_.enable_paper_constellation_fallback_ar ||
             usesGlonassAutocal(rtk_config_) ||
             std::any_of(dd_pairs.begin(), dd_pairs.end(), [](const DDPair& pair) {
                 return pair.ref_sat.system == GNSSSystem::GLONASS ||

--- a/src/algorithms/rtk_ar_selection.cpp
+++ b/src/algorithms/rtk_ar_selection.cpp
@@ -65,6 +65,18 @@ std::vector<std::vector<int>> buildPreferredSubsets(const std::vector<PairDescri
     };
 }
 
+std::vector<std::vector<int>> buildPaperConstellationFallbackSubsets(
+    const std::vector<PairDescriptor>& pairs) {
+    return {
+        buildSubsetExcluding(pairs, {GNSSSystem::GLONASS}),
+        buildSubsetExcluding(pairs, {GNSSSystem::BeiDou}),
+        buildSubsetExcluding(pairs, {GNSSSystem::GLONASS, GNSSSystem::BeiDou}),
+        buildSubsetExcluding(pairs, {GNSSSystem::GLONASS, GNSSSystem::Galileo}),
+        buildSubsetExcluding(
+            pairs, {GNSSSystem::GLONASS, GNSSSystem::Galileo, GNSSSystem::BeiDou}),
+    };
+}
+
 std::vector<std::vector<int>> buildBSRGuidedDropSubsets(
     const std::vector<PairDescriptor>& pairs,
     const Eigen::MatrixXd& Qb,

--- a/tests/test_rtk_ar_selection.cpp
+++ b/tests/test_rtk_ar_selection.cpp
@@ -47,6 +47,25 @@ TEST(RTKArSelectionTest, BuildsPreferredConstellationSubsets) {
     EXPECT_EQ(subsets[2], (std::vector<int>{0, 1, 3}));
 }
 
+TEST(RTKArSelectionTest, BuildsPaperConstellationFallbackSequence) {
+    const std::vector<rtk_ar_selection::PairDescriptor> pairs = {
+        {GNSSSystem::GPS, 0.01},
+        {GNSSSystem::QZSS, 0.02},
+        {GNSSSystem::Galileo, 0.03},
+        {GNSSSystem::BeiDou, 0.04},
+        {GNSSSystem::GLONASS, 0.05},
+    };
+
+    const auto subsets =
+        rtk_ar_selection::buildPaperConstellationFallbackSubsets(pairs);
+    ASSERT_EQ(subsets.size(), 5U);
+    EXPECT_EQ(subsets[0], (std::vector<int>{0, 1, 2, 3}));  // GQEB
+    EXPECT_EQ(subsets[1], (std::vector<int>{0, 1, 2, 4}));  // GQER
+    EXPECT_EQ(subsets[2], (std::vector<int>{0, 1, 2}));     // GQE
+    EXPECT_EQ(subsets[3], (std::vector<int>{0, 1, 3}));     // GQB
+    EXPECT_EQ(subsets[4], (std::vector<int>{0, 1}));        // GQ
+}
+
 TEST(RTKArSelectionTest, BuildsProgressiveWorstVarianceDropSubsets) {
     const std::vector<rtk_ar_selection::PairDescriptor> pairs = {
         {GNSSSystem::GPS, 0.01},

--- a/tests/test_rtk_legacy.cpp
+++ b/tests/test_rtk_legacy.cpp
@@ -692,6 +692,7 @@ TEST(RTKLegacyCompatibilityStandaloneTest, SubsetArFullRatioGateDefaultDisabled)
     RTKProcessor processor;
     EXPECT_EQ(processor.getRTKConfig().min_subset_pairs_for_ar, 4);
     EXPECT_EQ(processor.getRTKConfig().max_subset_drop_steps_for_ar, 6);
+    EXPECT_FALSE(processor.getRTKConfig().enable_paper_constellation_fallback_ar);
     EXPECT_EQ(processor.getRTKConfig().min_subset_sats_for_ar, 0);
     EXPECT_EQ(processor.getRTKConfig().min_subset_systems_for_ar, 0);
     EXPECT_EQ(processor.getRTKConfig().min_subset_frequencies_for_ar, 0);


### PR DESCRIPTION
## What changed

- add an opt-in RTKConfig policy for the Okada/Sasaki/Ando constellation fallback sequence
- evaluate GQEB, GQER, GQE, GQB, then GQ after a failed full GQEBR ambiguity-resolution attempt
- retain QZSS with GPS and keep the existing preferred subsets as the default
- add selection-order and legacy-default tests

## Why

The existing Partial AR candidates covered GQE, GQEB, and GQER but omitted the paper's GQB and GQ recovery candidates.

## Validation

- Clang/Ninja gnss_solve build passed before removing temporary evaluation CLI plumbing
- PPC 6 runs x 1200 epochs: weighted official score 7.955377% -> 7.976249% (+0.020872 pp)
- Nagoya run3: official 20.330521% -> 20.674034%, Fix 74.023615% -> 75.386013%, P95 horizontal unchanged at 5.688678 m
- git diff --check passed

Local MSVC currently hits the pre-existing C1061 nesting limit in apps/gnss_solve.cpp even with all app changes removed; GCC/Clang CI is authoritative for this PR.

Closes no issue; progress tracked in #299.