### PR TITLE
Match MADOCA ZTD initialization variance

### DIFF
--- a/src/algorithms/ppp_internal.hpp
+++ b/src/algorithms/ppp_internal.hpp
@@ -83,6 +83,16 @@ inline double madocaIonosphereProcessVariance(double zenith_variance_per_second,
            (sin_elevation * sin_elevation);
 }
 
+inline double initialTroposphereVariance(bool madoca_per_frequency,
+                                         bool broadcast_model,
+                                         double configured_variance) {
+    // MADOCALIB ppp.c initializes estimated ZTD with VAR_ZTD=SQR(0.12).
+    if (madoca_per_frequency) {
+        return 0.12 * 0.12;
+    }
+    return broadcast_model ? configured_variance : 25.0;
+}
+
 inline std::string trimCopy(const std::string& text) {
     const auto is_not_space = [](unsigned char ch) {
         return !std::isspace(ch);

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -373,8 +373,14 @@ bool PPPProcessor::initializeFilter(const ObservationData& obs,
         use_broadcast_rtklib_model ? ppp_config_.initial_clock_variance : 1e8;
     filter_state_.covariance(filter_state_.glo_clock_index, filter_state_.glo_clock_index) =
         use_broadcast_rtklib_model ? ppp_config_.initial_clock_variance : 1e8;
+    const bool madoca_per_frequency =
+        require_coherent_ssr_ && !ppp_config_.use_ionosphere_free &&
+        ppp_config_.estimate_ionosphere;
     filter_state_.covariance(filter_state_.trop_index, filter_state_.trop_index) =
-        use_broadcast_rtklib_model ? ppp_config_.initial_troposphere_variance : 25.0;
+        ppp_internal::initialTroposphereVariance(
+            madoca_per_frequency,
+            use_broadcast_rtklib_model,
+            ppp_config_.initial_troposphere_variance);
     // Per-system receiver clocks use the same epoch prior as GPS by default.
     const double system_clock_initial_variance =
         use_broadcast_rtklib_model ? ppp_config_.initial_clock_variance : 1e8;

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -145,6 +145,18 @@ TEST(PPPIonospherePrediction, MatchesMadocalibCarrierDeltaAndElevationNoise) {
         1e-12);
 }
 
+TEST(PPPStateInitialization, MadocaPerFrequencyUsesMadocalibZtdPrior) {
+    EXPECT_DOUBLE_EQ(
+        ppp_internal::initialTroposphereVariance(true, true, 0.36),
+        0.12 * 0.12);
+    EXPECT_DOUBLE_EQ(
+        ppp_internal::initialTroposphereVariance(false, true, 0.36),
+        0.36);
+    EXPECT_DOUBLE_EQ(
+        ppp_internal::initialTroposphereVariance(false, false, 0.36),
+        25.0);
+}
+
 TEST(PPPEnvOverridesTest, MadocaQzssL5DefaultsToThreeFrequencyParity) {
     EXPECT_TRUE(PPPEnvOverrides::fromEnvironment().madoca_qzss_l5);
 }


### PR DESCRIPTION
## Summary
- initialize coherent MADOCA per-frequency ZTD covariance with MADOCALIB's VAR_ZTD = 0.12^2 m^2
- preserve existing broadcast and precise-product priors outside that path
- pin the selection contract with a unit test

## Validation
- MSVC Release build: gnss_run_tests
- 146 PPP tests: 145 passed, 1 expected environment-isolated skip
- MIZU 120-epoch PPPAR A/B: 118 aligned, native Fix 92, wrong native Fix 0
- native-vs-oracle 3D RMS: 0.258171 m -> 0.239263 m
- native-vs-oracle max 3D: 0.886349 m -> 0.872905 m
- both-fixed 3D RMS: 0.233558 m -> 0.233197 m

## Issue
Progress toward #148 M2; this does not claim the M2 gate is complete.