### PR TITLE
Fix MADOCA postfit shadow geometry

### DIFF
--- a/src/algorithms/ppp_internal.hpp
+++ b/src/algorithms/ppp_internal.hpp
@@ -58,6 +58,21 @@ inline bool alwaysRestoreArTrialState(PPPProcessor::PPPConfig::ARMethod method) 
     return method == PPPProcessor::PPPConfig::ARMethod::DD_PER_FREQ;
 }
 
+inline Vector3d recenterPostfitReceiverPosition(
+    const Vector3d& corrected_receiver_position,
+    const Vector3d& prior_filter_position,
+    const Vector3d& updated_filter_position) {
+    // Precise corrections materialize the antenna phase-centre position at
+    // the epoch prior.  Only absolute positions should be recentered; a zero
+    // vector means the measurement model must obtain its receiver position
+    // from the filter state.
+    if (corrected_receiver_position.norm() <= 1000.0) {
+        return corrected_receiver_position;
+    }
+    return corrected_receiver_position +
+           (updated_filter_position - prior_filter_position);
+}
+
 inline double madocaIonosphereScale(double frequency_hz) {
     if (!(frequency_hz > 0.0)) {
         return std::numeric_limits<double>::quiet_NaN();

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -768,7 +768,24 @@ bool PPPProcessor::updateFilter(const ObservationData& obs,
         (ppp_config_.apply_static_anchor_blend || madoca_static_anchor_blend) &&
         !(precise_products_loaded_ && !ppp_config_.estimate_troposphere);
     if (madoca_postfit_shadow) {
-        const MeasurementEquation& postfit_eq = getPostfitEquation();
+        // applyPreciseCorrections() materializes each antenna phase-centre
+        // position at the epoch prior.  Recenter that corrected geometry on
+        // the accepted filter position for the diagnostic shadow; otherwise
+        // its nominal "postfit" residuals still use the SPP seed and show a
+        // metre-level, geometry-shaped false drift.
+        auto shadow_observations = if_obs;
+        const Vector3d prior_position =
+            pre_update_state.state.segment(pre_update_state.pos_index, 3);
+        const Vector3d updated_position =
+            filter_state_.state.segment(filter_state_.pos_index, 3);
+        for (auto& observation : shadow_observations) {
+            observation.receiver_position = recenterPostfitReceiverPosition(
+                observation.receiver_position,
+                prior_position,
+                updated_position);
+        }
+        const MeasurementEquation postfit_eq =
+            formMeasurementEquations(shadow_observations, nav, obs.time, false);
         const MadocaPostfitEpochStats postfit_stats =
             computeMadocaPostfitEpochStats(postfit_eq);
         writeMadocaPostfitShadow(

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -127,6 +127,30 @@ TEST(PPPArTrialState, PerFrequencyAttemptsAreAlwaysEphemeral) {
     EXPECT_FALSE(ppp_internal::alwaysRestoreArTrialState(ARMethod::DD_WLNL));
 }
 
+TEST(PPPPostfitGeometry, RecentersMaterializedReceiverPositionOnAcceptedState) {
+    const Vector3d corrected_position(3875000.0, 332500.0, 5029000.0);
+    const Vector3d prior_position(3874998.0, 332501.5, 5028996.0);
+    const Vector3d updated_position(3875000.5, 332499.0, 5029001.0);
+
+    const Vector3d recentered =
+        ppp_internal::recenterPostfitReceiverPosition(
+            corrected_position, prior_position, updated_position);
+
+    EXPECT_TRUE(recentered.isApprox(
+        corrected_position + updated_position - prior_position, 1e-12));
+}
+
+TEST(PPPPostfitGeometry, PreservesUnsetReceiverPosition) {
+    const Vector3d unset_position = Vector3d::Zero();
+    const Vector3d recentered =
+        ppp_internal::recenterPostfitReceiverPosition(
+            unset_position,
+            Vector3d(1.0, 2.0, 3.0),
+            Vector3d(4.0, 5.0, 6.0));
+
+    EXPECT_TRUE(recentered.isZero());
+}
+
 TEST(PPPIonospherePrediction, MatchesMadocalibCarrierDeltaAndElevationNoise) {
     constexpr double f1 = 1575.42e6;
     constexpr double f2 = 1227.60e6;


### PR DESCRIPTION
## What changed

- recenter materialized antenna phase-centre receiver positions from the epoch prior onto the accepted filter position before forming the MADOCA postfit shadow equation
- preserve unset receiver positions so the measurement model can continue to source them from filter state
- add focused regression coverage for both cases

## Root cause

`applyPreciseCorrections()` materializes an absolute receiver position before the filter update. The postfit shadow reused that stale position after accepting the update, so its nominal postfit residuals still contained the SPP-to-filter position delta and showed a false metre-level geometry-shaped drift.

This is deliberately limited to the diagnostic shadow. It does not change the accepted filter update or solution trajectory.

## Validation

- `ctest --test-dir build-madoca-parity -C Release -R '^run_tests$' --output-on-failure`
- focused `PPPPostfitGeometry.*` tests: 2 passed
- native MADOCA PPP-AR, 120 epochs: 118 valid / 90 Fix / 28 Float
- output `.pos` SHA-256 exactly matches the pre-change baseline: `1437CD0B70C5DB2FB147EEBC11C470D6839AEEA76153746B320D5326D7E86553`
- corrected GLONASS postfit shadow audit: per-satellite demeaned RMS 2.4–5.2 mm and span 1.6–3.4 cm, eliminating the former false metre-level drift

Part of #148.
