### PR TITLE
Streamline README benchmark sections

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,19 +147,6 @@ generalization claim. Definitions, commands, paths, and the machine-readable
 audit are in [PPC reproduction commands](docs/ppc_reproduction.md) and
 [`docs/ppc_kf_fgo_goal_metrics.json`](docs/ppc_kf_fgo_goal_metrics.json).
 
-### PPC RTK vs RTKLIB demo5
-
-Across six public PPC Tokyo/Nagoya moving-RTK replays, the coverage profile
-averages a **+17.0 pp** Positioning-rate lead, **+28.1 pp** PPC
-official-score lead, and **-11.96 m** P95 horizontal-error delta versus
-RTKLIB `demo5`.
-
-![PPC RTK coverage scorecard](docs/ppc_rtk_demo5_scorecard.png)
-
-See [Benchmarks](docs/benchmarks.md#ppc-coverage-profile) for the per-run
-matrix and analysis, and [PPC reproduction commands](docs/ppc_reproduction.md)
-for the evaluation workflow.
-
 ### GNSS/IMU Tightly-Coupled FGO vs tightly-coupled-gnss-imu-fgo
 
 GTSAM-based fixed-lag factor-graph backend (`FGOBackend::GTSAM`) with

--- a/README.md
+++ b/README.md
@@ -50,102 +50,24 @@ and the PPC score target from the [Turing tight-coupling slides](https://www.den
 
 ![PPC public targets](docs/ppc_public_targets.png)
 
-The XY view below shows where each selected solution is FIXED or FLOAT. Green
-points are correct FIX epochs, red crosses are FIX epochs with 3D error above
-0.5 m, orange points are FLOAT, and the light-gray line is the reference
-trajectory.
-
-Before the final confidence gate, a truth-free wrong-basin escape replaces 35
-Nagoya 2 FIX positions with its independent TC-FGO candidate and emits them as
-FLOAT only when baseline prefit RMS exceeds 8 m and at least 45 observations
-were suppressed. Nagoya 2 FIX errors above 10 m fall from 36 to 4 and those
-above 5 m from 42 to 10, while its P95 horizontal error improves from 19.092 m
-to 18.144 m.
-
-Nagoya 3 now uses a causal, truth-free KF/FGO consensus state machine. The FGO
-shadow never replaces the KF position: it only quarantines a FIX label while
-the estimators disagree, and recovery requires consecutive agreement. A
-runtime-only provisional-recovery gate retains five healthy FIX epochs without
-promoting the joint anchor early. This removes 16 wrong FIX labels and 15
-errors above 10 m without losing a correct FIX epoch.
-
-The final confidence layer demotes FIX to FLOAT when fewer than 8 satellites
-are used, or when at most 11 satellites are used and the AR ratio is at most
-15. Strong same-epoch telemetry may exonerate the boundary case only with at
-least 11 satellites, prefit RMS at most 0.5 m, and NIS/observation at most 0.2.
-A causal kinematic guard then quarantines the current and next two epochs after
-a jump above 12 m with acceleration above 200 m/s2. A bounded plateau extension
-continues quarantine for at most eight epochs while jumps stay below 0.1 m. A
-secondary trigger requires a jump above 5 m, acceleration above 100 m/s2,
-prefit RMS above 5 m, ratio at most 10, at least 10 suppressed outliers, and at
-most 13 satellites. It changes no positions and reads no reference truth.
-
-Tokyo 3 additionally replays two overlapping, independently initialized
-GNSS/IMU FGO shadow windows through the consensus state machine. FIX is
-quarantined after sustained KF/FGO separation above 5 m when the shadow has
-GDOP at most 4, DDPR RMS at most 40 m, and at least 8 satellites. The FGO
-position is never substituted. Soft primary telemetry cannot start an
-unrecoverable quarantine while the independent estimator is unavailable; hard
-primary suspects remain fail-closed. The two-window replay removes 142 wrong
-FIX labels at a cost of five correct FIX labels and finishes in NORMAL state.
-
-The final staged residual guard adds at most seven epochs (1.4 seconds at
-5 Hz) of output latency. It confirms eight consecutive FIX epochs only when
-prefit RMS exceeds 40 m, ratio is at most 15, at least 12 observations are
-suppressed, and suppressed observations comprise at least half of `RTKObs`.
-A separate single-epoch gate requires prefit RMS at least 40 m and at most 14
-satellites. These rules consume emitted RTK telemetry only and change status,
-not position. They remove 57 wrong FIX labels at a cost of ten correct FIX
-labels on PPC.
-
-The official score reaches **78.845491%**. Across six runs, aggregate wrong FIX
-falls from 869 to **574**, wrong FIX above 5 m from 96 to **42**, and wrong FIX
-above 10 m from 59 to **5**. Correct FIX/reference remains above its 66.230%
-floor and Tokyo 1 remains above its public FIX target. In six-fold leave-one-run-out selection,
-five folds select the production 12 m / 3-epoch primary policy and the remaining
-fold selects a 5-epoch hold. All extension folds select an eight-epoch maximum
-plateau age; the secondary thresholds vary and provide held-out catches only on
-two runs, so that component remains exploratory. See the
-[kinematic integrity LOO report](docs/ppc_kinematic_integrity_loo.md). This is
-a run-level robustness check, not an external-dataset generalization claim. The full severity audit is
-in [PPC FIX integrity audit](docs/ppc_fix_integrity_audit.md). The
-[wrong-FIX event ledger](docs/ppc_wrong_fix_event_ledger.md) groups all 574
-residual wrong-FIX epochs into 188 contiguous events and records truth-free
-runtime fingerprints for root-cause and regression work.
-The [Nagoya 3 root-cause report](docs/ppc_nagoya3_wrong_fix_root_cause.md)
-shows that the largest event is an overconfident float-KF basin followed by
-integer certification, rather than an inherited hold-FIX failure.
-The [online consensus design](docs/ppc_online_consensus_design.md) specifies the
-truth-free KF/FGO quarantine and recovery state machine that follows from it.
-The frozen staged policy was also replayed on full UrbanNav Odaiba/Shinjuku
-Trimble rover solutions. It demoted 22 of 49 FIX errors above 2 m, harmed zero
-correct FIX epochs, and consumed no reference truth at runtime; see the
-[external integrity audit](docs/ppc_residual_integrity_external_audit.md).
-The machine-readable requirement audit is tracked in
-[PPC goal completion audit](docs/ppc_goal_completion_audit.md).
+The audited runtime profile uses candidate telemetry only; reference truth is
+used after output generation for scoring. It reaches an official score of
+**78.845491%** while reducing aggregate wrong FIX from 869 to **574**, errors
+above 5 m from 96 to **42**, and errors above 10 m from 59 to **5**.
 
 ![PPC selected XY trajectories by FIX status](docs/ppc_kf_fgo_fix_status_xy.png)
 
 `gici-open` was reproduced from commit
 `e7666110a88d22e08aad24345a253564af9b8024` on its `forppc2024` branch and
-evaluated from exported NMEA with the same six references and metric code.
-The six-run libgnss++ FIX macro is **+16.613 pp** above that reproduction, and
-its macro Wrong FIX/FIX is **1.025 pp lower**.
-The GPL-3.0 program remains an external executable: no GICI source is copied,
-linked, or distributed here, so libgnss++ remains MIT.
+evaluated with the same six references and metric code. The libgnss++ FIX macro
+is **+16.613 pp** higher and Wrong FIX/FIX is **1.025 pp** lower. These are
+in-sample benchmark results, not a held-out generalization claim.
 
-The position selectors use candidate status/ratio/satellite/residual telemetry
-and candidate-to-current separation only. They preserve the baseline epoch
-grid and telemetry; the wrong-basin and consensus escapes intentionally
-replace position and status for their selected epochs. The final
-satellite-count/ratio confidence gate changes only
-the emitted status, from FIX to FLOAT; the online consensus and kinematic
-guards likewise retain the primary position. Reference truth is used only after
-output generation for scoring. Thresholds were tuned on this public benchmark,
-so these results are an in-sample benchmark rather than a held-out
-generalization claim. Definitions, commands, paths, and the machine-readable
-audit are in [PPC reproduction commands](docs/ppc_reproduction.md) and
-[`docs/ppc_kf_fgo_goal_metrics.json`](docs/ppc_kf_fgo_goal_metrics.json).
+See the [goal audit](docs/ppc_goal_completion_audit.md),
+[FIX integrity audit](docs/ppc_fix_integrity_audit.md),
+[kinematic integrity LOO report](docs/ppc_kinematic_integrity_loo.md), and
+[reproduction commands](docs/ppc_reproduction.md) for the gate design,
+external replay, event ledger, machine-readable metrics, and licensing details.
 
 ### GNSS/IMU Tightly-Coupled FGO vs tightly-coupled-gnss-imu-fgo
 

--- a/README.md
+++ b/README.md
@@ -149,25 +149,16 @@ audit are in [PPC reproduction commands](docs/ppc_reproduction.md) and
 
 ### PPC RTK vs RTKLIB demo5
 
-These are public PPC Tokyo/Nagoya moving-RTK replays using the same
-rover/base/nav observations for libgnss++ and RTKLIB `demo5`.
-
-<!-- PPC_COVERAGE_MATRIX:START -->
-| Run | gnssplusplus Positioning | RTKLIB Positioning | Delta | gnssplusplus Fix | RTKLIB Fix | PPC official score | RTKLIB official score | Official delta | P95 H delta |
-|---|---:|---:|---:|---:|---:|---:|---:|---:|---:|
-| Tokyo run1 | **90.0%** | 66.3% | **+23.7 pp** | **54.4%** | 30.5% | **34.9%** | 0.0% | **+34.9 pp** | +3.39 m |
-| Tokyo run2 | **95.3%** | 84.3% | **+11.0 pp** | **64.1%** | 27.6% | **69.0%** | 16.9% | **+52.1 pp** | -18.51 m |
-| Tokyo run3 | **95.7%** | 93.1% | **+2.5 pp** | **63.0%** | 40.5% | **60.6%** | 35.6% | **+25.0 pp** | -0.24 m |
-| Nagoya run1 | **88.8%** | 65.8% | **+23.0 pp** | **64.5%** | 33.8% | **49.5%** | 22.4% | **+27.1 pp** | -23.78 m |
-| Nagoya run2 | **85.6%** | 69.8% | **+15.8 pp** | **51.4%** | 18.8% | **20.9%** | 11.0% | **+9.9 pp** | -27.24 m |
-| Nagoya run3 | **93.8%** | 67.7% | **+26.1 pp** | **27.1%** | 13.9% | **27.4%** | 7.6% | **+19.7 pp** | -5.37 m |
-
-Across these six public runs, the coverage profile averages **+17.0 pp**
-Positioning-rate lead, **+28.1 pp** PPC official-score lead, and
-**-11.96 m** P95 horizontal-error delta versus RTKLIB `demo5`.
-<!-- PPC_COVERAGE_MATRIX:END -->
+Across six public PPC Tokyo/Nagoya moving-RTK replays, the coverage profile
+averages a **+17.0 pp** Positioning-rate lead, **+28.1 pp** PPC
+official-score lead, and **-11.96 m** P95 horizontal-error delta versus
+RTKLIB `demo5`.
 
 ![PPC RTK coverage scorecard](docs/ppc_rtk_demo5_scorecard.png)
+
+See [Benchmarks](docs/benchmarks.md#ppc-coverage-profile) for the per-run
+matrix and analysis, and [PPC reproduction commands](docs/ppc_reproduction.md)
+for the evaluation workflow.
 
 ### GNSS/IMU Tightly-Coupled FGO vs tightly-coupled-gnss-imu-fgo
 

--- a/docs/ppc_reproduction.md
+++ b/docs/ppc_reproduction.md
@@ -61,7 +61,8 @@ not accept relative `kinematic`, while the CLI option does.
 
 ## Coverage Matrix
 
-Use this for the README RTKLIB `demo5` comparison table:
+Use this for the RTKLIB `demo5` comparison table in
+[`docs/benchmarks.md`](benchmarks.md#ppc-coverage-profile):
 
 ```bash
 python3 apps/gnss.py ppc-coverage-matrix \

--- a/scripts/update_ppc_coverage_readme.py
+++ b/scripts/update_ppc_coverage_readme.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Synchronize README/docs PPC coverage tables from ppc-coverage-matrix JSON."""
+"""Synchronize the PPC coverage table from ppc-coverage-matrix JSON."""
 
 from __future__ import annotations
 
@@ -14,7 +14,6 @@ from typing import Any
 ROOT_DIR = Path(__file__).resolve().parents[1]
 DEFAULT_SUMMARY_JSON = ROOT_DIR / "output" / "ppc_coverage_matrix" / "summary.json"
 DEFAULT_TARGETS = (
-    ROOT_DIR / "README.md",
     ROOT_DIR / "docs" / "benchmarks.md",
 )
 START_MARKER = "<!-- PPC_COVERAGE_MATRIX:START -->"

--- a/tests/test_benchmark_scripts.py
+++ b/tests/test_benchmark_scripts.py
@@ -4852,6 +4852,12 @@ class KfFgoAlignmentTest(unittest.TestCase):
 
 
 class PPCCoverageReadmeUpdateTest(unittest.TestCase):
+    def test_default_target_keeps_generated_table_in_benchmarks(self) -> None:
+        self.assertEqual(
+            ppc_coverage_readme.DEFAULT_TARGETS,
+            (ppc_coverage_readme.ROOT_DIR / "docs" / "benchmarks.md",),
+        )
+
     def sample_summary(self) -> dict[str, object]:
         return {
             "runs": [


### PR DESCRIPTION
## Summary

- remove the redundant PPC/demo5 benchmark section from the README
- retain the scorecard image and full per-run matrix in `docs/benchmarks.md`
- condense the PPC 2024 goal narrative while retaining its comparison table and all three images
- link detailed gate, integrity, LOO, reproduction, and licensing evidence from the shorter overview
- make the coverage-table updater target the benchmark detail page only, so regeneration does not restore the removed README table

## Why

The README repeated PPC/demo5 results already summarized in its top-level
status table and documented in `docs/benchmarks.md`. Its PPC 2024 goal section
also embedded implementation-level gate descriptions that are maintained in
dedicated audit documents. This keeps the README focused without deleting
tables, images, or benchmark evidence.

## Impact

Documentation and benchmark-maintenance tooling only; solver behavior is
unchanged.

## Validation

- `python3 -m pytest tests/test_benchmark_scripts.py::PPCCoverageReadmeUpdateTest -q` (5 passed)
- `git diff --check`
