### PR TITLE
Use unittest skip for optional bindings

### DIFF
--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -7,12 +7,10 @@ import tempfile
 import unittest
 from pathlib import Path
 
-import pytest
-
-libgnsspp = pytest.importorskip(
-    "libgnsspp",
-    reason="optional pybind11 extension is not built in this test environment",
-)
+try:
+    import libgnsspp
+except ImportError:
+    libgnsspp = None
 
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
@@ -22,6 +20,10 @@ def repo_data_exists(*relative_paths: str) -> bool:
     return all((ROOT_DIR / relative_path).exists() for relative_path in relative_paths)
 
 
+@unittest.skipIf(
+    libgnsspp is None,
+    "optional pybind11 extension is not built in this test environment",
+)
 class PythonBindingsSmokeTest(unittest.TestCase):
     def setUp(self) -> None:
         method = self._testMethodName


### PR DESCRIPTION
## What

- skip optional Python binding smoke tests using `unittest.skipIf` when the extension is unavailable
- remove the accidental runtime dependency on pytest

## Root cause

The extended CTest environment builds and invokes an otherwise unittest-based script without installing pytest. The recently added `pytest.importorskip` therefore failed during module import before any binding checks could run.

## Fix

Use the Python standard library's existing unittest skip mechanism. Environments with the extension still execute all binding tests; environments without it report clean skips.

## Validation

- `python tests/test_python_bindings.py`: OK, 8 skipped when the optional extension is unavailable
- diff check clean
