### PR TITLE
Fix CLAS seed recovery and WLNL hold parity

### DIFF
--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -378,6 +378,7 @@ private:
     // MRTKLIB clas.toml float_count=15: consecutive PPP-FLOAT epochs before
     // the kinematic CLAS filter is reinitialized from the current SPP seed.
     int clas_mrtklib_float_count_ = 0;
+    int clas_seed_ar_quarantine_epochs_ = 0;
     // The CSV correction store is precomposed, while MRTKLIB's L6 decoder
     // starts empty and needs one 15 s CSSR cycle before CLAS OSR is usable.
     bool has_clas_mrtklib_stream_start_time_ = false;
@@ -387,6 +388,10 @@ private:
     // not enter ddmat/LAMBDA in this epoch.
     std::set<SatelliteId> clas_mrtklib_ar_rejected_ambiguities_;
     ppp_ar::WlnlHoldState clas_wlnl_hold_;
+    // Current accepted ddmat/LAMBDA rows, carried to the post-fix chi-square
+    // gate so holdamb parity does not reconstruct participants from stale
+    // ambiguity flags.
+    std::vector<ppp_ar::WlnlHoldConstraint> clas_wlnl_candidate_hold_constraints_;
     Vector3d last_published_solution_position_ecef_ = Vector3d::Zero();
     bool has_last_published_solution_position_ = false;
     // Anchors MRTKLIB rtk->sol.time's role in tt (=timediff) computation

--- a/include/libgnss++/algorithms/ppp_ar.hpp
+++ b/include/libgnss++/algorithms/ppp_ar.hpp
@@ -150,6 +150,11 @@ struct WlnlFixAttempt {
     int state_wlnl_noninteger_count = 0;
     int nb = 0;
     ppp_shared::PPPState constrained_state;
+    // Exact DD rows accepted by the direct state-DD LAMBDA path. MRTKLIB's
+    // holdamb() only constrains ssat rows marked FIX in the current ddmat()
+    // call; rebuilding this set from persistent ambiguity flags admits stale
+    // or PAR-excluded satellites.
+    std::vector<WlnlHoldConstraint> hold_constraints;
 };
 
 struct WlnlWideLaneFixSummary {

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -4,7 +4,9 @@
 #include <libgnss++/core/observation.hpp>
 #include <libgnss++/core/types.hpp>
 
+#include <algorithm>
 #include <array>
+#include <cmath>
 #include <map>
 #include <string>
 
@@ -18,6 +20,33 @@ enum class ConvergencePolicy {
 /// Check if PPP debug output is enabled via GNSS_PPP_DEBUG.
 inline bool pppDebugEnabled() {
     return pppEnvOverrides().debug;
+}
+
+/// Retry a CLAS reset seed with leave-one-out FDE only after the baseline
+/// seed has demonstrated the same failure that would feed the parity guards.
+inline bool shouldRetryClasSeedWithFde(bool seed_valid,
+                                       bool redundancy_gate_failed,
+                                       bool filter_initialized,
+                                       double filter_spp_distance_m,
+                                       double max_spp_divergence_m) {
+    return seed_valid &&
+           (redundancy_gate_failed ||
+            (filter_initialized && std::isfinite(filter_spp_distance_m) &&
+             max_spp_divergence_m > 0.0 &&
+             filter_spp_distance_m > max_spp_divergence_m));
+}
+
+/// Start one fixed AR quarantine window on a raw maxdiff event. Repeated
+/// maxdiff observations consume the active window instead of extending it.
+inline bool updateClasSeedArQuarantine(bool trigger,
+                                       int recovery_epochs,
+                                       int& remaining_epochs) {
+    if (remaining_epochs > 0) {
+        --remaining_epochs;
+    } else if (trigger) {
+        remaining_epochs = std::max(recovery_epochs, 0);
+    }
+    return remaining_epochs > 0;
 }
 
 struct PPPConfig {

--- a/src/algorithms/ppp_ar.cpp
+++ b/src/algorithms/ppp_ar.cpp
@@ -1463,9 +1463,30 @@ WlnlFixAttempt tryDirectStateDdFix(
 
     attempt.ratio = attempt.state_lambda_ratio;
     attempt.nb = attempt.state_dd_count;
-    // Mark participants fixed so the hold path (buildWlnlHoldConstraints
-    // requires wl_is_fixed && nl_is_fixed) sees them; the hold constraint
-    // values come from the constrained fixed state, not these flags.
+    attempt.hold_constraints.reserve(rows.size());
+    for (const auto& row : rows) {
+        const SatelliteId real_ref = clasRealSatellite(row.ref_satellite);
+        const SatelliteId real_sat = clasRealSatellite(row.sat_satellite);
+        const auto ref_el_it = satellite_elevations_rad->find(real_ref);
+        const auto sat_el_it = satellite_elevations_rad->find(real_sat);
+        WlnlHoldConstraint constraint;
+        constraint.ref_state = row.ref_state;
+        constraint.sat_state = row.sat_state;
+        constraint.fixed_dd_m =
+            attempt.constrained_state.state(row.ref_state) -
+            attempt.constrained_state.state(row.sat_state);
+        constraint.ambiguity_scale_m = row.ref_scale_m;
+        constraint.ref_elevation_rad =
+            ref_el_it != satellite_elevations_rad->end() ? ref_el_it->second : 0.0;
+        constraint.sat_elevation_rad =
+            sat_el_it != satellite_elevations_rad->end() ? sat_el_it->second : 0.0;
+        constraint.ref_satellite = row.ref_satellite;
+        constraint.sat_satellite = row.sat_satellite;
+        attempt.hold_constraints.push_back(constraint);
+    }
+    // Preserve the accepted-participant status for downstream diagnostics and
+    // non-direct callers. The direct hold path above carries its exact current
+    // DD rows and does not reconstruct participants from these persistent flags.
     for (const auto& row : rows) {
         for (const SatelliteId& satellite :
              {row.ref_satellite, row.sat_satellite}) {

--- a/src/algorithms/ppp_clas_epoch.cpp
+++ b/src/algorithms/ppp_clas_epoch.cpp
@@ -64,6 +64,10 @@ constexpr double kMrtklibPhaseResidualSigmaGate = 2.0;
 // (pos2-rejdiffpse -> opt.maxdiffp, pos2-poserrcnt; mrtk_ppp_rtk.c:2333-2352)
 constexpr double kMrtklibMaxSppDivergenceM = 10.0;
 constexpr int kMrtklibMaxSppDivergenceEpochs = 5;
+// Cover the observed interval in which a maxdiff-inconsistent float can
+// otherwise originate and hold a false WLNL fix, without allowing repeated
+// maxdiff observations to postpone AR indefinitely.
+constexpr int kClasSeedArQuarantineEpochs = 30;
 // Immediate (uncounted) sanity ceiling for the reset seed vs. the filter's
 // own tracked position -- see the long comment at its use site. Well above
 // any plausible ground-vehicle displacement per epoch, and far below the
@@ -74,12 +78,9 @@ constexpr double kClasSeedImplausibleJumpFloorM = 300.0;
 // MRTKLIB mrtk_spp.c valsol(): chi-square(alpha=0.001) table indexed by
 // degrees of freedom (nv-nx), used to validate every pntpos() solution
 // whenever raim_fde (clas.toml pos1-posopt5) is enabled -- which the real
-// clas.toml benchmark config does. The parity SPP seed above intentionally
-// runs with enable_raim_fde=false (the leave-one-out FDE loop shifts the
-// reset seed ~11 m at tow 177036; see comment above), which also silently
-// skips this codebase's equivalent of valsol()'s baseline chi-square check
-// (it is bundled behind the same flag as the FDE loop in MRTKLIB, but this
-// port exposes it as an independent, still-disabled knob). Left completely
+// clas.toml benchmark config does. The parity path first evaluates this gate
+// on the baseline seed, then permits leave-one-out FDE only for a rejected or
+// already maxdiff-inconsistent seed. Left completely
 // unchecked, a multi-GNSS SPP epoch with only 1-2 satellites per non-
 // reference system consumes all its redundancy on per-system clock/ISB
 // unknowns (dof collapses to 0) and reports a numerically "perfect"
@@ -886,6 +887,7 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
     // Set below (parity path only) once the redundancy/jump guards have run;
     // see the long comment at its assignment for what this gates.
     bool clas_seed_untrusted_this_epoch = false;
+    bool clas_baseline_seed_maxdiff_this_epoch = false;
     if (clas_mrtklib_parity) {
         const auto original_spp_config = spp_processor_.getSPPConfig();
         auto clas_spp_config = original_spp_config;
@@ -905,13 +907,42 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         clas_spp_config.use_variance_model = false;
         clas_spp_config.enable_outlier_detection = false;
         clas_spp_config.elevation_mask_override_deg = 15.0;
-        // clas.toml enables pos1-posopt5 (RAIM FDE).  It first becomes
-        // active in this dataset at the urban inconsistency near tow
-        // 177036; disabling it changes the SPP reset seed by about 11 m and
-        // prematurely triggers maxdiffp, shifting every later float reset.
+        // First solve the baseline exactly once. Applying native's
+        // leave-one-out selection to every valid epoch changes otherwise-good
+        // reset seeds and AR cadence. Retry with FDE below only when the seed
+        // has already failed the parity validity/maxdiff tests.
         clas_spp_config.enable_raim_fde = false;
         spp_processor_.setSPPConfig(clas_spp_config);
         seed = spp_processor_.processEpoch(obs, nav);
+        const bool clas_seed_redundancy_failed =
+            seed.isValid() && clasSeedFailsRedundancyGate(seed);
+        double baseline_filter_spp_distance_m =
+            std::numeric_limits<double>::quiet_NaN();
+        if (seed.isValid() && filter_initialized_ &&
+            filter_state_.pos_index >= 0 &&
+            filter_state_.pos_index + 2 < filter_state_.state.size()) {
+            baseline_filter_spp_distance_m =
+                (filter_state_.state.segment<3>(filter_state_.pos_index) -
+                 seed.position_ecef).norm();
+        }
+        const bool clas_seed_needs_fde =
+            ppp_shared::shouldRetryClasSeedWithFde(
+                seed.isValid(), clas_seed_redundancy_failed,
+                filter_initialized_, baseline_filter_spp_distance_m,
+                kMrtklibMaxSppDivergenceM);
+        clas_baseline_seed_maxdiff_this_epoch =
+            seed.isValid() && filter_initialized_ &&
+            std::isfinite(baseline_filter_spp_distance_m) &&
+            baseline_filter_spp_distance_m > kMrtklibMaxSppDivergenceM;
+        if (clas_seed_needs_fde) {
+            clas_spp_config.enable_raim_fde = true;
+            spp_processor_.setSPPConfig(clas_spp_config);
+            const PositionSolution fde_seed =
+                spp_processor_.processEpoch(obs, nav);
+            if (fde_seed.isValid()) {
+                seed = fde_seed;
+            }
+        }
         spp_processor_.setSPPConfig(original_spp_config);
         if (seed.isValid() && clasSeedFailsRedundancyGate(seed)) {
             if (pppDebugEnabled()) {
@@ -926,8 +957,7 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         // still pass the chi-square/dof check above (enough redundancy for
         // a numerically fine fit) while one of its few satellites carries an
         // undetected bias (bad ephemeris/SSR lookup, multipath) that a
-        // single-satellite RAIM/FDE exclusion would normally catch -- but
-        // enable_raim_fde is deliberately off above (see comment). Observed
+        // single-satellite RAIM/FDE exclusion would normally catch. Observed
         // on nagoya_run2 tow 557038.4: dof=1, chi2=2.27 (well under the
         // dof=1 table entry 10.8), yet the fix was ~4.2 km from the last
         // published position. That epoch is also mid-reset (filter_
@@ -981,7 +1011,13 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         // coasted state should not be allowed to originate a new
         // publishable fix, only to keep the float filter alive until a
         // trustworthy seed returns.
-        clas_seed_untrusted_this_epoch = !seed.isValid();
+        const bool clas_seed_ar_quarantined =
+            ppp_shared::updateClasSeedArQuarantine(
+                clas_baseline_seed_maxdiff_this_epoch,
+                kClasSeedArQuarantineEpochs,
+                clas_seed_ar_quarantine_epochs_);
+        clas_seed_untrusted_this_epoch =
+            !seed.isValid() || clas_seed_ar_quarantined;
         // Suppressing this epoch's AR *attempt* alone is not enough: lock
         // counts are untouched by that gate, so a short (2-3 epoch)
         // rejection window can still leave every ambiguity's lock_count
@@ -999,8 +1035,7 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         // outage_gap resets elsewhere in this function): this reuses the
         // existing lock_count>=min_lock_count gate to enforce a natural
         // kMrtklibMinLock+1-epoch (6 accepted-phase-epoch) cooldown after
-        // the seed becomes trustworthy again, instead of adding a new,
-        // bespoke cooldown counter.
+        // the rejected seed becomes trustworthy again.
         if (clas_seed_untrusted_this_epoch) {
             constexpr int kMrtklibMinLock = 5;
             for (auto& [_, ambiguity] : ambiguity_states_) {
@@ -1061,8 +1096,8 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
     // mode a failure falls through with tt frozen at 0 for that one epoch,
     // and the caller keeps running ppp_rtk_pos() on the stale state. The
     // redundancy/jump guards above are this port's equivalent of pntpos()
-    // rejecting a solution (enable_raim_fde/outlier detection are
-    // deliberately off on the reset seed; see clasSeedFailsRedundancyGate).
+    // rejecting a solution (generic outlier detection is deliberately off;
+    // RAIM/FDE is gated by the MRTKLIB baseline chi-square failure).
     // Capture "was the filter already running before this epoch" here,
     // before the floatcnt/measurement-update resets below can change
     // filter_initialized_, so the freeze below only ever applies to a
@@ -1685,15 +1720,20 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
                 }
                 ++clas_wlnl_hold_.consecutive_fix_count;
                 std::vector<ppp_ar::WlnlHoldConstraint> hold_constraints;
-                if (clas_wlnl_hold_.consecutive_fix_count >=
-                        ppp_ar::kMrtklibMinFixCount &&
+                if (!clas_wlnl_candidate_hold_constraints_.empty()) {
+                    hold_constraints = clas_wlnl_candidate_hold_constraints_;
+                } else {
                     ppp_ar::buildWlnlHoldConstraints(
                         last_clas_constrained_fixed_state_,
                         ambiguity_states_,
                         clas_satellite_elevations_rad,
                         hold_constraints,
                         ppp_config_.use_dynamics_model &&
-                            !ppp_config_.low_dynamics_mode)) {
+                            !ppp_config_.low_dynamics_mode);
+                }
+                if (clas_wlnl_hold_.consecutive_fix_count >=
+                        ppp_ar::kMrtklibMinFixCount &&
+                    !hold_constraints.empty()) {
                     clas_wlnl_hold_.constraints = std::move(hold_constraints);
                     clas_wlnl_hold_.active = true;
                     const bool hold_applied = ppp_ar::applyWlnlHoldAmbiguity(

--- a/src/algorithms/ppp_wlnl.cpp
+++ b/src/algorithms/ppp_wlnl.cpp
@@ -114,6 +114,7 @@ bool PPPProcessor::resolveAmbiguitiesWLNL(const ObservationData& obs, const Navi
     last_ar_ratio_ = 0.0;
     last_fixed_ambiguities_ = 0;
     last_clas_constrained_fixed_state_valid_ = false;
+    clas_wlnl_candidate_hold_constraints_.clear();
 
     auto wlnl_preparation = ppp_ar::prepareWlnlCandidates(
         ppp_config_,
@@ -243,6 +244,7 @@ bool PPPProcessor::resolveAmbiguitiesWLNL(const ObservationData& obs, const Navi
         // only holdamb() constraints nudge the float states.
         last_clas_constrained_fixed_state_ = attempt.constrained_state;
         last_clas_constrained_fixed_state_valid_ = true;
+        clas_wlnl_candidate_hold_constraints_ = attempt.hold_constraints;
         if (auto* debug = clasFixDebugStream(); debug != nullptr) {
             const Vector3d initial_position =
                 filter_state_.state.segment(filter_state_.pos_index, 3);

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -26,6 +26,30 @@ using namespace libgnss;
 
 namespace {
 
+TEST(PPPClasSeedFde, RetriesOnlyRejectedOrMaxdiffInconsistentSeeds) {
+    EXPECT_FALSE(ppp_shared::shouldRetryClasSeedWithFde(
+        false, true, true, 20.0, 10.0));
+    EXPECT_TRUE(ppp_shared::shouldRetryClasSeedWithFde(
+        true, true, false, 0.0, 10.0));
+    EXPECT_FALSE(ppp_shared::shouldRetryClasSeedWithFde(
+        true, false, true, 10.0, 10.0));
+    EXPECT_TRUE(ppp_shared::shouldRetryClasSeedWithFde(
+        true, false, true, 10.001, 10.0));
+    EXPECT_FALSE(ppp_shared::shouldRetryClasSeedWithFde(
+        true, false, false, 20.0, 10.0));
+}
+
+TEST(PPPClasSeedFde, QuarantineDoesNotExtendOnRepeatedMaxdiff) {
+    int remaining = 0;
+    EXPECT_TRUE(ppp_shared::updateClasSeedArQuarantine(true, 3, remaining));
+    EXPECT_EQ(remaining, 3);
+    EXPECT_TRUE(ppp_shared::updateClasSeedArQuarantine(true, 3, remaining));
+    EXPECT_EQ(remaining, 2);
+    EXPECT_TRUE(ppp_shared::updateClasSeedArQuarantine(true, 3, remaining));
+    EXPECT_FALSE(ppp_shared::updateClasSeedArQuarantine(false, 3, remaining));
+    EXPECT_EQ(remaining, 0);
+}
+
 TEST(PPPFilterIterations, MadocaPerFrequencyCommitsOneUpdatePerEpoch) {
     EXPECT_EQ(ppp_internal::filterIterationCount(true, false, 8), 1);
     EXPECT_EQ(ppp_internal::filterIterationCount(false, true, 8), 3);

--- a/tests/test_ppp_ar.cpp
+++ b/tests/test_ppp_ar.cpp
@@ -272,6 +272,66 @@ TEST(PPPArTest, ResolveWlnlFixUsesOnlyWideLaneFixedEligibleSatellites) {
     EXPECT_EQ(attempt.nb, 3);
 }
 
+TEST(PPPArTest, DirectStateDdHoldUsesOnlyCurrentAcceptedRows) {
+    ppp_shared::PPPConfig config;
+    config.clas_mrtklib_float_parity = true;
+    config.use_clas_osr_filter = true;
+    config.kinematic_mode = true;
+    config.use_dynamics_model = true;
+    config.low_dynamics_mode = false;
+
+    ppp_shared::PPPState state;
+    state.pos_index = 0;
+    state.amb_index = 3;
+    state.total_states = 11;
+    state.state = VectorXd::Zero(state.total_states);
+    state.covariance = MatrixXd::Identity(state.total_states, state.total_states) * 1e-6;
+
+    const std::vector<SatelliteId> satellites = {
+        {GNSSSystem::GPS, 1}, {GNSSSystem::GPS, 2},
+        {GNSSSystem::GPS, 3}, {GNSSSystem::GPS, 4},
+        {GNSSSystem::GPS, 101}, {GNSSSystem::GPS, 102},
+        {GNSSSystem::GPS, 103}, {GNSSSystem::GPS, 104},
+    };
+    ppp_ar::EligibleAmbiguities eligible;
+    for (int i = 0; i < static_cast<int>(satellites.size()); ++i) {
+        const int state_index = state.amb_index + i;
+        eligible.satellites.push_back(satellites[static_cast<size_t>(i)]);
+        eligible.state_indices.push_back(state_index);
+        eligible.scales.push_back(0.19);
+        state.ambiguity_indices[satellites[static_cast<size_t>(i)]] = state_index;
+        state.state(state_index) =
+            (i < 4 ? static_cast<double>(i) : 10.0 + static_cast<double>(i - 4)) * 0.19;
+    }
+
+    std::map<SatelliteId, ppp_shared::PPPAmbiguityInfo> ambiguity_states;
+    for (const auto& satellite : satellites) {
+        ambiguity_states[satellite].ambiguity_scale_m = 0.19;
+    }
+    const SatelliteId stale_satellite(GNSSSystem::GPS, 5);
+    ambiguity_states[stale_satellite].is_fixed = true;
+    ambiguity_states[stale_satellite].wl_is_fixed = true;
+    ambiguity_states[stale_satellite].nl_is_fixed = true;
+
+    std::map<SatelliteId, double> elevations;
+    for (int prn = 1; prn <= 4; ++prn) {
+        elevations[{GNSSSystem::GPS, static_cast<uint8_t>(prn)}] =
+            (35.0 + prn) * M_PI / 180.0;
+    }
+
+    const auto attempt = ppp_ar::resolveWlnlFix(
+        config, state, state.covariance, ambiguity_states, eligible,
+        ppp_ar::WlnlNlInfoProvider{}, false, &elevations);
+
+    ASSERT_TRUE(attempt.fixed);
+    EXPECT_EQ(attempt.nb, 6);
+    ASSERT_EQ(attempt.hold_constraints.size(), 6u);
+    for (const auto& constraint : attempt.hold_constraints) {
+        EXPECT_NE(ppp_ar::clasRealSatellite(constraint.ref_satellite), stale_satellite);
+        EXPECT_NE(ppp_ar::clasRealSatellite(constraint.sat_satellite), stale_satellite);
+    }
+}
+
 TEST(PPPArTest, BuildFixedObservationHelpersFilterInvalidProviders) {
     const SatelliteId sat1(GNSSSystem::GPS, 1);
     const SatelliteId sat2(GNSSSystem::GPS, 2);


### PR DESCRIPTION
## What changed

- retry CLAS SPP seeds with leave-one-out FDE only after baseline redundancy or maxdiff failure
- add a one-shot AR quarantine after raw maxdiff so a recovering float state cannot immediately originate and hold a false WLNL fix
- carry the accepted ddmat/LAMBDA rows into holdamb instead of rebuilding hold participants from stale ambiguity flags
- add focused unit coverage for FDE selection, quarantine cadence, and WLNL hold constraints

## Root cause

Native and MRTKLIB first diverged before AR at TOW 177472.8: native used a 14.325 m filter-SPP separation and incremented cntdiffp, while MRTKLIB stayed near 5.294 m with cntdiffp unchanged. Native's baseline SPP seed needed selective FDE, but globally enabling FDE shifted otherwise-good reset seeds. A later raw-maxdiff interval could also originate a stable false WLNL fix before recovery completed.

## Impact

On the full Tokyo run2 (9151 epochs), the target horizontal error improved from 8.161 m to 1.416 m. Fixed RMS improved from 0.500 m to 0.340 m, maximum fixed error from 3.855 m to 1.018 m, and fixed epochs above 2 m from 7 to 0. The conservative quarantine reduced fix rate from 15.17% to 11.47%.

## Validation

- C++: 596 tests, 541 passed, 55 skipped, 0 failed
- Python PPC/CLAS: 15 passed
- full Tokyo run2 9151-epoch comparison
- git diff --check
