### PR TITLE
Align MADOCA first-epoch phase admission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -607,6 +607,7 @@ jobs:
           grep -q '"ar_method": "per-freq"' native_pppar_smoke.json
           grep -q '"estimate_ionosphere": true' native_pppar_smoke.json
           grep -q '"use_ionosphere_free": false' native_pppar_smoke.json
+          grep -q '"phase_measurement_min_lock_count": 0' native_pppar_smoke.json
           grep -q '"convergence_gate_reason":' native_pppar_smoke.json
           grep -q '"convergence_max_position_deviation_m":' native_pppar_smoke.json
           grep -q '"convergence_max_horizontal_position_deviation_m":' native_pppar_smoke.json

--- a/apps/gnss_ppp.cpp
+++ b/apps/gnss_ppp.cpp
@@ -957,6 +957,14 @@ int main(int argc, char* argv[]) {
             ppp_config.code_phase_error_ratio_l1 = 300.0;
             ppp_config.code_phase_error_ratio_l2 = 300.0;
         }
+        if (!options.madoca_l6_paths.empty() && per_frequency_ar) {
+            // MADOCALIB initializes each per-frequency ambiguity immediately
+            // before ppp_res() and admits that epoch's carrier-phase row.  The
+            // shared native default waits for one completed lifecycle update,
+            // making the first usable MADOCA epoch code-only and shifting the
+            // float-state trajectory by one epoch.
+            ppp_config.phase_measurement_min_lock_count = 0;
+        }
         ppp_config.enable_ambiguity_resolution = options.enable_ar;
         ppp_config.convergence_min_epochs = options.convergence_min_epochs;
         ppp_config.convergence_policy =
@@ -1308,6 +1316,8 @@ int main(int argc, char* argv[]) {
                     << (ppp_config.estimate_ionosphere ? "true" : "false") << ",\n"
                     << "  \"use_ionosphere_free\": "
                     << (ppp_config.use_ionosphere_free ? "true" : "false") << ",\n"
+                    << "  \"phase_measurement_min_lock_count\": "
+                    << ppp_config.phase_measurement_min_lock_count << ",\n"
                     << "  \"ar_ratio_threshold\": " << options.ar_ratio_threshold << ",\n"
                     << "  \"processed_epochs\": " << processed_epochs << ",\n"
                     << "  \"valid_solutions\": " << valid_solutions << ",\n"

--- a/docs/madocalib_native_migration.md
+++ b/docs/madocalib_native_migration.md
@@ -238,6 +238,24 @@ from 4.391 m to 2.194 m, maximum delta falls from 14.78 m to 5.79 m, horizontal
 RMS is 1.396 m, Up RMS is 1.692 m, and final-30-minute RMS is 1.091 m.  M2 remains
 open because status agreement and fixed-position thresholds are not yet met.
 
+#### M2d -- First-epoch carrier-phase admission
+
+MADOCALIB initializes each per-frequency ambiguity before `ppp_res()` and uses
+the corresponding carrier-phase row in that same epoch.  Native previously
+required one completed ambiguity-lifecycle update, so its first usable MADOCA
+epoch contained 31 code rows and no phase rows.  Coherent MADOCA per-frequency
+mode now uses a zero minimum lock count while the shared non-MADOCA default
+remains one.
+
+On the pinned MIZU probe, the first native equation grows to 72 code and 68
+phase rows and its first-epoch native/oracle 3D delta falls from 1.320 m to
+0.770 m.  Across all 118 aligned solution epochs, native produces 47 complete
+fixes, all inside oracle Fix epochs, with no wrong Fix.  Full-window 3D delta
+RMS is 2.358 m, maximum is 5.907 m, and final-30-minute RMS is 1.125 m.  The
+full-window RMS is higher than M2c's 2.194 m, so this row-contract correction
+does not close M2; remaining native-only rows and state priors must be aligned
+before judging its combined trajectory effect.
+
 ### M3 -- Apply L6D ionosphere products
 
 - Promote the proven snapshot lookup from shadow telemetry to an explicit

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -4745,6 +4745,7 @@ class CLIToolsTest(unittest.TestCase):
             self.assertEqual(summary["ar_method"], "per-freq")
             self.assertTrue(summary["estimate_ionosphere"])
             self.assertFalse(summary["use_ionosphere_free"])
+            self.assertEqual(summary["phase_measurement_min_lock_count"], 1)
             self.assertEqual(summary["convergence_policy"], "local-enu")
             self.assertEqual(
                 summary["convergence_horizontal_position_deviation_threshold_m"],


### PR DESCRIPTION
## What changed

- admit coherent MADOCA per-frequency carrier-phase rows in the same epoch that their ambiguity states are initialized
- expose the effective phase lock gate in the CLI summary
- pin the MADOCA value to zero in the native PPP-AR CI smoke while retaining the shared non-MADOCA default of one
- record M2d evidence in the native migration ledger

## Why

MADOCALIB initializes frequency ambiguities before `ppp_res()` and consumes the corresponding phase rows immediately. Native waited for one completed ambiguity lifecycle update, making the first usable MADOCA epoch code-only and shifting the float trajectory by one epoch.

## Impact

On the pinned MIZU window, the first native equation changes from 31 code-only rows to 72 code and 68 phase rows. The first-epoch native/oracle 3D delta improves from 1.320 m to 0.770 m. Across all 118 aligned solutions, native produces 47 complete Fix epochs, all inside oracle Fix epochs, with zero wrong Fix. Full-window 3D RMS is 2.358 m, so M2 remains open while native-only rows and state priors are aligned.

Advances #148 M2; does not close the tracker.

## Validation

- 106 `MadocaL6eUra.*:PPP*` tests passed
- focused non-MADOCA CLI AR summary test passed
- pinned MIZU 10-epoch row/first-position probe
- pinned MIZU 120-epoch native/oracle solution and wrong-Fix probe
- `git diff --check`
