### PR TITLE
Track per-frequency PPP ambiguity lifecycle

### DIFF
--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -859,6 +859,9 @@ int main(int argc, char* argv[]) {
 
         libgnss::io::RINEXReader obs_reader;
         const auto& ppp_env_overrides = libgnss::pppEnvOverrides();
+        if (options.ar_method == "per-freq") {
+            obs_reader.setPreserveAdditionalFrequencyBands(true);
+        }
         if (!options.madoca_l6_paths.empty() &&
             !ppp_env_overrides.qzss_prefer_l1l_present) {
             obs_reader.setQzssL1Preference(true);

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -311,6 +311,14 @@ struct PPPState {
     int total_states = 9;
 };
 
+struct PPPFrequencyAmbiguityLifecycle {
+    double last_phase = 0.0;
+    GNSSTime last_time;
+    int lock_count = 0;
+    double quality_indicator = 0.0;
+    bool has_last_phase = false;
+};
+
 struct PPPAmbiguityInfo {
     double float_value = 0.0;
     double fixed_value = 0.0;
@@ -344,6 +352,23 @@ struct PPPAmbiguityInfo {
     double float_value_l2 = 0.0;
     double wavelength_l1 = 0.0;
     double wavelength_l2 = 0.0;
+    // Per-signal observation lifecycle used by multi-frequency PPP-AR. The
+    // satellite-level fields above remain the primary/secondary compatibility
+    // view until every ambiguity state is keyed by frequency.
+    std::map<SignalType, PPPFrequencyAmbiguityLifecycle> frequency_lifecycle;
 };
+
+inline void updateFrequencyAmbiguityLifecycle(PPPAmbiguityInfo& ambiguity,
+                                              SignalType signal,
+                                              double carrier_phase,
+                                              const GNSSTime& time,
+                                              double quality_indicator) {
+    auto& frequency = ambiguity.frequency_lifecycle[signal];
+    frequency.last_phase = carrier_phase;
+    frequency.last_time = time;
+    frequency.lock_count++;
+    frequency.quality_indicator = quality_indicator;
+    frequency.has_last_phase = true;
+}
 
 }  // namespace libgnss::ppp_shared

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -24,6 +24,21 @@ using namespace ppp_internal;
 
 namespace {
 
+ObservationData legacyDualFrequencySeedView(const ObservationData& obs) {
+    ObservationData seed_obs = obs;
+    seed_obs.observations.clear();
+    seed_obs.observations.reserve(obs.observations.size());
+
+    std::map<SatelliteId, int> observations_per_satellite;
+    for (const auto& observation : obs.observations) {
+        if (observations_per_satellite[observation.satellite]++ >= 2) {
+            continue;
+        }
+        seed_obs.observations.push_back(observation);
+    }
+    return seed_obs;
+}
+
 std::string normalizeStationName(const std::string& station_name) {
     return normalizeAntennaType(station_name);
 }
@@ -524,6 +539,12 @@ PositionSolution PPPProcessor::processEpochStandard(
         !filter_initialized_;
     const PositionSolution* seed_ptr = nullptr;
     const auto runSeedSpp = [&]() {
+        // Multi-frequency RINEX ingestion retains L3/L4 for PPP ambiguity
+        // lifecycle and future filter rows. Keep the embedded SPP seed on its
+        // historical primary/secondary view: its Doppler solver treats every
+        // observation as an independent row, so extra bands would otherwise
+        // reweight the initial kinematic velocity before PPP consumes them.
+        const ObservationData seed_obs = legacyDualFrequencySeedView(obs);
         const SPPProcessor::SPPConfig original_spp_config = spp_processor_.getSPPConfig();
         if (ssr_products_loaded_ && original_spp_config.enable_raim_fde) {
             SPPProcessor::SPPConfig seed_spp_config = original_spp_config;
@@ -533,7 +554,7 @@ PositionSolution PPPProcessor::processEpochStandard(
             seed_spp_config.enable_raim_fde = false;
             spp_processor_.setSPPConfig(seed_spp_config);
             try {
-                PositionSolution seed = spp_processor_.processEpoch(obs, nav);
+                PositionSolution seed = spp_processor_.processEpoch(seed_obs, nav);
                 spp_processor_.setSPPConfig(original_spp_config);
                 return seed;
             } catch (...) {
@@ -541,7 +562,7 @@ PositionSolution PPPProcessor::processEpochStandard(
                 throw;
             }
         }
-        return spp_processor_.processEpoch(obs, nav);
+        return spp_processor_.processEpoch(seed_obs, nav);
     };
 
     try {

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -1312,11 +1312,26 @@ void PPPProcessor::pruneStaleEstStecStates(const std::set<SatelliteId>& observed
 }
 
 void PPPProcessor::updateAmbiguityStates(const ObservationData& obs) {
+    std::map<SatelliteId, int> compatibility_updates;
     for (const auto& measurement : obs.observations) {
         if (!measurement.valid || !measurement.has_carrier_phase) {
             continue;
         }
         auto& ambiguity = ambiguity_states_[measurement.satellite];
+        ppp_shared::updateFrequencyAmbiguityLifecycle(
+            ambiguity,
+            measurement.signal,
+            measurement.carrier_phase,
+            obs.time,
+            measurement.snr);
+
+        // The historical satellite-level lifecycle is updated once for each of
+        // the reader's primary and secondary observations. Additional bands are
+        // recorded above but must not accelerate lock_count or overwrite the
+        // compatibility phase datum before L3/L4 states consume them directly.
+        if (compatibility_updates[measurement.satellite]++ >= 2) {
+            continue;
+        }
         ambiguity.last_phase = measurement.carrier_phase;
         ambiguity.last_time = obs.time;
         ambiguity.lock_count++;

--- a/tests/test_ppp_ar.cpp
+++ b/tests/test_ppp_ar.cpp
@@ -4,6 +4,38 @@
 
 using namespace libgnss;
 
+TEST(PPPArTest, FrequencyLifecycleTracksSignalsIndependently) {
+    ppp_shared::PPPAmbiguityInfo ambiguity;
+    const GNSSTime first_time(2360, 100.0);
+    const GNSSTime second_time(2360, 130.0);
+
+    ppp_shared::updateFrequencyAmbiguityLifecycle(
+        ambiguity, SignalType::GPS_L1CA, 123.5, first_time, 42.0);
+    ppp_shared::updateFrequencyAmbiguityLifecycle(
+        ambiguity, SignalType::GPS_L5, 456.25, first_time, 39.0);
+    ppp_shared::updateFrequencyAmbiguityLifecycle(
+        ambiguity, SignalType::GPS_L1CA, 124.0, second_time, 43.0);
+
+    ASSERT_EQ(ambiguity.frequency_lifecycle.size(), 2u);
+    const auto& l1 = ambiguity.frequency_lifecycle.at(SignalType::GPS_L1CA);
+    EXPECT_EQ(l1.lock_count, 2);
+    EXPECT_DOUBLE_EQ(l1.last_phase, 124.0);
+    EXPECT_EQ(l1.last_time.week, second_time.week);
+    EXPECT_DOUBLE_EQ(l1.last_time.tow, second_time.tow);
+    EXPECT_DOUBLE_EQ(l1.quality_indicator, 43.0);
+    EXPECT_TRUE(l1.has_last_phase);
+
+    const auto& l5 = ambiguity.frequency_lifecycle.at(SignalType::GPS_L5);
+    EXPECT_EQ(l5.lock_count, 1);
+    EXPECT_DOUBLE_EQ(l5.last_phase, 456.25);
+    EXPECT_DOUBLE_EQ(l5.quality_indicator, 39.0);
+    EXPECT_TRUE(l5.has_last_phase);
+
+    // The per-signal helper must not mutate the legacy satellite-level view.
+    EXPECT_EQ(ambiguity.lock_count, 0);
+    EXPECT_DOUBLE_EQ(ambiguity.last_phase, 0.0);
+}
+
 TEST(PPPArTest, WlnlPreparationTracksEligibilitySkipReasons) {
     ppp_shared::PPPConfig config;
     config.convergence_min_epochs = 3;


### PR DESCRIPTION
## What changed

- enable additional RINEX frequency bands for `gnss_ppp --ar-method per-freq`
- track carrier-phase lifecycle independently per signal
- retain the legacy primary/secondary satellite-level lifecycle until L3/L4 filter states are added
- keep PPP's embedded SPP seed on the historical two-band view so extra Doppler rows do not reweight kinematic initialization
- add a focused lifecycle regression test

## Why

Issue #148's M2 migration needs L3/L4 observations available before EWL and frequency-specific ambiguity states can be implemented. Simply exposing the extra bands accelerated the satellite-level lock counter and changed the SPP seed velocity, shifting the native MIZU trajectory.

## Impact

This provides the ingestion/lifecycle boundary for the next L3/L4 state and EWL PR while preserving current native PPP-AR behavior exactly.

## Validation

- `PPPArTest.FrequencyLifecycleTracksSignalsIndependently`: pass
- full C++ suite: 511 tests, 461 passed, 50 data-dependent skipped, 0 failed
- MIZU 120 epoch native regression: position output byte-for-byte identical to the verified baseline
- MIZU summary: 118 valid, 69 Fix, 49 Float, 45 WL-only
- `git diff --check`: pass

A normal MSVC dependency build also attempted unrelated `gnss_solve.cpp` and hit its existing C1061 nesting limit; rebuilding the test target with project references disabled succeeded.
