### PR TITLE
Preserve RINEX extra frequency bands

### DIFF
--- a/include/libgnss++/io/rinex.hpp
+++ b/include/libgnss++/io/rinex.hpp
@@ -85,6 +85,21 @@ public:
      * @brief Check whether QZSS secondary L5 preference is enabled.
      */
     bool qzssSecondaryL5Preference() const { return qzss_prefer_l5_secondary_; }
+
+    /**
+     * @brief Preserve one selected observation for every supported frequency band.
+     *
+     * The default reader contract emits only the primary and secondary signals.
+     * Per-frequency PPP-AR callers can enable this mode so L3/L4 observations
+     * needed by extra-wide-lane ambiguity resolution are not discarded at ingest.
+     */
+    void setPreserveAdditionalFrequencyBands(bool preserve) {
+        preserve_additional_frequency_bands_ = preserve;
+    }
+
+    bool preservesAdditionalFrequencyBands() const {
+        return preserve_additional_frequency_bands_;
+    }
     
     /**
      * @brief Open RINEX file
@@ -142,6 +157,7 @@ private:
     int current_line_ = 0;
     bool qzss_prefer_l1l_ = false;
     bool qzss_prefer_l5_secondary_ = false;
+    bool preserve_additional_frequency_bands_ = false;
 
     // State for parsing RINEX 3 "SYS / # / OBS TYPES" records that span
     // continuation lines (systems with more than 13 observation types, e.g.

--- a/src/io/rinex.cpp
+++ b/src/io/rinex.cpp
@@ -7,6 +7,7 @@
 #include <iomanip>
 #include <iostream>
 #include <cmath>
+#include <set>
 
 namespace libgnss {
 namespace io {
@@ -265,6 +266,35 @@ void maybeAssignSelectedObservation(ObservationSelection& selection,
                            lli,
                            signal_strength);
     selection.has_data = true;
+}
+
+void appendSelectedObservations(
+    const ObservationSelection& primary,
+    const ObservationSelection& secondary,
+    const std::map<int, ObservationSelection>& by_band,
+    bool preserve_additional_bands,
+    const std::map<SatelliteId, int>& glonass_frequency_channels,
+    ObservationData& observations) {
+    std::set<int> emitted_bands;
+    const auto append = [&](const ObservationSelection& selection) {
+        if (!selection.has_data || emitted_bands.count(selection.band) != 0) {
+            return;
+        }
+        Observation observation = selection.observation;
+        annotateGlonassFrequencyChannel(observation, glonass_frequency_channels);
+        observations.addObservation(observation);
+        emitted_bands.insert(selection.band);
+    };
+
+    append(primary);
+    append(secondary);
+    if (!preserve_additional_bands) {
+        return;
+    }
+    for (const auto& [band, selection] : by_band) {
+        (void)band;
+        append(selection);
+    }
 }
 
 char rinexCharForSystem(GNSSSystem system) {
@@ -995,6 +1025,7 @@ bool RINEXReader::parseObservationEpochV2(const std::string& line, ObservationDa
 
         ObservationSelection primary_selection;
         ObservationSelection secondary_selection;
+        std::map<int, ObservationSelection> band_selections;
 
         for (size_t i = 0; i < header_.observation_types.size() && i < obs_values.size(); ++i) {
             const std::string& obs_type = header_.observation_types[i];
@@ -1016,19 +1047,22 @@ bool RINEXReader::parseObservationEpochV2(const std::string& line, ObservationDa
                                            qzss_prefer_l1l_,
                                            qzss_prefer_l5_secondary_,
                                            false);
+            if (preserve_additional_frequency_bands_) {
+                const int band = rinexBand(obs_type);
+                const bool primary_band = isPrimaryBand(sat.system, band);
+                if (primary_band || isSecondaryBand(sat.system, band)) {
+                    maybeAssignSelectedObservation(
+                        band_selections[band], sat, obs_type, obs_values[i],
+                        lli_flags[i], signal_strength[i], qzss_prefer_l1l_,
+                        qzss_prefer_l5_secondary_, primary_band);
+                }
+            }
         }
 
-        // Add observations if they have data
-        if (primary_selection.has_data) {
-            annotateGlonassFrequencyChannel(primary_selection.observation,
-                                            header_.glonass_frequency_channels);
-            obs_data.addObservation(primary_selection.observation);
-        }
-        if (secondary_selection.has_data) {
-            annotateGlonassFrequencyChannel(secondary_selection.observation,
-                                            header_.glonass_frequency_channels);
-            obs_data.addObservation(secondary_selection.observation);
-        }
+        appendSelectedObservations(
+            primary_selection, secondary_selection, band_selections,
+            preserve_additional_frequency_bands_,
+            header_.glonass_frequency_channels, obs_data);
     }
 
     return true;
@@ -1136,6 +1170,7 @@ bool RINEXReader::parseObservationEpochV3(const std::string& epoch_line, Observa
 
             ObservationSelection primary_selection;
             ObservationSelection secondary_selection;
+            std::map<int, ObservationSelection> band_selections;
 
             for (size_t i = 0; i < obs_types.size() && i < obs_values.size(); ++i) {
                 const std::string& obs_type = obs_types[i];
@@ -1157,18 +1192,22 @@ bool RINEXReader::parseObservationEpochV3(const std::string& epoch_line, Observa
                                                qzss_prefer_l1l_,
                                                qzss_prefer_l5_secondary_,
                                                false);
+                if (preserve_additional_frequency_bands_) {
+                    const int band = rinexBand(obs_type);
+                    const bool primary_band = isPrimaryBand(sat.system, band);
+                    if (primary_band || isSecondaryBand(sat.system, band)) {
+                        maybeAssignSelectedObservation(
+                            band_selections[band], sat, obs_type, obs_values[i],
+                            lli_flags[i], signal_strength[i], qzss_prefer_l1l_,
+                            qzss_prefer_l5_secondary_, primary_band);
+                    }
+                }
             }
 
-            if (primary_selection.has_data) {
-                annotateGlonassFrequencyChannel(primary_selection.observation,
-                                                header_.glonass_frequency_channels);
-                obs_data.addObservation(primary_selection.observation);
-            }
-            if (secondary_selection.has_data) {
-                annotateGlonassFrequencyChannel(secondary_selection.observation,
-                                                header_.glonass_frequency_channels);
-                obs_data.addObservation(secondary_selection.observation);
-            }
+            appendSelectedObservations(
+                primary_selection, secondary_selection, band_selections,
+                preserve_additional_frequency_bands_,
+                header_.glonass_frequency_channels, obs_data);
         }
 
     } catch (const std::exception& e) {

--- a/tests/test_rinex_writer.cpp
+++ b/tests/test_rinex_writer.cpp
@@ -565,3 +565,60 @@ TEST(RINEXReaderTest, QzssSecondaryL5PreferenceSelectsL5Q) {
 
     std::filesystem::remove(temp_path);
 }
+
+TEST(RINEXReaderTest, AdditionalFrequencyModePreservesFourGalileoBands) {
+    const auto temp_path = std::filesystem::temp_directory_path() /
+        "libgnss_galileo_four_frequency_test.obs";
+    std::filesystem::remove(temp_path);
+
+    std::ofstream output(temp_path);
+    ASSERT_TRUE(output.is_open());
+    output << rinexHeaderLine(
+        "     3.04           OBSERVATION DATA    M",
+        "RINEX VERSION / TYPE");
+    output << rinexHeaderLine(
+        "E    8 C1C L1C C5Q L5Q C7Q L7Q C6C L6C",
+        "SYS / # / OBS TYPES");
+    output << rinexHeaderLine("", "END OF HEADER");
+    output << "> 2025 04 01 00 00 00.0000000  0  1\n";
+    output << "E09"
+           << rinexObsField("21000001.000")
+           << rinexObsField("110000001.000")
+           << rinexObsField("22000002.000")
+           << rinexObsField("120000002.000")
+           << rinexObsField("23000003.000")
+           << rinexObsField("130000003.000")
+           << rinexObsField("24000004.000")
+           << rinexObsField("140000004.000")
+           << "\n";
+    output.close();
+
+    const auto read_epoch = [&](bool preserve_additional_bands) {
+        io::RINEXReader reader;
+        reader.setPreserveAdditionalFrequencyBands(preserve_additional_bands);
+        EXPECT_TRUE(reader.open(temp_path.string()));
+        io::RINEXReader::RINEXHeader header;
+        EXPECT_TRUE(reader.readHeader(header));
+        ObservationData epoch;
+        EXPECT_TRUE(reader.readObservationEpoch(epoch));
+        reader.close();
+        return epoch;
+    };
+
+    const SatelliteId galileo_9(GNSSSystem::Galileo, 9);
+    const ObservationData default_epoch = read_epoch(false);
+    EXPECT_EQ(default_epoch.getObservations(galileo_9).size(), 2U);
+    EXPECT_NE(default_epoch.getObservation(galileo_9, SignalType::GAL_E1), nullptr);
+    EXPECT_NE(default_epoch.getObservation(galileo_9, SignalType::GAL_E5A), nullptr);
+    EXPECT_EQ(default_epoch.getObservation(galileo_9, SignalType::GAL_E5B), nullptr);
+    EXPECT_EQ(default_epoch.getObservation(galileo_9, SignalType::GAL_E6), nullptr);
+
+    const ObservationData four_frequency_epoch = read_epoch(true);
+    EXPECT_EQ(four_frequency_epoch.getObservations(galileo_9).size(), 4U);
+    EXPECT_NE(four_frequency_epoch.getObservation(galileo_9, SignalType::GAL_E1), nullptr);
+    EXPECT_NE(four_frequency_epoch.getObservation(galileo_9, SignalType::GAL_E5A), nullptr);
+    EXPECT_NE(four_frequency_epoch.getObservation(galileo_9, SignalType::GAL_E5B), nullptr);
+    EXPECT_NE(four_frequency_epoch.getObservation(galileo_9, SignalType::GAL_E6), nullptr);
+
+    std::filesystem::remove(temp_path);
+}


### PR DESCRIPTION
## What changed

- add an opt-in RINEX reader mode that preserves one best observation per supported frequency band
- share the emission logic between RINEX 2 and RINEX 3 parsers
- retain the existing primary/secondary ordering and default two-signal reader contract
- add a four-frequency Galileo test covering E1, E5a, E5b, and E6

## Why

MADOCALIB runs PPP-AR with four frequencies and fixes extra wide-lane combinations before ordinary WL/N1. The native reader previously collapsed every satellite to primary plus one secondary observation, permanently discarding the L3/L4 inputs before the PPP filter could create corresponding ambiguity states.

This PR provides the ingest surface required for the EWL state/model port without changing current solver behavior. During validation, enabling the new mode in `gnss_ppp` before making ambiguity lifecycle state frequency-specific changed the 120-epoch MIZU result from 69 to 70 Fix epochs and shifted the trajectory, because satellite-level phase history was overwritten by the extra observations. The CLI wiring is therefore deferred to the next PR, where frequency-specific lifecycle/state handling can be enabled atomically.

## Impact

- default callers continue to receive exactly primary plus secondary observations
- EWL callers can explicitly preserve all supported bands
- no native PPP/PPP-AR behavior changes in this PR

## Validation

- MSVC Release `gnss_lib` and `gnss_ppp` build
- `RINEXReaderTest.*`: 5/5 passed
- full C++ suite: 460 passed, 50 data-dependent skipped, 0 failed

Tracks #148.
