### PR TITLE
Enable MADOCA receiver antenna corrections

### DIFF
--- a/src/algorithms/ppp_corrections.cpp
+++ b/src/algorithms/ppp_corrections.cpp
@@ -1525,7 +1525,10 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
         // position shift bit-identical (corrections stay 0).
         observation.rx_ant_corr_l1_m = 0.0;
         observation.rx_ant_corr_l2_m = 0.0;
-        if (env_overrides_.pf_rx_antenna && receiver_antex_loaded_ &&
+        const bool coherent_madoca_receiver_antenna =
+            require_coherent_ssr_ && ssr_products_loaded_;
+        if ((env_overrides_.pf_rx_antenna || coherent_madoca_receiver_antenna) &&
+            receiver_antex_loaded_ &&
             !ppp_config_.use_ionosphere_free && ppp_config_.estimate_ionosphere &&
             !ppp_config_.use_clas_osr_filter && geometry.distance > 0.0 &&
             !ppp_config_.receiver_antenna_type.empty()) {


### PR DESCRIPTION
## Summary
- enable the existing per-frequency receiver ANTEX PCO/PCV path by default for coherent MADOCA SSR
- retain the environment opt-in for other estimated-STEC experiments
- leave IFLC, CLAS OSR, and generic PPP behavior unchanged

## Root cause
The bundled MADOCALIB PPP-AR profile has receiver antenna PCO/PCV enabled, while native kept its equivalent implementation behind `GNSS_PPP_PF_RX_ANTENNA`.

## Validation
- default-on output is SHA-256 identical to the previous environment opt-in output
- focused/default PPP tests: 145 passed, 1 dedicated-process skip
- pinned MIZU: 118 valid, native Fix 92 / Float 26, native-only Fix 0
- full 3D RMS: 0.201177 -> 0.196899 m
- horizontal RMS: 0.096355 -> 0.085183 m
- max 3D delta: 0.474507 -> 0.333247 m
- both-Fix 3D RMS: 0.197452 m (keeps the M2 <= 0.20 m gate passing)

M2 remains open for Fix-count and status-agreement parity.

Advances #148.