### PR TITLE
Align MADOCA SSR ephemeris admission

### DIFF
--- a/docs/madocalib_native_migration.md
+++ b/docs/madocalib_native_migration.md
@@ -256,6 +256,31 @@ full-window RMS is higher than M2c's 2.194 m, so this row-contract correction
 does not close M2; remaining native-only rows and state priors must be aligned
 before judging its combined trajectory effect.
 
+#### M2e -- Strict SSR broadcast-ephemeris admission
+
+MADOCALIB's `seleph()` requires the broadcast ephemeris referenced by the SSR
+orbit IODE and rejects a satellite when that record is unavailable.  Native's
+IODE-aware selector previously fell back to the nearest-age ephemeris, applying
+the SSR delta to a different broadcast orbit and admitting GPS, GLONASS, and
+BeiDou satellites before the oracle.  The selector now returns no state when
+the requested record is missing.  GPS, Galileo, QZSS, and GLONASS compare IODE
+directly; BeiDou follows MADOCALIB's Compact SSR rule,
+`toes mod 2048 == (IODE * 8) mod 2048`.
+
+On the pinned MIZU trace, native now reproduces the oracle's constellation
+admission sequence exactly: G08 appears at 00:02:00, GLONASS at 00:02:30, C28
+at 00:03:30, and the seven-satellite BeiDou set at 00:04:00.  GPS and BeiDou
+row counts also match at every checked early epoch.  The remaining row-count
+gap is isolated to six QZSS rows per epoch and four GLONASS rows after its
+admission, which are frequency-selection differences for a later slice.
+
+Across all 118 aligned solution epochs, native produces 65 complete fixes, all
+inside oracle Fix epochs, with no wrong Fix.  The full-window native/oracle 3D
+delta RMS is 0.317 m, maximum is 0.988 m, horizontal RMS is 0.213 m, Up RMS is
+0.235 m, and final-30-minute RMS is 0.299 m.  M2 remains open: 43 oracle Fix
+epochs are still native Float, status agreement remains below 95%, and the
+fixed-epoch RMS exit threshold is not yet proven.
+
 ### M3 -- Apply L6D ionosphere products
 
 - Promote the proven snapshot lookup from shadow telemetry to an explicit

--- a/include/libgnss++/core/navigation.hpp
+++ b/include/libgnss++/core/navigation.hpp
@@ -169,10 +169,11 @@ public:
     /**
      * @brief Get best ephemeris matching a desired IODE.
      *
-     * When desired_iode >= 0, prefer the ephemeris whose IODE equals it (so the
-     * broadcast orbit matches the IODE an SSR orbit correction references, as
-     * RTKLIB's ephpos(...,ssr->iode,...) does). Falls back to the nearest-age
-     * ephemeris when no IODE match exists or desired_iode < 0.
+     * When desired_iode >= 0, require the ephemeris referenced by an SSR orbit
+     * correction, as RTKLIB's ephpos(...,ssr->iode,...) does. BeiDou SSR IODE
+     * is matched against the broadcast toe modulo 2048 seconds. Returns null
+     * when no matching valid ephemeris exists. When desired_iode < 0, uses the
+     * ordinary nearest-age selection.
      */
     const Ephemeris* getEphemeris(const SatelliteId& sat, const GNSSTime& time,
                                   int desired_iode) const;
@@ -201,7 +202,7 @@ public:
                                double& clock_drift) const;
 
     /**
-     * @brief Calculate satellite state using the IODE-matched ephemeris.
+     * @brief Calculate satellite state using the strictly IODE-matched ephemeris.
      */
     bool calculateSatelliteState(const SatelliteId& sat,
                                const GNSSTime& time,

--- a/src/core/navigation.cpp
+++ b/src/core/navigation.cpp
@@ -1017,6 +1017,22 @@ inline bool galileoSkip(const SatelliteId& sat, const Ephemeris& eph,
     }
     return false;
 }
+
+// RTKLIB/MADOCALIB seleph() treats the Compact SSR BeiDou IODE as an
+// eight-second toe index rather than comparing it with the RINEX AODE field.
+// Other broadcast constellations compare the ephemeris IODE directly.
+inline bool ephemerisMatchesSsrIode(const SatelliteId& sat,
+                                    const Ephemeris& eph,
+                                    int desired_iode) {
+    if (sat.system == GNSSSystem::BeiDou) {
+        constexpr int kBeiDouIodeCycleSeconds = 2048;
+        const int toe_seconds = static_cast<int>(eph.toes);
+        const int correction_toe_seconds = desired_iode * 8;
+        return toe_seconds % kBeiDouIodeCycleSeconds ==
+               correction_toe_seconds % kBeiDouIodeCycleSeconds;
+    }
+    return static_cast<int>(eph.iode) == desired_iode;
+}
 }  // namespace
 
 const Ephemeris* NavigationData::getEphemeris(const SatelliteId& sat, const GNSSTime& time) const {
@@ -1054,17 +1070,18 @@ const Ephemeris* NavigationData::getEphemeris(const SatelliteId& sat,
     if (it == ephemeris_data.end()) {
         return nullptr;
     }
-    // Prefer a valid ephemeris whose IODE matches the SSR orbit correction's
-    // reference IODE (RTKLIB seleph() behaviour). Among matches pick the
-    // freshest (smallest age). Fall back to the nearest-age ephemeris (the
-    // IODE-agnostic selection) when nothing matches.
+    // Require a valid ephemeris whose IODE matches the SSR orbit correction's
+    // reference IODE (RTKLIB/MADOCALIB seleph() behaviour). Applying an SSR
+    // delta to a different broadcast orbit can introduce metre-level errors.
+    // Among matches pick the freshest (smallest age); do not fall back to an
+    // IODE-agnostic ephemeris when the referenced record is unavailable.
     const Ephemeris* best_match = nullptr;
     double min_age = 1e9;
     for (const auto& eph : it->second) {
         if (galileoSkip(sat, eph, time)) {
             continue;
         }
-        if (static_cast<int>(eph.iode) != desired_iode) {
+        if (!ephemerisMatchesSsrIode(sat, eph, desired_iode)) {
             continue;
         }
         if (!eph.isValid(time)) {
@@ -1076,7 +1093,7 @@ const Ephemeris* NavigationData::getEphemeris(const SatelliteId& sat,
             best_match = &eph;
         }
     }
-    return best_match != nullptr ? best_match : getEphemeris(sat, time);
+    return best_match;
 }
 
 bool NavigationData::hasMadocaGalileoEphemeris(const SatelliteId& sat,
@@ -1091,7 +1108,8 @@ bool NavigationData::hasMadocaGalileoEphemeris(const SatelliteId& sat,
     }
     constexpr int kGalInavClockBit = 1 << 9;
     for (const auto& eph : it->second) {
-        if (desired_iode >= 0 && static_cast<int>(eph.iode) != desired_iode) {
+        if (desired_iode >= 0 &&
+            !ephemerisMatchesSsrIode(sat, eph, desired_iode)) {
             continue;
         }
         if (!(eph.data_source_code & kGalInavClockBit)) {

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -31,6 +31,68 @@ TEST(PPPFilterIterations, MadocaPerFrequencyCommitsOneUpdatePerEpoch) {
     EXPECT_EQ(ppp_internal::filterIterationCount(false, false, 8), 8);
 }
 
+TEST(NavigationSsrIodeSelection, DoesNotFallBackWhenGpsIodeIsUnavailable) {
+    NavigationData navigation;
+    const SatelliteId satellite(GNSSSystem::GPS, 8);
+    const GNSSTime query_time(2300, 100000.0);
+
+    Ephemeris available;
+    available.satellite = satellite;
+    available.toe = query_time - 60.0;
+    available.toes = available.toe.tow;
+    available.iode = 17;
+    available.valid = true;
+    navigation.addEphemeris(available);
+
+    ASSERT_NE(navigation.getEphemeris(satellite, query_time), nullptr);
+    EXPECT_EQ(navigation.getEphemeris(satellite, query_time, 18), nullptr);
+}
+
+TEST(NavigationSsrIodeSelection, SelectsTheExactGpsIodeInsteadOfNearestAge) {
+    NavigationData navigation;
+    const SatelliteId satellite(GNSSSystem::GPS, 8);
+    const GNSSTime query_time(2300, 100000.0);
+
+    Ephemeris nearest;
+    nearest.satellite = satellite;
+    nearest.toe = query_time - 30.0;
+    nearest.toes = nearest.toe.tow;
+    nearest.iode = 17;
+    nearest.valid = true;
+    navigation.addEphemeris(nearest);
+
+    Ephemeris referenced = nearest;
+    referenced.toe = query_time - 120.0;
+    referenced.toes = referenced.toe.tow;
+    referenced.iode = 18;
+    navigation.addEphemeris(referenced);
+
+    const Ephemeris* selected =
+        navigation.getEphemeris(satellite, query_time, 18);
+    ASSERT_NE(selected, nullptr);
+    EXPECT_EQ(selected->iode, 18);
+}
+
+TEST(NavigationSsrIodeSelection, MatchesBeiDouIodeAgainstToeModuloCycle) {
+    NavigationData navigation;
+    const SatelliteId satellite(GNSSSystem::BeiDou, 19);
+    const GNSSTime query_time(2300, 100000.0);
+
+    Ephemeris referenced;
+    referenced.satellite = satellite;
+    referenced.toe = query_time - 60.0;
+    referenced.toes = 100000.0;
+    referenced.iode = 999;  // BeiDou AODE is not the Compact SSR IODE key.
+    referenced.valid = true;
+    navigation.addEphemeris(referenced);
+
+    constexpr int matching_iode = 212;  // 100000 mod 2048 == (212 * 8) mod 2048
+    ASSERT_NE(
+        navigation.getEphemeris(satellite, query_time, matching_iode), nullptr);
+    EXPECT_EQ(
+        navigation.getEphemeris(satellite, query_time, matching_iode + 1), nullptr);
+}
+
 GNSSTime makeTime(int year, int month, int day, int hour, int minute, double second) {
     std::tm epoch_tm{};
     epoch_tm.tm_year = year - 1900;


### PR DESCRIPTION
## What changed

- require the broadcast ephemeris referenced by an SSR orbit IODE instead of falling back to a nearest-age record
- match BeiDou Compact SSR IODE with MADOCALIB's `toes mod 2048 == (IODE * 8) mod 2048` rule
- add focused GPS and BeiDou selector regression tests
- record the M2e oracle evidence in the native migration plan

## Why

MADOCALIB `seleph()` drops a satellite until the exact SSR-referenced broadcast ephemeris is available. Native instead applied the SSR delta to another broadcast orbit and admitted GPS, GLONASS, and BeiDou satellites too early. This produced native-only rows and a large early state divergence.

## Measured impact

On the pinned 120-input-epoch MIZU sample (118 aligned solutions):

- native Fix: 65, all within oracle Fix epochs; wrong Fix: 0
- full native/oracle 3D delta RMS: 0.317 m
- maximum 3D delta: 0.988 m
- final-30-minute 3D delta RMS: 0.299 m
- early constellation admission timing now matches the oracle exactly

M2 remains open because 43 oracle Fix epochs remain native Float and QZSS/GLONASS frequency-row differences remain.

## Validation

- MSVC Release `gnss_lib_noopt`, `gnss_lib`, `gnss_run_tests`, and `gnss_ppp` builds
- `NavigationSsrIodeSelection.*`: 3/3 passed
- PPP/MADOCA/LAMBDA focused tests: 130/130 passed
- full C++ suite: 471 passed, 50 skipped (521 total)
- MADOCA CLI tests: 4/4 passed
- pinned MIZU 10-epoch postfit row trace and 120-epoch oracle diff

Tracks #148.
