### PR TITLE
Honor MADOCA RINEX frequency slots

### DIFF
--- a/include/libgnss++/algorithms/ppp_bias_identity.hpp
+++ b/include/libgnss++/algorithms/ppp_bias_identity.hpp
@@ -1,12 +1,28 @@
 #pragma once
 
 #include <libgnss++/algorithms/madoca_parity.hpp>
+#include <libgnss++/core/observation.hpp>
 #include <libgnss++/core/signals.hpp>
 
 #include <cstdint>
 #include <string_view>
 
 namespace libgnss::algorithms::ppp_bias_identity {
+
+inline const Observation* madocaFrequencySlotObservation(
+    const ObservationData& observations,
+    const SatelliteId& satellite,
+    int frequency_index,
+    const Observation* fallback) {
+    const std::string* slot = observations.getRinexFrequencySlot(
+        satellite.system, frequency_index);
+    if (slot == nullptr) {
+        return fallback;
+    }
+    // RTKLIB leaves a header-assigned normal-frequency slot empty when the
+    // selected tracking code is absent; it does not substitute another code.
+    return observations.getRinexTrackingObservation(satellite, *slot);
+}
 
 struct ObservationCodeMapEntry {
     std::string_view observation_type;

--- a/src/algorithms/ppp_observations.cpp
+++ b/src/algorithms/ppp_observations.cpp
@@ -75,7 +75,13 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
             continue;
         }
 
-        const Observation* primary = findObservationForSignals(obs, sat, primarySignals(sat.system));
+        const Observation* primary =
+            findObservationForSignals(obs, sat, primarySignals(sat.system));
+        if (require_coherent_ssr_) {
+            primary =
+                algorithms::ppp_bias_identity::madocaFrequencySlotObservation(
+                    obs, sat, 0, primary);
+        }
         if (primary == nullptr) {
             continue;
         }
@@ -155,6 +161,11 @@ std::vector<PPPProcessor::IonosphereFreeObs> PPPProcessor::formIonosphereFree(
         const Observation* secondary = findObservationForSignals(
             obs, sat, secondarySignalsForObservation(
                 sat, prefer_qzss_l5, require_coherent_ssr_));
+        if (require_coherent_ssr_) {
+            secondary =
+                algorithms::ppp_bias_identity::madocaFrequencySlotObservation(
+                    obs, sat, 1, secondary);
+        }
 
         // Per-frequency mode: carry BOTH L1 and L2 raw observables.
         // SSR corrections (orbit/clock/bias/iono) still applied below.

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -2503,6 +2503,32 @@ TEST(PPPMultifrequencyTest, PreservesMadocalibBeiDouExactBiasIdentity) {
               static_cast<std::uint8_t>(parity::kCodeL2I));
 }
 
+TEST(PPPMultifrequencyTest, UsesMadocalibHeaderFrequencySlotWithoutFallback) {
+    namespace identity = algorithms::ppp_bias_identity;
+    ObservationData epoch;
+    const SatelliteId satellite(GNSSSystem::GPS, 27);
+
+    Observation fallback;
+    fallback.satellite = satellite;
+    fallback.signal = SignalType::GPS_L2C;
+    fallback.pseudorange_observation_type = "C2L";
+    fallback.carrier_phase_observation_type = "L2L";
+
+    Observation exact = fallback;
+    exact.pseudorange_observation_type = "C2W";
+    exact.carrier_phase_observation_type = "L2W";
+    epoch.setRinexFrequencySlot(GNSSSystem::GPS, 1, "2W");
+    epoch.addRinexTrackingObservation("2W", exact);
+
+    EXPECT_EQ(
+        identity::madocaFrequencySlotObservation(epoch, satellite, 1, &fallback),
+        epoch.getRinexTrackingObservation(satellite, "2W"));
+    EXPECT_EQ(
+        identity::madocaFrequencySlotObservation(
+            epoch, SatelliteId(GNSSSystem::GPS, 31), 1, &fallback),
+        nullptr);
+}
+
 TEST(PPPMultifrequencyTest, SeparatesMadocalibBeiDouGenerationsForDoubleDifferences) {
     const auto bds2 = ppp_ar::ambiguityDdGroup(
         SatelliteId(GNSSSystem::BeiDou, 18));


### PR DESCRIPTION
## What changed

- select MADOCA primary/secondary observations from the normal-frequency slots assigned from the RINEX header
- leave an assigned slot empty when its exact tracking code is unavailable, matching RTKLIB behavior
- retain policy-selected fallback observations for inputs without RINEX slot metadata
- add regression coverage for exact-slot selection and no-substitution behavior

## Root cause

MADOCALIB fixes GPS frequency slot 1 from the RINEX header using RTKLIB's `PYWCMNDLXS` priority. For the MIZU file this is `C2W/L2W`. Native PPP instead used its policy-selected L2 observation and chose `C2L/L2L` on most satellites. That changed both the raw P1/P2 ionosphere seed and the SSR bias identity before ambiguity initialization.

At 00:06:00, exact slot selection reduced the representative GPS N1 mean disagreement from roughly 1–2 cycles to about 0.3–0.9 cycles and changed the native result to a full-set N1 fix.

## Validation

- Ninja/MSVC bridge-only `gnss_ppp` build
- 120-epoch MIZU MADOCA PPAR replay:
  - native Fix epochs: 87 -> 92
  - N1 ratio rejections: 21 -> 16
  - wrong native Fix epochs: 0
  - status agreement: 86.44%
  - both-fixed 3D RMS: 0.233558 m; max: 0.886349 m
- overall oracle/native 3D RMS changed from 0.254675 m to 0.258171 m, so position parity remains a separate open M2 item
- `git diff --check`

Advances #148; does not yet satisfy the M2 exit gate.