### PR TITLE
fix CLAS maxdiff AR recovery

### DIFF
--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -45,8 +45,8 @@ inline bool shouldCoastClasSeed(bool masked_admission_failed,
            (!filter_initialized && satellites_used >= 4);
 }
 
-/// Keep AR quarantined while raw maxdiff observations continue, then retain
-/// the quarantine for a bounded recovery window after the last event.
+/// Keep the maxdiff recovery marker active while raw maxdiff observations
+/// continue, then retain it for a bounded validation window.
 inline bool updateClasSeedArQuarantine(bool trigger,
                                        int recovery_epochs,
                                        int& remaining_epochs) {
@@ -56,6 +56,17 @@ inline bool updateClasSeedArQuarantine(bool trigger,
         --remaining_epochs;
     }
     return remaining_epochs > 0;
+}
+
+/// A just-recovered native state needs one more DD row than MRTKLIB's normal
+/// minamb=6 floor and must clear the kinematic ratio floor before it can
+/// publish FIX. Outside recovery, MRTKLIB's nb-dependent threshold is
+/// unchanged.
+inline bool clasRecoveryFixIsSupported(bool recovery_active,
+                                       int nb,
+                                       double ratio,
+                                       double ratio_floor) {
+    return !recovery_active || (nb >= 7 && ratio >= ratio_floor);
 }
 
 struct PPPConfig {

--- a/src/algorithms/ppp_clas_epoch.cpp
+++ b/src/algorithms/ppp_clas_epoch.cpp
@@ -64,10 +64,9 @@ constexpr double kMrtklibPhaseResidualSigmaGate = 2.0;
 // (pos2-rejdiffpse -> opt.maxdiffp, pos2-poserrcnt; mrtk_ppp_rtk.c:2333-2352)
 constexpr double kMrtklibMaxSppDivergenceM = 10.0;
 constexpr int kMrtklibMaxSppDivergenceEpochs = 5;
-// Cover the observed interval in which a maxdiff-inconsistent float can
-// otherwise originate and hold a false WLNL fix. Repeated raw maxdiff
-// observations refresh this window: MRTKLIB keeps resetting instead of
-// attempting AR while the SPP disagreement persists.
+// Keep a bounded recovery marker after raw maxdiff. It no longer suppresses
+// all AR attempts; recovery candidates receive stricter row-count and ratio
+// validation below.
 constexpr int kClasSeedArQuarantineEpochs = 30;
 // Immediate (uncounted) sanity ceiling for the reset seed vs. the filter's
 // own tracked position -- see the long comment at its use site. Well above
@@ -897,6 +896,7 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
     bool clas_seed_untrusted_this_epoch = false;
     bool clas_baseline_seed_maxdiff_this_epoch = false;
     bool clas_seed_failed_before_continuity_fallback = false;
+    bool clas_seed_ar_recovery_this_epoch = false;
     PositionSolution clas_continuity_output;
     bool has_clas_continuity_output = false;
     if (clas_mrtklib_parity) {
@@ -1035,7 +1035,7 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         // coasted state should not be allowed to originate a new
         // publishable fix, only to keep the float filter alive until a
         // trustworthy seed returns.
-        const bool clas_seed_ar_quarantined =
+        clas_seed_ar_recovery_this_epoch =
             ppp_shared::updateClasSeedArQuarantine(
                 clas_baseline_seed_maxdiff_this_epoch,
                 kClasSeedArQuarantineEpochs,
@@ -1043,7 +1043,7 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         clas_seed_failed_before_continuity_fallback = !seed.isValid();
         clas_seed_untrusted_this_epoch =
             clas_seed_failed_before_continuity_fallback ||
-            clas_seed_ar_quarantined;
+            clas_baseline_seed_maxdiff_this_epoch;
         // Suppressing this epoch's AR *attempt* alone is not enough: lock
         // counts are untouched by that gate, so a short (2-3 epoch)
         // rejection window can still leave every ambiguity's lock_count
@@ -1062,7 +1062,12 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         // existing lock_count>=min_lock_count gate to enforce a natural
         // kMrtklibMinLock+1-epoch (6 accepted-phase-epoch) cooldown after
         // the rejected seed becomes trustworthy again.
-        if (clas_seed_untrusted_this_epoch) {
+        // A raw maxdiff sample does not invalidate MRTKLIB's ambiguity locks:
+        // AR runs before cntdiffp is updated, and state reset only happens
+        // after poserrcnt consecutive excesses. Keep the ambiguity cooldown
+        // for an actually failed SPP seed, but let a maxdiff-only recovery
+        // epoch reuse the still-valid lock history.
+        if (clas_seed_failed_before_continuity_fallback) {
             constexpr int kMrtklibMinLock = 5;
             for (auto& [_, ambiguity] : ambiguity_states_) {
                 ambiguity.lock_count = -kMrtklibMinLock;
@@ -1730,6 +1735,22 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         }
 
         if (ambiguity_resolution.accepted &&
+            !ppp_shared::clasRecoveryFixIsSupported(
+                clas_seed_ar_recovery_this_epoch, last_fixed_ambiguities_,
+                last_ar_ratio_, kClasKinematicMinFixRatio)) {
+            // Native's minimum-row fixes immediately after a maxdiff event
+            // are the remaining wrong-integer mode (Tokyo run2: 24 bad FIX,
+            // all nb=6). MRTKLIB's desired recovery begins at nb=8 and the
+            // native equivalent at nb=7 with ratio above the normal
+            // kinematic publication floor, so keep AR running but reject
+            // only the under-supported recovery candidate.
+            clas_kinematic_chisq_rejected = true;
+            if (pppDebugEnabled()) {
+                std::cerr << "[CLAS-KIN-RECOVERY] reject nb="
+                          << last_fixed_ambiguities_ << " ratio="
+                          << last_ar_ratio_ << "\n";
+            }
+        } else if (ambiguity_resolution.accepted &&
             !last_clas_constrained_fixed_state_valid_) {
             // MRTKLIB publishes FIX only from the constrained xa solution
             // (sol.rr = xa). Without a validated state-DD LAMBDA fix the epoch

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -39,7 +39,7 @@ TEST(PPPClasSeedFde, RetriesOnlyRejectedOrMaxdiffInconsistentSeeds) {
         true, false, false, 20.0, 10.0));
 }
 
-TEST(PPPClasSeedFde, QuarantineRefreshesOnRepeatedMaxdiff) {
+TEST(PPPClasSeedFde, RecoveryMarkerCountsDownAfterMaxdiffClears) {
     int remaining = 0;
     EXPECT_TRUE(ppp_shared::updateClasSeedArQuarantine(true, 3, remaining));
     EXPECT_EQ(remaining, 3);
@@ -50,6 +50,13 @@ TEST(PPPClasSeedFde, QuarantineRefreshesOnRepeatedMaxdiff) {
     EXPECT_TRUE(ppp_shared::updateClasSeedArQuarantine(false, 3, remaining));
     EXPECT_FALSE(ppp_shared::updateClasSeedArQuarantine(false, 3, remaining));
     EXPECT_EQ(remaining, 0);
+}
+
+TEST(PPPClasSeedFde, RecoveryFixRequiresRowsAndKinematicRatioFloor) {
+    EXPECT_TRUE(ppp_shared::clasRecoveryFixIsSupported(false, 6, 2.0, 3.0));
+    EXPECT_FALSE(ppp_shared::clasRecoveryFixIsSupported(true, 6, 4.0, 3.0));
+    EXPECT_FALSE(ppp_shared::clasRecoveryFixIsSupported(true, 7, 2.9, 3.0));
+    EXPECT_TRUE(ppp_shared::clasRecoveryFixIsSupported(true, 7, 3.0, 3.0));
 }
 
 TEST(PPPClasSeedFde, MaskedAdmissionFailureCoastsWithTooFewSatellites) {


### PR DESCRIPTION
## Summary

- let CLAS AR resume during the bounded maxdiff recovery marker instead of suppressing all attempts
- preserve MRTKLIB ambiguity-lock ordering for raw maxdiff samples
- require recovery FIX candidates to have at least seven DD rows and clear the kinematic ratio floor

## Root cause

Native treated a 30-epoch maxdiff recovery marker as a blanket AR quarantine. MRTKLIB runs AR before updating `cntdiffp`, so native stayed FLOAT long after the seed/filter distance recovered. Removing the blanket gate alone exposed under-supported or wrong-integer recovery candidates; validating `nb` and ratio closes those modes without losing the desired recovery.

## Validation

- 670 unit tests: 615 passed, 55 known skips, 0 failures
- six PPC CLAS full runs: all >3 m bad FIX counts are zero
- tokyo2 FIX 15.413% -> 19.219%; first recovered FIX at TOW 178679.8 remains `nb=7`, `ratio=3.149857`
- tokyo1 FIX 7.703% -> 9.702%; wrong-FIX window 189350.6-189354.4 is FLOAT
- static CLAS base/candidate outputs are byte-identical (MD5 `d625ccb0e547baf3c9b1246488482801`)
