### PR TITLE
Reset MADOCA clocks from SPP system biases

### DIFF
--- a/include/libgnss++/algorithms/spp.hpp
+++ b/include/libgnss++/algorithms/spp.hpp
@@ -115,6 +115,13 @@ public:
     const SPPConfig& getSPPConfig() const { return spp_config_; }
 
     /**
+     * @brief Get estimated inter-system clock biases in metres
+     */
+    const std::map<GNSSSystem, double>& getSystemBiases() const {
+        return system_biases_;
+    }
+
+    /**
      * @brief Load IONEX ionosphere products for SPP ionosphere corrections
      */
     bool loadIONEXProducts(const std::string& ionex_file);

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -508,29 +508,42 @@ void PPPProcessor::predictState(double dt, const PositionSolution* seed_solution
     if (use_broadcast_rtklib_model && seed_solution != nullptr && seed_solution->isValid()) {
         if (ppp_config_.reset_clock_to_spp_each_epoch || useLowDynamicsBroadcastSeedAssist()) {
             const double gps_clock_before_reset = filter_state_.state(filter_state_.clock_index);
-            const auto reinitializeSystemClock = [&](int index) {
+            const bool madoca_per_frequency_clock_reset =
+                require_coherent_ssr_ && ssr_products_loaded_ &&
+                !ppp_config_.use_ionosphere_free && ppp_config_.estimate_ionosphere;
+            const auto& spp_system_biases = spp_processor_.getSystemBiases();
+            const auto reinitializeSystemClock =
+                [&](int index, GNSSSystem system, bool reset_to_gps_clock) {
                 if (index < 0) {
                     return;
                 }
                 const double inter_system_offset =
                     filter_state_.state(index) - gps_clock_before_reset;
+                const auto spp_bias_it = spp_system_biases.find(system);
+                const double reset_offset =
+                    madoca_per_frequency_clock_reset &&
+                            spp_bias_it != spp_system_biases.end()
+                        ? spp_bias_it->second
+                        : (reset_to_gps_clock ? 0.0 : inter_system_offset);
                 reinitializeScalarState(
                     index,
-                    seed_solution->receiver_clock_bias + inter_system_offset,
+                    seed_solution->receiver_clock_bias + reset_offset,
                     ppp_config_.initial_clock_variance);
             };
             reinitializeScalarState(
                 filter_state_.clock_index,
                 seed_solution->receiver_clock_bias,
                 ppp_config_.initial_clock_variance);
-            reinitializeScalarState(
-                filter_state_.glo_clock_index,
-                seed_solution->receiver_clock_bias,
-                ppp_config_.initial_clock_variance);
-            reinitializeSystemClock(filter_state_.gal_clock_index);
-            reinitializeSystemClock(filter_state_.qzs_clock_index);
-            reinitializeSystemClock(filter_state_.bds_clock_index);
-            reinitializeSystemClock(filter_state_.bds2_clock_index);
+            reinitializeSystemClock(
+                filter_state_.glo_clock_index, GNSSSystem::GLONASS, true);
+            reinitializeSystemClock(
+                filter_state_.gal_clock_index, GNSSSystem::Galileo, false);
+            reinitializeSystemClock(
+                filter_state_.qzs_clock_index, GNSSSystem::QZSS, false);
+            reinitializeSystemClock(
+                filter_state_.bds_clock_index, GNSSSystem::BeiDou, false);
+            reinitializeSystemClock(
+                filter_state_.bds2_clock_index, GNSSSystem::BeiDou, false);
         }
         if (ppp_config_.kinematic_mode &&
             !ppp_config_.low_dynamics_mode &&

--- a/src/algorithms/spp.cpp
+++ b/src/algorithms/spp.cpp
@@ -1628,7 +1628,7 @@ PositionSolution SPPProcessor::solvePositionLS(const std::vector<SPPObservation>
 
     estimated_position_ = position;
     receiver_clock_bias_ = clock_bias;
-    system_biases_.clear();
+    system_biases_ = bias_estimates;
     return solution;
 }
 

--- a/tests/test_spp.cpp
+++ b/tests/test_spp.cpp
@@ -805,6 +805,11 @@ TEST_F(SPPTest, UsesMultipleConstellationsOnOdaibaEpoch) {
     EXPECT_TRUE(used_systems.count(GNSSSystem::BeiDou));
     EXPECT_TRUE(used_systems.count(GNSSSystem::QZSS));
     EXPECT_GE(used_systems.size(), 4U);
+    const auto& system_biases = spp_processor_->getSystemBiases();
+    ASSERT_TRUE(system_biases.count(GNSSSystem::GLONASS));
+    ASSERT_TRUE(system_biases.count(GNSSSystem::BeiDou));
+    EXPECT_TRUE(std::isfinite(system_biases.at(GNSSSystem::GLONASS)));
+    EXPECT_TRUE(std::isfinite(system_biases.at(GNSSSystem::BeiDou)));
 }
 
 TEST_F(SPPTest, BeiDouEnabledSPPStaysCloseOnOdaibaSequence) {


### PR DESCRIPTION
## Summary
- retain SPP inter-system clock estimates after a successful mixed-constellation solution
- reset MADOCA per-frequency constellation clocks from the matching current-epoch SPP biases
- preserve the existing non-MADOCA and missing-bias fallback behavior

## Validation
- `gnss_run_tests --gtest_filter=SPPTest.UsesMultipleConstellationsOnOdaibaEpoch:PPP*`: 145 passed, 2 skipped (dedicated kill-switch process and unavailable local static fixture)
- 120-epoch MADOCA replay: 118 valid, native Fix 92 / Float 26, native-only Fix 0
- native/oracle agreement: 102/118 (86.44%); 3D RMS 0.238032 m; max 0.872566 m
- both-Fix subset: 92 epochs, 3D RMS 0.233181 m

This aligns the receiver clock reset contract but does not yet satisfy the M2 exit gate (108 native Fix, 95% status agreement, 0.20 m both-Fix RMS).

Advances #148.