### PR TITLE
Add PPP-AR convergence stage telemetry

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -609,6 +609,11 @@ jobs:
           grep -q '"use_ionosphere_free": false' native_pppar_smoke.json
           grep -q '"convergence_gate_reason":' native_pppar_smoke.json
           grep -q '"convergence_max_position_deviation_m":' native_pppar_smoke.json
+          grep -q '"convergence_max_horizontal_position_deviation_m":' native_pppar_smoke.json
+          grep -q '"convergence_max_vertical_position_deviation_m":' native_pppar_smoke.json
+          grep -q '"convergence_policy": "legacy-3d"' native_pppar_smoke.json
+          grep -q '"ar_stage_last":' native_pppar_smoke.json
+          grep -q '"ar_per_frequency_attempts":' native_pppar_smoke.json
           python3 "${GITHUB_WORKSPACE}/scripts/analysis/madoca_solution_diff.py" \
             madocalib_pppar_smoke.pos \
             native_pppar_smoke.pos \

--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -41,6 +41,9 @@ struct Options {
     std::string kml_path;
     int max_epochs = 0;
     int convergence_min_epochs = 20;
+    std::string convergence_policy = "legacy-3d";
+    double convergence_threshold_horizontal = 0.1;
+    double convergence_threshold_vertical = 0.2;
     double ssr_step_seconds = 1.0;
     bool estimate_troposphere = true;
     bool estimate_ionosphere = false;
@@ -124,6 +127,12 @@ void printUsage(const char* program_name) {
         << "  --max-epochs <count>     Limit processed epochs (default: all)\n"
         << "  --convergence-min-epochs <count>\n"
         << "                          Minimum epochs before PPP convergence/AR checks (default: 20)\n"
+        << "  --convergence-policy <legacy-3d|local-enu>\n"
+        << "                          Convergence metric policy (default: legacy-3d)\n"
+        << "  --convergence-threshold-horizontal <m>\n"
+        << "                          Horizontal threshold for local-enu policy (default: 0.1)\n"
+        << "  --convergence-threshold-vertical <m>\n"
+        << "                          Absolute Up threshold for local-enu policy (default: 0.2)\n"
         << "  --no-estimate-troposphere\n"
         << "                          Disable zenith troposphere estimation\n"
         << "  --estimate-troposphere  Enable zenith troposphere estimation (default)\n"
@@ -291,6 +300,12 @@ Options parseArguments(int argc, char* argv[]) {
             options.max_epochs = std::stoi(argv[++i]);
         } else if (arg == "--convergence-min-epochs" && i + 1 < argc) {
             options.convergence_min_epochs = std::stoi(argv[++i]);
+        } else if (arg == "--convergence-policy" && i + 1 < argc) {
+            options.convergence_policy = argv[++i];
+        } else if (arg == "--convergence-threshold-horizontal" && i + 1 < argc) {
+            options.convergence_threshold_horizontal = std::stod(argv[++i]);
+        } else if (arg == "--convergence-threshold-vertical" && i + 1 < argc) {
+            options.convergence_threshold_vertical = std::stod(argv[++i]);
         } else if (arg == "--ssr-step-seconds" && i + 1 < argc) {
             options.ssr_step_seconds = std::stod(argv[++i]);
         } else if (arg == "--no-estimate-troposphere") {
@@ -432,6 +447,16 @@ Options parseArguments(int argc, char* argv[]) {
     }
     if (options.convergence_min_epochs <= 0) {
         argumentError("--convergence-min-epochs must be positive", argv[0]);
+    }
+    if (options.convergence_policy != "legacy-3d" &&
+        options.convergence_policy != "local-enu") {
+        argumentError("--convergence-policy must be one of: legacy-3d, local-enu", argv[0]);
+    }
+    if (options.convergence_threshold_horizontal <= 0.0) {
+        argumentError("--convergence-threshold-horizontal must be positive", argv[0]);
+    }
+    if (options.convergence_threshold_vertical <= 0.0) {
+        argumentError("--convergence-threshold-vertical must be positive", argv[0]);
     }
     if (options.ar_ratio_threshold <= 0.0) {
         argumentError("--ar-ratio-threshold must be positive", argv[0]);
@@ -931,6 +956,14 @@ int main(int argc, char* argv[]) {
         }
         ppp_config.enable_ambiguity_resolution = options.enable_ar;
         ppp_config.convergence_min_epochs = options.convergence_min_epochs;
+        ppp_config.convergence_policy =
+            options.convergence_policy == "local-enu"
+                ? libgnss::ppp_shared::ConvergencePolicy::LOCAL_ENU_COMPONENTS
+                : libgnss::ppp_shared::ConvergencePolicy::LEGACY_ECEF_3D;
+        ppp_config.convergence_threshold_horizontal =
+            options.convergence_threshold_horizontal;
+        ppp_config.convergence_threshold_vertical =
+            options.convergence_threshold_vertical;
         ppp_config.ar_ratio_threshold = options.ar_ratio_threshold;
         using ARMethod = libgnss::PPPProcessor::PPPConfig::ARMethod;
         if (options.ar_method == "iflc") {
@@ -1201,6 +1234,7 @@ int main(int argc, char* argv[]) {
 
         const auto stats = processor.getStats();
         const auto& convergence = processor.getConvergenceTelemetry();
+        const auto& ar_stage = processor.getARStageTelemetry();
         const double ppp_solution_rate =
             valid_solutions > 0 ?
                 100.0 * static_cast<double>(ppp_float_solutions + ppp_fixed_solutions) /
@@ -1326,13 +1360,47 @@ int main(int argc, char* argv[]) {
                     << convergence.insufficient_history_epochs << ",\n"
                     << "  \"convergence_unstable_position_epochs\": "
                     << convergence.unstable_position_epochs << ",\n"
+                    << "  \"convergence_unstable_horizontal_epochs\": "
+                    << convergence.unstable_horizontal_epochs << ",\n"
+                    << "  \"convergence_unstable_vertical_epochs\": "
+                    << convergence.unstable_vertical_epochs << ",\n"
                     << "  \"convergence_window_epochs\": " << convergence.window_epochs << ",\n"
                     << "  \"convergence_required_window_epochs\": "
                     << convergence.required_window_epochs << ",\n"
                     << "  \"convergence_max_position_deviation_m\": "
                     << convergence.max_position_deviation_m << ",\n"
+                    << "  \"convergence_max_horizontal_position_deviation_m\": "
+                    << convergence.max_horizontal_position_deviation_m << ",\n"
+                    << "  \"convergence_max_vertical_position_deviation_m\": "
+                    << convergence.max_vertical_position_deviation_m << ",\n"
                     << "  \"convergence_position_deviation_threshold_m\": "
                     << convergence.position_deviation_threshold_m << ",\n"
+                    << "  \"convergence_horizontal_position_deviation_threshold_m\": "
+                    << convergence.horizontal_position_deviation_threshold_m << ",\n"
+                    << "  \"convergence_vertical_position_deviation_threshold_m\": "
+                    << convergence.vertical_position_deviation_threshold_m << ",\n"
+                    << "  \"convergence_policy\": \"" << convergence.policy << "\",\n"
+                    << "  \"ar_stage_last\": \"" << jsonEscape(ar_stage.last_stage) << "\",\n"
+                    << "  \"ar_per_frequency_attempts\": "
+                    << ar_stage.per_frequency_attempts << ",\n"
+                    << "  \"ar_insufficient_satellite_epochs\": "
+                    << ar_stage.insufficient_satellite_epochs << ",\n"
+                    << "  \"ar_no_wide_lane_epochs\": "
+                    << ar_stage.no_wide_lane_epochs << ",\n"
+                    << "  \"ar_wide_lane_only_epochs\": "
+                    << ar_stage.wide_lane_only_epochs << ",\n"
+                    << "  \"ar_n1_lambda_failure_epochs\": "
+                    << ar_stage.n1_lambda_failure_epochs << ",\n"
+                    << "  \"ar_n1_ratio_rejection_epochs\": "
+                    << ar_stage.n1_ratio_rejection_epochs << ",\n"
+                    << "  \"ar_n1_fixed_epochs\": " << ar_stage.n1_fixed_epochs << ",\n"
+                    << "  \"ar_last_satellite_candidates\": "
+                    << ar_stage.last_satellite_candidates << ",\n"
+                    << "  \"ar_last_wide_lane_pairs\": "
+                    << ar_stage.last_wide_lane_pairs << ",\n"
+                    << "  \"ar_last_n1_candidates\": "
+                    << ar_stage.last_n1_candidates << ",\n"
+                    << "  \"ar_last_n1_ratio\": " << ar_stage.last_n1_ratio << ",\n"
                     << "  \"average_processing_time_ms\": " << stats.average_processing_time_ms << "\n"
                     << "}\n";
         }

--- a/docs/madocalib_native_migration.md
+++ b/docs/madocalib_native_migration.md
@@ -136,6 +136,28 @@ Exit: after warm-up, at least one epoch reaches the per-frequency ambiguity
 candidate stage; telemetry distinguishes warm-up, horizontal, vertical, and
 candidate-stage rejection; default PPP/CLAS/MADOCA tests do not regress.
 
+#### M1 implementation evidence (2026-07-13)
+
+The native convergence window now reports the legacy ECEF 3D deviation plus
+local horizontal and vertical deviations.  `legacy-3d` remains the default, so
+existing admission behavior is unchanged; `local-enu` is an explicit diagnostic
+policy with separate horizontal and vertical thresholds.
+
+On the pinned MIZU 120-input-epoch smoke (118 published solutions), the legacy
+window reached maxima of 1.17008 m ECEF 3D, 0.660907 m horizontal, and 1.15825 m
+vertical and did not admit AR.  The strict 0.10 m horizontal / 0.20 m vertical
+policy also did not admit AR.  A bounded threshold sweep reached the native
+per-frequency resolver at 0.75 m horizontal / 1.25 m vertical (1200 s) and at
+1.50 m / 2.00 m (1080 s); these relaxed values are evidence probes, not new
+defaults.
+
+The 0.75 m / 1.25 m probe produced 78 resolver attempts.  All 78 stopped at
+`wide_lane_only_insufficient_n1`; zero reached a complete N1 integer fix.  The
+current solver nevertheless published those 78 epochs as `PPP_FIXED`.  M1
+therefore proves resolver reachability and identifies the exact next boundary:
+M2 must separate wide-lane-only updates from complete N1 Fix admission before
+any native Fix-rate or trajectory-parity claim is accepted.
+
 ### M2 -- Port `exec_pppar` ambiguity behavior
 
 - Compare ambiguity eligibility, frequency pairs, datum/reference selection,

--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -55,12 +55,43 @@ struct PPPConvergenceTelemetry {
     size_t evaluated_epochs = 0;
     size_t insufficient_history_epochs = 0;
     size_t unstable_position_epochs = 0;
+    size_t unstable_horizontal_epochs = 0;
+    size_t unstable_vertical_epochs = 0;
     size_t window_epochs = 0;
     size_t required_window_epochs = 0;
     double max_position_deviation_m = 0.0;
+    double max_horizontal_position_deviation_m = 0.0;
+    double max_vertical_position_deviation_m = 0.0;
     double position_deviation_threshold_m = 0.0;
+    double horizontal_position_deviation_threshold_m = 0.0;
+    double vertical_position_deviation_threshold_m = 0.0;
+    std::string policy = "legacy-3d";
     std::string gate_reason = "not_evaluated";
 };
+
+struct PPPConvergenceWindowMetrics {
+    double max_ecef_3d_m = 0.0;
+    double max_horizontal_m = 0.0;
+    double max_vertical_m = 0.0;
+};
+
+struct PPPARStageTelemetry {
+    size_t per_frequency_attempts = 0;
+    size_t insufficient_satellite_epochs = 0;
+    size_t no_wide_lane_epochs = 0;
+    size_t wide_lane_only_epochs = 0;
+    size_t n1_lambda_failure_epochs = 0;
+    size_t n1_ratio_rejection_epochs = 0;
+    size_t n1_fixed_epochs = 0;
+    int last_satellite_candidates = 0;
+    int last_wide_lane_pairs = 0;
+    int last_n1_candidates = 0;
+    double last_n1_ratio = 0.0;
+    std::string last_stage = "not_attempted";
+};
+
+PPPConvergenceWindowMetrics evaluatePPPConvergenceWindow(
+    const std::vector<Vector3d>& positions_ecef);
 
 /**
  * @brief Precise Point Positioning (PPP) processor
@@ -258,6 +289,9 @@ public:
     const PPPConvergenceTelemetry& getConvergenceTelemetry() const {
         return convergence_telemetry_;
     }
+    const PPPARStageTelemetry& getARStageTelemetry() const {
+        return ar_stage_telemetry_;
+    }
 
 private:
     void applyEnvironmentOverridesToPPPConfig();
@@ -313,6 +347,7 @@ private:
     double last_ar_ratio_ = 0.0;
     int last_fixed_ambiguities_ = 0;
     PPPConvergenceTelemetry convergence_telemetry_;
+    PPPARStageTelemetry ar_stage_telemetry_;
     int last_applied_atmos_trop_corrections_ = 0;
     int last_applied_atmos_iono_corrections_ = 0;
     double last_applied_atmos_trop_m_ = 0.0;

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -10,6 +10,11 @@
 
 namespace libgnss::ppp_shared {
 
+enum class ConvergencePolicy {
+    LEGACY_ECEF_3D,
+    LOCAL_ENU_COMPONENTS,
+};
+
 /// Check if PPP debug output is enabled via GNSS_PPP_DEBUG.
 inline bool pppDebugEnabled() {
     return pppEnvOverrides().debug;
@@ -269,6 +274,7 @@ struct PPPConfig {
     bool apply_relativity = true;
 
     // Convergence criteria
+    ConvergencePolicy convergence_policy = ConvergencePolicy::LEGACY_ECEF_3D;
     double convergence_threshold_horizontal = 0.1;
     double convergence_threshold_vertical = 0.2;
     int convergence_min_epochs = 20;

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -738,6 +738,7 @@ void PPPProcessor::reset() {
     last_ar_ratio_ = 0.0;
     last_fixed_ambiguities_ = 0;
     convergence_telemetry_ = {};
+    ar_stage_telemetry_ = {};
     ppp_ar::clearWlnlHoldState(clas_wlnl_hold_);
     last_clas_constrained_fixed_state_valid_ = false;
     clas_kinematic_fix_candidate_streak_ = 0;

--- a/src/algorithms/ppp_ambiguity.cpp
+++ b/src/algorithms/ppp_ambiguity.cpp
@@ -375,6 +375,12 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
     if (!converged_) {
         return false;
     }
+    ++ar_stage_telemetry_.per_frequency_attempts;
+    ar_stage_telemetry_.last_stage = "collect_candidates";
+    ar_stage_telemetry_.last_satellite_candidates = 0;
+    ar_stage_telemetry_.last_wide_lane_pairs = 0;
+    ar_stage_telemetry_.last_n1_candidates = 0;
+    ar_stage_telemetry_.last_n1_ratio = 0.0;
 
     // Restrict AR to satellites observed this epoch (the persistent ambiguity
     // map accumulates set satellites whose stale states must not enter the DD).
@@ -431,7 +437,10 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
         c.lambda2 = lam2;
         cands.push_back(c);
     }
+    ar_stage_telemetry_.last_satellite_candidates = static_cast<int>(cands.size());
     if (static_cast<int>(cands.size()) < ppp_config_.min_satellites_for_ar) {
+        ++ar_stage_telemetry_.insufficient_satellite_epochs;
+        ar_stage_telemetry_.last_stage = "insufficient_satellites";
         return false;
     }
 
@@ -488,8 +497,11 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
                   << " mean_frac=" << (wl_fix_count ? wl_frac_sum / wl_fix_count : 0.0) << "\n";
     }
     if (wl_pairs.empty()) {
+        ++ar_stage_telemetry_.no_wide_lane_epochs;
+        ar_stage_telemetry_.last_stage = "no_wide_lane";
         return false;
     }
+    ar_stage_telemetry_.last_wide_lane_pairs = static_cast<int>(wl_pairs.size());
 
     // 3) Apply the fixed wide-lane integers as a batched Kalman pseudo-measurement
     //    (cycles). Tight but not rigid so a wrong WL does not lock the filter.
@@ -554,9 +566,13 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
     }
     if (static_cast<int>(n1_sel.size()) < ppp_config_.min_satellites_for_ar) {
         last_fixed_ambiguities_ = nwl;  // wide-lane already applied
+        ++ar_stage_telemetry_.wide_lane_only_epochs;
+        ar_stage_telemetry_.last_n1_candidates = static_cast<int>(n1_sel.size());
+        ar_stage_telemetry_.last_stage = "wide_lane_only_insufficient_n1";
         return true;
     }
     const int nb = static_cast<int>(n1_sel.size());
+    ar_stage_telemetry_.last_n1_candidates = nb;
     VectorXd n1_float = VectorXd::Zero(nb);
     MatrixXd n1_cov = MatrixXd::Zero(nb, nb);
     for (int k = 0; k < nb; ++k) {
@@ -588,8 +604,12 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
     double ratio = 0.0;
     if (!lambdaSearch(n1_float, n1_cov, n1_fixed, ratio) || !std::isfinite(ratio)) {
         last_fixed_ambiguities_ = nwl;  // wide-lane already applied
+        ++ar_stage_telemetry_.wide_lane_only_epochs;
+        ++ar_stage_telemetry_.n1_lambda_failure_epochs;
+        ar_stage_telemetry_.last_stage = "wide_lane_only_lambda_failure";
         return true;
     }
+    ar_stage_telemetry_.last_n1_ratio = ratio;
     if (env_overrides_.pfdump) {
         std::cerr << "[PFN1] nb=" << nb << " ratio=" << ratio
                   << " threshold=" << ppp_config_.ar_ratio_threshold << "\n";
@@ -597,6 +617,9 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
     if (ratio < ppp_config_.ar_ratio_threshold) {
         last_ar_ratio_ = ratio;
         last_fixed_ambiguities_ = nwl;
+        ++ar_stage_telemetry_.wide_lane_only_epochs;
+        ++ar_stage_telemetry_.n1_ratio_rejection_epochs;
+        ar_stage_telemetry_.last_stage = "wide_lane_only_ratio_rejected";
         return true;
     }
 
@@ -621,6 +644,8 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
     const MatrixXd Sn_inv = Sn.ldlt().solve(MatrixXd::Identity(nb, nb));
     if (!Sn_inv.allFinite()) {
         last_fixed_ambiguities_ = nwl;
+        ++ar_stage_telemetry_.wide_lane_only_epochs;
+        ar_stage_telemetry_.last_stage = "wide_lane_only_n1_update_failure";
         return true;
     }
     const MatrixXd Kn = HPn.transpose() * Sn_inv;  // nx x nb
@@ -635,6 +660,8 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
     }
     last_ar_ratio_ = ratio;
     last_fixed_ambiguities_ = nb;
+    ++ar_stage_telemetry_.n1_fixed_epochs;
+    ar_stage_telemetry_.last_stage = "n1_fixed";
     return true;
 }
 

--- a/src/algorithms/ppp_measurement.cpp
+++ b/src/algorithms/ppp_measurement.cpp
@@ -473,6 +473,37 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
     return equation;
 }
 
+PPPConvergenceWindowMetrics evaluatePPPConvergenceWindow(
+    const std::vector<Vector3d>& positions_ecef) {
+    PPPConvergenceWindowMetrics metrics;
+    if (positions_ecef.empty()) {
+        return metrics;
+    }
+
+    Vector3d mean = Vector3d::Zero();
+    for (const auto& position : positions_ecef) {
+        mean += position;
+    }
+    mean /= static_cast<double>(positions_ecef.size());
+
+    double latitude = 0.0;
+    double longitude = 0.0;
+    double height = 0.0;
+    ecef2geodetic(mean, latitude, longitude, height);
+    (void)height;
+
+    for (const auto& position : positions_ecef) {
+        const Vector3d delta_ecef = position - mean;
+        const Vector3d delta_enu = ecef2enu(delta_ecef, latitude, longitude);
+        metrics.max_ecef_3d_m = std::max(metrics.max_ecef_3d_m, delta_ecef.norm());
+        metrics.max_horizontal_m =
+            std::max(metrics.max_horizontal_m, delta_enu.head<2>().norm());
+        metrics.max_vertical_m =
+            std::max(metrics.max_vertical_m, std::abs(delta_enu.z()));
+    }
+    return metrics;
+}
+
 void PPPProcessor::checkConvergence(const GNSSTime& current_time) {
     if (converged_) {
         return;
@@ -483,6 +514,14 @@ void PPPProcessor::checkConvergence(const GNSSTime& current_time) {
         static_cast<size_t>(ppp_config_.convergence_min_epochs);
     convergence_telemetry_.position_deviation_threshold_m =
         ppp_config_.convergence_threshold_horizontal;
+    convergence_telemetry_.horizontal_position_deviation_threshold_m =
+        ppp_config_.convergence_threshold_horizontal;
+    convergence_telemetry_.vertical_position_deviation_threshold_m =
+        ppp_config_.convergence_threshold_vertical;
+    convergence_telemetry_.policy =
+        ppp_config_.convergence_policy == ppp_shared::ConvergencePolicy::LOCAL_ENU_COMPONENTS
+            ? "local-enu"
+            : "legacy-3d";
 
     recent_positions_.push_back(filter_state_.state.segment(filter_state_.pos_index, 3));
     if (recent_positions_.size() > static_cast<size_t>(ppp_config_.convergence_min_epochs)) {
@@ -496,25 +535,44 @@ void PPPProcessor::checkConvergence(const GNSSTime& current_time) {
         return;
     }
 
-    Vector3d mean = Vector3d::Zero();
-    for (const auto& position : recent_positions_) {
-        mean += position;
-    }
-    mean /= static_cast<double>(recent_positions_.size());
+    const PPPConvergenceWindowMetrics metrics =
+        evaluatePPPConvergenceWindow(recent_positions_);
+    convergence_telemetry_.max_position_deviation_m = metrics.max_ecef_3d_m;
+    convergence_telemetry_.max_horizontal_position_deviation_m =
+        metrics.max_horizontal_m;
+    convergence_telemetry_.max_vertical_position_deviation_m = metrics.max_vertical_m;
 
-    double max_deviation = 0.0;
-    for (const auto& position : recent_positions_) {
-        max_deviation = std::max(max_deviation, (position - mean).norm());
-    }
-    convergence_telemetry_.max_position_deviation_m = max_deviation;
+    const bool horizontal_stable =
+        metrics.max_horizontal_m < ppp_config_.convergence_threshold_horizontal;
+    const bool vertical_stable =
+        metrics.max_vertical_m < ppp_config_.convergence_threshold_vertical;
+    const bool legacy_stable =
+        metrics.max_ecef_3d_m < ppp_config_.convergence_threshold_horizontal;
+    const bool local_enu_policy =
+        ppp_config_.convergence_policy == ppp_shared::ConvergencePolicy::LOCAL_ENU_COMPONENTS;
+    const bool stable = local_enu_policy
+        ? horizontal_stable && vertical_stable
+        : legacy_stable;
 
-    if (max_deviation < ppp_config_.convergence_threshold_horizontal) {
+    if (stable) {
         converged_ = true;
         convergence_time_ = current_time - convergence_start_time_;
         convergence_telemetry_.gate_reason = "converged";
     } else {
         ++convergence_telemetry_.unstable_position_epochs;
-        convergence_telemetry_.gate_reason = "position_deviation";
+        if (local_enu_policy && !horizontal_stable) {
+            ++convergence_telemetry_.unstable_horizontal_epochs;
+        }
+        if (local_enu_policy && !vertical_stable) {
+            ++convergence_telemetry_.unstable_vertical_epochs;
+        }
+        if (!local_enu_policy) {
+            convergence_telemetry_.gate_reason = "position_deviation";
+        } else if (!horizontal_stable) {
+            convergence_telemetry_.gate_reason = "horizontal_position_deviation";
+        } else {
+            convergence_telemetry_.gate_reason = "vertical_position_deviation";
+        }
     }
 }
 

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -4716,6 +4716,12 @@ class CLIToolsTest(unittest.TestCase):
                 "per-freq",
                 "--convergence-min-epochs",
                 "4",
+                "--convergence-policy",
+                "local-enu",
+                "--convergence-threshold-horizontal",
+                "10.0",
+                "--convergence-threshold-vertical",
+                "20.0",
                 "--ar-ratio-threshold",
                 "2.0",
                 "--obs",
@@ -4739,6 +4745,19 @@ class CLIToolsTest(unittest.TestCase):
             self.assertEqual(summary["ar_method"], "per-freq")
             self.assertTrue(summary["estimate_ionosphere"])
             self.assertFalse(summary["use_ionosphere_free"])
+            self.assertEqual(summary["convergence_policy"], "local-enu")
+            self.assertEqual(
+                summary["convergence_horizontal_position_deviation_threshold_m"],
+                10.0,
+            )
+            self.assertEqual(
+                summary["convergence_vertical_position_deviation_threshold_m"],
+                20.0,
+            )
+            self.assertIn("convergence_max_horizontal_position_deviation_m", summary)
+            self.assertIn("convergence_max_vertical_position_deviation_m", summary)
+            self.assertIn("ar_stage_last", summary)
+            self.assertIn("ar_per_frequency_attempts", summary)
             self.assertIn("PPP fixed solutions:", result.stdout)
             records = self.read_pos_records(out_path)
             self.assertEqual(len(records), 8)

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -1922,6 +1922,7 @@ TEST(PPPTest, ProcessorFixesSyntheticAmbiguitiesWithPreciseProducts) {
     EXPECT_GE(convergence.evaluated_epochs, 4u);
     EXPECT_EQ(convergence.required_window_epochs, 4u);
     EXPECT_EQ(convergence.position_deviation_threshold_m, 0.2);
+    EXPECT_EQ(convergence.policy, "legacy-3d");
     EXPECT_NE(convergence.gate_reason, "not_evaluated");
     if (saw_fixed_solution) {
         EXPECT_GE(best_fixed_ambiguities, 1);
@@ -1930,4 +1931,21 @@ TEST(PPPTest, ProcessorFixesSyntheticAmbiguitiesWithPreciseProducts) {
 
     std::filesystem::remove(sp3_path);
     std::filesystem::remove(clk_path);
+}
+
+TEST(PPPTest, ConvergenceWindowReportsEcefHorizontalAndVerticalComponents) {
+    const double latitude = 35.0 * M_PI / 180.0;
+    const double longitude = 139.0 * M_PI / 180.0;
+    const Vector3d center = geodetic2ecef(latitude, longitude, 45.0);
+    const Vector3d offset_enu(3.0, 4.0, 2.0);
+    const std::vector<Vector3d> positions = {
+        center + enu2ecef(offset_enu, latitude, longitude),
+        center - enu2ecef(offset_enu, latitude, longitude),
+    };
+
+    const PPPConvergenceWindowMetrics metrics =
+        evaluatePPPConvergenceWindow(positions);
+    EXPECT_NEAR(metrics.max_ecef_3d_m, std::sqrt(29.0), 1e-6);
+    EXPECT_NEAR(metrics.max_horizontal_m, 5.0, 1e-6);
+    EXPECT_NEAR(metrics.max_vertical_m, 2.0, 1e-6);
 }


### PR DESCRIPTION
## Summary

- keep the existing ECEF 3D PPP convergence gate as the default while adding an opt-in local ENU policy with separate horizontal and vertical thresholds
- expose convergence-window and per-frequency PPP-AR stage telemetry through the native CLI summary JSON
- record the MIZU M1 threshold sweep and the discovered wide-lane-only Fix-admission boundary in the MADOCALIB migration ledger
- cover the ENU metric helper, CLI contract, and CI smoke telemetry

## Why

Issue #148 M1 requires the native kinematic PPP-AR path to reach ambiguity candidate formation without changing the default solver behavior. The previous single ECEF norm did not distinguish horizontal and vertical instability, and the resolver did not expose where an AR attempt stopped.

The pinned MIZU probe now shows 78 per-frequency attempts, all stopping at `wide_lane_only_insufficient_n1`, with zero complete N1 fixes. The current solver still labels those epochs `PPP_FIXED`; this is now an explicit M2 Fix-admission target rather than an apparent native parity result.

## Impact

The default remains `legacy-3d`, preserving current PPP/CLAS/MADOCA admission. Users can opt into `local-enu` for diagnostics with explicit thresholds. Summary JSON gains convergence component and AR-stage fields.

## Validation

- `git diff --check`
- C++ test binary: 508 tests, 458 passed, 50 skipped
- focused PPP convergence and synthetic PPP-AR tests
- `CLIToolsTest.test_ppp_cli_can_enable_ambiguity_resolution`
- docs site build
- pinned MIZU 120-epoch diagnostic: 78 AR attempts, 78 WL-only stops, 0 N1 fixes

Tracks #148.
