### PR TITLE
Align MADOCA QZSS frequency rows

### DIFF
--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -36,7 +36,8 @@ second station (ALIC, neutral) with 1 h/6 h staying byte-exact.  The interim
 byte-identical under commit); the #144 spike guard (100 m) is kept as the
 opt-out-path safety net.  GLONASS
 phase, QZSS L5, SSR-replay, bias-identity, and pair-selection hypotheses were
-each measured and closed (default-off knobs kept where they were preview-only).
+each measured.  QZSS L5 was later promoted for M2 three-frequency row parity;
+the remaining preview-only knobs stay default-off.
 The repro harness and per-slice history live in the memory note
 `madoca-ppp-frontier` and in issue #148.
 

--- a/docs/madocalib_native_migration.md
+++ b/docs/madocalib_native_migration.md
@@ -281,6 +281,29 @@ delta RMS is 0.317 m, maximum is 0.988 m, horizontal RMS is 0.213 m, Up RMS is
 epochs are still native Float, status agreement remains below 95%, and the
 fixed-epoch RMS exit threshold is not yet proven.
 
+#### M2f -- QZSS three-frequency row parity
+
+MADOCALIB orders QZSS per-frequency observations as L1, L5, then L2.  Native
+already preserved all three RINEX bands and implemented additional-frequency
+states, corrections, and measurement rows, but selected L2 as the secondary
+frequency by default.  That made L2 ineligible for the additional slot and
+dropped L5, leaving six missing rows across J02/J03/J04 at every epoch.
+
+Coherent MADOCA now selects L5 as the secondary frequency and retains L2 as
+the additional MADOCALIB ordinal by default.  `GNSS_PPP_MADOCA_QZSS_L5=0`
+remains an opt-out.  A RINEX reader regression test pins simultaneous L1/L5/L2
+retention rather than testing L5 replacement alone.
+
+On the pinned early MIZU trace, QZSS grows from 12 to the oracle's 18 rows per
+epoch with exact L1/L5/L2 code-and-phase identities.  Across all 118 aligned
+solution epochs, native produces 61 complete fixes, all inside oracle Fix
+epochs, with no wrong Fix.  Full-window native/oracle 3D delta RMS is 0.337 m,
+maximum is 0.854 m, horizontal RMS is 0.232 m, Up RMS is 0.244 m, and the
+final-30-minute RMS is 0.309 m.  The full RMS is 0.020 m above M2e while the
+maximum improves by 0.134 m; this slice accepts the exact oracle row contract.
+GLONASS phase remains intentionally excluded until its measured FDMA residual
+drift is modelled, and M2 remains open.
+
 ### M3 -- Apply L6D ionosphere products
 
 - Promote the proven snapshot lookup from shadow telemetry to an explicit

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -71,9 +71,10 @@ struct PPPEnvOverrides {
     // GNSS_PPP_MADOCA_QZSS_PHASE: allow QZSS phase rows in coherent MADOCA.
     // Default true for MADOCALIB parity; set exactly to "0" to opt out.
     bool madoca_qzss_phase = true;
-    // GNSS_PPP_MADOCA_QZSS_L5: prefer QZSS L1/L5 over L1/L2 in coherent
-    // MADOCA when set exactly to "1". Default false while measured.
-    bool madoca_qzss_l5 = false;
+    // GNSS_PPP_MADOCA_QZSS_L5: prefer QZSS L1/L5 while retaining L2 as the
+    // additional MADOCALIB frequency in coherent MADOCA. Default true for
+    // three-frequency row parity; set exactly to "0" to opt out.
+    bool madoca_qzss_l5 = true;
     // GNSS_PPP_MADOCA_GLONASS: include GLONASS in coherent MADOCA unless set
     // exactly to "0". Default true.
     bool madoca_glonass = true;

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -150,7 +150,7 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
         !envExactOne("GNSS_PPP_DISABLE_QZSS_SSR_PRN_FIX");
     overrides.madoca_qzss_clock = !envExactZero("GNSS_PPP_MADOCA_QZSS_CLOCK");
     overrides.madoca_qzss_phase = !envExactZero("GNSS_PPP_MADOCA_QZSS_PHASE");
-    overrides.madoca_qzss_l5 = envExactOne("GNSS_PPP_MADOCA_QZSS_L5");
+    overrides.madoca_qzss_l5 = !envExactZero("GNSS_PPP_MADOCA_QZSS_L5");
     overrides.madoca_glonass = !envExactZero("GNSS_PPP_MADOCA_GLONASS");
     overrides.madoca_glonass_phase = envExactOne("GNSS_PPP_MADOCA_GLONASS_PHASE");
     overrides.madoca_low_elev = !envExactZero("GNSS_PPP_MADOCA_LOW_ELEV");

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -31,6 +31,10 @@ TEST(PPPFilterIterations, MadocaPerFrequencyCommitsOneUpdatePerEpoch) {
     EXPECT_EQ(ppp_internal::filterIterationCount(false, false, 8), 8);
 }
 
+TEST(PPPEnvOverridesTest, MadocaQzssL5DefaultsToThreeFrequencyParity) {
+    EXPECT_TRUE(PPPEnvOverrides::fromEnvironment().madoca_qzss_l5);
+}
+
 TEST(NavigationSsrIodeSelection, DoesNotFallBackWhenGpsIodeIsUnavailable) {
     NavigationData navigation;
     const SatelliteId satellite(GNSSSystem::GPS, 8);

--- a/tests/test_rinex_writer.cpp
+++ b/tests/test_rinex_writer.cpp
@@ -537,9 +537,10 @@ TEST(RINEXReaderTest, QzssSecondaryL5PreferenceSelectsL5Q) {
            << "\n";
     output.close();
 
-    auto read_epoch = [&](bool prefer_l5) {
+    auto read_epoch = [&](bool prefer_l5, bool preserve_additional_bands) {
         io::RINEXReader reader;
         reader.setQzssSecondaryL5Preference(prefer_l5);
+        reader.setPreserveAdditionalFrequencyBands(preserve_additional_bands);
         EXPECT_TRUE(reader.open(temp_path.string()));
         io::RINEXReader::RINEXHeader header;
         EXPECT_TRUE(reader.readHeader(header));
@@ -550,11 +551,11 @@ TEST(RINEXReaderTest, QzssSecondaryL5PreferenceSelectsL5Q) {
     };
 
     const SatelliteId qzss_2(GNSSSystem::QZSS, 2);
-    const ObservationData default_epoch = read_epoch(false);
+    const ObservationData default_epoch = read_epoch(false, false);
     EXPECT_NE(default_epoch.getObservation(qzss_2, SignalType::QZS_L2C), nullptr);
     EXPECT_EQ(default_epoch.getObservation(qzss_2, SignalType::QZS_L5), nullptr);
 
-    const ObservationData l5_epoch = read_epoch(true);
+    const ObservationData l5_epoch = read_epoch(true, false);
     EXPECT_EQ(l5_epoch.getObservation(qzss_2, SignalType::QZS_L2C), nullptr);
     const auto* qzss_l5 = l5_epoch.getObservation(qzss_2, SignalType::QZS_L5);
     ASSERT_NE(qzss_l5, nullptr);
@@ -562,6 +563,18 @@ TEST(RINEXReaderTest, QzssSecondaryL5PreferenceSelectsL5Q) {
     EXPECT_NEAR(qzss_l5->carrier_phase, 140000004.000, 1e-3);
     EXPECT_EQ(qzss_l5->pseudorange_observation_type, "C5Q");
     EXPECT_EQ(qzss_l5->carrier_phase_observation_type, "L5Q");
+
+    const ObservationData three_frequency_epoch = read_epoch(true, true);
+    EXPECT_EQ(three_frequency_epoch.getObservations(qzss_2).size(), 3U);
+    EXPECT_NE(
+        three_frequency_epoch.getObservation(qzss_2, SignalType::QZS_L1CA),
+        nullptr);
+    EXPECT_NE(
+        three_frequency_epoch.getObservation(qzss_2, SignalType::QZS_L5),
+        nullptr);
+    EXPECT_NE(
+        three_frequency_epoch.getObservation(qzss_2, SignalType::QZS_L2C),
+        nullptr);
 
     std::filesystem::remove(temp_path);
 }


### PR DESCRIPTION
## Summary

- make coherent MADOCA QZSS L5 selection default while retaining L2 as the additional frequency
- pin simultaneous QZSS L1/L5/L2 RINEX retention in regression coverage
- document M2f parity results and keep GLONASS phase opt-in pending FDMA drift modelling

## Validation

- Release build: `gnss_run_tests`, `gnss_ppp`
- C++ suite: 522 tests, 472 passed, 50 skipped, 0 failed
- MADOCA CLI: 4 passed
- MIZU 120 epochs: 61 native Fix, all within oracle Fix, 0 wrong Fix
- oracle/native delta: 3D RMS 0.337 m, max 0.854 m, horizontal RMS 0.232 m, Up RMS 0.244 m, tail-30min RMS 0.309 m
- QZSS rows: 18 (L1/L5/L2 code+phase); GLONASS remains 12 by design

Parent: #148
