### PR TITLE
Simplify gnss_fuse help for preset users

### DIFF
--- a/apps/gnss.py
+++ b/apps/gnss.py
@@ -126,7 +126,7 @@ COMMANDS = {
     "fuse": {
         "kind": "binary",
         "target": "gnss_fuse",
-        "summary": "Loosely-coupled IMU+GNSS fusion over a rover.obs/nav plus imu.csv.",
+        "summary": "GNSS/IMU fusion with SPP/RTK and validated tight-coupling presets.",
     },
     "vel-d": {
         "kind": "binary",

--- a/apps/native/gnss_fuse.cpp
+++ b/apps/native/gnss_fuse.cpp
@@ -310,6 +310,44 @@ void applyImuGradePreset(const std::string& grade, libgnss::ProcessNoiseConfig& 
 void printUsage(const char* program_name) {
     std::cout
         << "Usage: " << program_name
+        << " --data-dir <run-dir> [--navi776-tc] [options]\n"
+        << "       " << program_name
+        << " --rover <rover.obs> --nav <nav.rnx> --imu <imu.csv>"
+           " [--base <base.obs>] [options]\n\n"
+        << "GNSS/IMU fusion with in-process SPP or RTK positioning.\n"
+        << "Use --data-dir when a run directory contains rover.obs, base.obs,\n"
+        << "base.nav, and imu.csv. Existing advanced flags remain supported.\n\n"
+        << "Inputs:\n"
+        << "  --data-dir <dir>        Load the standard run files from one directory\n"
+        << "  --rover <path>          Rover RINEX observation file\n"
+        << "  --base <path>           Base RINEX observation file; enables RTK\n"
+        << "  --nav <path>            RINEX navigation file\n"
+        << "  --imu <path>            IMU CSV file\n"
+        << "  --gnss-pos <path>       Use an existing position/velocity solution\n\n"
+        << "Common options:\n"
+        << "  --navi776-tc            Validated short-baseline tight-coupling preset\n"
+        << "  --lever-arm x,y,z       IMU-to-antenna lever arm, body FLU, meters\n"
+        << "  --preset <name>         RTK preset: survey|low-cost|moving-base|odaiba\n"
+        << "  --ratio <value>         RTK ambiguity ratio threshold (default: 3.0)\n"
+        << "  --max-epochs <n>        Stop after n GNSS epochs (0 = no limit)\n"
+        << "  --out <path>            Fused solution output"
+           " (default: output/fused_solution.pos)\n"
+        << "  --rtk-pos-out <path>    Optional pre-fusion RTK solution output\n"
+        << "  --kml <path>            Optional KML trajectory output\n"
+        << "  --verbose               Print periodic progress\n"
+        << "  --quiet                 Suppress the run summary\n\n"
+        << "Help:\n"
+        << "  -h, --help              Show this everyday-use help\n"
+        << "  --help-advanced         Show every tuning, experiment, and diagnostic option\n\n"
+        << "Recommended PPC invocation:\n"
+        << "  " << program_name
+        << " --data-dir <run-dir> --lever-arm x,y,z --preset low-cost"
+           " --navi776-tc --rtk-pos-out output/rtk.pos\n";
+}
+
+void printAdvancedUsage(const char* program_name) {
+    std::cout
+        << "Usage: " << program_name
         << " --rover <rover.obs> --nav <nav.rnx> --imu <imu.csv> [--base <base.obs>] --out <fused.pos>\n"
         << "Loosely-coupled GNSS/IMU fusion (Stage 1, docs/design.md): a 15-state\n"
         << "error-state EKF mechanizes 100 Hz IMU samples and opportunistically\n"
@@ -515,7 +553,8 @@ void printUsage(const char* program_name) {
         << "                                replacement's elevation (default: 30.0)\n"
         << "  --verbose                    Print periodic per-epoch progress\n"
         << "  --quiet                      Suppress run summary\n"
-        << "  -h, --help                   Show this help\n";
+        << "  -h, --help                   Show concise everyday-use help\n"
+        << "  --help-advanced              Show this complete option reference\n";
 }
 
 // Converts the fusion filter's body(FLU)->ENU attitude quaternion into
@@ -632,6 +671,9 @@ FuseOptions parseArguments(int argc, char* argv[]) {
         const std::string arg = argv[i];
         if (arg == "-h" || arg == "--help") {
             printUsage(argv[0]);
+            std::exit(0);
+        } else if (arg == "--help-advanced") {
+            printAdvancedUsage(argv[0]);
             std::exit(0);
         } else if (arg == "--data-dir") {
             options.data_dir = requireValue(arg, i, argc, argv);

--- a/docs/imu_fusion.md
+++ b/docs/imu_fusion.md
@@ -63,6 +63,11 @@ Acc Z ≈ +9.81, despite the upstream README saying FRD).
 | Doppler LS velocity (feeds SPP/RTK solutions) | `src/algorithms/spp_velocity.cpp` |
 | CLI | `apps/native/gnss_fuse.cpp` (registered as `fuse` in `apps/gnss.py`) |
 
+`gnss fuse --help` intentionally shows only everyday inputs, outputs, and
+presets. The accepted tuning and research flags remain backward-compatible
+and are listed under `gnss fuse --help-advanced`. Prefer `--navi776-tc`
+instead of spelling out its component tight-coupling flags.
+
 The fusion deliberately does not reuse `algorithms/kalman.hpp`: its
 RTKLIB-style "active state" convention (`x[i] != 0`) is incompatible with an
 error state that is legitimately zero after injection.

--- a/docs/navi776_techniques.md
+++ b/docs/navi776_techniques.md
@@ -226,6 +226,10 @@ loop, velocity states, Doppler rows at sigma 0.5, and adaptive noise; both
 Doppler and adaptive-noise paths are gated at a 1000 m baseline. It also
 enables two measured-update optimizations:
 
+This preset is the only navi.776 control shown in the default
+`gnss_fuse --help`. The component controls remain accepted for reproducible
+experiments and are documented by `gnss_fuse --help-advanced`.
+
 - the Kalman update returns the already-solved weighted innovation and
   `diag(H P H^T)`, avoiding a second innovation-matrix factorization while
   preserving the adaptive tracker's row statistics;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -407,6 +407,14 @@ if(GTest_FOUND)
         NAME python_search_imu_time_offset_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_search_imu_time_offset.py
     )
+    add_test(
+        NAME python_gnss_fuse_cli_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_gnss_fuse_cli.py
+    )
+    set_tests_properties(
+        python_gnss_fuse_cli_tests
+        PROPERTIES ENVIRONMENT "GNSSPP_BINARY_DIR=${CMAKE_BINARY_DIR}"
+    )
     set_tests_properties(
         python_bindings_tests
         PROPERTIES ENVIRONMENT "PYTHONPATH=${CMAKE_BINARY_DIR}/python"
@@ -459,6 +467,7 @@ if(GTest_FOUND)
         python_spp_iteration_dump_summary_tests
         python_web_http_ux_tests
         python_experiment_runner_tests
+        python_gnss_fuse_cli_tests
         python_search_imu_time_offset_tests
     )
     set(GNSSPP_EXTENDED_TESTS

--- a/tests/test_cli_ux.py
+++ b/tests/test_cli_ux.py
@@ -458,8 +458,8 @@ class CliUxTest(unittest.TestCase):
         clas_row = clas_rows[0]
         for snippet in (
             "Six PPC Tokyo/Nagoya runs",
-            "22.055% aggregate FIX",
-            "36 FIX epochs above 3 m",
+            "24.851% aggregate FIX",
+            "19 FIX epochs (0.03%) exceed 3 m",
         ):
             self.assertIn(snippet, clas_row)
 
@@ -472,12 +472,12 @@ class CliUxTest(unittest.TestCase):
         for snippet in (
             "current moving-data gate",
             "all six public PPC Tokyo/Nagoya runs",
-            "Across 58,258 scored epochs",
+            "Across 58,259 scored epochs",
             "All RMS2D*",
             "SINGLE RMS2D*",
             "catastrophic FLOAT/SPP disagreement above 250 m",
             "excluded from ordinary filter admission, cold starts, and AR",
-            "FLOAT and SINGLE RMS2D are 16.615 m and 70.291 m",
+            "FLOAT and SINGLE RMS2D are 16.843 m and 70.337 m",
         ):
             self.assertIn(snippet, normalized_section)
 

--- a/tests/test_gnss_fuse_cli.py
+++ b/tests/test_gnss_fuse_cli.py
@@ -1,0 +1,60 @@
+"""Regression tests for the concise and advanced gnss_fuse help surfaces."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import unittest
+from pathlib import Path
+
+
+class GnssFuseCliTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        binary_dir = Path(os.environ["GNSSPP_BINARY_DIR"])
+        executable_name = "gnss_fuse.exe" if os.name == "nt" else "gnss_fuse"
+        candidates = [
+            binary_dir / "apps" / executable_name,
+            *(binary_dir / "apps" / config / executable_name
+              for config in ("Release", "RelWithDebInfo", "Debug")),
+        ]
+        cls.executable = next(
+            (candidate for candidate in candidates if candidate.is_file()),
+            None,
+        )
+        if cls.executable is None:
+            rendered = ", ".join(str(candidate) for candidate in candidates)
+            raise RuntimeError(f"gnss_fuse executable not found; checked: {rendered}")
+
+    @classmethod
+    def run_fuse(cls, option: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [str(cls.executable), option],
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_default_help_keeps_the_supported_path_concise(self) -> None:
+        result = self.run_fuse("--help")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("--data-dir <dir>", result.stdout)
+        self.assertIn("--navi776-tc", result.stdout)
+        self.assertIn("--help-advanced", result.stdout)
+        self.assertNotIn("--tc-doppler-sigma", result.stdout)
+        self.assertNotIn("--rtk-ins-prior-inflation", result.stdout)
+        self.assertLess(len(result.stdout), 5000)
+
+    def test_advanced_help_retains_research_option_discoverability(self) -> None:
+        result = self.run_fuse("--help-advanced")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("--navi776-tc", result.stdout)
+        self.assertIn("--tc-doppler-sigma", result.stdout)
+        self.assertIn("--rtk-ins-prior-inflation", result.stdout)
+        self.assertIn("--help-advanced", result.stdout)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- make `gnss_fuse --help` show only everyday inputs, outputs, and presets
- move the complete tuning, experiment, and diagnostic reference to `--help-advanced`
- keep every existing option accepted for backward compatibility
- present `--navi776-tc` as the supported public tight-coupling preset
- add cross-generator CLI regression coverage and update the fusion documentation
- refresh stale CLAS README contract values that blocked the Docs workflow

## Why

The single flat help page exposed too many internal and experimental controls, making the supported invocation difficult to identify. This separates the normal user path from the research surface without changing parsing or positioning behavior.

## Validation

- concise/advanced CLI regression tests: passed
- Docs/dispatcher CLI UX contract: 20 passed, 14 subtests passed
- C++ full suite: 665 passed, 51 skipped, 0 failed
- Clang/Ninja `gnss_fuse` build: passed
- MSVC Release `gnss_fuse` build: passed