### PR TITLE
Add compact TOML config for gnss_fuse

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -210,6 +210,7 @@ install(FILES
 )
 
 install(FILES
+    ${CMAKE_SOURCE_DIR}/configs/examples/fuse.example.toml
     ${CMAKE_SOURCE_DIR}/configs/examples/live.example.conf
     ${CMAKE_SOURCE_DIR}/configs/examples/web.example.toml
     DESTINATION configs/examples

--- a/apps/native/gnss_fuse.cpp
+++ b/apps/native/gnss_fuse.cpp
@@ -1,4 +1,5 @@
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 #include <cstdlib>
 #include <fstream>
@@ -325,6 +326,7 @@ void printUsage(const char* program_name) {
         << "  --imu <path>            IMU CSV file\n"
         << "  --gnss-pos <path>       Use an existing position/velocity solution\n\n"
         << "Common options:\n"
+        << "  --config <path>         Load flat TOML defaults; CLI options override them\n"
         << "  --navi776-tc            Validated short-baseline tight-coupling preset\n"
         << "  --lever-arm x,y,z       IMU-to-antenna lever arm, body FLU, meters\n"
         << "  --preset <name>         RTK preset: survey|low-cost|moving-base|odaiba\n"
@@ -355,6 +357,8 @@ void printAdvancedUsage(const char* program_name) {
         << "(SPP), or from --rover/--base/--nav (RTK, same RTKProcessor pipeline the\n"
         << "`solve` command uses) when --base is supplied.\n\n"
         << "Options:\n"
+        << "  --config <path>              Load flat TOML defaults from [gnss_fuse]. CLI\n"
+        << "                                options always override config values\n"
         << "  --data-dir <dir>             Use <dir>/rover.obs, base.obs, base.nav, imu.csv as\n"
         << "                                defaults for --rover/--base/--nav/--imu\n"
         << "  --rover <rover.obs>          RINEX observation file (required)\n"
@@ -628,7 +632,321 @@ private:
     std::exit(1);
 }
 
+std::string trim(std::string value) {
+    const auto first = std::find_if_not(value.begin(), value.end(), [](unsigned char ch) {
+        return std::isspace(ch) != 0;
+    });
+    const auto last = std::find_if_not(value.rbegin(), value.rend(), [](unsigned char ch) {
+        return std::isspace(ch) != 0;
+    }).base();
+    if (first >= last) {
+        return {};
+    }
+    return std::string(first, last);
+}
+
+std::string stripTomlComment(const std::string& line) {
+    bool in_single_quote = false;
+    bool in_double_quote = false;
+    bool escaped = false;
+    for (std::size_t i = 0; i < line.size(); ++i) {
+        const char ch = line[i];
+        if (in_double_quote && ch == '\\' && !escaped) {
+            escaped = true;
+            continue;
+        }
+        if (ch == '\'' && !in_double_quote) {
+            in_single_quote = !in_single_quote;
+        } else if (ch == '"' && !in_single_quote && !escaped) {
+            in_double_quote = !in_double_quote;
+        } else if (ch == '#' && !in_single_quote && !in_double_quote) {
+            return line.substr(0, i);
+        }
+        escaped = false;
+    }
+    return line;
+}
+
+std::size_t findTomlEquals(const std::string& line) {
+    bool in_single_quote = false;
+    bool in_double_quote = false;
+    bool escaped = false;
+    for (std::size_t i = 0; i < line.size(); ++i) {
+        const char ch = line[i];
+        if (in_double_quote && ch == '\\' && !escaped) {
+            escaped = true;
+            continue;
+        }
+        if (ch == '\'' && !in_double_quote) {
+            in_single_quote = !in_single_quote;
+        } else if (ch == '"' && !in_single_quote && !escaped) {
+            in_double_quote = !in_double_quote;
+        } else if (ch == '=' && !in_single_quote && !in_double_quote) {
+            return i;
+        }
+        escaped = false;
+    }
+    return std::string::npos;
+}
+
+std::string parseTomlString(const std::string& raw_value, const std::string& context) {
+    const std::string value = trim(raw_value);
+    if (value.size() < 2 ||
+        !((value.front() == '"' && value.back() == '"') ||
+          (value.front() == '\'' && value.back() == '\''))) {
+        return value;
+    }
+    if (value.front() == '\'') {
+        return value.substr(1, value.size() - 2);
+    }
+
+    std::string parsed;
+    parsed.reserve(value.size() - 2);
+    for (std::size_t i = 1; i + 1 < value.size(); ++i) {
+        if (value[i] != '\\') {
+            parsed.push_back(value[i]);
+            continue;
+        }
+        if (++i + 1 > value.size()) {
+            throw std::invalid_argument("invalid escape in " + context);
+        }
+        switch (value[i]) {
+            case '\\': parsed.push_back('\\'); break;
+            case '"': parsed.push_back('"'); break;
+            case 'n': parsed.push_back('\n'); break;
+            case 'r': parsed.push_back('\r'); break;
+            case 't': parsed.push_back('\t'); break;
+            default:
+                throw std::invalid_argument("unsupported escape in " + context +
+                                            " (use TOML single quotes for Windows paths)");
+        }
+    }
+    return parsed;
+}
+
+std::vector<std::string> parseTomlArray(const std::string& raw_value,
+                                        const std::string& context) {
+    const std::string value = trim(raw_value);
+    if (value.size() < 2 || value.front() != '[' || value.back() != ']') {
+        return {};
+    }
+    std::vector<std::string> values;
+    std::string item;
+    bool in_single_quote = false;
+    bool in_double_quote = false;
+    bool escaped = false;
+    for (std::size_t i = 1; i + 1 < value.size(); ++i) {
+        const char ch = value[i];
+        if (in_double_quote && ch == '\\' && !escaped) {
+            escaped = true;
+            item.push_back(ch);
+            continue;
+        }
+        if (ch == '\'' && !in_double_quote) {
+            in_single_quote = !in_single_quote;
+        } else if (ch == '"' && !in_single_quote && !escaped) {
+            in_double_quote = !in_double_quote;
+        }
+        if (ch == ',' && !in_single_quote && !in_double_quote) {
+            if (trim(item).empty()) {
+                throw std::invalid_argument("empty array item in " + context);
+            }
+            values.push_back(parseTomlString(item, context));
+            item.clear();
+        } else {
+            item.push_back(ch);
+        }
+        escaped = false;
+    }
+    if (in_single_quote || in_double_quote || trim(item).empty()) {
+        throw std::invalid_argument("malformed array in " + context);
+    }
+    values.push_back(parseTomlString(item, context));
+    return values;
+}
+
+struct TomlConfigEntry {
+    std::string key;
+    std::string value;
+    int line_number = 0;
+};
+
+std::vector<TomlConfigEntry> loadFuseTomlEntries(const std::string& path) {
+    std::ifstream input(path);
+    if (!input.is_open()) {
+        throw std::invalid_argument("cannot open --config file: " + path);
+    }
+
+    std::vector<TomlConfigEntry> root_entries;
+    std::vector<TomlConfigEntry> fuse_entries;
+    std::string section;
+    bool has_fuse_section = false;
+    std::string line;
+    int line_number = 0;
+    while (std::getline(input, line)) {
+        ++line_number;
+        line = trim(stripTomlComment(line));
+        if (line.empty()) {
+            continue;
+        }
+        if (line.front() == '[') {
+            if (line.size() < 3 || line.back() != ']') {
+                throw std::invalid_argument(path + ":" + std::to_string(line_number) +
+                                            ": malformed TOML table");
+            }
+            section = trim(line.substr(1, line.size() - 2));
+            if (section == "gnss_fuse") {
+                has_fuse_section = true;
+            }
+            continue;
+        }
+        const std::size_t equals = findTomlEquals(line);
+        if (equals == std::string::npos) {
+            throw std::invalid_argument(path + ":" + std::to_string(line_number) +
+                                        ": expected key = value");
+        }
+        TomlConfigEntry entry{trim(line.substr(0, equals)), trim(line.substr(equals + 1)),
+                              line_number};
+        if (entry.key.empty() || entry.value.empty()) {
+            throw std::invalid_argument(path + ":" + std::to_string(line_number) +
+                                        ": expected non-empty key and value");
+        }
+        if (section.empty()) {
+            root_entries.push_back(std::move(entry));
+        } else if (section == "gnss_fuse") {
+            fuse_entries.push_back(std::move(entry));
+        }
+    }
+    return has_fuse_section ? fuse_entries : root_entries;
+}
+
+std::string configKeyToOption(std::string key) {
+    key = trim(std::move(key));
+    if (key.size() >= 2 &&
+        ((key.front() == '"' && key.back() == '"') ||
+         (key.front() == '\'' && key.back() == '\''))) {
+        key = key.substr(1, key.size() - 2);
+    }
+    std::replace(key.begin(), key.end(), '_', '-');
+    if (key.empty() || key.front() == '-') {
+        throw std::invalid_argument("invalid gnss_fuse config key: " + key);
+    }
+    return "--" + key;
+}
+
+std::vector<std::string> configEntryToArguments(const TomlConfigEntry& entry,
+                                                const std::string& path) {
+    const std::string context = path + ":" + std::to_string(entry.line_number);
+    const std::string option = configKeyToOption(entry.key);
+    const std::string value = trim(entry.value);
+    std::string lowercase = value;
+    std::transform(lowercase.begin(), lowercase.end(), lowercase.begin(),
+                   [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+
+    if (lowercase == "true") {
+        if (option == "--base-interp") {
+            return {};
+        }
+        return {option};
+    }
+    if (lowercase == "false") {
+        if (option == "--zupt" || option == "--nhc" || option == "--arfilter") {
+            return {"--no-" + option.substr(2)};
+        }
+        if (option == "--base-interp") {
+            return {"--no-base-interp"};
+        }
+        // False is the default for the remaining enable-only switches.
+        return {};
+    }
+
+    const auto array_values = parseTomlArray(value, context);
+    if (!array_values.empty()) {
+        if (option == "--lever-arm" || option == "--imu-misalignment-rpy-deg") {
+            if (array_values.size() != 3) {
+                throw std::invalid_argument(context + ": " + entry.key +
+                                            " requires exactly 3 values");
+            }
+            return {option, array_values[0] + "," + array_values[1] + "," + array_values[2]};
+        }
+        if (option == "--base-ecef") {
+            if (array_values.size() != 3) {
+                throw std::invalid_argument(context + ": base_ecef requires exactly 3 values");
+            }
+            return {option, array_values[0], array_values[1], array_values[2]};
+        }
+        throw std::invalid_argument(context + ": arrays are not supported for " + entry.key);
+    }
+    return {option, parseTomlString(value, context)};
+}
+
+std::vector<std::string> expandConfigArguments(int argc, char* argv[]) {
+    std::string config_path;
+    std::vector<std::string> cli_arguments;
+    cli_arguments.reserve(static_cast<std::size_t>(argc));
+    cli_arguments.emplace_back(argv[0]);
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--config") {
+            if (i + 1 >= argc) {
+                throw std::invalid_argument("--config requires a path");
+            }
+            if (!config_path.empty()) {
+                throw std::invalid_argument("--config may only be specified once");
+            }
+            config_path = argv[++i];
+        } else if (arg.rfind("--config=", 0) == 0) {
+            if (!config_path.empty()) {
+                throw std::invalid_argument("--config may only be specified once");
+            }
+            config_path = arg.substr(std::string("--config=").size());
+            if (config_path.empty()) {
+                throw std::invalid_argument("--config requires a path");
+            }
+        } else {
+            cli_arguments.push_back(arg);
+        }
+    }
+    if (config_path.empty()) {
+        return cli_arguments;
+    }
+
+    std::vector<std::string> expanded;
+    expanded.push_back(argv[0]);
+    for (const auto& entry : loadFuseTomlEntries(config_path)) {
+        auto entry_arguments = configEntryToArguments(entry, config_path);
+        expanded.insert(expanded.end(),
+                        std::make_move_iterator(entry_arguments.begin()),
+                        std::make_move_iterator(entry_arguments.end()));
+    }
+    expanded.insert(expanded.end(),
+                    std::make_move_iterator(cli_arguments.begin() + 1),
+                    std::make_move_iterator(cli_arguments.end()));
+    return expanded;
+}
+
 FuseOptions parseArguments(int argc, char* argv[]) {
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "-h" || arg == "--help") {
+            printUsage(argv[0]);
+            std::exit(0);
+        }
+        if (arg == "--help-advanced") {
+            printAdvancedUsage(argv[0]);
+            std::exit(0);
+        }
+    }
+
+    std::vector<std::string> expanded_arguments = expandConfigArguments(argc, argv);
+    std::vector<char*> expanded_argv;
+    expanded_argv.reserve(expanded_arguments.size());
+    for (auto& argument : expanded_arguments) {
+        expanded_argv.push_back(argument.data());
+    }
+    argc = static_cast<int>(expanded_argv.size());
+    argv = expanded_argv.data();
+
     FuseOptions options;
     // LooseCouplingProcessor::Config's own library-wide default for both of
     // these is 0.0 (no innovation gating at all -- see

--- a/configs/README.md
+++ b/configs/README.md
@@ -11,4 +11,7 @@ or credentials. Benchmark profiles without the `.example` marker are pinned
 reproduction inputs and should only change with their documented acceptance
 criteria.
 
+`examples/fuse.example.toml` is the compact configuration surface for
+`gnss fuse --config`. Command-line values override its `[gnss_fuse]` defaults.
+
 Camera fixtures and other non-configuration assets live under `test_data/`.

--- a/configs/examples/fuse.example.toml
+++ b/configs/examples/fuse.example.toml
@@ -1,0 +1,17 @@
+# Copy this file and replace the dataset path and lever arm for your run.
+# Command-line options override every value in this file.
+
+[gnss_fuse]
+data_dir = "data/PPC-Dataset/tokyo/run1"
+out = "output/fused_solution.pos"
+rtk_pos_out = "output/rtk_solution.pos"
+
+# Validated high-level choices. Prefer these over individual research flags.
+preset = "low-cost"
+navi776_tc = true
+
+# IMU-to-antenna lever arm in body FLU coordinates, meters.
+lever_arm = [0.31, 0.0, 0.55]
+
+# 0 processes every epoch.
+max_epochs = 0

--- a/docs/imu_fusion.md
+++ b/docs/imu_fusion.md
@@ -68,6 +68,12 @@ presets. The accepted tuning and research flags remain backward-compatible
 and are listed under `gnss fuse --help-advanced`. Prefer `--navi776-tc`
 instead of spelling out its component tight-coupling flags.
 
+For repeatable runs, put defaults in a flat TOML `[gnss_fuse]` table and pass
+`--config <path>`. Keys may use `snake_case` or `kebab-case`; vector values
+such as `lever_arm` and `base_ecef` use three-element arrays. Command-line
+options are applied after the file regardless of where `--config` appears, so
+they are reliable one-run overrides. See `configs/examples/fuse.example.toml`.
+
 The fusion deliberately does not reuse `algorithms/kalman.hpp`: its
 RTKLIB-style "active state" convention (`x[i] != 0`) is incompatible with an
 error state that is legitimately zero after injection.

--- a/tests/test_gnss_fuse_cli.py
+++ b/tests/test_gnss_fuse_cli.py
@@ -1,9 +1,10 @@
-"""Regression tests for the concise and advanced gnss_fuse help surfaces."""
+"""Regression tests for gnss_fuse's concise help and TOML config surface."""
 
 from __future__ import annotations
 
 import os
 import subprocess
+import tempfile
 import unittest
 from pathlib import Path
 
@@ -27,9 +28,9 @@ class GnssFuseCliTest(unittest.TestCase):
             raise RuntimeError(f"gnss_fuse executable not found; checked: {rendered}")
 
     @classmethod
-    def run_fuse(cls, option: str) -> subprocess.CompletedProcess[str]:
+    def run_fuse(cls, *options: str) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
-            [str(cls.executable), option],
+            [str(cls.executable), *options],
             check=False,
             capture_output=True,
             text=True,
@@ -40,11 +41,54 @@ class GnssFuseCliTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("--data-dir <dir>", result.stdout)
+        self.assertIn("--config <path>", result.stdout)
         self.assertIn("--navi776-tc", result.stdout)
         self.assertIn("--help-advanced", result.stdout)
         self.assertNotIn("--tc-doppler-sigma", result.stdout)
         self.assertNotIn("--rtk-ins-prior-inflation", result.stdout)
         self.assertLess(len(result.stdout), 5000)
+
+    def test_config_supplies_defaults_and_cli_always_overrides_them(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_fuse_config_") as temp_dir:
+            config_path = Path(temp_dir) / "fuse.toml"
+            config_path.write_text(
+                "\n".join(
+                    [
+                        "[gnss_fuse]",
+                        'gnss_pos = "missing-solution.pos"',
+                        'imu = "missing-imu.csv"',
+                        "lever_arm = [0.31, 0.0, 0.55]",
+                        "navi776_tc = false",
+                        "max_epochs = -1",
+                    ]
+                ),
+                encoding="utf-8",
+            )
+
+            result = self.run_fuse(
+                "--max-epochs",
+                "0",
+                "--config",
+                str(config_path),
+            )
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("failed to load IMU CSV", result.stderr)
+        self.assertNotIn("--max-epochs must be non-negative", result.stderr)
+
+    def test_unknown_config_key_is_rejected_by_the_existing_option_parser(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_fuse_config_") as temp_dir:
+            config_path = Path(temp_dir) / "fuse.toml"
+            config_path.write_text(
+                "[gnss_fuse]\nthis_option_does_not_exist = 1\n",
+                encoding="utf-8",
+            )
+
+            result = self.run_fuse("--config", str(config_path))
+
+        self.assertEqual(result.returncode, 1)
+        self.assertIn("unknown or incomplete argument: --this-option-does-not-exist",
+                      result.stderr)
 
     def test_advanced_help_retains_research_option_discoverability(self) -> None:
         result = self.run_fuse("--help-advanced")

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -128,6 +128,7 @@ class PackagingSmokeTest(unittest.TestCase):
                 prefix / "scripts" / "generate_feature_overview_card.py",
                 prefix / "scripts" / "generate_odaiba_social_card.py",
                 prefix / "configs" / "README.md",
+                prefix / "configs" / "examples" / "fuse.example.toml",
                 prefix / "configs" / "examples" / "live.example.conf",
                 prefix / "configs" / "examples" / "web.example.toml",
                 prefix / "configs" / "signoff" / "ppp_products_ppc.example.toml",


### PR DESCRIPTION
## Summary

- add a compact `--config <path>` surface to `gnss_fuse`
- load flat TOML defaults from `[gnss_fuse]` while preserving all existing CLI flags
- apply CLI arguments after config values for reliable one-run overrides
- add a packaged example config, documentation, and regression coverage

## Why

`gnss_fuse` accepts many research and tuning flags. A checked-in configuration keeps normal invocations short and reproducible without breaking existing experiment commands.

## Validation

- clang-ninja `gnss_fuse` build
- MSVC Release `gnss_fuse` build
- `python tests/test_gnss_fuse_cli.py` (4 tests)
- C++ suite: 670 passed, 51 skipped, 0 failed
- 5-epoch direct CLI vs TOML smoke: fused and RTK outputs MD5-identical
- `git diff --check`