### PR TITLE
fix(ppp): match MADOCA GLONASS code IFB variance

### DIFF
--- a/docs/madocalib_native_migration.md
+++ b/docs/madocalib_native_migration.md
@@ -324,6 +324,21 @@ solution epochs remain aligned, native remains at 90 Fix / 28 Float with no
 wrong Fix, and full-window 3D delta RMS improves from 0.196 m to 0.193 m.
 M2 remains open because the early-window status agreement gate is not met.
 
+#### M2h -- GLONASS receiver code-IFB variance
+
+MADOCALIB adds `VAR_GLO_IFB=SQR(0.6)` to every GLONASS pseudorange row
+while leaving carrier-phase rows unchanged. Native previously used the common
+code variance for GLONASS, underestimating its code sigma after the constellation
+entered the filter.
+
+Coherent MADOCA per-frequency mode now adds the same `0.36 m^2` code-only
+variance. At GPS week 2360, TOW 173160, the native/oracle GLONASS code sigmas
+agree at trace precision: R09 is 3.1256 m, R19 is 6.3378 m, and R21 is
+2.5205 m. On the pinned 120-epoch MIZU probe, all 118 solution epochs remain
+aligned, native remains at 90 Fix / 28 Float with no wrong Fix, and full-window
+3D delta RMS is 0.193236 m with a 0.330669 m maximum. M2 remains open because
+the early-window status agreement gate is not met.
+
 ### M3 -- Apply L6D ionosphere products
 
 - Promote the proven snapshot lookup from shadow telemetry to an explicit

--- a/src/algorithms/ppp_corrections.cpp
+++ b/src/algorithms/ppp_corrections.cpp
@@ -1497,6 +1497,13 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
             deferred_variance_pr += kMadocalibEstimatedTropVarianceM2;
             deferred_variance_cp += kMadocalibEstimatedTropVarianceM2;
         }
+        const bool madoca_per_frequency =
+            require_coherent_ssr_ &&
+            !ppp_config_.use_ionosphere_free &&
+            ppp_config_.estimate_ionosphere;
+        deferred_variance_pr += ppp_internal::madocaGlonassCodeIfbVariance(
+            madoca_per_frequency,
+            observation.satellite.system);
         observation.variance_pr = safeVariance(observation.variance_pr + deferred_variance_pr, 1e-6);
         observation.variance_cp = safeVariance(observation.variance_cp + deferred_variance_cp, 1e-8);
         // Optional diagnostic scaling after the RTKLIB code/phase ratio. The

--- a/src/algorithms/ppp_internal.hpp
+++ b/src/algorithms/ppp_internal.hpp
@@ -142,6 +142,15 @@ inline double madocaIonosphereProcessVariance(double zenith_variance_per_second,
            (sin_elevation * sin_elevation);
 }
 
+inline double madocaGlonassCodeIfbVariance(bool madoca_per_frequency,
+                                           GNSSSystem system) {
+    // MADOCALIB ppp_res(): VAR_GLO_IFB=SQR(0.6) is added to GLONASS
+    // pseudorange rows only. Carrier rows never call this helper.
+    return madoca_per_frequency && system == GNSSSystem::GLONASS
+        ? 0.6 * 0.6
+        : 0.0;
+}
+
 inline double initialTroposphereVariance(bool madoca_per_frequency,
                                          bool broadcast_model,
                                          double configured_variance) {

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -151,6 +151,21 @@ TEST(PPPPostfitGeometry, PreservesUnsetReceiverPosition) {
     EXPECT_TRUE(recentered.isZero());
 }
 
+TEST(PPPMeasurementVariance, MadocaPerFrequencyAddsGlonassCodeIfb) {
+    EXPECT_DOUBLE_EQ(
+        ppp_internal::madocaGlonassCodeIfbVariance(
+            true, GNSSSystem::GLONASS),
+        0.36);
+    EXPECT_DOUBLE_EQ(
+        ppp_internal::madocaGlonassCodeIfbVariance(
+            false, GNSSSystem::GLONASS),
+        0.0);
+    EXPECT_DOUBLE_EQ(
+        ppp_internal::madocaGlonassCodeIfbVariance(
+            true, GNSSSystem::GPS),
+        0.0);
+}
+
 TEST(PPPIonospherePrediction, MatchesMadocalibCarrierDeltaAndElevationNoise) {
     constexpr double f1 = 1575.42e6;
     constexpr double f2 = 1227.60e6;


### PR DESCRIPTION
## What

- add the MADOCALIB GLONASS code IFB variance (0.36 m²) only to pseudorange rows in coherent MADOCA per-frequency mode
- keep carrier-phase variance unchanged
- add a focused unit test and record the M2h parity evidence

## Root cause

MADOCALIB adds `VAR_GLO_IFB = SQR(0.6)` to GLONASS pseudorange measurements. The native PPP path omitted this term, so its GLONASS code sigmas were underestimated.

## Validation

- 6 related tests pass: `PPPMeasurementVariance.*:PPPIonospherePrediction.*:PPPStateInitialization.*`
- shadow GLONASS code sigmas now match the oracle at trace precision:
  - R09: 3.1256006446
  - R19: 6.3377535429
  - R21: 2.5204686223
- 120-epoch M2 run: 118 aligned epochs, native Fix/Float 90/28, no native-only Fix
- position difference: 3D RMS 0.193236 m, max 0.330669 m

Issue #148 remains open: the M2 Fix-count/agreement gates are not yet met.