### PR TITLE
Fix MADOCA ionosphere history after cycle slips

### DIFF
--- a/src/algorithms/ppp_internal.hpp
+++ b/src/algorithms/ppp_internal.hpp
@@ -53,6 +53,16 @@ inline std::set<SignalType> geometryFreeSlippedSignals(
     return slipped;
 }
 
+inline void clearCarrierIonospherePredictionHistory(
+    ppp_shared::PPPAmbiguityInfo& ambiguity) {
+    // A geometry-free discontinuity invalidates the carrier-derived temporal
+    // ionosphere delta along with the affected ambiguities. Applying that
+    // discontinuity to the ionosphere state before re-seeding the ambiguities
+    // double-counts the slip; MADOCALIB keeps the ionosphere state unchanged
+    // on the reset epoch and establishes a new carrier baseline instead.
+    ambiguity.has_last_carrier_ionosphere = false;
+}
+
 inline int perFrequencyArMinLockCount(bool madoca_per_frequency,
                                       bool ssr_products_loaded,
                                       int convergence_min_epochs) {

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -1833,6 +1833,7 @@ void PPPProcessor::resetMadocaAmbiguityFrequencies(
     ambiguity.fractional_bias_samples = 0;
     ambiguity.wl_is_fixed = false;
     ambiguity.nl_is_fixed = false;
+    ppp_internal::clearCarrierIonospherePredictionHistory(ambiguity);
     ambiguity.frequency_lifecycle.erase(primary_signal);
     for (const auto signal : slipped_nonprimary_signals) {
         ambiguity.frequency_lifecycle.erase(signal);

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -134,6 +134,17 @@ TEST(PPPCycleSlips, MadocaChecksEveryNonPrimaryFrequency) {
         0.15).empty());
 }
 
+TEST(PPPCycleSlips, MadocaResetInvalidatesCarrierIonosphereDeltaHistory) {
+    ppp_shared::PPPAmbiguityInfo ambiguity;
+    ambiguity.last_carrier_ionosphere_m = 19.7377;
+    ambiguity.has_last_carrier_ionosphere = true;
+
+    ppp_internal::clearCarrierIonospherePredictionHistory(ambiguity);
+
+    EXPECT_FALSE(ambiguity.has_last_carrier_ionosphere);
+    EXPECT_DOUBLE_EQ(ambiguity.last_carrier_ionosphere_m, 19.7377);
+}
+
 TEST(PPPArAdmission, CoherentSsrDoesNotAddALockCountGate) {
     EXPECT_EQ(ppp_internal::perFrequencyArMinLockCount(true, true, 20), 0);
     EXPECT_EQ(ppp_internal::perFrequencyArMinLockCount(false, true, 20), 10);


### PR DESCRIPTION
## Summary
- invalidate carrier-derived ionosphere delta history when coherent MADOCA resets only the affected ambiguity frequencies
- establish a fresh carrier-ionosphere baseline after a geometry-free discontinuity instead of applying the slip jump to the ionosphere state
- add a focused cycle-slip regression test

## Root cause
At GPS TOW 175020 and later G31 geometry-free reset epochs, the per-frequency ambiguity lifecycle was reset but `has_last_carrier_ionosphere` remained set. After ambiguity re-seeding, the carrier discontinuity was therefore applied once more as a temporal ionosphere delta. MADOCALIB keeps the ionosphere state unchanged on the reset epoch and establishes a new carrier baseline.

Refs #148

## Validation
- `PPPCycleSlips.*`: 3/3 passed on Windows Release
- Windows 120-epoch MIZU parity: 108 Fix / 10 Float, 118/118 status agreement, no wrong Fix; 3D delta RMS 0.05294 m, max 0.41981 m
- Ubuntu 120-epoch MIZU parity: 83 Fix / 35 Float, no wrong Fix; 3D delta RMS 0.17259 m, max 0.42889 m
- `git diff --check`

The complete Windows `run_tests` binary ran 740 tests: 687 passed, 51 skipped, and 2 pre-existing/environmental failures unrelated to this change (`NlosWeightsTest.MissingRequiredColumnsThrows` has a Windows temporary-file sharing violation; `MadocaBridgeConfig.TideOracleIsAlsoOptIn` reflects this parity-linked build configuration). The focused suite passes.