### PR TITLE
Align MADOCA per-frequency AR admission

### DIFF
--- a/src/algorithms/ppp_ambiguity.cpp
+++ b/src/algorithms/ppp_ambiguity.cpp
@@ -422,9 +422,10 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
         int wl_int = 0;
         bool wl_fixed = false;
     };
-    const int min_lock = ssr_products_loaded_
-        ? std::min(ppp_config_.convergence_min_epochs, 10)
-        : ppp_config_.convergence_min_epochs;
+    const int min_lock = ppp_internal::perFrequencyArMinLockCount(
+        require_coherent_ssr_ && ssr_products_loaded_,
+        ssr_products_loaded_,
+        ppp_config_.convergence_min_epochs);
     std::vector<Cand> cands;
     for (const auto& [sat, l1_index] : filter_state_.ambiguity_indices) {
         // MADOCALIB gen_sat_sd excludes GLONASS from PPP-AR even when it is

--- a/src/algorithms/ppp_corrections.cpp
+++ b/src/algorithms/ppp_corrections.cpp
@@ -620,10 +620,6 @@ double rtklibSystemErrorFactor(GNSSSystem system) {
     }
 }
 
-bool usesGpsL5ErrorFactor(SignalType signal) {
-    return signal == SignalType::GPS_L5 || signal == SignalType::QZS_L5;
-}
-
 }  // namespace
 
 double PPPProcessor::modeledZenithTroposphereDelayMeters(
@@ -1617,8 +1613,14 @@ double PPPProcessor::measurementVariance(const IonosphereFreeObs& observation,
                                          bool carrier_phase) const {
     const double sin_elevation = std::sin(std::max(observation.elevation, kRtkLibMinElevationRadians));
     double factor = rtklibSystemErrorFactor(observation.satellite.system);
-    if (usesGpsL5ErrorFactor(observation.primary_signal) ||
-        usesGpsL5ErrorFactor(observation.secondary_signal)) {
+    const bool madoca_per_frequency =
+        require_coherent_ssr_ && ssr_products_loaded_ &&
+        !ppp_config_.use_ionosphere_free && ppp_config_.estimate_ionosphere &&
+        !ppp_config_.use_clas_osr_filter;
+    if (ppp_internal::applyGpsL5MeasurementErrorFactor(
+            madoca_per_frequency,
+            observation.primary_signal,
+            observation.secondary_signal)) {
         factor *= kRtkLibGpsL5ErrorFactor;
     }
     if (ppp_config_.use_ionosphere_free) {

--- a/src/algorithms/ppp_internal.hpp
+++ b/src/algorithms/ppp_internal.hpp
@@ -23,6 +23,33 @@ inline int filterIterationCount(bool madoca_per_frequency_update,
     return precise_products_loaded ? 3 : configured_iterations;
 }
 
+inline int perFrequencyArMinLockCount(bool madoca_per_frequency,
+                                      bool ssr_products_loaded,
+                                      int convergence_min_epochs) {
+    // MADOCALIB gen_sat_sd() admits every currently valid phase pair.  Its
+    // ambiguity search has no separate lock-count gate in coherent SSR mode.
+    if (madoca_per_frequency) {
+        return 0;
+    }
+    return ssr_products_loaded
+        ? std::min(convergence_min_epochs, 10)
+        : convergence_min_epochs;
+}
+
+inline bool applyGpsL5MeasurementErrorFactor(
+    bool madoca_per_frequency,
+    SignalType primary_signal,
+    SignalType secondary_signal) {
+    const auto is_l5 = [](SignalType signal) {
+        return signal == SignalType::GPS_L5 || signal == SignalType::QZS_L5;
+    };
+    // The generic RTKLIB-compatible path de-weights L5. MADOCALIB's
+    // ppp.c::varerr() does not: its per-frequency profile applies the same
+    // elevation/system variance to L1, L2/L5, and the additional bands.
+    return !madoca_per_frequency &&
+           (is_l5(primary_signal) || is_l5(secondary_signal));
+}
+
 inline std::string trimCopy(const std::string& text) {
     const auto is_not_space = [](unsigned char ch) {
         return !std::isspace(ch);

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -31,6 +31,23 @@ TEST(PPPFilterIterations, MadocaPerFrequencyCommitsOneUpdatePerEpoch) {
     EXPECT_EQ(ppp_internal::filterIterationCount(false, false, 8), 8);
 }
 
+TEST(PPPArAdmission, CoherentSsrDoesNotAddALockCountGate) {
+    EXPECT_EQ(ppp_internal::perFrequencyArMinLockCount(true, true, 20), 0);
+    EXPECT_EQ(ppp_internal::perFrequencyArMinLockCount(false, true, 20), 10);
+    EXPECT_EQ(ppp_internal::perFrequencyArMinLockCount(false, false, 20), 20);
+}
+
+TEST(PPPMeasurementVariance, MadocaPerFrequencyDoesNotDeweightQzssL5) {
+    EXPECT_FALSE(ppp_internal::applyGpsL5MeasurementErrorFactor(
+        true, SignalType::QZS_L1CA, SignalType::QZS_L5));
+    EXPECT_TRUE(ppp_internal::applyGpsL5MeasurementErrorFactor(
+        false, SignalType::QZS_L1CA, SignalType::QZS_L5));
+    EXPECT_TRUE(ppp_internal::applyGpsL5MeasurementErrorFactor(
+        false, SignalType::GPS_L1CA, SignalType::GPS_L5));
+    EXPECT_FALSE(ppp_internal::applyGpsL5MeasurementErrorFactor(
+        false, SignalType::GPS_L1CA, SignalType::GPS_L2C));
+}
+
 TEST(PPPEnvOverridesTest, MadocaQzssL5DefaultsToThreeFrequencyParity) {
     EXPECT_TRUE(PPPEnvOverrides::fromEnvironment().madoca_qzss_l5);
 }


### PR DESCRIPTION
## What changed

- remove the extra ambiguity lock-count gate from coherent MADOCA per-frequency AR candidate admission
- keep the prior lock behavior for generic SSR and non-SSR processing
- stop applying the generic 10x L5 measurement-error factor to MADOCALIB-compatible per-frequency rows
- add focused regression tests for both policies

## Root cause

MADOCALIB `gen_sat_sd()` has no separate ambiguity lock-count gate, while the native path required up to 10 locks. In addition, native measurement variance treated a QZSS L1/L5/L2 observation as L5-weighted for every row. MADOCALIB `ppp.c::varerr()` applies the same elevation/system variance to these per-frequency rows, so native QZSS covariance contracted roughly an order of magnitude too slowly.

## Validation

- C++ suite: 524 tests, 474 passed, 50 skipped
- focused policy tests: 2 passed
- 120-epoch MIZU MADOCA PPP-AR:
  - native Fix: 61 -> 62
  - oracle Fix / native Float: 47 -> 46
  - wrong native Fix: 0
  - oracle/native 3D delta RMS: 0.331404 m -> 0.311584 m
  - QZSS J02-J03 at 00:06: EWL sigma 0.8218 -> 0.0919 cycles; WL sigma 4.0787 -> 0.4932 cycles
- `git diff --check` passed

Part of #148.
