### PR TITLE
Restore MADOCA per-frequency AR trial state

### DIFF
--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -675,7 +675,14 @@ PositionSolution PPPProcessor::processEpochStandard(
                     solution.position_geodetic = GeodeticCoord(latitude, longitude, height);
                 }
                 had_fixed_last_epoch_ = accepted_fixed_solution;
-                if (wide_lane_only) {
+                if (ppp_internal::alwaysRestoreArTrialState(
+                        ppp_config_.ar_method)) {
+                    // MADOCALIB ppp_ar() receives an xp/Pp working copy.  Keep
+                    // every per-frequency EWL/WL/N1 attempt ephemeral, even
+                    // when it exits before setting the WL-only status.
+                    filter_state_ = float_filter_state;
+                    ambiguity_states_ = float_ambiguity_states;
+                } else if (wide_lane_only) {
                     // MADOCALIB SOLQ_FIX_WL parity: publish the current epoch
                     // from the WL-constrained working state as PPP/FLOAT, but
                     // do not hold that temporary constraint in the float filter.
@@ -684,9 +691,10 @@ PositionSolution PPPProcessor::processEpochStandard(
                 } else if (fixed && !accepted_fixed_solution) {
                     filter_state_ = float_filter_state;
                     ambiguity_states_ = float_ambiguity_states;
-                } else if (accepted_fixed_solution && ppp_config_.ar_method != PPPConfig::ARMethod::DD_WLNL) {
-                    // For DD_IFLC/DD_PER_FREQ: revert to float state to avoid
-                    // poisoning later epochs with a bad fix.
+                } else if (accepted_fixed_solution &&
+                           ppp_config_.ar_method != PPPConfig::ARMethod::DD_WLNL) {
+                    // For DD_IFLC: revert to float state to avoid poisoning
+                    // later epochs with a bad fix.
                     filter_state_ = float_filter_state;
                     ambiguity_states_ = float_ambiguity_states;
                 }

--- a/src/algorithms/ppp_internal.hpp
+++ b/src/algorithms/ppp_internal.hpp
@@ -50,6 +50,13 @@ inline bool applyGpsL5MeasurementErrorFactor(
            (is_l5(primary_signal) || is_l5(secondary_signal));
 }
 
+inline bool alwaysRestoreArTrialState(PPPProcessor::PPPConfig::ARMethod method) {
+    // MADOCALIB runs per-frequency EWL/WL/N1 constraints on xp/Pp, a copy of
+    // the float filter.  The trial is never committed to rtk->x/P, including
+    // early exits after EWL conditioning but before a usable WL set exists.
+    return method == PPPProcessor::PPPConfig::ARMethod::DD_PER_FREQ;
+}
+
 inline std::string trimCopy(const std::string& text) {
     const auto is_not_space = [](unsigned char ch) {
         return !std::isspace(ch);

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -48,6 +48,13 @@ TEST(PPPMeasurementVariance, MadocaPerFrequencyDoesNotDeweightQzssL5) {
         false, SignalType::GPS_L1CA, SignalType::GPS_L2C));
 }
 
+TEST(PPPArTrialState, PerFrequencyAttemptsAreAlwaysEphemeral) {
+    using ARMethod = PPPProcessor::PPPConfig::ARMethod;
+    EXPECT_TRUE(ppp_internal::alwaysRestoreArTrialState(ARMethod::DD_PER_FREQ));
+    EXPECT_FALSE(ppp_internal::alwaysRestoreArTrialState(ARMethod::DD_IFLC));
+    EXPECT_FALSE(ppp_internal::alwaysRestoreArTrialState(ARMethod::DD_WLNL));
+}
+
 TEST(PPPEnvOverridesTest, MadocaQzssL5DefaultsToThreeFrequencyParity) {
     EXPECT_TRUE(PPPEnvOverrides::fromEnvironment().madoca_qzss_l5);
 }


### PR DESCRIPTION
## What changed

- restore the pre-AR float filter and ambiguity state after every `DD_PER_FREQ` attempt
- cover the MADOCALIB-specific trial-state policy with a regression test
- retain the existing state behavior for `DD_IFLC` and `DD_WLNL`

## Root cause

MADOCALIB runs `ppp_ar()` against `xp/Pp`, working copies of the float state. Native per-frequency AR could apply an EWL constraint and then return before setting the wide-lane-only flag. That early exit bypassed the caller's restore branches, so a rejected trial constraint leaked into later float epochs.

## Impact

Per-frequency EWL/WL/N1 conditioning is now ephemeral like MADOCALIB, including early exits. On the frozen MIZU 120-epoch oracle case, native Fix increased from 62 to 64, oracle-only Fix decreased from 46 to 44, and wrong native Fix remained 0.

## Validation

- `run_tests.exe`: 538 tests, 488 passed, 50 skipped, 0 failed
- MIZU 20-epoch PFDUMP: second J02-J03 EWL sigma changed from the leaked-state 0.2127 to 0.2823 (first attempt 0.3977)
- MIZU 120 epochs: 64 Fix / 54 Float; wrong native Fix 0
- Oracle delta RMS: horizontal 0.2032 m, Up 0.2436 m, 3D 0.3173 m
- Oracle delta RMS over trailing 1800 s: 3D 0.2911 m

Part of #148.