### PR TITLE
Align MADOCA SSR clock and first-fix safety

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -651,7 +651,7 @@ jobs:
           grep -q '"convergence_policy": "legacy-3d"' native_pppar_smoke.json
           grep -q '"ar_stage_last":' native_pppar_smoke.json
           grep -q '"ar_per_frequency_attempts":' native_pppar_smoke.json
-          ./apps/gnss_ppp \
+          GNSS_PPP_PFDUMP=1 ./apps/gnss_ppp \
             --kinematic \
             --enable-ar \
             --ar-method per-freq \
@@ -668,7 +668,7 @@ jobs:
             --emit-epoch-time \
             --out native_pppar_partial_ar_smoke.pos \
             --summary-json native_pppar_partial_ar_smoke.json \
-            --quiet
+            --quiet 2> native_pppar_partial_ar_trace.log
           grep -q '"convergence_policy": "local-enu"' native_pppar_partial_ar_smoke.json
           n1_fixed="$(python3 -c 'import json; print(json.load(open("native_pppar_partial_ar_smoke.json"))["ar_n1_fixed_epochs"])')"
           fixed_solutions="$(python3 -c 'import json; print(json.load(open("native_pppar_partial_ar_smoke.json"))["ppp_fixed_solutions"])')"
@@ -719,6 +719,7 @@ jobs:
           build-madoca-parity/native_pppar_smoke.json
           build-madoca-parity/native_pppar_partial_ar_smoke.pos
           build-madoca-parity/native_pppar_partial_ar_smoke.json
+          build-madoca-parity/native_pppar_partial_ar_trace.log
           build-madoca-parity/madoca_pppar_solution_diff.json
           build-madoca-parity/madoca_pppar_solution_matches.csv
         if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -651,7 +651,7 @@ jobs:
           grep -q '"convergence_policy": "legacy-3d"' native_pppar_smoke.json
           grep -q '"ar_stage_last":' native_pppar_smoke.json
           grep -q '"ar_per_frequency_attempts":' native_pppar_smoke.json
-          GNSS_PPP_PFDUMP=1 ./apps/gnss_ppp \
+          ./apps/gnss_ppp \
             --kinematic \
             --enable-ar \
             --ar-method per-freq \
@@ -668,7 +668,7 @@ jobs:
             --emit-epoch-time \
             --out native_pppar_partial_ar_smoke.pos \
             --summary-json native_pppar_partial_ar_smoke.json \
-            --quiet 2> native_pppar_partial_ar_trace.log
+            --quiet
           grep -q '"convergence_policy": "local-enu"' native_pppar_partial_ar_smoke.json
           n1_fixed="$(python3 -c 'import json; print(json.load(open("native_pppar_partial_ar_smoke.json"))["ar_n1_fixed_epochs"])')"
           fixed_solutions="$(python3 -c 'import json; print(json.load(open("native_pppar_partial_ar_smoke.json"))["ppp_fixed_solutions"])')"
@@ -698,13 +698,9 @@ jobs:
           test "$matched_epochs" -eq 118
           oracle_fixes="$(awk -F, 'NR > 1 && $5 == 1 {n++} END {print n+0}' madoca_pppar_solution_matches.csv)"
           test "$oracle_fixes" -eq 108
-          test "$fixed_solutions" -ge "$oracle_fixes"
+          test "$fixed_solutions" -ge 77
           wrong_fixes="$(awk -F, 'NR > 1 && $6 == 6 && $5 != 1 {n++} END {print n+0}' madoca_pppar_solution_matches.csv)"
           test "$wrong_fixes" -eq 0
-          missed_fixes="$(awk -F, 'NR > 1 && $5 == 1 && $6 != 6 {n++} END {print n+0}' madoca_pppar_solution_matches.csv)"
-          test "$missed_fixes" -eq 0
-          status_mismatches="$(awk -F, 'NR > 1 && (($5 == 1 && $6 != 6) || ($5 != 1 && $6 == 6)) {n++} END {print n+0}' madoca_pppar_solution_matches.csv)"
-          test "$status_mismatches" -eq 0
           python3 -c 'import json; d=json.load(open("madoca_pppar_solution_diff.json")); assert d["comparison"]["delta_rms_3d_m"] <= 0.2; assert d["events"]["max_delta_3d"]["delta_3d_m"] <= 1.0'
 
     - name: Upload MADOCA PPP-AR baseline
@@ -719,7 +715,6 @@ jobs:
           build-madoca-parity/native_pppar_smoke.json
           build-madoca-parity/native_pppar_partial_ar_smoke.pos
           build-madoca-parity/native_pppar_partial_ar_smoke.json
-          build-madoca-parity/native_pppar_partial_ar_trace.log
           build-madoca-parity/madoca_pppar_solution_diff.json
           build-madoca-parity/madoca_pppar_solution_matches.csv
         if-no-files-found: warn

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -695,9 +695,17 @@ jobs:
             --json-out madoca_pppar_solution_diff.json \
             --match-csv madoca_pppar_solution_matches.csv
           matched_epochs="$(awk -F, 'NR > 1 {n++} END {print n+0}' madoca_pppar_solution_matches.csv)"
-          test "$matched_epochs" -gt 0
+          test "$matched_epochs" -eq 118
+          oracle_fixes="$(awk -F, 'NR > 1 && $5 == 1 {n++} END {print n+0}' madoca_pppar_solution_matches.csv)"
+          test "$oracle_fixes" -eq 108
+          test "$fixed_solutions" -ge "$oracle_fixes"
           wrong_fixes="$(awk -F, 'NR > 1 && $6 == 6 && $5 != 1 {n++} END {print n+0}' madoca_pppar_solution_matches.csv)"
           test "$wrong_fixes" -eq 0
+          missed_fixes="$(awk -F, 'NR > 1 && $5 == 1 && $6 != 6 {n++} END {print n+0}' madoca_pppar_solution_matches.csv)"
+          test "$missed_fixes" -eq 0
+          status_mismatches="$(awk -F, 'NR > 1 && (($5 == 1 && $6 != 6) || ($5 != 1 && $6 == 6)) {n++} END {print n+0}' madoca_pppar_solution_matches.csv)"
+          test "$status_mismatches" -eq 0
+          python3 -c 'import json; d=json.load(open("madoca_pppar_solution_diff.json")); assert d["comparison"]["delta_rms_3d_m"] <= 0.2; assert d["events"]["max_delta_3d"]["delta_3d_m"] <= 1.0'
 
     - name: Upload MADOCA PPP-AR baseline
       if: always()

--- a/docs/madocalib_native_migration.md
+++ b/docs/madocalib_native_migration.md
@@ -85,7 +85,7 @@ does not yet match end-to-end behavior; **open** has no accepted native parity.
 | PPP commit-on-success and diagnostics | Native postfit validation/shadow telemetry | native | MIZU 1 h/6 h/24 h and ALIC regression gates remain green |
 | GLONASS phase in MADOCA PPP | Native L1/L2 rows plus corrected postfit-shadow audit | native | Keep the pinned per-satellite demeaned RMS at millimetre scale and span below 4 cm |
 | MADOCALIB `exec_ppp` | Native PPP runs end to end; remaining solution delta is tracked | partial | M4/M5 matrix meets the declared trajectory thresholds |
-| MADOCALIB `exec_pppar` | Native per-frequency path reaches 95 Fix versus 108 oracle Fix in 118 matched epochs, with no native-only Fix | partial | M2 must resolve the remaining 13 oracle-Fix/native-Float epochs |
+| MADOCALIB `exec_pppar` | Native per-frequency path matches the oracle's 108 Fix / 10 Float in all 118 matched epochs, with no native-only Fix | native | Keep the pinned M2 status, wrong-Fix, and trajectory gates green |
 | MADOCALIB `exec_pppar-ion` | Bridge profile/input validation exists; native L6D state injection does not | open | M3 then M5 PPP-AR-ion sign-off |
 | Triple/quad-frequency PPP-AR | Upstream 2.0 behavior has not been fully audited or signed off | open | Dedicated fixtures and ambiguity/state parity after dual-frequency M2 |
 | Linked `postpos()` bridge | `madocalib_bridge` | oracle-only | Retain until M6; never select it in production runtime |
@@ -93,20 +93,20 @@ does not yet match end-to-end behavior; **open** has no accepted native parity.
 ## Current Numerical Baselines
 
 The frozen one-hour MIZU PPP-AR CI window has 118 matched output epochs.  The
-MADOCALIB `pppar` oracle produces 108 Fix and 10 Float.  After frequency-scoped
-multi-frequency geometry-free slip handling and the MADOCALIB solid-earth-tide
-convention, the native per-frequency path produces 95 Fix and 23 Float with no
-native-only Fix.  Status agreement is 105/118 (88.98%).  The recorded
-native/oracle 3D delta RMS is 0.112100 m, with 0.070070 m over the trailing
-1800 seconds.
+MADOCALIB `pppar` oracle and the native per-frequency path both produce 108 Fix
+and 10 Float.  Status agreement is 118/118, with no native-only or oracle-only
+Fix.  The recorded native/oracle 3D delta RMS is 0.040094 m, the maximum is
+0.246063 m, and the trailing-1800-second RMS is 0.032859 m.
 
-The convergence gate now admits the per-frequency resolver after the declared
-local-ENU warm-up policy.  The remaining M2 blocker is inside the float-state
-trajectory presented to LAMBDA: at the first oracle-Fix/native-Float split
-(TOW 173190), both implementations form the same 10 N1 double differences and
-exclude J03 first, but the oracle's reduced ratio is 2.846 while native remains
-at 1.232.  Candidate identities and diagonal sigmas align; float DD means
-differ by up to about 0.21 cycle.
+M2 is complete.  The final discrepancy came from MADOCALIB `satpos_ssr()`
+replacing the broadcast eccentric-anomaly clock-relativity approximation with
+RTKLIB's position/1-ms-forward-velocity dot product.  Harmonic orbit terms made
+the two nominally equivalent forms differ by satellite-specific centimetres.
+After aligning that clock contract, a single near-threshold initial LAMBDA
+candidate ordering could still publish one native Fix one epoch early.  The
+coherent-MADOCA path now requires the first N1 success to repeat on the next AR
+attempt before publishing Fix; thresholds and later reacquisition behavior are
+unchanged.
 
 The float-PPP history and older MIZU/ALIC/full-day measurements remain in issue
 #148 and `madoca_port_plan.md`; they are regression context, not proof that
@@ -372,6 +372,31 @@ the full native/oracle 3D RMS improves from 0.209425 m to 0.112100 m and the
 trailing-1800-second RMS improves from 0.221474 m to 0.070070 m.  M2 remains
 open because the status and native-Fix-count gates are not met.
 
+#### M2k -- SSR clock relativity and first-N1 confirmation
+
+MADOCALIB `satpos_ssr()` recomputes broadcast clock relativity as
+`-2 * dot(position, velocity) / c^2`, using RTKLIB's 1 ms forward-difference
+velocity.  Native previously retained the eccentric-anomaly form returned by
+its broadcast ephemeris propagation.  The difference is satellite-specific at
+centimetre scale once harmonic orbit terms are included and was sufficient to
+shift the tightly weighted carrier residuals and PAR candidate ordering.
+Coherent MADOCA now reproduces the state-vector form with the exact SSR IODE;
+other PPP profiles keep their existing clock convention.
+
+The clock correction alone recovers every oracle Fix but admits one
+near-threshold native Fix one epoch early.  To keep the established
+no-wrong-Fix guard without tuning the ratio threshold, the first
+coherent-MADOCA N1 success is provisional and must be followed by a consecutive
+successful AR attempt.  The already-applied EWL/WL state is retained and
+published as Float during that confirmation epoch.  After the first N1 commit,
+normal single-attempt reacquisition applies.
+
+On the pinned 120-input-epoch MIZU probe, all 118 solution epochs align: native
+and oracle both produce 108 Fix / 10 Float, with zero native-only and zero
+oracle-only Fix.  The native/oracle 3D delta RMS is 0.040094 m, the maximum is
+0.246063 m, and the trailing-1800-second RMS is 0.032859 m.  This satisfies
+every M2 exit criterion.
+
 ### M3 -- Apply L6D ionosphere products
 
 - Promote the proven snapshot lookup from shadow telemetry to an explicit
@@ -440,11 +465,8 @@ remains open.
 
 ## Immediate Slice
 
-Continue M2 from the first float measurement update.  Compare the code-driven
-allocation among position, constellation clocks, ZTD, STEC, receiver-frequency
-biases, and carrier ambiguities before changing admission thresholds.  EWL/WL
-conditioning, PAR availability, active-state filtering, IFB process noise,
-wet-troposphere mapping, and nominal-yaw phase windup have been excluded as the
-remaining status cause.  Preserve the two hard guards established so far:
-never publish a wide-lane-only result as Fix, and never publish a native Fix
+Begin M3 by promoting the proven L6D snapshot lookup from measurement-neutral
+shadow telemetry to an opt-in PPP STEC state and row.  Preserve the completed
+M2 guards: never publish a wide-lane-only result as Fix, require confirmation
+before the first coherent-MADOCA N1 commit, and never publish a native Fix
 outside an oracle Fix epoch.

--- a/docs/madocalib_native_migration.md
+++ b/docs/madocalib_native_migration.md
@@ -85,28 +85,26 @@ does not yet match end-to-end behavior; **open** has no accepted native parity.
 | PPP commit-on-success and diagnostics | Native postfit validation/shadow telemetry | native | MIZU 1 h/6 h/24 h and ALIC regression gates remain green |
 | GLONASS phase in MADOCA PPP | Native L1/L2 rows plus corrected postfit-shadow audit | native | Keep the pinned per-satellite demeaned RMS at millimetre scale and span below 4 cm |
 | MADOCALIB `exec_ppp` | Native PPP runs end to end; remaining solution delta is tracked | partial | M4/M5 matrix meets the declared trajectory thresholds |
-| MADOCALIB `exec_pppar` | Native per-frequency path matches the oracle's 108 Fix / 10 Float in all 118 matched epochs, with no native-only Fix | native | Keep the pinned M2 status, wrong-Fix, and trajectory gates green |
+| MADOCALIB `exec_pppar` | Windows Release matches 108 Fix / 10 Float; authoritative Ubuntu Release reaches 77 Fix / 41 Float, with no native-only Fix | partial | M2 must resolve the 31 Ubuntu oracle-Fix/native-Float epochs |
 | MADOCALIB `exec_pppar-ion` | Bridge profile/input validation exists; native L6D state injection does not | open | M3 then M5 PPP-AR-ion sign-off |
 | Triple/quad-frequency PPP-AR | Upstream 2.0 behavior has not been fully audited or signed off | open | Dedicated fixtures and ambiguity/state parity after dual-frequency M2 |
 | Linked `postpos()` bridge | `madocalib_bridge` | oracle-only | Retain until M6; never select it in production runtime |
 
 ## Current Numerical Baselines
 
-The frozen one-hour MIZU PPP-AR CI window has 118 matched output epochs.  The
-MADOCALIB `pppar` oracle and the native per-frequency path both produce 108 Fix
-and 10 Float.  Status agreement is 118/118, with no native-only or oracle-only
-Fix.  The recorded native/oracle 3D delta RMS is 0.040094 m, the maximum is
-0.246063 m, and the trailing-1800-second RMS is 0.032859 m.
+The frozen one-hour MIZU PPP-AR window has 118 matched output epochs.  On the
+Windows Release evidence lane, the MADOCALIB `pppar` oracle and native path both
+produce 108 Fix / 10 Float.  Status agreement is 118/118, with no native-only
+or oracle-only Fix.  The native/oracle 3D delta RMS is 0.040094 m, the maximum
+is 0.246063 m, and the trailing-1800-second RMS is 0.032859 m.
 
-M2 is complete.  The final discrepancy came from MADOCALIB `satpos_ssr()`
-replacing the broadcast eccentric-anomaly clock-relativity approximation with
-RTKLIB's position/1-ms-forward-velocity dot product.  Harmonic orbit terms made
-the two nominally equivalent forms differ by satellite-specific centimetres.
-After aligning that clock contract, a single near-threshold initial LAMBDA
-candidate ordering could still publish one native Fix one epoch early.  The
-coherent-MADOCA path now requires the first N1 success to repeat on the next AR
-attempt before publishing Fix; thresholds and later reacquisition behavior are
-unchanged.
+The authoritative Ubuntu Release job exposes a remaining numerical path
+difference: oracle remains 108 Fix / 10 Float while native produces 77 Fix /
+41 Float.  Status agreement is 87/118 (73.73%), with no native-only Fix and 31
+oracle-Fix/native-Float epochs.  Full-window native/oracle 3D delta RMS is
+0.155003 m, the maximum is 0.420124 m, and the trailing-1800-second RMS is
+0.212379 m.  M2 therefore remains open even though the Windows lane satisfies
+its status and trajectory criteria.
 
 The float-PPP history and older MIZU/ALIC/full-day measurements remain in issue
 #148 and `madoca_port_plan.md`; they are regression context, not proof that
@@ -383,19 +381,29 @@ shift the tightly weighted carrier residuals and PAR candidate ordering.
 Coherent MADOCA now reproduces the state-vector form with the exact SSR IODE;
 other PPP profiles keep their existing clock convention.
 
-The clock correction alone recovers every oracle Fix but admits one
-near-threshold native Fix one epoch early.  To keep the established
+On Windows Release, the clock correction alone recovers every oracle Fix but
+admits one near-threshold native Fix one epoch early.  To keep the established
 no-wrong-Fix guard without tuning the ratio threshold, the first
 coherent-MADOCA N1 success is provisional and must be followed by a consecutive
 successful AR attempt.  The already-applied EWL/WL state is retained and
 published as Float during that confirmation epoch.  After the first N1 commit,
 normal single-attempt reacquisition applies.
 
-On the pinned 120-input-epoch MIZU probe, all 118 solution epochs align: native
-and oracle both produce 108 Fix / 10 Float, with zero native-only and zero
-oracle-only Fix.  The native/oracle 3D delta RMS is 0.040094 m, the maximum is
-0.246063 m, and the trailing-1800-second RMS is 0.032859 m.  This satisfies
-every M2 exit criterion.
+On the Windows Release probe, all 118 solution epochs align: native and oracle
+both produce 108 Fix / 10 Float, with zero native-only and zero oracle-only Fix.
+The native/oracle 3D delta RMS is 0.040094 m, the maximum is 0.246063 m, and the
+trailing-1800-second RMS is 0.032859 m.
+
+The authoritative Ubuntu Release probe improves from its previous 76 Fix / 42
+Float baseline to 77 Fix / 41 Float, still with zero native-only Fix.  It
+misses 31 oracle Fix epochs, so M2 remains open.  At the first cross-platform
+split (TOW 175260), Windows retains 16 WL pairs and reaches an N1 Fix, while
+Ubuntu retains 15 after E31-E06 crosses the 0.20-cycle WL admission boundary.
+The oracle starts with 18 N1 pairs, excludes only G31 and C09, then fixes 16 at
+ratio 2.333 against its 1.20 dimension-adjusted threshold.  Ubuntu exhausts
+ten PAR exclusions without a fix.  Covariance sigmas remain closely aligned;
+the remaining cause is the accumulated float ambiguity mean and WL candidate
+path, not the SSR clock formula.
 
 ### M3 -- Apply L6D ionosphere products
 
@@ -465,8 +473,10 @@ remains open.
 
 ## Immediate Slice
 
-Begin M3 by promoting the proven L6D snapshot lookup from measurement-neutral
-shadow telemetry to an opt-in PPP STEC state and row.  Preserve the completed
-M2 guards: never publish a wide-lane-only result as Fix, require confirmation
-before the first coherent-MADOCA N1 commit, and never publish a native Fix
-outside an oracle Fix epoch.
+Continue M2 at the first authoritative-CI split, TOW 175260.  Compare the
+Windows, Ubuntu, and oracle float ambiguity means before EWL conditioning,
+after EWL, and at WL admission, starting with E31-E06 and the oracle-only
+G02/G31 pairs.  Preserve the established guards: never publish a
+wide-lane-only result as Fix, require confirmation before the first
+coherent-MADOCA N1 commit, and never publish a native Fix outside an oracle Fix
+epoch.

--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -347,6 +347,7 @@ private:
     double last_ar_ratio_ = 0.0;
     int last_fixed_ambiguities_ = 0;
     bool last_ar_wide_lane_only_ = false;
+    bool madoca_first_n1_confirmation_pending_ = false;
     PPPConvergenceTelemetry convergence_telemetry_;
     PPPARStageTelemetry ar_stage_telemetry_;
     int last_applied_atmos_trop_corrections_ = 0;

--- a/include/libgnss++/algorithms/ppp_correction_contract.hpp
+++ b/include/libgnss++/algorithms/ppp_correction_contract.hpp
@@ -77,6 +77,29 @@ constexpr bool excludePhaseWindupFromAmbiguitySeed(bool madoca_convention) {
     return madoca_convention;
 }
 
+// MADOCALIB satpos_ssr() replaces the broadcast eccentric-anomaly
+// approximation with RTKLIB's state-vector form after ephpos() has formed a
+// 1 ms forward-difference velocity. Harmonic orbit terms make the two forms
+// differ by centimetres for real ephemerides.
+constexpr double madocalibSsrBroadcastClock(double polynomial_clock_s,
+                                            double position_velocity_dot_m2_s,
+                                            double speed_of_light_m_s) {
+    return polynomial_clock_s -
+        2.0 * position_velocity_dot_m2_s /
+            (speed_of_light_m_s * speed_of_light_m_s);
+}
+
+// The first coherent-MADOCA N1 solution is published only after two
+// consecutive successful ambiguity attempts. Once an N1 epoch has been
+// committed, normal single-epoch reacquisition applies.
+constexpr bool deferFirstMadocaN1Fix(bool madoca_convention,
+                                     std::size_t committed_n1_epochs,
+                                     bool confirmation_pending) {
+    return madoca_convention &&
+        committed_n1_epochs == 0 &&
+        !confirmation_pending;
+}
+
 // MADOCALIB's PPP receiver geometry uses its legacy Love-number solid-earth
 // tide model. Keep the IERS model selectable for every other PPP profile.
 constexpr bool useIersSolidEarthTide(bool madoca_convention,

--- a/src/algorithms/ppp_ambiguity.cpp
+++ b/src/algorithms/ppp_ambiguity.cpp
@@ -2,6 +2,7 @@
 
 #include <libgnss++/algorithms/lambda.hpp>
 #include <libgnss++/algorithms/ppp_ar.hpp>
+#include <libgnss++/algorithms/ppp_correction_contract.hpp>
 #include <libgnss++/algorithms/ppp_multifrequency.hpp>
 #include <libgnss++/algorithms/ppp_utils.hpp>
 #include <libgnss++/core/constants.hpp>
@@ -370,6 +371,13 @@ bool PPPProcessor::resolveAmbiguitiesDecoupledIf(const ObservationData& obs,
 
 bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
                                              const NavigationData& nav) {
+    // Consume the prior epoch's provisional success at the start of every
+    // attempt. Any early return below therefore breaks the required
+    // consecutive-success sequence.
+    const bool had_madoca_n1_confirmation =
+        madoca_first_n1_confirmation_pending_;
+    madoca_first_n1_confirmation_pending_ = false;
+
     last_ar_ratio_ = 0.0;
     last_fixed_ambiguities_ = 0;
     ++ar_stage_telemetry_.per_frequency_attempts;
@@ -998,6 +1006,25 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
         return false;
     }
 
+    // Require one independent epoch of confirmation before the first
+    // coherent-MADOCA N1 commit. This keeps the first ratio/PAR success
+    // provisional (the already-applied EWL/WL state is retained) and prevents
+    // a single sensitive LAMBDA candidate ordering from publishing an early
+    // Fix. Subsequent accepted epochs use the normal commit path.
+    if (algorithms::ppp_correction_contract::deferFirstMadocaN1Fix(
+            require_coherent_ssr_,
+            ar_stage_telemetry_.n1_fixed_epochs,
+            had_madoca_n1_confirmation)) {
+        madoca_first_n1_confirmation_pending_ = true;
+        last_ar_ratio_ = ratio;
+        last_fixed_ambiguities_ = nwl;
+        ++ar_stage_telemetry_.wide_lane_only_epochs;
+        ar_stage_telemetry_.last_stage =
+            "wide_lane_only_n1_confirmation_pending";
+        last_ar_wide_lane_only_ = true;
+        return false;
+    }
+
     // 5) Apply the fixed N1 double differences as a tight Kalman pseudo-obs on
     //    the L1 ambiguity states (cycles).
     MatrixXd Hn = MatrixXd::Zero(nb, nx);
@@ -1067,6 +1094,7 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
     last_ar_ratio_ = ratio;
     last_fixed_ambiguities_ = nb;
     ++ar_stage_telemetry_.n1_fixed_epochs;
+    madoca_first_n1_confirmation_pending_ = false;
     ar_stage_telemetry_.last_stage = "n1_fixed";
     return true;
 }

--- a/src/algorithms/ppp_corrections.cpp
+++ b/src/algorithms/ppp_corrections.cpp
@@ -979,6 +979,55 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                     observation.valid = false;
                     continue;
                 }
+                // satpos_ssr() recomputes the broadcast clock relativity term
+                // from the state-vector dot product after ephpos() forms its
+                // 1 ms forward-difference velocity. The usual eccentric-
+                // anomaly expression differs by centimetres once harmonic
+                // orbit terms are included, which is enough to alter the
+                // tightly weighted MADOCA carrier update and N1 candidates.
+                const Ephemeris* ssr_eph =
+                    nav.getEphemeris(
+                        observation.satellite, emission_time, ssr_orbit_iode);
+                const bool madocalib_ssr_clock_system =
+                    observation.satellite.system == GNSSSystem::GPS ||
+                    observation.satellite.system == GNSSSystem::Galileo ||
+                    observation.satellite.system == GNSSSystem::QZSS ||
+                    observation.satellite.system == GNSSSystem::BeiDou;
+                if (require_coherent_ssr_ && madocalib_ssr_clock_system) {
+                    if (ssr_eph == nullptr) {
+                        observation.valid = false;
+                        continue;
+                    }
+                    constexpr double kRtklibVelocityStepSeconds = 1.0e-3;
+                    Vector3d forward_position = Vector3d::Zero();
+                    Vector3d ignored_velocity = Vector3d::Zero();
+                    double ignored_clock_bias = 0.0;
+                    double ignored_clock_drift = 0.0;
+                    if (!ssr_eph->calculateSatelliteState(
+                            emission_time + kRtklibVelocityStepSeconds,
+                            forward_position,
+                            ignored_velocity,
+                            ignored_clock_bias,
+                            ignored_clock_drift)) {
+                        observation.valid = false;
+                        continue;
+                    }
+                    const Vector3d rtklib_velocity =
+                        (forward_position - sat_position) /
+                        kRtklibVelocityStepSeconds;
+                    const double tc = emission_time - ssr_eph->toc;
+                    const double polynomial_clock =
+                        ssr_eph->af0 + ssr_eph->af1 * tc +
+                        ssr_eph->af2 * tc * tc;
+                    sat_clock_bias =
+                        algorithms::ppp_correction_contract::
+                            madocalibSsrBroadcastClock(
+                                polynomial_clock,
+                                sat_position.dot(rtklib_velocity),
+                                constants::SPEED_OF_LIGHT);
+                    sat_clock_drift =
+                        ssr_eph->af1 + 2.0 * ssr_eph->af2 * tc;
+                }
             }
         }
 

--- a/tests/test_ppp_correction_contract.cpp
+++ b/tests/test_ppp_correction_contract.cpp
@@ -1,11 +1,36 @@
 #include <gtest/gtest.h>
 
 #include <libgnss++/algorithms/ppp_correction_contract.hpp>
+#include <libgnss++/core/constants.hpp>
 
 #include <set>
 #include <string>
 
 namespace contract = libgnss::algorithms::ppp_correction_contract;
+
+TEST(PPPCorrectionContractTest, MadocalibSsrClockUsesStateVectorRelativity) {
+    constexpr double polynomial_clock_s = 5.0e-4;
+    constexpr double position_velocity_dot_m2_s = 1.25e11;
+    constexpr double expected_relativity_s =
+        -2.0 * position_velocity_dot_m2_s /
+        (libgnss::constants::SPEED_OF_LIGHT *
+         libgnss::constants::SPEED_OF_LIGHT);
+
+    EXPECT_DOUBLE_EQ(
+        contract::madocalibSsrBroadcastClock(
+            polynomial_clock_s,
+            position_velocity_dot_m2_s,
+            libgnss::constants::SPEED_OF_LIGHT),
+        polynomial_clock_s + expected_relativity_s);
+}
+
+TEST(PPPCorrectionContractTest,
+     FirstMadocaN1FixRequiresOneConsecutiveConfirmation) {
+    EXPECT_TRUE(contract::deferFirstMadocaN1Fix(true, 0, false));
+    EXPECT_FALSE(contract::deferFirstMadocaN1Fix(false, 0, false));
+    EXPECT_FALSE(contract::deferFirstMadocaN1Fix(true, 0, true));
+    EXPECT_FALSE(contract::deferFirstMadocaN1Fix(true, 1, false));
+}
 
 TEST(PPPCorrectionContractTest, ApplicationStagesAreUniqueAndOrdered) {
     std::set<contract::Stage> stages;


### PR DESCRIPTION
## Summary

- reproduce MADOCALIB `satpos_ssr()` broadcast-clock relativity using the RTKLIB 1 ms forward-difference state vector
- require one consecutive confirmation before the first coherent-MADOCA N1 Fix commit, without changing the ratio threshold or later reacquisition
- add Ubuntu regression gates for the accepted safety and trajectory envelope
- record the remaining cross-platform M2 blocker instead of claiming milestone completion

## Root cause addressed

Native retained the broadcast eccentric-anomaly relativity term, while MADOCALIB replaces it with `-2 * dot(position, velocity) / c^2`. Harmonic orbit terms make these nominally equivalent forms differ by satellite-specific centimetres, shifting carrier residuals and PAR candidate ordering. On Windows, aligning this clock recovers every oracle Fix but admits one near-threshold Fix one epoch early, so the first coherent-MADOCA N1 success is now provisional until the next AR attempt succeeds too.

## Validation

- build: `gnss_ppp` and `run_tests`
- PPP tests: 158 passed, 1 expected dedicated-process skip
- correction-contract tests: 8 passed
- solution-diff Python tests: 4 passed
- Windows Release: 118/118 status agreement, 108 Fix / 10 Float in both implementations, zero native-only Fix, zero missed Fix; 3D delta RMS 0.040094 m, maximum 0.246063 m
- Ubuntu Release CI: improves from 76 Fix / 42 Float to 77 Fix / 41 Float, zero native-only Fix; 3D delta RMS 0.155003 m, maximum 0.420124 m

## Remaining M2 blocker

The authoritative Ubuntu lane still misses 31 oracle Fix epochs. At the first split, TOW 175260, Windows retains 16 WL pairs while Ubuntu retains 15 after E31-E06 crosses the 0.20-cycle WL boundary. The oracle starts with 18 N1 pairs and fixes 16 after two PAR exclusions; Ubuntu exhausts ten exclusions. The migration ledger now records this float-mean/WL-candidate difference as the next slice.

Refs #148
