### PR TITLE
fix(ppp): seed MADOCA STEC from corrected codes

### DIFF
--- a/src/algorithms/ppp_internal.hpp
+++ b/src/algorithms/ppp_internal.hpp
@@ -76,6 +76,29 @@ inline double madocaIonosphereStateFromPrimaryMeters(
     return primary_frequency_ionosphere_m / primary_scale;
 }
 
+inline double madocaCorrectedCodeIonosphereStateMeters(
+    double fallback_primary_ionosphere_m,
+    double corrected_primary_code_m,
+    double corrected_secondary_code_m,
+    double primary_frequency_hz,
+    double secondary_frequency_hz) {
+    double primary_ionosphere_m = fallback_primary_ionosphere_m;
+    if (primary_frequency_hz > 0.0 &&
+        secondary_frequency_hz > 0.0 &&
+        std::isfinite(corrected_primary_code_m) &&
+        std::isfinite(corrected_secondary_code_m)) {
+        const double ratio = primary_frequency_hz / secondary_frequency_hz;
+        const double denominator = 1.0 - ratio * ratio;
+        if (std::abs(denominator) > 1e-6) {
+            primary_ionosphere_m =
+                (corrected_primary_code_m - corrected_secondary_code_m) /
+                denominator;
+        }
+    }
+    return madocaIonosphereStateFromPrimaryMeters(
+        primary_ionosphere_m, primary_frequency_hz);
+}
+
 inline double madocaCarrierIonosphereMeters(double phase_l1_m,
                                             double phase_l2_m,
                                             double frequency_l1_hz,

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -1334,9 +1334,17 @@ int PPPProcessor::getOrCreateIonosphereState(const IonosphereFreeObs& observatio
     double initial_ionosphere_m =
         observation.has_iono_init ? observation.iono_init_m : 0.0;
     if (observation.has_iono_init && madoca_per_frequency) {
+        // MADOCALIB initializes the STEC state from corr_meas() P1/P2 after
+        // receiver-antenna and SSR code-bias corrections. Its ambiguity seeds
+        // retain the separately captured raw-code ionosphere value, so only
+        // rederive the state value here.
         const double gps_l1_ionosphere_m =
-            ppp_internal::madocaIonosphereStateFromPrimaryMeters(
-                observation.iono_init_m, observation.freq_l1);
+            ppp_internal::madocaCorrectedCodeIonosphereStateMeters(
+                observation.iono_init_m,
+                observation.pseudorange_l1,
+                observation.pseudorange_l2,
+                observation.freq_l1,
+                observation.has_l2 ? observation.freq_l2 : 0.0);
         if (std::isfinite(gps_l1_ionosphere_m)) {
             initial_ionosphere_m = gps_l1_ionosphere_m;
         }

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -165,6 +165,24 @@ TEST(PPPIonospherePrediction, MatchesMadocalibCarrierDeltaAndElevationNoise) {
         1e-12);
 }
 
+TEST(PPPIonospherePrediction, SeedsStateFromCorrectedCodesWithoutChangingRawFallback) {
+    constexpr double f1 = 1575.42e6;
+    constexpr double f2 = 1227.60e6;
+    constexpr double corrected_p1 = 24000000.0;
+    constexpr double corrected_p2 = 24000005.0;
+    const double expected_primary =
+        (corrected_p1 - corrected_p2) / (1.0 - std::pow(f1 / f2, 2));
+    EXPECT_NEAR(
+        ppp_internal::madocaCorrectedCodeIonosphereStateMeters(
+            7.5, corrected_p1, corrected_p2, f1, f2),
+        expected_primary,
+        1e-12);
+    EXPECT_DOUBLE_EQ(
+        ppp_internal::madocaCorrectedCodeIonosphereStateMeters(
+            7.5, corrected_p1, corrected_p2, f1, 0.0),
+        7.5);
+}
+
 TEST(PPPStateInitialization, MadocaPerFrequencyUsesMadocalibZtdPrior) {
     EXPECT_DOUBLE_EQ(
         ppp_internal::initialTroposphereVariance(true, true, 0.36),


### PR DESCRIPTION
## Summary

- derive the MADOCA per-frequency STEC state prior from receiver-antenna and SSR code-bias corrected P1/P2
- preserve the raw-code ionosphere value used by the separate ambiguity-seed contract
- add focused coverage for corrected-code derivation and raw fallback behavior

## Root cause

MADOCALIB initializes its ionosphere state from `corr_meas()` P1/P2, after receiver antenna and SSR code-bias corrections. Native PPP reused the raw `iono_init_m` value for both the ambiguity seed and the STEC state. The ambiguity side was intentional, but the state side was not, causing the initial ionosphere prior to differ before the first filter update.

On the MIZU parity fixture, the first-epoch priors now match the oracle:

- G04: 8.7009 m
- G31: 9.5402 m

The ambiguity priors remain unchanged (G04 3.3582 m, G31 2.8173 m).

## Validation

- `git diff --check`
- `run_tests.exe --gtest_filter=PPPIonospherePrediction.*`: 2/2 passed
- `run_tests.exe --gtest_filter=PPP*`: 147 passed, 1 expected skip, 0 failed
- 118-epoch MIZU parity replay:
  - native Fix/Float: 90/28 (baseline 92/26)
  - Fix/Float agreement: 100/118 (baseline 102/118)
  - fixed 3D RMS: 0.195234 m (baseline 0.196832 m)
  - fixed maximum 3D error: 0.325412 m (baseline 0.333764 m)
  - native-only fixes: 0

This is an exact initialization-contract correction and improves the position-error metrics, but it does not yet satisfy the Issue #148 M2 status gates; the two-fix regression is recorded explicitly for follow-up.

Refs #148