### PR TITLE
Align MADOCA ionosphere state prediction

### DIFF
--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -422,11 +422,17 @@ private:
      * @brief Predict filter state
      */
     void predictState(double dt, const PositionSolution* seed_solution = nullptr);
+
+    struct IonosphereFreeObs;
     
     /**
      * @brief Update filter with measurements
      */
-    bool updateFilter(const ObservationData& obs, const NavigationData& nav);
+    bool updateFilter(const ObservationData& obs, const NavigationData& nav,
+                      double dt, bool apply_iono_prediction = true);
+
+    void updateMadocaPerFrequencyIonospherePrediction(
+        const std::vector<IonosphereFreeObs>& observations, double dt);
 
     bool hasEnoughCoherentSsrObservations(const ObservationData& obs,
                                           const NavigationData& nav);

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -381,6 +381,8 @@ struct PPPAmbiguityInfo {
     int fractional_bias_samples = 0;
     double last_geometry_free_m = 0.0;
     bool has_last_geometry_free = false;
+    double last_carrier_ionosphere_m = 0.0;
+    bool has_last_carrier_ionosphere = false;
     double last_melbourne_wubbena_m = 0.0;
     bool has_last_melbourne_wubbena = false;
     GNSSTime last_slip_time;

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -588,7 +588,7 @@ PositionSolution PPPProcessor::processEpochStandard(
             detectCycleSlips(obs, nav);
             predictState(dt, seed_ptr);
 
-            bool updated = updateFilter(obs, nav);
+            bool updated = updateFilter(obs, nav, dt);
             if (!updated && ppp_config_.enable_ambiguity_resolution) {
                 bool had_fixed_ambiguities = false;
                 for (auto& [satellite, ambiguity] : ambiguity_states_) {
@@ -602,7 +602,7 @@ PositionSolution PPPProcessor::processEpochStandard(
                     if (pppDebugEnabled()) {
                         std::cerr << "[PPP-AR] retry update after resetting fixed ambiguities\n";
                     }
-                    updated = updateFilter(obs, nav);
+                    updated = updateFilter(obs, nav, dt, false);
                 }
             }
 

--- a/src/algorithms/ppp_internal.hpp
+++ b/src/algorithms/ppp_internal.hpp
@@ -57,6 +57,32 @@ inline bool alwaysRestoreArTrialState(PPPProcessor::PPPConfig::ARMethod method) 
     return method == PPPProcessor::PPPConfig::ARMethod::DD_PER_FREQ;
 }
 
+inline double madocaCarrierIonosphereMeters(double phase_l1_m,
+                                            double phase_l2_m,
+                                            double frequency_l1_hz,
+                                            double frequency_l2_hz) {
+    if (!(frequency_l1_hz > 0.0) || !(frequency_l2_hz > 0.0)) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    const double ratio = frequency_l1_hz / frequency_l2_hz;
+    const double denominator = 1.0 - ratio * ratio;
+    if (std::abs(denominator) < 1e-12) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    // MADOCALIB udiono_ppp(): ionc = -(L1-L2)/(1-(f1/f2)^2).
+    return -(phase_l1_m - phase_l2_m) / denominator;
+}
+
+inline double madocaIonosphereProcessVariance(double zenith_variance_per_second,
+                                              double elevation_rad,
+                                              double dt_seconds) {
+    constexpr double kMinimumElevationRad = 5.0 * M_PI / 180.0;
+    const double sin_elevation = std::sin(std::max(elevation_rad,
+                                                   kMinimumElevationRad));
+    return zenith_variance_per_second * std::abs(dt_seconds) /
+           (sin_elevation * sin_elevation);
+}
+
 inline std::string trimCopy(const std::string& text) {
     const auto is_not_space = [](unsigned char ch) {
         return !std::isspace(ch);

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -485,10 +485,16 @@ void PPPProcessor::predictState(double dt, const PositionSolution* seed_solution
     for (int idx = filter_state_.amb_index; idx < filter_state_.total_states; ++idx) {
         Q(idx, idx) = ppp_config_.process_noise_ambiguity * dt;
     }
-    // Ionosphere process noise
+    // Ionosphere process noise. Coherent MADOCA applies the per-satellite
+    // elevation scaling later, after corrected observations provide az/el.
+    const bool madoca_per_frequency =
+        require_coherent_ssr_ && ssr_products_loaded_ &&
+        !ppp_config_.use_ionosphere_free && ppp_config_.estimate_ionosphere;
     if (ppp_config_.estimate_ionosphere) {
         for (const auto& [sat, idx] : filter_state_.ionosphere_indices) {
-            Q(idx, idx) = ppp_config_.process_noise_ionosphere * dt;
+            Q(idx, idx) = madoca_per_frequency
+                ? 0.0
+                : ppp_config_.process_noise_ionosphere * dt;
         }
     }
 
@@ -534,7 +540,58 @@ void PPPProcessor::predictState(double dt, const PositionSolution* seed_solution
     constrainStaticAnchorPosition();
 }
 
-bool PPPProcessor::updateFilter(const ObservationData& obs, const NavigationData& nav) {
+void PPPProcessor::updateMadocaPerFrequencyIonospherePrediction(
+    const std::vector<IonosphereFreeObs>& observations, double dt) {
+    const bool madoca_per_frequency =
+        require_coherent_ssr_ && ssr_products_loaded_ &&
+        !ppp_config_.use_ionosphere_free && ppp_config_.estimate_ionosphere;
+    if (!madoca_per_frequency) {
+        return;
+    }
+
+    for (const auto& observation : observations) {
+        const auto ionosphere_it =
+            filter_state_.ionosphere_indices.find(observation.satellite);
+        if (!observation.valid ||
+            ionosphere_it == filter_state_.ionosphere_indices.end()) {
+            continue;
+        }
+        const int index = ionosphere_it->second;
+        filter_state_.covariance(index, index) +=
+            ppp_internal::madocaIonosphereProcessVariance(
+                ppp_config_.process_noise_ionosphere,
+                observation.elevation,
+                dt);
+
+        auto& ambiguity = ambiguity_states_[observation.satellite];
+        if (!observation.has_carrier_phase ||
+            !observation.has_carrier_phase_l2) {
+            ambiguity.has_last_carrier_ionosphere = false;
+            continue;
+        }
+        const double carrier_ionosphere =
+            ppp_internal::madocaCarrierIonosphereMeters(
+                observation.carrier_phase_l1,
+                observation.carrier_phase_l2,
+                observation.freq_l1,
+                observation.freq_l2);
+        if (!std::isfinite(carrier_ionosphere)) {
+            ambiguity.has_last_carrier_ionosphere = false;
+            continue;
+        }
+        if (ambiguity.has_last_carrier_ionosphere) {
+            filter_state_.state(index) +=
+                carrier_ionosphere - ambiguity.last_carrier_ionosphere_m;
+        }
+        ambiguity.last_carrier_ionosphere_m = carrier_ionosphere;
+        ambiguity.has_last_carrier_ionosphere = true;
+    }
+}
+
+bool PPPProcessor::updateFilter(const ObservationData& obs,
+                                const NavigationData& nav,
+                                double dt,
+                                bool apply_iono_prediction) {
     auto if_obs = formIonosphereFree(obs, nav);
     if (if_obs.size() < static_cast<size_t>(config_.min_satellites)) {
         if (pppDebugEnabled()) {
@@ -546,6 +603,9 @@ bool PPPProcessor::updateFilter(const ObservationData& obs, const NavigationData
 
     applyPreciseCorrections(if_obs, nav, obs.time);
     ensureAmbiguityStates(if_obs);
+    if (apply_iono_prediction) {
+        updateMadocaPerFrequencyIonospherePrediction(if_obs, dt);
+    }
     if (!ppp_config_.use_ionosphere_free && ppp_config_.estimate_ionosphere &&
         !ppp_config_.use_clas_osr_filter) {
         std::set<SatelliteId> observed_now;

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -55,6 +55,24 @@ TEST(PPPArTrialState, PerFrequencyAttemptsAreAlwaysEphemeral) {
     EXPECT_FALSE(ppp_internal::alwaysRestoreArTrialState(ARMethod::DD_WLNL));
 }
 
+TEST(PPPIonospherePrediction, MatchesMadocalibCarrierDeltaAndElevationNoise) {
+    constexpr double f1 = 1575.42e6;
+    constexpr double f2 = 1227.60e6;
+    const double denominator = 1.0 - (f1 / f2) * (f1 / f2);
+    EXPECT_NEAR(
+        ppp_internal::madocaCarrierIonosphereMeters(12.4, 12.1, f1, f2),
+        -0.3 / denominator,
+        1e-12);
+    EXPECT_NEAR(
+        ppp_internal::madocaIonosphereProcessVariance(1e-4, M_PI / 6.0, 30.0),
+        0.012,
+        1e-12);
+    EXPECT_NEAR(
+        ppp_internal::madocaIonosphereProcessVariance(1e-4, M_PI / 2.0, 30.0),
+        0.003,
+        1e-12);
+}
+
 TEST(PPPEnvOverridesTest, MadocaQzssL5DefaultsToThreeFrequencyParity) {
     EXPECT_TRUE(PPPEnvOverrides::fromEnvironment().madoca_qzss_l5);
 }


### PR DESCRIPTION
## What changed

- advance coherent MADOCA per-frequency ionosphere states with the corrected L1/L2 carrier geometry-free delta used by MADOCALIB `udiono_ppp()`
- scale ionosphere process noise by `1 / sin²(elevation)` with MADOCALIB's 5-degree floor
- avoid applying the temporal prediction twice when a failed measurement update is retried
- add focused formula regressions while preserving generic PPP/CLAS behavior

## Root cause

Native predicted each estimated ionosphere state as a zero-mean random walk with constant variance. MADOCALIB carries the state mean forward from the corrected carrier-derived ionosphere change and applies elevation-scaled process noise. The missing mean prediction displaced N1 float ambiguities by up to about three cycles even though their covariance diagonals already matched closely.

At 00:06, this changes the native first/second N1 candidate match from 2/11 to 10/11, matching the oracle, and changes the first partial-AR exclusion from J03 to the oracle's C09.

## Impact

On the frozen MIZU 120-input-epoch case:

- 118/118 solution epochs aligned; wrong native Fix remains 0
- full-window 3D delta RMS: 0.317250 m to 0.300143 m
- horizontal RMS: 0.203230 m to 0.159425 m
- trailing-1800-second 3D RMS: 0.291125 m to 0.286982 m
- native Fix changes from 64 to 59, so M2 remains open and the residual ratio trajectory still needs another slice

## Validation

- focused ionosphere prediction regression passed
- full local C++ suite: 539 tests, 489 passed, 50 skipped, 0 failed
- MIZU 20-epoch PFDUMP and 120-epoch oracle comparison
- existing SSR discontinuity opt-in was tested and is bit-identical on this window

Part of #148.