### PR TITLE
Fix MADOCALIB bridge QZSS signal order

### DIFF
--- a/src/algorithms/madocalib_bridge.cpp
+++ b/src/algorithms/madocalib_bridge.cpp
@@ -219,6 +219,7 @@ void applySignalSelection(const prcopt_t& prcopt) {
     const int freq_nums_l1l2[MAXFREQ] = {1, 2, 0, 0, 0};
     const int freq_nums_l1l5[MAXFREQ] = {1, 5, 0, 0, 0};
     const int freq_nums_l1l2l5[MAXFREQ] = {1, 2, 5, 0, 0};
+    const int freq_nums_l1l5l2[MAXFREQ] = {1, 5, 2, 0, 0};
 
     const int freq_nums_e1e5a[MAXFREQ] = {1, 5, 0, 0, 0};
     const int freq_nums_e1e5b[MAXFREQ] = {1, 7, 0, 0, 0};
@@ -251,7 +252,9 @@ void applySignalSelection(const prcopt_t& prcopt) {
         set_obsdef(SYS_QZS, freq_nums_l1l2);
         break;
     default:
-        set_obsdef(SYS_QZS, freq_nums_l1l2l5);
+        // Match rnx2rtkp's pos2-sigqzs=L1/L5/L2 contract. QZSS uses L5 as
+        // frequency slot 1 and L2 as slot 2, unlike GPS L1/L2/L5.
+        set_obsdef(SYS_QZS, freq_nums_l1l5l2);
         break;
     }
     switch (prcopt.pppsig[2]) {


### PR DESCRIPTION
## What changed

- map the bundled MADOCALIB `pos2-sigqzs=L1/L5/L2` profile to frequency numbers `{1, 5, 2}` in the in-process bridge
- keep the GPS `L1/L2/L5` mapping unchanged

## Root cause

The bridge reused the GPS `{1, 2, 5}` ordering for QZSS. Upstream MADOCALIB's `rnx2rtkp` uses `{1, 5, 2}` for QZSS selection 2, so bridge-based oracle runs initialized QZSS STEC and ambiguities from L1/L2 while the actual MADOCALIB CLI and native parity path use L1/L5 with L2 as the third frequency.

## Impact

Bridge oracle runs now reproduce the official MADOCALIB QZSS frequency-slot contract. This prevents Issue #148 investigations from optimizing native code against a misordered oracle.

## Validation

- focused C++ suite: 149 passed, 1 expected skip, 0 failed (150 tests)
- 2-minute trace: J02/J03/J04 corrected STEC seeds now exactly match native (3.9280, 11.4274, 22.2560 m)
- 118-epoch parity rerun: 118 aligned; fixed-epoch 3D RMS 0.19568 m; max 0.32532 m; status counts remain oracle Fix 108 / Float 10 and native Fix 90 / Float 28

Tracks #148.
