### PR TITLE
Align MADOCA GLONASS and STEC priors

### DIFF
--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -41,15 +41,14 @@ the remaining preview-only knobs stay default-off.
 The repro harness and per-slice history live in the memory note
 `madoca-ppp-frontier` and in issue #148.
 
-GLONASS phase was re-diagnosed and closed as a parity lever: the per-satellite
-~1.5 m residual is not an unabsorbed constant but a covariance-collapse plus
-within-pass-varying (elevation-arched) phase error — the float ambiguity
-variance collapses to ~0.03 within ~38 epochs and can no longer track the drift,
-and GLONASS code carries large FDMA inter-frequency biases too.  MADOCA SSR
-provides no GLONASS phase-bias product, so default GLONASS-phase-off is correct
-(matches MADOCALIB excluding GLO from the precise phase/AR solution).
+The original GLONASS-phase diagnosis below was invalidated in M2g.  Its
+metre-scale residual used stale pre-update receiver geometry in the postfit
+shadow.  Corrected geometry shows 2.4--5.2 mm demeaned RMS and 1.6--3.4 cm
+spans, and MADOCALIB does admit GLONASS L1/L2 phase in the float filter.
+GLONASS phase is therefore default-on for coherent MADOCA; it remains excluded
+from integer ambiguity candidates, matching `gen_sat_sd()`.
 
-Generate the evidence with `GNSS_PPP_MADOCA_GLONASS_PHASE=1` and
+Generate the default-on evidence with
 `GNSS_PPP_MADOCA_POSTFIT_SHADOW=<csv>`, then run
 `scripts/analysis/madoca_glonass_phase_audit.py <csv> --json-out <json>`.
 The `madoca_glonass_phase_audit.v1` report records per-satellite raw and

--- a/docs/madocalib_native_migration.md
+++ b/docs/madocalib_native_migration.md
@@ -83,9 +83,9 @@ does not yet match end-to-end behavior; **open** has no accepted native parity.
 | L6D use inside PPP | `--madoca-l6d-shadow` performs measurement-neutral lookup only | partial | M3 must add opt-in STEC state/row application and prove row/value parity |
 | PPP correction signs and ordering | Native correction contract plus materialization/residual diff tools | native | Default PPP parity matrix remains within the accepted MIZU/ALIC envelope |
 | PPP commit-on-success and diagnostics | Native postfit validation/shadow telemetry | native | MIZU 1 h/6 h/24 h and ALIC regression gates remain green |
-| GLONASS phase in MADOCA PPP | Intentionally excluded: no MADOCA phase-bias product and measured time-varying residual | native policy | Keep phase preview off unless new correction evidence changes the model |
+| GLONASS phase in MADOCA PPP | Native L1/L2 rows plus corrected postfit-shadow audit | native | Keep the pinned per-satellite demeaned RMS at millimetre scale and span below 4 cm |
 | MADOCALIB `exec_ppp` | Native PPP runs end to end; remaining solution delta is tracked | partial | M4/M5 matrix meets the declared trajectory thresholds |
-| MADOCALIB `exec_pppar` | Native per-frequency path is reachable, but the pinned baseline is 0 native Fix versus 108 oracle Fix in 118 matched epochs | open | M1/M2 must match candidate, admission, status, and constrained-state behavior |
+| MADOCALIB `exec_pppar` | Native per-frequency path reaches 90 Fix versus 108 oracle Fix in 118 matched epochs, with no native-only Fix | partial | M2 must close the remaining early-window status gap |
 | MADOCALIB `exec_pppar-ion` | Bridge profile/input validation exists; native L6D state injection does not | open | M3 then M5 PPP-AR-ion sign-off |
 | Triple/quad-frequency PPP-AR | Upstream 2.0 behavior has not been fully audited or signed off | open | Dedicated fixtures and ambiguity/state parity after dual-frequency M2 |
 | Linked `postpos()` bridge | `madocalib_bridge` | oracle-only | Retain until M6; never select it in production runtime |
@@ -93,10 +93,10 @@ does not yet match end-to-end behavior; **open** has no accepted native parity.
 ## Current Numerical Baselines
 
 The frozen one-hour MIZU PPP-AR CI window has 118 matched output epochs.  The
-MADOCALIB `pppar` oracle produces 108 Fix and 10 Float; the native per-frequency
-path produces 0 Fix and 118 Float.  The recorded native/oracle 3D delta RMS is
-10.090 m with a 45.380 m maximum after selecting the correct uncombined/STEC
-state model.
+MADOCALIB `pppar` oracle produces 108 Fix and 10 Float; after M2f and the QZSS
+oracle-order bridge correction, the native per-frequency path produces 90 Fix
+and 28 Float with no native-only Fix.  Status agreement is 100/118 (84.75%).
+The recorded native/oracle 3D delta RMS is 0.196 m with a 0.325 m maximum.
 
 Convergence telemetry localizes the immediate blocker before LAMBDA: 118
 evaluations comprise 19 insufficient-history epochs and 99 position-deviation
@@ -301,8 +301,28 @@ epochs, with no wrong Fix.  Full-window native/oracle 3D delta RMS is 0.337 m,
 maximum is 0.854 m, horizontal RMS is 0.232 m, Up RMS is 0.244 m, and the
 final-30-minute RMS is 0.309 m.  The full RMS is 0.020 m above M2e while the
 maximum improves by 0.134 m; this slice accepts the exact oracle row contract.
-GLONASS phase remains intentionally excluded until its measured FDMA residual
-drift is modelled, and M2 remains open.
+M2 remains open.
+
+#### M2g -- GLONASS phase rows and STEC prior parity
+
+MADOCALIB initializes each estimated STEC state with `VAR_IONO=SQR(60.0)` and
+admits both GLONASS L1 and L2 carrier-phase rows in the float filter.  Native
+previously used a 100 m² generic STEC prior and suppressed only the GLONASS L1
+phase row; L2 remained active despite the code-only comment and opt-out.
+
+Coherent MADOCA now uses the oracle's 3600 m² STEC prior and enables both
+GLONASS phase rows by default.  `GNSS_PPP_INIT_IONO_VAR` remains an explicit
+prior override, and `GNSS_PPP_MADOCA_GLONASS_PHASE=0` consistently suppresses
+both GLONASS phase rows.
+
+The earlier metre-scale GLONASS drift diagnosis was caused by postfit telemetry
+using receiver geometry materialized before the accepted filter update.  With
+the corrected shadow from M2g's prerequisite PR, the four pinned GLONASS
+satellites show demeaned residual RMS of 2.4--5.2 mm, spans of 1.6--3.4 cm, and
+near-zero residual/elevation correlation.  On the 120-epoch MIZU probe, all 118
+solution epochs remain aligned, native remains at 90 Fix / 28 Float with no
+wrong Fix, and full-window 3D delta RMS improves from 0.196 m to 0.193 m.
+M2 remains open because the early-window status agreement gate is not met.
 
 ### M3 -- Apply L6D ionosphere products
 

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -78,9 +78,9 @@ struct PPPEnvOverrides {
     // GNSS_PPP_MADOCA_GLONASS: include GLONASS in coherent MADOCA unless set
     // exactly to "0". Default true.
     bool madoca_glonass = true;
-    // GNSS_PPP_MADOCA_GLONASS_PHASE: allow GLONASS phase rows in MADOCA when
-    // set exactly to "1". Default false.
-    bool madoca_glonass_phase = false;
+    // GNSS_PPP_MADOCA_GLONASS_PHASE: allow GLONASS phase rows in coherent
+    // MADOCA. Default true for MADOCALIB parity; set exactly to "0" to opt out.
+    bool madoca_glonass_phase = true;
     // GNSS_PPP_MADOCA_LOW_ELEV: admit coherent MADOCA observations down to the
     // MADOCALIB 10 degree mask unless set exactly to "0". Default true.
     bool madoca_low_elev = true;

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -152,7 +152,8 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
     overrides.madoca_qzss_phase = !envExactZero("GNSS_PPP_MADOCA_QZSS_PHASE");
     overrides.madoca_qzss_l5 = !envExactZero("GNSS_PPP_MADOCA_QZSS_L5");
     overrides.madoca_glonass = !envExactZero("GNSS_PPP_MADOCA_GLONASS");
-    overrides.madoca_glonass_phase = envExactOne("GNSS_PPP_MADOCA_GLONASS_PHASE");
+    overrides.madoca_glonass_phase =
+        !envExactZero("GNSS_PPP_MADOCA_GLONASS_PHASE");
     overrides.madoca_low_elev = !envExactZero("GNSS_PPP_MADOCA_LOW_ELEV");
     overrides.madoca_galileo_gate =
         envExactOne("GNSS_PPP_MADOCA_GALILEO_GATE") ||

--- a/src/algorithms/ppp_internal.hpp
+++ b/src/algorithms/ppp_internal.hpp
@@ -152,6 +152,17 @@ inline double initialTroposphereVariance(bool madoca_per_frequency,
     return broadcast_model ? configured_variance : 25.0;
 }
 
+inline double initialIonosphereVariance(bool madoca_per_frequency,
+                                        double configured_override,
+                                        double configured_variance) {
+    if (configured_override > 0.0) {
+        return configured_override;
+    }
+    // MADOCALIB ppp.c initializes every estimated STEC state with
+    // VAR_IONO=SQR(60.0).
+    return madoca_per_frequency ? 60.0 * 60.0 : configured_variance;
+}
+
 inline std::string trimCopy(const std::string& text) {
     const auto is_not_space = [](unsigned char ch) {
         return !std::isspace(ch);

--- a/src/algorithms/ppp_measurement.cpp
+++ b/src/algorithms/ppp_measurement.cpp
@@ -289,9 +289,8 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
         const bool qzss_code_only =
             env_overrides_.qzss_code_only ||
             (require_coherent_ssr_ && !env_overrides_.madoca_qzss_phase);
-        // GLONASS FDMA phase rows remain preview-only in coherent MADOCA:
-        // full-row enablement exposes a time-varying relative phase residual,
-        // while code rows improve bridge parity.
+        // MADOCALIB admits both GLONASS FDMA phase rows. Keep a diagnostic
+        // code-only opt-out, applied consistently to L1 and L2.
         const bool glonass_code_only =
             require_coherent_ssr_ && env_overrides_.madoca_glonass &&
             !env_overrides_.madoca_glonass_phase &&
@@ -436,6 +435,7 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
             const auto amb_it = ambiguity_states_.find(observation.satellite);
             const bool l2_phase_ready =
                 use_phase_rows && observation.has_carrier_phase_l2 &&
+                !glonass_code_only &&
                 amb2_it != filter_state_.ambiguity_l2_indices.end() &&
                 amb_it != ambiguity_states_.end() &&
                 !amb_it->second.needs_reinitialization &&

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -398,20 +398,13 @@ bool PPPProcessor::initializeFilter(const ObservationData& obs,
         filter_state_.covariance(
             filter_state_.bds2_clock_index, filter_state_.bds2_clock_index) =
             system_clock_initial_variance;
-    // Initialize per-satellite ionosphere states. GNSS_PPP_INIT_IONO_VAR (>0)
-    // overrides the per-satellite initial ionosphere covariance. The est-stec
-    // KF has a rank-deficient gauge in (iono, N1, N2, cdtr) -- a uniform shift
-    // (iono+Δ, λN+Δ, cdtr−Δ) leaves the phase observations invariant -- so
-    // when the constellation membership shifts (e.g. orbit-fix dropping a sat
-    // missing its SSR orbit correction) the null-space anchor moves and the
-    // filter settles to a different common-mode iono level. A tight prior pins
-    // this gauge: on the MADOCA est-stec parity workload, var=1 lets a
-    // low-latitude station (ALIC) stack cleanly with the orbit-fix lever for
-    // bridge-parity float, while the default (100) is correct at mid-latitude
-    // (MIZU); the right value is station-dependent, so this is opt-in.
-    const double iono_init_var = env_overrides_.init_iono_var > 0.0
-                                     ? env_overrides_.init_iono_var
-                                     : ppp_config_.initial_ionosphere_variance;
+    // Initialize per-satellite ionosphere states. Coherent MADOCA uses the
+    // frozen oracle's 60 m STEC sigma; GNSS_PPP_INIT_IONO_VAR (>0) remains an
+    // explicit diagnostic override.
+    const double iono_init_var = initialIonosphereVariance(
+        madoca_per_frequency,
+        env_overrides_.init_iono_var,
+        ppp_config_.initial_ionosphere_variance);
     if (ppp_config_.estimate_ionosphere) {
         for (const auto& [sat, idx] : filter_state_.ionosphere_indices) {
             filter_state_.state(idx) = 0.0;  // Initial iono delay = 0 (will be constrained by STEC)
@@ -1370,9 +1363,10 @@ int PPPProcessor::getOrCreateIonosphereState(const IonosphereFreeObs& observatio
     // Mirror the GNSS_PPP_INIT_IONO_VAR override at the lazy-create site so a
     // satellite appearing mid-run lands in the same anchored gauge.
     filter_state_.covariance(new_index, new_index) =
-        env_overrides_.init_iono_var > 0.0
-            ? env_overrides_.init_iono_var
-            : ppp_config_.initial_ionosphere_variance;
+        initialIonosphereVariance(
+            madoca_per_frequency,
+            env_overrides_.init_iono_var,
+            ppp_config_.initial_ionosphere_variance);
     filter_state_.ionosphere_indices[observation.satellite] = new_index;
     return new_index;
 }

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -219,8 +219,24 @@ TEST(PPPStateInitialization, MadocaPerFrequencyUsesMadocalibZtdPrior) {
         25.0);
 }
 
+TEST(PPPStateInitialization, MadocaPerFrequencyUsesMadocalibStecPrior) {
+    EXPECT_DOUBLE_EQ(
+        ppp_internal::initialIonosphereVariance(true, 0.0, 100.0),
+        60.0 * 60.0);
+    EXPECT_DOUBLE_EQ(
+        ppp_internal::initialIonosphereVariance(false, 0.0, 100.0),
+        100.0);
+    EXPECT_DOUBLE_EQ(
+        ppp_internal::initialIonosphereVariance(true, 25.0, 100.0),
+        25.0);
+}
+
 TEST(PPPEnvOverridesTest, MadocaQzssL5DefaultsToThreeFrequencyParity) {
     EXPECT_TRUE(PPPEnvOverrides::fromEnvironment().madoca_qzss_l5);
+}
+
+TEST(PPPEnvOverridesTest, MadocaGlonassPhaseDefaultsToParityRows) {
+    EXPECT_TRUE(PPPEnvOverrides::fromEnvironment().madoca_glonass_phase);
 }
 
 TEST(NavigationSsrIodeSelection, DoesNotFallBackWhenGpsIodeIsUnavailable) {


### PR DESCRIPTION
## Summary

- use MADOCALIB's 60 m initial STEC sigma in coherent MADOCA
- admit GLONASS L1/L2 phase rows by default while preserving an exact-zero diagnostic opt-out
- correct the stale GLONASS parity documentation and record the M2g evidence

## Validation

- focused tests: 4 passed
- C++ suite: 679 passed, 51 fixture-dependent skipped
- 120-epoch MIZU: 118 matched, 90 Fix / 28 Float, no native-only Fix
- native/oracle delta: 3D RMS 0.193102 m, max 0.327052 m
- GLONASS phase audit: 552 rows, passed; per-satellite demeaned RMS 2.4–5.1 mm and span 1.6–3.4 cm

Tracks #148. M2 remains open because status agreement is 84.75%, below the 95% gate.
