### PR TITLE
CLAS: fix per-satellite outage counter false positives (MRTKLIB reset parity)

### DIFF
--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -188,6 +188,19 @@ struct PPPEnvOverrides {
     // GNSS_PPP_CLAS_MRTKLIB_FLOAT_PARITY: use the MRTKLIB-equivalent CLAS
     // float variance model unless set exactly to "0". Default true.
     bool clas_mrtklib_float_parity = true;
+    // GNSS_PPP_CLAS_OUTAGE_RESET_PARITY: clear a satellite's per-frequency
+    // outage counter (ambiguity.outage_count) as soon as this epoch's raw
+    // observation for that frequency is usable, mirroring MRTKLIB's
+    // udbias_ppp()/vsat-gated outc[f]=0 clear (mrtk_ppp_rtk.c ~2342) that
+    // our port was missing at the point per_sat_outage is evaluated. Without
+    // it, a single missed post-fit acceptance leaves the counter parked
+    // above maxout forever (reset_frequency() preserves, never zeroes, an
+    // overflowed count -- matching MRTKLIB's own increment-before-test
+    // ordering) and "outage_sat" re-fires every subsequent epoch even while
+    // the satellite is observed and corrected continuously. Default true
+    // (fix ON); exact "0" restores the unconditional-increment-only legacy
+    // behavior byte-for-byte.
+    bool clas_outage_reset_parity = true;
     // GNSS_PPP_CLAS_SIS_BOUNDARY: apply the CLAS SIS continuity delta with
     // CLASLIB-style SSR-update-boundary semantics (hold the delta captured at
     // a 30s orbit/clock boundary for the following 15s, matching the

--- a/src/algorithms/ppp_clas.cpp
+++ b/src/algorithms/ppp_clas.cpp
@@ -1222,12 +1222,44 @@ ClasSlipDetectionStats detectClasCycleSlips(
         bool per_sat_outage = false;
         bool l1_outage_overflow = false;
         bool l2_outage_overflow = false;
-        int l1_outage_count = ambiguity.outage_count;
-        int l2_outage_count = 0;
         const SatelliteId l2_ambiguity_satellite(
             osr.satellite.system,
             static_cast<uint8_t>(std::min(
                 255, static_cast<int>(osr.satellite.prn) + 100)));
+        // MRTKLIB udbias_ppp() increments outc[f] for every extant ambiguity
+        // (mirrored at the top of this function), then clears it back to 0
+        // for every satellite whose phase row survives that epoch's
+        // post-fit residual test (mrtk_ppp_rtk.c ~2342: "if (!vsat[f])
+        // continue; ...outc[f]=0;"). Our post-fit acceptance path
+        // (updateObservedAmbiguities()) mirrors that clear, but only for
+        // rows that actually reach DD/measurement construction; a satellite
+        // that silently drops out of that build for one epoch (reference
+        // reselection etc., not a slip or a genuine residual-test
+        // rejection) never gets the chance, and because the overflow branch
+        // below deliberately *preserves* -- never zeroes -- an already
+        // elevated count (matching MRTKLIB's own increment-before-test
+        // ordering), the counter is then parked above maxout permanently:
+        // "outage_sat" re-fires every subsequent epoch even though the
+        // satellite continues to be observed and corrected (G15 at
+        // nagoya/run3 tow 553825-553830: fires every 0.2s epoch once
+        // tripped, though raw obs + OSR corrections are valid throughout).
+        // Clear the counter directly from this epoch's raw observation
+        // validity -- the same underlying signal MRTKLIB's vsat[f]
+        // ultimately reduces to for a satellite that was never rejected --
+        // so a continuously observed satellite cannot get stuck above
+        // maxout. Kill switch: GNSS_PPP_CLAS_OUTAGE_RESET_PARITY=0 restores
+        // the unconditional-increment-only legacy behavior exactly.
+        if (mrtklib_float_parity && !outage_gap &&
+            pppEnvOverrides().clas_outage_reset_parity) {
+            if (l1_raw_usable) {
+                ambiguity.outage_count = 0;
+            }
+            if (l2_raw_usable) {
+                ambiguity_states[l2_ambiguity_satellite].outage_count = 0;
+            }
+        }
+        int l1_outage_count = ambiguity.outage_count;
+        int l2_outage_count = 0;
         const auto l2_ambiguity_it = ambiguity_states.find(l2_ambiguity_satellite);
         if (l2_ambiguity_it != ambiguity_states.end()) {
             l2_outage_count = l2_ambiguity_it->second.outage_count;

--- a/src/algorithms/ppp_clas_epoch.cpp
+++ b/src/algorithms/ppp_clas_epoch.cpp
@@ -57,6 +57,29 @@ constexpr int kClasKinematicMinFixCount = 1;
 // MRTKLIB clas.toml rejection.hold_chi_square / fix_chi_square (mrtk_ppp_rtk.c:2312-2315)
 constexpr double kMrtklibHoldChiSquareGate = 0.5;
 constexpr double kMrtklibFixChiSquareGate = 5.0;
+// Measurement-only override for the post-fix DD phase chi-square gate
+// (kMrtklibFixChiSquareGate above, applied at its use site further down this
+// file). Unset (the default): behavior is exactly kMrtklibFixChiSquareGate,
+// bit-identical to before this override existed. Set to a finite float: that
+// value replaces the gate threshold for this process, so
+// GNSS_PPP_CLAS_KIN_CHISQ_MAX=1e9 effectively disables the gate (chisq is
+// never >= 1e9) while e.g. =20 loosens it. Used to measure how much of the
+// kinematic AR attrition on nagoya_run3 (292 AR-accepted epochs vs. 250
+// scored FIX) this single gate accounts for -- see [CLAS-KIN-CHISQ] reject
+// logging at the use site.
+double clasKinematicChiSquareGateM() {
+    static const double gate = [] {
+        const char* env = std::getenv("GNSS_PPP_CLAS_KIN_CHISQ_MAX");
+        if (env == nullptr) return kMrtklibFixChiSquareGate;
+        char* end = nullptr;
+        const double parsed = std::strtod(env, &end);
+        if (end == env || !std::isfinite(parsed)) {
+            return kMrtklibFixChiSquareGate;
+        }
+        return parsed;
+    }();
+    return gate;
+}
 // MRTKLIB clas.toml rejection.l1_l2_residual (pos2-rejionno1) sigma gate used
 // by residual_test() to drop individual outlier carrier residuals.
 constexpr double kMrtklibPhaseResidualSigmaGate = 2.0;
@@ -2022,7 +2045,7 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
                           << " ratio=" << last_ar_ratio_ << "\n";
             }
             if (!std::isfinite(phase_chisq) ||
-                phase_chisq >= kMrtklibFixChiSquareGate) {
+                phase_chisq >= clasKinematicChiSquareGateM()) {
                 clas_kinematic_chisq_rejected = true;
             } else if (phase_chisq < kMrtklibHoldChiSquareGate) {
                 std::map<SatelliteId, double> clas_satellite_elevations_rad;
@@ -2082,7 +2105,7 @@ PositionSolution PPPProcessor::processEpochCLAS(const ObservationData& obs,
         ppp_ar::clearWlnlHoldState(clas_wlnl_hold_);
         if (pppDebugEnabled()) {
             std::cerr << "[CLAS-KIN-CHISQ] reject fix (chisq >= "
-                      << kMrtklibFixChiSquareGate << ")\n";
+                      << clasKinematicChiSquareGateM() << ")\n";
         }
     }
     if (ambiguity_resolution.rejected_after_fix) {

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -200,6 +200,8 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
         envStringOrEmpty("GNSS_PPP_CLAS_DD_ROW_DUMP");
     overrides.clas_mrtklib_float_parity =
         !envExactZero("GNSS_PPP_CLAS_MRTKLIB_FLOAT_PARITY");
+    overrides.clas_outage_reset_parity =
+        !envExactZero("GNSS_PPP_CLAS_OUTAGE_RESET_PARITY");
     overrides.clas_sis_boundary =
         envExactOne("GNSS_PPP_CLAS_SIS_BOUNDARY");
     overrides.clas_base_clock_parity =


### PR DESCRIPTION
## Root cause

`ambiguity.outage_count` increments unconditionally every epoch (correct MRTKLIB parity), but the clear-to-zero only happened for satellites reaching full DD/measurement-row construction. A satellite that silently drops out of that build for a single epoch (e.g. reference-satellite reselection — not a slip, not a residual-test rejection) never gets cleared, and since the overflow branch deliberately preserves an elevated count, the counter parks above `maxout=1` **permanently**: `outage_sat` then re-fires every epoch even while the satellite is continuously observed and corrected.

Verified on nagoya run3: G15 falsely flagged 171×/run (25/25 flagged epochs have raw RINEX observations; verified against raw obs, our OSR pipeline, and a real MRTKLIB v0.5.1 run on identical inputs which sees nothing wrong). The false flag at tow 553825.0 killed a healthy 7-epoch fix hold and pushed the solver into a 15-float-epoch full-state wipe loop for the rest of the window. QZSS J02 was chronically flagged (1662×/run).

## Fix

Clear the per-frequency outage counter from this epoch's raw-observation validity at the point `per_sat_outage` is evaluated (`detectClasCycleSlips()`), mirroring MRTKLIB's `udbias_ppp()` outc[f]=0 clear (mrtk_ppp_rtk.c ~2342). Kill switch: `GNSS_PPP_CLAS_OUTAGE_RESET_PARITY=0` restores legacy behavior **byte-for-byte** (md5-verified: `dd1fd422…` identical to develop-equivalent baseline).

**Parity caveat (documented in code/commit):** MRTKLIB's clear is vsat-gated (post-fit residual survivors); ours is raw-observation-gated — slightly looser. A chronically residual-rejected satellite would escalate to outage in MRTKLIB but not here. The six-run validation below specifically stress-tested this (nagoya run2's pre-existing >3 m burst) and found no regression.

Debug-log effect (n3): `outage_sat` flags 2243→224 (−90%), G15 window flags 23→0, J02 1662→0, full-Kalman wipes 195→181.

## Six-run validation (raw antenna reference basis; every run re-scored)

| Run | FIX (base→fix) | fix% | FIX RMS2D | max FIX | >3 m |
|---|---|---:|---|---:|---:|
| Tokyo 1 | 1155→1270 | 9.735→10.704 | 0.306→0.352 | 1.961 | 0 |
| Tokyo 2 | 1899→1955 | 20.891→21.507 | 0.326→0.322 | 1.013 | 0 |
| Tokyo 3 | 5733→5783 | 37.623→37.951 | 0.185→0.192 | 2.986 | 0 |
| Nagoya 1 | 2769→2770 | 36.724→36.737 | 0.444→0.450 | 1.043 | 0 |
| Nagoya 2 | 2240→2249 | 23.863→23.959 | 0.614→0.625 | 3.200 | **19→19** |
| Nagoya 3 | 250→451 | 4.865→8.776 | 0.317→0.304 | 0.587 | 0 |

- **Aggregate: 24.110% → 24.852% FIX (+432 epochs), aggregate FIX RMS2D 0.370→0.377 m, zero new >3 m epochs.**
- Nagoya 2's 19 >3 m epochs are the **identical pre-existing burst** (tow 556406.4–556410.4, max 3.200) present in the baseline — provably unchanged.
- Nagoya 3 fix rate nearly doubles and now exceeds the MRTKLIB v0.4.2 published target (8.78% vs 6.3%); Tokyo 2 closes to 21.51% vs target 21.7%.
- Tokyo 1 note: +115 fixes with RMS softening 0.306→0.352 (new fixes cluster at tow 188810–189357, all <2 m); no gate violation.
- Reproducibility: n3 .pos md5 `a251f8a3…` byte-identical across independent reruns; t3 completed with peak RSS ~2.0 GB (earlier validation-run kills were host memory pressure, unrelated to this change).

The branch also carries edcdc9d ("env-tunable KIN-CHISQ threshold", default bit-identical) — a measurement knob from the investigation that found this bug; default behavior is unchanged by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EXeVZLkt6NF26a38wbw2CN