### PR TITLE
Make MADOCALIB AR diagnostics locally repeatable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,10 @@ else()
     message(STATUS "CHOLMOD disabled; using Eigen sparse covariance solver")
 endif()
 option(MADOCALIB_PARITY_LINK "Link external MADOCALIB C sources for opt-in parity oracle tests" OFF)
+option(
+    MADOCALIB_PARITY_ORACLE
+    "Enable the full MADOCALIB C++ oracle wrapper (disable for bridge-only parity runs)"
+    ON)
 set(MADOCALIB_ROOT_DIR
     ""
     CACHE PATH "Path to the MADOCALIB checkout root")
@@ -212,6 +216,12 @@ if(MADOCALIB_PARITY_LINK)
     )
     target_link_libraries(madocalib PUBLIC Threads::Threads)
     if(WIN32)
+        # The Visual Studio generator defines WIN32 implicitly, but Ninja with
+        # MSVC does not. MADOCALIB uses this spelling (rather than _WIN32) to
+        # select its Win32 headers and synchronization implementation. The
+        # native oracle wrapper includes the same upstream header.
+        target_compile_definitions(madocalib PRIVATE WIN32)
+        target_compile_definitions(gnss_lib PRIVATE WIN32)
         # rtkcmn.c tickget() calls timeGetTime.
         target_link_libraries(madocalib PUBLIC winmm)
     else()
@@ -226,7 +236,6 @@ if(MADOCALIB_PARITY_LINK)
     target_compile_definitions(gnss_lib
         PUBLIC
             GNSSPP_HAS_MADOCALIB_BRIDGE=1
-            GNSSPP_HAS_MADOCALIB_ORACLE=1
         PRIVATE
             TRACE
             ENAGLO
@@ -238,8 +247,21 @@ if(MADOCALIB_PARITY_LINK)
             NEXOBS=5
             "GNSSPP_MADOCALIB_ROOT=\"${MADOCALIB_ROOT_DIR}\""
     )
+    if(MADOCALIB_PARITY_ORACLE)
+        target_compile_definitions(gnss_lib PUBLIC GNSSPP_HAS_MADOCALIB_ORACLE=1)
+    else()
+        target_compile_definitions(gnss_lib PUBLIC GNSSPP_HAS_MADOCALIB_ORACLE=0)
+    endif()
     target_compile_definitions(gnss_lib PRIVATE GNSSPP_HAS_MADOCALIB_TIDE=1)
     target_link_libraries(gnss_lib PUBLIC madocalib)
+    if(MSVC)
+        # Optimizing the C oracle wrapper can make cl.exe consume more than
+        # 20 GiB even though the wrapper is not runtime-hot. Keep Windows
+        # parity builds locally repeatable without changing solver code.
+        set_source_files_properties(
+            src/algorithms/madocalib_oracle.cpp
+            PROPERTIES COMPILE_OPTIONS "/Od")
+    endif()
 else()
     target_compile_definitions(gnss_lib
         PUBLIC

--- a/apps/native/gnss_ppp.cpp
+++ b/apps/native/gnss_ppp.cpp
@@ -69,6 +69,7 @@ struct Options {
     std::string madocalib_end_time;
     double madocalib_time_interval_seconds = 0.0;
     int madocalib_trace_level = 0;
+    bool madocalib_trace_ar = false;
     bool kinematic_mode = false;
     bool low_dynamics_mode = false;
     bool use_dynamics_model = false;
@@ -175,6 +176,8 @@ void printUsage(const char* program_name) {
         << "                          MADOCALIB output interval passed to postpos()\n"
         << "  --madocalib-trace <level>\n"
         << "                          MADOCALIB trace level (default: 0)\n"
+        << "  --madocalib-trace-ar   Include MADOCALIB ambiguity means, covariance,\n"
+        << "                          LAMBDA candidates, and partial-AR decisions in trace\n"
         << "  --static                Use a static PPP motion model (default)\n"
         << "  --kinematic             Use a kinematic PPP motion model\n"
         << "  --use-dynamics-model    Continuous pos/vel dynamics (MRTKLIB accel model)\n"
@@ -354,6 +357,8 @@ Options parseArguments(int argc, char* argv[]) {
             options.madocalib_time_interval_seconds = std::stod(argv[++i]);
         } else if (arg == "--madocalib-trace" && i + 1 < argc) {
             options.madocalib_trace_level = std::stoi(argv[++i]);
+        } else if (arg == "--madocalib-trace-ar") {
+            options.madocalib_trace_ar = true;
         } else if (arg == "--no-ionosphere-free") {
             options.use_ionosphere_free = false;
         } else if (arg == "--ionosphere-free") {
@@ -750,6 +755,7 @@ int main(int argc, char* argv[]) {
             bridge_options.time_interval_seconds =
                 options.madocalib_time_interval_seconds;
             bridge_options.trace_level = options.madocalib_trace_level;
+            bridge_options.trace_ar = options.madocalib_trace_ar;
             if (!options.sp3_path.empty()) {
                 bridge_options.auxiliary_input_paths.push_back(options.sp3_path);
             }
@@ -837,6 +843,8 @@ int main(int argc, char* argv[]) {
                         << ",\n"
                         << "  \"madocalib_time_interval_seconds\": "
                         << options.madocalib_time_interval_seconds << ",\n"
+                        << "  \"madocalib_trace_ar\": "
+                        << (options.madocalib_trace_ar ? "true" : "false") << ",\n"
                         << "  \"madocalib_l6_inputs\": [";
                 bool first_l6 = true;
                 for (const std::string& l6_path : options.madocalib_l6_paths) {

--- a/include/libgnss++/external/madocalib_bridge.hpp
+++ b/include/libgnss++/external/madocalib_bridge.hpp
@@ -17,6 +17,7 @@ struct PostposOptions {
     std::string end_time;
     double time_interval_seconds = 0.0;
     int trace_level = 0;
+    bool trace_ar = false;
 };
 
 bool isAvailable();

--- a/src/algorithms/madocalib_bridge.cpp
+++ b/src/algorithms/madocalib_bridge.cpp
@@ -385,6 +385,18 @@ int runPostpos(const PostposOptions& options, std::string* error_message) {
     if (prcopt.ionocorr || prcopt.modear >= ARMODE_CONT) {
         prcopt.ionoopt = IONOOPT_EST;
     }
+    if (options.trace_ar && std::strstr(prcopt.pppopt, "-TRACE_AR") == nullptr) {
+        const std::string current_options(prcopt.pppopt);
+        const std::string trace_options =
+            current_options.empty() ? "-TRACE_AR" : current_options + " -TRACE_AR";
+        if (trace_options.size() >= sizeof(prcopt.pppopt)) {
+            if (error_message != nullptr) {
+                *error_message = "MADOCALIB pppopt is too long to enable -TRACE_AR";
+            }
+            return -1;
+        }
+        std::snprintf(prcopt.pppopt, sizeof(prcopt.pppopt), "%s", trace_options.c_str());
+    }
     applySignalSelection(prcopt);
 
     for (size_t i = 0; i < options.mdciono_paths.size() && i < MIONO_MAX_PRN; ++i) {

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -4033,6 +4033,7 @@ class CLIToolsTest(unittest.TestCase):
         result = self.run_gnss("ppp", "--help")
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         self.assertIn("--madocalib-bridge", result.stdout)
+        self.assertIn("--madocalib-trace-ar", result.stdout)
         self.assertIn("--madocalib-l6", result.stdout)
         self.assertIn("--madocalib-mdciono", result.stdout)
         self.assertIn("--madocalib-profile", result.stdout)


### PR DESCRIPTION
## What changed

- add a bridge-only MADOCALIB parity build mode so the memory-heavy C++ oracle wrapper can be disabled
- make Ninja + MSVC select MADOCALIB's Windows implementation explicitly
- disable optimization for the oracle wrapper on MSVC to reduce peak compiler memory
- add `--madocalib-trace-ar` to emit upstream ambiguity means, covariance, LAMBDA candidates, and partial-AR decisions
- expose the trace setting in the run summary and CLI regression coverage

## Why

Issue #148 is now limited by native/MADOCALIB ambiguity-state and ratio divergence. The full oracle translation unit consumes more than 20 GiB under optimized MSVC builds, and AR internals previously required editing an upstream config. These changes make the next parity investigations repeatable on Windows without changing solver behavior.

## Validation

- Ninja/MSVC bridge-only `gnss_ppp` build
- direct `gnss_ppp --help` assertion for `--madocalib-trace-ar`
- bounded MADOCA PPAR run with an AR trace containing ambiguity, covariance, candidate, and PAR diagnostics
- parsed native and oracle summary JSON files
- `python -m py_compile apps/gnss.py tests/test_cli_tools.py`
- `git diff --check`

Supports #148.