### PR TITLE
Fix MADOCA float covariance overconfidence

### DIFF
--- a/docs/madocalib_native_migration.md
+++ b/docs/madocalib_native_migration.md
@@ -192,6 +192,28 @@ wide-lane-only attempts, exposing a remaining platform/state-trajectory delta
 for M2b.  A dedicated parity CI gate rejects any published Fix on every valid
 row while no complete N1 fix exists, independently of that row-count delta.
 
+#### M2b -- One covariance update per MADOCA epoch
+
+The pinned MADOCALIB `pppos()` loop copies `rtk->x` and `rtk->P` into its
+temporary state before every residual-screening pass and commits the first
+accepted result.  It therefore applies an epoch's measurement covariance
+update once.  Native previously fed the already-updated covariance into as
+many as eight relinearization iterations, repeatedly consuming the same rows
+and becoming overconfident before ambiguity resolution.
+
+The opt-in `GNSS_PPP_PFDUMP` trace now reports the position covariance norm at
+the pre-EWL, post-EWL, and post-WL boundaries with GPS week/TOW.  At 00:03:00
+the native post-WL norm changes from 0.962 m to 2.281 m, versus 2.49 m in the
+MADOCALIB trace.  At 00:03:30 it changes from 0.742 m to 1.812 m, versus
+2.28 m.  Remaining float-state differences are tracked separately; this slice
+only removes the proven repeated-update mismatch.
+
+On the pinned 120-input-epoch MIZU probe, all 118 solution epochs remain
+aligned.  Native produces 31 complete fixes, all inside MADOCALIB fixed epochs,
+and no wrong fix.  The full-window native/oracle 3D delta RMS improves from
+10.923 m to 4.391 m; the final 30-minute RMS is 1.046 m.  The M2 exit criteria
+are not yet met.
+
 ### M3 -- Apply L6D ionosphere products
 
 - Promote the proven snapshot lookup from shadow telemetry to an explicit

--- a/src/algorithms/ppp_ambiguity.cpp
+++ b/src/algorithms/ppp_ambiguity.cpp
@@ -379,6 +379,26 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
     ar_stage_telemetry_.last_n1_candidates = 0;
     ar_stage_telemetry_.last_n1_ratio = 0.0;
 
+    const auto dump_position_covariance = [&](const char* stage) {
+        if (!env_overrides_.pfdump) {
+            return;
+        }
+        double variance_sum = 0.0;
+        for (int axis = 0; axis < 3; ++axis) {
+            variance_sum += std::max(
+                0.0,
+                filter_state_.covariance(
+                    filter_state_.pos_index + axis,
+                    filter_state_.pos_index + axis));
+        }
+        std::cerr << "[PFCOV] week=" << obs.time.week
+                  << " tow=" << obs.time.tow
+                  << " stage=" << stage
+                  << " pos_std_norm=" << std::sqrt(variance_sum)
+                  << "\n";
+    };
+    dump_position_covariance("pre_ewl");
+
     // Restrict AR to satellites observed this epoch (the persistent ambiguity
     // map accumulates set satellites whose stale states must not enter the DD).
     std::set<SatelliteId> observed_now;
@@ -681,6 +701,7 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
         filter_state_.covariance = 0.5 *
             (filter_state_.covariance + filter_state_.covariance.transpose());
     }
+    dump_position_covariance("post_ewl");
 
     auto wl_cycles = [&](const Cand& c) {
         return x(c.l1_index) / c.lambda1 - x(c.l2_index) / c.lambda2;
@@ -781,6 +802,7 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
     filter_state_.covariance -= Kwl * HPwl;
     filter_state_.covariance =
         0.5 * (filter_state_.covariance + filter_state_.covariance.transpose());
+    dump_position_covariance("post_wl");
 
     // MADOCALIB snapshots the WL-conditioned float state before N1 and
     // restores it when the final fixed-position covariance gate rejects.

--- a/src/algorithms/ppp_internal.hpp
+++ b/src/algorithms/ppp_internal.hpp
@@ -14,6 +14,15 @@ namespace libgnss::ppp_internal {
 
 inline constexpr double kDefaultZenithDelayMeters = 2.3;
 
+inline int filterIterationCount(bool madoca_per_frequency_update,
+                                bool precise_products_loaded,
+                                int configured_iterations) {
+    if (madoca_per_frequency_update) {
+        return 1;
+    }
+    return precise_products_loaded ? 3 : configured_iterations;
+}
+
 inline std::string trimCopy(const std::string& text) {
     const auto is_not_space = [](unsigned char ch) {
         return !std::isspace(ch);

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -568,7 +568,17 @@ bool PPPProcessor::updateFilter(const ObservationData& obs, const NavigationData
         return false;
     }
 
-    const int filter_iterations = precise_products_loaded_ ? 3 : ppp_config_.filter_iterations;
+    // MADOCALIB restarts each residual-screening pass from rtk->x/rtk->P and
+    // commits one measurement update per epoch. Re-applying the same epoch's
+    // rows to the already-updated covariance makes the native uncombined
+    // MADOCA filter overconfident before PPP-AR (ppp.c:1359-1378).
+    const bool madoca_per_frequency_update =
+        require_coherent_ssr_ && ssr_products_loaded_ &&
+        !ppp_config_.use_ionosphere_free && ppp_config_.estimate_ionosphere;
+    const int filter_iterations = filterIterationCount(
+        madoca_per_frequency_update,
+        precise_products_loaded_,
+        ppp_config_.filter_iterations);
     const PPPState pre_update_state = filter_state_;
     const bool madoca_static_spike_guard =
         require_coherent_ssr_ && ssr_products_loaded_ &&

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -8,6 +8,8 @@
 #include <libgnss++/core/coordinates.hpp>
 #include <libgnss++/models/troposphere.hpp>
 
+#include "../src/algorithms/ppp_internal.hpp"
+
 #include <chrono>
 #include <cmath>
 #include <ctime>
@@ -22,6 +24,12 @@
 using namespace libgnss;
 
 namespace {
+
+TEST(PPPFilterIterations, MadocaPerFrequencyCommitsOneUpdatePerEpoch) {
+    EXPECT_EQ(ppp_internal::filterIterationCount(true, false, 8), 1);
+    EXPECT_EQ(ppp_internal::filterIterationCount(false, true, 8), 3);
+    EXPECT_EQ(ppp_internal::filterIterationCount(false, false, 8), 8);
+}
 
 GNSSTime makeTime(int year, int month, int day, int hour, int minute, double second) {
     std::tm epoch_tm{};


### PR DESCRIPTION
## What changed

- commit one measurement covariance update per epoch on the coherent MADOCA per-frequency path
- retain the existing iteration policy for precise-product and other PPP paths
- add opt-in pre-EWL, post-EWL, and post-WL position covariance diagnostics with epoch identity
- document the MADOCALIB source contract and the pinned 120-epoch evidence

## Root cause

MADOCALIB restarts every residual-screening pass from the epoch's prior state and covariance, then commits one accepted measurement update. Native instead fed the already-updated covariance into as many as eight relinearization passes, repeatedly consuming the same observation rows and becoming overconfident before ambiguity resolution.

## Evidence

- 118/118 MIZU solution epochs remain aligned
- native fixes: 31, all within MADOCALIB fixed epochs; wrong fixes: 0
- full-window native/oracle 3D delta RMS: 10.923 m -> 4.391 m
- final 30-minute 3D delta RMS: 1.046 m
- 00:03:00 post-WL position covariance norm: 0.962 m -> 2.281 m, MADOCALIB 2.49 m

## Validation

- `run_tests.exe --gtest_filter=PPP* --gtest_brief=1` (105 passed)
- focused 120-input-epoch MIZU native/oracle probe
- `git diff --check`

Part of #148 (M2b). The M2 exit criteria are not yet met.
