### PR TITLE
Preserve raw MADOCA ionosphere ambiguity seed

### DIFF
--- a/include/libgnss++/algorithms/ppp_correction_contract.hpp
+++ b/include/libgnss++/algorithms/ppp_correction_contract.hpp
@@ -63,6 +63,13 @@ constexpr double ssrMeasurementBiasSign(bool madoca_convention) {
     return madoca_convention ? 1.0 : -1.0;
 }
 
+// MADOCALIB initializes per-frequency ambiguity states with corrected carrier
+// phase/code observations but computes the ionosphere seed from the original
+// raw P1/P2 pair. Preserve that seed for coherent MADOCA SSR processing.
+constexpr bool rederiveIonosphereSeedAfterSsrBias(bool madoca_convention) {
+    return !madoca_convention;
+}
+
 // Neutral atmosphere delays are removed from code and phase alike, while the
 // first-order ionosphere is dispersive: remove it from code, add it to phase.
 constexpr double measurementCorrectionSign(bool carrier_phase, bool dispersive) {

--- a/src/algorithms/ppp_corrections.cpp
+++ b/src/algorithms/ppp_corrections.cpp
@@ -1194,8 +1194,12 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                             extra.phase_bias_m = pb;
                         }
                     }
-                    // Re-derive the ionosphere seed from bias-corrected codes.
-                    if (observation.has_l2 && observation.pseudorange_l1 != 0.0 &&
+                    // MADOCALIB's udbias_ppp() intentionally combines
+                    // corrected L/P with an ionosphere seed from raw P1/P2.
+                    if (algorithms::ppp_correction_contract::
+                            rederiveIonosphereSeedAfterSsrBias(
+                                require_coherent_ssr_) &&
+                        observation.has_l2 && observation.pseudorange_l1 != 0.0 &&
                         observation.freq_l1 > 0.0 && observation.freq_l2 > 0.0) {
                         const double ratio = observation.freq_l1 / observation.freq_l2;
                         const double denom = 1.0 - ratio * ratio;

--- a/tests/test_ppp_correction_contract.cpp
+++ b/tests/test_ppp_correction_contract.cpp
@@ -30,6 +30,11 @@ TEST(PPPCorrectionContractTest, MadocaBiasConventionAddsMeasurementBiases) {
     EXPECT_DOUBLE_EQ(contract::ssrMeasurementBiasSign(false), -1.0);
 }
 
+TEST(PPPCorrectionContractTest, MadocaPreservesRawCodeIonosphereSeed) {
+    EXPECT_FALSE(contract::rederiveIonosphereSeedAfterSsrBias(true));
+    EXPECT_TRUE(contract::rederiveIonosphereSeedAfterSsrBias(false));
+}
+
 TEST(PPPCorrectionContractTest, AtmosphereSignsMatchCodeAndPhasePhysics) {
     EXPECT_DOUBLE_EQ(contract::measurementCorrectionSign(false, false), -1.0);
     EXPECT_DOUBLE_EQ(contract::measurementCorrectionSign(true, false), -1.0);


### PR DESCRIPTION
## What changed

- preserve the raw P1/P2 ionosphere seed when coherent MADOCA SSR biases are applied
- retain the existing bias-corrected seed behavior for non-MADOCA SSR inputs
- encode and test the distinction in the PPP correction contract

## Root cause

MADOCALIB `udbias_ppp()` builds each per-frequency ambiguity from corrected phase/code measurements while deriving its ionosphere term from the original observation P1/P2 pair. Native libgnss++ was recomputing that ionosphere seed after applying SSR code biases, shifting float ambiguity means by roughly one cycle for several satellites and changing LAMBDA ratios.

## Validation

- Ninja/MSVC bridge-only `gnss_ppp` build
- PPP correction-contract regression test added
- 120-epoch MIZU MADOCA PPAR replay:
  - native Fix epochs: 85 -> 87
  - N1 ratio rejections: 23 -> 21
  - oracle/native 3D RMS delta: 0.256884 m -> 0.254675 m
  - max 3D delta remains below 1 m (0.832230 m)
- `git diff --check`

Advances #148.