### PR TITLE
Port MADOCALIB L3/L4 ambiguity states

### DIFF
--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -424,6 +424,26 @@ private:
      * @brief Form ionosphere-free combinations
      */
     struct IonosphereFreeObs {
+        struct AdditionalFrequencyObs {
+            int ordinal = 2;
+            SignalType signal = SignalType::SIGNAL_TYPE_COUNT;
+            std::string observation_type;
+            std::string pseudorange_observation_type;
+            std::string carrier_phase_observation_type;
+            int pseudorange_rtklib_code = 0;
+            int carrier_phase_rtklib_code = 0;
+            double pseudorange = 0.0;
+            double carrier_phase = 0.0;
+            double wavelength = 0.0;
+            double frequency = 0.0;
+            double variance_pr = 0.0;
+            double variance_cp = 0.0;
+            double code_bias_m = 0.0;
+            double phase_bias_m = 0.0;
+            double rx_ant_corr_m = 0.0;
+            bool has_carrier_phase = false;
+            bool valid = false;
+        };
         SatelliteId satellite;
         SignalType primary_signal = SignalType::SIGNAL_TYPE_COUNT;
         SignalType secondary_signal = SignalType::SIGNAL_TYPE_COUNT;
@@ -504,6 +524,7 @@ private:
         bool has_iono_init = false;
         bool has_l2 = false;
         bool has_carrier_phase_l2 = false;
+        std::vector<AdditionalFrequencyObs> additional_frequencies;
         // Wet mapping function and a priori zenith hydrostatic delay for the
         // RTKLIB-style split trop model (est-stec): trop = m_h*ZHD + m_w*(ZTD-ZHD).
         double trop_mapping_wet = 0.0;
@@ -564,6 +585,11 @@ private:
      * @brief Get or create the per-frequency L2 ambiguity state (est-stec only).
      */
     int getOrCreateAmbiguityStateL2(const IonosphereFreeObs& observation);
+    int getOrCreateAdditionalAmbiguityState(
+        const IonosphereFreeObs& observation,
+        const IonosphereFreeObs::AdditionalFrequencyObs& frequency);
+    int getOrCreateReceiverFrequencyBiasState(const SatelliteId& satellite,
+                                              int frequency_ordinal);
 
     /**
      * @brief Get or create the per-satellite ionosphere (STEC) state, seeded

--- a/include/libgnss++/algorithms/ppp_bias_identity.hpp
+++ b/include/libgnss++/algorithms/ppp_bias_identity.hpp
@@ -28,6 +28,8 @@ inline constexpr ObservationCodeMapEntry kObservationCodeMap[] = {
     {"C2X", madoca_parity::kCodeL2X}, {"L2X", madoca_parity::kCodeL2X},
     {"C2P", madoca_parity::kCodeL2P}, {"L2P", madoca_parity::kCodeL2P},
     {"C2W", madoca_parity::kCodeL2W}, {"L2W", madoca_parity::kCodeL2W},
+    {"C2I", madoca_parity::kCodeL2I}, {"L2I", madoca_parity::kCodeL2I},
+    {"C2Q", madoca_parity::kCodeL2Q}, {"L2Q", madoca_parity::kCodeL2Q},
     {"C5I", madoca_parity::kCodeL5I}, {"L5I", madoca_parity::kCodeL5I},
     {"C5Q", madoca_parity::kCodeL5Q}, {"L5Q", madoca_parity::kCodeL5Q},
     {"C5X", madoca_parity::kCodeL5X}, {"L5X", madoca_parity::kCodeL5X},
@@ -49,6 +51,7 @@ inline int rtklibSystemForGnss(GNSSSystem system) {
         case GNSSSystem::GPS: return madoca_parity::kSysGps;
         case GNSSSystem::Galileo: return madoca_parity::kSysGal;
         case GNSSSystem::QZSS: return madoca_parity::kSysQzs;
+        case GNSSSystem::BeiDou: return madoca_parity::kSysCmp;
         default: return madoca_parity::kSysNone;
     }
 }

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -89,9 +89,9 @@ struct PPPEnvOverrides {
     // GNSS_PPP_MADOCA_EARLY_WINDOW.
     bool madoca_galileo_gate = false;
     // GNSS_PPP_MADOCA_BIAS_IDENTITY: preserve MADOCA SSR code/phase-bias
-    // signal identity instead of collapsed RTCM band ids when set exactly to
-    // "1". Default false while the parity impact is measured.
-    bool madoca_bias_identity = false;
+    // signal identity instead of collapsed RTCM band ids unless set exactly
+    // to "0". Exact identity is required for distinct BDS-3 B2a biases.
+    bool madoca_bias_identity = true;
     // GNSS_PPP_PB_ADD: add non-MADOCA SSR phase biases instead of subtracting.
     // Default false.
     bool pb_add = false;

--- a/include/libgnss++/algorithms/ppp_multifrequency.hpp
+++ b/include/libgnss++/algorithms/ppp_multifrequency.hpp
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <libgnss++/core/types.hpp>
+
+#include <utility>
+#include <vector>
+
+namespace libgnss::algorithms::ppp_multifrequency {
+
+// MADOCALIB rtkcmn.c obsdef_* frequency-index order. Only indices 2 and 3
+// become the L3/L4 states introduced by the native est-STEC path.
+inline bool isMadocalibBeiDou2(const SatelliteId& satellite) {
+    return satellite.system == GNSSSystem::BeiDou && satellite.prn < 19;
+}
+
+inline std::pair<GNSSSystem, int> receiverFrequencyBiasKey(
+    const SatelliteId& satellite,
+    int frequency_ordinal) {
+    // MADOCALIB allocates I3/I4 for every NC(opt) clock group, including
+    // separate BDS-2 and BDS-3 entries. Keep the public state key compact by
+    // reserving +10 for the legacy BDS-2 group.
+    const int group_ordinal = isMadocalibBeiDou2(satellite)
+        ? frequency_ordinal + 10
+        : frequency_ordinal;
+    return {satellite.system, group_ordinal};
+}
+
+inline std::vector<SignalType> signalsForFrequencyOrdinal(
+                                                          const SatelliteId& satellite,
+                                                          int ordinal) {
+    switch (satellite.system) {
+        case GNSSSystem::GPS:
+            if (ordinal == 2) return {SignalType::GPS_L5};
+            break;
+        case GNSSSystem::Galileo:
+            if (ordinal == 2) return {SignalType::GAL_E5B};
+            if (ordinal == 3) return {SignalType::GAL_E6};
+            break;
+        case GNSSSystem::BeiDou:
+            if (ordinal == 2) {
+                return isMadocalibBeiDou2(satellite)
+                    ? std::vector<SignalType>{SignalType::BDS_B2I}
+                    : std::vector<SignalType>{SignalType::BDS_B2A};
+            }
+            break;
+        case GNSSSystem::QZSS:
+            if (ordinal == 2) return {SignalType::QZS_L2C};
+            break;
+        default:
+            break;
+    }
+    return {};
+}
+
+inline double ionosphereScale(double primary_frequency_hz,
+                              double frequency_hz) {
+    if (!(primary_frequency_hz > 0.0) || !(frequency_hz > 0.0)) {
+        return 0.0;
+    }
+    const double ratio = primary_frequency_hz / frequency_hz;
+    return ratio * ratio;
+}
+
+inline double ambiguitySeedMeters(double carrier_phase_m,
+                                  double pseudorange_m,
+                                  double ionosphere_l1_m,
+                                  double primary_frequency_hz,
+                                  double frequency_hz) {
+    return carrier_phase_m - pseudorange_m +
+           2.0 * ionosphere_l1_m *
+               ionosphereScale(primary_frequency_hz, frequency_hz);
+}
+
+inline double ambiguityDifferenceCycles(double first_ambiguity_m,
+                                        double first_wavelength_m,
+                                        double second_ambiguity_m,
+                                        double second_wavelength_m) {
+    if (!(first_wavelength_m > 0.0) || !(second_wavelength_m > 0.0)) {
+        return 0.0;
+    }
+    return first_ambiguity_m / first_wavelength_m -
+           second_ambiguity_m / second_wavelength_m;
+}
+
+inline double extraWideLaneDoubleDifferenceCycles(
+    double reference_l2_ambiguity_m,
+    double reference_l2_wavelength_m,
+    double reference_extra_ambiguity_m,
+    double reference_extra_wavelength_m,
+    double satellite_l2_ambiguity_m,
+    double satellite_l2_wavelength_m,
+    double satellite_extra_ambiguity_m,
+    double satellite_extra_wavelength_m) {
+    return ambiguityDifferenceCycles(
+               reference_l2_ambiguity_m, reference_l2_wavelength_m,
+               reference_extra_ambiguity_m, reference_extra_wavelength_m) -
+           ambiguityDifferenceCycles(
+               satellite_l2_ambiguity_m, satellite_l2_wavelength_m,
+               satellite_extra_ambiguity_m, satellite_extra_wavelength_m);
+}
+
+}  // namespace libgnss::algorithms::ppp_multifrequency

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -298,6 +298,7 @@ struct PPPState {
     int gal_clock_index = -1;
     int qzs_clock_index = -1;
     int bds_clock_index = -1;
+    int bds2_clock_index = -1;
     int trop_index = 8;
     int iono_index = 9;
     int amb_index = 9;
@@ -308,6 +309,12 @@ struct PPPState {
     // amb_index/total_states and the ambiguity_indices layout are byte-identical
     // to the ionosphere-free path. L1 ambiguities stay in ambiguity_indices.
     std::map<SatelliteId, int> ambiguity_l2_indices;
+    // Third/fourth-frequency ambiguity states use the actual signal as part of
+    // the key because the available band depends on the constellation.
+    std::map<std::pair<SatelliteId, SignalType>, int> additional_ambiguity_indices;
+    // MADOCALIB I3/I4 receiver inter-frequency code biases. The integer key is
+    // the zero-based additional-frequency ordinal (2 = L3, 3 = L4).
+    std::map<std::pair<GNSSSystem, int>, int> receiver_frequency_bias_indices;
     int total_states = 9;
 };
 
@@ -317,6 +324,9 @@ struct PPPFrequencyAmbiguityLifecycle {
     int lock_count = 0;
     double quality_indicator = 0.0;
     bool has_last_phase = false;
+    double float_value_m = 0.0;
+    double wavelength_m = 0.0;
+    int state_index = -1;
 };
 
 struct PPPAmbiguityInfo {

--- a/src/algorithms/ppp_ambiguity.cpp
+++ b/src/algorithms/ppp_ambiguity.cpp
@@ -2,12 +2,14 @@
 
 #include <libgnss++/algorithms/lambda.hpp>
 #include <libgnss++/algorithms/ppp_ar.hpp>
+#include <libgnss++/algorithms/ppp_multifrequency.hpp>
 #include <libgnss++/algorithms/ppp_utils.hpp>
 #include <libgnss++/core/constants.hpp>
 #include <libgnss++/core/coordinates.hpp>
 #include <libgnss++/core/signals.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <iostream>
 #include <limits>
@@ -394,6 +396,8 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
         int l2_index = -1;
         double lambda1 = 0.0;
         double lambda2 = 0.0;
+        std::array<int, 2> extra_indices{{-1, -1}};
+        std::array<double, 2> extra_wavelengths{{0.0, 0.0}};
         double elevation = -M_PI_2;
         int wl_int = 0;
         bool wl_fixed = false;
@@ -437,6 +441,28 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
         c.l2_index = l2_it->second;
         c.lambda1 = lam1;
         c.lambda2 = lam2;
+        for (int ordinal = 2; ordinal <= 3; ++ordinal) {
+            const auto signals =
+                algorithms::ppp_multifrequency::signalsForFrequencyOrdinal(
+                    sat, ordinal);
+            for (const SignalType signal : signals) {
+                const auto state_it =
+                    filter_state_.additional_ambiguity_indices.find({sat, signal});
+                const auto lifecycle_it =
+                    amb_it->second.frequency_lifecycle.find(signal);
+                if (state_it == filter_state_.additional_ambiguity_indices.end() ||
+                    lifecycle_it == amb_it->second.frequency_lifecycle.end() ||
+                    state_it->second < 0 ||
+                    state_it->second >= filter_state_.total_states ||
+                    !(lifecycle_it->second.wavelength_m > 0.0)) {
+                    continue;
+                }
+                const size_t slot = static_cast<size_t>(ordinal - 2);
+                c.extra_indices[slot] = state_it->second;
+                c.extra_wavelengths[slot] = lifecycle_it->second.wavelength_m;
+                break;
+            }
+        }
 
         Vector3d satellite_position;
         Vector3d satellite_velocity;
@@ -467,6 +493,14 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
         }
         c.elevation = std::asin(
             line_of_sight.normalized().dot(receiver_position.normalized()));
+        // Frozen MADOCALIB pppar profile: pos2-arelmask=15 degrees. The
+        // measurement filter still uses the 10-degree observation mask, but
+        // gen_sat_sd() excludes lower satellites from integer candidates.
+        constexpr double kMadocalibArElevationMaskRad = 15.0 * M_PI / 180.0;
+        if (ssr_products_loaded_ &&
+            c.elevation < kMadocalibArElevationMaskRad) {
+            continue;
+        }
         cands.push_back(c);
     }
     ar_stage_telemetry_.last_satellite_candidates = static_cast<int>(cands.size());
@@ -479,19 +513,175 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
     // 2) Wide-lane integer per satellite, double-differenced against the
     //    highest-elevation candidate of each system.
     //    WL_s = x[L1]/lambda1 - x[L2]/lambda2 (cycles).
-    std::map<GNSSSystem, int> ref_of_system;
+    std::map<std::pair<GNSSSystem, int>, int> ref_of_group;
     for (size_t i = 0; i < cands.size(); ++i) {
+        // MADOCALIB gen_sat_sd() never uses the BDS IGSO satellites as the
+        // datum, although they remain eligible as non-reference candidates.
+        if (cands[i].sat.system == GNSSSystem::BeiDou &&
+            cands[i].sat.prn >= 38 && cands[i].sat.prn <= 40) {
+            continue;
+        }
+        const auto group = ppp_ar::ambiguityDdGroup(cands[i].sat);
         const auto [it, inserted] =
-            ref_of_system.emplace(cands[i].sat.system, static_cast<int>(i));
+            ref_of_group.emplace(group, static_cast<int>(i));
         if (!inserted &&
             cands[i].elevation > cands[static_cast<size_t>(it->second)].elevation) {
             it->second = static_cast<int>(i);
         }
     }
-    struct DdPair { int ref = -1; int sat = -1; int wl_int = 0; };
+    struct DdPair {
+        int ref = -1;
+        int sat = -1;
+        int wl_int = 0;
+        double constraint_sigma_cycles = 0.01;
+    };
     std::vector<DdPair> wl_pairs;
     const VectorXd& x = filter_state_.state;
     const MatrixXd& P = filter_state_.covariance;
+    const int nx = filter_state_.total_states;
+
+    if (env_overrides_.pfdump) {
+        for (size_t i = 0; i < cands.size(); ++i) {
+            const auto ref_it = ref_of_group.find(
+                ppp_ar::ambiguityDdGroup(cands[i].sat));
+            if (ref_it == ref_of_group.end()) {
+                continue;
+            }
+            const int ref_idx = ref_it->second;
+            if (ref_idx == static_cast<int>(i)) {
+                continue;
+            }
+            const Cand& ref = cands[static_cast<size_t>(ref_idx)];
+            const Cand& sat = cands[i];
+            const double wl_dd =
+                (x(ref.l1_index) / ref.lambda1 -
+                 x(ref.l2_index) / ref.lambda2) -
+                (x(sat.l1_index) / sat.lambda1 -
+                 x(sat.l2_index) / sat.lambda2);
+            std::cerr << "[PFWL-PRE-EWL] " << ref.sat.toString() << "-"
+                      << sat.sat.toString() << " wl=" << wl_dd
+                      << " frac=" << std::abs(std::round(wl_dd) - wl_dd)
+                      << "\n";
+        }
+    }
+
+    // MADOCALIB STEP_EWL: condition the extra-frequency states with accepted
+    // F2-F3 and F2-F4 integer double differences before ordinary F1-F2 WL.
+    struct EwlPair {
+        int ref = -1;
+        int sat = -1;
+        int slot = 0;
+        int integer = 0;
+        double sigma_cycles = 0.10;
+    };
+    std::vector<EwlPair> ewl_pairs;
+    constexpr double kMaxFracEwl = 0.20;
+    constexpr double kMaxStdEwl = 1.0;
+    for (size_t i = 0; i < cands.size(); ++i) {
+        const auto ref_it = ref_of_group.find(
+            ppp_ar::ambiguityDdGroup(cands[i].sat));
+        if (ref_it == ref_of_group.end()) {
+            continue;
+        }
+        const int ref_idx = ref_it->second;
+        if (ref_idx == static_cast<int>(i)) {
+            continue;
+        }
+        const Cand& ref = cands[static_cast<size_t>(ref_idx)];
+        const Cand& sat = cands[i];
+        for (int slot = 0; slot < 2; ++slot) {
+            const int ref_extra = ref.extra_indices[static_cast<size_t>(slot)];
+            const int sat_extra = sat.extra_indices[static_cast<size_t>(slot)];
+            const double ref_lambda =
+                ref.extra_wavelengths[static_cast<size_t>(slot)];
+            const double sat_lambda =
+                sat.extra_wavelengths[static_cast<size_t>(slot)];
+            if (ref_extra < 0 || sat_extra < 0 || !(ref_lambda > 0.0) ||
+                !(sat_lambda > 0.0)) {
+                continue;
+            }
+            const double ewl_dd =
+                algorithms::ppp_multifrequency::extraWideLaneDoubleDifferenceCycles(
+                    x(ref.l2_index), ref.lambda2, x(ref_extra), ref_lambda,
+                    x(sat.l2_index), sat.lambda2, x(sat_extra), sat_lambda);
+            const double integer = std::round(ewl_dd);
+            const double frac = std::abs(integer - ewl_dd);
+            const auto single_sat_variance = [&](int l2_index,
+                                                 double lambda2,
+                                                 int extra_index,
+                                                 double extra_lambda) {
+                return P(l2_index, l2_index) / (lambda2 * lambda2) +
+                       P(extra_index, extra_index) /
+                           (extra_lambda * extra_lambda) -
+                       2.0 * P(l2_index, extra_index) /
+                           (lambda2 * extra_lambda);
+            };
+            // Match search_amb_ewl(): sum the two single-satellite variances.
+            const double variance =
+                single_sat_variance(
+                    ref.l2_index, ref.lambda2, ref_extra, ref_lambda) +
+                single_sat_variance(
+                    sat.l2_index, sat.lambda2, sat_extra, sat_lambda);
+            const double std_cycles = variance > 0.0
+                ? std::sqrt(variance) : std::numeric_limits<double>::infinity();
+            if (env_overrides_.pfdump) {
+                std::cerr << "[PFEWL] " << ref.sat.toString() << "-"
+                          << sat.sat.toString() << " F2-F" << (slot + 3)
+                          << " value=" << ewl_dd << " frac=" << frac
+                          << " std=" << std_cycles << "\n";
+            }
+            if (std_cycles > kMaxStdEwl || frac > kMaxFracEwl) {
+                continue;
+            }
+            double constraint_sigma = 0.01;
+            if (sat.sat.system == GNSSSystem::GPS ||
+                sat.sat.system == GNSSSystem::BeiDou ||
+                (sat.sat.system == GNSSSystem::Galileo && slot == 1)) {
+                constraint_sigma = 0.10;
+            }
+            ewl_pairs.push_back({
+                ref_idx, static_cast<int>(i), slot,
+                static_cast<int>(integer), constraint_sigma});
+        }
+    }
+    if (env_overrides_.pfdump) {
+        std::cerr << "[PFEWL-SUM] fixed=" << ewl_pairs.size() << "\n";
+    }
+    if (!ewl_pairs.empty()) {
+        const int ne = static_cast<int>(ewl_pairs.size());
+        MatrixXd Hewl = MatrixXd::Zero(ne, nx);
+        VectorXd vewl = VectorXd::Zero(ne);
+        MatrixXd Rewl = MatrixXd::Zero(ne, ne);
+        for (int k = 0; k < ne; ++k) {
+            const EwlPair& pair = ewl_pairs[static_cast<size_t>(k)];
+            const Cand& ref = cands[static_cast<size_t>(pair.ref)];
+            const Cand& sat = cands[static_cast<size_t>(pair.sat)];
+            const size_t slot = static_cast<size_t>(pair.slot);
+            Hewl(k, ref.l2_index) += 1.0 / ref.lambda2;
+            Hewl(k, ref.extra_indices[slot]) +=
+                -1.0 / ref.extra_wavelengths[slot];
+            Hewl(k, sat.l2_index) += -1.0 / sat.lambda2;
+            Hewl(k, sat.extra_indices[slot]) +=
+                1.0 / sat.extra_wavelengths[slot];
+            const double float_value = (Hewl.row(k) * filter_state_.state)(0);
+            vewl(k) = static_cast<double>(pair.integer) - float_value;
+            Rewl(k, k) = pair.sigma_cycles * pair.sigma_cycles;
+        }
+        const MatrixXd HP = Hewl * filter_state_.covariance;
+        const MatrixXd innovation_covariance =
+            HP * Hewl.transpose() + Rewl;
+        const MatrixXd inverse = innovation_covariance.ldlt().solve(
+            MatrixXd::Identity(ne, ne));
+        if (!inverse.allFinite()) {
+            return false;
+        }
+        const MatrixXd gain = HP.transpose() * inverse;
+        filter_state_.state += gain * vewl;
+        filter_state_.covariance -= gain * HP;
+        filter_state_.covariance = 0.5 *
+            (filter_state_.covariance + filter_state_.covariance.transpose());
+    }
+
     auto wl_cycles = [&](const Cand& c) {
         return x(c.l1_index) / c.lambda1 - x(c.l2_index) / c.lambda2;
     };
@@ -500,7 +690,12 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
     int wl_fix_count = 0;
     double wl_frac_sum = 0.0;
     for (size_t i = 0; i < cands.size(); ++i) {
-        const int ref_idx = ref_of_system[cands[i].sat.system];
+        const auto ref_it = ref_of_group.find(
+            ppp_ar::ambiguityDdGroup(cands[i].sat));
+        if (ref_it == ref_of_group.end()) {
+            continue;
+        }
+        const int ref_idx = ref_it->second;
         if (ref_idx == static_cast<int>(i)) {
             continue;
         }
@@ -509,23 +704,34 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
         const double wl_dd = wl_cycles(ref) - wl_cycles(sat);
         const double n = std::round(wl_dd);
         const double frac = std::abs(n - wl_dd);
-        // Variance of the WL DD (cycles^2) from the 4 contributing states.
-        const double cr1 = 1.0 / ref.lambda1, cr2 = -1.0 / ref.lambda2;
-        const double cs1 = -1.0 / sat.lambda1, cs2 = 1.0 / sat.lambda2;
+        // Match search_amb_wl(): sum each satellite's internal WL variance.
+        // The oracle intentionally omits cross-satellite covariance terms in
+        // this integer-admission gate, even though the subsequent Kalman
+        // constraint uses the complete covariance matrix.
         const int ir1 = ref.l1_index, ir2 = ref.l2_index;
         const int is1 = sat.l1_index, is2 = sat.l2_index;
-        double var = cr1 * cr1 * P(ir1, ir1) + cr2 * cr2 * P(ir2, ir2) +
-                     cs1 * cs1 * P(is1, is1) + cs2 * cs2 * P(is2, is2) +
-                     2.0 * (cr1 * cr2 * P(ir1, ir2) + cr1 * cs1 * P(ir1, is1) +
-                            cr1 * cs2 * P(ir1, is2) + cr2 * cs1 * P(ir2, is1) +
-                            cr2 * cs2 * P(ir2, is2) + cs1 * cs2 * P(is1, is2));
+        const auto wl_variance = [&](int l1_index,
+                                     double lambda1,
+                                     int l2_index,
+                                     double lambda2) {
+            return P(l1_index, l1_index) / (lambda1 * lambda1) +
+                   P(l2_index, l2_index) / (lambda2 * lambda2) -
+                   2.0 * P(l1_index, l2_index) / (lambda1 * lambda2);
+        };
+        const double var =
+            wl_variance(ir1, ref.lambda1, ir2, ref.lambda2) +
+            wl_variance(is1, sat.lambda1, is2, sat.lambda2);
         const double sd = var > 0.0 ? std::sqrt(var) : 9.9;
         if (env_overrides_.pfdump) {
             std::cerr << "[PFWL] " << ref.sat.toString() << "-" << sat.sat.toString()
                       << " wl=" << wl_dd << " frac=" << frac << " std=" << sd << "\n";
         }
         if (frac < kMaxFracWl && sd < kMaxStdWl) {
-            wl_pairs.push_back({ref_idx, static_cast<int>(i), static_cast<int>(n)});
+            const double constraint_sigma =
+                sat.sat.system == GNSSSystem::BeiDou ? 0.05 : 0.01;
+            wl_pairs.push_back({
+                ref_idx, static_cast<int>(i), static_cast<int>(n),
+                constraint_sigma});
             wl_fix_count++;
             wl_frac_sum += frac;
         }
@@ -543,16 +749,10 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
 
     // 3) Apply the fixed wide-lane integers as a batched Kalman pseudo-measurement
     //    (cycles). Tight but not rigid so a wrong WL does not lock the filter.
-    const int nx = filter_state_.total_states;
     const int nwl = static_cast<int>(wl_pairs.size());
     MatrixXd Hwl = MatrixXd::Zero(nwl, nx);
     VectorXd vwl = VectorXd::Zero(nwl);
     MatrixXd Rwl = MatrixXd::Zero(nwl, nwl);
-    // Until the oracle's preceding extra-WL (L2/L3) stage is ported, retain a
-    // 0.10-cycle guard against over-constraining a marginal WL integer.  The
-    // pinned oracle uses this value for EWL and tightens ordinary WL to 0.01
-    // only after EWL has conditioned the extra-frequency states.
-    constexpr double kWlConstraintSigmaCyc = 0.10;
     for (int k = 0; k < nwl; ++k) {
         const Cand& ref = cands[static_cast<size_t>(wl_pairs[static_cast<size_t>(k)].ref)];
         const Cand& sat = cands[static_cast<size_t>(wl_pairs[static_cast<size_t>(k)].sat)];
@@ -562,7 +762,9 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
         Hwl(k, sat.l2_index) += 1.0 / sat.lambda2;
         const double wl_dd_float = wl_cycles(ref) - wl_cycles(sat);
         vwl(k) = static_cast<double>(wl_pairs[static_cast<size_t>(k)].wl_int) - wl_dd_float;
-        Rwl(k, k) = kWlConstraintSigmaCyc * kWlConstraintSigmaCyc;
+        const double sigma =
+            wl_pairs[static_cast<size_t>(k)].constraint_sigma_cycles;
+        Rwl(k, k) = sigma * sigma;
     }
     // Standard Kalman update written as P -= K (H P) to avoid the O(nx^3)
     // Joseph form on the large per-frequency state (nx ~ 300). The fix is
@@ -579,6 +781,11 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
     filter_state_.covariance -= Kwl * HPwl;
     filter_state_.covariance =
         0.5 * (filter_state_.covariance + filter_state_.covariance.transpose());
+
+    // MADOCALIB snapshots the WL-conditioned float state before N1 and
+    // restores it when the final fixed-position covariance gate rejects.
+    const VectorXd wide_lane_state = filter_state_.state;
+    const MatrixXd wide_lane_covariance = filter_state_.covariance;
 
     // 4) Narrow-lane N1: LAMBDA on the L1 ambiguity double differences for the
     //    WL-fixed pairs, read from the (now WL-tightened) L1 states. Mirrors the
@@ -773,16 +980,18 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
     MatrixXd Hn = MatrixXd::Zero(nb, nx);
     VectorXd vn = VectorXd::Zero(nb);
     MatrixXd Rn = MatrixXd::Zero(nb, nb);
-    constexpr double kN1ConstraintSigmaCyc = 0.01;
     for (int k = 0; k < nb; ++k) {
-        const Cand& rk = cands[static_cast<size_t>(wl_pairs[static_cast<size_t>(n1_sel[static_cast<size_t>(k)])].ref)];
-        const Cand& sk = cands[static_cast<size_t>(wl_pairs[static_cast<size_t>(n1_sel[static_cast<size_t>(k)])].sat)];
+        const DdPair& pair =
+            wl_pairs[static_cast<size_t>(n1_sel[static_cast<size_t>(k)])];
+        const Cand& rk = cands[static_cast<size_t>(pair.ref)];
+        const Cand& sk = cands[static_cast<size_t>(pair.sat)];
         Hn(k, rk.l1_index) += 1.0 / rk.lambda1;
         Hn(k, sk.l1_index) += -1.0 / sk.lambda1;
         vn(k) = n1_fixed(k) -
                 (filter_state_.state(rk.l1_index) / rk.lambda1 -
                  filter_state_.state(sk.l1_index) / sk.lambda1);
-        Rn(k, k) = kN1ConstraintSigmaCyc * kN1ConstraintSigmaCyc;
+        const double sigma = pair.constraint_sigma_cycles;
+        Rn(k, k) = sigma * sigma;
     }
     const MatrixXd HPn = Hn * filter_state_.covariance;  // nb x nx
     MatrixXd Sn = HPn * Hn.transpose() + Rn;
@@ -799,6 +1008,27 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
     filter_state_.covariance -= Kn * HPn;
     filter_state_.covariance =
         0.5 * (filter_state_.covariance + filter_state_.covariance.transpose());
+
+    double fixed_position_std_norm_sq = 0.0;
+    for (int axis = 0; axis < 3; ++axis) {
+        fixed_position_std_norm_sq += std::max(
+            0.0,
+            filter_state_.covariance(
+                filter_state_.pos_index + axis,
+                filter_state_.pos_index + axis));
+    }
+    constexpr double kMaxFixedPositionStdNormM = 0.15;
+    if (std::sqrt(fixed_position_std_norm_sq) >
+        kMaxFixedPositionStdNormM) {
+        filter_state_.state = wide_lane_state;
+        filter_state_.covariance = wide_lane_covariance;
+        last_fixed_ambiguities_ = nwl;
+        ++ar_stage_telemetry_.wide_lane_only_epochs;
+        ar_stage_telemetry_.last_stage =
+            "wide_lane_only_fixed_position_std_gate";
+        last_ar_wide_lane_only_ = true;
+        return false;
+    }
 
     for (const int selected : n1_sel) {
         const DdPair& pair = wl_pairs[static_cast<size_t>(selected)];

--- a/src/algorithms/ppp_ar.cpp
+++ b/src/algorithms/ppp_ar.cpp
@@ -36,7 +36,17 @@ SatelliteId clasRealSatellite(const SatelliteId& satellite) {
 }
 
 std::pair<GNSSSystem, int> ambiguityDdGroup(const SatelliteId& satellite) {
-    return {satellite.system, satellite.prn > 100 ? 1 : 0};
+    const bool clas_virtual = satellite.prn > 100;
+    const int real_prn = clas_virtual
+        ? std::max(1, static_cast<int>(satellite.prn) - 100)
+        : static_cast<int>(satellite.prn);
+    int group = clas_virtual ? 1 : 0;
+    if (satellite.system == GNSSSystem::BeiDou) {
+        // MADOCALIB's NC(opt) has distinct BDS-3 (SYS_CMP) and BDS-2
+        // (SYS_BD2) clock/datum groups. PRN 19 is the pinned boundary.
+        group += real_prn < 19 ? 2 : 4;
+    }
+    return {satellite.system, group};
 }
 
 double claslibRatioThresholdForNb(int nb) {

--- a/src/algorithms/ppp_corrections.cpp
+++ b/src/algorithms/ppp_corrections.cpp
@@ -1029,6 +1029,29 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
             if (atmos_tokens.empty() && !epoch_atmos_tokens.empty()) {
                 atmos_tokens = epoch_atmos_tokens;
             }
+            if (require_coherent_ssr_) {
+                // MADOCALIB corr_meas() drops an individual raw observable
+                // when its SSR bias is unavailable. Keep a usable L1/L2
+                // satellite while applying that rule independently to L3/L4.
+                for (auto& extra : observation.additional_frequencies) {
+                    if (!ssrBiasPresent(
+                            code_bias_m, observation.satellite.system,
+                            extra.signal, extra.observation_type,
+                            madoca_bias_identity)) {
+                        extra.valid = false;
+                        extra.has_carrier_phase = false;
+                        continue;
+                    }
+                    if (observation.satellite.system != GNSSSystem::GLONASS &&
+                        extra.has_carrier_phase &&
+                        !ssrBiasPresent(
+                            phase_bias_m, observation.satellite.system,
+                            extra.signal, extra.observation_type,
+                            madoca_bias_identity)) {
+                        extra.has_carrier_phase = false;
+                    }
+                }
+            }
             if (require_coherent_ssr_ &&
                 (!ssr_ok ||
                  !madocaSsrCorrectionIsCoherent(ssr_status, time) ||
@@ -1115,6 +1138,18 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                         observation.pseudorange_l2 += ssr_bias_sign * cb_l2;
                         observation.code_bias_l2_m = cb_l2;
                     }
+                    for (auto& extra : observation.additional_frequencies) {
+                        if (!extra.valid) {
+                            continue;
+                        }
+                        const double cb = observationCodeBiasMeters(
+                            observation.satellite.system, extra.signal,
+                            SignalType::SIGNAL_TYPE_COUNT, false, code_bias_m,
+                            1.0, 0.0, extra.observation_type, std::string(),
+                            madoca_bias_identity);
+                        extra.pseudorange += ssr_bias_sign * cb;
+                        extra.code_bias_m = cb;
+                    }
                     // MADOCALIB ppp.c:451 ADDS the SSR phase bias to the carrier
                     // phase (L[i]+=pb); applying it with the opposite sign pushes
                     // the per-frequency ambiguity away from its integer. Non-MADOCA
@@ -1149,6 +1184,18 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                                 madoca_bias_identity);
                             observation.carrier_phase_l2 += phase_bias_sign * pb_l2;
                             observation.phase_bias_l2_m = pb_l2;
+                        }
+                        for (auto& extra : observation.additional_frequencies) {
+                            if (!extra.valid || !extra.has_carrier_phase) {
+                                continue;
+                            }
+                            const double pb = observationPhaseBiasMeters(
+                                observation.satellite.system, extra.signal,
+                                SignalType::SIGNAL_TYPE_COUNT, false, phase_bias_m,
+                                1.0, 0.0, extra.observation_type, std::string(),
+                                madoca_bias_identity);
+                            extra.carrier_phase += phase_bias_sign * pb;
+                            extra.phase_bias_m = pb;
                         }
                     }
                     // Re-derive the ionosphere seed from bias-corrected codes.
@@ -1487,6 +1534,19 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                         receiverAntennaPcvMeters(observation.secondary_signal,
                                                  observation.elevation);
                 }
+                const auto l1_it = ant_it->second.find(observation.primary_signal);
+                for (auto& extra : observation.additional_frequencies) {
+                    const auto extra_it = ant_it->second.find(extra.signal);
+                    double pco_delta_m = 0.0;
+                    if (l1_it != ant_it->second.end() && extra_it != ant_it->second.end()) {
+                        const Vector3d delta_ecef =
+                            enu2ecef(extra_it->second - l1_it->second, rx_lat, rx_lon);
+                        pco_delta_m = -los_unit.dot(delta_ecef);
+                    }
+                    extra.rx_ant_corr_m =
+                        pco_delta_m +
+                        receiverAntennaPcvMeters(extra.signal, observation.elevation);
+                }
             }
         }
 
@@ -1524,6 +1584,11 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                 }
                 if (observation.has_carrier_phase_l2 && observation.wavelength_l2 > 0.0) {
                     observation.carrier_phase_l2 -= new_windup * observation.wavelength_l2;
+                }
+                for (auto& extra : observation.additional_frequencies) {
+                    if (extra.has_carrier_phase && extra.wavelength > 0.0) {
+                        extra.carrier_phase -= new_windup * extra.wavelength;
+                    }
                 }
             }
         }

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -157,7 +157,8 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
     overrides.madoca_galileo_gate =
         envExactOne("GNSS_PPP_MADOCA_GALILEO_GATE") ||
         overrides.madoca_early_window;
-    overrides.madoca_bias_identity = envExactOne("GNSS_PPP_MADOCA_BIAS_IDENTITY");
+    overrides.madoca_bias_identity =
+        !envExactZero("GNSS_PPP_MADOCA_BIAS_IDENTITY");
     overrides.pb_add = envPresent("GNSS_PPP_PB_ADD");
     overrides.no_phase_bias = envPresent("GNSS_PPP_NO_PHASE_BIAS");
     overrides.l2_reset_fix = envFirstCharNotZero("GNSS_PPP_L2_RESET_FIX");

--- a/src/algorithms/ppp_measurement.cpp
+++ b/src/algorithms/ppp_measurement.cpp
@@ -1,5 +1,7 @@
 #include "ppp_internal.hpp"
 
+#include <libgnss++/algorithms/ppp_multifrequency.hpp>
+
 #include <libgnss++/core/constants.hpp>
 #include <libgnss++/core/coordinates.hpp>
 
@@ -77,6 +79,32 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
         row_secondary_frequencies_hz.push_back(observation.secondary_frequency_hz);
         row_primary_if_coefficients.push_back(observation.primary_code_bias_coeff);
         row_secondary_if_coefficients.push_back(observation.secondary_code_bias_coeff);
+        row_ssr_orbit_ages_s.push_back(observation.ssr_orbit_age_s);
+        row_ssr_clock_ages_s.push_back(observation.ssr_clock_age_s);
+        row_ssr_orbit_iods.push_back(observation.ssr_orbit_iod);
+        row_ssr_clock_iods.push_back(observation.ssr_clock_iod);
+        row_ssr_orbit_iodes.push_back(observation.ssr_orbit_iode);
+    };
+    const auto appendAdditionalShadowMetadata = [&]
+        (const IonosphereFreeObs& observation,
+         const IonosphereFreeObs::AdditionalFrequencyObs& frequency,
+         bool phase) {
+        if (!capture_shadow_metadata) {
+            return;
+        }
+        row_rinex_codes.push_back(
+            phase ? frequency.carrier_phase_observation_type
+                  : frequency.pseudorange_observation_type);
+        row_rtklib_codes.push_back(
+            phase ? frequency.carrier_phase_rtklib_code
+                  : frequency.pseudorange_rtklib_code);
+        row_signal_families.push_back(signalFamilyName(frequency.signal));
+        row_azimuths.push_back(observation.azimuth);
+        row_glonass_frequency_channels.push_back(observation.glonass_frequency_channel);
+        row_primary_frequencies_hz.push_back(frequency.frequency);
+        row_secondary_frequencies_hz.push_back(0.0);
+        row_primary_if_coefficients.push_back(1.0);
+        row_secondary_if_coefficients.push_back(0.0);
         row_ssr_orbit_ages_s.push_back(observation.ssr_orbit_age_s);
         row_ssr_clock_ages_s.push_back(observation.ssr_clock_age_s);
         row_ssr_orbit_iods.push_back(observation.ssr_orbit_iod);
@@ -431,6 +459,130 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
                     row_signal_bands.push_back("L2");
                     appendShadowMetadata(observation, true, true);
                 }
+            }
+        }
+
+        // --- MADOCALIB f=2/f=3 (L3/L4) code + phase rows ---
+        for (const auto& frequency : observation.additional_frequencies) {
+            if (env_overrides_.res_dump) {
+                std::cerr << "[PPP-FREQ-ROW] " << observation.satellite.toString()
+                          << " ordinal=" << frequency.ordinal
+                          << " valid=" << frequency.valid
+                          << " f1=" << observation.freq_l1
+                          << " fx=" << frequency.frequency << "\n";
+            }
+            if (!frequency.valid || !(observation.freq_l1 > 0.0) ||
+                !(frequency.frequency > 0.0)) {
+                continue;
+            }
+            const double ratio2 =
+                algorithms::ppp_multifrequency::ionosphereScale(
+                    observation.freq_l1, frequency.frequency);
+            const auto iono_it =
+                filter_state_.ionosphere_indices.find(observation.satellite);
+            const int iono_index = iono_it != filter_state_.ionosphere_indices.end()
+                ? iono_it->second : -1;
+            const double iono_m = iono_index >= 0
+                ? filter_state_.state(iono_index) : 0.0;
+            const auto ifb_it = filter_state_.receiver_frequency_bias_indices.find(
+                algorithms::ppp_multifrequency::receiverFrequencyBiasKey(
+                    observation.satellite, frequency.ordinal));
+            if (ifb_it == filter_state_.receiver_frequency_bias_indices.end()) {
+                continue;
+            }
+            const int ifb_index = ifb_it->second;
+            const double base_pred = geometric_range + clock_bias_m -
+                constants::SPEED_OF_LIGHT * observation.satellite_clock_bias +
+                troposphere_delay + frequency.rx_ant_corr_m;
+
+            Eigen::RowVectorXd code =
+                Eigen::RowVectorXd::Zero(filter_state_.total_states);
+            code.segment(filter_state_.pos_index, 3) = -line_of_sight;
+            code(clock_state_index) = 1.0;
+            code(filter_state_.trop_index) = trop_partial;
+            code(ifb_index) = 1.0;
+            if (iono_index >= 0) code(iono_index) = ratio2;
+            const double code_pred = base_pred + ratio2 * iono_m +
+                                     filter_state_.state(ifb_index);
+            const double code_resid = frequency.pseudorange - code_pred;
+            // The oracle applies the same elevation/system/URA variance model
+            // to every code band. The flat ingest variance is only a fallback
+            // before precise geometry has populated observation.variance_pr.
+            const double var_pr = observation.variance_pr > 0.0
+                ? observation.variance_pr
+                : safeVariance(frequency.variance_pr, 1e-6);
+            const double code_limit = std::max(
+                ppp_config_.outlier_threshold * std::sqrt(var_pr) * 10.0,
+                converged_ ? 500.0 : 20000.0);
+            const std::string band = "L" + std::to_string(frequency.ordinal + 1);
+            if (env_overrides_.res_dump) dumpRes(band.c_str(), "code", code_resid);
+            if (!apply_outlier_detection || !ppp_config_.enable_outlier_detection ||
+                std::abs(code_resid) <= code_limit) {
+                rows.push_back(code);
+                measured_values.push_back(frequency.pseudorange);
+                predicted_values.push_back(code_pred);
+                variances.push_back(var_pr);
+                row_satellites.push_back(observation.satellite);
+                row_is_phase.push_back(false);
+                row_elevations.push_back(observation.elevation);
+                row_signals.push_back(frequency.signal);
+                row_signal_bands.push_back(band);
+                appendAdditionalShadowMetadata(observation, frequency, false);
+            }
+
+            const auto amb_state = filter_state_.additional_ambiguity_indices.find(
+                {observation.satellite, frequency.signal});
+            const auto amb_it = ambiguity_states_.find(observation.satellite);
+            const ppp_shared::PPPFrequencyAmbiguityLifecycle* lifecycle = nullptr;
+            if (amb_it != ambiguity_states_.end()) {
+                const auto lifecycle_it =
+                    amb_it->second.frequency_lifecycle.find(frequency.signal);
+                if (lifecycle_it != amb_it->second.frequency_lifecycle.end()) {
+                    lifecycle = &lifecycle_it->second;
+                }
+            }
+            const bool phase_ready =
+                use_phase_rows && frequency.has_carrier_phase &&
+                amb_state != filter_state_.additional_ambiguity_indices.end() &&
+                amb_it != ambiguity_states_.end() &&
+                lifecycle != nullptr &&
+                lifecycle->lock_count >=
+                    ppp_config_.phase_measurement_min_lock_count &&
+                !(qzss_code_only && observation.satellite.system == GNSSSystem::QZSS) &&
+                !glonass_code_only;
+            if (!phase_ready) {
+                continue;
+            }
+            const int ambiguity_index = amb_state->second;
+            Eigen::RowVectorXd phase =
+                Eigen::RowVectorXd::Zero(filter_state_.total_states);
+            phase.segment(filter_state_.pos_index, 3) = -line_of_sight;
+            phase(clock_state_index) = 1.0;
+            phase(filter_state_.trop_index) = trop_partial;
+            phase(ambiguity_index) = 1.0;
+            if (iono_index >= 0) phase(iono_index) = -ratio2;
+            const double phase_pred = base_pred - ratio2 * iono_m +
+                                      filter_state_.state(ambiguity_index);
+            const double phase_resid = frequency.carrier_phase - phase_pred;
+            const double var_cp = observation.variance_cp > 0.0
+                ? observation.variance_cp
+                : safeVariance(frequency.variance_cp, 1e-8);
+            const double phase_limit = std::max(
+                ppp_config_.outlier_threshold * std::sqrt(var_cp) * 10.0,
+                converged_ ? 10.0 : 50.0);
+            if (env_overrides_.res_dump) dumpRes(band.c_str(), "phase", phase_resid);
+            if (!apply_outlier_detection || !ppp_config_.enable_outlier_detection ||
+                std::abs(phase_resid) <= phase_limit) {
+                rows.push_back(phase);
+                measured_values.push_back(frequency.carrier_phase);
+                predicted_values.push_back(phase_pred);
+                variances.push_back(var_cp);
+                row_satellites.push_back(observation.satellite);
+                row_is_phase.push_back(true);
+                row_elevations.push_back(observation.elevation);
+                row_signals.push_back(frequency.signal);
+                row_signal_bands.push_back(band);
+                appendAdditionalShadowMetadata(observation, frequency, true);
             }
         }
     }

--- a/src/algorithms/ppp_observations.cpp
+++ b/src/algorithms/ppp_observations.cpp
@@ -1,11 +1,13 @@
 #include "ppp_internal.hpp"
 
 #include <libgnss++/algorithms/ppp_bias_identity.hpp>
+#include <libgnss++/algorithms/ppp_multifrequency.hpp>
 #include <libgnss++/algorithms/ppp_utils.hpp>
 #include <libgnss++/core/signal_policy.hpp>
 #include <libgnss++/core/signals.hpp>
 
 #include <cmath>
+#include <iostream>
 #include <vector>
 
 namespace libgnss {
@@ -15,7 +17,12 @@ using namespace ppp_internal;
 namespace {
 
 std::vector<SignalType> secondarySignalsForObservation(const SatelliteId& sat,
-                                                       bool prefer_qzss_l5) {
+                                                       bool prefer_qzss_l5,
+                                                       bool madoca_frequency_order) {
+    if (madoca_frequency_order && sat.system == GNSSSystem::BeiDou) {
+        return {SignalType::BDS_B3I, SignalType::BDS_B2I,
+                SignalType::BDS_B2A};
+    }
     if (prefer_qzss_l5 && sat.system == GNSSSystem::QZSS) {
         return {SignalType::QZS_L5, SignalType::QZS_L2C};
     }
@@ -63,9 +70,6 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
     for (const auto& sat : obs.getSatellites()) {
         // Keep the native MADOCA parity path on systems whose L6 SSR handling is
         // coherent with the MADOCALIB bridge for this loader.
-        if (require_coherent_ssr_ && sat.system == GNSSSystem::BeiDou) {
-            continue;
-        }
         if (require_coherent_ssr_ && sat.system == GNSSSystem::GLONASS &&
             !env_overrides_.madoca_glonass) {
             continue;
@@ -149,7 +153,8 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
         const bool prefer_qzss_l5 =
             require_coherent_ssr_ && env_overrides_.madoca_qzss_l5;
         const Observation* secondary = findObservationForSignals(
-            obs, sat, secondarySignalsForObservation(sat, prefer_qzss_l5));
+            obs, sat, secondarySignalsForObservation(
+                sat, prefer_qzss_l5, require_coherent_ssr_));
 
         // Per-frequency mode: carry BOTH L1 and L2 raw observables.
         // SSR corrections (orbit/clock/bias/iono) still applied below.
@@ -202,6 +207,60 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
                         }
                     }
                 }
+            }
+            // MADOCALIB indexes frequencies by constellation-specific obsdef
+            // order, not by the order in which RINEX observations were read.
+            for (int ordinal = 2; ordinal <= 3; ++ordinal) {
+                const auto signals =
+                    algorithms::ppp_multifrequency::signalsForFrequencyOrdinal(
+                        sat, ordinal);
+                const Observation* candidate =
+                    findObservationForSignals(obs, sat, signals);
+                if (candidate == nullptr || candidate == primary ||
+                    candidate == secondary) {
+                    continue;
+                }
+                const double frequency_hz = signalFrequencyHz(candidate->signal, eph);
+                if (!(frequency_hz > 0.0)) {
+                    continue;
+                }
+                IonosphereFreeObs::AdditionalFrequencyObs extra;
+                extra.ordinal = ordinal;
+                extra.signal = candidate->signal;
+                extra.observation_type = candidate->exactBiasObservationType();
+                extra.pseudorange_observation_type =
+                    candidate->pseudorange_observation_type;
+                extra.carrier_phase_observation_type =
+                    candidate->carrier_phase_observation_type;
+                extra.pseudorange_rtklib_code =
+                    algorithms::ppp_bias_identity::rtklibCodeForObservationType(
+                        candidate->pseudorange_observation_type);
+                extra.carrier_phase_rtklib_code =
+                    algorithms::ppp_bias_identity::rtklibCodeForObservationType(
+                        candidate->carrier_phase_observation_type);
+                extra.pseudorange = candidate->pseudorange;
+                extra.frequency = frequency_hz;
+                extra.wavelength = signalWavelengthMeters(candidate->signal, eph);
+                extra.variance_pr = safeVariance(
+                    ppp_config_.pseudorange_sigma * ppp_config_.pseudorange_sigma,
+                    1e-6);
+                extra.variance_cp = safeVariance(
+                    ppp_config_.carrier_phase_sigma * ppp_config_.carrier_phase_sigma,
+                    1e-8);
+                if (candidate->has_carrier_phase && extra.wavelength > 0.0) {
+                    extra.carrier_phase = candidate->carrier_phase * extra.wavelength;
+                    extra.has_carrier_phase = true;
+                }
+                extra.valid = true;
+                entry.additional_frequencies.push_back(std::move(extra));
+            }
+            if (env_overrides_.res_dump && !entry.additional_frequencies.empty()) {
+                std::cerr << "[PPP-FREQ] " << sat.toString() << " extra=";
+                for (const auto& frequency : entry.additional_frequencies) {
+                    std::cerr << ' ' << static_cast<int>(frequency.signal)
+                              << '@' << frequency.frequency;
+                }
+                std::cerr << "\n";
             }
             entry.valid = true;
             combined.push_back(entry);

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -1,5 +1,7 @@
 #include "ppp_internal.hpp"
 
+#include <libgnss++/algorithms/ppp_multifrequency.hpp>
+
 #include <libgnss++/algorithms/ppp_utils.hpp>
 #include <libgnss++/core/constants.hpp>
 #include <libgnss++/core/coordinates.hpp>
@@ -286,6 +288,7 @@ bool PPPProcessor::initializeFilter(const ObservationData& obs,
     filter_state_.gal_clock_index = -1;
     filter_state_.qzs_clock_index = -1;
     filter_state_.bds_clock_index = -1;
+    filter_state_.bds2_clock_index = -1;
     // Without these states QZSS/Galileo/BeiDou share the GPS clock and any
     // receiver inter-system hardware bias leaks into code residuals. Native
     // MADOCA coherent mode needs QZSS by default because the L6 stream carries
@@ -311,8 +314,12 @@ bool PPPProcessor::initializeFilter(const ObservationData& obs,
         visible_systems.count(GNSSSystem::QZSS)) {
         filter_state_.qzs_clock_index = isb_start++;
     }
-    if (env_overrides_.estimate_isb_bds && visible_systems.count(GNSSSystem::BeiDou)) {
+    if ((env_overrides_.estimate_isb_bds || require_coherent_ssr_) &&
+        visible_systems.count(GNSSSystem::BeiDou)) {
         filter_state_.bds_clock_index = isb_start++;
+        if (require_coherent_ssr_) {
+            filter_state_.bds2_clock_index = isb_start++;
+        }
     }
 
     // Reserve ionosphere states for visible satellites.
@@ -326,6 +333,8 @@ bool PPPProcessor::initializeFilter(const ObservationData& obs,
         !ppp_config_.use_clas_osr_filter;
     int n_iono_states = 0;
     filter_state_.ionosphere_indices.clear();
+    filter_state_.additional_ambiguity_indices.clear();
+    filter_state_.receiver_frequency_bias_indices.clear();
     if (ppp_config_.estimate_ionosphere && !madoca_per_freq_est_stec) {
         filter_state_.iono_index = isb_start;
         for (const auto& sat : obs.getSatellites()) {
@@ -349,6 +358,8 @@ bool PPPProcessor::initializeFilter(const ObservationData& obs,
         filter_state_.state(filter_state_.qzs_clock_index) = initial_clock_bias_m;
     if (filter_state_.bds_clock_index >= 0)
         filter_state_.state(filter_state_.bds_clock_index) = initial_clock_bias_m;
+    if (filter_state_.bds2_clock_index >= 0)
+        filter_state_.state(filter_state_.bds2_clock_index) = initial_clock_bias_m;
     filter_state_.state(filter_state_.trop_index) =
         ppp_config_.estimate_troposphere ?
             modeledZenithTroposphereDelayMeters(initial_position, obs.time) :
@@ -375,6 +386,10 @@ bool PPPProcessor::initializeFilter(const ObservationData& obs,
             system_clock_initial_variance;
     if (filter_state_.bds_clock_index >= 0)
         filter_state_.covariance(filter_state_.bds_clock_index, filter_state_.bds_clock_index) =
+            system_clock_initial_variance;
+    if (filter_state_.bds2_clock_index >= 0)
+        filter_state_.covariance(
+            filter_state_.bds2_clock_index, filter_state_.bds2_clock_index) =
             system_clock_initial_variance;
     // Initialize per-satellite ionosphere states. GNSS_PPP_INIT_IONO_VAR (>0)
     // overrides the per-satellite initial ionosphere covariance. The est-stec
@@ -459,6 +474,9 @@ void PPPProcessor::predictState(double dt, const PositionSolution* seed_solution
     if (filter_state_.bds_clock_index >= 0)
         Q(filter_state_.bds_clock_index, filter_state_.bds_clock_index) =
             env_overrides_.isb_process_noise * dt;
+    if (filter_state_.bds2_clock_index >= 0)
+        Q(filter_state_.bds2_clock_index, filter_state_.bds2_clock_index) =
+            env_overrides_.isb_process_noise * dt;
     Q(filter_state_.trop_index, filter_state_.trop_index) =
         ppp_config_.process_noise_troposphere * dt;
     // Ambiguity process noise for every appended state. Ionosphere states may
@@ -500,6 +518,7 @@ void PPPProcessor::predictState(double dt, const PositionSolution* seed_solution
             reinitializeSystemClock(filter_state_.gal_clock_index);
             reinitializeSystemClock(filter_state_.qzs_clock_index);
             reinitializeSystemClock(filter_state_.bds_clock_index);
+            reinitializeSystemClock(filter_state_.bds2_clock_index);
         }
         if (ppp_config_.kinematic_mode &&
             !ppp_config_.low_dynamics_mode &&
@@ -967,6 +986,24 @@ void PPPProcessor::ensureAmbiguityStates(const std::vector<IonosphereFreeObs>& o
             if (observation.has_carrier_phase_l2) {
                 getOrCreateAmbiguityStateL2(observation);
             }
+            for (const auto& frequency : observation.additional_frequencies) {
+                if (!frequency.valid) {
+                    continue;
+                }
+                getOrCreateReceiverFrequencyBiasState(
+                    observation.satellite, frequency.ordinal);
+                if (frequency.has_carrier_phase) {
+                    getOrCreateAdditionalAmbiguityState(observation, frequency);
+                }
+                if (env_overrides_.res_dump) {
+                    std::cerr << "[PPP-FREQ-STATE] "
+                              << observation.satellite.toString()
+                              << " ordinal=" << frequency.ordinal
+                              << " valid=" << frequency.valid
+                              << " phase=" << frequency.has_carrier_phase
+                              << "\n";
+                }
+            }
         }
         getOrCreateAmbiguityState(observation);
     }
@@ -1055,6 +1092,7 @@ void PPPProcessor::recoverLowDynamicsBroadcastState(const ObservationData& obs,
     reinitializeSystemClock(filter_state_.gal_clock_index);
     reinitializeSystemClock(filter_state_.qzs_clock_index);
     reinitializeSystemClock(filter_state_.bds_clock_index);
+    reinitializeSystemClock(filter_state_.bds2_clock_index);
     reinitializeScalarState(
         filter_state_.trop_index,
         modeledZenithTroposphereDelayMeters(anchored_position, obs.time),
@@ -1088,6 +1126,9 @@ int PPPProcessor::receiverClockStateIndex(const SatelliteId& satellite) const {
             return filter_state_.qzs_clock_index >= 0
                 ? filter_state_.qzs_clock_index : filter_state_.clock_index;
         case GNSSSystem::BeiDou:
+            if (satellite.prn < 19 && filter_state_.bds2_clock_index >= 0) {
+                return filter_state_.bds2_clock_index;
+            }
             return filter_state_.bds_clock_index >= 0
                 ? filter_state_.bds_clock_index : filter_state_.clock_index;
         default:
@@ -1226,6 +1267,72 @@ int PPPProcessor::getOrCreateAmbiguityStateL2(const IonosphereFreeObs& observati
     return index;
 }
 
+int PPPProcessor::getOrCreateReceiverFrequencyBiasState(
+    const SatelliteId& satellite,
+    int frequency_ordinal) {
+    const auto key =
+        algorithms::ppp_multifrequency::receiverFrequencyBiasKey(
+            satellite, frequency_ordinal);
+    const auto existing = filter_state_.receiver_frequency_bias_indices.find(key);
+    if (existing != filter_state_.receiver_frequency_bias_indices.end()) {
+        return existing->second;
+    }
+    const int index = filter_state_.total_states++;
+    filter_state_.state.conservativeResize(filter_state_.total_states);
+    filter_state_.covariance.conservativeResize(
+        filter_state_.total_states, filter_state_.total_states);
+    filter_state_.covariance.row(index).setZero();
+    filter_state_.covariance.col(index).setZero();
+    filter_state_.state(index) = 1e-6;
+    filter_state_.covariance(index, index) = 30.0 * 30.0;
+    filter_state_.receiver_frequency_bias_indices[key] = index;
+    return index;
+}
+
+int PPPProcessor::getOrCreateAdditionalAmbiguityState(
+    const IonosphereFreeObs& observation,
+    const IonosphereFreeObs::AdditionalFrequencyObs& frequency) {
+    const auto key = std::make_pair(observation.satellite, frequency.signal);
+    const auto existing = filter_state_.additional_ambiguity_indices.find(key);
+    auto& lifecycle =
+        ambiguity_states_[observation.satellite].frequency_lifecycle[frequency.signal];
+    if (existing != filter_state_.additional_ambiguity_indices.end()) {
+        if (lifecycle.state_index != existing->second) {
+            const double ion = observation.has_iono_init ? observation.iono_init_m : 0.0;
+            filter_state_.state(existing->second) =
+                algorithms::ppp_multifrequency::ambiguitySeedMeters(
+                    frequency.carrier_phase, frequency.pseudorange, ion,
+                    observation.freq_l1, frequency.frequency);
+            filter_state_.covariance.row(existing->second).setZero();
+            filter_state_.covariance.col(existing->second).setZero();
+            filter_state_.covariance(existing->second, existing->second) =
+                60.0 * 60.0;
+        }
+        lifecycle.float_value_m = filter_state_.state(existing->second);
+        lifecycle.wavelength_m = frequency.wavelength;
+        lifecycle.state_index = existing->second;
+        return existing->second;
+    }
+    const int index = filter_state_.total_states++;
+    filter_state_.state.conservativeResize(filter_state_.total_states);
+    filter_state_.covariance.conservativeResize(
+        filter_state_.total_states, filter_state_.total_states);
+    filter_state_.covariance.row(index).setZero();
+    filter_state_.covariance.col(index).setZero();
+    const double ion = observation.has_iono_init ? observation.iono_init_m : 0.0;
+    filter_state_.state(index) =
+        algorithms::ppp_multifrequency::ambiguitySeedMeters(
+            frequency.carrier_phase, frequency.pseudorange, ion,
+            observation.freq_l1, frequency.frequency);
+    filter_state_.covariance(index, index) =
+        60.0 * 60.0;
+    filter_state_.additional_ambiguity_indices[key] = index;
+    lifecycle.float_value_m = filter_state_.state(index);
+    lifecycle.wavelength_m = frequency.wavelength;
+    lifecycle.state_index = index;
+    return index;
+}
+
 void PPPProcessor::pruneStaleEstStecStates(const std::set<SatelliteId>& observed) {
     if (ppp_config_.use_ionosphere_free || !ppp_config_.estimate_ionosphere ||
         ppp_config_.use_clas_osr_filter) {
@@ -1258,6 +1365,12 @@ void PPPProcessor::pruneStaleEstStecStates(const std::set<SatelliteId>& observed
         collect(filter_state_.ambiguity_indices, sat);
         collect(filter_state_.ambiguity_l2_indices, sat);
         collect(filter_state_.ionosphere_indices, sat);
+        for (const auto& [key, index] : filter_state_.additional_ambiguity_indices) {
+            if (key.first == sat && index >= filter_state_.amb_index &&
+                index < filter_state_.total_states) {
+                remove.insert(index);
+            }
+        }
     }
     const int old_n = filter_state_.total_states;
     std::vector<int> new_index(static_cast<size_t>(old_n), -1);
@@ -1305,6 +1418,32 @@ void PPPProcessor::pruneStaleEstStecStates(const std::set<SatelliteId>& observed
     reindex(filter_state_.ambiguity_indices);
     reindex(filter_state_.ambiguity_l2_indices);
     reindex(filter_state_.ionosphere_indices);
+    for (auto it = filter_state_.additional_ambiguity_indices.begin();
+         it != filter_state_.additional_ambiguity_indices.end();) {
+        const int ni = (it->second >= 0 && it->second < old_n)
+                           ? new_index[static_cast<size_t>(it->second)] : -1;
+        if (ni < 0) {
+            it = filter_state_.additional_ambiguity_indices.erase(it);
+        } else {
+            it->second = ni;
+            ++it;
+        }
+    }
+    for (auto& [key, index] : filter_state_.receiver_frequency_bias_indices) {
+        (void)key;
+        index = new_index[static_cast<size_t>(index)];
+    }
+    for (const auto& [key, index] :
+         filter_state_.additional_ambiguity_indices) {
+        auto sat_it = ambiguity_states_.find(key.first);
+        if (sat_it == ambiguity_states_.end()) {
+            continue;
+        }
+        auto lifecycle_it = sat_it->second.frequency_lifecycle.find(key.second);
+        if (lifecycle_it != sat_it->second.frequency_lifecycle.end()) {
+            lifecycle_it->second.state_index = index;
+        }
+    }
     for (const auto& sat : drop) {
         ambiguity_states_.erase(sat);
         est_stec_outage_.erase(sat);
@@ -1324,6 +1463,15 @@ void PPPProcessor::updateAmbiguityStates(const ObservationData& obs) {
             measurement.carrier_phase,
             obs.time,
             measurement.snr);
+        const auto extra_state = filter_state_.additional_ambiguity_indices.find(
+            {measurement.satellite, measurement.signal});
+        if (extra_state != filter_state_.additional_ambiguity_indices.end() &&
+            extra_state->second >= 0 &&
+            extra_state->second < filter_state_.total_states) {
+            auto& lifecycle = ambiguity.frequency_lifecycle[measurement.signal];
+            lifecycle.state_index = extra_state->second;
+            lifecycle.float_value_m = filter_state_.state(extra_state->second);
+        }
 
         // The historical satellite-level lifecycle is updated once for each of
         // the reader's primary and secondary observations. Additional bands are
@@ -1408,6 +1556,21 @@ void PPPProcessor::resetAmbiguity(const SatelliteId& satellite, SignalType signa
             filter_state_.covariance(l2_index, l2_index) =
                 precise_products_loaded_ ? 1e6 : ppp_config_.initial_ambiguity_variance;
         }
+    }
+    for (const auto& [key, index] : filter_state_.additional_ambiguity_indices) {
+        if (key.first != satellite || index < 0 ||
+            index >= filter_state_.total_states) {
+            continue;
+        }
+        filter_state_.state(index) = 0.0;
+        filter_state_.covariance.row(index).setZero();
+        filter_state_.covariance.col(index).setZero();
+        filter_state_.covariance(index, index) =
+            precise_products_loaded_ ? 1e6 : ppp_config_.initial_ambiguity_variance;
+    }
+    for (auto& [frequency, lifecycle] : ambiguity.frequency_lifecycle) {
+        (void)frequency;
+        lifecycle.state_index = -1;
     }
 }
 

--- a/src/io/madoca_l6.cpp
+++ b/src/io/madoca_l6.cpp
@@ -928,7 +928,8 @@ bool useMadocaBiasIdentityKey(libgnss::GNSSSystem system,
     }
     return system == libgnss::GNSSSystem::GPS ||
            system == libgnss::GNSSSystem::Galileo ||
-           system == libgnss::GNSSSystem::QZSS;
+           system == libgnss::GNSSSystem::QZSS ||
+           system == libgnss::GNSSSystem::BeiDou;
 }
 
 const char* gnssSystemName(libgnss::GNSSSystem system) {

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -2,6 +2,9 @@
 
 #include <libgnss++/algorithms/ppp.hpp>
 #include <libgnss++/algorithms/madoca_core.hpp>
+#include <libgnss++/algorithms/ppp_ar.hpp>
+#include <libgnss++/algorithms/ppp_bias_identity.hpp>
+#include <libgnss++/algorithms/ppp_multifrequency.hpp>
 #include <libgnss++/core/coordinates.hpp>
 #include <libgnss++/models/troposphere.hpp>
 
@@ -1948,4 +1951,93 @@ TEST(PPPTest, ConvergenceWindowReportsEcefHorizontalAndVerticalComponents) {
     EXPECT_NEAR(metrics.max_ecef_3d_m, std::sqrt(29.0), 1e-6);
     EXPECT_NEAR(metrics.max_horizontal_m, 5.0, 1e-6);
     EXPECT_NEAR(metrics.max_vertical_m, 2.0, 1e-6);
+}
+
+TEST(PPPMultifrequencyTest, UsesMadocalibFrequencyOrdinalOrder) {
+    using algorithms::ppp_multifrequency::signalsForFrequencyOrdinal;
+
+    EXPECT_EQ(signalsForFrequencyOrdinal(SatelliteId(GNSSSystem::GPS, 1), 2),
+              std::vector<SignalType>({SignalType::GPS_L5}));
+    EXPECT_EQ(signalsForFrequencyOrdinal(SatelliteId(GNSSSystem::Galileo, 1), 2),
+              std::vector<SignalType>({SignalType::GAL_E5B}));
+    EXPECT_EQ(signalsForFrequencyOrdinal(SatelliteId(GNSSSystem::Galileo, 1), 3),
+              std::vector<SignalType>({SignalType::GAL_E6}));
+    EXPECT_EQ(signalsForFrequencyOrdinal(SatelliteId(GNSSSystem::QZSS, 1), 2),
+              std::vector<SignalType>({SignalType::QZS_L2C}));
+    EXPECT_EQ(signalsForFrequencyOrdinal(SatelliteId(GNSSSystem::BeiDou, 18), 2),
+              std::vector<SignalType>({SignalType::BDS_B2I}));
+    EXPECT_EQ(signalsForFrequencyOrdinal(SatelliteId(GNSSSystem::BeiDou, 19), 2),
+              std::vector<SignalType>({SignalType::BDS_B2A}));
+    EXPECT_TRUE(signalsForFrequencyOrdinal(
+                    SatelliteId(GNSSSystem::BeiDou, 19), 3).empty());
+}
+
+TEST(PPPMultifrequencyTest, PreservesMadocalibBeiDouExactBiasIdentity) {
+    namespace identity = algorithms::ppp_bias_identity;
+    namespace parity = algorithms::madoca_parity;
+
+    EXPECT_EQ(identity::rtklibCodeForObservationType("C2I"), parity::kCodeL2I);
+    EXPECT_EQ(identity::rtklibCodeForObservationType("L2I"), parity::kCodeL2I);
+    EXPECT_EQ(identity::rtklibCodeForObservationType("C6I"), parity::kCodeL6I);
+    EXPECT_EQ(identity::rtklibCodeForObservationType("L6I"), parity::kCodeL6I);
+    EXPECT_EQ(identity::rtklibCodeForObservationType("C5P"), parity::kCodeL5P);
+    EXPECT_EQ(identity::rtklibCodeForObservationType("L5P"), parity::kCodeL5P);
+    EXPECT_EQ(identity::madocaBiasIdentityIdForObservation(
+                  GNSSSystem::BeiDou, SignalType::BDS_B1I, "C2I", true),
+              static_cast<std::uint8_t>(parity::kCodeL2I));
+}
+
+TEST(PPPMultifrequencyTest, SeparatesMadocalibBeiDouGenerationsForDoubleDifferences) {
+    const auto bds2 = ppp_ar::ambiguityDdGroup(
+        SatelliteId(GNSSSystem::BeiDou, 18));
+    const auto bds3 = ppp_ar::ambiguityDdGroup(
+        SatelliteId(GNSSSystem::BeiDou, 19));
+
+    EXPECT_NE(bds2, bds3);
+    EXPECT_EQ(ppp_ar::ambiguityDdGroup(SatelliteId(GNSSSystem::GPS, 19)),
+              std::make_pair(GNSSSystem::GPS, 0));
+    EXPECT_NE(algorithms::ppp_multifrequency::receiverFrequencyBiasKey(
+                  SatelliteId(GNSSSystem::BeiDou, 18), 2),
+              algorithms::ppp_multifrequency::receiverFrequencyBiasKey(
+                  SatelliteId(GNSSSystem::BeiDou, 19), 2));
+}
+
+TEST(PPPMultifrequencyTest, MatchesMadocalibIonosphereAndAmbiguityEquations) {
+    using algorithms::ppp_multifrequency::ambiguitySeedMeters;
+    using algorithms::ppp_multifrequency::ionosphereScale;
+
+    constexpr double f1 = 1575.42e6;
+    constexpr double f3 = 1207.14e6;
+    constexpr double ion_l1 = 4.25;
+    constexpr double carrier_m = 20200012.5;
+    constexpr double code_m = 20200003.0;
+    const double expected_scale = (f1 / f3) * (f1 / f3);
+
+    EXPECT_NEAR(ionosphereScale(f1, f3), expected_scale, 1e-15);
+    EXPECT_NEAR(ambiguitySeedMeters(carrier_m, code_m, ion_l1, f1, f3),
+                carrier_m - code_m + 2.0 * ion_l1 * expected_scale,
+                1e-12);
+    EXPECT_EQ(ionosphereScale(0.0, f3), 0.0);
+}
+
+TEST(PPPMultifrequencyTest, MatchesMadocalibExtraWideLaneDoubleDifference) {
+    using algorithms::ppp_multifrequency::extraWideLaneDoubleDifferenceCycles;
+
+    constexpr double lambda2 = 0.2442102134;
+    constexpr double lambda3 = 0.2548280488;
+    constexpr double ref_n2_cycles = 120.25;
+    constexpr double ref_n3_cycles = 80.10;
+    constexpr double sat_n2_cycles = 105.05;
+    constexpr double sat_n3_cycles = 65.02;
+    const double value = extraWideLaneDoubleDifferenceCycles(
+        ref_n2_cycles * lambda2, lambda2,
+        ref_n3_cycles * lambda3, lambda3,
+        sat_n2_cycles * lambda2, lambda2,
+        sat_n3_cycles * lambda3, lambda3);
+
+    EXPECT_NEAR(value,
+                (ref_n2_cycles - ref_n3_cycles) -
+                    (sat_n2_cycles - sat_n3_cycles),
+                1e-12);
+    EXPECT_NEAR(value, 0.12, 1e-12);
 }


### PR DESCRIPTION
## What changed

- form MADOCALIB L3/L4 observations and add code/phase measurement rows
- add per-signal ambiguity and receiver I3/I4 bias states, including lifecycle/pruning
- port EWL-before-WL conditioning and MADOCALIB constraint variances
- preserve exact MADOCA bias identities and support BDS2/BDS3 signal/state/DD groups
- apply the pinned 15° AR elevation mask and final fixed covariance admission gate
- add focused multifrequency/BDS/equation tests

## Why

Issue #148 M2 still lacked the MADOCALIB 2.0 triple/quad-frequency state model. BDS was also blanket-disabled, and collapsed bias IDs could not represent BDS3 B2a.

## Validation

- Release gnss_lib and gnss_ppp build
- run_tests --gtest_filter=PPPMultifrequencyTest.* (5 passed)
- run_tests --gtest_filter=PPP* (104 passed)
- pinned MIZU 120-epoch run: 118 valid, 30 Fix, 88 Float
- 118/118 epochs aligned with MADOCALIB; zero native Fix outside oracle Fix epochs

## Remaining M2 gap

This is an incremental Issue #148 slice, not M2 completion. Oracle has 108 Fix while native has 30, and the 3D trajectory delta RMS is 10.923 m. The next slice will target pre-N1 float ambiguity/covariance parity.

Refs #148