### PR TITLE
Align MADOCA measurement variance

### DIFF
--- a/docs/madocalib_native_migration.md
+++ b/docs/madocalib_native_migration.md
@@ -214,6 +214,30 @@ and no wrong fix.  The full-window native/oracle 3D delta RMS improves from
 10.923 m to 4.391 m; the final 30-minute RMS is 1.046 m.  The M2 exit criteria
 are not yet met.
 
+#### M2c -- Measurement variance parity
+
+The coherent MADOCA CLI already applies MADOCALIB's 300:1 code-to-phase error
+ratio.  The per-frequency filter then multiplied the resulting code variance by
+the legacy diagnostic default of 9.0, making code sigma exactly three times the
+oracle value.  That scale now defaults to 1.0 and remains available only as an
+explicit diagnostic override.
+
+Two other variance terms were missing.  MADOCALIB adds `0.01^2 m^2` estimated-
+troposphere model variance to every code and phase row and adds 0.1 times the
+SSR URA variance.  Native now applies both terms on the coherent MADOCA path.
+The L6E decoder already retained subtype-7 URA indices, but product conversion
+dropped them; conversion now carries the DF389/MADOCALIB sigma into the SSR
+correction.  A focused unit test pins the complete URA-index mapping.
+
+At GPS week 2360, TOW 173010, native/oracle sigmas now agree at trace precision:
+G04 code/phase are 2.2719/0.0143 m, G08 are 1.8963/0.0136 m, and G16 are
+1.3174/0.0129 m.  On the pinned 120-input-epoch probe, all 118 solution epochs
+remain aligned.  Native publishes 38 complete fixes, all within the oracle's
+fixed epochs, with no wrong fix.  Full-window native/oracle 3D delta RMS improves
+from 4.391 m to 2.194 m, maximum delta falls from 14.78 m to 5.79 m, horizontal
+RMS is 1.396 m, Up RMS is 1.692 m, and final-30-minute RMS is 1.091 m.  M2 remains
+open because status agreement and fixed-position thresholds are not yet met.
+
 ### M3 -- Apply L6D ionosphere products
 
 - Promote the proven snapshot lookup from shadow telemetry to an explicit
@@ -282,14 +306,8 @@ remains open.
 
 ## Immediate Slice
 
-M1 begins with a measurement correction, not a threshold increase:
-
-1. compute ECEF deltas from the convergence-window mean;
-2. rotate them to local ENU at the mean position;
-3. track maximum horizontal norm and maximum absolute Up separately;
-4. preserve the legacy 3D metric for compatibility telemetry;
-5. add a typed kinematic convergence policy and focused unit tests; and
-6. rerun the pinned 118-epoch native/oracle case before selecting thresholds.
-
-This prevents the current mislabeled metric from turning a parameter sweep into
-an accidental change of meaning.
+Continue M2 from the now-matched measurement variance surface.  Compare the
+remaining float-state initialization/process-noise and ambiguity candidate-row
+differences before changing admission thresholds.  Preserve the two hard
+guards established so far: never publish a wide-lane-only result as Fix, and
+never publish a native Fix outside an oracle Fix epoch.

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -113,9 +113,9 @@ struct PPPEnvOverrides {
     // GNSS_PPP_TIDE_ITRS_SUN_MOON: rotate sun/moon vectors to ITRS before IERS
     // solid tide when present. Default false.
     bool tide_itrs_sun_moon = false;
-    // GNSS_PPP_PF_CODE_VAR_SCALE: per-frequency code variance scale.
-    // Default 9.0.
-    double pf_code_var_scale = 9.0;
+    // GNSS_PPP_PF_CODE_VAR_SCALE: diagnostic per-frequency code variance
+    // scale applied after the RTKLIB error-ratio model. Default 1.0.
+    double pf_code_var_scale = 1.0;
     // GNSS_PPP_PF_RX_ANTENNA: enable per-frequency receiver antenna correction
     // when present. Default false.
     bool pf_rx_antenna = false;

--- a/include/libgnss++/io/madoca_l6.hpp
+++ b/include/libgnss++/io/madoca_l6.hpp
@@ -138,6 +138,10 @@ std::uint8_t madocaBiasCodeToRtcmSsrId(libgnss::GNSSSystem system, int code);
 int madocaL6eSnapshotToProducts(const MadocaL6eDecoder& decoder,
                                 libgnss::SSRProducts& products);
 
+// Compact SSR DF389 URA indicator to one-sigma accuracy in meters. Matches
+// MADOCALIB var_urassr() before its configured variance ratio is applied.
+double madocaSsrUraSigmaMeters(int ura_index);
+
 // Decode one or more MADOCA L6E files into a time series of SSR products,
 // driving the decoder byte-for-byte and snapshotting each satellite whenever
 // its orbit or clock correction epoch advances. gps_week seeds the decoder's

--- a/src/algorithms/ppp_corrections.cpp
+++ b/src/algorithms/ppp_corrections.cpp
@@ -1211,7 +1211,12 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                     }
                 }
                 if (ura_sigma_m > 0.0 && std::isfinite(ura_sigma_m)) {
-                    const double ura_variance = ura_sigma_m * ura_sigma_m;
+                    // sample_pppar.conf uses stats-uraratio=0.1, and
+                    // MADOCALIB applies that ratio to var_urassr() in ppp_res.
+                    const double ura_variance_ratio =
+                        require_coherent_ssr_ ? 0.1 : 1.0;
+                    const double ura_variance =
+                        ura_variance_ratio * ura_sigma_m * ura_sigma_m;
                     deferred_variance_pr += ura_variance;
                     deferred_variance_cp += ura_variance;
                 }
@@ -1476,14 +1481,22 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
             observation.variance_pr = measurementVariance(observation, false);
             observation.variance_cp = measurementVariance(observation, true);
         }
+        // MADOCALIB trop_model_prec() contributes a 1 cm model sigma to every
+        // code and phase row while ZTD is estimated (ppp.c:982-1003, 1176-1178).
+        // Omitting it makes the native per-frequency covariance overconfident.
+        if (require_coherent_ssr_ &&
+            !ppp_config_.use_ionosphere_free &&
+            ppp_config_.estimate_ionosphere &&
+            ppp_config_.estimate_troposphere) {
+            constexpr double kMadocalibEstimatedTropVarianceM2 = 0.01 * 0.01;
+            deferred_variance_pr += kMadocalibEstimatedTropVarianceM2;
+            deferred_variance_cp += kMadocalibEstimatedTropVarianceM2;
+        }
         observation.variance_pr = safeVariance(observation.variance_pr + deferred_variance_pr, 1e-6);
         observation.variance_cp = safeVariance(observation.variance_cp + deferred_variance_cp, 1e-8);
-        // Per-frequency (est-stec) code de-weighting: the uncombined L1/L2 code
-        // carries a systematic (multipath / residual code-bias) error that, when
-        // trusted as tightly as the elevation model implies, biases the converged
-        // position (observed E+0.37 m at MIZU). The IFLC path implicitly de-weights
-        // code via the 3x ionosphere-free noise amplification; mirror that here so
-        // phase drives the converged solution. Env-overridable for tuning.
+        // Optional diagnostic scaling after the RTKLIB code/phase ratio. The
+        // coherent MADOCA CLI already selects the oracle's ratio=300, so the
+        // default scale must remain one rather than de-weighting code twice.
         if (!ppp_config_.use_ionosphere_free && ppp_config_.estimate_ionosphere &&
             !ppp_config_.use_clas_osr_filter) {
             observation.variance_pr *= env_overrides_.pf_code_var_scale;

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -166,7 +166,7 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
     overrides.ssr_discnt_slip = envPresent("GNSS_PPP_SSR_DISCNT_SLIP");
     overrides.no_solid_tide = envPresent("GNSS_PPP_NO_SOLID_TIDE");
     overrides.tide_itrs_sun_moon = envPresent("GNSS_PPP_TIDE_ITRS_SUN_MOON");
-    overrides.pf_code_var_scale = envDoubleOr("GNSS_PPP_PF_CODE_VAR_SCALE", 9.0);
+    overrides.pf_code_var_scale = envDoubleOr("GNSS_PPP_PF_CODE_VAR_SCALE", 1.0);
     overrides.pf_rx_antenna = envPresent("GNSS_PPP_PF_RX_ANTENNA");
     overrides.pf_wet_trop = envPresent("GNSS_PPP_PF_WET_TROP");
 

--- a/src/io/madoca_l6.cpp
+++ b/src/io/madoca_l6.cpp
@@ -730,6 +730,19 @@ libgnss::GNSSSystem mpSysToGnss(int mpsys) {
 
 }  // namespace
 
+double madocaSsrUraSigmaMeters(int ura_index) {
+    if (ura_index <= 0) {
+        return 0.15;
+    }
+    if (ura_index >= 63) {
+        return 5.4665;
+    }
+    return (std::pow(3.0, static_cast<double>((ura_index >> 3) & 0x07)) *
+                (1.0 + static_cast<double>(ura_index & 0x07) / 4.0) -
+            1.0) *
+           1e-3;
+}
+
 // Build one native SSR correction from a satellite's decoded Compact SSR state.
 // Returns false when the satellite carries no orbit/clock or maps to no system.
 // The sample is time-stamped at the most recent of the orbit/clock t0 so a live
@@ -817,6 +830,10 @@ bool buildMadocaSsrCorrection(int sat, const MadocaSsrCorrection& c,
         int clock_week = 0;
         const double clock_tow = time2gpst(c.t0[1], &clock_week);
         out.clock_reference_time = libgnss::GNSSTime(clock_week, clock_tow);
+    }
+    if (c.t0[3].time != 0) {
+        out.ura_sigma_m = madocaSsrUraSigmaMeters(c.ura);
+        out.ura_valid = true;
     }
 
     for (int k = 0; k < MadocaSsrCorrection::kMaxCode; ++k) {

--- a/tests/test_madoca_parity.cpp
+++ b/tests/test_madoca_parity.cpp
@@ -628,7 +628,7 @@ TEST_F(MadocaParity, L6eSnapshotConvertsToSsrProducts) {
             default: return libgnss::GNSSSystem::UNKNOWN;
         }
     };
-    int orbit_checks = 0, clock_checks = 0, bias_checks = 0;
+    int orbit_checks = 0, clock_checks = 0, ura_checks = 0, bias_checks = 0;
     for (int sat = 1; sat <= libgnss::io::MadocaL6eDecoder::kMaxSat; ++sat) {
         const auto& c = decoder.correction(sat);
         if (c.t0[0].time == 0 && c.t0[1].time == 0) {
@@ -660,6 +660,13 @@ TEST_F(MadocaParity, L6eSnapshotConvertsToSsrProducts) {
             EXPECT_TRUE(corr.clock_valid);
             EXPECT_DOUBLE_EQ(corr.clock_correction_m, c.dclk[0]);
             ++clock_checks;
+        }
+        if (c.t0[3].time != 0) {
+            EXPECT_TRUE(corr.ura_valid);
+            EXPECT_DOUBLE_EQ(
+                corr.ura_sigma_m,
+                libgnss::io::madocaSsrUraSigmaMeters(c.ura));
+            ++ura_checks;
         }
         // Mirror the converter's effective key policy. Coherent MADOCA keeps
         // the original tracking-code identity for constellations that need
@@ -702,6 +709,7 @@ TEST_F(MadocaParity, L6eSnapshotConvertsToSsrProducts) {
     }
     EXPECT_GT(orbit_checks, 0) << "no orbit corrections converted";
     EXPECT_GT(clock_checks, 0) << "no clock corrections converted";
+    EXPECT_GT(ura_checks, 0) << "no URA corrections converted";
     EXPECT_GT(bias_checks, 0) << "no code biases converted";
 }
 
@@ -734,6 +742,13 @@ TEST(MadocaParityDefault, OracleDisabledInDefaultBuild) {
 }
 
 #endif
+
+TEST(MadocaL6eUra, MatchesMadocalibDf389Sigma) {
+    EXPECT_DOUBLE_EQ(libgnss::io::madocaSsrUraSigmaMeters(0), 0.15);
+    EXPECT_DOUBLE_EQ(libgnss::io::madocaSsrUraSigmaMeters(1), 0.00025);
+    EXPECT_DOUBLE_EQ(libgnss::io::madocaSsrUraSigmaMeters(5), 0.00125);
+    EXPECT_DOUBLE_EQ(libgnss::io::madocaSsrUraSigmaMeters(63), 5.4665);
+}
 
 // Pure mapping check (no oracle / no sample): MADOCA Compact SSR bias codes
 // (RTKLIB CODE_* values) must re-key to the RTCM SSR signal ids that the PPP


### PR DESCRIPTION
## What changed

- removed the duplicate default code-variance scaling after the MADOCA 300:1 code/phase ratio
- added MADOCALIB's estimated-troposphere model variance and 0.1 SSR URA variance ratio
- propagated L6E subtype-7 URA through native SSR product conversion using the DF389 mapping
- added focused URA conversion/parity coverage and recorded M2c evidence in the migration ledger

## Why

The native per-frequency filter used code sigma three times larger than MADOCALIB, omitted its 1 cm estimated-troposphere model sigma, and discarded decoded URA during product conversion. These differences changed the filter covariance and ambiguity trajectory.

## Impact

At GPS week 2360/TOW 173010, representative native code/phase sigmas now match the oracle trace to four decimal places. On the pinned 120-input-epoch MIZU probe, all 118 solution epochs remain aligned, all 38 native Fix epochs are inside oracle Fix epochs, and full-window 3D RMS delta improves from 4.391 m to 2.194 m (maximum 14.78 m to 5.79 m). M2 remains open.

Closes no issue; advances #148 M2.

## Validation

- `run_tests.exe --gtest_filter=MadocaL6eUra.*:PPP* --gtest_brief=1` — 106 passed
- pinned MIZU 120-epoch native/oracle variance and trajectory probe
- `git diff --check`
