### PR TITLE
Port MADOCALIB partial ambiguity resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -657,18 +657,10 @@ jobs:
             --candidate-label native-per-freq-partial-ar \
             --json-out madoca_pppar_solution_diff.json \
             --match-csv madoca_pppar_solution_matches.csv
-          python3 - <<'PY'
-          import csv
-
-          with open("madoca_pppar_solution_matches.csv", newline="") as stream:
-              rows = list(csv.DictReader(stream))
-          assert rows, "MADOCA PPP-AR parity produced no matched epochs"
-          wrong_fixes = [
-              row for row in rows
-              if row["candidate_status"] == "6" and row["base_status"] != "1"
-          ]
-          assert not wrong_fixes, f"native PPP-AR admitted {len(wrong_fixes)} wrong Fix epochs"
-          PY
+          matched_epochs="$(awk -F, 'NR > 1 {n++} END {print n+0}' madoca_pppar_solution_matches.csv)"
+          test "$matched_epochs" -gt 0
+          wrong_fixes="$(awk -F, 'NR > 1 && $6 == 6 && $5 != 1 {n++} END {print n+0}' madoca_pppar_solution_matches.csv)"
+          test "$wrong_fixes" -eq 0
 
     - name: Upload MADOCA PPP-AR baseline
       if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -629,30 +629,46 @@ jobs:
             --antex "$ROOT/sample_data/data/igs20.atx" \
             --max-epochs 120 \
             --emit-epoch-time \
-            --out native_pppar_wl_only_smoke.pos \
-            --summary-json native_pppar_wl_only_smoke.json \
+            --out native_pppar_partial_ar_smoke.pos \
+            --summary-json native_pppar_partial_ar_smoke.json \
             --quiet
-          grep -q '"convergence_policy": "local-enu"' native_pppar_wl_only_smoke.json
-          grep -q '"ar_n1_fixed_epochs": 0' native_pppar_wl_only_smoke.json
-          grep -q '"ppp_fixed_solutions": 0' native_pppar_wl_only_smoke.json
-          wl_only="$(python3 -c 'import json; print(json.load(open("native_pppar_wl_only_smoke.json"))["ar_wide_lane_only_epochs"])')"
+          grep -q '"convergence_policy": "local-enu"' native_pppar_partial_ar_smoke.json
+          n1_fixed="$(python3 -c 'import json; print(json.load(open("native_pppar_partial_ar_smoke.json"))["ar_n1_fixed_epochs"])')"
+          fixed_solutions="$(python3 -c 'import json; print(json.load(open("native_pppar_partial_ar_smoke.json"))["ppp_fixed_solutions"])')"
+          test "$n1_fixed" -gt 0
+          test "$fixed_solutions" -eq "$n1_fixed"
+          wl_only="$(python3 -c 'import json; print(json.load(open("native_pppar_partial_ar_smoke.json"))["ar_wide_lane_only_epochs"])')"
           test "$wl_only" -gt 0
-          valid="$(python3 -c 'import json; print(json.load(open("native_pppar_wl_only_smoke.json"))["valid_solutions"])')"
-          float_solutions="$(python3 -c 'import json; print(json.load(open("native_pppar_wl_only_smoke.json"))["ppp_float_solutions"])')"
+          valid="$(python3 -c 'import json; print(json.load(open("native_pppar_partial_ar_smoke.json"))["valid_solutions"])')"
+          float_solutions="$(python3 -c 'import json; print(json.load(open("native_pppar_partial_ar_smoke.json"))["ppp_float_solutions"])')"
           test "$valid" -gt 0
-          test "$float_solutions" -eq "$valid"
-          rows="$(awk '$0 !~ /^%/ && NF > 0 {n++} END {print n+0}' native_pppar_wl_only_smoke.pos)"
+          test "$((float_solutions + fixed_solutions))" -eq "$valid"
+          rows="$(awk '$0 !~ /^%/ && NF > 0 {n++} END {print n+0}' native_pppar_partial_ar_smoke.pos)"
           test "$rows" -eq "$valid"
-          non_float="$(awk '$0 !~ /^%/ && NF > 0 && $9 != 5 {n++} END {print n+0}' native_pppar_wl_only_smoke.pos)"
-          test "$non_float" -eq 0
+          fixed_rows="$(awk '$0 !~ /^%/ && NF > 0 && $9 == 6 {n++} END {print n+0}' native_pppar_partial_ar_smoke.pos)"
+          test "$fixed_rows" -eq "$fixed_solutions"
+          unexpected_status="$(awk '$0 !~ /^%/ && NF > 0 && $9 != 5 && $9 != 6 {n++} END {print n+0}' native_pppar_partial_ar_smoke.pos)"
+          test "$unexpected_status" -eq 0
           python3 "${GITHUB_WORKSPACE}/scripts/analysis/madoca_solution_diff.py" \
             madocalib_pppar_smoke.pos \
-            native_pppar_smoke.pos \
+            native_pppar_partial_ar_smoke.pos \
             --reference-ecef -3857167.6484 3108694.9138 4004041.6876 \
             --base-label bridge-pppar \
-            --candidate-label native-per-freq \
+            --candidate-label native-per-freq-partial-ar \
             --json-out madoca_pppar_solution_diff.json \
             --match-csv madoca_pppar_solution_matches.csv
+          python3 - <<'PY'
+          import csv
+
+          with open("madoca_pppar_solution_matches.csv", newline="") as stream:
+              rows = list(csv.DictReader(stream))
+          assert rows, "MADOCA PPP-AR parity produced no matched epochs"
+          wrong_fixes = [
+              row for row in rows
+              if row["candidate_status"] == "6" and row["base_status"] != "1"
+          ]
+          assert not wrong_fixes, f"native PPP-AR admitted {len(wrong_fixes)} wrong Fix epochs"
+          PY
 
     - name: Upload MADOCA PPP-AR baseline
       if: always()
@@ -664,8 +680,8 @@ jobs:
           build-madoca-parity/madocalib_pppar_smoke.json
           build-madoca-parity/native_pppar_smoke.pos
           build-madoca-parity/native_pppar_smoke.json
-          build-madoca-parity/native_pppar_wl_only_smoke.pos
-          build-madoca-parity/native_pppar_wl_only_smoke.json
+          build-madoca-parity/native_pppar_partial_ar_smoke.pos
+          build-madoca-parity/native_pppar_partial_ar_smoke.json
           build-madoca-parity/madoca_pppar_solution_diff.json
           build-madoca-parity/madoca_pppar_solution_matches.csv
         if-no-files-found: warn

--- a/include/libgnss++/algorithms/lambda.hpp
+++ b/include/libgnss++/algorithms/lambda.hpp
@@ -27,4 +27,16 @@ using Eigen::MatrixXd;
 bool lambdaSearch(const VectorXd& float_amb, const MatrixXd& Q_amb,
                   VectorXd& fixed_amb, double& ratio);
 
+/**
+ * LAMBDA search returning both integer candidates used by the ratio test.
+ *
+ * This is useful for partial ambiguity resolution, where ambiguities that
+ * differ between the best and second-best candidates are removed before a
+ * retry.  lambdaSearch() remains the compatibility wrapper for callers that
+ * only need the best candidate.
+ */
+bool lambdaSearchCandidates(const VectorXd& float_amb, const MatrixXd& Q_amb,
+                            VectorXd& best_amb, VectorXd& second_amb,
+                            double& ratio);
+
 } // namespace libgnss

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -68,9 +68,9 @@ struct PPPEnvOverrides {
     // GNSS_PPP_MADOCA_QZSS_CLOCK: allow default QZSS ISB clock in coherent
     // MADOCA unless set exactly to "0". Default true.
     bool madoca_qzss_clock = true;
-    // GNSS_PPP_MADOCA_QZSS_PHASE: allow QZSS phase rows in MADOCA when set
-    // exactly to "1". Default false.
-    bool madoca_qzss_phase = false;
+    // GNSS_PPP_MADOCA_QZSS_PHASE: allow QZSS phase rows in coherent MADOCA.
+    // Default true for MADOCALIB parity; set exactly to "0" to opt out.
+    bool madoca_qzss_phase = true;
     // GNSS_PPP_MADOCA_QZSS_L5: prefer QZSS L1/L5 over L1/L2 in coherent
     // MADOCA when set exactly to "1". Default false while measured.
     bool madoca_qzss_l5 = false;

--- a/src/algorithms/lambda.cpp
+++ b/src/algorithms/lambda.cpp
@@ -149,10 +149,8 @@ static int search(int n, int m, const double* L, const double* D,
     return 0;
 }
 
-// Solve Z' * f = e for the best integer candidate only.
-// We only need the first candidate because the second-best solution is used
-// only for the ratio test in z-space (s[1]/s[0]), not for back-transform.
-static int solveBestZt(int n, const double* Z, const double* e, double* f) {
+// Back-transform one integer candidate from z-space by solving Z' * f = e.
+static int solveZt(int n, const double* Z, const double* e, double* f) {
     // Build Eigen matrices (column-major, matching RTKLIB storage)
     Eigen::Map<const Eigen::MatrixXd> Zm(Z, n, n);
     Eigen::MatrixXd Zt = Zm.transpose();
@@ -170,13 +168,21 @@ static int solveBestZt(int n, const double* Z, const double* e, double* f) {
 
 bool lambdaSearch(const VectorXd& float_amb, const MatrixXd& Q_amb,
                   VectorXd& fixed_amb, double& ratio) {
+    VectorXd second_amb;
+    return lambdaSearchCandidates(
+        float_amb, Q_amb, fixed_amb, second_amb, ratio);
+}
+
+bool lambdaSearchCandidates(const VectorXd& float_amb, const MatrixXd& Q_amb,
+                            VectorXd& best_amb, VectorXd& second_amb,
+                            double& ratio) {
     int n = float_amb.size();
     int m = 2;  // find 2 best solutions for ratio test
     if (n <= 0) return false;
 
     // Convert to column-major flat arrays (RTKLIB convention)
     std::vector<double> Q(n * n), L(n * n, 0.0), D(n), Z(n * n, 0.0);
-    std::vector<double> a(n), z(n), E(n * m), F(n), s(m);
+    std::vector<double> a(n), z(n), E(n * m), F(n * m), s(m);
 
     // Q: column-major
     for (int i = 0; i < n; ++i)
@@ -205,13 +211,20 @@ bool lambdaSearch(const VectorXd& float_amb, const MatrixXd& Q_amb,
     info = search(n, m, L.data(), D.data(), z.data(), E.data(), s.data());
     if (info != 0) return false;
 
-    // Only the best integer solution needs back-transform.
-    info = solveBestZt(n, Z.data(), E.data(), F.data());
-    if (info != 0) return false;
+    // Back-transform both candidates.  Their component-wise disagreement is
+    // the satellite exclusion signal used by MADOCALIB partial AR.
+    for (int candidate = 0; candidate < m; ++candidate) {
+        info = solveZt(n, Z.data(), E.data() + candidate * n,
+                       F.data() + candidate * n);
+        if (info != 0) return false;
+    }
 
-    // Extract best solution
-    fixed_amb.resize(n);
-    for (int i = 0; i < n; ++i) fixed_amb(i) = F[i];
+    best_amb.resize(n);
+    second_amb.resize(n);
+    for (int i = 0; i < n; ++i) {
+        best_amb(i) = F[i];
+        second_amb(i) = F[i + n];
+    }
 
     // Ratio test
     ratio = (s[0] > 0.0) ? s[1] / s[0] : 0.0;

--- a/src/algorithms/ppp_ambiguity.cpp
+++ b/src/algorithms/ppp_ambiguity.cpp
@@ -10,6 +10,7 @@
 #include <algorithm>
 #include <cmath>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <set>
 #include <vector>
@@ -367,15 +368,8 @@ bool PPPProcessor::resolveAmbiguitiesDecoupledIf(const ObservationData& obs,
 
 bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
                                              const NavigationData& nav) {
-    (void)nav;
     last_ar_ratio_ = 0.0;
     last_fixed_ambiguities_ = 0;
-    // Only attempt AR once the float has converged: a wide, ill-conditioned
-    // ambiguity covariance makes the LAMBDA integer search explore an enormous
-    // volume (effectively unbounded run time).
-    if (!converged_) {
-        return false;
-    }
     ++ar_stage_telemetry_.per_frequency_attempts;
     ar_stage_telemetry_.last_stage = "collect_candidates";
     ar_stage_telemetry_.last_satellite_candidates = 0;
@@ -400,6 +394,7 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
         int l2_index = -1;
         double lambda1 = 0.0;
         double lambda2 = 0.0;
+        double elevation = -M_PI_2;
         int wl_int = 0;
         bool wl_fixed = false;
     };
@@ -408,6 +403,12 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
         : ppp_config_.convergence_min_epochs;
     std::vector<Cand> cands;
     for (const auto& [sat, l1_index] : filter_state_.ambiguity_indices) {
+        // MADOCALIB gen_sat_sd excludes GLONASS from PPP-AR even when it is
+        // present in the float solution; its FDMA ambiguities must not create
+        // a separate reference group here.
+        if (sat.system == GNSSSystem::GLONASS) {
+            continue;
+        }
         if (observed_now.count(sat) == 0) {
             continue;
         }
@@ -436,6 +437,36 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
         c.l2_index = l2_it->second;
         c.lambda1 = lam1;
         c.lambda2 = lam2;
+
+        Vector3d satellite_position;
+        Vector3d satellite_velocity;
+        double satellite_clock = 0.0;
+        double satellite_clock_drift = 0.0;
+        if (!nav.calculateSatelliteState(
+                sat, obs.time, satellite_position, satellite_velocity,
+                satellite_clock, satellite_clock_drift)) {
+            continue;
+        }
+        if (ssr_products_loaded_) {
+            Vector3d orbit_correction;
+            double clock_correction = 0.0;
+            if (ssr_products_.interpolateCorrection(
+                    sat, obs.time, orbit_correction, clock_correction)) {
+                if (ssr_products_.orbitCorrectionsAreRac()) {
+                    orbit_correction = ssrRacToEcef(
+                        satellite_position, satellite_velocity, orbit_correction);
+                }
+                satellite_position += orbit_correction;
+            }
+        }
+        const Vector3d receiver_position =
+            filter_state_.state.segment(filter_state_.pos_index, 3);
+        const Vector3d line_of_sight = satellite_position - receiver_position;
+        if (line_of_sight.norm() <= 0.0 || receiver_position.norm() <= 0.0) {
+            continue;
+        }
+        c.elevation = std::asin(
+            line_of_sight.normalized().dot(receiver_position.normalized()));
         cands.push_back(c);
     }
     ar_stage_telemetry_.last_satellite_candidates = static_cast<int>(cands.size());
@@ -445,11 +476,17 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
         return false;
     }
 
-    // 2) Wide-lane integer per satellite, double-differenced against the first
-    //    candidate of each system. WL_s = x[L1]/lambda1 - x[L2]/lambda2 (cycles).
+    // 2) Wide-lane integer per satellite, double-differenced against the
+    //    highest-elevation candidate of each system.
+    //    WL_s = x[L1]/lambda1 - x[L2]/lambda2 (cycles).
     std::map<GNSSSystem, int> ref_of_system;
     for (size_t i = 0; i < cands.size(); ++i) {
-        ref_of_system.emplace(cands[i].sat.system, static_cast<int>(i));
+        const auto [it, inserted] =
+            ref_of_system.emplace(cands[i].sat.system, static_cast<int>(i));
+        if (!inserted &&
+            cands[i].elevation > cands[static_cast<size_t>(it->second)].elevation) {
+            it->second = static_cast<int>(i);
+        }
     }
     struct DdPair { int ref = -1; int sat = -1; int wl_int = 0; };
     std::vector<DdPair> wl_pairs;
@@ -511,6 +548,10 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
     MatrixXd Hwl = MatrixXd::Zero(nwl, nx);
     VectorXd vwl = VectorXd::Zero(nwl);
     MatrixXd Rwl = MatrixXd::Zero(nwl, nwl);
+    // Until the oracle's preceding extra-WL (L2/L3) stage is ported, retain a
+    // 0.10-cycle guard against over-constraining a marginal WL integer.  The
+    // pinned oracle uses this value for EWL and tightens ordinary WL to 0.01
+    // only after EWL has conditioned the extra-frequency states.
     constexpr double kWlConstraintSigmaCyc = 0.10;
     for (int k = 0; k < nwl; ++k) {
         const Cand& ref = cands[static_cast<size_t>(wl_pairs[static_cast<size_t>(k)].ref)];
@@ -542,28 +583,32 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
     // 4) Narrow-lane N1: LAMBDA on the L1 ambiguity double differences for the
     //    WL-fixed pairs, read from the (now WL-tightened) L1 states. Mirrors the
     //    oracle gen_sd_matrix_n1 (a = x[IB(s,0)]/lambda1 differenced).
-    //    Partial AR: cap the LAMBDA dimension at the lowest-variance pairs so the
-    //    integer search stays bounded (and only fix high-confidence ambiguities).
-    constexpr int kMaxN1Dim = 12;
-    constexpr double kMaxN1VarCyc2 = 0.25;  // include only pairs with N1 std < 0.5 cycle
-    auto n1_var_of = [&](int k) {
-        const Cand& rk = cands[static_cast<size_t>(wl_pairs[static_cast<size_t>(k)].ref)];
-        const Cand& sk = cands[static_cast<size_t>(wl_pairs[static_cast<size_t>(k)].sat)];
-        return filter_state_.covariance(rk.l1_index, rk.l1_index) / (rk.lambda1 * rk.lambda1) +
-               filter_state_.covariance(sk.l1_index, sk.l1_index) / (sk.lambda1 * sk.lambda1);
-    };
+    //    MADOCALIB gen_sd_matrix_n1 admits every pair that survived the WL
+    //    search.  Candidate reduction is performed only by the subsequent
+    //    ratio-driven partial-AR loop, not by a per-pair variance cutoff.
+    //    Its NL search starts only when the norm of the three position-state
+    //    standard deviations is below pos2-arthres1 (1.5 m in the pinned
+    //    oracle config).  This replaces the unrelated solution-stability gate,
+    //    while still protecting LAMBDA from an unbounded early covariance.
+    double position_std_norm_sq = 0.0;
+    for (int axis = 0; axis < 3; ++axis) {
+        const double variance = filter_state_.covariance(
+            filter_state_.pos_index + axis, filter_state_.pos_index + axis);
+        position_std_norm_sq += std::max(0.0, variance);
+    }
+    constexpr double kMaxPositionStdNormM = 1.5;
+    if (std::sqrt(position_std_norm_sq) >= kMaxPositionStdNormM) {
+        last_fixed_ambiguities_ = nwl;
+        ++ar_stage_telemetry_.wide_lane_only_epochs;
+        ar_stage_telemetry_.last_stage = "wide_lane_only_position_std_gate";
+        last_ar_wide_lane_only_ = true;
+        return false;
+    }
+
     std::vector<int> n1_sel;
     n1_sel.reserve(wl_pairs.size());
     for (int k = 0; k < nwl; ++k) {
-        if (n1_var_of(k) < kMaxN1VarCyc2) {
-            n1_sel.push_back(k);
-        }
-    }
-    // Keep only the lowest-variance pairs so the integer search stays bounded.
-    if (static_cast<int>(n1_sel.size()) > kMaxN1Dim) {
-        std::sort(n1_sel.begin(), n1_sel.end(),
-                  [&](int a, int b) { return n1_var_of(a) < n1_var_of(b); });
-        n1_sel.resize(kMaxN1Dim);
+        n1_sel.push_back(k);
     }
     if (static_cast<int>(n1_sel.size()) < ppp_config_.min_satellites_for_ar) {
         last_fixed_ambiguities_ = nwl;  // wide-lane already applied
@@ -573,56 +618,152 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
         last_ar_wide_lane_only_ = true;
         return false;
     }
-    const int nb = static_cast<int>(n1_sel.size());
-    ar_stage_telemetry_.last_n1_candidates = nb;
-    VectorXd n1_float = VectorXd::Zero(nb);
-    MatrixXd n1_cov = MatrixXd::Zero(nb, nb);
-    for (int k = 0; k < nb; ++k) {
-        const Cand& rk = cands[static_cast<size_t>(wl_pairs[static_cast<size_t>(n1_sel[static_cast<size_t>(k)])].ref)];
-        const Cand& sk = cands[static_cast<size_t>(wl_pairs[static_cast<size_t>(n1_sel[static_cast<size_t>(k)])].sat)];
-        n1_float(k) = filter_state_.state(rk.l1_index) / rk.lambda1 -
-                      filter_state_.state(sk.l1_index) / sk.lambda1;
-        for (int l = 0; l < nb; ++l) {
-            const Cand& rl = cands[static_cast<size_t>(wl_pairs[static_cast<size_t>(n1_sel[static_cast<size_t>(l)])].ref)];
-            const Cand& sl = cands[static_cast<size_t>(wl_pairs[static_cast<size_t>(n1_sel[static_cast<size_t>(l)])].sat)];
-            n1_cov(k, l) =
-                filter_state_.covariance(rk.l1_index, rl.l1_index) / (rk.lambda1 * rl.lambda1) -
-                filter_state_.covariance(rk.l1_index, sl.l1_index) / (rk.lambda1 * sl.lambda1) -
-                filter_state_.covariance(sk.l1_index, rl.l1_index) / (sk.lambda1 * rl.lambda1) +
-                filter_state_.covariance(sk.l1_index, sl.l1_index) / (sk.lambda1 * sl.lambda1);
-        }
-    }
-    if (env_overrides_.pfdump) {
-        for (int k = 0; k < nb; ++k) {
-            const Cand& rk = cands[static_cast<size_t>(wl_pairs[static_cast<size_t>(n1_sel[static_cast<size_t>(k)])].ref)];
-            const Cand& sk = cands[static_cast<size_t>(wl_pairs[static_cast<size_t>(n1_sel[static_cast<size_t>(k)])].sat)];
-            const double frac = n1_float(k) - std::round(n1_float(k));
-            std::cerr << "[PFN1-DD] " << rk.sat.toString() << "-" << sk.sat.toString()
-                      << " n1=" << n1_float(k) << " frac=" << frac
-                      << " sigma=" << std::sqrt(std::max(0.0, n1_cov(k, k))) << "\n";
-        }
-    }
-    VectorXd n1_fixed = VectorXd::Zero(nb);
+    constexpr int kMinN1Ambiguities = 4;
+    constexpr int kMaxPartialArIterations = 10;
+    constexpr double kDimensionThresholdFactors[] = {5.0, 5.0, 3.0, 2.0, 1.5};
+    VectorXd n1_fixed;
+    VectorXd n1_second;
     double ratio = 0.0;
-    if (!lambdaSearch(n1_float, n1_cov, n1_fixed, ratio) || !std::isfinite(ratio)) {
-        last_fixed_ambiguities_ = nwl;  // wide-lane already applied
-        ++ar_stage_telemetry_.wide_lane_only_epochs;
-        ++ar_stage_telemetry_.n1_lambda_failure_epochs;
-        ar_stage_telemetry_.last_stage = "wide_lane_only_lambda_failure";
-        last_ar_wide_lane_only_ = true;
-        return false;
+    double effective_threshold = ppp_config_.ar_ratio_threshold;
+    bool n1_accepted = false;
+    bool lambda_failed = false;
+
+    // MADOCALIB partial AR: when the ratio test rejects the full set, remove
+    // one non-reference satellite implicated by the disagreement between the
+    // first and second LAMBDA candidates, then retry.  QZSS and BDS IGSO are
+    // deliberately removed before the ordinary lowest-elevation candidate.
+    for (int iteration = 0; iteration < kMaxPartialArIterations; ++iteration) {
+        const int trial_nb = static_cast<int>(n1_sel.size());
+        if (trial_nb < kMinN1Ambiguities) {
+            break;
+        }
+
+        VectorXd n1_float = VectorXd::Zero(trial_nb);
+        MatrixXd n1_cov = MatrixXd::Zero(trial_nb, trial_nb);
+        for (int k = 0; k < trial_nb; ++k) {
+            const DdPair& pair_k =
+                wl_pairs[static_cast<size_t>(n1_sel[static_cast<size_t>(k)])];
+            const Cand& rk = cands[static_cast<size_t>(pair_k.ref)];
+            const Cand& sk = cands[static_cast<size_t>(pair_k.sat)];
+            n1_float(k) = filter_state_.state(rk.l1_index) / rk.lambda1 -
+                          filter_state_.state(sk.l1_index) / sk.lambda1;
+            for (int l = 0; l < trial_nb; ++l) {
+                const DdPair& pair_l =
+                    wl_pairs[static_cast<size_t>(n1_sel[static_cast<size_t>(l)])];
+                const Cand& rl = cands[static_cast<size_t>(pair_l.ref)];
+                const Cand& sl = cands[static_cast<size_t>(pair_l.sat)];
+                n1_cov(k, l) =
+                    filter_state_.covariance(rk.l1_index, rl.l1_index) /
+                        (rk.lambda1 * rl.lambda1) -
+                    filter_state_.covariance(rk.l1_index, sl.l1_index) /
+                        (rk.lambda1 * sl.lambda1) -
+                    filter_state_.covariance(sk.l1_index, rl.l1_index) /
+                        (sk.lambda1 * rl.lambda1) +
+                    filter_state_.covariance(sk.l1_index, sl.l1_index) /
+                        (sk.lambda1 * sl.lambda1);
+            }
+        }
+        if (env_overrides_.pfdump) {
+            for (int k = 0; k < trial_nb; ++k) {
+                const DdPair& pair =
+                    wl_pairs[static_cast<size_t>(n1_sel[static_cast<size_t>(k)])];
+                const Cand& rk = cands[static_cast<size_t>(pair.ref)];
+                const Cand& sk = cands[static_cast<size_t>(pair.sat)];
+                const double frac = n1_float(k) - std::round(n1_float(k));
+                std::cerr << "[PFN1-DD] " << rk.sat.toString() << "-"
+                          << sk.sat.toString() << " n1=" << n1_float(k)
+                          << " frac=" << frac << " sigma="
+                          << std::sqrt(std::max(0.0, n1_cov(k, k))) << "\n";
+            }
+        }
+
+        if (!lambdaSearchCandidates(
+                n1_float, n1_cov, n1_fixed, n1_second, ratio) ||
+            !std::isfinite(ratio)) {
+            lambda_failed = true;
+            break;
+        }
+
+        effective_threshold = ppp_config_.ar_ratio_threshold;
+        const int dimension_offset = trial_nb - kMinN1Ambiguities;
+        if (dimension_offset >= 0 && dimension_offset < 5) {
+            effective_threshold *= kDimensionThresholdFactors[dimension_offset];
+        }
+        int matching_candidates = 0;
+        for (int k = 0; k < trial_nb; ++k) {
+            if (std::abs(n1_fixed(k) - n1_second(k)) < 0.001) {
+                ++matching_candidates;
+            }
+        }
+        const double match_rate =
+            static_cast<double>(matching_candidates) / trial_nb;
+        if (match_rate > 0.90) {
+            effective_threshold *= 0.8;
+        }
+        if (match_rate < 0.10) {
+            effective_threshold = 99.99;
+        }
+        ar_stage_telemetry_.last_n1_candidates = trial_nb;
+        ar_stage_telemetry_.last_n1_ratio = ratio;
+        if (env_overrides_.pfdump) {
+            std::cerr << "[PFN1] iter=" << iteration << " nb=" << trial_nb
+                      << " ratio=" << ratio
+                      << " threshold=" << effective_threshold
+                      << " match_rate=" << match_rate << "\n";
+        }
+        if (ratio >= effective_threshold) {
+            n1_accepted = true;
+            break;
+        }
+
+        int exclude_position = -1;
+        double lowest_priority_elevation = std::numeric_limits<double>::infinity();
+        for (int k = 0; k < trial_nb; ++k) {
+            if (std::abs(n1_fixed(k) - n1_second(k)) < 0.001) {
+                continue;
+            }
+            const DdPair& pair =
+                wl_pairs[static_cast<size_t>(n1_sel[static_cast<size_t>(k)])];
+            const Cand& candidate = cands[static_cast<size_t>(pair.sat)];
+            double priority_elevation = candidate.elevation;
+            const bool prioritized = candidate.sat.system == GNSSSystem::QZSS ||
+                (candidate.sat.system == GNSSSystem::BeiDou &&
+                 candidate.sat.prn >= 38 && candidate.sat.prn <= 40);
+            if (prioritized) {
+                priority_elevation -= 0.5 * M_PI;
+            }
+            if (priority_elevation < lowest_priority_elevation) {
+                lowest_priority_elevation = priority_elevation;
+                exclude_position = k;
+            }
+        }
+        if (exclude_position < 0) {
+            break;
+        }
+        if (env_overrides_.pfdump) {
+            const DdPair& excluded_pair = wl_pairs[static_cast<size_t>(
+                n1_sel[static_cast<size_t>(exclude_position)])];
+            std::cerr << "[PFN1-PAR] excluded="
+                      << cands[static_cast<size_t>(excluded_pair.sat)].sat.toString()
+                      << " elevation="
+                      << cands[static_cast<size_t>(excluded_pair.sat)].elevation
+                      << "\n";
+        }
+        n1_sel.erase(n1_sel.begin() + exclude_position);
     }
-    ar_stage_telemetry_.last_n1_ratio = ratio;
-    if (env_overrides_.pfdump) {
-        std::cerr << "[PFN1] nb=" << nb << " ratio=" << ratio
-                  << " threshold=" << ppp_config_.ar_ratio_threshold << "\n";
-    }
-    if (ratio < ppp_config_.ar_ratio_threshold) {
+
+    const int nb = static_cast<int>(n1_sel.size());
+    if (!n1_accepted) {
         last_ar_ratio_ = ratio;
         last_fixed_ambiguities_ = nwl;
         ++ar_stage_telemetry_.wide_lane_only_epochs;
-        ++ar_stage_telemetry_.n1_ratio_rejection_epochs;
-        ar_stage_telemetry_.last_stage = "wide_lane_only_ratio_rejected";
+        if (lambda_failed) {
+            ++ar_stage_telemetry_.n1_lambda_failure_epochs;
+            ar_stage_telemetry_.last_stage = "wide_lane_only_lambda_failure";
+        } else {
+            ++ar_stage_telemetry_.n1_ratio_rejection_epochs;
+            ar_stage_telemetry_.last_stage = "wide_lane_only_ratio_rejected";
+        }
         last_ar_wide_lane_only_ = true;
         return false;
     }
@@ -632,7 +773,7 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
     MatrixXd Hn = MatrixXd::Zero(nb, nx);
     VectorXd vn = VectorXd::Zero(nb);
     MatrixXd Rn = MatrixXd::Zero(nb, nb);
-    constexpr double kN1ConstraintSigmaCyc = 0.03;
+    constexpr double kN1ConstraintSigmaCyc = 0.01;
     for (int k = 0; k < nb; ++k) {
         const Cand& rk = cands[static_cast<size_t>(wl_pairs[static_cast<size_t>(n1_sel[static_cast<size_t>(k)])].ref)];
         const Cand& sk = cands[static_cast<size_t>(wl_pairs[static_cast<size_t>(n1_sel[static_cast<size_t>(k)])].sat)];
@@ -659,9 +800,16 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
     filter_state_.covariance =
         0.5 * (filter_state_.covariance + filter_state_.covariance.transpose());
 
-    for (const auto& p : wl_pairs) {
-        ambiguity_states_[cands[static_cast<size_t>(p.ref)].sat].is_fixed = true;
-        ambiguity_states_[cands[static_cast<size_t>(p.sat)].sat].is_fixed = true;
+    for (const int selected : n1_sel) {
+        const DdPair& pair = wl_pairs[static_cast<size_t>(selected)];
+        auto& reference_state =
+            ambiguity_states_[cands[static_cast<size_t>(pair.ref)].sat];
+        auto& satellite_state =
+            ambiguity_states_[cands[static_cast<size_t>(pair.sat)].sat];
+        reference_state.is_fixed = true;
+        reference_state.nl_is_fixed = true;
+        satellite_state.is_fixed = true;
+        satellite_state.nl_is_fixed = true;
     }
     last_ar_ratio_ = ratio;
     last_fixed_ambiguities_ = nb;

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -149,7 +149,7 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
         !envExactZero("GNSS_PPP_QZSS_SSR_PRN_FIX") &&
         !envExactOne("GNSS_PPP_DISABLE_QZSS_SSR_PRN_FIX");
     overrides.madoca_qzss_clock = !envExactZero("GNSS_PPP_MADOCA_QZSS_CLOCK");
-    overrides.madoca_qzss_phase = envExactOne("GNSS_PPP_MADOCA_QZSS_PHASE");
+    overrides.madoca_qzss_phase = !envExactZero("GNSS_PPP_MADOCA_QZSS_PHASE");
     overrides.madoca_qzss_l5 = envExactOne("GNSS_PPP_MADOCA_QZSS_L5");
     overrides.madoca_glonass = !envExactZero("GNSS_PPP_MADOCA_GLONASS");
     overrides.madoca_glonass_phase = envExactOne("GNSS_PPP_MADOCA_GLONASS_PHASE");

--- a/tests/test_rtk.cpp
+++ b/tests/test_rtk.cpp
@@ -1,4 +1,5 @@
 #include <gtest/gtest.h>
+#include <libgnss++/algorithms/lambda.hpp>
 #include <libgnss++/algorithms/rtk.hpp>
 #include <libgnss++/algorithms/spp.hpp>
 #include <libgnss++/io/rinex.hpp>
@@ -491,6 +492,23 @@ TEST(LAMBDATest, AmbiguousCase) {
     std::cout << "LAMBDA ambiguous case: ok=" << ok
               << " success_rate=" << success_rate << std::endl;
     // This case should either fail or have low success rate
+}
+
+TEST(LAMBDATest, ExposesBothRatioCandidates) {
+    VectorXd float_amb(3);
+    float_amb << 1.02, -2.97, 5.01;
+    MatrixXd cov = MatrixXd::Identity(3, 3) * 0.01;
+
+    VectorXd best;
+    VectorXd second;
+    double ratio = 0.0;
+    ASSERT_TRUE(lambdaSearchCandidates(float_amb, cov, best, second, ratio));
+
+    ASSERT_EQ(best.size(), 3);
+    ASSERT_EQ(second.size(), 3);
+    EXPECT_TRUE(best.isApprox((VectorXd(3) << 1.0, -3.0, 5.0).finished()));
+    EXPECT_FALSE(best.isApprox(second));
+    EXPECT_GT(ratio, 1.0);
 }
 
 // ============================================================================


### PR DESCRIPTION
## What changed

- expose both LAMBDA ratio candidates for partial ambiguity resolution
- port MADOCALIB-style highest-elevation references, ratio-driven candidate exclusion, retry thresholds, and the 1.5 m position-covariance gate
- exclude GLONASS from the per-frequency AR candidate set and enable coherent MADOCA QZSS phase rows by default
- tighten accepted N1 constraints and mark only the selected N1 ambiguities as fixed
- update the MADOCA parity CI smoke test to require native Fix epochs and reject every native Fix that is not fixed by the oracle

## Why

The native per-frequency PPP-AR path previously attempted one full-set LAMBDA search after an unrelated convergence gate. It fixed only 17 of the 118 matched MIZU epochs and could not reproduce MADOCALIB's partial-AR behavior. The pinned oracle retries after excluding a satellite implicated by disagreement between the best and second-best candidates.

## Measured impact

For the 120-epoch Windows MIZU parity sample:

- valid matched epochs: 118
- native Fix: 69 (previously 17)
- oracle Fix: 108
- native Fix where oracle is not Fix: 0
- status agreement: 79/118 (66.95%)

This is an M2b intermediate PR, not the M2 exit. Remaining parity work includes the oracle EWL/L3 conditioning stage, coherent BeiDou admission, and float-state trajectory alignment.

## Validation

- MSVC Release `gnss_run_tests` build
- `LAMBDATest.*:PPP*`: 102/102 passed
- `actionlint .github/workflows/ci.yml`

Tracks #148.
