### PR TITLE
Match RTKLIB receiver phase windup frame

### DIFF
--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -989,8 +989,8 @@ double calculatePhaseWindup(const Vector3d& receiver_pos,
     e_y_sat /= y_norm;
     const Vector3d e_x_sat = e_y_sat.cross(e_z_sat);
 
-    // Receiver local north-east-up (north, east, up are standard PPP/RTKLIB):
-    //   x_rcv → North, y_rcv → East, z_rcv → Up.
+    // Receiver local north-west-up, matching RTKLIB/MADOCALIB model_phw():
+    //   x_rcv → North, y_rcv → West, z_rcv → Up.
     double latitude_rad = 0.0;
     double longitude_rad = 0.0;
     double height_m = 0.0;
@@ -1001,8 +1001,8 @@ double calculatePhaseWindup(const Vector3d& receiver_pos,
     const double cos_lon = std::cos(longitude_rad);
     // North (X): -sin(lat) cos(lon), -sin(lat) sin(lon), cos(lat)
     const Vector3d e_x_rcv(-sin_lat * cos_lon, -sin_lat * sin_lon, cos_lat);
-    // East  (Y): -sin(lon),                cos(lon),           0
-    const Vector3d e_y_rcv(-sin_lon, cos_lon, 0.0);
+    // West  (Y): sin(lon),                -cos(lon),           0
+    const Vector3d e_y_rcv(sin_lon, -cos_lon, 0.0);
 
     // Effective dipole vectors (Wu et al. 1993, eq. 7)
     const Vector3d d_sat = e_x_sat - e_sr * (e_sr.dot(e_x_sat))

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -1304,6 +1304,8 @@ TEST(PPPTest, CalculatePhaseWindupResolvesAmbiguityAgainstPriorAccumulator) {
     const double w0 = calculatePhaseWindup(receiver, satellite, sun, 0.0);
     EXPECT_TRUE(std::isfinite(w0));
     EXPECT_LE(std::abs(w0), 0.5);
+    // RTKLIB/MADOCALIB model_phw() uses receiver North/West dipoles.
+    EXPECT_NEAR(w0, 0.16090686844133648, 1e-12);
 
     // Same geometry, accumulator advanced by 5 cycles → output must track it
     // within half a cycle (the function rounds to the nearest integer of


### PR DESCRIPTION
## Summary
- use the RTKLIB/MADOCALIB receiver North/West dipole frame in the general PPP phase-windup model
- pin the fixed-geometry wind-up result so an East-axis regression is detected

## Root cause
MADOCALIB `model_phw()` defines the receiver Y dipole as West. Native used East while retaining the same Wu cross-product equation, reversing that term and shifting satellite-dependent ambiguity fractions.

## Validation
- focused/default PPP tests: 145 passed, 1 dedicated-process skip
- pinned 120-epoch MIZU replay: 118 valid, native Fix 92 / Float 26, native-only Fix 0
- full 3D RMS: 0.238032 -> 0.201177 m
- horizontal RMS: 0.151625 -> 0.096355 m
- max 3D delta: 0.872566 -> 0.474507 m
- both-Fix 3D RMS: 0.233181 -> 0.184877 m (passes the M2 <= 0.20 m gate)

M2 remains open because native Fix count is 92/108 and status agreement is 86.44%/95%.

Advances #148.