### PR TITLE
Stabilize MADOCA N1 partial-AR subset selection

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -698,9 +698,13 @@ jobs:
           test "$matched_epochs" -eq 118
           oracle_fixes="$(awk -F, 'NR > 1 && $5 == 1 {n++} END {print n+0}' madoca_pppar_solution_matches.csv)"
           test "$oracle_fixes" -eq 108
-          test "$fixed_solutions" -ge 83
+          test "$fixed_solutions" -eq "$oracle_fixes"
           wrong_fixes="$(awk -F, 'NR > 1 && $6 == 6 && $5 != 1 {n++} END {print n+0}' madoca_pppar_solution_matches.csv)"
           test "$wrong_fixes" -eq 0
+          missed_fixes="$(awk -F, 'NR > 1 && $5 == 1 && $6 != 6 {n++} END {print n+0}' madoca_pppar_solution_matches.csv)"
+          test "$missed_fixes" -eq 0
+          status_mismatches="$(awk -F, 'NR > 1 && !(($5 == 1 && $6 == 6) || ($5 == 6 && $6 == 5)) {n++} END {print n+0}' madoca_pppar_solution_matches.csv)"
+          test "$status_mismatches" -eq 0
           python3 -c 'import json; d=json.load(open("madoca_pppar_solution_diff.json")); assert d["comparison"]["delta_rms_3d_m"] <= 0.2; assert d["events"]["max_delta_3d"]["delta_3d_m"] <= 1.0'
 
     - name: Upload MADOCA PPP-AR baseline

--- a/docs/madocalib_native_migration.md
+++ b/docs/madocalib_native_migration.md
@@ -85,26 +85,23 @@ does not yet match end-to-end behavior; **open** has no accepted native parity.
 | PPP commit-on-success and diagnostics | Native postfit validation/shadow telemetry | native | MIZU 1 h/6 h/24 h and ALIC regression gates remain green |
 | GLONASS phase in MADOCA PPP | Native L1/L2 rows plus corrected postfit-shadow audit | native | Keep the pinned per-satellite demeaned RMS at millimetre scale and span below 4 cm |
 | MADOCALIB `exec_ppp` | Native PPP runs end to end; remaining solution delta is tracked | partial | M4/M5 matrix meets the declared trajectory thresholds |
-| MADOCALIB `exec_pppar` | Windows Release matches 108 Fix / 10 Float; authoritative Ubuntu Release reaches 83 Fix / 35 Float, with no native-only Fix | partial | M2 must resolve the 25 Ubuntu oracle-Fix/native-Float epochs |
+| MADOCALIB `exec_pppar` | Windows and authoritative Ubuntu Release both match the oracle's 108 Fix / 10 Float over all 118 epochs | native | Keep exact status agreement, no wrong/missed Fix, RMS at most 0.20 m, and maximum at most 1.0 m |
 | MADOCALIB `exec_pppar-ion` | Bridge profile/input validation exists; native L6D state injection does not | open | M3 then M5 PPP-AR-ion sign-off |
 | Triple/quad-frequency PPP-AR | Upstream 2.0 behavior has not been fully audited or signed off | open | Dedicated fixtures and ambiguity/state parity after dual-frequency M2 |
 | Linked `postpos()` bridge | `madocalib_bridge` | oracle-only | Retain until M6; never select it in production runtime |
 
 ## Current Numerical Baselines
 
-The frozen one-hour MIZU PPP-AR window has 118 matched output epochs.  On the
-Windows Release evidence lane, the MADOCALIB `pppar` oracle and native path both
-produce 108 Fix / 10 Float.  Status agreement is 118/118, with no native-only
-or oracle-only Fix.  The native/oracle 3D delta RMS is 0.040094 m, the maximum
-is 0.246063 m, and the trailing-1800-second RMS is 0.032859 m.
+The frozen one-hour MIZU PPP-AR window has 118 matched output epochs.  On both
+the Windows Release evidence lane and the authoritative Ubuntu Release lane,
+the MADOCALIB `pppar` oracle and native path produce 108 Fix / 10 Float with
+exact 118/118 status agreement and no native-only or oracle-only Fix.
 
-The authoritative Ubuntu Release job exposes a remaining numerical path
-difference: oracle remains 108 Fix / 10 Float while native produces 83 Fix /
-35 Float.  Status agreement is 93/118 (78.81%), with no native-only Fix and 25
-oracle-Fix/native-Float epochs.  Full-window native/oracle 3D delta RMS is
-0.172757 m, the maximum is 0.439642 m, and the trailing-1800-second RMS is
-0.237799 m.  M2 therefore remains open even though the Windows lane satisfies
-its status and trajectory criteria.
+On Windows, the native/oracle 3D delta RMS is 0.054269 m, the maximum is
+0.419804 m, and the trailing-1800-second RMS is 0.035616 m.  On Ubuntu, the
+3D delta RMS is 0.189146 m and the maximum is 0.451489 m.  These results meet
+the M2 status and trajectory exit gates.  M3--M6 remain open, so this does not
+complete the overall migration.
 
 The float-PPP history and older MIZU/ALIC/full-day measurements remain in issue
 #148 and `madoca_port_plan.md`; they are regression context, not proof that
@@ -430,6 +427,45 @@ native-only Fix.  Full-window 3D delta RMS is 0.172757 m and the maximum is
 0.439642 m.  Twenty-five oracle-Fix/native-Float epochs remain, beginning at
 TOW 175320, so M2 remains open.
 
+#### M2m -- Frequency-scoped STEC discontinuity reset
+
+At the first remaining miss, G31 suffered a frequency-specific carrier slip.
+MADOCALIB reset that carrier ambiguity and then cleared the carrier-derived
+ionosphere-delta history before the next STEC prediction.  Native reset the
+ambiguity but retained the old delta baseline, so it counted the same carrier
+discontinuity again in the ionosphere prediction and displaced the ambiguity
+mean used by partial AR.
+
+The native frequency-scoped reset now also clears the affected carrier's
+ionosphere-delta history.  At TOW 175320, G31's pre-update native STEC then
+agrees with the oracle within 0.039 m and its post-update STEC within 0.006 m.
+Ubuntu remains at 83 Fix / 35 Float with no wrong Fix; full-window 3D delta RMS
+is 0.172594 m and the maximum is 0.428885 m.  Windows remains exactly 108 Fix /
+10 Float.  The state-transition defect is removed, but M2 remains open because
+the cross-platform ambiguity-gauge sensitivity still requires an admission
+rule that is deterministic for equivalent valid partial-AR subsets.
+
+#### M2n -- One-removal N1 subset lookahead
+
+MADOCALIB's partial AR greedily removes the lowest-elevation satellite on which
+the first two LAMBDA candidates disagree.  After the STEC reset was aligned,
+weak ambiguity/STEC gauge differences still changed that disagreement set and
+therefore the greedy removal order across platforms.  At TOW 175320, the
+ordinary 14-pair Ubuntu set rejects at ratio 1.3746; removing the implicated
+G26 pair produces a 13-pair child at ratio 1.5179 against its unchanged 1.20
+threshold and passes the existing candidate-agreement gate.
+
+Before taking the greedy removal, coherent MADOCA per-frequency AR now examines
+implicated one-satellite children in canonical order and accepts the first one
+that already passes the same LAMBDA ratio, dimension, and candidate-agreement
+contracts.  It adds no ambiguity candidate and relaxes no threshold.  When no
+child passes, the previous MADOCALIB-compatible greedy path is unchanged.
+
+Both Windows and authoritative Ubuntu Release now match the oracle's 108 Fix /
+10 Float at all 118 epochs, with no wrong or missed Fix.  Windows 3D delta RMS
+is 0.054269 m with a 0.419804 m maximum; Ubuntu RMS is 0.189146 m with a
+0.451489 m maximum.  The M2 exit criteria are therefore satisfied.
+
 ### M3 -- Apply L6D ionosphere products
 
 - Promote the proven snapshot lookup from shadow telemetry to an explicit
@@ -498,9 +534,9 @@ remains open.
 
 ## Immediate Slice
 
-Continue M2 at the next authoritative-CI miss, TOW 175320.  Compare the
-MW-supported 16-pair native N1 set with the oracle's 18-pair set, especially
-the oracle-only G02/G31 rows and the differing partial-AR exclusion order.
-Preserve the established guards: never publish a wide-lane-only result as Fix,
-require confirmation before the first coherent-MADOCA N1 commit, and never
-publish a native Fix outside an oracle Fix epoch.
+Begin M3 by promoting the existing measurement-neutral L6D shadow lookup to an
+explicit opt-in STEC input.  First pin receiver-area selection, correction age,
+delay, standard deviation, signal coefficient, and snapshot application keys;
+then compare the common native/oracle `pppar-ion` residual rows before judging
+Fix status or trajectories.  Preserve the established M2 guards and keep the
+feature opt-in until the M5 matrix passes.

--- a/src/algorithms/ppp_ambiguity.cpp
+++ b/src/algorithms/ppp_ambiguity.cpp
@@ -893,6 +893,68 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
     bool n1_accepted = false;
     bool lambda_failed = false;
 
+    const auto build_n1_problem =
+        [&](const std::vector<int>& selection,
+            VectorXd& float_values,
+            MatrixXd& covariance) {
+            const int count = static_cast<int>(selection.size());
+            float_values = VectorXd::Zero(count);
+            covariance = MatrixXd::Zero(count, count);
+            for (int k = 0; k < count; ++k) {
+                const DdPair& pair_k = wl_pairs[static_cast<size_t>(
+                    selection[static_cast<size_t>(k)])];
+                const Cand& rk = cands[static_cast<size_t>(pair_k.ref)];
+                const Cand& sk = cands[static_cast<size_t>(pair_k.sat)];
+                float_values(k) =
+                    filter_state_.state(rk.l1_index) / rk.lambda1 -
+                    filter_state_.state(sk.l1_index) / sk.lambda1;
+                for (int l = 0; l < count; ++l) {
+                    const DdPair& pair_l = wl_pairs[static_cast<size_t>(
+                        selection[static_cast<size_t>(l)])];
+                    const Cand& rl = cands[static_cast<size_t>(pair_l.ref)];
+                    const Cand& sl = cands[static_cast<size_t>(pair_l.sat)];
+                    covariance(k, l) =
+                        filter_state_.covariance(
+                            rk.l1_index, rl.l1_index) /
+                            (rk.lambda1 * rl.lambda1) -
+                        filter_state_.covariance(
+                            rk.l1_index, sl.l1_index) /
+                            (rk.lambda1 * sl.lambda1) -
+                        filter_state_.covariance(
+                            sk.l1_index, rl.l1_index) /
+                            (sk.lambda1 * rl.lambda1) +
+                        filter_state_.covariance(
+                            sk.l1_index, sl.l1_index) /
+                            (sk.lambda1 * sl.lambda1);
+                }
+            }
+        };
+    const auto n1_ratio_threshold =
+        [&](int count,
+            const VectorXd& fixed,
+            const VectorXd& second,
+            double& match_rate) {
+            double threshold = ppp_config_.ar_ratio_threshold;
+            const int dimension_offset = count - kMinN1Ambiguities;
+            if (dimension_offset >= 0 && dimension_offset < 5) {
+                threshold *= kDimensionThresholdFactors[dimension_offset];
+            }
+            int matching = 0;
+            for (int k = 0; k < count; ++k) {
+                if (std::abs(fixed(k) - second(k)) < 0.001) {
+                    ++matching;
+                }
+            }
+            match_rate = static_cast<double>(matching) / count;
+            if (match_rate > 0.90) {
+                threshold *= 0.8;
+            }
+            if (match_rate < 0.10) {
+                threshold = 99.99;
+            }
+            return threshold;
+        };
+
     // MADOCALIB partial AR: when the ratio test rejects the full set, remove
     // one non-reference satellite implicated by the disagreement between the
     // first and second LAMBDA candidates, then retry.  QZSS and BDS IGSO are
@@ -903,31 +965,9 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
             break;
         }
 
-        VectorXd n1_float = VectorXd::Zero(trial_nb);
-        MatrixXd n1_cov = MatrixXd::Zero(trial_nb, trial_nb);
-        for (int k = 0; k < trial_nb; ++k) {
-            const DdPair& pair_k =
-                wl_pairs[static_cast<size_t>(n1_sel[static_cast<size_t>(k)])];
-            const Cand& rk = cands[static_cast<size_t>(pair_k.ref)];
-            const Cand& sk = cands[static_cast<size_t>(pair_k.sat)];
-            n1_float(k) = filter_state_.state(rk.l1_index) / rk.lambda1 -
-                          filter_state_.state(sk.l1_index) / sk.lambda1;
-            for (int l = 0; l < trial_nb; ++l) {
-                const DdPair& pair_l =
-                    wl_pairs[static_cast<size_t>(n1_sel[static_cast<size_t>(l)])];
-                const Cand& rl = cands[static_cast<size_t>(pair_l.ref)];
-                const Cand& sl = cands[static_cast<size_t>(pair_l.sat)];
-                n1_cov(k, l) =
-                    filter_state_.covariance(rk.l1_index, rl.l1_index) /
-                        (rk.lambda1 * rl.lambda1) -
-                    filter_state_.covariance(rk.l1_index, sl.l1_index) /
-                        (rk.lambda1 * sl.lambda1) -
-                    filter_state_.covariance(sk.l1_index, rl.l1_index) /
-                        (sk.lambda1 * rl.lambda1) +
-                    filter_state_.covariance(sk.l1_index, sl.l1_index) /
-                        (sk.lambda1 * sl.lambda1);
-            }
-        }
+        VectorXd n1_float;
+        MatrixXd n1_cov;
+        build_n1_problem(n1_sel, n1_float, n1_cov);
         if (env_overrides_.pfdump) {
             for (int k = 0; k < trial_nb; ++k) {
                 const DdPair& pair =
@@ -949,25 +989,9 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
             break;
         }
 
-        effective_threshold = ppp_config_.ar_ratio_threshold;
-        const int dimension_offset = trial_nb - kMinN1Ambiguities;
-        if (dimension_offset >= 0 && dimension_offset < 5) {
-            effective_threshold *= kDimensionThresholdFactors[dimension_offset];
-        }
-        int matching_candidates = 0;
-        for (int k = 0; k < trial_nb; ++k) {
-            if (std::abs(n1_fixed(k) - n1_second(k)) < 0.001) {
-                ++matching_candidates;
-            }
-        }
-        const double match_rate =
-            static_cast<double>(matching_candidates) / trial_nb;
-        if (match_rate > 0.90) {
-            effective_threshold *= 0.8;
-        }
-        if (match_rate < 0.10) {
-            effective_threshold = 99.99;
-        }
+        double match_rate = 0.0;
+        effective_threshold = n1_ratio_threshold(
+            trial_nb, n1_fixed, n1_second, match_rate);
         ar_stage_telemetry_.last_n1_candidates = trial_nb;
         ar_stage_telemetry_.last_n1_ratio = ratio;
         if (env_overrides_.pfdump) {
@@ -986,6 +1010,82 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
         }
 
         int exclude_position = -1;
+        // The oracle's greedy lowest-elevation removal is deterministic for
+        // its float means, but a weak ambiguity/STEC gauge can change the
+        // disagreement set across platforms. Before committing that removal,
+        // test each implicated one-satellite child with the same LAMBDA ratio,
+        // dimension, and candidate-agreement gates. This adds no candidate and
+        // relaxes no threshold: it only accepts a subset that already passes
+        // the ordinary N1 contract. If none passes, retain the oracle's greedy
+        // removal below.
+        if (require_coherent_ssr_ && ssr_products_loaded_) {
+            for (int removed = 0; removed < trial_nb; ++removed) {
+                if (std::abs(n1_fixed(removed) - n1_second(removed)) < 0.001) {
+                    continue;
+                }
+                std::vector<int> child_sel = n1_sel;
+                child_sel.erase(child_sel.begin() + removed);
+                const int child_nb = static_cast<int>(child_sel.size());
+                if (child_nb < kMinN1Ambiguities) {
+                    continue;
+                }
+                VectorXd child_float;
+                MatrixXd child_cov;
+                build_n1_problem(child_sel, child_float, child_cov);
+                VectorXd child_fixed;
+                VectorXd child_second;
+                double child_ratio = 0.0;
+                if (!lambdaSearchCandidates(
+                        child_float,
+                        child_cov,
+                        child_fixed,
+                        child_second,
+                        child_ratio) ||
+                    !std::isfinite(child_ratio)) {
+                    continue;
+                }
+                double child_match_rate = 0.0;
+                const double child_threshold = n1_ratio_threshold(
+                    child_nb,
+                    child_fixed,
+                    child_second,
+                    child_match_rate);
+                const double child_score =
+                    child_threshold > 0.0
+                        ? child_ratio / child_threshold
+                        : -std::numeric_limits<double>::infinity();
+                if (env_overrides_.pfdump) {
+                    const DdPair& removed_pair =
+                        wl_pairs[static_cast<size_t>(
+                            n1_sel[static_cast<size_t>(removed)])];
+                    std::cerr << "[PFN1-LOOKAHEAD] removed="
+                              << cands[static_cast<size_t>(
+                                     removed_pair.sat)].sat.toString()
+                              << " ratio=" << child_ratio
+                              << " threshold=" << child_threshold
+                              << " match_rate=" << child_match_rate
+                              << " score=" << child_score << "\n";
+                }
+                if (madocaHighAgreementRatioAccepted(
+                        true,
+                        child_ratio,
+                        child_threshold,
+                        child_match_rate)) {
+                    n1_sel = std::move(child_sel);
+                    n1_fixed = std::move(child_fixed);
+                    n1_second = std::move(child_second);
+                    ratio = child_ratio;
+                    effective_threshold = child_threshold;
+                    n1_accepted = true;
+                    ar_stage_telemetry_.last_n1_candidates = child_nb;
+                    ar_stage_telemetry_.last_n1_ratio = ratio;
+                    break;
+                }
+            }
+            if (n1_accepted) {
+                break;
+            }
+        }
         double lowest_priority_elevation = std::numeric_limits<double>::infinity();
         for (int k = 0; k < trial_nb; ++k) {
             if (std::abs(n1_fixed(k) - n1_second(k)) < 0.001) {


### PR DESCRIPTION
## Summary

- factor N1 float/covariance and ratio-threshold construction into shared local helpers
- before MADOCALIB-compatible greedy PAR removal, examine disagreement-implicated one-satellite children in canonical order
- accept only the first child that already passes the existing LAMBDA ratio, dimension, candidate-agreement, and high-agreement gates; otherwise retain the prior greedy path unchanged
- strengthen the MADOCA parity CI gate from the old Ubuntu 83-Fix floor to exact 118-epoch Fix/Float agreement with no wrong or missed Fix
- record M2m/M2n evidence and mark the `exec_pppar` M2 surface native

## Cause

After the carrier-derived ionosphere history reset was aligned in #379, weak ambiguity/STEC gauge differences could still alter which LAMBDA coordinates disagreed across platforms. That changed MADOCALIB's greedy lowest-elevation removal order even when another implicated one-removal child already satisfied the ordinary N1 contract.

At TOW 175320, the Ubuntu 14-pair set rejects at ratio 1.3746. Removing implicated G26 yields a 13-pair child at ratio 1.5179 against the unchanged 1.20 threshold and passes the existing agreement gate.

## Evidence

Pinned 120-input / 118-output MIZU PPP-AR window:

- Ubuntu 22.04 Release: 108 Fix / 10 Float; exact 118/118 oracle status agreement; wrong Fix 0; missed Fix 0; 3D delta RMS 0.189146 m; maximum 0.451489 m
- Windows Release: 108 Fix / 10 Float; exact 118/118 oracle status agreement; wrong Fix 0; missed Fix 0; 3D delta RMS 0.054269 m; maximum 0.419804 m
- repeated Ubuntu run is byte-identical
- `git diff --check`
- Windows Release build of `gnss_ppp` and `run_tests`
- focused PPP AR/cycle-slip/ionosphere tests: 9/9 passed
- full tests: 687 passed, 51 skipped, 2 pre-existing/configuration-dependent failures (`NlosWeightsTest.MissingRequiredColumnsThrows`, `MadocaBridgeConfig.TideOracleIsAlsoOptIn`)

Refs #148. M3-M6 remain open, so this PR does not close the tracker.