### PR TITLE
Fix PPP wide-lane-only admission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -614,6 +614,37 @@ jobs:
           grep -q '"convergence_policy": "legacy-3d"' native_pppar_smoke.json
           grep -q '"ar_stage_last":' native_pppar_smoke.json
           grep -q '"ar_per_frequency_attempts":' native_pppar_smoke.json
+          ./apps/gnss_ppp \
+            --kinematic \
+            --enable-ar \
+            --ar-method per-freq \
+            --ar-ratio-threshold 1.5 \
+            --convergence-policy local-enu \
+            --convergence-threshold-horizontal 0.75 \
+            --convergence-threshold-vertical 1.25 \
+            --obs "$ROOT/sample_data/data/rinex/MIZU00JPN_R_20250910000_01D_30S_MO.rnx" \
+            --nav "$ROOT/sample_data/data/rinex/BRDM00DLR_S_20250910000_01D_MN.rnx" \
+            --madoca-l6 "$ROOT/sample_data/data/l6_is-qzss-mdc-004/2025/091/2025091A.204.l6" \
+            --madoca-l6 "$ROOT/sample_data/data/l6_is-qzss-mdc-004/2025/091/2025091A.206.l6" \
+            --antex "$ROOT/sample_data/data/igs20.atx" \
+            --max-epochs 120 \
+            --emit-epoch-time \
+            --out native_pppar_wl_only_smoke.pos \
+            --summary-json native_pppar_wl_only_smoke.json \
+            --quiet
+          grep -q '"convergence_policy": "local-enu"' native_pppar_wl_only_smoke.json
+          grep -q '"ar_n1_fixed_epochs": 0' native_pppar_wl_only_smoke.json
+          grep -q '"ppp_fixed_solutions": 0' native_pppar_wl_only_smoke.json
+          wl_only="$(python3 -c 'import json; print(json.load(open("native_pppar_wl_only_smoke.json"))["ar_wide_lane_only_epochs"])')"
+          test "$wl_only" -gt 0
+          valid="$(python3 -c 'import json; print(json.load(open("native_pppar_wl_only_smoke.json"))["valid_solutions"])')"
+          float_solutions="$(python3 -c 'import json; print(json.load(open("native_pppar_wl_only_smoke.json"))["ppp_float_solutions"])')"
+          test "$valid" -gt 0
+          test "$float_solutions" -eq "$valid"
+          rows="$(awk '$0 !~ /^%/ && NF > 0 {n++} END {print n+0}' native_pppar_wl_only_smoke.pos)"
+          test "$rows" -eq "$valid"
+          non_float="$(awk '$0 !~ /^%/ && NF > 0 && $9 != 5 {n++} END {print n+0}' native_pppar_wl_only_smoke.pos)"
+          test "$non_float" -eq 0
           python3 "${GITHUB_WORKSPACE}/scripts/analysis/madoca_solution_diff.py" \
             madocalib_pppar_smoke.pos \
             native_pppar_smoke.pos \
@@ -633,6 +664,8 @@ jobs:
           build-madoca-parity/madocalib_pppar_smoke.json
           build-madoca-parity/native_pppar_smoke.pos
           build-madoca-parity/native_pppar_smoke.json
+          build-madoca-parity/native_pppar_wl_only_smoke.pos
+          build-madoca-parity/native_pppar_wl_only_smoke.json
           build-madoca-parity/madoca_pppar_solution_diff.json
           build-madoca-parity/madoca_pppar_solution_matches.csv
         if-no-files-found: warn

--- a/docs/madocalib_native_migration.md
+++ b/docs/madocalib_native_migration.md
@@ -173,6 +173,25 @@ native Fix count is at least the oracle's 108; matched fixed-epoch 3D delta RMS
 is at most 0.20 m and maximum is at most 1.0 m.  If upstream numerical limits
 make one threshold infeasible, change it only in a dedicated evidence PR.
 
+#### M2a -- Wide-lane-only admission contract
+
+The pinned MADOCALIB source returns `1` for a wide-lane-only result and `2` for
+a complete narrow-lane fix (`src/ppp_ar.c`).  `src/ppp.c` uses the temporary
+wide-lane-constrained state for that epoch's position, maps `SOLQ_FIX_WL` back
+to `SOLQ_PPP`, and only holds the ambiguity state for `SOLQ_FIX`.  Native follows
+the same contract: a wide-lane-only result publishes its temporary position as
+`PPP_FLOAT`, reports zero fixed ambiguities and zero ratio, then restores the
+pre-AR float filter state.
+
+On the pinned 120-input-epoch MIZU Windows Release probe this changes 78
+incorrectly labelled Fix rows to Float without changing any of the 118
+published positions (before versus after 3D delta RMS and maximum are both
+0 m).  The stage counts remain 78 wide-lane-only attempts and zero complete N1
+fixes.  The Linux parity build currently publishes 84 Float rows with 44
+wide-lane-only attempts, exposing a remaining platform/state-trajectory delta
+for M2b.  A dedicated parity CI gate rejects any published Fix on every valid
+row while no complete N1 fix exists, independently of that row-count delta.
+
 ### M3 -- Apply L6D ionosphere products
 
 - Promote the proven snapshot lookup from shadow telemetry to an explicit

--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -346,6 +346,7 @@ private:
     bool has_static_anchor_position_ = false;
     double last_ar_ratio_ = 0.0;
     int last_fixed_ambiguities_ = 0;
+    bool last_ar_wide_lane_only_ = false;
     PPPConvergenceTelemetry convergence_telemetry_;
     PPPARStageTelemetry ar_stage_telemetry_;
     int last_applied_atmos_trop_corrections_ = 0;

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -598,7 +598,11 @@ PositionSolution PPPProcessor::processEpochStandard(
                 const auto float_ambiguity_states = ambiguity_states_;
                 const bool fixed =
                     ppp_config_.enable_ambiguity_resolution && resolveAmbiguities(obs, nav);
-                solution = fixed ? generateSolution(obs.time, corrected_if_obs) : float_solution;
+                const bool wide_lane_only =
+                    ppp_config_.enable_ambiguity_resolution && last_ar_wide_lane_only_;
+                solution = (fixed || wide_lane_only)
+                    ? generateSolution(obs.time, corrected_if_obs)
+                    : float_solution;
                 solution.status = fixed ? SolutionStatus::PPP_FIXED : SolutionStatus::PPP_FLOAT;
                 solution.ratio = fixed ? last_ar_ratio_ : 0.0;
                 solution.num_fixed_ambiguities = fixed ? last_fixed_ambiguities_ : 0;
@@ -650,7 +654,13 @@ PositionSolution PPPProcessor::processEpochStandard(
                     solution.position_geodetic = GeodeticCoord(latitude, longitude, height);
                 }
                 had_fixed_last_epoch_ = accepted_fixed_solution;
-                if (fixed && !accepted_fixed_solution) {
+                if (wide_lane_only) {
+                    // MADOCALIB SOLQ_FIX_WL parity: publish the current epoch
+                    // from the WL-constrained working state as PPP/FLOAT, but
+                    // do not hold that temporary constraint in the float filter.
+                    filter_state_ = float_filter_state;
+                    ambiguity_states_ = float_ambiguity_states;
+                } else if (fixed && !accepted_fixed_solution) {
                     filter_state_ = float_filter_state;
                     ambiguity_states_ = float_ambiguity_states;
                 } else if (accepted_fixed_solution && ppp_config_.ar_method != PPPConfig::ARMethod::DD_WLNL) {
@@ -737,6 +747,7 @@ void PPPProcessor::reset() {
     has_static_anchor_position_ = false;
     last_ar_ratio_ = 0.0;
     last_fixed_ambiguities_ = 0;
+    last_ar_wide_lane_only_ = false;
     convergence_telemetry_ = {};
     ar_stage_telemetry_ = {};
     ppp_ar::clearWlnlHoldState(clas_wlnl_hold_);

--- a/src/algorithms/ppp_ambiguity.cpp
+++ b/src/algorithms/ppp_ambiguity.cpp
@@ -21,6 +21,7 @@ using namespace ppp_internal;
 bool PPPProcessor::resolveAmbiguities(const ObservationData& obs, const NavigationData& nav) {
     last_ar_ratio_ = 0.0;
     last_fixed_ambiguities_ = 0;
+    last_ar_wide_lane_only_ = false;
 
     if (!ppp_config_.enable_ambiguity_resolution || (!precise_products_loaded_ && !ssr_products_loaded_)) {
         if (pppDebugEnabled()) {
@@ -569,7 +570,8 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
         ++ar_stage_telemetry_.wide_lane_only_epochs;
         ar_stage_telemetry_.last_n1_candidates = static_cast<int>(n1_sel.size());
         ar_stage_telemetry_.last_stage = "wide_lane_only_insufficient_n1";
-        return true;
+        last_ar_wide_lane_only_ = true;
+        return false;
     }
     const int nb = static_cast<int>(n1_sel.size());
     ar_stage_telemetry_.last_n1_candidates = nb;
@@ -607,7 +609,8 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
         ++ar_stage_telemetry_.wide_lane_only_epochs;
         ++ar_stage_telemetry_.n1_lambda_failure_epochs;
         ar_stage_telemetry_.last_stage = "wide_lane_only_lambda_failure";
-        return true;
+        last_ar_wide_lane_only_ = true;
+        return false;
     }
     ar_stage_telemetry_.last_n1_ratio = ratio;
     if (env_overrides_.pfdump) {
@@ -620,7 +623,8 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
         ++ar_stage_telemetry_.wide_lane_only_epochs;
         ++ar_stage_telemetry_.n1_ratio_rejection_epochs;
         ar_stage_telemetry_.last_stage = "wide_lane_only_ratio_rejected";
-        return true;
+        last_ar_wide_lane_only_ = true;
+        return false;
     }
 
     // 5) Apply the fixed N1 double differences as a tight Kalman pseudo-obs on
@@ -646,7 +650,8 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
         last_fixed_ambiguities_ = nwl;
         ++ar_stage_telemetry_.wide_lane_only_epochs;
         ar_stage_telemetry_.last_stage = "wide_lane_only_n1_update_failure";
-        return true;
+        last_ar_wide_lane_only_ = true;
+        return false;
     }
     const MatrixXd Kn = HPn.transpose() * Sn_inv;  // nx x nb
     filter_state_.state += Kn * vn;


### PR DESCRIPTION
## Summary

- distinguish per-frequency wide-lane-only updates from complete N1 ambiguity fixes
- publish the temporary WL-constrained epoch position as PPP Float, then restore the pre-AR float filter state
- add a pinned MIZU parity gate that rejects false Fix publication when all attempts stop before N1
- document the MADOCALIB `SOLQ_FIX_WL` state and status contract

## Root cause

The native per-frequency resolver returned `true` after applying only wide-lane constraints when N1 candidates were insufficient, LAMBDA failed, the ratio was rejected, or the N1 update failed. The caller interpreted every `true` as a complete ambiguity fix and published `PPP_FIXED`.

MADOCALIB uses a distinct wide-lane-only return value. It publishes the temporary WL-constrained position for that epoch, maps the public status back to PPP/Float, and only holds the filter state after a complete narrow-lane fix.

## Impact

On the pinned MIZU 120-input-epoch probe, 78 false Fix rows become Float. All 118 published positions remain bit-for-bit equivalent at solution precision: before/after 3D delta RMS and maximum are both 0 m. Stage telemetry remains 78 WL-only attempts and zero N1 fixes.

## Validation

- updated `gnss_ppp` Release build
- pinned MIZU probe: Fix 0, Float 118, WL-only 78, N1 Fix 0
- before/after solution comparison: 118 matched, 0 m RMS/max delta
- workflow YAML parse
- docs site build
- `git diff --check`

Tracks #148.
