### PR TITLE
Simplify gnss_solve CLI configuration

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -40,7 +40,10 @@ if(GTSAM_FOUND)
     target_link_libraries(gnss_fgo_parity PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)
 endif()
 
-add_executable(gnss_fuse ${GNSS_NATIVE_DIR}/gnss_fuse.cpp)
+add_executable(gnss_fuse
+    ${GNSS_NATIVE_DIR}/gnss_fuse.cpp
+    ${GNSS_NATIVE_DIR}/cli_toml_config.cpp
+)
 target_link_libraries(gnss_fuse PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)
 
 add_executable(gnss_vel_d ${GNSS_NATIVE_DIR}/gnss_vel_d.cpp)
@@ -58,7 +61,10 @@ target_link_libraries(gnss_pos_vel_pdc PRIVATE gnss_lib gnss_lib_noopt Threads::
 add_executable(gnss_pos_vel_pd ${GNSS_NATIVE_DIR}/gnss_pos_vel_pd.cpp)
 target_link_libraries(gnss_pos_vel_pd PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)
 
-add_executable(gnss_solve ${GNSS_NATIVE_DIR}/gnss_solve.cpp)
+add_executable(gnss_solve
+    ${GNSS_NATIVE_DIR}/gnss_solve.cpp
+    ${GNSS_NATIVE_DIR}/cli_toml_config.cpp
+)
 target_link_libraries(gnss_solve PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)
 
 add_executable(gnss_ppp ${GNSS_NATIVE_DIR}/gnss_ppp.cpp)
@@ -212,6 +218,7 @@ install(FILES
 install(FILES
     ${CMAKE_SOURCE_DIR}/configs/examples/fuse.example.toml
     ${CMAKE_SOURCE_DIR}/configs/examples/live.example.conf
+    ${CMAKE_SOURCE_DIR}/configs/examples/solve.example.toml
     ${CMAKE_SOURCE_DIR}/configs/examples/web.example.toml
     DESTINATION configs/examples
 )

--- a/apps/native/cli_toml_config.cpp
+++ b/apps/native/cli_toml_config.cpp
@@ -1,0 +1,308 @@
+#include "cli_toml_config.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <fstream>
+#include <iterator>
+#include <stdexcept>
+#include <utility>
+
+namespace libgnss_apps {
+namespace {
+
+struct TomlEntry {
+    std::string key;
+    std::string value;
+    int line_number = 0;
+};
+
+std::string trim(std::string value) {
+    const auto first = std::find_if_not(value.begin(), value.end(), [](unsigned char ch) {
+        return std::isspace(ch) != 0;
+    });
+    const auto last = std::find_if_not(value.rbegin(), value.rend(), [](unsigned char ch) {
+        return std::isspace(ch) != 0;
+    }).base();
+    return first >= last ? std::string{} : std::string(first, last);
+}
+
+std::string stripComment(const std::string& line) {
+    bool single = false;
+    bool doubled = false;
+    bool escaped = false;
+    for (std::size_t i = 0; i < line.size(); ++i) {
+        const char ch = line[i];
+        if (doubled && ch == '\\' && !escaped) {
+            escaped = true;
+            continue;
+        }
+        if (ch == '\'' && !doubled) {
+            single = !single;
+        } else if (ch == '"' && !single && !escaped) {
+            doubled = !doubled;
+        } else if (ch == '#' && !single && !doubled) {
+            return line.substr(0, i);
+        }
+        escaped = false;
+    }
+    return line;
+}
+
+std::size_t findEquals(const std::string& line) {
+    bool single = false;
+    bool doubled = false;
+    bool escaped = false;
+    for (std::size_t i = 0; i < line.size(); ++i) {
+        const char ch = line[i];
+        if (doubled && ch == '\\' && !escaped) {
+            escaped = true;
+            continue;
+        }
+        if (ch == '\'' && !doubled) {
+            single = !single;
+        } else if (ch == '"' && !single && !escaped) {
+            doubled = !doubled;
+        } else if (ch == '=' && !single && !doubled) {
+            return i;
+        }
+        escaped = false;
+    }
+    return std::string::npos;
+}
+
+std::string parseString(const std::string& raw, const std::string& context) {
+    const std::string value = trim(raw);
+    if (value.size() < 2 ||
+        !((value.front() == '"' && value.back() == '"') ||
+          (value.front() == '\'' && value.back() == '\''))) {
+        return value;
+    }
+    if (value.front() == '\'') {
+        return value.substr(1, value.size() - 2);
+    }
+
+    std::string parsed;
+    parsed.reserve(value.size() - 2);
+    for (std::size_t i = 1; i + 1 < value.size(); ++i) {
+        if (value[i] != '\\') {
+            parsed.push_back(value[i]);
+            continue;
+        }
+        ++i;
+        switch (value[i]) {
+            case '\\': parsed.push_back('\\'); break;
+            case '"': parsed.push_back('"'); break;
+            case 'n': parsed.push_back('\n'); break;
+            case 'r': parsed.push_back('\r'); break;
+            case 't': parsed.push_back('\t'); break;
+            default:
+                throw std::invalid_argument(
+                    "unsupported escape in " + context +
+                    " (use TOML single quotes for Windows paths)");
+        }
+    }
+    return parsed;
+}
+
+std::vector<std::string> parseArray(const std::string& raw,
+                                    const std::string& context) {
+    const std::string value = trim(raw);
+    if (value.size() < 2 || value.front() != '[' || value.back() != ']') {
+        return {};
+    }
+
+    std::vector<std::string> values;
+    std::string item;
+    bool single = false;
+    bool doubled = false;
+    bool escaped = false;
+    for (std::size_t i = 1; i + 1 < value.size(); ++i) {
+        const char ch = value[i];
+        if (doubled && ch == '\\' && !escaped) {
+            escaped = true;
+            item.push_back(ch);
+            continue;
+        }
+        if (ch == '\'' && !doubled) {
+            single = !single;
+        } else if (ch == '"' && !single && !escaped) {
+            doubled = !doubled;
+        }
+        if (ch == ',' && !single && !doubled) {
+            if (trim(item).empty()) {
+                throw std::invalid_argument("empty array item in " + context);
+            }
+            values.push_back(parseString(item, context));
+            item.clear();
+        } else {
+            item.push_back(ch);
+        }
+        escaped = false;
+    }
+    if (single || doubled || trim(item).empty()) {
+        throw std::invalid_argument("malformed array in " + context);
+    }
+    values.push_back(parseString(item, context));
+    return values;
+}
+
+std::vector<TomlEntry> loadEntries(const std::string& path,
+                                   const std::string& section_name) {
+    std::ifstream input(path);
+    if (!input.is_open()) {
+        throw std::invalid_argument("cannot open --config file: " + path);
+    }
+
+    std::vector<TomlEntry> root;
+    std::vector<TomlEntry> selected;
+    std::string section;
+    bool has_selected_section = false;
+    std::string line;
+    int line_number = 0;
+    while (std::getline(input, line)) {
+        ++line_number;
+        line = trim(stripComment(line));
+        if (line.empty()) {
+            continue;
+        }
+        if (line.front() == '[') {
+            if (line.size() < 3 || line.back() != ']') {
+                throw std::invalid_argument(path + ":" + std::to_string(line_number) +
+                                            ": malformed TOML table");
+            }
+            section = trim(line.substr(1, line.size() - 2));
+            has_selected_section |= section == section_name;
+            continue;
+        }
+        const std::size_t equals = findEquals(line);
+        if (equals == std::string::npos) {
+            throw std::invalid_argument(path + ":" + std::to_string(line_number) +
+                                        ": expected key = value");
+        }
+        TomlEntry entry{trim(line.substr(0, equals)), trim(line.substr(equals + 1)),
+                        line_number};
+        if (entry.key.empty() || entry.value.empty()) {
+            throw std::invalid_argument(path + ":" + std::to_string(line_number) +
+                                        ": expected non-empty key and value");
+        }
+        if (section.empty()) {
+            root.push_back(std::move(entry));
+        } else if (section == section_name) {
+            selected.push_back(std::move(entry));
+        }
+    }
+    return has_selected_section ? selected : root;
+}
+
+std::string keyToOption(std::string key) {
+    key = trim(std::move(key));
+    if (key.size() >= 2 &&
+        ((key.front() == '"' && key.back() == '"') ||
+         (key.front() == '\'' && key.back() == '\''))) {
+        key = key.substr(1, key.size() - 2);
+    }
+    std::replace(key.begin(), key.end(), '_', '-');
+    if (key.empty() || key.front() == '-') {
+        throw std::invalid_argument("invalid config key: " + key);
+    }
+    return "--" + key;
+}
+
+std::vector<std::string> entryArguments(const TomlEntry& entry,
+                                        const std::string& path,
+                                        const TomlCliSchema& schema) {
+    const std::string context = path + ":" + std::to_string(entry.line_number);
+    const std::string option = keyToOption(entry.key);
+    const std::string value = trim(entry.value);
+    std::string lowercase = value;
+    std::transform(lowercase.begin(), lowercase.end(), lowercase.begin(),
+                   [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+
+    if (lowercase == "true") {
+        const auto positive = schema.true_options.find(option);
+        if (positive == schema.true_options.end()) {
+            return {option};
+        }
+        return positive->second.empty()
+            ? std::vector<std::string>{}
+            : std::vector<std::string>{positive->second};
+    }
+    if (lowercase == "false") {
+        const auto negative = schema.false_options.find(option);
+        if (negative == schema.false_options.end()) {
+            throw std::invalid_argument(
+                context + ": boolean false is not supported for " + entry.key +
+                "; omit default-off options instead");
+        }
+        return negative->second.empty()
+            ? std::vector<std::string>{}
+            : std::vector<std::string>{negative->second};
+    }
+
+    const auto array = parseArray(value, context);
+    if (!array.empty()) {
+        const auto style = schema.array_options.find(option);
+        if (style == schema.array_options.end()) {
+            throw std::invalid_argument(context + ": arrays are not supported for " +
+                                        entry.key);
+        }
+        if (array.size() != 3) {
+            throw std::invalid_argument(context + ": " + entry.key +
+                                        " requires exactly 3 values");
+        }
+        if (style->second == TomlArrayStyle::COMMA_JOINED) {
+            return {option, array[0] + "," + array[1] + "," + array[2]};
+        }
+        return {option, array[0], array[1], array[2]};
+    }
+    return {option, parseString(value, context)};
+}
+
+}  // namespace
+
+std::vector<std::string> expandTomlConfigArguments(
+    int argc, char* argv[], const TomlCliSchema& schema) {
+    std::string config_path;
+    std::vector<std::string> cli;
+    cli.reserve(static_cast<std::size_t>(argc));
+    cli.emplace_back(argv[0]);
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "--config") {
+            if (i + 1 >= argc) {
+                throw std::invalid_argument("--config requires a path");
+            }
+            if (!config_path.empty()) {
+                throw std::invalid_argument("--config may only be specified once");
+            }
+            config_path = argv[++i];
+        } else if (arg.rfind("--config=", 0) == 0) {
+            if (!config_path.empty()) {
+                throw std::invalid_argument("--config may only be specified once");
+            }
+            config_path = arg.substr(std::string("--config=").size());
+            if (config_path.empty()) {
+                throw std::invalid_argument("--config requires a path");
+            }
+        } else {
+            cli.push_back(arg);
+        }
+    }
+    if (config_path.empty()) {
+        return cli;
+    }
+
+    std::vector<std::string> expanded{argv[0]};
+    for (const auto& entry : loadEntries(config_path, schema.section_name)) {
+        auto arguments = entryArguments(entry, config_path, schema);
+        expanded.insert(expanded.end(),
+                        std::make_move_iterator(arguments.begin()),
+                        std::make_move_iterator(arguments.end()));
+    }
+    expanded.insert(expanded.end(),
+                    std::make_move_iterator(cli.begin() + 1),
+                    std::make_move_iterator(cli.end()));
+    return expanded;
+}
+
+}  // namespace libgnss_apps

--- a/apps/native/cli_toml_config.hpp
+++ b/apps/native/cli_toml_config.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace libgnss_apps {
+
+enum class TomlArrayStyle {
+    COMMA_JOINED,
+    SEPARATE_ARGUMENTS,
+};
+
+struct TomlCliSchema {
+    std::string section_name;
+    std::unordered_map<std::string, std::string> true_options;
+    std::unordered_map<std::string, std::string> false_options;
+    std::unordered_map<std::string, TomlArrayStyle> array_options;
+};
+
+/// Expands one optional --config TOML file into ordinary CLI arguments.
+///
+/// The selected table is converted first and the original CLI arguments are
+/// appended afterward, so command-line values reliably override file defaults.
+/// Keys may use snake_case or kebab-case and map to the corresponding --option.
+std::vector<std::string> expandTomlConfigArguments(
+    int argc, char* argv[], const TomlCliSchema& schema);
+
+}  // namespace libgnss_apps

--- a/apps/native/gnss_fuse.cpp
+++ b/apps/native/gnss_fuse.cpp
@@ -1,5 +1,4 @@
 #include <algorithm>
-#include <cctype>
 #include <cmath>
 #include <cstdlib>
 #include <fstream>
@@ -22,6 +21,7 @@
 #include <libgnss++/io/imu.hpp>
 #include <libgnss++/io/rinex.hpp>
 
+#include "cli_toml_config.hpp"
 #include "rtk_base_epoch_align.hpp"
 
 namespace {
@@ -632,299 +632,6 @@ private:
     std::exit(1);
 }
 
-std::string trim(std::string value) {
-    const auto first = std::find_if_not(value.begin(), value.end(), [](unsigned char ch) {
-        return std::isspace(ch) != 0;
-    });
-    const auto last = std::find_if_not(value.rbegin(), value.rend(), [](unsigned char ch) {
-        return std::isspace(ch) != 0;
-    }).base();
-    if (first >= last) {
-        return {};
-    }
-    return std::string(first, last);
-}
-
-std::string stripTomlComment(const std::string& line) {
-    bool in_single_quote = false;
-    bool in_double_quote = false;
-    bool escaped = false;
-    for (std::size_t i = 0; i < line.size(); ++i) {
-        const char ch = line[i];
-        if (in_double_quote && ch == '\\' && !escaped) {
-            escaped = true;
-            continue;
-        }
-        if (ch == '\'' && !in_double_quote) {
-            in_single_quote = !in_single_quote;
-        } else if (ch == '"' && !in_single_quote && !escaped) {
-            in_double_quote = !in_double_quote;
-        } else if (ch == '#' && !in_single_quote && !in_double_quote) {
-            return line.substr(0, i);
-        }
-        escaped = false;
-    }
-    return line;
-}
-
-std::size_t findTomlEquals(const std::string& line) {
-    bool in_single_quote = false;
-    bool in_double_quote = false;
-    bool escaped = false;
-    for (std::size_t i = 0; i < line.size(); ++i) {
-        const char ch = line[i];
-        if (in_double_quote && ch == '\\' && !escaped) {
-            escaped = true;
-            continue;
-        }
-        if (ch == '\'' && !in_double_quote) {
-            in_single_quote = !in_single_quote;
-        } else if (ch == '"' && !in_single_quote && !escaped) {
-            in_double_quote = !in_double_quote;
-        } else if (ch == '=' && !in_single_quote && !in_double_quote) {
-            return i;
-        }
-        escaped = false;
-    }
-    return std::string::npos;
-}
-
-std::string parseTomlString(const std::string& raw_value, const std::string& context) {
-    const std::string value = trim(raw_value);
-    if (value.size() < 2 ||
-        !((value.front() == '"' && value.back() == '"') ||
-          (value.front() == '\'' && value.back() == '\''))) {
-        return value;
-    }
-    if (value.front() == '\'') {
-        return value.substr(1, value.size() - 2);
-    }
-
-    std::string parsed;
-    parsed.reserve(value.size() - 2);
-    for (std::size_t i = 1; i + 1 < value.size(); ++i) {
-        if (value[i] != '\\') {
-            parsed.push_back(value[i]);
-            continue;
-        }
-        if (++i + 1 > value.size()) {
-            throw std::invalid_argument("invalid escape in " + context);
-        }
-        switch (value[i]) {
-            case '\\': parsed.push_back('\\'); break;
-            case '"': parsed.push_back('"'); break;
-            case 'n': parsed.push_back('\n'); break;
-            case 'r': parsed.push_back('\r'); break;
-            case 't': parsed.push_back('\t'); break;
-            default:
-                throw std::invalid_argument("unsupported escape in " + context +
-                                            " (use TOML single quotes for Windows paths)");
-        }
-    }
-    return parsed;
-}
-
-std::vector<std::string> parseTomlArray(const std::string& raw_value,
-                                        const std::string& context) {
-    const std::string value = trim(raw_value);
-    if (value.size() < 2 || value.front() != '[' || value.back() != ']') {
-        return {};
-    }
-    std::vector<std::string> values;
-    std::string item;
-    bool in_single_quote = false;
-    bool in_double_quote = false;
-    bool escaped = false;
-    for (std::size_t i = 1; i + 1 < value.size(); ++i) {
-        const char ch = value[i];
-        if (in_double_quote && ch == '\\' && !escaped) {
-            escaped = true;
-            item.push_back(ch);
-            continue;
-        }
-        if (ch == '\'' && !in_double_quote) {
-            in_single_quote = !in_single_quote;
-        } else if (ch == '"' && !in_single_quote && !escaped) {
-            in_double_quote = !in_double_quote;
-        }
-        if (ch == ',' && !in_single_quote && !in_double_quote) {
-            if (trim(item).empty()) {
-                throw std::invalid_argument("empty array item in " + context);
-            }
-            values.push_back(parseTomlString(item, context));
-            item.clear();
-        } else {
-            item.push_back(ch);
-        }
-        escaped = false;
-    }
-    if (in_single_quote || in_double_quote || trim(item).empty()) {
-        throw std::invalid_argument("malformed array in " + context);
-    }
-    values.push_back(parseTomlString(item, context));
-    return values;
-}
-
-struct TomlConfigEntry {
-    std::string key;
-    std::string value;
-    int line_number = 0;
-};
-
-std::vector<TomlConfigEntry> loadFuseTomlEntries(const std::string& path) {
-    std::ifstream input(path);
-    if (!input.is_open()) {
-        throw std::invalid_argument("cannot open --config file: " + path);
-    }
-
-    std::vector<TomlConfigEntry> root_entries;
-    std::vector<TomlConfigEntry> fuse_entries;
-    std::string section;
-    bool has_fuse_section = false;
-    std::string line;
-    int line_number = 0;
-    while (std::getline(input, line)) {
-        ++line_number;
-        line = trim(stripTomlComment(line));
-        if (line.empty()) {
-            continue;
-        }
-        if (line.front() == '[') {
-            if (line.size() < 3 || line.back() != ']') {
-                throw std::invalid_argument(path + ":" + std::to_string(line_number) +
-                                            ": malformed TOML table");
-            }
-            section = trim(line.substr(1, line.size() - 2));
-            if (section == "gnss_fuse") {
-                has_fuse_section = true;
-            }
-            continue;
-        }
-        const std::size_t equals = findTomlEquals(line);
-        if (equals == std::string::npos) {
-            throw std::invalid_argument(path + ":" + std::to_string(line_number) +
-                                        ": expected key = value");
-        }
-        TomlConfigEntry entry{trim(line.substr(0, equals)), trim(line.substr(equals + 1)),
-                              line_number};
-        if (entry.key.empty() || entry.value.empty()) {
-            throw std::invalid_argument(path + ":" + std::to_string(line_number) +
-                                        ": expected non-empty key and value");
-        }
-        if (section.empty()) {
-            root_entries.push_back(std::move(entry));
-        } else if (section == "gnss_fuse") {
-            fuse_entries.push_back(std::move(entry));
-        }
-    }
-    return has_fuse_section ? fuse_entries : root_entries;
-}
-
-std::string configKeyToOption(std::string key) {
-    key = trim(std::move(key));
-    if (key.size() >= 2 &&
-        ((key.front() == '"' && key.back() == '"') ||
-         (key.front() == '\'' && key.back() == '\''))) {
-        key = key.substr(1, key.size() - 2);
-    }
-    std::replace(key.begin(), key.end(), '_', '-');
-    if (key.empty() || key.front() == '-') {
-        throw std::invalid_argument("invalid gnss_fuse config key: " + key);
-    }
-    return "--" + key;
-}
-
-std::vector<std::string> configEntryToArguments(const TomlConfigEntry& entry,
-                                                const std::string& path) {
-    const std::string context = path + ":" + std::to_string(entry.line_number);
-    const std::string option = configKeyToOption(entry.key);
-    const std::string value = trim(entry.value);
-    std::string lowercase = value;
-    std::transform(lowercase.begin(), lowercase.end(), lowercase.begin(),
-                   [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
-
-    if (lowercase == "true") {
-        if (option == "--base-interp") {
-            return {};
-        }
-        return {option};
-    }
-    if (lowercase == "false") {
-        if (option == "--zupt" || option == "--nhc" || option == "--arfilter") {
-            return {"--no-" + option.substr(2)};
-        }
-        if (option == "--base-interp") {
-            return {"--no-base-interp"};
-        }
-        // False is the default for the remaining enable-only switches.
-        return {};
-    }
-
-    const auto array_values = parseTomlArray(value, context);
-    if (!array_values.empty()) {
-        if (option == "--lever-arm" || option == "--imu-misalignment-rpy-deg") {
-            if (array_values.size() != 3) {
-                throw std::invalid_argument(context + ": " + entry.key +
-                                            " requires exactly 3 values");
-            }
-            return {option, array_values[0] + "," + array_values[1] + "," + array_values[2]};
-        }
-        if (option == "--base-ecef") {
-            if (array_values.size() != 3) {
-                throw std::invalid_argument(context + ": base_ecef requires exactly 3 values");
-            }
-            return {option, array_values[0], array_values[1], array_values[2]};
-        }
-        throw std::invalid_argument(context + ": arrays are not supported for " + entry.key);
-    }
-    return {option, parseTomlString(value, context)};
-}
-
-std::vector<std::string> expandConfigArguments(int argc, char* argv[]) {
-    std::string config_path;
-    std::vector<std::string> cli_arguments;
-    cli_arguments.reserve(static_cast<std::size_t>(argc));
-    cli_arguments.emplace_back(argv[0]);
-    for (int i = 1; i < argc; ++i) {
-        const std::string arg = argv[i];
-        if (arg == "--config") {
-            if (i + 1 >= argc) {
-                throw std::invalid_argument("--config requires a path");
-            }
-            if (!config_path.empty()) {
-                throw std::invalid_argument("--config may only be specified once");
-            }
-            config_path = argv[++i];
-        } else if (arg.rfind("--config=", 0) == 0) {
-            if (!config_path.empty()) {
-                throw std::invalid_argument("--config may only be specified once");
-            }
-            config_path = arg.substr(std::string("--config=").size());
-            if (config_path.empty()) {
-                throw std::invalid_argument("--config requires a path");
-            }
-        } else {
-            cli_arguments.push_back(arg);
-        }
-    }
-    if (config_path.empty()) {
-        return cli_arguments;
-    }
-
-    std::vector<std::string> expanded;
-    expanded.push_back(argv[0]);
-    for (const auto& entry : loadFuseTomlEntries(config_path)) {
-        auto entry_arguments = configEntryToArguments(entry, config_path);
-        expanded.insert(expanded.end(),
-                        std::make_move_iterator(entry_arguments.begin()),
-                        std::make_move_iterator(entry_arguments.end()));
-    }
-    expanded.insert(expanded.end(),
-                    std::make_move_iterator(cli_arguments.begin() + 1),
-                    std::make_move_iterator(cli_arguments.end()));
-    return expanded;
-}
-
 FuseOptions parseArguments(int argc, char* argv[]) {
     for (int i = 1; i < argc; ++i) {
         const std::string arg = argv[i];
@@ -938,7 +645,26 @@ FuseOptions parseArguments(int argc, char* argv[]) {
         }
     }
 
-    std::vector<std::string> expanded_arguments = expandConfigArguments(argc, argv);
+    const libgnss_apps::TomlCliSchema schema{
+        "gnss_fuse",
+        {
+            {"--base-interp", ""},
+        },
+        {
+            {"--arfilter", "--no-arfilter"},
+            {"--base-interp", "--no-base-interp"},
+            {"--nhc", "--no-nhc"},
+            {"--navi776-tc", ""},
+            {"--zupt", "--no-zupt"},
+        },
+        {
+            {"--base-ecef", libgnss_apps::TomlArrayStyle::SEPARATE_ARGUMENTS},
+            {"--imu-misalignment-rpy-deg", libgnss_apps::TomlArrayStyle::COMMA_JOINED},
+            {"--lever-arm", libgnss_apps::TomlArrayStyle::COMMA_JOINED},
+        },
+    };
+    std::vector<std::string> expanded_arguments =
+        libgnss_apps::expandTomlConfigArguments(argc, argv, schema);
     std::vector<char*> expanded_argv;
     expanded_argv.reserve(expanded_arguments.size());
     for (auto& argument : expanded_arguments) {

--- a/apps/native/gnss_solve.cpp
+++ b/apps/native/gnss_solve.cpp
@@ -26,6 +26,7 @@
 #include <libgnss++/io/solution_writer.hpp>
 #include <libgnss++/models/troposphere.hpp>
 
+#include "cli_toml_config.hpp"
 #include "rtk_base_epoch_align.hpp"
 
 namespace {
@@ -1057,7 +1058,38 @@ private:
 
 void printUsage(const char* program_name) {
     std::cout
+        << "Usage: " << program_name << " --data-dir <dir> [options]\n"
+        << "       " << program_name
+        << " --rover <file> --base <file> --nav <file> [options]\n\n"
+        << "Batch RTK post-processing. Prefer a preset or TOML config for repeatable runs.\n\n"
+        << "Inputs:\n"
+        << "  --data-dir <dir>        Load rover.obs, base.obs, and navigation.nav\n"
+        << "  --rover <file>          Rover RINEX observation file\n"
+        << "  --base <file>           Base RINEX observation file\n"
+        << "  --nav <file>            Navigation RINEX file\n\n"
+        << "Common options:\n"
+        << "  --config <path>         Load flat TOML defaults; CLI options override them\n"
+        << "  --preset <name>         survey|low-cost|moving-base|odaiba\n"
+        << "  --mode <name>           auto|kinematic|static|moving-base\n"
+        << "  --iono <name>           auto|off|iflc|est\n"
+        << "  --ratio <value>         Ambiguity ratio threshold\n"
+        << "  --max-epochs <n>        Stop after n epochs (0 = no limit)\n"
+        << "  --out <file>            Solution output (default: output/rtk_solution.pos)\n"
+        << "  --kml <file>            Optional KML output path\n"
+        << "  --no-kml                Disable KML output\n"
+        << "  --verbose               Print per-epoch progress\n\n"
+        << "Help:\n"
+        << "  -h, --help              Show this everyday-use help\n"
+        << "  --help-advanced         Show every tuning, experiment, and diagnostic option\n\n"
+        << "Example:\n"
+        << "  " << program_name
+        << " --data-dir <run-dir> --preset low-cost --out output/rtk.pos\n";
+}
+
+void printAdvancedUsage(const char* program_name) {
+    std::cout
         << "Usage: " << program_name << " [options]\n"
+        << "  --config <path>           Load flat TOML defaults from [gnss_solve]; CLI wins\n"
         << "  --data-dir <dir>           Use <dir>/rover.obs, base.obs, navigation.nav\n"
         << "  --rover <file>             Rover RINEX observation file\n"
         << "  --base <file>              Base RINEX observation file\n"
@@ -1504,7 +1536,8 @@ void printUsage(const char* program_name) {
         << "  --no-kinematic-post-filter Disable the kinematic output post-filter\n"
         << "  --no-base-interp           Require exact rover/base epoch alignment\n"
         << "  --verbose                  Print per-epoch progress summary\n"
-        << "  -h, --help                 Show this help\n";
+        << "  -h, --help                 Show concise everyday-use help\n"
+        << "  --help-advanced            Show this complete option reference\n";
 }
 
 [[noreturn]] void argumentError(const std::string& message, const char* program_name) {
@@ -1643,6 +1676,55 @@ libgnss::io::SolutionWriter::Format parseOutputFormat(const std::string& value,
 }
 
 SolveConfig parseArguments(int argc, char* argv[]) {
+    for (int i = 1; i < argc; ++i) {
+        const std::string arg = argv[i];
+        if (arg == "-h" || arg == "--help") {
+            printUsage(argv[0]);
+            std::exit(0);
+        }
+        if (arg == "--help-advanced") {
+            printAdvancedUsage(argv[0]);
+            std::exit(0);
+        }
+    }
+
+    const libgnss_apps::TomlCliSchema schema{
+        "gnss_solve",
+        {
+            {"--base-interp", ""},
+            {"--beidou", ""},
+            {"--glonass", ""},
+            {"--kinematic-post-filter", ""},
+            {"--kml", ""},
+            {"--wide-lane-ar", "--enable-wide-lane-ar"},
+        },
+        {
+            {"--arfilter", "--no-arfilter"},
+            {"--base-interp", "--no-base-interp"},
+            {"--beidou", "--no-beidou"},
+            {"--fixed-bridge-burst-guard", "--no-fixed-bridge-burst-guard"},
+            {"--float-bridge-tail-guard", "--no-float-bridge-tail-guard"},
+            {"--glonass", "--no-glonass"},
+            {"--integrity-base-gate", "--no-integrity-base-gate"},
+            {"--kinematic-post-filter", "--no-kinematic-post-filter"},
+            {"--kml", "--no-kml"},
+            {"--nonfix-drift-guard", "--no-nonfix-drift-guard"},
+            {"--spp-height-step-guard", "--no-spp-height-step-guard"},
+            {"--enable-wide-lane-ar", "--no-wide-lane-ar"},
+            {"--wide-lane-ar", "--no-wide-lane-ar"},
+        },
+        {},
+    };
+    std::vector<std::string> expanded_arguments =
+        libgnss_apps::expandTomlConfigArguments(argc, argv, schema);
+    std::vector<char*> expanded_argv;
+    expanded_argv.reserve(expanded_arguments.size());
+    for (auto& argument : expanded_arguments) {
+        expanded_argv.push_back(argument.data());
+    }
+    argc = static_cast<int>(expanded_argv.size());
+    argv = expanded_argv.data();
+
     SolveConfig config;
 
     for (int i = 1; i < argc; ++i) {

--- a/configs/README.md
+++ b/configs/README.md
@@ -13,5 +13,7 @@ criteria.
 
 `examples/fuse.example.toml` is the compact configuration surface for
 `gnss fuse --config`. Command-line values override its `[gnss_fuse]` defaults.
+`examples/solve.example.toml` provides the same pattern for `gnss solve` and
+its `[gnss_solve]` table.
 
 Camera fixtures and other non-configuration assets live under `test_data/`.

--- a/configs/examples/solve.example.toml
+++ b/configs/examples/solve.example.toml
@@ -1,0 +1,22 @@
+# Copy this file and replace the run directory for your dataset.
+# Command-line options are applied after these defaults.
+
+[gnss_solve]
+data_dir = "data/PPC-Dataset/tokyo/run1"
+# PPC-Dataset names this file base.nav; --data-dir otherwise expects navigation.nav.
+nav = "data/PPC-Dataset/tokyo/run1/base.nav"
+out = "output/rtk_solution.pos"
+
+# Prefer named presets over spelling out their individual tuning controls.
+preset = "low-cost"
+mode = "kinematic"
+iono = "auto"
+ratio = 2.4
+
+# Common low-cost receiver choices.
+max_subset_ar_drop_steps = 18
+rtk_snr_weighting = true
+arfilter = false
+
+# 0 processes every epoch.
+max_epochs = 0

--- a/docs/research_quickstart.md
+++ b/docs/research_quickstart.md
@@ -49,6 +49,20 @@ The `.pos` file is the trajectory. The `.json` file is the experiment record:
 it captures metrics, solver settings, wall time, reference matching, and
 threshold results.
 
+For direct native-solver runs, keep the RTK defaults in
+`configs/examples/solve.example.toml` and use:
+
+```bash
+gnss_solve --config configs/examples/solve.example.toml \
+  --max-epochs 1000 \
+  --out output/research/native_rtk.pos
+```
+
+The native solver applies CLI arguments after `[gnss_solve]`, so temporary
+overrides do not require copying or editing the profile. Its normal `--help`
+shows only inputs, outputs, and high-level choices; use `--help-advanced` for
+the backward-compatible research controls.
+
 ## Add explicit thresholds
 
 When promoting an experiment result, add requirements so the command fails if a

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -412,8 +412,12 @@ if(GTest_FOUND)
         NAME python_gnss_fuse_cli_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_gnss_fuse_cli.py
     )
+    add_test(
+        NAME python_gnss_solve_cli_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_gnss_solve_cli.py
+    )
     set_tests_properties(
-        python_gnss_fuse_cli_tests
+        python_gnss_fuse_cli_tests python_gnss_solve_cli_tests
         PROPERTIES ENVIRONMENT "GNSSPP_BINARY_DIR=${CMAKE_BINARY_DIR}"
     )
     set_tests_properties(
@@ -469,6 +473,7 @@ if(GTest_FOUND)
         python_web_http_ux_tests
         python_experiment_runner_tests
         python_gnss_fuse_cli_tests
+        python_gnss_solve_cli_tests
         python_search_imu_time_offset_tests
     )
     set(GNSSPP_EXTENDED_TESTS

--- a/tests/test_gnss_solve_cli.py
+++ b/tests/test_gnss_solve_cli.py
@@ -1,4 +1,4 @@
-"""Regression tests for gnss_fuse's concise help and TOML config surface."""
+"""Regression tests for gnss_solve's concise help and TOML config surface."""
 
 from __future__ import annotations
 
@@ -9,11 +9,11 @@ import unittest
 from pathlib import Path
 
 
-class GnssFuseCliTest(unittest.TestCase):
+class GnssSolveCliTest(unittest.TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         binary_dir = Path(os.environ["GNSSPP_BINARY_DIR"])
-        executable_name = "gnss_fuse.exe" if os.name == "nt" else "gnss_fuse"
+        executable_name = "gnss_solve.exe" if os.name == "nt" else "gnss_solve"
         candidates = [
             binary_dir / "apps" / executable_name,
             *(binary_dir / "apps" / config / executable_name
@@ -25,10 +25,10 @@ class GnssFuseCliTest(unittest.TestCase):
         )
         if cls.executable is None:
             rendered = ", ".join(str(candidate) for candidate in candidates)
-            raise RuntimeError(f"gnss_fuse executable not found; checked: {rendered}")
+            raise RuntimeError(f"gnss_solve executable not found; checked: {rendered}")
 
     @classmethod
-    def run_fuse(cls, *options: str) -> subprocess.CompletedProcess[str]:
+    def run_solve(cls, *options: str) -> subprocess.CompletedProcess[str]:
         return subprocess.run(
             [str(cls.executable), *options],
             check=False,
@@ -39,36 +39,43 @@ class GnssFuseCliTest(unittest.TestCase):
         )
 
     def test_default_help_keeps_the_supported_path_concise(self) -> None:
-        result = self.run_fuse("--help")
+        result = self.run_solve("--help")
 
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("--data-dir <dir>", result.stdout)
         self.assertIn("--config <path>", result.stdout)
-        self.assertIn("--navi776-tc", result.stdout)
+        self.assertIn("--preset <name>", result.stdout)
         self.assertIn("--help-advanced", result.stdout)
-        self.assertNotIn("--tc-doppler-sigma", result.stdout)
-        self.assertNotIn("--rtk-ins-prior-inflation", result.stdout)
+        self.assertNotIn("--rtk-adaptive-noise-alpha-phase", result.stdout)
+        self.assertNotIn("--fixed-bridge-burst-max-residual", result.stdout)
         self.assertLess(len(result.stdout), 5000)
 
+    def test_advanced_help_retains_research_option_discoverability(self) -> None:
+        result = self.run_solve("--help-advanced")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        self.assertIn("--config <path>", result.stdout)
+        self.assertIn("--rtk-adaptive-noise-alpha-phase", result.stdout)
+        self.assertIn("--fixed-bridge-burst-max-residual", result.stdout)
+
     def test_config_supplies_defaults_and_cli_always_overrides_them(self) -> None:
-        with tempfile.TemporaryDirectory(prefix="gnss_fuse_config_") as temp_dir:
-            config_path = Path(temp_dir) / "fuse.toml"
+        with tempfile.TemporaryDirectory(prefix="gnss_solve_config_") as temp_dir:
+            config_path = Path(temp_dir) / "solve.toml"
             config_path.write_text(
                 "\n".join(
                     [
-                        "[gnss_fuse]",
-                        'gnss_pos = "missing-solution.pos"',
-                        'imu = "missing-imu.csv"',
-                        "lever_arm = [0.31, 0.0, 0.55]",
-                        "navi776_tc = false",
-                        "base_interp = true",
+                        "[gnss_solve]",
+                        'data_dir = "missing-run"',
+                        "preset = 'low-cost'",
+                        "rtk_snr_weighting = true",
+                        "arfilter = false",
                         "max_epochs = -1",
                     ]
                 ),
                 encoding="utf-8",
             )
 
-            result = self.run_fuse(
+            result = self.run_solve(
                 "--max-epochs",
                 "0",
                 "--config",
@@ -76,31 +83,22 @@ class GnssFuseCliTest(unittest.TestCase):
             )
 
         self.assertEqual(result.returncode, 1)
-        self.assertIn("failed to load IMU CSV", result.stderr)
-        self.assertNotIn("--max-epochs must be non-negative", result.stderr)
+        self.assertIn("cannot open rover observation file", result.stderr)
+        self.assertNotIn("--max-epochs must be >= 0", result.stderr)
 
     def test_unknown_config_key_is_rejected_by_the_existing_option_parser(self) -> None:
-        with tempfile.TemporaryDirectory(prefix="gnss_fuse_config_") as temp_dir:
-            config_path = Path(temp_dir) / "fuse.toml"
+        with tempfile.TemporaryDirectory(prefix="gnss_solve_config_") as temp_dir:
+            config_path = Path(temp_dir) / "solve.toml"
             config_path.write_text(
-                "[gnss_fuse]\nthis_option_does_not_exist = 1\n",
+                "[gnss_solve]\nthis_option_does_not_exist = 1\n",
                 encoding="utf-8",
             )
 
-            result = self.run_fuse("--config", str(config_path))
+            result = self.run_solve("--config", str(config_path))
 
         self.assertEqual(result.returncode, 1)
         self.assertIn("unknown or incomplete argument: --this-option-does-not-exist",
                       result.stderr)
-
-    def test_advanced_help_retains_research_option_discoverability(self) -> None:
-        result = self.run_fuse("--help-advanced")
-
-        self.assertEqual(result.returncode, 0, msg=result.stderr)
-        self.assertIn("--navi776-tc", result.stdout)
-        self.assertIn("--tc-doppler-sigma", result.stdout)
-        self.assertIn("--rtk-ins-prior-inflation", result.stdout)
-        self.assertIn("--help-advanced", result.stdout)
 
 
 if __name__ == "__main__":

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -130,6 +130,7 @@ class PackagingSmokeTest(unittest.TestCase):
                 prefix / "configs" / "README.md",
                 prefix / "configs" / "examples" / "fuse.example.toml",
                 prefix / "configs" / "examples" / "live.example.conf",
+                prefix / "configs" / "examples" / "solve.example.toml",
                 prefix / "configs" / "examples" / "web.example.toml",
                 prefix / "configs" / "signoff" / "ppp_products_ppc.example.toml",
                 prefix / "configs" / "signoff" / "moving_base_signoff.example.toml",


### PR DESCRIPTION
## Summary

- add a compact `gnss_solve --config <path>` surface backed by `[gnss_solve]` flat TOML
- reduce normal `gnss_solve --help` from roughly 30 KB / 451 lines to about 1.5 KB / 30 lines
- preserve all existing tuning and research flags under `--help-advanced`
- extract the native TOML argument expansion into shared support used by both `gnss_solve` and `gnss_fuse`
- add a packaged solve example, documentation, and CLI regression coverage

## Why

`gnss_solve` accepts roughly 187 options because operational inputs, stable presets, research controls, and diagnostics all share one command surface. That made ordinary use difficult to discover and repeat. The new config path keeps common invocations short while retaining full backward compatibility for existing experiment commands.

## User impact

Existing CLI invocations continue to work. TOML values are expanded before command-line arguments, so explicit CLI values reliably override file defaults. Unknown keys and unsupported boolean negations fail instead of being ignored.

## Validation

- clang-ninja builds for `gnss_solve` and `gnss_fuse`
- MSVC Release builds for `gnss_solve` and `gnss_fuse`
- CLI regression tests: 8/8 passed
- C++ suite: 670 passed, 51 skipped, 0 failed
- direct CLI vs TOML 10-epoch `gnss_solve` outputs are MD5-identical
- `git diff --check`
- packaging install placed `configs/examples/solve.example.toml` correctly; the broader packaging test later hit the existing Windows `WinError 193` when directly launching an installed Python script, after installation completed