### PR TITLE
fix(ppp): match MADOCA geometry-free slip threshold

### DIFF
--- a/src/algorithms/ppp_internal.hpp
+++ b/src/algorithms/ppp_internal.hpp
@@ -24,6 +24,18 @@ inline int filterIterationCount(bool madoca_per_frequency_update,
     return precise_products_loaded ? 3 : configured_iterations;
 }
 
+inline double geometryFreeSlipThresholdMeters(
+    bool madoca_per_frequency,
+    double configured_threshold_m) {
+    constexpr double kDefaultMinimumMeters = 0.5;
+    constexpr double kMadocalibMinimumMeters = 0.15;
+    return std::max(
+        configured_threshold_m,
+        madoca_per_frequency
+            ? kMadocalibMinimumMeters
+            : kDefaultMinimumMeters);
+}
+
 inline int perFrequencyArMinLockCount(bool madoca_per_frequency,
                                       bool ssr_products_loaded,
                                       int convergence_min_epochs) {

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -863,7 +863,6 @@ void PPPProcessor::detectCycleSlips(const ObservationData& obs, const Navigation
         return;
     }
 
-    constexpr double kMinimumGeometryFreeSlipThresholdMeters = 0.5;
     constexpr double kMinimumMwSlipThresholdMeters = 10.0;
     // Enable combination (GF/MW) slip detection in SSR mode even for static,
     // because MW averaging is needed for Wide-Lane AR. CLAS kinematic OSR uses
@@ -966,11 +965,18 @@ void PPPProcessor::detectCycleSlips(const ObservationData& obs, const Navigation
             if (lambda1 > 0.0 && lambda2 > 0.0) {
                 gf_m = primary->carrier_phase * lambda1 - secondary->carrier_phase * lambda2;
                 have_gf = std::isfinite(gf_m);
+                const bool madoca_per_frequency =
+                    require_coherent_ssr_ && ssr_products_loaded_ &&
+                    !ppp_config_.use_ionosphere_free &&
+                    ppp_config_.estimate_ionosphere;
+                const double gf_slip_threshold =
+                    ppp_internal::geometryFreeSlipThresholdMeters(
+                        madoca_per_frequency,
+                        ppp_config_.cycle_slip_threshold);
                 if (have_gf &&
                     ambiguity.has_last_geometry_free &&
                     std::abs(gf_m - ambiguity.last_geometry_free_m) >
-                        std::max(ppp_config_.cycle_slip_threshold,
-                                 kMinimumGeometryFreeSlipThresholdMeters)) {
+                        gf_slip_threshold) {
                     gf_slip = true;
                 }
             }

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -103,6 +103,18 @@ TEST(PPPFilterIterations, MadocaPerFrequencyCommitsOneUpdatePerEpoch) {
     EXPECT_EQ(ppp_internal::filterIterationCount(false, false, 8), 8);
 }
 
+TEST(PPPCycleSlips, MadocaPerFrequencyUsesMadocalibGeometryFreeThreshold) {
+    EXPECT_DOUBLE_EQ(
+        ppp_internal::geometryFreeSlipThresholdMeters(true, 0.05),
+        0.15);
+    EXPECT_DOUBLE_EQ(
+        ppp_internal::geometryFreeSlipThresholdMeters(true, 0.2),
+        0.2);
+    EXPECT_DOUBLE_EQ(
+        ppp_internal::geometryFreeSlipThresholdMeters(false, 0.05),
+        0.5);
+}
+
 TEST(PPPArAdmission, CoherentSsrDoesNotAddALockCountGate) {
     EXPECT_EQ(ppp_internal::perFrequencyArMinLockCount(true, true, 20), 0);
     EXPECT_EQ(ppp_internal::perFrequencyArMinLockCount(false, true, 20), 10);


### PR DESCRIPTION
## Summary
- use MADOCALIB's 0.15 m geometry-free slip threshold in coherent per-frequency MADOCA PPP
- preserve the existing 0.5 m safety floor for other PPP modes
- add focused threshold regression coverage

## Evidence
- reproduces oracle G28/C37 geometry-free reset sequence
- TOW 173160 N1 ratio: 1.48210 -> 1.62248; first native Fix now matches oracle epoch
- M2 120 epochs: native Fix 90 -> 91, agreement 84.75% -> 85.59%, native-only Fix 0
- position delta RMS 0.198292 m, max 0.506788 m

## Tests
- `run_tests.exe --gtest_filter=PPP*`: 153 passed, 1 existing dedicated-process skip
- native MADOCA 120-epoch replay and oracle solution diff

Refs #148