### PR TITLE
Improve CLAS partial AR recovery

### DIFF
--- a/src/algorithms/ppp_ar.cpp
+++ b/src/algorithms/ppp_ar.cpp
@@ -1565,7 +1565,12 @@ WlnlFixAttempt resolveWlnlFix(
                                    ambiguity_states,
                                    debug_enabled,
                                    &eligible_ambiguities.satellites,
-                                   2);
+                                   // A single-frequency constellation DD can
+                                   // poison every otherwise-valid PAR trial.
+                                   // Keep it eligible for exclusion even
+                                   // though dual-frequency satellites remain
+                                   // the preferred candidates by elevation.
+                                   1);
     }
     const auto nl_info = buildWlnlNlInfoMap(
         eligible_ambiguities.satellites,

--- a/tests/test_ppp_ar.cpp
+++ b/tests/test_ppp_ar.cpp
@@ -30,6 +30,25 @@ TEST(PPPArTest, MrtklibParCandidatesRequireTwoActiveFrequencyStates) {
     EXPECT_EQ(candidates[1], gps6);
 }
 
+TEST(PPPArTest, ParCandidatesCanIncludeSingleFrequencyConstellationFallback) {
+    const SatelliteId gps6(GNSSSystem::GPS, 6);
+    const SatelliteId gps6_l2(GNSSSystem::GPS, 106);
+    const SatelliteId qzss2(GNSSSystem::QZSS, 2);
+
+    const std::vector<SatelliteId> eligible = {gps6, gps6_l2, qzss2};
+    const std::map<SatelliteId, double> elevations = {
+        {gps6, 54.0 * M_PI / 180.0},
+        {qzss2, 33.0 * M_PI / 180.0},
+    };
+
+    const auto candidates =
+        ppp_ar::selectMrtklibParCandidates(eligible, elevations, 1);
+
+    ASSERT_EQ(candidates.size(), 2u);
+    EXPECT_EQ(candidates[0], qzss2);
+    EXPECT_EQ(candidates[1], gps6);
+}
+
 TEST(PPPArTest, FrequencyLifecycleTracksSignalsIndependently) {
     ppp_shared::PPPAmbiguityInfo ambiguity;
     const GNSSTime first_time(2360, 100.0);


### PR DESCRIPTION
## What changed

- allow the direct state-DD partial-AR fallback to exclude a one-frequency constellation participant
- retain the existing dual-frequency preference, elevation ordering, four-satellite exclusion budget, and CLASLIB ratio table
- add coverage for explicitly selecting a one-frequency QZSS fallback candidate

## Why

At TOW 177085.6, MRTKLIB recovered by excluding GPS G11 and accepted `nb=6, ratio=3.756`. Native tried the same exclusion, but a newly reacquired QZSS J02-J03 DD remained about 0.51 cycles away from MRTKLIB's float state and collapsed the ratio to 1.004. Because one-frequency participants were never PAR candidates, every native retry retained the poisoned row.

## Impact

Tokyo run2 full scoring improves FIX from 1008/8788 (11.470%) to 1134/8788 (12.904%). MRTKLIB-overlapping FIX epochs improve from 893 to 998. Bad FIX epochs above 2 m remain zero; the 143 newly fixed epochs have 0.369 m RMS and 0.592 m maximum horizontal error. All-solution RMS improves from 20.180 m to 15.589 m.

## Validation

- `build/tests/run_tests`: 542 passed, 55 skipped
- `python3 -m pytest -q tests/test_ppc_clas_scorecard.py`: 9 passed
- Tokyo run2 520-epoch targeted probe: FIX 30 -> 79, bad FIX 0 -> 0
- Tokyo run2 full run: FIX 1008 -> 1134, bad FIX remains 0
- `git diff --check`
