### PR TITLE
Match MADOCA STEC windup propagation

### DIFF
--- a/src/algorithms/ppp_internal.hpp
+++ b/src/algorithms/ppp_internal.hpp
@@ -144,6 +144,24 @@ inline double madocaCarrierIonosphereMeters(double phase_l1_m,
     return -(phase_l1_m - phase_l2_m) / denominator;
 }
 
+inline double madocaCarrierIonosphereMetersExcludingWindup(
+    double corrected_phase_l1_m,
+    double corrected_phase_l2_m,
+    double wavelength_l1_m,
+    double wavelength_l2_m,
+    double windup_cycles,
+    double frequency_l1_hz,
+    double frequency_l2_hz) {
+    // MADOCALIB udiono_ppp() calls corr_meas(..., phw=0). Native corrected
+    // phases already have phw*lambda removed, so restore that term before
+    // deriving the temporal carrier-ionosphere increment.
+    return madocaCarrierIonosphereMeters(
+        corrected_phase_l1_m + windup_cycles * wavelength_l1_m,
+        corrected_phase_l2_m + windup_cycles * wavelength_l2_m,
+        frequency_l1_hz,
+        frequency_l2_hz);
+}
+
 inline double madocaIonosphereProcessVariance(double zenith_variance_per_second,
                                               double elevation_rad,
                                               double dt_seconds) {

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -582,10 +582,18 @@ void PPPProcessor::updateMadocaPerFrequencyIonospherePrediction(
             ambiguity.has_last_carrier_ionosphere = false;
             continue;
         }
+        const auto windup_it = windup_cache_.find(observation.satellite);
+        const double windup_cycles =
+            windup_it != windup_cache_.end() && std::isfinite(windup_it->second)
+                ? windup_it->second
+                : 0.0;
         const double carrier_ionosphere =
-            ppp_internal::madocaCarrierIonosphereMeters(
+            ppp_internal::madocaCarrierIonosphereMetersExcludingWindup(
                 observation.carrier_phase_l1,
                 observation.carrier_phase_l2,
+                observation.wavelength_l1,
+                observation.wavelength_l2,
+                windup_cycles,
                 observation.freq_l1,
                 observation.freq_l2);
         if (!std::isfinite(carrier_ionosphere)) {

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -216,6 +216,33 @@ TEST(PPPIonospherePrediction, MatchesMadocalibCarrierDeltaAndElevationNoise) {
         1e-12);
 }
 
+TEST(PPPIonospherePrediction, ExcludesPhaseWindupFromCarrierDelta) {
+    constexpr double f1 = 1575.42e6;
+    constexpr double f2 = 1227.60e6;
+    constexpr double windup_cycles = 0.37;
+    const double wavelength_l1 = constants::SPEED_OF_LIGHT / f1;
+    const double wavelength_l2 = constants::SPEED_OF_LIGHT / f2;
+    constexpr double raw_phase_l1 = 12.4;
+    constexpr double raw_phase_l2 = 12.1;
+    const double corrected_phase_l1 =
+        raw_phase_l1 - windup_cycles * wavelength_l1;
+    const double corrected_phase_l2 =
+        raw_phase_l2 - windup_cycles * wavelength_l2;
+
+    EXPECT_NEAR(
+        ppp_internal::madocaCarrierIonosphereMetersExcludingWindup(
+            corrected_phase_l1,
+            corrected_phase_l2,
+            wavelength_l1,
+            wavelength_l2,
+            windup_cycles,
+            f1,
+            f2),
+        ppp_internal::madocaCarrierIonosphereMeters(
+            raw_phase_l1, raw_phase_l2, f1, f2),
+        1e-12);
+}
+
 TEST(PPPIonospherePrediction, SeedsStateFromCorrectedCodesWithoutChangingRawFallback) {
     constexpr double f1 = 1575.42e6;
     constexpr double f2 = 1227.60e6;


### PR DESCRIPTION
## What changed

- Restore the per-frequency phase-windup term before deriving the carrier-based temporal STEC increment.
- Add a focused helper and regression test for the MADOCALIB `udiono_ppp()` contract.

## Root cause

MADOCALIB computes its temporal carrier-ionosphere update through `corr_meas(..., phw=0)`. Native correction materialization had already removed `phw * wavelength` from each carrier phase, so its L1/L2 phase difference leaked the wavelength-dependent windup term into STEC propagation.

## Impact

The native state propagation now follows the oracle contract without changing the measurement phase-windup correction itself. On the pinned 120-epoch MIZU run, this is a correctness/parity cleanup but does not change the current M2 headline count: native remains 91 Fix epochs, so Issue #148 stays open.

## Validation

- `run_tests.exe --gtest_filter=PPP*`: 155 tests run, 154 passed, 1 existing dedicated-process skip.
- Pinned 120-epoch MIZU native/oracle replay completed successfully.
