### PR TITLE
fix(ppp): match MADOCA ambiguity windup seed

### DIFF
--- a/include/libgnss++/algorithms/ppp_correction_contract.hpp
+++ b/include/libgnss++/algorithms/ppp_correction_contract.hpp
@@ -70,6 +70,13 @@ constexpr bool rederiveIonosphereSeedAfterSsrBias(bool madoca_convention) {
     return !madoca_convention;
 }
 
+// MADOCALIB udbias_ppp() deliberately calls corr_meas() with phw=0 while the
+// ordinary measurement residual uses the accumulated phase windup. Match that
+// initialization convention only for coherent MADOCA processing.
+constexpr bool excludePhaseWindupFromAmbiguitySeed(bool madoca_convention) {
+    return madoca_convention;
+}
+
 // Neutral atmosphere delays are removed from code and phase alike, while the
 // first-order ionosphere is dispersive: remove it from code, add it to phase.
 constexpr double measurementCorrectionSign(bool carrier_phase, bool dispersive) {

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -1,5 +1,6 @@
 #include "ppp_internal.hpp"
 
+#include <libgnss++/algorithms/ppp_correction_contract.hpp>
 #include <libgnss++/algorithms/ppp_multifrequency.hpp>
 
 #include <libgnss++/algorithms/ppp_utils.hpp>
@@ -1274,13 +1275,27 @@ void PPPProcessor::initializeAmbiguityState(const IonosphereFreeObs& observation
             observation.modeled_trop_delay_m);
     auto& ambiguity = ambiguity_states_[observation.satellite];
     if (!ppp_config_.use_ionosphere_free && ppp_config_.estimate_ionosphere) {
+        const bool madoca_per_frequency =
+            require_coherent_ssr_ && ssr_products_loaded_ &&
+            !ppp_config_.use_clas_osr_filter;
+        const auto windup_it = windup_cache_.find(observation.satellite);
+        const double windup_cycles =
+            windup_it != windup_cache_.end() && std::isfinite(windup_it->second)
+                ? windup_it->second
+                : 0.0;
+        const double seed_windup_m =
+            algorithms::ppp_correction_contract::excludePhaseWindupFromAmbiguitySeed(
+                madoca_per_frequency)
+                ? windup_cycles * observation.wavelength_l1
+                : 0.0;
         // Per-frequency L1 ambiguity in meters, seeded geometry-free consistent
         // with the ionosphere state: bias_1 = L1 - P1 + 2*ion*(f1/f1)^2.
         // (f1/f1)^2 = 1; this removes the +/-iono on code/phase so the residual
         // is the integer-recoverable phase bias lambda1*N1.
         const double ion = observation.has_iono_init ? observation.iono_init_m : 0.0;
         filter_state_.state(state_index) =
-            observation.carrier_phase_l1 - observation.pseudorange_l1 + 2.0 * ion;
+            observation.carrier_phase_l1 + seed_windup_m -
+            observation.pseudorange_l1 + 2.0 * ion;
         filter_state_.covariance(state_index, state_index) =
             ppp_config_.initial_ambiguity_variance;
         ambiguity.wavelength_l1 = observation.wavelength_l1;
@@ -1347,7 +1362,20 @@ int PPPProcessor::getOrCreateAmbiguityStateL2(const IonosphereFreeObs& observati
     const double ion = observation.has_iono_init ? observation.iono_init_m : 0.0;
     const double ratio =
         observation.freq_l2 > 0.0 ? (observation.freq_l1 / observation.freq_l2) : 0.0;
-    filter_state_.state(index) = observation.carrier_phase_l2 -
+    const bool madoca_per_frequency =
+        require_coherent_ssr_ && ssr_products_loaded_ &&
+        !ppp_config_.use_clas_osr_filter;
+    const auto windup_it = windup_cache_.find(observation.satellite);
+    const double windup_cycles =
+        windup_it != windup_cache_.end() && std::isfinite(windup_it->second)
+            ? windup_it->second
+            : 0.0;
+    const double seed_windup_m =
+        algorithms::ppp_correction_contract::excludePhaseWindupFromAmbiguitySeed(
+            madoca_per_frequency)
+            ? windup_cycles * observation.wavelength_l2
+            : 0.0;
+    filter_state_.state(index) = observation.carrier_phase_l2 + seed_windup_m -
                                  observation.pseudorange_l2 +
                                  2.0 * ion * ratio * ratio;
     filter_state_.covariance(index, index) = ppp_config_.initial_ambiguity_variance;
@@ -1385,12 +1413,26 @@ int PPPProcessor::getOrCreateAdditionalAmbiguityState(
     const auto existing = filter_state_.additional_ambiguity_indices.find(key);
     auto& lifecycle =
         ambiguity_states_[observation.satellite].frequency_lifecycle[frequency.signal];
+    const bool madoca_per_frequency =
+        require_coherent_ssr_ && ssr_products_loaded_ &&
+        !ppp_config_.use_clas_osr_filter;
+    const auto windup_it = windup_cache_.find(observation.satellite);
+    const double windup_cycles =
+        windup_it != windup_cache_.end() && std::isfinite(windup_it->second)
+            ? windup_it->second
+            : 0.0;
+    const double seed_windup_m =
+        algorithms::ppp_correction_contract::excludePhaseWindupFromAmbiguitySeed(
+            madoca_per_frequency)
+            ? windup_cycles * frequency.wavelength
+            : 0.0;
     if (existing != filter_state_.additional_ambiguity_indices.end()) {
         if (lifecycle.state_index != existing->second) {
             const double ion = observation.has_iono_init ? observation.iono_init_m : 0.0;
             filter_state_.state(existing->second) =
                 algorithms::ppp_multifrequency::ambiguitySeedMeters(
-                    frequency.carrier_phase, frequency.pseudorange, ion,
+                    frequency.carrier_phase + seed_windup_m,
+                    frequency.pseudorange, ion,
                     observation.freq_l1, frequency.frequency);
             filter_state_.covariance.row(existing->second).setZero();
             filter_state_.covariance.col(existing->second).setZero();
@@ -1411,7 +1453,8 @@ int PPPProcessor::getOrCreateAdditionalAmbiguityState(
     const double ion = observation.has_iono_init ? observation.iono_init_m : 0.0;
     filter_state_.state(index) =
         algorithms::ppp_multifrequency::ambiguitySeedMeters(
-            frequency.carrier_phase, frequency.pseudorange, ion,
+            frequency.carrier_phase + seed_windup_m,
+            frequency.pseudorange, ion,
             observation.freq_l1, frequency.frequency);
     filter_state_.covariance(index, index) =
         60.0 * 60.0;

--- a/tests/test_ppp_correction_contract.cpp
+++ b/tests/test_ppp_correction_contract.cpp
@@ -35,6 +35,11 @@ TEST(PPPCorrectionContractTest, MadocaPreservesRawCodeIonosphereSeed) {
     EXPECT_TRUE(contract::rederiveIonosphereSeedAfterSsrBias(false));
 }
 
+TEST(PPPCorrectionContractTest, MadocaExcludesWindupFromAmbiguitySeed) {
+    EXPECT_TRUE(contract::excludePhaseWindupFromAmbiguitySeed(true));
+    EXPECT_FALSE(contract::excludePhaseWindupFromAmbiguitySeed(false));
+}
+
 TEST(PPPCorrectionContractTest, AtmosphereSignsMatchCodeAndPhasePhysics) {
     EXPECT_DOUBLE_EQ(contract::measurementCorrectionSign(false, false), -1.0);
     EXPECT_DOUBLE_EQ(contract::measurementCorrectionSign(true, false), -1.0);


### PR DESCRIPTION
## Summary
- match MADOCALIB `udbias_ppp()` by excluding accumulated phase windup from coherent MADOCA ambiguity seeds
- keep normal residual phase-windup corrections and non-MADOCA paths unchanged
- cover the convention in the PPP correction contract tests

## Validation
- MADOCA 120-epoch A/B: 118 valid, 92 Fix / 26 Float (no regression)
- TOW 173190 DD mean alignment improved: G09 error 0.829 -> 0.029 cycles; C40 0.308 -> 0.039 cycles
- TOW 173190 post-J03 PAR ratio improved: 1.052 -> 1.228
- PPP tests: 146 passed, 1 expected skip

Contributes to #148. The issue remains open because the M2 Fix/agreement gates are not yet met.