### PR TITLE
Align MADOCA materialization bias contract

### DIFF
--- a/scripts/ci/run_madoca_materialization_selfdiff.py
+++ b/scripts/ci/run_madoca_materialization_selfdiff.py
@@ -26,7 +26,25 @@ DEFAULT_MADOCALIB_REPO = "https://github.com/QZSS-Strategy-Office/madocalib.git"
 DEFAULT_MADOCALIB_REF = "0089f7dc97e8e2ba283a40be2edf4b73a140df6c"
 DEFAULT_MIN_ROWS = 1000
 DEFAULT_REQUIRED_SYSTEMS = ("GPS", "GLONASS", "Galileo", "QZSS", "BeiDou")
-DEFAULT_REQUIRED_BIAS_IDS = ("2", "8", "9", "14", "22")
+# Exact MADOCA tracking-code identities present in the pinned public sample:
+# GPS 1/12/18/20/25/26, Galileo 12/26/29/31, QZSS 1/12/18/26,
+# BeiDou 26/27/40/42/58, plus GLONASS compatibility ids 2/8.
+DEFAULT_REQUIRED_BIAS_IDS = (
+    "1",
+    "2",
+    "8",
+    "12",
+    "18",
+    "20",
+    "25",
+    "26",
+    "27",
+    "29",
+    "31",
+    "40",
+    "42",
+    "58",
+)
 REQUIRED_DATA_FILES = (
     "sample_data/data/rinex/BRDM00DLR_S_20250910000_01D_MN.rnx",
     "sample_data/data/l6/2025/091/2025091A.204.l6",

--- a/tests/test_madoca_materialization_selfdiff.py
+++ b/tests/test_madoca_materialization_selfdiff.py
@@ -36,6 +36,25 @@ class MadocaMaterializationSelfdiffTest(unittest.TestCase):
             self.assertEqual(config.madocalib_ref, selfdiff.DEFAULT_MADOCALIB_REF)
             self.assertEqual(config.min_rows, selfdiff.DEFAULT_MIN_ROWS)
             self.assertEqual(config.required_systems, selfdiff.DEFAULT_REQUIRED_SYSTEMS)
+            self.assertEqual(
+                selfdiff.DEFAULT_REQUIRED_BIAS_IDS,
+                (
+                    "1",
+                    "2",
+                    "8",
+                    "12",
+                    "18",
+                    "20",
+                    "25",
+                    "26",
+                    "27",
+                    "29",
+                    "31",
+                    "40",
+                    "42",
+                    "58",
+                ),
+            )
             self.assertEqual(config.required_code_bias_ids, selfdiff.DEFAULT_REQUIRED_BIAS_IDS)
             self.assertEqual(config.required_phase_bias_ids, selfdiff.DEFAULT_REQUIRED_BIAS_IDS)
 
@@ -120,8 +139,12 @@ class MadocaMaterializationSelfdiffTest(unittest.TestCase):
                     "systems": {"GPS": 2, "GLONASS": 1, "Galileo": 1, "QZSS": 1, "BeiDou": 1},
                     "row_key": {"groups": 2, "duplicate_groups": 0, "max_duplicate_occurrences": 1},
                     "bias_identity": {
-                        "code_bias_ids": {"2": 2, "8": 1, "9": 1, "14": 1, "22": 1},
-                        "phase_bias_ids": {"2": 2, "8": 1, "9": 1, "14": 1, "22": 1},
+                        "code_bias_ids": {
+                            signal_id: 1 for signal_id in selfdiff.DEFAULT_REQUIRED_BIAS_IDS
+                        },
+                        "phase_bias_ids": {
+                            signal_id: 1 for signal_id in selfdiff.DEFAULT_REQUIRED_BIAS_IDS
+                        },
                     },
                 },
                 selfdiff_report={


### PR DESCRIPTION
## What changed

- replace the legacy collapsed RTCM bias-ID defaults with the exact MADOCA identities present in the pinned public sample
- document the per-constellation identity coverage, including BDS-3 B2a and GLONASS compatibility IDs
- pin the default contract in unit tests and derive the passing fixture from the shared constant

## Root cause

PR #313 made exact MADOCA bias identity the default. The optional materialization self-diff still required collapsed IDs 9, 14, and 22, so it failed even though the dump correctly preserved exact identities.

## Validation

- 12 related Python unit tests passed
- both changed Python files passed bytecode compilation
- `git diff --cached --check` passed before commit
- the PR #314 artifact was revalidated with the new contract: 64,693 rows, 97 satellites, five constellations, zero duplicate groups, zero failures
- code and phase coverage includes IDs 1, 2, 8, 12, 18, 20, 25, 26, 27, 29, 31, 40, 42, and 58

Fixes the optional-signoff follow-up failure from #314.
Refs #148
