### PR TITLE
Restore MADOCALIB opt-in build contract

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,22 +220,6 @@ if(MADOCALIB_PARITY_LINK)
     target_compile_definitions(gnss_lib PRIVATE GNSSPP_HAS_MADOCALIB_TIDE=1)
     target_link_libraries(gnss_lib PUBLIC madocalib)
 else()
-    # CLAS parity needs RTKLIB's exact tidedisp() convention independently of
-    # the optional full decoder/oracle bridge.
-    set(MADOCALIB_TIDE_SRC_DIR "${CMAKE_CURRENT_SOURCE_DIR}/external/madocalib/src")
-    add_library(madocalib_tide STATIC
-        ${MADOCALIB_TIDE_SRC_DIR}/rtkcmn.c
-        ${MADOCALIB_TIDE_SRC_DIR}/tides.c)
-    target_include_directories(madocalib_tide PRIVATE ${MADOCALIB_TIDE_SRC_DIR})
-    target_compile_definitions(madocalib_tide PRIVATE
-        TRACE ENAGLO ENAQZS ENAGAL ENACMP ENAIRN NFREQ=5 NEXOBS=5)
-    target_link_libraries(madocalib_tide PUBLIC m Threads::Threads)
-    if(UNIX AND NOT APPLE)
-        target_link_libraries(madocalib_tide PUBLIC rt)
-    endif()
-    target_include_directories(gnss_lib PRIVATE ${MADOCALIB_TIDE_SRC_DIR})
-    target_compile_definitions(gnss_lib PRIVATE GNSSPP_HAS_MADOCALIB_TIDE=1)
-    target_link_libraries(gnss_lib PRIVATE madocalib_tide)
     target_compile_definitions(gnss_lib
         PUBLIC
             GNSSPP_HAS_MADOCALIB_BRIDGE=0
@@ -286,10 +270,6 @@ set(GNSS_INSTALL_TARGETS gnss_lib gnss_lib_noopt sofa ginan_iers2010)
 if(MADOCALIB_PARITY_LINK)
     list(APPEND GNSS_INSTALL_TARGETS madocalib)
 endif()
-if(TARGET madocalib_tide)
-    list(APPEND GNSS_INSTALL_TARGETS madocalib_tide)
-endif()
-
 install(
     # Note: sofa and ginan_iers2010 are PRIVATE link deps of gnss_lib but
     # must still appear in the same export set because static archives do

--- a/tests/test_madoca_parity.cpp
+++ b/tests/test_madoca_parity.cpp
@@ -111,6 +111,14 @@ TEST(MadocaBridgeConfig, AvailabilityMatchesBuildFlag) {
 #endif
 }
 
+TEST(MadocaBridgeConfig, TideOracleIsAlsoOptIn) {
+#if GNSSPP_HAS_MADOCALIB_ORACLE
+    EXPECT_TRUE(libgnss::external::madocalib_oracle::tideAvailable());
+#else
+    EXPECT_FALSE(libgnss::external::madocalib_oracle::tideAvailable());
+#endif
+}
+
 TEST(MadocaMaterializationDump, WritesStableCsvContract) {
     libgnss::SSRProducts products;
     products.setOrbitCorrectionsAreRac(true);


### PR DESCRIPTION
## What changed

- remove the unconditional default-build link to `external/madocalib/src/rtkcmn.c` and `tides.c`
- keep MADOCALIB tidal/oracle code behind `MADOCALIB_PARITY_LINK=ON`
- add a regression test that verifies tidal oracle availability follows the opt-in oracle build

## Why

PR #326 made a normal configure require an untracked MADOCALIB checkout. The standard GCC, Clang, and macOS CI jobs do not checkout that oracle dependency, so all three failed during CMake configure. It also contradicted the native migration contract that default build, install, and runtime must not depend on MADOCALIB sources.

## Impact

Default builds work again without `external/madocalib`. The pinned MADOCALIB parity job remains unchanged and still enables the exact tidal oracle through `MADOCALIB_PARITY_LINK=ON`.

## Validation

- fresh default CMake configure without an `external/madocalib` directory: passed
- `git diff --check`: passed
- full build/test matrix: delegated to CI
