### PR TITLE
fix(ppp): use GPS L1 MADOCA ionosphere state

### DIFF
--- a/src/algorithms/ppp_internal.hpp
+++ b/src/algorithms/ppp_internal.hpp
@@ -2,6 +2,7 @@
 
 #include <libgnss++/algorithms/ppp.hpp>
 #include <libgnss++/algorithms/ppp_utils.hpp>
+#include <libgnss++/core/constants.hpp>
 
 #include <algorithm>
 #include <cctype>
@@ -57,19 +58,39 @@ inline bool alwaysRestoreArTrialState(PPPProcessor::PPPConfig::ARMethod method) 
     return method == PPPProcessor::PPPConfig::ARMethod::DD_PER_FREQ;
 }
 
+inline double madocaIonosphereScale(double frequency_hz) {
+    if (!(frequency_hz > 0.0)) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    const double ratio = constants::GPS_L1_FREQ / frequency_hz;
+    return ratio * ratio;
+}
+
+inline double madocaIonosphereStateFromPrimaryMeters(
+    double primary_frequency_ionosphere_m,
+    double primary_frequency_hz) {
+    const double primary_scale = madocaIonosphereScale(primary_frequency_hz);
+    if (!std::isfinite(primary_scale) || !(primary_scale > 0.0)) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    return primary_frequency_ionosphere_m / primary_scale;
+}
+
 inline double madocaCarrierIonosphereMeters(double phase_l1_m,
                                             double phase_l2_m,
                                             double frequency_l1_hz,
                                             double frequency_l2_hz) {
-    if (!(frequency_l1_hz > 0.0) || !(frequency_l2_hz > 0.0)) {
+    const double scale_l1 = madocaIonosphereScale(frequency_l1_hz);
+    const double scale_l2 = madocaIonosphereScale(frequency_l2_hz);
+    if (!std::isfinite(scale_l1) || !std::isfinite(scale_l2)) {
         return std::numeric_limits<double>::quiet_NaN();
     }
-    const double ratio = frequency_l1_hz / frequency_l2_hz;
-    const double denominator = 1.0 - ratio * ratio;
+    const double denominator = scale_l1 - scale_l2;
     if (std::abs(denominator) < 1e-12) {
         return std::numeric_limits<double>::quiet_NaN();
     }
-    // MADOCALIB udiono_ppp(): ionc = -(L1-L2)/(1-(f1/f2)^2).
+    // MADOCALIB udiono_ppp(): the estimated STEC state is referenced to the
+    // fixed GPS L1 frequency, including for non-GPS primary signals.
     return -(phase_l1_m - phase_l2_m) / denominator;
 }
 

--- a/src/algorithms/ppp_measurement.cpp
+++ b/src/algorithms/ppp_measurement.cpp
@@ -121,6 +121,22 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
             continue;
         }
 
+        const bool madoca_gps_l1_ionosphere =
+            require_coherent_ssr_ && ssr_products_loaded_ &&
+            !ppp_config_.use_ionosphere_free &&
+            ppp_config_.estimate_ionosphere &&
+            !ppp_config_.use_clas_osr_filter;
+        const auto ionosphereScale = [&](double frequency_hz) {
+            return madoca_gps_l1_ionosphere
+                ? ppp_internal::madocaIonosphereScale(frequency_hz)
+                : algorithms::ppp_multifrequency::ionosphereScale(
+                      observation.freq_l1, frequency_hz);
+        };
+        const double primary_ionosphere_scale =
+            madoca_gps_l1_ionosphere
+                ? ionosphereScale(observation.freq_l1)
+                : 1.0;
+
         const Vector3d receiver_position =
             observation.receiver_position.norm() > 1000.0 ?
                 observation.receiver_position :
@@ -173,7 +189,7 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
         if (ppp_config_.estimate_ionosphere) {
             const auto iono_it = filter_state_.ionosphere_indices.find(observation.satellite);
             if (iono_it != filter_state_.ionosphere_indices.end()) {
-                row(iono_it->second) = 1.0;  // +iono for pseudorange
+                row(iono_it->second) = primary_ionosphere_scale;
                 iono_state_m = filter_state_.state(iono_it->second);
             }
         }
@@ -181,7 +197,8 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
         const double predicted =
             geometric_range + clock_bias_m -
             constants::SPEED_OF_LIGHT * observation.satellite_clock_bias + troposphere_delay
-            + iono_state_m + observation.rx_ant_corr_l1_m;
+            + primary_ionosphere_scale * iono_state_m +
+            observation.rx_ant_corr_l1_m;
         const double residual = observation.pseudorange_if - predicted;
 
         // Env-gated pre-fit residual dump for native-vs-bridge measurement diff.
@@ -311,7 +328,9 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
                 if (ppp_config_.estimate_ionosphere) {
                     const auto iono_it = filter_state_.ionosphere_indices.find(observation.satellite);
                     if (iono_it != filter_state_.ionosphere_indices.end()) {
-                        iono_phase_correction = -2.0 * filter_state_.state(iono_it->second);
+                        iono_phase_correction =
+                            -2.0 * primary_ionosphere_scale *
+                            filter_state_.state(iono_it->second);
                     }
                 }
                 const double predicted_phase = predicted + iono_phase_correction
@@ -339,7 +358,8 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
                     if (ppp_config_.estimate_ionosphere) {
                         const auto iono_it = filter_state_.ionosphere_indices.find(observation.satellite);
                         if (iono_it != filter_state_.ionosphere_indices.end()) {
-                            phase_row(iono_it->second) = -1.0;
+                            phase_row(iono_it->second) =
+                                -primary_ionosphere_scale;
                         }
                     }
                     phase_row(ambiguity_index) = 1.0;
@@ -363,8 +383,7 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
         // by (f1/f2)^2. Code carries +iono, phase carries -iono (oracle ppp.c).
         if (!ppp_config_.use_ionosphere_free && ppp_config_.estimate_ionosphere &&
             observation.has_l2 && observation.freq_l1 > 0.0 && observation.freq_l2 > 0.0) {
-            const double ratio = observation.freq_l1 / observation.freq_l2;
-            const double ratio2 = ratio * ratio;
+            const double ratio2 = ionosphereScale(observation.freq_l2);
             const auto iono_it = filter_state_.ionosphere_indices.find(observation.satellite);
             const int iono_index =
                 iono_it != filter_state_.ionosphere_indices.end() ? iono_it->second : -1;
@@ -475,9 +494,7 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
                 !(frequency.frequency > 0.0)) {
                 continue;
             }
-            const double ratio2 =
-                algorithms::ppp_multifrequency::ionosphereScale(
-                    observation.freq_l1, frequency.frequency);
+            const double ratio2 = ionosphereScale(frequency.frequency);
             const auto iono_it =
                 filter_state_.ionosphere_indices.find(observation.satellite);
             const int iono_index = iono_it != filter_state_.ionosphere_indices.end()

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -1326,8 +1326,22 @@ int PPPProcessor::getOrCreateIonosphereState(const IonosphereFreeObs& observatio
         filter_state_.total_states, filter_state_.total_states);
     filter_state_.covariance.row(new_index).setZero();
     filter_state_.covariance.col(new_index).setZero();
-    filter_state_.state(new_index) =
+    const bool madoca_per_frequency =
+        require_coherent_ssr_ && ssr_products_loaded_ &&
+        !ppp_config_.use_ionosphere_free &&
+        ppp_config_.estimate_ionosphere &&
+        !ppp_config_.use_clas_osr_filter;
+    double initial_ionosphere_m =
         observation.has_iono_init ? observation.iono_init_m : 0.0;
+    if (observation.has_iono_init && madoca_per_frequency) {
+        const double gps_l1_ionosphere_m =
+            ppp_internal::madocaIonosphereStateFromPrimaryMeters(
+                observation.iono_init_m, observation.freq_l1);
+        if (std::isfinite(gps_l1_ionosphere_m)) {
+            initial_ionosphere_m = gps_l1_ionosphere_m;
+        }
+    }
+    filter_state_.state(new_index) = initial_ionosphere_m;
     // Mirror the GNSS_PPP_INIT_IONO_VAR override at the lazy-create site so a
     // satellite appearing mid-run lands in the same anchored gauge.
     filter_state_.covariance(new_index, new_index) =

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -130,10 +130,30 @@ TEST(PPPArTrialState, PerFrequencyAttemptsAreAlwaysEphemeral) {
 TEST(PPPIonospherePrediction, MatchesMadocalibCarrierDeltaAndElevationNoise) {
     constexpr double f1 = 1575.42e6;
     constexpr double f2 = 1227.60e6;
-    const double denominator = 1.0 - (f1 / f2) * (f1 / f2);
+    const double denominator =
+        std::pow(constants::GPS_L1_FREQ / f1, 2) -
+        std::pow(constants::GPS_L1_FREQ / f2, 2);
     EXPECT_NEAR(
         ppp_internal::madocaCarrierIonosphereMeters(12.4, 12.1, f1, f2),
         -0.3 / denominator,
+        1e-12);
+    constexpr double bds_b1i = 1561.098e6;
+    constexpr double bds_b3i = 1268.52e6;
+    const double bds_primary_scale =
+        std::pow(constants::GPS_L1_FREQ / bds_b1i, 2);
+    const double bds_secondary_scale =
+        std::pow(constants::GPS_L1_FREQ / bds_b3i, 2);
+    EXPECT_NEAR(ppp_internal::madocaIonosphereScale(bds_b1i),
+                bds_primary_scale, 1e-15);
+    EXPECT_NEAR(
+        ppp_internal::madocaIonosphereStateFromPrimaryMeters(
+            4.25, bds_b1i),
+        4.25 / bds_primary_scale,
+        1e-12);
+    EXPECT_NEAR(
+        ppp_internal::madocaCarrierIonosphereMeters(
+            12.4, 12.1, bds_b1i, bds_b3i),
+        -0.3 / (bds_primary_scale - bds_secondary_scale),
         1e-12);
     EXPECT_NEAR(
         ppp_internal::madocaIonosphereProcessVariance(1e-4, M_PI / 6.0, 30.0),


### PR DESCRIPTION
## What changed

- Reference coherent MADOCA STEC filter states to the fixed GPS L1 frequency, matching MADOCALIB `ppp.c`.
- Convert primary-frequency code seeds only when initializing the filter ionosphere state.
- Keep ambiguity seeds primary-frequency referenced, matching the separate `udbias_ppp()` equation.
- Apply the GPS-L1 scale consistently to L1/L2/additional-frequency code and phase rows.
- Add focused GPS and BeiDou formula coverage.

## Root cause

Native PPP used each satellite's primary frequency as the ionosphere-state reference for both state evolution and residual rows. MADOCALIB instead uses `SQR(FREQ1/freq)` with fixed GPS L1 in `udiono_ppp()` and `ppp_res()`, while retaining primary-frequency scaling only for ambiguity initialization. The difference affects BeiDou B1I observations in the pinned MIZU window.

## Validation

- Windows Release `gnss_ppp` build: pass.
- Pinned MIZU 120-input-epoch A/B: 118 aligned; oracle 108 Fix / 10 Float; native 92 Fix / 26 Float; no wrong native Fix; status agreement 102/118 (86.44%).
- Native/oracle trajectory: 3D RMS 0.196832 m, maximum 0.333764 m, horizontal RMS 0.085093 m, Up RMS 0.177489 m.
- Baseline before this slice: 3D RMS 0.196866 m with the same Fix/Float counts. This exact formula correction is non-regressive but does not by itself close M2.
- `git diff --check`: pass.

The local monolithic MSVC `gnss_run_tests` build was stopped after its MADOCALIB oracle translation unit reached about 2.6 GB and spent an extended period swapping. CI is expected to provide the authoritative Linux test/build matrix.

Tracks #148.
