### PR TITLE
Fix MADOCA L6D secondary-channel snapshot time

### DIFF
--- a/docs/madocalib_native_migration.md
+++ b/docs/madocalib_native_migration.md
@@ -479,6 +479,26 @@ within `1e-6`; the configured common residual row set has no unmatched rows;
 MIZU `pppar-ion` produces no wrong Fix and improves or preserves M2 trajectory
 metrics.  The feature remains opt-in until M5.
 
+#### M3 prerequisite -- key snapshots by the completed L6D message
+
+The file decoder previously keyed every snapshot with `decodeTime()`, whose
+contract is the primary PRN-200 channel time used by the global staleness gate.
+When a PRN-201 ionosphere message completed independently, its satellite
+correction times advanced but the snapshot key remained at the PRN-200
+reference time.  A downstream causal lookup could therefore select a snapshot
+whose corrections appeared about 3,487 seconds in the future and reject every
+one against MADOCALIB's 300-second age gate.
+
+`messageTime()` now records the channel time of the most recently completed
+message, while `decodeTime()` retains its primary-channel contract.  File
+snapshots use `messageTime()`.  The real MIZU PRN-201 fixture verifies that no
+satellite correction is newer than its snapshot and that completed corrections
+share the snapshot time.  In a layered, not-yet-published M3 STEC application
+experiment, this changes the first valid epochs from zero accepted rows to
+9, 9, and 10 rows, each with a 24-second correction age.  This establishes the
+causal snapshot fix as a prerequisite; row/value and solution parity remain M3
+work.
+
 ### M4 -- Close remaining row and boundary differences
 
 - Resolve QZSS atmosphere admission and every unexplained native-only or
@@ -534,9 +554,10 @@ remains open.
 
 ## Immediate Slice
 
-Begin M3 by promoting the existing measurement-neutral L6D shadow lookup to an
-explicit opt-in STEC input.  First pin receiver-area selection, correction age,
-delay, standard deviation, signal coefficient, and snapshot application keys;
-then compare the common native/oracle `pppar-ion` residual rows before judging
-Fix status or trajectories.  Preserve the established M2 guards and keep the
+Begin M3 by landing the completed-message snapshot-time prerequisite, then
+promote the existing measurement-neutral L6D shadow lookup to an explicit
+opt-in STEC input.  Pin receiver-area selection, correction age, delay,
+standard deviation, signal coefficient, and snapshot application keys; then
+compare the common native/oracle `pppar-ion` residual rows before judging Fix
+status or trajectories.  Preserve the established M2 guards and keep the
 feature opt-in until the M5 matrix passes.

--- a/include/libgnss++/io/madoca_l6d.hpp
+++ b/include/libgnss++/io/madoca_l6d.hpp
@@ -72,6 +72,11 @@ public:
     // the staleness gate consumed by MadocaIonoStore::getCorr / miono_get_corr.
     const MadocaGtime& decodeTime() const { return channels_[0].gt; }
 
+    // Epoch of the most recently completed message, mirroring
+    // mdcl6d_t::time. Unlike decodeTime(), this advances for PRN 201/197 and is
+    // therefore the causal key for file snapshots from a secondary channel.
+    const MadocaGtime& messageTime() const { return last_message_time_; }
+
     // Mirror postpos.c update_qzssl6d() reset of the scratch region between
     // messages: clear rvalid and every area's avalid plus per-sat t0.time.
     void clearRegionAfterUse();
@@ -101,6 +106,7 @@ private:
     int nbyte_ = 0;
     MadocaGtime seed_;                  // week-determination reference epoch
     ChannelState channels_[kMaxPrn];
+    MadocaGtime last_message_time_;
     MadocaIonoRegion re_;               // decoded scratch region (mdcl6d.re)
     int rid_ = 0;                       // decoded region ID (mdcl6d.rid)
 };

--- a/src/io/madoca_l6d.cpp
+++ b/src/io/madoca_l6d.cpp
@@ -196,6 +196,7 @@ void MadocaL6dDecoder::reset() {
         channels_[p] = ChannelState{};
         channels_[p].gt = seed_;  // seed week-number determination
     }
+    last_message_time_ = seed_;
     re_ = MadocaIonoRegion{};
     rid_ = 0;
 }
@@ -422,6 +423,11 @@ int MadocaL6dDecoder::decodeL6dMessage() {
         if (i >= imax) break;
     }
     ch.maxframe = 0;
+    // MADOCALIB assigns mdcl6d->time from the channel that completed this
+    // message. The primary-channel clock remains a separate global staleness
+    // gate; using it as a secondary-file snapshot key placed every PRN-201
+    // update at the reference epoch and exposed future per-satellite t0 values.
+    last_message_time_ = ch.gt;
     return ret;
 }
 
@@ -691,7 +697,7 @@ bool decodeMadocaL6dFileToSnapshots(
         }
         ++completed_messages;
         store->update(decoder->regionId(), decoder->region());
-        appendMadocaIonoSnapshot(*store, receiver_ecef, decoder->decodeTime(),
+        appendMadocaIonoSnapshot(*store, receiver_ecef, decoder->messageTime(),
                                  decoder->regionId(), snapshots, gloFreqHz);
         decoder->clearRegionAfterUse();
     }

--- a/tests/test_madoca_parity.cpp
+++ b/tests/test_madoca_parity.cpp
@@ -12,6 +12,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <filesystem>
 #include <fstream>
 #include <map>
 #include <memory>
@@ -585,6 +586,49 @@ TEST_F(MadocaParity, L6dFileSnapshotsMatchOracleApplicationSequence) {
     ASSERT_NE(latest, nullptr);
     EXPECT_EQ(latest->correction.rid, native_snapshots.back().correction.rid);
     EXPECT_EQ(latest->correction.anum, native_snapshots.back().correction.anum);
+}
+
+TEST_F(MadocaParity, L6dSecondaryChannelSnapshotsUseMessageTime) {
+    const std::string root = libgnss::external::madocalib::defaultRootDir();
+    if (root.empty()) {
+        GTEST_SKIP() << "MADOCALIB root unavailable";
+    }
+    const std::string l6_path =
+        root + "/sample_data/data/l6/2025/091/2025091A.201.l6";
+    if (!std::filesystem::is_regular_file(l6_path)) {
+        GTEST_SKIP() << "L6D PRN-201 sample missing: " << l6_path;
+    }
+
+    const double ref_ep[6] = {2025.0, 4.0, 1.0, 0.0, 0.0, 0.0};
+    const double receiver_ecef[3] = {
+        -3857167.6484, 3108694.9138, 4004041.6876,
+    };
+    std::vector<libgnss::io::MadocaIonoSnapshot> snapshots;
+    std::string error;
+    ASSERT_TRUE(libgnss::io::decodeMadocaL6dFileToSnapshots(
+        l6_path, ref_ep, receiver_ecef, snapshots, &error)) << error;
+    ASSERT_FALSE(snapshots.empty());
+
+    int correction_times_checked = 0;
+    int corrections_at_message_time = 0;
+    for (const auto& snapshot : snapshots) {
+        for (const auto& correction_time : snapshot.correction.t0) {
+            if (correction_time.time == 0) {
+                continue;
+            }
+            const double age_s =
+                static_cast<double>(
+                    snapshot.decode_time.time - correction_time.time) +
+                snapshot.decode_time.sec - correction_time.sec;
+            EXPECT_GE(age_s, 0.0);
+            if (age_s == 0.0) {
+                ++corrections_at_message_time;
+            }
+            ++correction_times_checked;
+        }
+    }
+    EXPECT_GT(correction_times_checked, 0);
+    EXPECT_GT(corrections_at_message_time, 0);
 }
 
 TEST_F(MadocaParity, L6eSnapshotConvertsToSsrProducts) {


### PR DESCRIPTION
## Summary
- distinguish the primary-channel decode clock from the channel time of the most recently completed L6D message
- key file snapshots by that completed-message time
- cover the PRN-201 path with the real MIZU fixture and document the M3 prerequisite evidence

## Cause
`decodeTime()` intentionally reports PRN-200 time for the decoder-wide staleness gate. Reusing it as every file snapshot key made PRN-201 corrections appear about 3,487 seconds in the future, so MADOCALIB's 300-second causal age gate rejected all of them.

## Validation
- Windows MSVC: `gnss_madoca_parity_tests` target builds
- Ubuntu 22.04 MADOCALIB-linked: `MadocaParity.L6dFileSnapshotsMatchOracleApplicationSequence` and `MadocaParity.L6dSecondaryChannelSnapshotsUseMessageTime` pass (2/2)
- layered M3 experiment: first valid epochs change from 0 accepted STEC rows to 9, 9, and 10 rows at age 24 seconds
- `git diff --check`

Refs #148 (M3 prerequisite; does not close the tracker)