### PR TITLE
Fix MADOCA bias identity parity expectation

### DIFF
--- a/tests/test_madoca_parity.cpp
+++ b/tests/test_madoca_parity.cpp
@@ -661,18 +661,25 @@ TEST_F(MadocaParity, L6eSnapshotConvertsToSsrProducts) {
             EXPECT_DOUBLE_EQ(corr.clock_correction_m, c.dclk[0]);
             ++clock_checks;
         }
-        // Group decoded code biases by target RTCM id, mirroring the converter's
-        // ascending-code last-wins. Most ids have a single source code (exact
-        // value check); a few RTCM ids are coarser than MADOCA tracking codes
-        // (e.g. GPS L5I/L5Q/L5X all map to id 22), so the stored value must be
-        // one of the candidates.
+        // Mirror the converter's effective key policy. Coherent MADOCA keeps
+        // the original tracking-code identity for constellations that need
+        // distinct code/phase biases (notably BDS-3 B2a). The compatibility
+        // path and GLONASS still collapse codes onto RTCM SSR signal ids, where
+        // ascending-code last-wins and the stored value must be one candidate.
+        const bool preserve_bias_identity =
+            decoder.envOverrides().madoca_bias_identity &&
+            (gsys == libgnss::GNSSSystem::GPS ||
+             gsys == libgnss::GNSSSystem::Galileo ||
+             gsys == libgnss::GNSSSystem::QZSS ||
+             gsys == libgnss::GNSSSystem::BeiDou);
         std::map<std::uint8_t, std::vector<double>> expected;
         for (int k = 0; k < libgnss::io::MadocaSsrCorrection::kMaxCode; ++k) {
             if (!c.vcbias[k]) {
                 continue;
             }
-            const std::uint8_t rid =
-                libgnss::io::madocaBiasCodeToRtcmSsrId(gsys, k + 1);
+            const std::uint8_t rid = preserve_bias_identity
+                ? static_cast<std::uint8_t>(k + 1)
+                : libgnss::io::madocaBiasCodeToRtcmSsrId(gsys, k + 1);
             if (rid != 0) {
                 expected[rid].push_back(c.cbias[k]);
             }


### PR DESCRIPTION
## What changed

- make the L6E snapshot parity test follow the decoder's effective bias-key policy
- expect exact MADOCA tracking-code identities for GPS, Galileo, QZSS, and BeiDou when enabled
- retain the collapsed RTCM SSR ID expectation for the compatibility path and GLONASS

## Root cause

PR #313 made exact MADOCA bias identity the default so BDS-3 B2a remains distinct. The structural parity test still expected every decoded bias to collapse onto an RTCM band ID, producing six actual keys versus four expected keys.

## Validation

- `git diff --cached --check` passed before commit
- source diff is limited to `tests/test_madoca_parity.cpp`
- local MADOCALIB parity build was attempted, but the Windows build did not complete; Linux `madoca-parity` CI is the authoritative gate
- the regular Windows build reached an unrelated existing MSVC C1061 limit in `apps/gnss_solve.cpp`

Fixes the merge-follow-up CI failure from #313.
Refs #148
