### PR TITLE
Add realtime FIX integrity gate and fix MADOCA MSVC/CI build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -554,21 +554,36 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libeigen3-dev libgtest-dev cmake build-essential python3-dev pybind11-dev
+        sudo apt-get install -y libeigen3-dev libgtest-dev cmake build-essential python3-dev pybind11-dev ccache
+
+    - name: Restore MADOCA ccache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ccache
+        key: Linux-madoca-ccache-${{ hashFiles('CMakeLists.txt', 'src/**', 'include/**', 'tests/test_madoca_parity.cpp') }}
+        restore-keys: |
+          Linux-madoca-ccache-
+          Linux-ccache-
 
     - name: Configure CMake with MADOCALIB parity link
       run: |
         cmake -B build-madoca-parity \
           -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INTERPROCEDURAL_OPTIMIZATION=OFF \
+          -DCMAKE_C_COMPILER_LAUNCHER=ccache \
+          -DCMAKE_CXX_COMPILER_LAUNCHER=ccache \
           -DMADOCALIB_PARITY_LINK=ON \
           -DMADOCALIB_ROOT_DIR="${GITHUB_WORKSPACE}/external/madocalib"
 
     - name: Build MadocaParity tests and bridge tool
-      run: cmake --build build-madoca-parity --config Release --parallel --target run_tests
+      run: cmake --build build-madoca-parity --config Release --parallel --target gnss_madoca_parity_tests gnss_ppp
+
+    - name: Show MADOCA ccache stats
+      run: ccache -s
 
     - name: Run MadocaParity
       working-directory: build-madoca-parity
-      run: ./tests/run_tests --gtest_filter='*MadocaParity*:MadocaBridgeConfig.*'
+      run: ./tests/madoca_parity_tests --gtest_filter='*MadocaParity*:MadocaBridgeConfig.*'
 
     - name: Run MADOCALIB bridge smoke
       working-directory: build-madoca-parity

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -209,7 +209,14 @@ if(MADOCALIB_PARITY_LINK)
             NFREQ=5
             NEXOBS=5
     )
-    target_link_libraries(madocalib PUBLIC m Threads::Threads)
+    target_link_libraries(madocalib PUBLIC Threads::Threads)
+    if(WIN32)
+        # rtkcmn.c tickget() calls timeGetTime.
+        target_link_libraries(madocalib PUBLIC winmm)
+    else()
+        # libm is implicit in the MSVC CRT; an explicit m.lib breaks the link.
+        target_link_libraries(madocalib PUBLIC m)
+    endif()
     if(UNIX AND NOT APPLE)
         target_link_libraries(madocalib PUBLIC rt)
     endif()

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -1420,7 +1420,8 @@ HorizError horizontalErrorVsRef(const libgnss::FGOProcessor::FGOResult& r,
 // exact same nearest-in-time reference cursor as horizontalErrorVsRef() so the
 // per-epoch numbers are consistent with the printed headline metrics. Columns:
 //   tow,status,e_err_m,n_err_m,u_err_m,horiz_err_m,e_pos_m,n_pos_m,u_pos_m,
-//   x_ecef_m,y_ecef_m,z_ecef_m,ref_e_pos_m,ref_n_pos_m,ref_u_pos_m
+//   x_ecef_m,y_ecef_m,z_ecef_m,position_covariance_trace_m2,
+//   ref_e_pos_m,ref_n_pos_m,ref_u_pos_m
 // where *_err_m is the ENU delta vs the time-matched reference.csv row (the
 // same quantity the fix-rate/RMS metrics are computed from) and *_pos_m is the
 // solution/reference position in local ENU relative to the trajectory start
@@ -1446,7 +1447,8 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
     out << std::fixed;
     out.precision(3);
     out << "tow,status,e_err_m,n_err_m,u_err_m,horiz_err_m,e_pos_m,n_pos_m,u_pos_m,"
-           "x_ecef_m,y_ecef_m,z_ecef_m,ref_e_pos_m,ref_n_pos_m,ref_u_pos_m,"
+           "x_ecef_m,y_ecef_m,z_ecef_m,position_covariance_trace_m2,"
+           "ref_e_pos_m,ref_n_pos_m,ref_u_pos_m,"
            "vel_e_mps,vel_n_mps,vel_u_mps,"
            "ratio,ratio_threshold,nfixed,ar_outcome,ddpr_rms_m,sd_doppler_rms_mps,gdop,nsat,sd_doppler_n,"
            "amb_candidates,lambda_attempts,lambda_stage,amb_var_median,amb_var_max,"
@@ -1484,10 +1486,30 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
             si < r.epoch_velocity_nav_mps.size()
                 ? r.epoch_velocity_nav_mps[si]
                 : libgnss::Vector3d::Zero();
+        // Fix 3 (agent/realtime-fix-integrity follow-up): a non-positive (or
+        // exactly all-zero) covariance is never a genuine position
+        // uncertainty for any real KF/FGO estimator -- it means this
+        // solution path never populated position_covariance (PositionSolution
+        // leaves it default-constructed/uninitialized). Emitting 0.000 in
+        // that case is indistinguishable downstream from a real sub-
+        // millimetre estimate; ShadowEstimateHealthGate on the consuming
+        // side then (correctly) either trusts a fake perfect covariance or,
+        // once fixed, treats a bare 0.0 as unpopulated -- so the CSV must
+        // carry "missing", not "zero", here. See
+        // output/ppc_realtime_fix_integrity_matrix.md's "After fix" section
+        // (Gap 2) for the regression this closes.
+        const double covariance_trace = s.position_covariance.trace();
+        const bool covariance_populated = std::isfinite(covariance_trace) &&
+            covariance_trace > 0.0 &&
+            !(s.position_covariance.array() == 0.0).all();
         out << s.time.tow << ',' << status << ','
             << err_enu.x() << ',' << err_enu.y() << ',' << err_enu.z() << ','
             << horiz << ',' << pos_enu.x() << ',' << pos_enu.y() << ',' << pos_enu.z() << ','
-            << s.position_ecef.x() << ',' << s.position_ecef.y() << ',' << s.position_ecef.z() << ','
+            << s.position_ecef.x() << ',' << s.position_ecef.y() << ',' << s.position_ecef.z() << ',';
+        if (covariance_populated) {
+            out << covariance_trace;
+        }
+        out << ','
             << ref_pos_enu.x() << ',' << ref_pos_enu.y() << ',' << ref_pos_enu.z() << ','
             << velocity_nav.x() << ',' << velocity_nav.y() << ',' << velocity_nav.z() << ','
             << s.ratio;

--- a/apps/native/gnss_solve.cpp
+++ b/apps/native/gnss_solve.cpp
@@ -8,10 +8,12 @@
 #include <limits>
 #include <map>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <vector>
 
+#include <libgnss++/algorithms/integrity_consensus.hpp>
 #include <libgnss++/algorithms/nlos_weights.hpp>
 #include <libgnss++/algorithms/float_trust_policy.hpp>
 #include <libgnss++/algorithms/rtk.hpp>
@@ -228,6 +230,30 @@ struct SolveConfig {
     double demote_fixed_status_low_satellite_max_ratio = 0.0;
     double min_demote_fixed_status_baseline_m = 0.0;
     double max_demote_fixed_status_baseline_m = 0.0;
+    bool enable_realtime_fix_integrity = false;
+    // Fix 1 (agent/realtime-fix-integrity follow-up): opt-in, off by
+    // default. Ported field-for-field from the frozen offline external
+    // audit and safe there (Shinjuku-Trimble: 22 caught / 0 harmed), but
+    // net-harmful on the plain KF PPC baseline (nagoya2: 80 caught / 177
+    // harmed) -- see output/ppc_realtime_fix_integrity_matrix.md's "After
+    // fix" section. Recommended for low-FIX-rate receivers matching the
+    // audited offline external policy.
+    bool enable_integrity_base_gate = false;
+    std::string integrity_shadow_csv_path;
+    std::string integrity_log_path;
+    double integrity_shadow_match_tolerance_s = 0.25;
+    double integrity_shadow_max_age_s = 1.0;
+    double integrity_shadow_max_gdop = 4.0;
+    double integrity_shadow_max_ddpr_rms_m = 40.0;
+    int integrity_shadow_min_satellites = 8;
+    double integrity_shadow_default_covariance_trace_m2 = 4.0;
+    // Health must bound position accuracy, not just availability -- see
+    // libgnss::ShadowEstimateHealthGate's doc comment. A missing/unpopulated
+    // (non-positive) covariance trace disables demotion authority unless
+    // integrity_shadow_assume_default_covariance_trace is explicitly set.
+    double integrity_shadow_max_covariance_trace_m2 = 4.0;
+    bool integrity_shadow_assume_default_covariance_trace = false;
+    bool integrity_shadow_require_fixed_status = true;
     int max_consecutive_float_for_reset = 0;
     int max_consecutive_nonfix_for_reset = 0;
     double max_postfix_residual_rms = 0.0;
@@ -353,6 +379,235 @@ bool shouldDemoteFixedStatus(const SolveConfig& config,
     }
     return false;
 }
+
+std::vector<std::string> parseCsvFields(const std::string& line) {
+    std::vector<std::string> fields;
+    std::string field;
+    bool quoted = false;
+    for (std::size_t i = 0; i < line.size(); ++i) {
+        const char ch = line[i];
+        if (ch == '"') {
+            if (quoted && i + 1 < line.size() && line[i + 1] == '"') {
+                field.push_back('"');
+                ++i;
+            } else {
+                quoted = !quoted;
+            }
+        } else if (ch == ',' && !quoted) {
+            fields.push_back(field);
+            field.clear();
+        } else {
+            field.push_back(ch);
+        }
+    }
+    fields.push_back(field);
+    return fields;
+}
+
+std::optional<double> parseFiniteDouble(const std::string& text) {
+    if (text.empty()) return std::nullopt;
+    char* end = nullptr;
+    const double value = std::strtod(text.c_str(), &end);
+    if (end == text.c_str() || *end != '\0' || !std::isfinite(value)) {
+        return std::nullopt;
+    }
+    return value;
+}
+
+class IntegrityShadowTimeline {
+public:
+    struct Config {
+        double match_tolerance_s = 0.25;
+        libgnss::ShadowEstimateHealthGate::Config health;
+    };
+
+    explicit IntegrityShadowTimeline(Config config)
+        : config_(config), health_gate_(config.health) {}
+
+    // Diagnostics for reporting how often the shadow qualifies as demotion
+    // authority under the configured health gate.
+    std::uint64_t lookups() const { return lookups_; }
+    std::uint64_t healthyLookups() const { return healthy_lookups_; }
+
+    bool load(const std::string& path) {
+        std::ifstream input(path);
+        if (!input) return false;
+        std::string line;
+        if (!std::getline(input, line)) return false;
+        const auto header = parseCsvFields(line);
+        std::map<std::string, std::size_t> columns;
+        for (std::size_t i = 0; i < header.size(); ++i) columns[header[i]] = i;
+        for (const char* required : {"tow", "status", "x_ecef_m", "y_ecef_m", "z_ecef_m"}) {
+            if (columns.find(required) == columns.end()) return false;
+        }
+
+        auto field = [&](const std::vector<std::string>& row,
+                         const char* name) -> std::string {
+            const auto it = columns.find(name);
+            return it != columns.end() && it->second < row.size()
+                ? row[it->second]
+                : std::string{};
+        };
+        while (std::getline(input, line)) {
+            const auto row = parseCsvFields(line);
+            const auto tow = parseFiniteDouble(field(row, "tow"));
+            const auto x = parseFiniteDouble(field(row, "x_ecef_m"));
+            const auto y = parseFiniteDouble(field(row, "y_ecef_m"));
+            const auto z = parseFiniteDouble(field(row, "z_ecef_m"));
+            if (!tow || !x || !y || !z) continue;
+            Sample sample;
+            sample.tow_s = *tow;
+            sample.position_ecef = Eigen::Vector3d(*x, *y, *z);
+            const std::string status = field(row, "status");
+            sample.status_fixed = status == "FIXED" || status == "4";
+            sample.status_present = sample.status_fixed || status == "FLOAT" ||
+                status == "3";
+            sample.gdop = parseFiniteDouble(field(row, "gdop"));
+            sample.ddpr_rms_m = parseFiniteDouble(field(row, "ddpr_rms_m"));
+            if (const auto nsat = parseFiniteDouble(field(row, "nsat"))) {
+                sample.num_satellites = static_cast<int>(*nsat);
+            }
+            sample.covariance_trace_m2 = parseFiniteDouble(
+                field(row, "position_covariance_trace_m2"));
+            if (const auto generation = parseFiniteDouble(
+                    field(row, "reset_generation"))) {
+                sample.reset_generation = static_cast<std::uint64_t>(
+                    std::max(0.0, *generation));
+            }
+            samples_.push_back(std::move(sample));
+        }
+        std::sort(samples_.begin(), samples_.end(), [](const Sample& lhs, const Sample& rhs) {
+            return lhs.tow_s < rhs.tow_s;
+        });
+        return !samples_.empty();
+    }
+
+    libgnss::RealtimeFixIntegrityGate::IndependentEstimate lookup(
+        const libgnss::GNSSTime& time) const {
+        libgnss::RealtimeFixIntegrityGate::IndependentEstimate output;
+        if (samples_.empty()) return output;
+        // Never consume a future shadow estimate.  The CSV may have been
+        // generated offline, but the gate must behave exactly like a live
+        // KF/FGO subscriber at this epoch.
+        const auto after = std::upper_bound(
+            samples_.begin(), samples_.end(), time.tow,
+            [](double tow, const Sample& sample) { return tow < sample.tow_s; });
+        if (after == samples_.begin()) return output;
+        const Sample* best = &*std::prev(after);
+        const double age_s = time.tow - best->tow_s;
+        if (age_s > config_.match_tolerance_s) return output;
+
+        output.present = true;
+        output.age_s = age_s;
+        output.reset_generation = best->reset_generation;
+        output.estimate.valid = best->position_ecef.allFinite();
+        output.estimate.position_ecef = best->position_ecef;
+
+        libgnss::ShadowEstimateHealthGate::Sample health_sample;
+        health_sample.status_fixed = best->status_fixed;
+        health_sample.status_present = best->status_present;
+        health_sample.gdop = best->gdop;
+        health_sample.ddpr_rms_m = best->ddpr_rms_m;
+        health_sample.num_satellites = best->num_satellites;
+        health_sample.covariance_trace_m2 = best->covariance_trace_m2;
+        health_sample.age_s = age_s;
+        const auto health = health_gate_.evaluate(health_sample);
+        output.estimate.covariance_trace_m2 = health.covariance_trace_m2;
+
+        ++lookups_;
+        if (health.healthy) ++healthy_lookups_;
+        return output;
+    }
+
+private:
+    struct Sample {
+        double tow_s = 0.0;
+        bool status_fixed = false;
+        bool status_present = false;
+        Eigen::Vector3d position_ecef = Eigen::Vector3d::Zero();
+        std::optional<double> gdop;
+        std::optional<double> ddpr_rms_m;
+        std::optional<int> num_satellites;
+        std::optional<double> covariance_trace_m2;
+        std::uint64_t reset_generation = 0;
+    };
+
+    Config config_;
+    libgnss::ShadowEstimateHealthGate health_gate_;
+    std::vector<Sample> samples_;
+    mutable std::uint64_t lookups_ = 0;
+    mutable std::uint64_t healthy_lookups_ = 0;
+};
+
+const char* integrityStateName(libgnss::IntegrityConsensusManager::State state) {
+    using State = libgnss::IntegrityConsensusManager::State;
+    switch (state) {
+        case State::NORMAL: return "NORMAL";
+        case State::SUSPECT: return "SUSPECT";
+        case State::QUARANTINE: return "QUARANTINE";
+        case State::RECOVERY: return "RECOVERY";
+    }
+    return "UNKNOWN";
+}
+
+class IntegrityTelemetryWriter {
+public:
+    bool open(const std::string& path) {
+        if (path.empty()) return true;
+        output_.open(path);
+        if (!output_) return false;
+        output_ << "gps_week,tow,status,state,reasons,allow_fixed,request_primary_reset,"
+                   "promote_joint_anchor,disagreement_m,aperture_m,recovery_streak,"
+                   "primary_suspect,hard_primary_suspect,independent_present,"
+                   "independent_valid,independent_age_s,primary_covariance_trace_m2,"
+                   "independent_covariance_trace_m2,independent_reset_generation,"
+                   "residual_streak_match,residual_streak_demoted,residual_spike_demoted,"
+                   "consensus_demoted,output_demoted,output_latency_epochs,"
+                   "base_confidence_demoted\n";
+        return true;
+    }
+
+    void write(const libgnss::RealtimeFixIntegrityGate::Emission& emission) {
+        if (!output_) return;
+        const auto& solution = emission.solution;
+        const auto& telemetry = emission.telemetry;
+        output_ << solution.time.week << ',' << std::fixed << std::setprecision(3)
+                << solution.time.tow << ',' << static_cast<int>(solution.status) << ','
+                << integrityStateName(telemetry.consensus.state) << ','
+                << telemetry.consensus.reasons << ','
+                << telemetry.consensus.allow_fixed << ','
+                << telemetry.consensus.request_primary_reset << ','
+                << telemetry.consensus.promote_joint_anchor << ',';
+        writeNumber(telemetry.consensus.disagreement_m);
+        output_ << ',';
+        writeNumber(telemetry.consensus.aperture_m);
+        output_ << ',' << telemetry.consensus.recovery_streak << ','
+                << telemetry.primary_suspect << ','
+                << telemetry.hard_primary_suspect << ','
+                << telemetry.independent_present << ','
+                << telemetry.independent_valid << ',';
+        writeNumber(telemetry.independent_age_s);
+        output_ << ',';
+        writeNumber(telemetry.primary_covariance_trace_m2);
+        output_ << ',';
+        writeNumber(telemetry.independent_covariance_trace_m2);
+        output_ << ',' << telemetry.independent_reset_generation << ','
+                << telemetry.residual_streak_match << ','
+                << telemetry.residual_streak_demoted << ','
+                << telemetry.residual_spike_demoted << ','
+                << telemetry.consensus_demoted << ','
+                << telemetry.output_demoted << ','
+                << telemetry.output_latency_epochs << ','
+                << telemetry.base_confidence_demoted << '\n';
+    }
+
+private:
+    void writeNumber(double value) {
+        if (std::isfinite(value)) output_ << std::setprecision(9) << value;
+    }
+
+    std::ofstream output_;
+};
 
 std::string modeChoiceString(ModeChoice mode) {
     switch (mode) {
@@ -1176,6 +1431,47 @@ void printUsage(const char* program_name) {
         << "                             Maximum trusted-anchor age (default: 6)\n"
         << "  --rover-seed-pos <file>    Inject ECEF seed positions from .pos file per epoch\n"
         << "  --diagnostics-csv <file>   Write per-epoch RTK candidate diagnostics CSV (PPC pipeline format)\n"
+        << "  --realtime-fix-integrity   Gate FIX output with bounded-latency residual checks\n"
+        << "                             (default: off; maximum latency: 7 epochs)\n"
+        << "  --integrity-base-gate      Also enable the frozen offline low-satellite/ratio\n"
+        << "                             confidence gate (default: off). Recommended for\n"
+        << "                             low-FIX-rate receivers matching the audited offline\n"
+        << "                             external policy (UrbanNav Shinjuku-Trimble: 22 caught,\n"
+        << "                             0 harmed); on the plain KF PPC baseline it over-demotes\n"
+        << "                             (net-harmful on at least one PPC run) -- see\n"
+        << "                             output/ppc_realtime_fix_integrity_matrix.md.\n"
+        << "  --no-integrity-base-gate   Disable the base confidence gate (default)\n"
+        << "  --integrity-shadow-csv <file>\n"
+        << "                             Add causal KF/FGO position consensus from an epoch CSV;\n"
+        << "                             implies --realtime-fix-integrity\n"
+        << "  --integrity-shadow-match-tolerance <s>\n"
+        << "                             Max age of a shadow sample to match an epoch (default: 0.25)\n"
+        << "  --integrity-shadow-max-age <s>\n"
+        << "                             Max shadow sample age accepted as healthy (default: 1.0)\n"
+        << "  --integrity-shadow-max-gdop <v>\n"
+        << "                             Max shadow GDOP accepted as healthy (default: 4.0)\n"
+        << "  --integrity-shadow-max-ddpr-rms <m>\n"
+        << "                             Max shadow DD-prefit RMS accepted as healthy (default: 40.0)\n"
+        << "  --integrity-shadow-min-satellites <n>\n"
+        << "                             Min shadow satellite count accepted as healthy (default: 8)\n"
+        << "  --integrity-shadow-max-covariance-trace <m^2>\n"
+        << "                             Max shadow position_covariance_trace_m2 accepted as\n"
+        << "                             demotion authority (default: 4.0)\n"
+        << "  --integrity-shadow-assume-default-covariance-trace\n"
+        << "                             Opt in to substituting --integrity-shadow-default-covariance-trace\n"
+        << "                             when the shadow CSV's own trace is missing/non-positive\n"
+        << "                             (default: off -- a missing/unpopulated trace disables\n"
+        << "                             demotion authority rather than silently granting it)\n"
+        << "  --integrity-shadow-default-covariance-trace <m^2>\n"
+        << "                             Fallback trace used only with --integrity-shadow-assume-\n"
+        << "                             default-covariance-trace (default: 4.0)\n"
+        << "  --integrity-shadow-require-fixed-status\n"
+        << "                             Require shadow status FIXED for demotion authority (default: on)\n"
+        << "  --integrity-shadow-allow-float-status\n"
+        << "                             Allow shadow status FLOAT to act as demotion authority too\n"
+        << "                             (default: off; FLOAT shadow samples were found badly diverged\n"
+        << "                             on PPC tokyo1 despite passing GDOP/DDPR-RMS/nsat/age)\n"
+        << "  --integrity-log <file>     Write real-time integrity decisions and latency CSV\n"
         << "  --rtk-update-outlier-threshold <v>\n"
         << "                             Outlier rejection threshold for RTK measurement update (default: 30.0)\n"
         << "  --no-kinematic-post-filter Disable the kinematic output post-filter\n"
@@ -1420,6 +1716,68 @@ SolveConfig parseArguments(int argc, char* argv[]) {
         }
         if (arg == "--ddpr-anchor-max-fde-removals" && i + 1 < argc) {
             config.ddpr_anchor_max_fde_removals = std::stoi(argv[++i]);
+            continue;
+        }
+        if (arg == "--realtime-fix-integrity") {
+            config.enable_realtime_fix_integrity = true;
+            continue;
+        }
+        if (arg == "--integrity-base-gate") {
+            config.enable_integrity_base_gate = true;
+            continue;
+        }
+        if (arg == "--no-integrity-base-gate") {
+            config.enable_integrity_base_gate = false;
+            continue;
+        }
+        if (arg == "--integrity-shadow-csv" && i + 1 < argc) {
+            config.integrity_shadow_csv_path = argv[++i];
+            config.enable_realtime_fix_integrity = true;
+            continue;
+        }
+        if (arg == "--integrity-shadow-match-tolerance" && i + 1 < argc) {
+            config.integrity_shadow_match_tolerance_s = std::stod(argv[++i]);
+            continue;
+        }
+        if (arg == "--integrity-shadow-max-age" && i + 1 < argc) {
+            config.integrity_shadow_max_age_s = std::stod(argv[++i]);
+            continue;
+        }
+        if (arg == "--integrity-shadow-max-gdop" && i + 1 < argc) {
+            config.integrity_shadow_max_gdop = std::stod(argv[++i]);
+            continue;
+        }
+        if (arg == "--integrity-shadow-max-ddpr-rms" && i + 1 < argc) {
+            config.integrity_shadow_max_ddpr_rms_m = std::stod(argv[++i]);
+            continue;
+        }
+        if (arg == "--integrity-shadow-min-satellites" && i + 1 < argc) {
+            config.integrity_shadow_min_satellites = std::stoi(argv[++i]);
+            continue;
+        }
+        if (arg == "--integrity-shadow-max-covariance-trace" && i + 1 < argc) {
+            config.integrity_shadow_max_covariance_trace_m2 = std::stod(argv[++i]);
+            continue;
+        }
+        if (arg == "--integrity-shadow-default-covariance-trace" && i + 1 < argc) {
+            config.integrity_shadow_default_covariance_trace_m2 = std::stod(argv[++i]);
+            continue;
+        }
+        if (arg == "--integrity-shadow-assume-default-covariance-trace") {
+            config.integrity_shadow_assume_default_covariance_trace = true;
+            continue;
+        }
+        if (arg == "--integrity-shadow-require-fixed-status") {
+            config.integrity_shadow_require_fixed_status = true;
+            continue;
+        }
+        if (arg == "--integrity-shadow-allow-float-status") {
+            config.integrity_shadow_require_fixed_status = false;
+            continue;
+        }
+        if (arg == "--integrity-log" && i + 1 < argc) {
+            config.integrity_log_path = argv[++i];
+            config.enable_realtime_fix_integrity = true;
             continue;
         }
         if (arg == "--low-ratio-guard-threshold" && i + 1 < argc) {
@@ -2473,6 +2831,46 @@ int main(int argc, char* argv[]) {
             writeDiagnosticsHeader(diagnostics_csv);
         }
 
+        std::unique_ptr<IntegrityShadowTimeline> integrity_shadow;
+        if (!config.integrity_shadow_csv_path.empty()) {
+            IntegrityShadowTimeline::Config shadow_config;
+            shadow_config.match_tolerance_s = config.integrity_shadow_match_tolerance_s;
+            shadow_config.health.max_age_s = config.integrity_shadow_max_age_s;
+            shadow_config.health.max_gdop = config.integrity_shadow_max_gdop;
+            shadow_config.health.max_ddpr_rms_m = config.integrity_shadow_max_ddpr_rms_m;
+            shadow_config.health.min_satellites = config.integrity_shadow_min_satellites;
+            shadow_config.health.max_covariance_trace_m2 =
+                config.integrity_shadow_max_covariance_trace_m2;
+            shadow_config.health.assume_default_covariance_trace =
+                config.integrity_shadow_assume_default_covariance_trace;
+            shadow_config.health.default_covariance_trace_m2 =
+                config.integrity_shadow_default_covariance_trace_m2;
+            shadow_config.health.require_fixed_status =
+                config.integrity_shadow_require_fixed_status;
+            integrity_shadow = std::make_unique<IntegrityShadowTimeline>(shadow_config);
+            if (!integrity_shadow->load(config.integrity_shadow_csv_path)) {
+                std::cerr << "Error: failed to load integrity shadow CSV: "
+                          << config.integrity_shadow_csv_path << std::endl;
+                return 1;
+            }
+        }
+
+        std::unique_ptr<libgnss::RealtimeFixIntegrityGate> integrity_gate;
+        IntegrityTelemetryWriter integrity_writer;
+        if (config.enable_realtime_fix_integrity) {
+            libgnss::RealtimeFixIntegrityGate::Config integrity_config;
+            integrity_config.enable_consensus = integrity_shadow != nullptr;
+            integrity_config.enable_base_confidence_policy =
+                config.enable_integrity_base_gate;
+            integrity_gate =
+                std::make_unique<libgnss::RealtimeFixIntegrityGate>(integrity_config);
+            if (!integrity_writer.open(config.integrity_log_path)) {
+                std::cerr << "Error: failed to open integrity log: "
+                          << config.integrity_log_path << std::endl;
+                return 1;
+            }
+        }
+
         std::cout << "libgnss++ post-process solver" << std::endl;
         std::cout << "  rover: " << config.rover_obs_path << std::endl;
         std::cout << "  base: " << config.base_obs_path << std::endl;
@@ -2496,6 +2894,11 @@ int main(int argc, char* argv[]) {
                   << std::endl;
         std::cout << "  base interpolation: "
                   << (config.enable_base_interpolation ? "enabled" : "disabled") << std::endl;
+        if (integrity_gate) {
+            std::cout << "  real-time FIX integrity: enabled (max latency "
+                      << integrity_gate->maxOutputLatencyEpochs() << " epochs, consensus "
+                      << (integrity_shadow ? "enabled" : "disabled") << ')' << std::endl;
+        }
 
         libgnss::io::RINEXReader rover_reader;
         libgnss::io::RINEXReader base_reader;
@@ -2606,6 +3009,32 @@ int main(int argc, char* argv[]) {
         int fixed_bridge_burst_guard_rejected_epochs = 0;
         libgnss::PositionSolution last_fixed_output;
         bool have_last_fixed_output = false;
+        libgnss::PositionSolution last_guard_output;
+        bool have_last_guard_output = false;
+
+        const auto record_output = [&](const libgnss::PositionSolution& output_solution) {
+            if (!output_solution.isValid()) return;
+            solution.addSolution(output_solution);
+            ++valid_solution_count;
+            if (output_solution.isFixed()) ++fixed_solution_count;
+            if (config.verbose &&
+                (valid_solution_count <= 5 || valid_solution_count % 100 == 0)) {
+                std::cout << "epoch " << valid_solution_count
+                          << " tow=" << std::fixed << std::setprecision(3)
+                          << output_solution.time.tow
+                          << " status=" << static_cast<int>(output_solution.status)
+                          << " sats=" << output_solution.num_satellites
+                          << " ratio=" << std::setprecision(2) << output_solution.ratio
+                          << std::endl;
+            }
+        };
+
+        const auto record_integrity_emissions = [&](const auto& emissions) {
+            for (const auto& emission : emissions) {
+                integrity_writer.write(emission);
+                record_output(emission.solution);
+            }
+        };
 
         while (rover_ok) {
             if (config.max_epochs > 0 && processed_rover_epochs >= config.max_epochs) {
@@ -2668,8 +3097,9 @@ int main(int argc, char* argv[]) {
             }
 
             auto pos_solution = rtk_processor.processRTKEpoch(rover_obs, aligned_base_obs, nav_data);
-            const libgnss::PositionSolution* last_output = solution.getLastSolution();
-            const bool have_last_output = last_output != nullptr && last_output->isValid();
+            const libgnss::PositionSolution* last_output =
+                have_last_guard_output ? &last_guard_output : nullptr;
+            const bool have_last_output = last_output != nullptr;
             const auto jump_from_last_output = [&](const libgnss::PositionSolution& candidate) {
                 if (!have_last_output || !candidate.isValid()) {
                     return std::numeric_limits<double>::infinity();
@@ -2742,6 +3172,29 @@ int main(int argc, char* argv[]) {
                 pos_solution.status = libgnss::SolutionStatus::FLOAT;
             }
 
+            auto gated_feedback_solution = feedback_solution;
+            bool integrity_reset_requested = false;
+            if (integrity_gate) {
+                libgnss::RealtimeFixIntegrityGate::EpochInput integrity_input;
+                integrity_input.primary = pos_solution;
+                if (integrity_shadow) {
+                    integrity_input.independent = integrity_shadow->lookup(pos_solution.time);
+                }
+                auto integrity_update = integrity_gate->push(std::move(integrity_input));
+                if (integrity_update.current.output_demoted) {
+                    pos_solution.status = libgnss::SolutionStatus::FLOAT;
+                    if (gated_feedback_solution.isFixed()) {
+                        gated_feedback_solution.status = libgnss::SolutionStatus::FLOAT;
+                    }
+                }
+                integrity_reset_requested =
+                    integrity_update.current.consensus.request_primary_reset ||
+                    integrity_update.current.residual_streak_demoted ||
+                    integrity_update.current.residual_spike_demoted ||
+                    integrity_update.current.base_confidence_demoted;
+                record_integrity_emissions(integrity_update.emitted);
+            }
+
             debug_writer.write(pos_solution, rtk_processor.getLastDebugTelemetry());
 
             if (diagnostics_csv.is_open()) {
@@ -2765,24 +3218,20 @@ int main(int argc, char* argv[]) {
                 writeDiagnosticsRow(diagnostics_csv, diag);
             }
 
-            if (pos_solution.isValid()) {
-                solution.addSolution(pos_solution);
-                valid_solution_count++;
-                if (pos_solution.isFixed()) {
-                    fixed_solution_count++;
-                }
-                if (feedback_solution.isFixed()) {
-                    last_fixed_output = feedback_solution;
-                    have_last_fixed_output = true;
-                }
+            if (integrity_reset_requested) {
+                rtk_processor.reset();
+                have_last_fixed_output = false;
+            }
 
-                if (config.verbose && (valid_solution_count <= 5 || valid_solution_count % 100 == 0)) {
-                    std::cout << "epoch " << valid_solution_count
-                              << " tow=" << std::fixed << std::setprecision(3) << pos_solution.time.tow
-                              << " status=" << static_cast<int>(pos_solution.status)
-                              << " sats=" << pos_solution.num_satellites
-                              << " ratio=" << std::setprecision(2) << pos_solution.ratio
-                              << std::endl;
+            if (!integrity_gate) {
+                record_output(pos_solution);
+            }
+            if (pos_solution.isValid()) {
+                last_guard_output = pos_solution;
+                have_last_guard_output = true;
+                if (gated_feedback_solution.isFixed()) {
+                    last_fixed_output = gated_feedback_solution;
+                    have_last_fixed_output = true;
                 }
             }
 
@@ -2792,8 +3241,8 @@ int main(int argc, char* argv[]) {
                 const bool trusted_spp_seed =
                     pos_solution.status == libgnss::SolutionStatus::SPP &&
                     pos_solution.num_satellites >= 7;
-                if (feedback_solution.isFixed()) {
-                    rover_obs.receiver_position = feedback_solution.position_ecef;
+                if (gated_feedback_solution.isFixed()) {
+                    rover_obs.receiver_position = gated_feedback_solution.position_ecef;
                 } else if (trusted_spp_seed) {
                     rover_obs.receiver_position = pos_solution.position_ecef;
                 } else {
@@ -2801,6 +3250,10 @@ int main(int argc, char* argv[]) {
                 }
             }
             processed_rover_epochs++;
+        }
+
+        if (integrity_gate) {
+            record_integrity_emissions(integrity_gate->flush());
         }
 
         if (config.enable_nonfix_drift_guard &&
@@ -2994,6 +3447,18 @@ int main(int argc, char* argv[]) {
             rover_header.approximate_position.norm() > 0.0 && mean_count > 0) {
             std::cout << "  header vs mean diff: "
                       << (mean_pos - rover_header.approximate_position).norm() << " m" << std::endl;
+        }
+        if (integrity_shadow) {
+            const auto lookups = integrity_shadow->lookups();
+            const auto healthy = integrity_shadow->healthyLookups();
+            std::cout << "  integrity shadow health: " << healthy << '/' << lookups;
+            if (lookups > 0) {
+                std::cout << " (" << std::fixed << std::setprecision(2)
+                          << (100.0 * static_cast<double>(healthy) /
+                              static_cast<double>(lookups))
+                          << "% qualified as demotion authority)";
+            }
+            std::cout << std::endl;
         }
         std::cout << "  output written: " << config.output_pos_path << std::endl;
         if (config.write_kml) {

--- a/docs/ppc_online_consensus_design.md
+++ b/docs/ppc_online_consensus_design.md
@@ -164,6 +164,38 @@ and harmed zero correct FIX, yielding
 Because Shinjuku had only 51 FIX epochs (0.29%), this is active but limited
 receiver-diversity evidence rather than a broad multi-city generalization.
 
+## Realtime output gate
+
+`RealtimeFixIntegrityGate` (algorithms/integrity_consensus) is the causal C++
+port of the policies above, wired into `gnss_solve` behind
+`--realtime-fix-integrity`, `--integrity-shadow-csv`, `--integrity-log`, and
+the opt-in `--integrity-base-gate`. It buffers at most seven epochs so a
+confirmed eight-epoch residual streak can demote its prefix, and it never
+consumes reference truth or a future shadow epoch.
+
+Validation on 2026-07-23 (reports:
+`output/ppc_realtime_fix_integrity_matrix.md`,
+`output/urbannav_realtime_fix_integrity_external.md`):
+
+- Default configuration (residual streak/spike only) on the six public PPC
+  runs over a plain `low-cost` KF baseline: total wrong FIX 3618 to 2847
+  (495 caught, 8 correct harmed); bit-inert on Tokyo 1-3 and Nagoya 3; the
+  gated matrix keeps macro FIX 73.4% versus the 54.3% GICI reproduction.
+- The offline `base` low-satellite/ratio gate is ported but **off by
+  default**: on the plain KF stream it over-demotes (Nagoya 2 net-harmful),
+  because its frozen thresholds were validated against the staged FGO
+  pipeline. With `--integrity-base-gate`, the UrbanNav Trimble Shinjuku
+  holdout reproduces the offline external audit exactly (22 caught above
+  2 m, zero harmed; Odaiba zero demotions).
+- Shadow consensus fails closed: a shadow epoch without a positive
+  `position_covariance_trace_m2` (or failing the FIXED-status/GDOP/DDPR/nsat/
+  age bars) is treated as absent, cannot arm or hold `QUARANTINE`, and the
+  strict default is byte-identical to running without a shadow. The
+  `--integrity-shadow-assume-default-covariance-trace` escape hatch exists
+  but the Tokyo 1 FGO shadow is not accurate enough to be net-positive;
+  populating a real fixed-lag marginal trace is a scoped follow-up
+  (see the TODO in `fgo_gtsam_backend.cpp`).
+
 ## License boundary
 
 The manager, state machine, telemetry schema, tests, and libgnss++ estimator

--- a/include/libgnss++/algorithms/integrity_consensus.hpp
+++ b/include/libgnss++/algorithms/integrity_consensus.hpp
@@ -1,10 +1,14 @@
 #pragma once
 
 #include <cstdint>
+#include <deque>
 #include <limits>
+#include <optional>
 #include <vector>
 
 #include <Eigen/Core>
+
+#include "libgnss++/core/solution.hpp"
 
 namespace libgnss {
 
@@ -151,6 +155,215 @@ public:
     explicit MultiShadowPositionConsensus(Config config);
 
     Decision evaluate(const Input& input) const;
+
+private:
+    Config config_;
+};
+
+// Causal output gate that combines the KF/FGO state machine with the frozen
+// bounded-latency residual policy.  It never consumes reference truth.  A
+// streak of N suspicious FIX candidates is held for N-1 epochs so its prefix
+// can still be demoted when the Nth epoch confirms the sequence.
+class RealtimeFixIntegrityGate {
+public:
+    struct Config {
+        bool enable_consensus = true;
+        bool enable_residual_policy = true;
+        IntegrityConsensusManager::Config consensus;
+
+        double primary_max_prefit_rms_m = 10.0;
+        int primary_min_suppressed_outliers = 35;
+        double primary_max_covariance_trace_m2 = 0.05;
+
+        double recovery_min_ratio = 3.0;
+        double recovery_max_separation_m = 6.0;
+        double recovery_max_prefit_rms_m = 5.0;
+        int recovery_max_suppressed_outliers = 20;
+        bool allow_provisional_recovery_fixed = false;
+
+        double residual_streak_min_prefit_rms_m = 40.0;
+        double residual_streak_max_ratio = 15.0;
+        int residual_streak_min_suppressed_outliers = 12;
+        double residual_streak_min_outlier_fraction = 0.5;
+        int residual_streak_epochs = 8;
+        double residual_spike_min_prefit_rms_m = 40.0;
+        int residual_spike_max_satellites = 14;
+
+        // Frozen offline "base" low-satellite/ratio confidence gate, ported
+        // field-for-field from scripts/apply_ppc_status_demotion.py's
+        // should_demote()/should_exonerate() with the audited defaults
+        // (--min-satellites 8 --low-satellite-ceiling 11
+        // --low-satellite-max-ratio 15 --exonerate-min-satellites 11
+        // --exonerate-max-prefit-rms-m 0.5 --exonerate-max-nis-per-obs 0.2).
+        // Unlike the residual streak/spike rules this is per-epoch: it can
+        // demote a FIX candidate immediately, with no streak confirmation,
+        // so it still interacts correctly with the 7-epoch retroactive
+        // buffer (same immediate-demote path as the spike rule).
+        //
+        // Off by default (opt-in): this gate was frozen/audited against a
+        // separately-engineered staged FGO pipeline
+        // (base_selected=0 on all six PPC runs there), where it reproduces
+        // the offline audit's "22 caught / 0 harmed" result exactly (see
+        // output/urbannav_realtime_fix_integrity_external.md). On the plain
+        // KF PPC baseline it over-demotes: offline replay shows
+        // base_selected=387/53/68 with correct_harmed=122/11/46 on
+        // tokyo1/nagoya1/nagoya2, and the realtime A/B (with the cascade
+        // effect) is net-harmful on nagoya2 (80 caught / 177 harmed; see
+        // output/ppc_realtime_fix_integrity_matrix.md's "After fix"
+        // section). Recommended for low-FIX-rate receivers / configurations
+        // close to the audited offline external policy (e.g. UrbanNav
+        // Trimble); enable explicitly via gnss_solve's
+        // --integrity-base-gate flag once that trade-off has been reviewed
+        // for the target receiver/pipeline.
+        bool enable_base_confidence_policy = false;
+        int base_confidence_min_satellites = 8;
+        int base_confidence_low_satellite_ceiling = 11;
+        double base_confidence_low_satellite_max_ratio = 15.0;
+        int base_confidence_exonerate_min_satellites = 11;
+        double base_confidence_exonerate_max_prefit_rms_m = 0.5;
+        double base_confidence_exonerate_max_nis_per_obs = 0.2;
+    };
+
+    struct IndependentEstimate {
+        bool present = false;
+        IntegrityConsensusManager::Estimate estimate;
+        double age_s = std::numeric_limits<double>::infinity();
+        std::uint64_t reset_generation = 0;
+    };
+
+    struct EpochInput {
+        PositionSolution primary;
+        IndependentEstimate independent;
+    };
+
+    struct Telemetry {
+        IntegrityConsensusManager::Decision consensus;
+        bool fixed_candidate = false;
+        bool primary_suspect = false;
+        bool hard_primary_suspect = false;
+        bool residual_streak_match = false;
+        bool residual_streak_demoted = false;
+        bool residual_spike_demoted = false;
+        bool base_confidence_demoted = false;
+        bool consensus_demoted = false;
+        bool output_demoted = false;
+        bool independent_present = false;
+        bool independent_valid = false;
+        double primary_covariance_trace_m2 =
+            std::numeric_limits<double>::quiet_NaN();
+        double independent_covariance_trace_m2 =
+            std::numeric_limits<double>::quiet_NaN();
+        double independent_age_s = std::numeric_limits<double>::infinity();
+        std::uint64_t independent_reset_generation = 0;
+        int output_latency_epochs = 0;
+    };
+
+    struct Emission {
+        PositionSolution solution;
+        Telemetry telemetry;
+    };
+
+    struct Update {
+        Telemetry current;
+        std::vector<Emission> emitted;
+    };
+
+    RealtimeFixIntegrityGate();
+    explicit RealtimeFixIntegrityGate(Config config);
+
+    Update push(EpochInput input);
+    std::vector<Emission> flush();
+    void reset();
+    std::size_t pending() const { return pending_.size(); }
+    int maxOutputLatencyEpochs() const;
+
+private:
+    struct PendingEpoch {
+        PositionSolution solution;
+        Telemetry telemetry;
+        std::uint64_t arrival_index = 0;
+    };
+
+    Config config_;
+    IntegrityConsensusManager consensus_;
+    std::deque<PendingEpoch> pending_;
+    int residual_streak_count_ = 0;
+    std::uint64_t epoch_index_ = 0;
+
+    bool residualStreakMatches(const PositionSolution& solution) const;
+    bool residualSpikeMatches(const PositionSolution& solution) const;
+    bool baseConfidenceMatches(const PositionSolution& solution) const;
+    // True only when the independent estimate is present, position-valid,
+    // fresh, and its own covariance trace is finite and within
+    // config_.consensus.max_independent_covariance_trace_m2 -- i.e. the same
+    // "independent_healthy" bar IntegrityConsensusManager::update() applies
+    // internally for disagreement/agreement evidence. A present-but-unhealthy
+    // independent (e.g. an unpopulated/placeholder covariance trace) must
+    // behave exactly like an absent one for every consensus evidence path,
+    // including hard_primary_suspect -- see docs/ppc_online_consensus_design.md.
+    bool independentHealthy(const IndependentEstimate& independent) const;
+    static void demote(PendingEpoch& epoch, bool Telemetry::*reason);
+    Emission emitFront(std::uint64_t current_index);
+};
+
+// Truth-free health gate for an externally produced independent position
+// shadow (e.g. an FGO CSV dump) before it may act as
+// RealtimeFixIntegrityGate consensus/demotion authority. Health must bound
+// *accuracy*, not merely availability: status/GDOP/DD-prefit-RMS/satellite
+// count/age alone do not bound position error (see
+// docs/ppc_online_consensus_design.md and the PPC tokyo1 shadow validation
+// that motivated this class). A missing or non-positive covariance trace is
+// treated as unhealthy by default -- absence (or an unpopulated placeholder)
+// of accuracy evidence must not silently grant demotion authority.
+class ShadowEstimateHealthGate {
+public:
+    struct Config {
+        double max_age_s = 1.0;
+        double max_gdop = 4.0;
+        double max_ddpr_rms_m = 40.0;
+        int min_satellites = 8;
+        // Ceiling on the shadow's own reported position_covariance_trace_m2.
+        double max_covariance_trace_m2 = 4.0;
+        // A missing (or non-positive, see class doc comment) trace sample is
+        // unhealthy unless the caller explicitly opts in to substituting
+        // default_covariance_trace_m2. Off by default: silently assuming a
+        // default covariance is exactly the bug this gate exists to close.
+        bool assume_default_covariance_trace = false;
+        double default_covariance_trace_m2 = 4.0;
+        // Require the shadow sample's own status to be FIXED (not FLOAT) to
+        // act as demotion authority. Empirically, on the PPC tokyo1 shipping
+        // FGO shadow, FLOAT samples are frequently diverged by tens to
+        // thousands of meters while GDOP/DDPR-RMS/nsat/age stay within the
+        // otherwise-healthy range, so those signals alone cannot separate
+        // trustworthy FLOAT from wrong-basin FLOAT. Defaults to true.
+        bool require_fixed_status = true;
+    };
+
+    struct Sample {
+        // True for a "FIXED"/"4" status token in the shadow source.
+        bool status_fixed = false;
+        // True for "FIXED"/"FLOAT"/"3"/"4" (i.e. not a dropped/invalid
+        // epoch); required regardless of require_fixed_status.
+        bool status_present = false;
+        std::optional<double> gdop;
+        std::optional<double> ddpr_rms_m;
+        std::optional<int> num_satellites;
+        std::optional<double> covariance_trace_m2;
+        double age_s = std::numeric_limits<double>::infinity();
+    };
+
+    struct Result {
+        bool healthy = false;
+        // Trace to feed the consensus manager: the sample's own trace when
+        // healthy, otherwise +infinity so it can never itself satisfy a
+        // downstream max-covariance-trace aperture check.
+        double covariance_trace_m2 = std::numeric_limits<double>::infinity();
+    };
+
+    ShadowEstimateHealthGate();
+    explicit ShadowEstimateHealthGate(Config config);
+
+    Result evaluate(const Sample& sample) const;
 
 private:
     Config config_;

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -4762,6 +4762,26 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
     }
 
     // --- Per-epoch solutions ---
+    // TODO(agent/realtime-fix-integrity follow-up, Fix 3): solution.position_
+    // covariance is intentionally left unpopulated (default-constructed) on
+    // this fixed-lag path -- dumpEpochCsv() in gnss_fgo_parity.cpp now emits
+    // an empty CSV field for it rather than a fake 0.0, so downstream
+    // consumers (e.g. ShadowEstimateHealthGate) correctly treat it as
+    // missing. A real per-epoch trace IS already computed nearby
+    // (antenna_position_cov / provisional_fixed_cov, both derived from
+    // smoother.getISAM2().jointMarginalCovariance(keys) during the per-epoch
+    // LAMBDA block above) but only for the pose_i snapshot AT THE MOMENT
+    // LAMBDA runs for epoch i. epoch_float_position[i] (see the window
+    // re-read loop above, "Re-read every still-in-window pose") keeps being
+    // refined by later epochs until i leaves the fixed-lag window, so that
+    // captured trace would silently stop matching the final reported
+    // position by the time this loop reads it -- wiring it through without
+    // re-deriving a matching marginal at emission time would trade a
+    // visibly-missing value for a silently-stale one. Left unpopulated
+    // rather than risk feeding a mismatched covariance into a health/
+    // consensus gate; a correct fix would recompute (or cache) the marginal
+    // for each epoch's FINAL window-exit pose, which is a larger, separately
+    // scoped change.
     const bool have_amb = !problem.ambiguity_states.empty();
     result.epoch_diagnostics = std::move(epoch_diagnostics);
     result.epoch_attitude_rpy_deg.resize(num_epochs);

--- a/src/algorithms/integrity_consensus.cpp
+++ b/src/algorithms/integrity_consensus.cpp
@@ -276,4 +276,319 @@ MultiShadowPositionConsensus::Decision MultiShadowPositionConsensus::evaluate(
     return decision;
 }
 
+RealtimeFixIntegrityGate::RealtimeFixIntegrityGate()
+    : RealtimeFixIntegrityGate(Config{}) {}
+
+RealtimeFixIntegrityGate::RealtimeFixIntegrityGate(Config config)
+    : config_(std::move(config)), consensus_(config_.consensus) {
+    if (config_.primary_max_prefit_rms_m <= 0.0 ||
+        config_.primary_min_suppressed_outliers < 1 ||
+        config_.primary_max_covariance_trace_m2 <= 0.0 ||
+        config_.recovery_min_ratio <= 0.0 ||
+        config_.recovery_max_separation_m <= 0.0 ||
+        config_.recovery_max_prefit_rms_m <= 0.0 ||
+        config_.recovery_max_suppressed_outliers < 0 ||
+        config_.residual_streak_min_prefit_rms_m <= 0.0 ||
+        config_.residual_streak_max_ratio <= 0.0 ||
+        config_.residual_streak_min_suppressed_outliers < 1 ||
+        config_.residual_streak_min_outlier_fraction < 0.0 ||
+        config_.residual_streak_min_outlier_fraction > 1.0 ||
+        config_.residual_streak_epochs < 1 ||
+        config_.residual_spike_min_prefit_rms_m <= 0.0 ||
+        config_.residual_spike_max_satellites < 1 ||
+        config_.base_confidence_min_satellites < 1 ||
+        config_.base_confidence_low_satellite_ceiling < 0 ||
+        config_.base_confidence_low_satellite_max_ratio <= 0.0 ||
+        config_.base_confidence_exonerate_min_satellites < 0 ||
+        config_.base_confidence_exonerate_max_prefit_rms_m <= 0.0 ||
+        config_.base_confidence_exonerate_max_nis_per_obs <= 0.0) {
+        throw std::invalid_argument("invalid realtime FIX integrity configuration");
+    }
+}
+
+int RealtimeFixIntegrityGate::maxOutputLatencyEpochs() const {
+    return config_.enable_residual_policy
+        ? std::max(0, config_.residual_streak_epochs - 1)
+        : 0;
+}
+
+bool RealtimeFixIntegrityGate::residualStreakMatches(
+    const PositionSolution& solution) const {
+    return solution.isFixed() &&
+        std::isfinite(solution.rtk_update_prefit_residual_rms_m) &&
+        solution.rtk_update_prefit_residual_rms_m >
+            config_.residual_streak_min_prefit_rms_m &&
+        std::isfinite(solution.ratio) &&
+        solution.ratio <= config_.residual_streak_max_ratio &&
+        solution.rtk_update_suppressed_outliers >=
+            config_.residual_streak_min_suppressed_outliers &&
+        solution.rtk_update_observations > 0 &&
+        static_cast<double>(solution.rtk_update_suppressed_outliers) /
+                static_cast<double>(solution.rtk_update_observations) >=
+            config_.residual_streak_min_outlier_fraction;
+}
+
+bool RealtimeFixIntegrityGate::residualSpikeMatches(
+    const PositionSolution& solution) const {
+    return solution.isFixed() &&
+        std::isfinite(solution.rtk_update_prefit_residual_rms_m) &&
+        solution.rtk_update_prefit_residual_rms_m >=
+            config_.residual_spike_min_prefit_rms_m &&
+        solution.num_satellites <= config_.residual_spike_max_satellites;
+}
+
+bool RealtimeFixIntegrityGate::independentHealthy(
+    const IndependentEstimate& independent) const {
+    return independent.present && independent.estimate.valid &&
+        independent.estimate.position_ecef.allFinite() &&
+        std::isfinite(independent.age_s) && independent.age_s >= 0.0 &&
+        independent.age_s <= config_.consensus.max_independent_age_s &&
+        std::isfinite(independent.estimate.covariance_trace_m2) &&
+        independent.estimate.covariance_trace_m2 <=
+            config_.consensus.max_independent_covariance_trace_m2;
+}
+
+bool RealtimeFixIntegrityGate::baseConfidenceMatches(
+    const PositionSolution& solution) const {
+    if (!solution.isFixed()) return false;
+    // Field-for-field port of should_demote()'s satellite/ratio gate in
+    // scripts/apply_ppc_status_demotion.py: demote when the satellite count
+    // is below the hard floor, or the satellite count is at/below the
+    // low-satellite ceiling with a weak ambiguity ratio.
+    const bool low_satellites =
+        solution.num_satellites < config_.base_confidence_min_satellites;
+    const bool low_satellite_low_ratio =
+        solution.num_satellites <= config_.base_confidence_low_satellite_ceiling &&
+        std::isfinite(solution.ratio) &&
+        solution.ratio <= config_.base_confidence_low_satellite_max_ratio;
+    if (!low_satellites && !low_satellite_low_ratio) return false;
+
+    // Field-for-field port of should_exonerate(): strong runtime telemetry
+    // (high satellite count, tight prefit RMS, tight NIS/observation) may
+    // override the base gate even though the low-satellite/ratio confidence
+    // check fired.
+    const bool exonerated =
+        solution.num_satellites >= config_.base_confidence_exonerate_min_satellites &&
+        std::isfinite(solution.rtk_update_prefit_residual_rms_m) &&
+        solution.rtk_update_prefit_residual_rms_m <=
+            config_.base_confidence_exonerate_max_prefit_rms_m &&
+        std::isfinite(
+            solution.rtk_update_normalized_innovation_squared_per_observation) &&
+        solution.rtk_update_normalized_innovation_squared_per_observation <=
+            config_.base_confidence_exonerate_max_nis_per_obs;
+    return !exonerated;
+}
+
+void RealtimeFixIntegrityGate::demote(
+    PendingEpoch& epoch, bool Telemetry::*reason) {
+    epoch.telemetry.*reason = true;
+    if (epoch.solution.isFixed()) {
+        epoch.solution.status = SolutionStatus::FLOAT;
+        epoch.telemetry.output_demoted = true;
+    }
+}
+
+RealtimeFixIntegrityGate::Emission RealtimeFixIntegrityGate::emitFront(
+    std::uint64_t current_index) {
+    PendingEpoch epoch = std::move(pending_.front());
+    pending_.pop_front();
+    const std::uint64_t latency = current_index >= epoch.arrival_index
+        ? current_index - epoch.arrival_index
+        : 0;
+    epoch.telemetry.output_latency_epochs = static_cast<int>(latency);
+    return Emission{std::move(epoch.solution), std::move(epoch.telemetry)};
+}
+
+RealtimeFixIntegrityGate::Update RealtimeFixIntegrityGate::push(EpochInput input) {
+    PendingEpoch pending;
+    pending.solution = std::move(input.primary);
+    pending.arrival_index = epoch_index_;
+    pending.telemetry.fixed_candidate = pending.solution.isFixed();
+
+    const double primary_covariance_trace = pending.solution.position_covariance.trace();
+    pending.telemetry.primary_covariance_trace_m2 = primary_covariance_trace;
+    pending.telemetry.independent_present = input.independent.present;
+    pending.telemetry.independent_valid =
+        input.independent.present && input.independent.estimate.valid;
+    pending.telemetry.independent_covariance_trace_m2 =
+        input.independent.estimate.covariance_trace_m2;
+    pending.telemetry.independent_age_s = input.independent.age_s;
+    pending.telemetry.independent_reset_generation =
+        input.independent.reset_generation;
+    const double prefit = pending.solution.rtk_update_prefit_residual_rms_m;
+    const int outliers = pending.solution.rtk_update_suppressed_outliers;
+    pending.telemetry.primary_suspect = pending.telemetry.fixed_candidate &&
+        std::isfinite(prefit) && prefit > config_.primary_max_prefit_rms_m &&
+        outliers >= config_.primary_min_suppressed_outliers;
+    // hard_primary_suspect must not be corroborated by a present-but-
+    // unhealthy independent estimate: an unhealthy independent (e.g. a
+    // shadow whose covariance trace is unpopulated/placeholder, per
+    // ShadowEstimateHealthGate) carries no real accuracy evidence and must
+    // behave exactly like an absent one here, otherwise a residual storm on
+    // the primary can lock QUARANTINE forever (RECOVERY requires
+    // estimators_agree, which needs a healthy independent that can never
+    // arrive). See docs/ppc_online_consensus_design.md.
+    pending.telemetry.hard_primary_suspect = pending.telemetry.primary_suspect &&
+        independentHealthy(input.independent) &&
+        std::isfinite(primary_covariance_trace) &&
+        primary_covariance_trace <= config_.primary_max_covariance_trace_m2;
+
+    if (config_.enable_consensus) {
+        IntegrityConsensusManager::Input manager_input;
+        manager_input.primary.valid = pending.solution.isValid();
+        manager_input.primary.position_ecef = pending.solution.position_ecef;
+        manager_input.primary.covariance_trace_m2 = primary_covariance_trace;
+        if (input.independent.present) {
+            manager_input.independent = input.independent.estimate;
+            manager_input.independent_age_s = input.independent.age_s;
+            manager_input.independent_reset_generation =
+                input.independent.reset_generation;
+        }
+        manager_input.fixed_candidate = pending.telemetry.fixed_candidate;
+        manager_input.primary_suspect = pending.telemetry.primary_suspect;
+        manager_input.hard_primary_suspect = pending.telemetry.hard_primary_suspect;
+
+        const double recovery_separation_m =
+            input.independent.present && input.independent.estimate.valid
+            ? (pending.solution.position_ecef -
+               input.independent.estimate.position_ecef).norm()
+            : std::numeric_limits<double>::infinity();
+        const bool recovery_telemetry_healthy =
+            pending.telemetry.fixed_candidate &&
+            std::isfinite(recovery_separation_m) &&
+            recovery_separation_m <= config_.recovery_max_separation_m &&
+            std::isfinite(pending.solution.ratio) &&
+            pending.solution.ratio >= config_.recovery_min_ratio &&
+            std::isfinite(prefit) && prefit <= config_.recovery_max_prefit_rms_m &&
+            outliers <= config_.recovery_max_suppressed_outliers;
+        manager_input.recovery_candidate_healthy =
+            config_.allow_provisional_recovery_fixed &&
+            recovery_telemetry_healthy;
+        pending.telemetry.consensus = consensus_.update(manager_input);
+        if (pending.telemetry.fixed_candidate &&
+            !pending.telemetry.consensus.allow_fixed) {
+            demote(pending, &Telemetry::consensus_demoted);
+        }
+    }
+
+    if (config_.enable_residual_policy) {
+        pending.telemetry.residual_streak_match =
+            residualStreakMatches(pending.solution) ||
+            (pending.telemetry.fixed_candidate &&
+             std::isfinite(prefit) &&
+             prefit > config_.residual_streak_min_prefit_rms_m &&
+             std::isfinite(pending.solution.ratio) &&
+             pending.solution.ratio <= config_.residual_streak_max_ratio &&
+             outliers >= config_.residual_streak_min_suppressed_outliers &&
+             pending.solution.rtk_update_observations > 0 &&
+             static_cast<double>(outliers) /
+                     static_cast<double>(pending.solution.rtk_update_observations) >=
+                 config_.residual_streak_min_outlier_fraction);
+        residual_streak_count_ = pending.telemetry.residual_streak_match
+            ? residual_streak_count_ + 1
+            : 0;
+        const bool spike = residualSpikeMatches(pending.solution) ||
+            (pending.telemetry.fixed_candidate &&
+             std::isfinite(prefit) &&
+             prefit >= config_.residual_spike_min_prefit_rms_m &&
+             pending.solution.num_satellites <=
+                 config_.residual_spike_max_satellites);
+        if (spike) demote(pending, &Telemetry::residual_spike_demoted);
+    } else {
+        residual_streak_count_ = 0;
+    }
+
+    // Frozen offline "base" confidence gate: per-epoch, no streak
+    // confirmation needed, so it demotes the current candidate immediately
+    // (same immediate-demote path as the spike rule above) before the epoch
+    // is pushed into the retroactive-demotion buffer.
+    if (config_.enable_base_confidence_policy && baseConfidenceMatches(pending.solution)) {
+        demote(pending, &Telemetry::base_confidence_demoted);
+    }
+
+    pending_.push_back(std::move(pending));
+    if (config_.enable_residual_policy &&
+        residual_streak_count_ >= config_.residual_streak_epochs) {
+        const std::size_t count = std::min<std::size_t>(
+            static_cast<std::size_t>(config_.residual_streak_epochs),
+            pending_.size());
+        for (std::size_t offset = 0; offset < count; ++offset) {
+            auto& epoch = pending_[pending_.size() - 1 - offset];
+            if (epoch.telemetry.residual_streak_match) {
+                demote(epoch, &Telemetry::residual_streak_demoted);
+            }
+        }
+    }
+
+    Update result;
+    result.current = pending_.back().telemetry;
+    const std::size_t max_pending =
+        static_cast<std::size_t>(maxOutputLatencyEpochs());
+    while (pending_.size() > max_pending) {
+        result.emitted.push_back(emitFront(epoch_index_));
+    }
+    ++epoch_index_;
+    return result;
+}
+
+std::vector<RealtimeFixIntegrityGate::Emission> RealtimeFixIntegrityGate::flush() {
+    std::vector<Emission> output;
+    const std::uint64_t current_index = epoch_index_ == 0 ? 0 : epoch_index_ - 1;
+    while (!pending_.empty()) output.push_back(emitFront(current_index));
+    return output;
+}
+
+void RealtimeFixIntegrityGate::reset() {
+    consensus_.reset();
+    pending_.clear();
+    residual_streak_count_ = 0;
+    epoch_index_ = 0;
+}
+
+ShadowEstimateHealthGate::ShadowEstimateHealthGate()
+    : ShadowEstimateHealthGate(Config{}) {}
+
+ShadowEstimateHealthGate::ShadowEstimateHealthGate(Config config)
+    : config_(std::move(config)) {}
+
+ShadowEstimateHealthGate::Result ShadowEstimateHealthGate::evaluate(
+    const Sample& sample) const {
+    Result result;
+    const bool status_ok = sample.status_present &&
+        (!config_.require_fixed_status || sample.status_fixed);
+    const bool telemetry_complete = sample.gdop.has_value() &&
+        sample.ddpr_rms_m.has_value() && sample.num_satellites.has_value();
+    const bool telemetry_healthy = telemetry_complete &&
+        *sample.gdop <= config_.max_gdop &&
+        *sample.ddpr_rms_m <= config_.max_ddpr_rms_m &&
+        *sample.num_satellites >= config_.min_satellites &&
+        std::isfinite(sample.age_s) && sample.age_s >= 0.0 &&
+        sample.age_s <= config_.max_age_s;
+
+    // A covariance trace must be present AND strictly positive (a reported
+    // exact zero is never a physically meaningful position uncertainty for
+    // any real KF/FGO estimator; it indicates the shadow source did not
+    // actually populate the field) to count as real accuracy evidence.
+    // Absence of that evidence disables demotion authority unless the
+    // caller explicitly opts in to a substituted default.
+    const bool trace_present = sample.covariance_trace_m2.has_value() &&
+        std::isfinite(*sample.covariance_trace_m2) &&
+        *sample.covariance_trace_m2 > 0.0;
+    double effective_trace = std::numeric_limits<double>::quiet_NaN();
+    bool trace_healthy = false;
+    if (trace_present) {
+        effective_trace = *sample.covariance_trace_m2;
+        trace_healthy = effective_trace <= config_.max_covariance_trace_m2;
+    } else if (config_.assume_default_covariance_trace) {
+        effective_trace = config_.default_covariance_trace_m2;
+        trace_healthy = effective_trace <= config_.max_covariance_trace_m2;
+    }
+
+    result.healthy = status_ok && telemetry_healthy && trace_healthy;
+    result.covariance_trace_m2 = result.healthy
+        ? effective_trace
+        : std::numeric_limits<double>::infinity();
+    return result;
+}
+
 }  // namespace libgnss

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -130,8 +130,48 @@ if(GTest_FOUND)
         gnss_vel_d
     )
 
+    # Keep the MADOCALIB oracle job independent from the monolithic test
+    # executable.  The parity workflow only executes tests from
+    # test_madoca_parity.cpp; compiling every unrelated test translation unit
+    # made the Ubuntu runner vulnerable to infrastructure SIGTERM (exit 143)
+    # before the oracle tests could start.
+    add_executable(gnss_madoca_parity_tests test_madoca_parity.cpp)
+    set_target_properties(gnss_madoca_parity_tests PROPERTIES
+        OUTPUT_NAME madoca_parity_tests
+    )
+    if(NOT MSVC)
+        target_compile_options(gnss_madoca_parity_tests PRIVATE -g)
+    endif()
+    target_compile_definitions(gnss_madoca_parity_tests PRIVATE
+        GNSSPP_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+        GNSSPP_BINARY_DIR="${CMAKE_BINARY_DIR}"
+    )
+    target_link_libraries(gnss_madoca_parity_tests
+        gnss_lib gnss_lib_noopt
+        sofa
+        ginan_iers2010
+        GTest::GTest
+        GTest::Main
+        Threads::Threads
+    )
+    add_dependencies(gnss_madoca_parity_tests gnss_ppp)
+
+    add_executable(gnss_integrity_tests test_integrity_consensus.cpp)
+    target_link_libraries(gnss_integrity_tests
+        gnss_lib gnss_lib_noopt
+        GTest::GTest
+        GTest::Main
+        Threads::Threads
+    )
+
     # Add test to CTest
     add_test(NAME run_tests COMMAND gnss_run_tests)
+    add_test(
+        NAME madoca_parity_tests
+        COMMAND gnss_madoca_parity_tests
+                --gtest_filter=*MadocaParity*:MadocaBridgeConfig.*
+    )
+    add_test(NAME integrity_tests COMMAND gnss_integrity_tests)
     add_test(
         NAME python_benchmark_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_benchmark_scripts.py

--- a/tests/test_integrity_consensus.cpp
+++ b/tests/test_integrity_consensus.cpp
@@ -1,11 +1,15 @@
 #include <gtest/gtest.h>
 
+#include <cmath>
+#include <limits>
+
 #include "libgnss++/algorithms/integrity_consensus.hpp"
 
 namespace {
 
 using Manager = libgnss::IntegrityConsensusManager;
 using PositionConsensus = libgnss::MultiShadowPositionConsensus;
+using RealtimeGate = libgnss::RealtimeFixIntegrityGate;
 
 Manager::Input input(double separation_m = 0.0) {
     Manager::Input value;
@@ -197,6 +201,548 @@ TEST(MultiShadowPositionConsensusTest, PredictionMustBeAvailableWhenConfigured) 
     const auto decision = consensus.evaluate(value);
     EXPECT_FALSE(decision.replace_primary_position);
     EXPECT_NE(decision.reasons & PositionConsensus::PREDICTION_UNAVAILABLE, 0U);
+}
+
+libgnss::PositionSolution fixed_solution(double x = 0.0) {
+    libgnss::PositionSolution solution;
+    solution.status = libgnss::SolutionStatus::FIXED;
+    solution.num_satellites = 20;
+    solution.position_ecef = Eigen::Vector3d(x, 0.0, 0.0);
+    solution.position_covariance = Eigen::Matrix3d::Identity() * 0.01;
+    solution.ratio = 10.0;
+    solution.rtk_update_observations = 24;
+    solution.rtk_update_suppressed_outliers = 12;
+    solution.rtk_update_prefit_residual_rms_m = 41.0;
+    return solution;
+}
+
+RealtimeGate::IndependentEstimate independent(double x) {
+    RealtimeGate::IndependentEstimate estimate;
+    estimate.present = true;
+    estimate.estimate.valid = true;
+    estimate.estimate.position_ecef = Eigen::Vector3d(x, 0.0, 0.0);
+    estimate.estimate.covariance_trace_m2 = 0.25;
+    estimate.age_s = 0.0;
+    return estimate;
+}
+
+// Mirrors ShadowEstimateHealthGate::Result for an unhealthy sample: present
+// and position-valid, but covariance_trace_m2 == +infinity (e.g. an
+// unpopulated/placeholder shadow trace, per the PPC tokyo1 regression this
+// guards). Must behave exactly like an absent independent for every
+// consensus evidence path.
+RealtimeGate::IndependentEstimate unhealthy_independent(double x) {
+    RealtimeGate::IndependentEstimate estimate;
+    estimate.present = true;
+    estimate.estimate.valid = true;
+    estimate.estimate.position_ecef = Eigen::Vector3d(x, 0.0, 0.0);
+    estimate.estimate.covariance_trace_m2 =
+        std::numeric_limits<double>::infinity();
+    estimate.age_s = 0.0;
+    return estimate;
+}
+
+libgnss::PositionSolution suspicious_primary_solution(double x = 0.0) {
+    auto solution = fixed_solution(x);
+    solution.rtk_update_prefit_residual_rms_m = 50.0;   // > primary_max_prefit_rms_m (10.0)
+    solution.rtk_update_suppressed_outliers = 40;        // >= primary_min_suppressed_outliers (35)
+    return solution;
+}
+
+TEST(RealtimeFixIntegrityGateTest, ConfirmedResidualStreakDemotesBufferedPrefix) {
+    RealtimeGate::Config config;
+    config.enable_consensus = false;
+    RealtimeGate gate(config);
+
+    for (int epoch = 0; epoch < 7; ++epoch) {
+        RealtimeGate::EpochInput input;
+        input.primary = fixed_solution(static_cast<double>(epoch));
+        EXPECT_TRUE(gate.push(std::move(input)).emitted.empty());
+    }
+    RealtimeGate::EpochInput eighth;
+    eighth.primary = fixed_solution(7.0);
+    auto update = gate.push(std::move(eighth));
+    ASSERT_EQ(update.emitted.size(), 1U);
+    EXPECT_EQ(update.emitted.front().solution.status, libgnss::SolutionStatus::FLOAT);
+    EXPECT_TRUE(update.emitted.front().telemetry.residual_streak_demoted);
+    EXPECT_EQ(update.emitted.front().telemetry.output_latency_epochs, 7);
+
+    const auto tail = gate.flush();
+    ASSERT_EQ(tail.size(), 7U);
+    for (const auto& emission : tail) {
+        EXPECT_EQ(emission.solution.status, libgnss::SolutionStatus::FLOAT);
+        EXPECT_TRUE(emission.telemetry.residual_streak_demoted);
+    }
+}
+
+TEST(RealtimeFixIntegrityGateTest, UnconfirmedResidualPrefixFailsOpenOnFlush) {
+    RealtimeGate::Config config;
+    config.enable_consensus = false;
+    RealtimeGate gate(config);
+    for (int epoch = 0; epoch < 7; ++epoch) {
+        RealtimeGate::EpochInput input;
+        input.primary = fixed_solution(static_cast<double>(epoch));
+        gate.push(std::move(input));
+    }
+    const auto output = gate.flush();
+    ASSERT_EQ(output.size(), 7U);
+    for (const auto& emission : output) {
+        EXPECT_EQ(emission.solution.status, libgnss::SolutionStatus::FIXED);
+        EXPECT_FALSE(emission.telemetry.output_demoted);
+    }
+}
+
+TEST(RealtimeFixIntegrityGateTest, MissingIndependentDoesNotLatchSoftSuspect) {
+    RealtimeGate::Config config;
+    config.enable_residual_policy = false;
+    RealtimeGate gate(config);
+    for (int epoch = 0; epoch < 5; ++epoch) {
+        RealtimeGate::EpochInput input;
+        input.primary = fixed_solution();
+        input.primary.rtk_update_prefit_residual_rms_m = 20.0;
+        input.primary.rtk_update_suppressed_outliers = 35;
+        const auto update = gate.push(std::move(input));
+        ASSERT_EQ(update.emitted.size(), 1U);
+        EXPECT_EQ(update.current.consensus.state, Manager::State::NORMAL);
+        EXPECT_EQ(update.emitted.front().solution.status,
+                  libgnss::SolutionStatus::FIXED);
+    }
+}
+
+// --- Base confidence gate (ported from scripts/apply_ppc_status_demotion.py
+// should_demote()/should_exonerate() with the frozen audited defaults). ---
+
+libgnss::PositionSolution base_confidence_solution(
+    int nsat, double ratio, double prefit_rms_m = 1.0,
+    double nis_per_obs = 0.0, int outliers = 0) {
+    auto solution = fixed_solution();
+    solution.num_satellites = nsat;
+    solution.ratio = ratio;
+    // Keep prefit/outliers away from the residual streak/spike thresholds
+    // (prefit > 40, outliers >= 12) so these tests isolate the base gate.
+    solution.rtk_update_prefit_residual_rms_m = prefit_rms_m;
+    solution.rtk_update_suppressed_outliers = outliers;
+    solution.rtk_update_normalized_innovation_squared_per_observation =
+        nis_per_obs;
+    return solution;
+}
+
+TEST(RealtimeFixIntegrityGateTest, BaseConfidenceDisabledByDefaultNeverDemotes) {
+    // Fix 1: enable_base_confidence_policy now defaults to false (opt-in via
+    // gnss_solve's --integrity-base-gate). Verify the default alone -- no
+    // explicit config.enable_base_confidence_policy write -- never demotes,
+    // even for a solution that would otherwise clearly fail the base gate.
+    RealtimeGate::Config config;
+    config.enable_consensus = false;
+    config.enable_residual_policy = false;
+    RealtimeGate gate(config);
+    RealtimeGate::EpochInput input;
+    input.primary = base_confidence_solution(/*nsat=*/3, /*ratio=*/1.0);
+    auto update = gate.push(std::move(input));
+    ASSERT_EQ(update.emitted.size(), 1U);
+    EXPECT_EQ(update.emitted.front().solution.status,
+              libgnss::SolutionStatus::FIXED);
+    EXPECT_FALSE(update.emitted.front().telemetry.base_confidence_demoted);
+}
+
+TEST(RealtimeFixIntegrityGateTest, BaseConfidenceDemotesBelowMinSatellites) {
+    RealtimeGate::Config config;
+    config.enable_consensus = false;
+    config.enable_residual_policy = false;
+    config.enable_base_confidence_policy = true;
+    RealtimeGate gate(config);
+    RealtimeGate::EpochInput input;
+    input.primary = base_confidence_solution(/*nsat=*/5, /*ratio=*/50.0);
+    auto update = gate.push(std::move(input));
+    ASSERT_EQ(update.emitted.size(), 1U);
+    EXPECT_EQ(update.emitted.front().solution.status,
+              libgnss::SolutionStatus::FLOAT);
+    EXPECT_TRUE(update.emitted.front().telemetry.base_confidence_demoted);
+    EXPECT_TRUE(update.emitted.front().telemetry.output_demoted);
+}
+
+TEST(RealtimeFixIntegrityGateTest, BaseConfidenceDemotesLowSatelliteWeakRatio) {
+    RealtimeGate::Config config;
+    config.enable_consensus = false;
+    config.enable_residual_policy = false;
+    config.enable_base_confidence_policy = true;
+    RealtimeGate gate(config);
+    RealtimeGate::EpochInput input;
+    // nsat=10 is >= min_satellites(8) but <= low_satellite_ceiling(11), and
+    // ratio=5 <= low_satellite_max_ratio(15).
+    input.primary = base_confidence_solution(/*nsat=*/10, /*ratio=*/5.0);
+    auto update = gate.push(std::move(input));
+    ASSERT_EQ(update.emitted.size(), 1U);
+    EXPECT_EQ(update.emitted.front().solution.status,
+              libgnss::SolutionStatus::FLOAT);
+    EXPECT_TRUE(update.emitted.front().telemetry.base_confidence_demoted);
+}
+
+TEST(RealtimeFixIntegrityGateTest, BaseConfidenceIgnoresHealthySatelliteCount) {
+    RealtimeGate::Config config;
+    config.enable_consensus = false;
+    config.enable_residual_policy = false;
+    config.enable_base_confidence_policy = true;
+    RealtimeGate gate(config);
+    RealtimeGate::EpochInput input;
+    // nsat=20 clears both the hard floor and the low-satellite ceiling.
+    input.primary = base_confidence_solution(/*nsat=*/20, /*ratio=*/1.0);
+    auto update = gate.push(std::move(input));
+    ASSERT_EQ(update.emitted.size(), 1U);
+    EXPECT_EQ(update.emitted.front().solution.status,
+              libgnss::SolutionStatus::FIXED);
+    EXPECT_FALSE(update.emitted.front().telemetry.base_confidence_demoted);
+}
+
+TEST(RealtimeFixIntegrityGateTest, BaseConfidenceExplicitlyDisabledNeverDemotes) {
+    // Explicit false (same as the default -- see
+    // BaseConfidenceDisabledByDefaultNeverDemotes above) is still respected
+    // when set alongside an otherwise-enabled config.
+    RealtimeGate::Config config;
+    config.enable_consensus = false;
+    config.enable_residual_policy = false;
+    config.enable_base_confidence_policy = false;
+    RealtimeGate gate(config);
+    RealtimeGate::EpochInput input;
+    input.primary = base_confidence_solution(/*nsat=*/3, /*ratio=*/1.0);
+    auto update = gate.push(std::move(input));
+    ASSERT_EQ(update.emitted.size(), 1U);
+    EXPECT_EQ(update.emitted.front().solution.status,
+              libgnss::SolutionStatus::FIXED);
+    EXPECT_FALSE(update.emitted.front().telemetry.base_confidence_demoted);
+}
+
+TEST(RealtimeFixIntegrityGateTest, BaseConfidenceExonerationRequiresSatelliteFloor) {
+    RealtimeGate::Config config;
+    config.enable_consensus = false;
+    config.enable_residual_policy = false;
+    config.enable_base_confidence_policy = true;
+    RealtimeGate gate(config);
+    RealtimeGate::EpochInput input;
+    // Gate fires (nsat=10 <= ceiling, ratio <= max), but nsat=10 is below
+    // exonerate_min_satellites(11), so exoneration cannot apply even with
+    // otherwise-perfect telemetry.
+    input.primary = base_confidence_solution(
+        /*nsat=*/10, /*ratio=*/10.0, /*prefit_rms_m=*/0.1, /*nis_per_obs=*/0.1);
+    auto update = gate.push(std::move(input));
+    ASSERT_EQ(update.emitted.size(), 1U);
+    EXPECT_EQ(update.emitted.front().solution.status,
+              libgnss::SolutionStatus::FLOAT);
+    EXPECT_TRUE(update.emitted.front().telemetry.base_confidence_demoted);
+}
+
+TEST(RealtimeFixIntegrityGateTest, BaseConfidenceExonerationRequiresTightPrefit) {
+    RealtimeGate::Config config;
+    config.enable_consensus = false;
+    config.enable_residual_policy = false;
+    config.enable_base_confidence_policy = true;
+    RealtimeGate gate(config);
+    RealtimeGate::EpochInput input;
+    input.primary = base_confidence_solution(
+        /*nsat=*/11, /*ratio=*/10.0, /*prefit_rms_m=*/1.0, /*nis_per_obs=*/0.1);
+    auto update = gate.push(std::move(input));
+    ASSERT_EQ(update.emitted.size(), 1U);
+    EXPECT_EQ(update.emitted.front().solution.status,
+              libgnss::SolutionStatus::FLOAT);
+    EXPECT_TRUE(update.emitted.front().telemetry.base_confidence_demoted);
+}
+
+TEST(RealtimeFixIntegrityGateTest, BaseConfidenceExonerationRequiresTightNis) {
+    RealtimeGate::Config config;
+    config.enable_consensus = false;
+    config.enable_residual_policy = false;
+    config.enable_base_confidence_policy = true;
+    RealtimeGate gate(config);
+    RealtimeGate::EpochInput input;
+    input.primary = base_confidence_solution(
+        /*nsat=*/11, /*ratio=*/10.0, /*prefit_rms_m=*/0.1, /*nis_per_obs=*/0.5);
+    auto update = gate.push(std::move(input));
+    ASSERT_EQ(update.emitted.size(), 1U);
+    EXPECT_EQ(update.emitted.front().solution.status,
+              libgnss::SolutionStatus::FLOAT);
+    EXPECT_TRUE(update.emitted.front().telemetry.base_confidence_demoted);
+}
+
+TEST(RealtimeFixIntegrityGateTest, BaseConfidenceExonerationOverridesDemotion) {
+    RealtimeGate::Config config;
+    config.enable_consensus = false;
+    config.enable_residual_policy = false;
+    config.enable_base_confidence_policy = true;
+    RealtimeGate gate(config);
+    RealtimeGate::EpochInput input;
+    input.primary = base_confidence_solution(
+        /*nsat=*/11, /*ratio=*/10.0, /*prefit_rms_m=*/0.1, /*nis_per_obs=*/0.1);
+    auto update = gate.push(std::move(input));
+    ASSERT_EQ(update.emitted.size(), 1U);
+    EXPECT_EQ(update.emitted.front().solution.status,
+              libgnss::SolutionStatus::FIXED);
+    EXPECT_FALSE(update.emitted.front().telemetry.base_confidence_demoted);
+}
+
+TEST(RealtimeFixIntegrityGateTest, BaseConfidenceInteractsWithSevenEpochBuffer) {
+    RealtimeGate::Config config;
+    config.enable_consensus = false;
+    config.enable_base_confidence_policy = true;
+    RealtimeGate gate(config);  // enable_residual_policy default true -> 7-epoch buffer.
+
+    RealtimeGate::EpochInput first;
+    first.primary = base_confidence_solution(/*nsat=*/5, /*ratio=*/50.0);
+    EXPECT_TRUE(gate.push(std::move(first)).emitted.empty());
+
+    for (int epoch = 0; epoch < 6; ++epoch) {
+        RealtimeGate::EpochInput input;
+        input.primary = fixed_solution(static_cast<double>(epoch));
+        input.primary.rtk_update_prefit_residual_rms_m = 1.0;
+        input.primary.rtk_update_suppressed_outliers = 0;
+        EXPECT_TRUE(gate.push(std::move(input)).emitted.empty());
+    }
+
+    RealtimeGate::EpochInput eighth;
+    eighth.primary = fixed_solution(6.0);
+    eighth.primary.rtk_update_prefit_residual_rms_m = 1.0;
+    eighth.primary.rtk_update_suppressed_outliers = 0;
+    auto update = gate.push(std::move(eighth));
+    ASSERT_EQ(update.emitted.size(), 1U);
+    EXPECT_EQ(update.emitted.front().solution.status,
+              libgnss::SolutionStatus::FLOAT);
+    EXPECT_TRUE(update.emitted.front().telemetry.base_confidence_demoted);
+    EXPECT_EQ(update.emitted.front().telemetry.output_latency_epochs, 7);
+
+    const auto tail = gate.flush();
+    ASSERT_EQ(tail.size(), 7U);
+    for (const auto& emission : tail) {
+        EXPECT_EQ(emission.solution.status, libgnss::SolutionStatus::FIXED);
+        EXPECT_FALSE(emission.telemetry.base_confidence_demoted);
+    }
+}
+
+TEST(RealtimeFixIntegrityGateTest, IndependentDisagreementControlsEmittedStatus) {
+    RealtimeGate::Config config;
+    config.enable_residual_policy = false;
+    config.consensus.aperture_min_m = 1.0;
+    config.consensus.aperture_max_m = 1.0;
+    RealtimeGate gate(config);
+
+    for (int epoch = 0; epoch < 3; ++epoch) {
+        RealtimeGate::EpochInput input;
+        input.primary = fixed_solution();
+        input.primary.rtk_update_prefit_residual_rms_m = 0.1;
+        input.primary.rtk_update_suppressed_outliers = 0;
+        input.independent = independent(10.0);
+        const auto update = gate.push(std::move(input));
+        ASSERT_EQ(update.emitted.size(), 1U);
+        if (epoch == 0) {
+            EXPECT_EQ(update.current.consensus.state, Manager::State::NORMAL);
+            EXPECT_EQ(update.emitted.front().solution.status,
+                      libgnss::SolutionStatus::FIXED);
+        } else {
+            EXPECT_TRUE(update.current.consensus_demoted);
+            EXPECT_EQ(update.emitted.front().solution.status,
+                      libgnss::SolutionStatus::FLOAT);
+        }
+    }
+}
+
+// --- hard_primary_suspect must require a HEALTHY independent, not merely a
+// present one (Fix 2: an unhealthy independent must contribute nothing to
+// consensus evidence, entering OR keeping QUARANTINE). ---
+
+TEST(RealtimeFixIntegrityGateTest, HealthyIndependentPreservesHardSuspectQuarantine) {
+    RealtimeGate::Config config;
+    config.enable_residual_policy = false;
+    RealtimeGate gate(config);
+    RealtimeGate::EpochInput input;
+    input.primary = suspicious_primary_solution();
+    input.independent = independent(0.0);  // healthy: trace 0.25 <= default ceiling 25.0
+    const auto update = gate.push(std::move(input));
+    EXPECT_TRUE(update.current.hard_primary_suspect);
+    EXPECT_EQ(update.current.consensus.state, Manager::State::QUARANTINE);
+    EXPECT_TRUE(update.current.consensus_demoted);
+}
+
+TEST(RealtimeFixIntegrityGateTest, UnhealthyIndependentCannotArmHardSuspect) {
+    RealtimeGate::Config config;
+    config.enable_residual_policy = false;
+    RealtimeGate gate(config);
+    RealtimeGate::EpochInput input;
+    input.primary = suspicious_primary_solution();
+    input.independent = unhealthy_independent(0.0);  // present, valid, but trace = +inf
+    const auto update = gate.push(std::move(input));
+    EXPECT_FALSE(update.current.hard_primary_suspect);
+    EXPECT_EQ(update.current.consensus.state, Manager::State::NORMAL);
+    EXPECT_TRUE(update.current.consensus.allow_fixed);
+}
+
+TEST(RealtimeFixIntegrityGateTest,
+     UnhealthyIndependentIdenticalToAbsentForHardSuspectEntry) {
+    RealtimeGate::Config config;
+    config.enable_residual_policy = false;
+
+    RealtimeGate gate_absent(config);
+    RealtimeGate::EpochInput absent_input;
+    absent_input.primary = suspicious_primary_solution();
+    // independent left default-constructed: present == false.
+    const auto absent_update = gate_absent.push(std::move(absent_input));
+
+    RealtimeGate gate_unhealthy(config);
+    RealtimeGate::EpochInput unhealthy_input;
+    unhealthy_input.primary = suspicious_primary_solution();
+    unhealthy_input.independent = unhealthy_independent(0.0);
+    const auto unhealthy_update = gate_unhealthy.push(std::move(unhealthy_input));
+
+    EXPECT_EQ(absent_update.current.hard_primary_suspect,
+              unhealthy_update.current.hard_primary_suspect);
+    EXPECT_FALSE(unhealthy_update.current.hard_primary_suspect);
+    EXPECT_EQ(absent_update.current.consensus.state,
+              unhealthy_update.current.consensus.state);
+    EXPECT_EQ(absent_update.current.consensus.allow_fixed,
+              unhealthy_update.current.consensus.allow_fixed);
+}
+
+TEST(RealtimeFixIntegrityGateTest, UnhealthyIndependentCannotClearActiveQuarantine) {
+    RealtimeGate::Config config;
+    config.enable_residual_policy = false;
+    RealtimeGate gate(config);
+
+    // Enter QUARANTINE via a healthy independent + hard primary suspect.
+    RealtimeGate::EpochInput trigger;
+    trigger.primary = suspicious_primary_solution();
+    trigger.independent = independent(0.0);
+    const auto triggered = gate.push(std::move(trigger));
+    ASSERT_EQ(triggered.current.consensus.state, Manager::State::QUARANTINE);
+    ASSERT_TRUE(triggered.current.hard_primary_suspect);
+
+    // From here on the independent is present but permanently unhealthy
+    // (e.g. an unpopulated shadow covariance trace, per the PPC tokyo1
+    // regression). This must behave exactly like an absent independent:
+    // estimators_agree can never become true, so QUARANTINE must never
+    // clear via RECOVERY -- not "exonerated", simply inert.
+    for (int i = 0; i < 10; ++i) {
+        RealtimeGate::EpochInput input;
+        input.primary = fixed_solution(static_cast<double>(i));
+        input.independent = unhealthy_independent(static_cast<double>(i));
+        const auto update = gate.push(std::move(input));
+        EXPECT_EQ(update.current.consensus.state, Manager::State::QUARANTINE);
+        EXPECT_FALSE(update.current.consensus.allow_fixed);
+    }
+}
+
+// --- ShadowEstimateHealthGate: truth-free accuracy-bounding health gate for
+// an externally produced independent position shadow (e.g. an FGO CSV dump)
+// before it may act as RealtimeFixIntegrityGate consensus/demotion
+// authority. ---
+
+using HealthGate = libgnss::ShadowEstimateHealthGate;
+
+HealthGate::Sample healthy_shadow_sample() {
+    HealthGate::Sample sample;
+    sample.status_fixed = true;
+    sample.status_present = true;
+    sample.gdop = 2.0;
+    sample.ddpr_rms_m = 1.0;
+    sample.num_satellites = 20;
+    sample.covariance_trace_m2 = 0.5;
+    sample.age_s = 0.1;
+    return sample;
+}
+
+TEST(ShadowEstimateHealthGateTest, HealthySampleIsAuthorizedWithItsOwnTrace) {
+    HealthGate gate;
+    const auto result = gate.evaluate(healthy_shadow_sample());
+    EXPECT_TRUE(result.healthy);
+    EXPECT_NEAR(result.covariance_trace_m2, 0.5, 1e-12);
+}
+
+TEST(ShadowEstimateHealthGateTest, FloatStatusUnhealthyByDefault) {
+    HealthGate gate;  // require_fixed_status defaults to true.
+    auto sample = healthy_shadow_sample();
+    sample.status_fixed = false;  // FLOAT, but status_present stays true.
+    const auto result = gate.evaluate(sample);
+    EXPECT_FALSE(result.healthy);
+    EXPECT_TRUE(std::isinf(result.covariance_trace_m2));
+}
+
+TEST(ShadowEstimateHealthGateTest, FloatStatusAllowedWhenNotRequiredFixed) {
+    HealthGate::Config config;
+    config.require_fixed_status = false;
+    HealthGate gate(config);
+    auto sample = healthy_shadow_sample();
+    sample.status_fixed = false;
+    const auto result = gate.evaluate(sample);
+    EXPECT_TRUE(result.healthy);
+}
+
+TEST(ShadowEstimateHealthGateTest, DroppedStatusNeverHealthy) {
+    HealthGate::Config config;
+    config.require_fixed_status = false;
+    HealthGate gate(config);
+    auto sample = healthy_shadow_sample();
+    sample.status_present = false;
+    const auto result = gate.evaluate(sample);
+    EXPECT_FALSE(result.healthy);
+}
+
+TEST(ShadowEstimateHealthGateTest, MissingTraceDisablesAuthorityByDefault) {
+    HealthGate gate;  // assume_default_covariance_trace defaults to false.
+    auto sample = healthy_shadow_sample();
+    sample.covariance_trace_m2.reset();
+    const auto result = gate.evaluate(sample);
+    EXPECT_FALSE(result.healthy);
+    EXPECT_TRUE(std::isinf(result.covariance_trace_m2));
+}
+
+TEST(ShadowEstimateHealthGateTest, ZeroTraceTreatedAsUnpopulatedNotSubMillimeter) {
+    // Regression: the PPC tokyo1 shipping FGO shadow CSV reports
+    // position_covariance_trace_m2 == 0.000 on literally every one of its
+    // 11905 rows (a placeholder, not a genuine zero-uncertainty estimate).
+    // A present-but-non-positive trace must be treated the same as a
+    // missing one, not as a trivially-passing "perfect" covariance.
+    HealthGate gate;
+    auto sample = healthy_shadow_sample();
+    sample.covariance_trace_m2 = 0.0;
+    const auto result = gate.evaluate(sample);
+    EXPECT_FALSE(result.healthy);
+}
+
+TEST(ShadowEstimateHealthGateTest, MissingTraceAllowedWithExplicitOptIn) {
+    HealthGate::Config config;
+    config.assume_default_covariance_trace = true;
+    config.default_covariance_trace_m2 = 2.0;
+    config.max_covariance_trace_m2 = 4.0;
+    HealthGate gate(config);
+    auto sample = healthy_shadow_sample();
+    sample.covariance_trace_m2.reset();
+    const auto result = gate.evaluate(sample);
+    EXPECT_TRUE(result.healthy);
+    EXPECT_NEAR(result.covariance_trace_m2, 2.0, 1e-12);
+}
+
+TEST(ShadowEstimateHealthGateTest, TraceAboveCeilingUnhealthy) {
+    HealthGate::Config config;
+    config.max_covariance_trace_m2 = 1.0;
+    HealthGate gate(config);
+    auto sample = healthy_shadow_sample();
+    sample.covariance_trace_m2 = 5.0;
+    const auto result = gate.evaluate(sample);
+    EXPECT_FALSE(result.healthy);
+}
+
+TEST(ShadowEstimateHealthGateTest, IncompleteTelemetryUnhealthy) {
+    HealthGate gate;
+    auto sample = healthy_shadow_sample();
+    sample.gdop.reset();
+    const auto result = gate.evaluate(sample);
+    EXPECT_FALSE(result.healthy);
+}
+
+TEST(ShadowEstimateHealthGateTest, StaleAgeUnhealthy) {
+    HealthGate::Config config;
+    config.max_age_s = 0.5;
+    HealthGate gate(config);
+    auto sample = healthy_shadow_sample();
+    sample.age_s = 0.6;
+    const auto result = gate.evaluate(sample);
+    EXPECT_FALSE(result.healthy);
 }
 
 }  // namespace


### PR DESCRIPTION
## Summary
- **RealtimeFixIntegrityGate**: causal C++ port of the frozen bounded-latency residual policy + KF/FGO consensus state machine into `gnss_solve` (`--realtime-fix-integrity`, `--integrity-shadow-csv`, `--integrity-log`). Buffers at most 7 epochs so a confirmed 8-epoch suspicious FIX streak is retroactively demoted to FLOAT; never consumes reference truth or future shadow epochs. Default off; with the flag on but default sub-policies, output is bit-identical on runs where nothing fires.
- **Opt-in base confidence gate** (`--integrity-base-gate`): field-for-field port of the offline low-satellite/ratio policy. Off by default because it over-demotes on the plain KF PPC baseline; with the flag it reproduces the audited UrbanNav Trimble Shinjuku external result exactly (22 caught >2 m, 0 correct harmed; Odaiba 0 demotions).
- **Fail-closed shadow health** (`ShadowEstimateHealthGate` + `--integrity-shadow-*` flags): a shadow epoch without a positive `position_covariance_trace_m2` (or failing FIXED-status/GDOP/DDPR/nsat/age bars) is treated as absent and can neither arm nor hold QUARANTINE; strict default is byte-identical to running without a shadow. `gnss_fgo_parity` now emits an empty field instead of a fake `0.0` trace.
- **MADOCA CI/build**: dedicated `gnss_madoca_parity_tests` target (stops compiling every unrelated test TU in the parity lane), IPO off + ccache in CI, and MSVC link fixes for `madocalib` (`m` only on non-Windows; `winmm` for `timeGetTime`). Full MSVC Release build with `MADOCALIB_PARITY_LINK=ON` passes the CI gtest filter 14/14.

## Validation
- Six public PPC runs (low-cost KF baseline, 0.5 m threshold): total wrong FIX **3618 -> 2847** (495 caught, 8 correct harmed); bit-inert on tokyo1-3 and nagoya3; positions on non-demoted epochs identical. Macro FIX 73.4% vs the documented 54.3% GICI reproduction.
- UrbanNav external holdout (2.0 m threshold): default gate no-op confirmed; `--integrity-base-gate` matches the offline external audit (22/0 Shinjuku, 0 Odaiba).
- 42/42 integrity unit tests; full reports in `output/ppc_realtime_fix_integrity_matrix.md` and `output/urbannav_realtime_fix_integrity_external.md` (untracked); design notes in `docs/ppc_online_consensus_design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016mNfPiAuzJsY1wnL51AycZ