### PR TITLE
Fix CLAS float recovery parity after bad seeds

### DIFF
--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -392,6 +392,11 @@ private:
     // gate so holdamb parity does not reconstruct participants from stale
     // ambiguity flags.
     std::vector<ppp_ar::WlnlHoldConstraint> clas_wlnl_candidate_hold_constraints_;
+    // MRTKLIB rtk->sol.rr is updated by every successful pntpos() call even
+    // when the later PPP update fails, and remains unchanged on pntpos()
+    // failure. Keep that lifecycle separate from published filter solutions.
+    PositionSolution clas_last_valid_spp_seed_;
+    bool has_clas_last_valid_spp_seed_ = false;
     Vector3d last_published_solution_position_ecef_ = Vector3d::Zero();
     bool has_last_published_solution_position_ = false;
     // Anchors MRTKLIB rtk->sol.time's role in tt (=timediff) computation

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -36,15 +36,24 @@ inline bool shouldRetryClasSeedWithFde(bool seed_valid,
              filter_spp_distance_m > max_spp_divergence_m));
 }
 
-/// Start one fixed AR quarantine window on a raw maxdiff event. Repeated
-/// maxdiff observations consume the active window instead of extending it.
+/// MRTKLIB dynamics keeps the previous sol.rr when masked pntpos admission
+/// fails. Native guard rejections still require a minimally populated solve.
+inline bool shouldCoastClasSeed(bool masked_admission_failed,
+                                bool filter_initialized,
+                                int satellites_used) {
+    return masked_admission_failed ||
+           (!filter_initialized && satellites_used >= 4);
+}
+
+/// Keep AR quarantined while raw maxdiff observations continue, then retain
+/// the quarantine for a bounded recovery window after the last event.
 inline bool updateClasSeedArQuarantine(bool trigger,
                                        int recovery_epochs,
                                        int& remaining_epochs) {
-    if (remaining_epochs > 0) {
-        --remaining_epochs;
-    } else if (trigger) {
+    if (trigger) {
         remaining_epochs = std::max(recovery_epochs, 0);
+    } else if (remaining_epochs > 0) {
+        --remaining_epochs;
     }
     return remaining_epochs > 0;
 }

--- a/include/libgnss++/algorithms/spp.hpp
+++ b/include/libgnss++/algorithms/spp.hpp
@@ -58,6 +58,7 @@ public:
         double max_position_jump_min_m = 0.0;         ///< Minimum allowed position step [m]
         bool use_ionosphere_free_combination = false; ///< Use dual-frequency code IFLC when available
         bool mrtklib_iflc_code_bias = false;          ///< Match MRTKLIB prange() IFLC TGD handling
+        bool mrtklib_clas_snr_mask = false;           ///< Apply the CLAS rover elevation/SNR mask
         bool use_ionex_corrections = true;            ///< Prefer loaded IONEX TEC maps over broadcast ionosphere
         bool use_dcb_corrections = true;              ///< Apply loaded OSB/DCB code-bias products when available
         bool use_precise_products = true;             ///< Use loaded SP3/CLK products for satellite orbit/clock
@@ -367,6 +368,9 @@ namespace spp_utils {
      * @brief Apply SNR-dependent weighting
      */
     double calculateSNRWeight(double snr_db, double min_snr_db = 35.0);
+
+    /** Match the CLAS benchmark rover SNR mask used by MRTKLIB testsnr(). */
+    double mrtklibClasSnrThresholdDbHz(double elevation_rad);
 
     struct MeasurementVarianceInputs {
         double elevation_rad = 0.0;

--- a/src/algorithms/ppp_ar.cpp
+++ b/src/algorithms/ppp_ar.cpp
@@ -1450,19 +1450,26 @@ WlnlFixAttempt tryDirectStateDdFix(
         return WlnlFixAttempt{};
     }
     if (!attempt.has_constrained_state ||
-        !std::isfinite(attempt.state_lambda_ratio) ||
-        attempt.state_lambda_ratio < attempt.state_required_ratio) {
+        !std::isfinite(attempt.state_lambda_ratio)) {
+        return WlnlFixAttempt{};
+    }
+
+    // resamb_LAMBDA() leaves rtk->sol.ratio populated after a valid LAMBDA
+    // solve even when the ratio test rejects the candidate. MRTKLIB's outer
+    // PAR loop uses that failed-trial ratio to choose the satellite to carry
+    // into the next exclusion iteration, so preserve it here as well.
+    attempt.ratio = attempt.state_lambda_ratio;
+    attempt.nb = attempt.state_dd_count;
+    if (attempt.state_lambda_ratio < attempt.state_required_ratio) {
         if (debug_enabled) {
             std::cerr << "[PPP-RESAMB-DIRECT] ratio reject: nb="
                       << attempt.state_dd_count
                       << " ratio=" << attempt.state_lambda_ratio
                       << " threshold=" << attempt.state_required_ratio << "\n";
         }
-        return WlnlFixAttempt{};
+        return attempt;
     }
 
-    attempt.ratio = attempt.state_lambda_ratio;
-    attempt.nb = attempt.state_dd_count;
     attempt.hold_constraints.reserve(rows.size());
     for (const auto& row : rows) {
         const SatelliteId real_ref = clasRealSatellite(row.ref_satellite);

--- a/src/algorithms/ppp_clas_epoch.cpp
+++ b/src/algorithms/ppp_clas_epoch.cpp
@@ -65,8 +65,9 @@ constexpr double kMrtklibPhaseResidualSigmaGate = 2.0;
 constexpr double kMrtklibMaxSppDivergenceM = 10.0;
 constexpr int kMrtklibMaxSppDivergenceEpochs = 5;
 // Cover the observed interval in which a maxdiff-inconsistent float can
-// otherwise originate and hold a false WLNL fix, without allowing repeated
-// maxdiff observations to postpone AR indefinitely.
+// otherwise originate and hold a false WLNL fix. Repeated raw maxdiff
+// observations refresh this window: MRTKLIB keeps resetting instead of
+// attempting AR while the SPP disagreement persists.
 constexpr int kClasSeedArQuarantineEpochs = 30;
 // Immediate (uncounted) sanity ceiling for the reset seed vs. the filter's
 // own tracked position -- see the long comment at its use site. Well above
@@ -836,6 +837,8 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         GNSSTime last_processed_time;
         int last_clas_atmos_network_id = -1;
         bool has_last_clas_atmos_network_id = false;
+        PositionSolution last_valid_spp_seed;
+        bool has_last_valid_spp_seed = false;
     };
     const ClasFallbackSnapshot fallback_snapshot{
         filter_state_,
@@ -852,6 +855,8 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         last_processed_time_,
         last_clas_atmos_network_id_,
         has_last_clas_atmos_network_id_,
+        clas_last_valid_spp_seed_,
+        has_clas_last_valid_spp_seed_,
     };
     const auto restore_clas_snapshot = [&]() {
         filter_state_ = fallback_snapshot.filter_state;
@@ -870,6 +875,9 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
             fallback_snapshot.last_clas_atmos_network_id;
         has_last_clas_atmos_network_id_ =
             fallback_snapshot.has_last_clas_atmos_network_id;
+        clas_last_valid_spp_seed_ = fallback_snapshot.last_valid_spp_seed;
+        has_clas_last_valid_spp_seed_ =
+            fallback_snapshot.has_last_valid_spp_seed;
     };
     const bool allow_hybrid_fallback =
         ppp_config_.clas_epoch_policy ==
@@ -888,6 +896,9 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
     // see the long comment at its assignment for what this gates.
     bool clas_seed_untrusted_this_epoch = false;
     bool clas_baseline_seed_maxdiff_this_epoch = false;
+    bool clas_seed_failed_before_continuity_fallback = false;
+    PositionSolution clas_continuity_output;
+    bool has_clas_continuity_output = false;
     if (clas_mrtklib_parity) {
         const auto original_spp_config = spp_processor_.getSPPConfig();
         auto clas_spp_config = original_spp_config;
@@ -903,6 +914,10 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         // and MAD clipping are not part of that solve.
         clas_spp_config.use_ionosphere_free_combination = true;
         clas_spp_config.mrtklib_iflc_code_bias = true;
+        clas_spp_config.mrtklib_clas_snr_mask = true;
+        // rtkpos() forces EPHOPT_BRDC for the PPP-RTK pntpos() seed even
+        // though the subsequent CLAS filter uses SSR APC products.
+        clas_spp_config.use_ssr_corrections = false;
         clas_spp_config.pseudorange_sigma = 1.0;
         clas_spp_config.use_variance_model = false;
         clas_spp_config.enable_outlier_detection = false;
@@ -943,6 +958,12 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
                 seed = fde_seed;
             }
         }
+        // pntpos() failure includes valsol() rejecting an otherwise finite LS
+        // solution (chi-square/redundancy), not just failure to form the LS.
+        // Capture the final FDE result using that same definition so dynamics
+        // can preserve the prior sol.rr below.
+        const bool clas_masked_spp_admission_failed =
+            !seed.isValid() || clasSeedFailsRedundancyGate(seed);
         spp_processor_.setSPPConfig(original_spp_config);
         if (seed.isValid() && clasSeedFailsRedundancyGate(seed)) {
             if (pppDebugEnabled()) {
@@ -992,10 +1013,13 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
                 seed.status = SolutionStatus::NONE;
             }
         }
-        // Captured *before* the coast-splice fallback below patches a
-        // rejected seed back to isValid()=true for filter-(re)init
-        // purposes: this is the guards' true verdict on the raw SPP this
-        // epoch (redundancy/chi-square gate, jump gate, or a plain
+        if (seed.isValid()) {
+            clas_last_valid_spp_seed_ = seed;
+            has_clas_last_valid_spp_seed_ = true;
+        }
+        // Captured before the output-only coast splice below: this is the
+        // guards' true verdict on the raw SPP this epoch
+        // (redundancy/chi-square gate, jump gate, or a plain
         // pre-existing SPP failure -- e.g. <4 usable satellites -- all
         // collapse to !seed.isValid() here). Debug evidence on
         // nagoya_run2 (tow 556698-556733, a 176-epoch/35 s continuous
@@ -1016,8 +1040,10 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
                 clas_baseline_seed_maxdiff_this_epoch,
                 kClasSeedArQuarantineEpochs,
                 clas_seed_ar_quarantine_epochs_);
+        clas_seed_failed_before_continuity_fallback = !seed.isValid();
         clas_seed_untrusted_this_epoch =
-            !seed.isValid() || clas_seed_ar_quarantined;
+            clas_seed_failed_before_continuity_fallback ||
+            clas_seed_ar_quarantined;
         // Suppressing this epoch's AR *attempt* alone is not enough: lock
         // counts are untouched by that gate, so a short (2-3 epoch)
         // rejection window can still leave every ambiguity's lock_count
@@ -1043,34 +1069,59 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
                 ambiguity.outage_count = 0;
             }
         }
-        // Coverage fallback for a rejected seed encountered mid-(re)init.
+        // Coverage fallback for a rejected seed.
         // mrtk_rtkpos.c:2417-2425: when pntpos() fails, MRTKLIB's caller
         // only skips the epoch outright in the static branch
         // (!rtk->opt.dynamics -> return 0); in dynamics mode (our path) it
         // falls through and keeps running ppp_rtk_pos() on the *stale*
         // rtk->sol.rr left by the last successful pntpos (sol_t is only
         // overwritten on success), i.e. it coasts rather than drops the
-        // epoch. This port's cold-(re)init path (prepareEpochState,
-        // filter_initialized_==false after every floatcnt/maxdiffp reset)
-        // instead requires seed_solution.isValid() and returns not-ready
-        // when it fails, silently suppressing the row. Mirror the literal
-        // behavior: when a gate above rejected the seed and there is no
-        // filter to fall back on, but a prior published fix exists, splice
-        // that stale-but-trustworthy position into the seed (position/
-        // velocity only -- initializeFilterState always applies its own
-        // fixed 30 m-sigma init variance regardless of seed quality, so no
-        // covariance bookkeeping is needed) so the epoch still initializes
-        // and publishes, instead of being dropped.
-        if (!seed.isValid() && !filter_initialized_ &&
+        // epoch. Native passes the current SPP result through later early
+        // returns, so an invalid result can suppress a row even when the
+        // filter is already running. Mirror the publication continuity by
+        // preparing a stale-but-trustworthy output row while leaving the
+        // invalid seed and filter lifecycle unchanged.
+        // A plain masked-admission failure commonly reports fewer than four
+        // satellites in native's invalid result. MRTKLIB still coasts in that
+        // exact case because the failed pntpos() leaves the prior sol.rr
+        // untouched. Keep the >=4 guard only for native redundancy/jump
+        // rejections, where it prevents manufacturing an epoch without a
+        // minimally viable current solve.
+        const bool coast_from_last_spp =
+            clas_masked_spp_admission_failed &&
+            has_clas_last_valid_spp_seed_;
+        const bool coast_from_last_published =
+            !clas_masked_spp_admission_failed &&
             has_last_published_solution_position_ &&
-            seed.num_satellites >= 4) {
+            ppp_shared::shouldCoastClasSeed(
+                false, filter_initialized_,
+                static_cast<int>(seed.satellites_used.size()));
+        if (!seed.isValid() &&
+            (coast_from_last_spp || coast_from_last_published)) {
             if (pppDebugEnabled()) {
                 std::cerr << "[CLAS-SEED-COAST] tow=" << obs.time.tow
                           << " coasting to last published position\n";
             }
-            seed.position_ecef = last_published_solution_position_ecef_;
-            seed.velocity_ecef = Vector3d::Zero();
-            seed.status = SolutionStatus::SPP;
+            PositionSolution coast_seed = seed;
+            if (coast_from_last_spp) {
+                coast_seed = clas_last_valid_spp_seed_;
+                coast_seed.time = obs.time;
+            } else {
+                coast_seed.position_ecef =
+                    last_published_solution_position_ecef_;
+                coast_seed.num_satellites =
+                    static_cast<int>(coast_seed.satellites_used.size());
+            }
+            coast_seed.velocity_ecef = Vector3d::Zero();
+            coast_seed.status = SolutionStatus::SPP;
+            // Preserve MRTKLIB's stale-sol continuity row without feeding it
+            // into native's filter. The original invalid seed must continue
+            // through the unchanged clear-path lifecycle; only an otherwise
+            // invalid return value is spliced below. Injecting the stale code
+            // position into either cold initialization or a running filter
+            // can originate delayed wrong fixes.
+            clas_continuity_output = coast_seed;
+            has_clas_continuity_output = coast_seed.isValid();
         }
     } else {
         seed = spp_processor_.processEpoch(obs, nav);
@@ -1104,7 +1155,8 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
     // genuine mid-stream coast (never a cold/re-init epoch, which already
     // has its own seed-availability handling).
     const bool clas_seed_guard_rejected_mid_stream =
-        clas_mrtklib_parity && filter_initialized_ && !seed.isValid();
+        clas_mrtklib_parity && filter_initialized_ &&
+        clas_seed_failed_before_continuity_fallback;
     // Advances clas_last_accepted_seed_time_ alongside every
     // last_processed_time_ update below, except on an epoch the guards
     // above just rejected -- i.e. exactly the pntpos-success gating
@@ -1219,6 +1271,15 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
     if (!epoch_preparation.ready) {
         if (allow_hybrid_fallback) {
             return fallback_to_standard("prepare_epoch_state");
+        }
+        if (has_clas_continuity_output) {
+            solution = clas_continuity_output;
+            applyOptionalSolutionEpochMetadata(solution, obs.time, ppp_config_);
+            // Output-only splice: preserve the exact pre-existing filter
+            // lifecycle. Advancing time/counters here changes the dt seen by
+            // the next genuinely accepted seed and suppresses later FIX
+            // recovery, even though no filter epoch was processed now.
+            return solution;
         }
         return solution;
     }
@@ -1372,7 +1433,9 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
             last_processed_time_ = obs.time;
             clas_update_seed_anchor();
         }
-        solution = seed;
+        solution = has_clas_continuity_output
+            ? clas_continuity_output
+            : seed;
         return solution;
     }
 
@@ -1485,7 +1548,9 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
             clas_dd_accumulator_ = {};
             ppp_ar::clearWlnlHoldState(clas_wlnl_hold_);
             last_clas_constrained_fixed_state_valid_ = false;
-            solution = seed;
+            solution = has_clas_continuity_output
+                ? clas_continuity_output
+                : seed;
             applyOptionalSolutionEpochMetadata(solution, obs.time, ppp_config_);
             has_last_processed_time_ = true;
             last_processed_time_ = obs.time;
@@ -1522,7 +1587,9 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
             last_processed_time_ = obs.time;
             clas_update_seed_anchor();
         }
-        solution = seed;
+        solution = has_clas_continuity_output
+            ? clas_continuity_output
+            : seed;
         return solution;
     }
     dumpClasFloatPosition(obs.time, filter_state_, epoch_update, osr_corrections.size());
@@ -2009,12 +2076,9 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
                 clas_kinematic_spp_divergence_count_ = 0;
                 ppp_ar::clearWlnlHoldState(clas_wlnl_hold_);
                 if (clas_mrtklib_parity && ppp_config_.use_dynamics_model) {
-                    // mrtk_ppp_rtk.c resets every element of x after maxdiffp
-                    // produces SOLQ_NONE when dynamics is enabled.  Resetting
-                    // only position/velocity leaves tightly constrained stale
-                    // ionosphere and ambiguity states attached to the new SPP
-                    // position.  The following epoch can then report a
-                    // high-ratio false FIX at that inconsistent state.
+                    // Drop the stale ambiguity/ionosphere state attached to
+                    // the pre-reset position. AR stays quarantined through
+                    // the recovery window above while the filter rebuilds.
                     filter_state_ = PPPState{};
                     filter_initialized_ = false;
                     ambiguity_states_.clear();

--- a/src/algorithms/spp.cpp
+++ b/src/algorithms/spp.cpp
@@ -904,6 +904,19 @@ PositionSolution SPPProcessor::solvePositionLS(const std::vector<SPPObservation>
             if (geom.elevation < min_elevation_rad) {
                 continue;
             }
+            // The CLAS benchmark enables MRTKLIB's rover SNR mask on both
+            // IFLC code slots. The native scalar SNR gate is evaluated before
+            // geometry and cannot reproduce its elevation interpolation.
+            // combinedSnr() is the minimum of the two code C/N0 values, so
+            // this single comparison is equivalent to testsnr() on P[0] and
+            // P[1]. At Tokyo run2 tow=178509.6 this rejects the weak G04 code
+            // and changes the seed from 63.3 m to 35.75 m (MRTKLIB: 35.73 m),
+            // restoring the same maxdiffp branch.
+            if (spp_config_.mrtklib_clas_snr_mask &&
+                obs.snr < spp_utils::mrtklibClasSnrThresholdDbHz(
+                              geom.elevation)) {
+                continue;
+            }
 
             double trop_delay = 0.0;
             // pntpos() uses the broadcast Saastamoinen correction for its
@@ -1951,6 +1964,19 @@ void SPPProcessor::updateStatistics(double processing_time_ms, bool success) con
 
 // Utility functions
 namespace spp_utils {
+
+double mrtklibClasSnrThresholdDbHz(double elevation_rad) {
+    constexpr double kMaskDbHz[] = {
+        10.0, 10.0, 10.0, 10.0, 30.0, 30.0, 30.0, 30.0, 30.0};
+    double interpolation =
+        (elevation_rad / kDegreesToRadians + 5.0) / 10.0;
+    const int index = static_cast<int>(std::floor(interpolation));
+    interpolation -= static_cast<double>(index);
+    if (index < 1) return kMaskDbHz[0];
+    if (index > 8) return kMaskDbHz[8];
+    return (1.0 - interpolation) * kMaskDbHz[index - 1] +
+           interpolation * kMaskDbHz[index];
+}
 
 double calculateElevation(const Vector3d& receiver_pos, const Vector3d& satellite_pos) {
     Vector3d los = satellite_pos - receiver_pos;

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -39,15 +39,25 @@ TEST(PPPClasSeedFde, RetriesOnlyRejectedOrMaxdiffInconsistentSeeds) {
         true, false, false, 20.0, 10.0));
 }
 
-TEST(PPPClasSeedFde, QuarantineDoesNotExtendOnRepeatedMaxdiff) {
+TEST(PPPClasSeedFde, QuarantineRefreshesOnRepeatedMaxdiff) {
     int remaining = 0;
     EXPECT_TRUE(ppp_shared::updateClasSeedArQuarantine(true, 3, remaining));
     EXPECT_EQ(remaining, 3);
     EXPECT_TRUE(ppp_shared::updateClasSeedArQuarantine(true, 3, remaining));
+    EXPECT_EQ(remaining, 3);
+    EXPECT_TRUE(ppp_shared::updateClasSeedArQuarantine(false, 3, remaining));
     EXPECT_EQ(remaining, 2);
-    EXPECT_TRUE(ppp_shared::updateClasSeedArQuarantine(true, 3, remaining));
+    EXPECT_TRUE(ppp_shared::updateClasSeedArQuarantine(false, 3, remaining));
     EXPECT_FALSE(ppp_shared::updateClasSeedArQuarantine(false, 3, remaining));
     EXPECT_EQ(remaining, 0);
+}
+
+TEST(PPPClasSeedFde, MaskedAdmissionFailureCoastsWithTooFewSatellites) {
+    EXPECT_TRUE(ppp_shared::shouldCoastClasSeed(true, true, 0));
+    EXPECT_TRUE(ppp_shared::shouldCoastClasSeed(true, false, 0));
+    EXPECT_TRUE(ppp_shared::shouldCoastClasSeed(false, false, 4));
+    EXPECT_FALSE(ppp_shared::shouldCoastClasSeed(false, true, 4));
+    EXPECT_FALSE(ppp_shared::shouldCoastClasSeed(false, false, 3));
 }
 
 TEST(PPPFilterIterations, MadocaPerFrequencyCommitsOneUpdatePerEpoch) {

--- a/tests/test_ppp_ar.cpp
+++ b/tests/test_ppp_ar.cpp
@@ -351,6 +351,64 @@ TEST(PPPArTest, DirectStateDdHoldUsesOnlyCurrentAcceptedRows) {
     }
 }
 
+TEST(PPPArTest, DirectStateDdRatioRejectPreservesRatioForNextParIteration) {
+    ppp_shared::PPPConfig config;
+    config.clas_mrtklib_float_parity = true;
+    config.use_clas_osr_filter = true;
+    config.kinematic_mode = true;
+    config.use_dynamics_model = true;
+    config.low_dynamics_mode = false;
+
+    ppp_shared::PPPState state;
+    state.pos_index = 0;
+    state.amb_index = 3;
+    state.total_states = 11;
+    state.state = VectorXd::Zero(state.total_states);
+    state.covariance = MatrixXd::Identity(state.total_states, state.total_states) * 1e-6;
+
+    const std::vector<SatelliteId> satellites = {
+        {GNSSSystem::GPS, 1}, {GNSSSystem::GPS, 2},
+        {GNSSSystem::GPS, 3}, {GNSSSystem::GPS, 4},
+        {GNSSSystem::GPS, 101}, {GNSSSystem::GPS, 102},
+        {GNSSSystem::GPS, 103}, {GNSSSystem::GPS, 104},
+    };
+    ppp_ar::EligibleAmbiguities eligible;
+    for (int i = 0; i < static_cast<int>(satellites.size()); ++i) {
+        const int state_index = state.amb_index + i;
+        eligible.satellites.push_back(satellites[static_cast<size_t>(i)]);
+        eligible.state_indices.push_back(state_index);
+        eligible.scales.push_back(0.19);
+        state.ambiguity_indices[satellites[static_cast<size_t>(i)]] = state_index;
+        double cycles = i < 4 ? static_cast<double>(i)
+                              : 10.0 + static_cast<double>(i - 4);
+        if (i == 3) {
+            cycles += 0.5;
+        }
+        state.state(state_index) = cycles * 0.19;
+    }
+
+    std::map<SatelliteId, ppp_shared::PPPAmbiguityInfo> ambiguity_states;
+    for (const auto& satellite : satellites) {
+        ambiguity_states[satellite].ambiguity_scale_m = 0.19;
+    }
+    std::map<SatelliteId, double> elevations;
+    for (int prn = 1; prn <= 4; ++prn) {
+        elevations[{GNSSSystem::GPS, static_cast<uint8_t>(prn)}] =
+            (35.0 + prn) * M_PI / 180.0;
+    }
+
+    const auto attempt = ppp_ar::resolveWlnlFix(
+        config, state, state.covariance, ambiguity_states, eligible,
+        ppp_ar::WlnlNlInfoProvider{}, false, &elevations);
+
+    EXPECT_FALSE(attempt.fixed);
+    EXPECT_TRUE(attempt.has_constrained_state);
+    EXPECT_EQ(attempt.nb, 6);
+    EXPECT_TRUE(std::isfinite(attempt.ratio));
+    EXPECT_GT(attempt.ratio, 0.0);
+    EXPECT_LT(attempt.ratio, attempt.state_required_ratio);
+}
+
 TEST(PPPArTest, BuildFixedObservationHelpersFilterInvalidProviders) {
     const SatelliteId sat1(GNSSSystem::GPS, 1);
     const SatelliteId sat2(GNSSSystem::GPS, 2);

--- a/tests/test_spp.cpp
+++ b/tests/test_spp.cpp
@@ -256,6 +256,19 @@ TEST(SPPUtilsTest, PseudorangeVariancePenalizesLowElevationAndWeakSnr) {
     EXPECT_GT(low_variance, high_variance);
 }
 
+TEST(SPPUtilsTest, MrtklibClasSnrMaskInterpolatesElevationBins) {
+    EXPECT_DOUBLE_EQ(spp_utils::mrtklibClasSnrThresholdDbHz(30.0 * M_PI / 180.0),
+                     10.0);
+    EXPECT_DOUBLE_EQ(spp_utils::mrtklibClasSnrThresholdDbHz(35.0 * M_PI / 180.0),
+                     10.0);
+    EXPECT_DOUBLE_EQ(spp_utils::mrtklibClasSnrThresholdDbHz(40.0 * M_PI / 180.0),
+                     20.0);
+    EXPECT_DOUBLE_EQ(spp_utils::mrtklibClasSnrThresholdDbHz(45.0 * M_PI / 180.0),
+                     30.0);
+    EXPECT_DOUBLE_EQ(spp_utils::mrtklibClasSnrThresholdDbHz(90.0 * M_PI / 180.0),
+                     30.0);
+}
+
 TEST(SPPUtilsTest, PseudorangeVariancePenalizesUnmodeledAtmosphere) {
     spp_utils::MeasurementVarianceInputs corrected;
     corrected.elevation_rad = 45.0 * M_PI / 180.0;


### PR DESCRIPTION
## What changed

- match MRTKLIB CLAS SPP admission with broadcast ephemerides and its elevation-dependent rover SNR mask
- preserve rejected LAMBDA ratios for PAR exclusion and refresh AR quarantine during repeated maxdiff events
- fully reset stale ambiguity/ionosphere state on maxdiff
- preserve MRTKLIB-style stale SPP output continuity without feeding stale positions into the filter
- add focused tests for AR, quarantine, coast, and SNR-mask behavior

## Root cause

The first epoch-level divergence was SPP admission/maxdiff: native seeded CLAS SPP with SSR and a scalar SNR gate, while MRTKLIB uses broadcast ephemerides plus an elevation-dependent CLAS rover mask. After that branch, native discarded failed-LAMBDA ratio information and retained stale ambiguity/ionosphere state across maxdiff reset, delaying float recovery and enabling unsafe later fixes.

In the principal Tokyo run2 recovery window (TOW 177802.6-177839.4), the old native lifecycle repeatedly reached `float_count=15` and reset while remaining FLOAT for all 185 epochs. This patch produces 174 FIX / 11 FLOAT in that same window. The danger window (TOW 178508-178538) remains 0 FIX.

## Validation

| Run | Coverage | FIX | rmsFIX m | maxFIX m | FIX >2 m |
|---|---:|---:|---:|---:|---:|
| tokyo1 | 99.782% | 7.703% | 0.508 | 1.454 | 0 |
| tokyo2 | 99.989% | 15.413% | 0.343 | 1.018 | 0 |
| tokyo3 | 99.980% | 33.548% | 0.317 | 2.064 | 4 |
| nagoya1 | 99.333% | 32.679% | 0.861 | 1.501 | 0 |
| nagoya2 | 99.958% | 17.737% | 0.724 | 1.270 | 0 |
| nagoya3 | 99.923% | 4.691% | 0.961 | 1.494 | 0 |

Tradeoff: FIX rate falls on tokyo1/nagoya2/nagoya3, while fixed-solution quality and coverage improve. Tokyo3 retains four marginal >2 m fixed epochs (max 2.064 m), down from 16 >2 m fixed epochs and max 4.226 m on develop.

- local GCC Release: 613 passed, 55 data-dependent skipped, 0 failed (668 total)
- Ubuntu clang CI: pass
- macOS clang CI: pass
- static-analysis, hygiene, and madoca-parity CI: pass
- static CLAS output byte-identical to both saved anchors: `d625ccb0e547baf3c9b1246488482801`
- Ubuntu GCC Actions job was attempted three times; each was terminated by the hosted runner with `exit 143 / runner received a shutdown signal` during a successful build, with no compiler or test failure
