### PR TITLE
fix(ppp): align MADOCA solid tide convention

### DIFF
--- a/include/libgnss++/algorithms/ppp_correction_contract.hpp
+++ b/include/libgnss++/algorithms/ppp_correction_contract.hpp
@@ -77,6 +77,13 @@ constexpr bool excludePhaseWindupFromAmbiguitySeed(bool madoca_convention) {
     return madoca_convention;
 }
 
+// MADOCALIB's PPP receiver geometry uses its legacy Love-number solid-earth
+// tide model. Keep the IERS model selectable for every other PPP profile.
+constexpr bool useIersSolidEarthTide(bool madoca_convention,
+                                     bool configured_iers_model) {
+    return configured_iers_model && !madoca_convention;
+}
+
 // Neutral atmosphere delays are removed from code and phase alike, while the
 // first-order ionosphere is dispersive: remove it from code, add it to phase.
 constexpr double measurementCorrectionSign(bool carrier_phase, bool dispersive) {

--- a/src/algorithms/ppp_corrections.cpp
+++ b/src/algorithms/ppp_corrections.cpp
@@ -1719,7 +1719,13 @@ Vector3d PPPProcessor::calculateSolidEarthTides(const Vector3d& position,
         return Vector3d::Zero();
     }
 
-    if (ppp_config_.use_iers_solid_tide) {
+    const bool madoca_per_frequency =
+        require_coherent_ssr_ && ssr_products_loaded_ &&
+        !ppp_config_.use_ionosphere_free &&
+        ppp_config_.estimate_ionosphere &&
+        !ppp_config_.use_clas_osr_filter;
+    if (algorithms::ppp_correction_contract::useIersSolidEarthTide(
+            madoca_per_frequency, ppp_config_.use_iers_solid_tide)) {
         // IERS Conventions 2010 §7.1.1 (Dehant) Step-1 + Step-2 model
         // via the libgnss::iers wrapper. Sun and Moon are supplied in
         // ICRS — see the FRAME NOTE in libgnss++/iers/tides.hpp for

--- a/tests/test_ppp_correction_contract.cpp
+++ b/tests/test_ppp_correction_contract.cpp
@@ -40,6 +40,12 @@ TEST(PPPCorrectionContractTest, MadocaExcludesWindupFromAmbiguitySeed) {
     EXPECT_FALSE(contract::excludePhaseWindupFromAmbiguitySeed(false));
 }
 
+TEST(PPPCorrectionContractTest, MadocaUsesMadocalibSolidEarthTideModel) {
+    EXPECT_FALSE(contract::useIersSolidEarthTide(true, true));
+    EXPECT_TRUE(contract::useIersSolidEarthTide(false, true));
+    EXPECT_FALSE(contract::useIersSolidEarthTide(false, false));
+}
+
 TEST(PPPCorrectionContractTest, AtmosphereSignsMatchCodeAndPhasePhysics) {
     EXPECT_DOUBLE_EQ(contract::measurementCorrectionSign(false, false), -1.0);
     EXPECT_DOUBLE_EQ(contract::measurementCorrectionSign(true, false), -1.0);


### PR DESCRIPTION
## Summary
- route native MADOCA per-frequency PPP through MADOCALIB's legacy Love-number solid-earth-tide convention
- retain the configured IERS solid-tide model for every non-MADOCA PPP profile
- cover the profile-selection contract with focused unit tests

## Root cause
MADOCALIB forms receiver geometry with its legacy Love-number solid-earth-tide path, while native MADOCA inherited the generic default IERS 2010 model. The resulting receiver-displacement difference biased the native float trajectory even though correction materialization and AR candidate selection were already aligned.

## Validation
- `PPP*`: 157 tests, 156 passed, 1 existing known skip
- 120-epoch MIZU native MADOCA run: 118 valid, 95 Fix / 23 Float
- default MADOCA output exactly matches the explicit `--no-iers-solid-tide` A/B output (118/118 solution rows)
- native-vs-MADOCALIB 3D RMS: 0.209425 m -> 0.1121 m
- tail 3D RMS: 0.221474 m -> 0.0700698 m
- status mismatches remain 13 and will be handled as a separate float-state/AR slice

Part of #148; does not close it.