### PR TITLE
Apply native MADOCA L6D STEC constraints

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -706,6 +706,64 @@ jobs:
           status_mismatches="$(awk -F, 'NR > 1 && !(($5 == 1 && $6 == 6) || ($5 == 6 && $6 == 5)) {n++} END {print n+0}' madoca_pppar_solution_matches.csv)"
           test "$status_mismatches" -eq 0
           python3 -c 'import json; d=json.load(open("madoca_pppar_solution_diff.json")); assert d["comparison"]["delta_rms_3d_m"] <= 0.2; assert d["events"]["max_delta_3d"]["delta_3d_m"] <= 1.0'
+          ./apps/gnss_ppp \
+            --madocalib-bridge \
+            --madocalib-profile pppar-ion \
+            --obs "$ROOT/sample_data/data/rinex/MIZU00JPN_R_20250910000_01D_30S_MO.rnx" \
+            --nav "$ROOT/sample_data/data/rinex/BRDM00DLR_S_20250910000_01D_MN.rnx" \
+            --madocalib-l6 "$ROOT/sample_data/data/l6_is-qzss-mdc-004/2025/091/2025091A.204.l6" \
+            --madocalib-l6 "$ROOT/sample_data/data/l6_is-qzss-mdc-004/2025/091/2025091A.206.l6" \
+            --madocalib-mdciono "$ROOT/sample_data/data/l6/2025/091/2025091A.200.l6" \
+            --madocalib-mdciono "$ROOT/sample_data/data/l6/2025/091/2025091A.201.l6" \
+            --antex "$ROOT/sample_data/data/igs20.atx" \
+            --madocalib-start "2025/04/01 00:00:00" \
+            --madocalib-end "2025/04/01 00:59:30" \
+            --madocalib-ti 30 \
+            --out madocalib_pppar_ion_smoke.pos \
+            --summary-json madocalib_pppar_ion_smoke.json \
+            --quiet
+          ./apps/gnss_ppp \
+            --kinematic \
+            --enable-ar \
+            --ar-method per-freq \
+            --ar-ratio-threshold 1.5 \
+            --convergence-policy local-enu \
+            --convergence-threshold-horizontal 0.75 \
+            --convergence-threshold-vertical 1.25 \
+            --obs "$ROOT/sample_data/data/rinex/MIZU00JPN_R_20250910000_01D_30S_MO.rnx" \
+            --nav "$ROOT/sample_data/data/rinex/BRDM00DLR_S_20250910000_01D_MN.rnx" \
+            --madoca-l6 "$ROOT/sample_data/data/l6_is-qzss-mdc-004/2025/091/2025091A.204.l6" \
+            --madoca-l6 "$ROOT/sample_data/data/l6_is-qzss-mdc-004/2025/091/2025091A.206.l6" \
+            --madoca-l6d "$ROOT/sample_data/data/l6/2025/091/2025091A.200.l6" \
+            --madoca-l6d "$ROOT/sample_data/data/l6/2025/091/2025091A.201.l6" \
+            --antex "$ROOT/sample_data/data/igs20.atx" \
+            --max-epochs 120 \
+            --emit-epoch-time \
+            --out native_pppar_ion_smoke.pos \
+            --summary-json native_pppar_ion_smoke.json \
+            --quiet
+          test "$(python3 -c 'import json; print(json.load(open("native_pppar_ion_smoke.json"))["madoca_l6d_constraint_epochs"])')" -eq 1
+          test "$(python3 -c 'import json; print(json.load(open("native_pppar_ion_smoke.json"))["madoca_l6d_constraint_rows"])')" -eq 9
+          test "$(python3 -c 'import json; print(json.load(open("native_pppar_ion_smoke.json"))["madoca_l6d_constraint_position_gate_epochs"])')" -eq 117
+          ion_fixed_solutions="$(python3 -c 'import json; print(json.load(open("native_pppar_ion_smoke.json"))["ppp_fixed_solutions"])')"
+          test "$ion_fixed_solutions" -eq 89
+          python3 "${GITHUB_WORKSPACE}/scripts/analysis/madoca_solution_diff.py" \
+            madocalib_pppar_ion_smoke.pos \
+            native_pppar_ion_smoke.pos \
+            --reference-ecef -3857167.6484 3108694.9138 4004041.6876 \
+            --base-label bridge-pppar-ion \
+            --candidate-label native-pppar-ion \
+            --json-out madoca_pppar_ion_solution_diff.json \
+            --match-csv madoca_pppar_ion_solution_matches.csv
+          ion_matched_epochs="$(awk -F, 'NR > 1 {n++} END {print n+0}' madoca_pppar_ion_solution_matches.csv)"
+          test "$ion_matched_epochs" -eq 118
+          ion_oracle_fixes="$(awk -F, 'NR > 1 && $5 == 1 {n++} END {print n+0}' madoca_pppar_ion_solution_matches.csv)"
+          test "$ion_oracle_fixes" -eq 97
+          ion_wrong_fixes="$(awk -F, 'NR > 1 && $6 == 6 && $5 != 1 {n++} END {print n+0}' madoca_pppar_ion_solution_matches.csv)"
+          test "$ion_wrong_fixes" -eq 0
+          ion_missed_fixes="$(awk -F, 'NR > 1 && $5 == 1 && $6 != 6 {n++} END {print n+0}' madoca_pppar_ion_solution_matches.csv)"
+          test "$ion_missed_fixes" -eq 8
+          python3 -c 'import json; m2=json.load(open("madoca_pppar_solution_diff.json")); ion=json.load(open("madoca_pppar_ion_solution_diff.json")); assert ion["base"]["reference_rms_3d_m"] <= m2["base"]["reference_rms_3d_m"]; assert ion["candidate"]["reference_rms_3d_m"] <= m2["candidate"]["reference_rms_3d_m"]; assert ion["comparison"]["delta_rms_3d_m"] <= 0.25; assert ion["events"]["max_delta_3d"]["delta_3d_m"] <= 1.0'
 
     - name: Upload MADOCA PPP-AR baseline
       if: always()
@@ -721,6 +779,12 @@ jobs:
           build-madoca-parity/native_pppar_partial_ar_smoke.json
           build-madoca-parity/madoca_pppar_solution_diff.json
           build-madoca-parity/madoca_pppar_solution_matches.csv
+          build-madoca-parity/madocalib_pppar_ion_smoke.pos
+          build-madoca-parity/madocalib_pppar_ion_smoke.json
+          build-madoca-parity/native_pppar_ion_smoke.pos
+          build-madoca-parity/native_pppar_ion_smoke.json
+          build-madoca-parity/madoca_pppar_ion_solution_diff.json
+          build-madoca-parity/madoca_pppar_ion_solution_matches.csv
         if-no-files-found: warn
 
     - name: Upload MadocaParity diagnostics
@@ -741,6 +805,12 @@ jobs:
           build-madoca-parity/native_pppar_smoke.json
           build-madoca-parity/madoca_pppar_solution_diff.json
           build-madoca-parity/madoca_pppar_solution_matches.csv
+          build-madoca-parity/madocalib_pppar_ion_smoke.pos
+          build-madoca-parity/madocalib_pppar_ion_smoke.json
+          build-madoca-parity/native_pppar_ion_smoke.pos
+          build-madoca-parity/native_pppar_ion_smoke.json
+          build-madoca-parity/madoca_pppar_ion_solution_diff.json
+          build-madoca-parity/madoca_pppar_ion_solution_matches.csv
         if-no-files-found: ignore
 
   static-analysis:

--- a/apps/native/gnss_ppp.cpp
+++ b/apps/native/gnss_ppp.cpp
@@ -27,6 +27,7 @@ struct Options {
     std::string ssr_path;
     std::string ssr_rtcm_path;
     std::vector<std::string> madoca_l6_paths;
+    std::vector<std::string> madoca_l6d_paths;
     std::vector<std::string> madoca_l6d_shadow_paths;
     std::string madoca_materialization_dump_path;
     bool madoca_materialization_dump_only = false;
@@ -102,6 +103,8 @@ void printUsage(const char* program_name) {
         << "                          RTCM SSR source converted/read for PPP use\n"
         << "  --madoca-l6 <file>       Native MADOCA L6E SSR channel (repeatable,\n"
         << "                          e.g. PRN 204 and 206); requires --nav\n"
+        << "  --madoca-l6d <file>      Native MADOCA L6D STEC input (repeatable);\n"
+        << "                          opt-in application for per-frequency PPP\n"
         << "  --madoca-l6d-shadow <file>\n"
         << "                          Native L6D ionosphere shadow input (repeatable);\n"
         << "                          reports lookup diagnostics without changing PPP\n"
@@ -275,6 +278,8 @@ Options parseArguments(int argc, char* argv[]) {
             options.ssr_rtcm_path = argv[++i];
         } else if (arg == "--madoca-l6" && i + 1 < argc) {
             options.madoca_l6_paths.push_back(argv[++i]);
+        } else if (arg == "--madoca-l6d" && i + 1 < argc) {
+            options.madoca_l6d_paths.push_back(argv[++i]);
         } else if (arg == "--madoca-l6d-shadow" && i + 1 < argc) {
             options.madoca_l6d_shadow_paths.push_back(argv[++i]);
         } else if (arg == "--madoca-materialization-dump" && i + 1 < argc) {
@@ -446,6 +451,30 @@ Options parseArguments(int argc, char* argv[]) {
     }
     if (!options.madoca_l6_paths.empty() && options.nav_path.empty()) {
         argumentError("--madoca-l6 requires --nav (broadcast ephemeris)", argv[0]);
+    }
+    if (!options.madoca_l6d_paths.empty() &&
+        !options.madoca_l6d_shadow_paths.empty()) {
+        argumentError(
+            "--madoca-l6d cannot be combined with --madoca-l6d-shadow",
+            argv[0]);
+    }
+    if (!options.madoca_l6d_paths.empty() &&
+        options.madoca_l6_paths.empty()) {
+        argumentError(
+            "--madoca-l6d requires native --madoca-l6 corrections",
+            argv[0]);
+    }
+    if (!options.madoca_l6d_paths.empty() &&
+        options.ar_method != "per-freq") {
+        argumentError(
+            "--madoca-l6d requires --ar-method per-freq",
+            argv[0]);
+    }
+    if (options.madoca_l6d_paths.size() > 3 ||
+        options.madoca_l6d_shadow_paths.size() > 3) {
+        argumentError(
+            "MADOCA L6D input accepts at most three files",
+            argv[0]);
     }
     if (options.max_epochs < 0) {
         argumentError("--max-epochs must be non-negative", argv[0]);
@@ -939,6 +968,8 @@ int main(int argc, char* argv[]) {
         const bool per_frequency_ar = options.ar_method == "per-freq";
         ppp_config.estimate_ionosphere = options.estimate_ionosphere || per_frequency_ar;
         ppp_config.use_ionosphere_free = options.use_ionosphere_free && !per_frequency_ar;
+        ppp_config.apply_madoca_l6d_ionosphere =
+            !options.madoca_l6d_paths.empty();
         ppp_config.use_clas_osr_filter = options.use_clas_osr_filter;
         ppp_config.clas_epoch_policy =
             parseClasEpochPolicy(options.clas_epoch_policy);
@@ -1169,10 +1200,14 @@ int main(int argc, char* argv[]) {
             std::cerr << "Error: failed to load MADOCA L6E corrections\n";
             return 1;
         }
-        if (!options.madoca_l6d_shadow_paths.empty()) {
+        const auto& madoca_l6d_input_paths =
+            !options.madoca_l6d_paths.empty()
+                ? options.madoca_l6d_paths
+                : options.madoca_l6d_shadow_paths;
+        if (!madoca_l6d_input_paths.empty()) {
             if (obs_header.first_obs.week <= 0 ||
                 obs_header.approximate_position.norm() <= 1e3) {
-                std::cerr << "Error: --madoca-l6d-shadow requires RINEX first-observation "
+                std::cerr << "Error: MADOCA L6D input requires RINEX first-observation "
                              "time and approximate receiver position\n";
                 return 1;
             }
@@ -1199,8 +1234,8 @@ int main(int argc, char* argv[]) {
                 obs_header.approximate_position.z(),
             };
             if (!processor.loadMadocaL6dProducts(
-                    options.madoca_l6d_shadow_paths, reference_epoch, receiver_ecef)) {
-                std::cerr << "Error: failed to load MADOCA L6D shadow corrections\n";
+                    madoca_l6d_input_paths, reference_epoch, receiver_ecef)) {
+                std::cerr << "Error: failed to load MADOCA L6D corrections\n";
                 return 1;
             }
         }
@@ -1223,6 +1258,9 @@ int main(int argc, char* argv[]) {
         double madoca_l6d_shadow_max_age_s = 0.0;
         int madoca_l6d_shadow_last_region = -1;
         int madoca_l6d_shadow_last_area = 0;
+        int madoca_l6d_constraint_epochs = 0;
+        int madoca_l6d_constraint_rows = 0;
+        int madoca_l6d_constraint_position_gate_epochs = 0;
         std::map<std::string, int> clas_hybrid_fallback_reasons;
         double atmospheric_trop_meters = 0.0;
         double atmospheric_iono_meters = 0.0;
@@ -1265,6 +1303,14 @@ int main(int argc, char* argv[]) {
                 madoca_l6d_shadow_last_area = l6d_shadow.area_number;
             } else if (l6d_shadow.stale) {
                 ++madoca_l6d_shadow_stale_epochs;
+            }
+            if (l6d_shadow.constraint_rows > 0) {
+                ++madoca_l6d_constraint_epochs;
+                madoca_l6d_constraint_rows +=
+                    l6d_shadow.constraint_rows;
+            }
+            if (l6d_shadow.constraint_skipped_position_covariance) {
+                ++madoca_l6d_constraint_position_gate_epochs;
             }
             if (processor.getLastClasHybridFallbackUsed()) {
                 ++clas_hybrid_fallback_epochs;
@@ -1410,6 +1456,15 @@ int main(int argc, char* argv[]) {
                     << madoca_l6d_shadow_last_region << ",\n"
                     << "  \"madoca_l6d_shadow_last_area\": "
                     << madoca_l6d_shadow_last_area << ",\n"
+                    << "  \"madoca_l6d_apply_enabled\": "
+                    << (ppp_config.apply_madoca_l6d_ionosphere ? "true" : "false")
+                    << ",\n"
+                    << "  \"madoca_l6d_constraint_epochs\": "
+                    << madoca_l6d_constraint_epochs << ",\n"
+                    << "  \"madoca_l6d_constraint_rows\": "
+                    << madoca_l6d_constraint_rows << ",\n"
+                    << "  \"madoca_l6d_constraint_position_gate_epochs\": "
+                    << madoca_l6d_constraint_position_gate_epochs << ",\n"
                     << "  \"clas_hybrid_fallback_reasons\": {";
             bool first_reason = true;
             for (const auto& [reason, count] : clas_hybrid_fallback_reasons) {
@@ -1510,12 +1565,18 @@ int main(int argc, char* argv[]) {
                           << options.madoca_materialization_dump_path << "\n";
             }
             if (processor.hasLoadedMadocaL6dProducts()) {
-                std::cout << "  MADOCA L6D shadow snapshot epochs: "
+                std::cout << "  MADOCA L6D snapshot epochs: "
                           << madoca_l6d_shadow_snapshot_epochs << "\n";
-                std::cout << "  MADOCA L6D shadow stale epochs: "
+                std::cout << "  MADOCA L6D stale epochs: "
                           << madoca_l6d_shadow_stale_epochs << "\n";
-                std::cout << "  MADOCA L6D shadow matched satellites: "
+                std::cout << "  MADOCA L6D matched satellites: "
                           << madoca_l6d_shadow_matched_satellites << "\n";
+                if (ppp_config.apply_madoca_l6d_ionosphere) {
+                    std::cout << "  MADOCA L6D constraint epochs: "
+                              << madoca_l6d_constraint_epochs << "\n";
+                    std::cout << "  MADOCA L6D constraint rows: "
+                              << madoca_l6d_constraint_rows << "\n";
+                }
             }
             if (atmospheric_trop_corrections > 0 || atmospheric_iono_corrections > 0) {
                 std::cout << "  atmospheric trop corrections: "

--- a/docs/madocalib_native_migration.md
+++ b/docs/madocalib_native_migration.md
@@ -80,13 +80,13 @@ does not yet match end-to-end behavior; **open** has no accepted native parity.
 | L6D coverage/correction decode | `MadocaL6dDecoder` | native | Byte-stepped region/area parity remains green |
 | L6D receiver-area selection and delay/std | `MadocaIonoStore` | native | Selected receiver correction values match the oracle |
 | L6D causal product snapshots | `MadocaIonoSnapshot`, `MadocaIonoProducts` | native | File snapshot/application sequence parity remains green |
-| L6D use inside PPP | `--madoca-l6d-shadow` performs measurement-neutral lookup only | partial | M3 must add opt-in STEC state/row application and prove row/value parity |
+| L6D use inside PPP | `--madoca-l6d` applies opt-in STEC rows; `--madoca-l6d-shadow` remains measurement-neutral | native opt-in | M3 one-hour row, gate, status-safety, and trajectory gates are pinned |
 | PPP correction signs and ordering | Native correction contract plus materialization/residual diff tools | native | Default PPP parity matrix remains within the accepted MIZU/ALIC envelope |
 | PPP commit-on-success and diagnostics | Native postfit validation/shadow telemetry | native | MIZU 1 h/6 h/24 h and ALIC regression gates remain green |
 | GLONASS phase in MADOCA PPP | Native L1/L2 rows plus corrected postfit-shadow audit | native | Keep the pinned per-satellite demeaned RMS at millimetre scale and span below 4 cm |
 | MADOCALIB `exec_ppp` | Native PPP runs end to end; remaining solution delta is tracked | partial | M4/M5 matrix meets the declared trajectory thresholds |
 | MADOCALIB `exec_pppar` | Windows and authoritative Ubuntu Release both match the oracle's 108 Fix / 10 Float over all 118 epochs | native | Keep exact status agreement, no wrong/missed Fix, RMS at most 0.20 m, and maximum at most 1.0 m |
-| MADOCALIB `exec_pppar-ion` | Bridge profile/input validation exists; native L6D state injection does not | open | M3 then M5 PPP-AR-ion sign-off |
+| MADOCALIB `exec_pppar-ion` | Bridge and native opt-in profiles run in the required parity lane | partial | M4 closes eight missed Fix and M5 expands the dataset/duration matrix |
 | Triple/quad-frequency PPP-AR | Upstream 2.0 behavior has not been fully audited or signed off | open | Dedicated fixtures and ambiguity/state parity after dual-frequency M2 |
 | Linked `postpos()` bridge | `madocalib_bridge` | oracle-only | Retain until M6; never select it in production runtime |
 
@@ -499,6 +499,32 @@ experiment, this changes the first valid epochs from zero accepted rows to
 causal snapshot fix as a prerequisite; row/value and solution parity remain M3
 work.
 
+#### M3 opt-in STEC application
+
+`--madoca-l6d` now promotes the proven snapshots to prefit STEC state rows only
+for coherent native MADOCA per-frequency PPP.  The default path and
+`--madoca-l6d-shadow` remain measurement-neutral.  Admission matches
+`const_iono_corr()`: GPS, GLONASS, Galileo, and QZSS only; absolute age at most
+300 seconds; standard deviation at most 1 m; independent constellation mean
+bias removal; `H=1`; and variance `std^2`.
+
+The convergence gate uses the previous published solution covariance, matching
+MADOCALIB `prev_qr`, rather than the current predicted filter covariance.  On
+the pinned MIZU hour this applies exactly the oracle's nine rows at the first
+valid epoch and skips the following 117 epochs after the horizontal/vertical
+2 m/3 m covariance gate closes.  The real decoder/oracle tests retain
+delay/std equality within `1e-6`, and the first-epoch row satellites, residuals,
+standard deviations, and constellation biases match the oracle trace.
+
+The active L6D constraint removes the unconstrained STEC-gauge premise of the
+M2 one-child N1 lookahead, so this opt-in path retains MADOCALIB's literal
+greedy partial-AR removal.  The one-hour gate records native 89 Fix / 29 Float
+against oracle 97 Fix / 21 Float: eight Fix are conservatively missed and
+there are zero wrong Fix.  Both reference trajectories improve over M2
+(oracle 3D RMS 4.49578 to 4.44821 m; native 4.51256 to 4.44202 m).
+Native/oracle 3D delta RMS is 0.244372 m with a 0.459645 m maximum; the
+remaining status and component convergence belongs to M4.
+
 ### M4 -- Close remaining row and boundary differences
 
 - Resolve QZSS atmosphere admission and every unexplained native-only or
@@ -554,10 +580,9 @@ remains open.
 
 ## Immediate Slice
 
-Begin M3 by landing the completed-message snapshot-time prerequisite, then
-promote the existing measurement-neutral L6D shadow lookup to an explicit
-opt-in STEC input.  Pin receiver-area selection, correction age, delay,
-standard deviation, signal coefficient, and snapshot application keys; then
-compare the common native/oracle `pppar-ion` residual rows before judging Fix
-status or trajectories.  Preserve the established M2 guards and keep the
-feature opt-in until the M5 matrix passes.
+Begin M4 with the eight conservative `pppar-ion` missed-Fix epochs.  Compare
+materialization, satellite and row sets, residual components, then N1
+candidates without relaxing the zero-wrong-Fix gate.  In parallel, reduce the
+0.244372 m one-hour native/oracle delta RMS toward the M2 baseline and extend
+the same accounting to QZSS atmosphere admission and the 24-hour boundary.
+Keep L6D application opt-in until the M5 matrix passes.

--- a/include/libgnss++/algorithms/ppp.hpp
+++ b/include/libgnss++/algorithms/ppp.hpp
@@ -49,6 +49,11 @@ struct MadocaL6dShadowStatus {
     int region_id = -1;
     int area_number = 0;
     int matched_satellites = 0;
+    bool constraint_enabled = false;
+    bool constraint_skipped_position_covariance = false;
+    int constraint_rows = 0;
+    double constraint_horizontal_position_std_m = 0.0;
+    double constraint_vertical_position_std_m = 0.0;
 };
 
 struct PPPConvergenceTelemetry {
@@ -149,8 +154,9 @@ public:
      */
     bool loadMadocaL6Products(const std::vector<std::string>& l6_files);
 
-    // Load receiver-specific L6D ionosphere snapshots for diagnostic shadow
-    // lookup. This does not change PPP measurements or filter state.
+    // Load receiver-specific L6D ionosphere snapshots. They remain
+    // measurement-neutral unless PPPConfig::apply_madoca_l6d_ionosphere is
+    // explicitly enabled.
     bool loadMadocaL6dProducts(const std::vector<std::string>& l6d_files,
                                const double reference_epoch[6],
                                const double receiver_ecef[3]);
@@ -359,6 +365,8 @@ private:
     double last_applied_ionex_m_ = 0.0;
     double last_applied_dcb_m_ = 0.0;
     MadocaL6dShadowStatus last_madoca_l6d_shadow_status_;
+    Matrix3d previous_solution_position_covariance_ = Matrix3d::Zero();
+    bool has_previous_solution_position_covariance_ = false;
     bool last_clas_hybrid_fallback_used_ = false;
     std::string last_clas_hybrid_fallback_reason_;
     
@@ -806,7 +814,8 @@ private:
         const std::vector<IonosphereFreeObs>& observations,
         const NavigationData& nav,
         const GNSSTime& time,
-        bool apply_outlier_detection = true);
+        bool apply_outlier_detection = true,
+        bool include_external_constraints = true);
     
     /**
      * @brief Check convergence

--- a/include/libgnss++/algorithms/ppp_shared.hpp
+++ b/include/libgnss++/algorithms/ppp_shared.hpp
@@ -230,6 +230,7 @@ struct PPPConfig {
     // Atmospheric modeling
     bool estimate_troposphere = true;
     bool estimate_ionosphere = false;
+    bool apply_madoca_l6d_ionosphere = false;
     double initial_ionosphere_variance = 100.0;
     double process_noise_ionosphere = 1e-3;
     bool use_ionosphere_free = true;

--- a/src/algorithms/ppp.cpp
+++ b/src/algorithms/ppp.cpp
@@ -725,6 +725,11 @@ PositionSolution PPPProcessor::processEpochStandard(
 
     has_last_processed_time_ = true;
     last_processed_time_ = obs.time;
+    if (solution.isValid() && solution.position_covariance.allFinite()) {
+        previous_solution_position_covariance_ =
+            solution.position_covariance;
+        has_previous_solution_position_covariance_ = true;
+    }
 
     return finalizeSolution(solution);
 }
@@ -799,6 +804,8 @@ void PPPProcessor::reset() {
     last_applied_ionex_m_ = 0.0;
     last_applied_dcb_m_ = 0.0;
     last_madoca_l6d_shadow_status_ = {};
+    previous_solution_position_covariance_.setZero();
+    has_previous_solution_position_covariance_ = false;
 
     std::lock_guard<std::mutex> lock(stats_mutex_);
     total_epochs_processed_ = 0;

--- a/src/algorithms/ppp_ambiguity.cpp
+++ b/src/algorithms/ppp_ambiguity.cpp
@@ -1011,14 +1011,17 @@ bool PPPProcessor::resolveAmbiguitiesPerFreq(const ObservationData& obs,
 
         int exclude_position = -1;
         // The oracle's greedy lowest-elevation removal is deterministic for
-        // its float means, but a weak ambiguity/STEC gauge can change the
-        // disagreement set across platforms. Before committing that removal,
-        // test each implicated one-satellite child with the same LAMBDA ratio,
-        // dimension, and candidate-agreement gates. This adds no candidate and
-        // relaxes no threshold: it only accepts a subset that already passes
-        // the ordinary N1 contract. If none passes, retain the oracle's greedy
+        // its float means, but a weak unconstrained ambiguity/STEC gauge can
+        // change the disagreement set across platforms. Before committing
+        // that removal, test each implicated one-satellite child with the same
+        // LAMBDA ratio, dimension, and candidate-agreement gates. Active L6D
+        // STEC rows remove that unconstrained-gauge premise, so that mode keeps
+        // the literal oracle greedy path. This adds no candidate and relaxes
+        // no threshold: it only accepts a subset that already passes the
+        // ordinary N1 contract. If none passes, retain the oracle's greedy
         // removal below.
-        if (require_coherent_ssr_ && ssr_products_loaded_) {
+        if (require_coherent_ssr_ && ssr_products_loaded_ &&
+            !ppp_config_.apply_madoca_l6d_ionosphere) {
             for (int removed = 0; removed < trial_nb; ++removed) {
                 if (std::abs(n1_fixed(removed) - n1_second(removed)) < 0.001) {
                     continue;

--- a/src/algorithms/ppp_corrections.cpp
+++ b/src/algorithms/ppp_corrections.cpp
@@ -821,8 +821,24 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
             shadow_satellites.push_back(observation.satellite);
         }
     }
-    last_madoca_l6d_shadow_status_ =
+    const MadocaL6dShadowStatus previous_l6d_status =
+        last_madoca_l6d_shadow_status_;
+    MadocaL6dShadowStatus inspected_l6d_status =
         inspectMadocaL6dShadow(shadow_satellites, time);
+    // Correction application can run again after the prefit measurement
+    // update. Preserve the constraint telemetry captured while forming that
+    // update instead of replacing it with the second shadow inspection.
+    inspected_l6d_status.constraint_enabled =
+        previous_l6d_status.constraint_enabled;
+    inspected_l6d_status.constraint_skipped_position_covariance =
+        previous_l6d_status.constraint_skipped_position_covariance;
+    inspected_l6d_status.constraint_rows =
+        previous_l6d_status.constraint_rows;
+    inspected_l6d_status.constraint_horizontal_position_std_m =
+        previous_l6d_status.constraint_horizontal_position_std_m;
+    inspected_l6d_status.constraint_vertical_position_std_m =
+        previous_l6d_status.constraint_vertical_position_std_m;
+    last_madoca_l6d_shadow_status_ = inspected_l6d_status;
 
     // Pre-fetch epoch-wide atmosphere tokens from any satellite that has them.
     // CLAS atmosphere corrections are network-wide, not per-satellite, so we

--- a/src/algorithms/ppp_internal.hpp
+++ b/src/algorithms/ppp_internal.hpp
@@ -125,6 +125,111 @@ inline bool alwaysRestoreArTrialState(PPPProcessor::PPPConfig::ARMethod method) 
     return method == PPPProcessor::PPPConfig::ARMethod::DD_PER_FREQ;
 }
 
+struct MadocaIonoConstraintInput {
+    SatelliteId satellite;
+    int state_index = -1;
+    double ionosphere_state_m = 0.0;
+    double delay_m = 0.0;
+    double std_m = 0.0;
+    double age_s = std::numeric_limits<double>::infinity();
+};
+
+struct MadocaIonoConstraintRow {
+    SatelliteId satellite;
+    int state_index = -1;
+    double target_m = 0.0;
+    double residual_m = 0.0;
+    double variance_m2 = 0.0;
+    double system_bias_m = 0.0;
+};
+
+inline int madocaIonoConstraintSystemSlot(GNSSSystem system) {
+    switch (system) {
+        case GNSSSystem::GPS: return 0;
+        case GNSSSystem::GLONASS: return 1;
+        case GNSSSystem::Galileo: return 2;
+        case GNSSSystem::QZSS: return 3;
+        default: return -1;
+    }
+}
+
+inline bool madocaIonoConstraintPositionGatePasses(
+    double horizontal_position_std_m,
+    double vertical_position_std_m) {
+    constexpr double kHorizontalThresholdM = 2.0;
+    constexpr double kVerticalThresholdM = 3.0;
+    // MADOCALIB applies L6D constraints while the previous position covariance
+    // is still loose. It stops only when both non-zero ENU standard deviations
+    // are below their convergence thresholds.
+    return !(
+        horizontal_position_std_m != 0.0 &&
+        vertical_position_std_m != 0.0 &&
+        horizontal_position_std_m < kHorizontalThresholdM &&
+        vertical_position_std_m < kVerticalThresholdM);
+}
+
+inline std::vector<MadocaIonoConstraintRow> buildMadocaIonoConstraintRows(
+    const std::vector<MadocaIonoConstraintInput>& inputs,
+    double horizontal_position_std_m,
+    double vertical_position_std_m) {
+    constexpr double kMaximumAgeSeconds = 300.0;
+    constexpr double kMaximumStdM = 1.0;
+    if (!madocaIonoConstraintPositionGatePasses(
+            horizontal_position_std_m, vertical_position_std_m)) {
+        return {};
+    }
+
+    std::array<double, 4> bias_sums{};
+    std::array<int, 4> bias_counts{};
+    const auto accepted = [&](const MadocaIonoConstraintInput& input) {
+        return madocaIonoConstraintSystemSlot(input.satellite.system) >= 0 &&
+               input.state_index >= 0 &&
+               std::isfinite(input.ionosphere_state_m) &&
+               std::isfinite(input.delay_m) &&
+               std::isfinite(input.std_m) &&
+               input.std_m <= kMaximumStdM &&
+               std::isfinite(input.age_s) &&
+               std::abs(input.age_s) <= kMaximumAgeSeconds;
+    };
+    for (const auto& input : inputs) {
+        if (!accepted(input)) {
+            continue;
+        }
+        const int slot = madocaIonoConstraintSystemSlot(input.satellite.system);
+        bias_sums[static_cast<size_t>(slot)] +=
+            input.delay_m - input.ionosphere_state_m;
+        ++bias_counts[static_cast<size_t>(slot)];
+    }
+
+    std::array<double, 4> system_biases{};
+    for (size_t slot = 0; slot < system_biases.size(); ++slot) {
+        if (bias_counts[slot] > 0) {
+            system_biases[slot] =
+                bias_sums[slot] / static_cast<double>(bias_counts[slot]);
+        }
+    }
+
+    std::vector<MadocaIonoConstraintRow> rows;
+    rows.reserve(inputs.size());
+    for (const auto& input : inputs) {
+        if (!accepted(input)) {
+            continue;
+        }
+        const int slot = madocaIonoConstraintSystemSlot(input.satellite.system);
+        const double system_bias = system_biases[static_cast<size_t>(slot)];
+        const double target = input.delay_m - system_bias;
+        rows.push_back({
+            input.satellite,
+            input.state_index,
+            target,
+            target - input.ionosphere_state_m,
+            input.std_m * input.std_m,
+            system_bias,
+        });
+    }
+    return rows;
+}
+
 inline Vector3d recenterPostfitReceiverPosition(
     const Vector3d& corrected_receiver_position,
     const Vector3d& prior_filter_position,

--- a/src/algorithms/ppp_measurement.cpp
+++ b/src/algorithms/ppp_measurement.cpp
@@ -1,5 +1,6 @@
 #include "ppp_internal.hpp"
 
+#include <libgnss++/algorithms/madoca_core.hpp>
 #include <libgnss++/algorithms/ppp_multifrequency.hpp>
 
 #include <libgnss++/core/constants.hpp>
@@ -21,9 +22,9 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
     const std::vector<IonosphereFreeObs>& observations,
     const NavigationData& nav,
     const GNSSTime& time,
-    bool apply_outlier_detection) {
+    bool apply_outlier_detection,
+    bool include_external_constraints) {
     (void)nav;
-    (void)time;
 
     std::vector<Eigen::RowVectorXd> rows;
     std::vector<double> measured_values;
@@ -600,6 +601,191 @@ PPPProcessor::MeasurementEquation PPPProcessor::formMeasurementEquations(
                 row_signals.push_back(frequency.signal);
                 row_signal_bands.push_back(band);
                 appendAdditionalShadowMetadata(observation, frequency, true);
+            }
+        }
+    }
+
+    const bool apply_madoca_l6d =
+        include_external_constraints &&
+        ppp_config_.apply_madoca_l6d_ionosphere &&
+        require_coherent_ssr_ &&
+        ssr_products_loaded_ &&
+        !ppp_config_.use_ionosphere_free &&
+        ppp_config_.estimate_ionosphere &&
+        !madoca_iono_products_.empty();
+    if (ppp_config_.apply_madoca_l6d_ionosphere) {
+        last_madoca_l6d_shadow_status_.constraint_enabled = true;
+    }
+    if (apply_madoca_l6d) {
+        const Vector3d receiver_position =
+            filter_state_.state.segment(filter_state_.pos_index, 3);
+        double latitude = 0.0;
+        double longitude = 0.0;
+        double height = 0.0;
+        ecef2geodetic(
+            receiver_position, latitude, longitude, height);
+        (void)height;
+        Matrix3d ecef_to_enu;
+        ecef_to_enu.col(0) =
+            ecef2enu(Vector3d::UnitX(), latitude, longitude);
+        ecef_to_enu.col(1) =
+            ecef2enu(Vector3d::UnitY(), latitude, longitude);
+        ecef_to_enu.col(2) =
+            ecef2enu(Vector3d::UnitZ(), latitude, longitude);
+        // MADOCALIB gates const_iono_corr() with prev_qr: the covariance of
+        // the previously published solution, before this epoch's prediction.
+        // Its zero-initialized first-epoch value deliberately keeps the
+        // constraint active.
+        const Matrix3d position_covariance_ecef =
+            has_previous_solution_position_covariance_
+                ? previous_solution_position_covariance_
+                : Matrix3d::Zero();
+        const Matrix3d position_covariance_enu =
+            ecef_to_enu * position_covariance_ecef * ecef_to_enu.transpose();
+        const double horizontal_position_std_m = std::sqrt(std::max(
+            0.0,
+            position_covariance_enu(0, 0) +
+                position_covariance_enu(1, 1)));
+        const double vertical_position_std_m =
+            std::sqrt(std::max(0.0, position_covariance_enu(2, 2)));
+        last_madoca_l6d_shadow_status_
+            .constraint_horizontal_position_std_m =
+                horizontal_position_std_m;
+        last_madoca_l6d_shadow_status_
+            .constraint_vertical_position_std_m =
+                vertical_position_std_m;
+        const bool position_gate_passes =
+            madocaIonoConstraintPositionGatePasses(
+                horizontal_position_std_m,
+                vertical_position_std_m);
+        last_madoca_l6d_shadow_status_
+            .constraint_skipped_position_covariance =
+                !position_gate_passes;
+
+        const auto query_time =
+            algorithms::madoca_core::madocaGtimeFromGpsTime(time);
+        const auto* snapshot =
+            madoca_iono_products_.latestAtOrBefore(query_time, 300.0);
+        if (position_gate_passes && snapshot != nullptr) {
+            std::vector<MadocaIonoConstraintInput> inputs;
+            inputs.reserve(observations.size());
+            for (const auto& observation : observations) {
+                if (!observation.valid) {
+                    continue;
+                }
+                const auto ionosphere =
+                    filter_state_.ionosphere_indices.find(
+                        observation.satellite);
+                if (ionosphere ==
+                    filter_state_.ionosphere_indices.end()) {
+                    continue;
+                }
+                const int sat =
+                    algorithms::madoca_core::rtklibSatelliteNumber(
+                        observation.satellite);
+                if (sat <= 0 ||
+                    sat > io::MadocaIonoCorr::kMaxSat) {
+                    continue;
+                }
+                const int correction_index = sat - 1;
+                const auto& correction_time =
+                    snapshot->correction.t0[correction_index];
+                if (correction_time.time == 0) {
+                    continue;
+                }
+                const double age_s =
+                    static_cast<double>(
+                        query_time.time - correction_time.time) +
+                    query_time.sec - correction_time.sec;
+                if (env_overrides_.pfdump) {
+                    std::cerr << "[PFL6D-STEC-IN] "
+                              << observation.satellite.toString()
+                              << " delay="
+                              << snapshot->correction.dly[
+                                     correction_index]
+                              << " std="
+                              << snapshot->correction.std[
+                                     correction_index]
+                              << " age=" << age_s
+                              << " state="
+                              << filter_state_.state(
+                                     ionosphere->second)
+                              << "\n";
+                }
+                inputs.push_back({
+                    observation.satellite,
+                    ionosphere->second,
+                    filter_state_.state(ionosphere->second),
+                    snapshot->correction.dly[correction_index],
+                    snapshot->correction.std[correction_index],
+                    age_s,
+                });
+            }
+
+            const auto constraint_rows =
+                buildMadocaIonoConstraintRows(
+                    inputs,
+                    horizontal_position_std_m,
+                    vertical_position_std_m);
+            if (env_overrides_.pfdump) {
+                std::cerr << "[PFL6D-STEC-SUM] inputs="
+                          << inputs.size()
+                          << " rows=" << constraint_rows.size()
+                          << " hstd="
+                          << horizontal_position_std_m
+                          << " vstd="
+                          << vertical_position_std_m
+                          << "\n";
+            }
+            last_madoca_l6d_shadow_status_.constraint_rows =
+                static_cast<int>(constraint_rows.size());
+            for (const auto& constraint : constraint_rows) {
+                Eigen::RowVectorXd row =
+                    Eigen::RowVectorXd::Zero(
+                        filter_state_.total_states);
+                row(constraint.state_index) = 1.0;
+                rows.push_back(row);
+                measured_values.push_back(constraint.target_m);
+                predicted_values.push_back(
+                    filter_state_.state(constraint.state_index));
+                variances.push_back(constraint.variance_m2);
+                row_satellites.push_back(constraint.satellite);
+                row_is_phase.push_back(false);
+                const auto observation = std::find_if(
+                    observations.begin(),
+                    observations.end(),
+                    [&](const IonosphereFreeObs& candidate) {
+                        return candidate.satellite ==
+                               constraint.satellite;
+                    });
+                row_elevations.push_back(
+                    observation != observations.end()
+                        ? observation->elevation
+                        : std::numeric_limits<double>::quiet_NaN());
+                row_signals.push_back(
+                    observation != observations.end()
+                        ? observation->primary_signal
+                        : SignalType::SIGNAL_TYPE_COUNT);
+                row_signal_bands.emplace_back("L6D-STEC");
+                if (observation != observations.end()) {
+                    appendShadowMetadata(*observation, false, false);
+                }
+                if (env_overrides_.pfdump) {
+                    std::cerr << "[PFL6D-STEC] "
+                              << constraint.satellite.toString()
+                              << " target=" << constraint.target_m
+                              << " state="
+                              << filter_state_.state(
+                                     constraint.state_index)
+                              << " residual="
+                              << constraint.residual_m
+                              << " sigma="
+                              << std::sqrt(
+                                     constraint.variance_m2)
+                              << " system_bias="
+                              << constraint.system_bias_m
+                              << "\n";
+                }
             }
         }
     }

--- a/src/algorithms/ppp_state.cpp
+++ b/src/algorithms/ppp_state.cpp
@@ -753,7 +753,9 @@ bool PPPProcessor::updateFilter(const ObservationData& obs,
     bool have_cached_postfit_eq = false;
     const auto getPostfitEquation = [&]() -> const MeasurementEquation& {
         if (!have_cached_postfit_eq) {
-            cached_postfit_eq = formMeasurementEquations(if_obs, nav, obs.time, false);
+            cached_postfit_eq =
+                formMeasurementEquations(
+                    if_obs, nav, obs.time, false, false);
             have_cached_postfit_eq = true;
         }
         return cached_postfit_eq;
@@ -786,7 +788,8 @@ bool PPPProcessor::updateFilter(const ObservationData& obs,
                 updated_position);
         }
         const MeasurementEquation postfit_eq =
-            formMeasurementEquations(shadow_observations, nav, obs.time, false);
+            formMeasurementEquations(
+                shadow_observations, nav, obs.time, false, false);
         const MadocaPostfitEpochStats postfit_stats =
             computeMadocaPostfitEpochStats(postfit_eq);
         writeMadocaPostfitShadow(

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -103,6 +103,68 @@ TEST(PPPFilterIterations, MadocaPerFrequencyCommitsOneUpdatePerEpoch) {
     EXPECT_EQ(ppp_internal::filterIterationCount(false, false, 8), 8);
 }
 
+TEST(PPPMadocaL6dConstraints, RemovesIndependentConstellationBiases) {
+    const std::vector<ppp_internal::MadocaIonoConstraintInput> inputs = {
+        {SatelliteId(GNSSSystem::GPS, 1), 10, 1.0, 3.0, 0.2, 30.0},
+        {SatelliteId(GNSSSystem::GPS, 2), 11, 2.0, 5.0, 0.3, 30.0},
+        {SatelliteId(GNSSSystem::Galileo, 1), 12, 4.0, 10.0, 0.4, 30.0},
+        {SatelliteId(GNSSSystem::BeiDou, 1), 13, 6.0, 8.0, 0.5, 30.0},
+    };
+
+    const auto rows =
+        ppp_internal::buildMadocaIonoConstraintRows(inputs, 2.0, 3.0);
+
+    ASSERT_EQ(rows.size(), 3U);
+    EXPECT_EQ(rows[0].satellite, SatelliteId(GNSSSystem::GPS, 1));
+    EXPECT_EQ(rows[0].state_index, 10);
+    EXPECT_DOUBLE_EQ(rows[0].system_bias_m, 2.5);
+    EXPECT_DOUBLE_EQ(rows[0].target_m, 0.5);
+    EXPECT_DOUBLE_EQ(rows[0].residual_m, -0.5);
+    EXPECT_DOUBLE_EQ(rows[0].variance_m2, 0.04);
+    EXPECT_DOUBLE_EQ(rows[1].system_bias_m, 2.5);
+    EXPECT_DOUBLE_EQ(rows[1].target_m, 2.5);
+    EXPECT_DOUBLE_EQ(rows[1].residual_m, 0.5);
+    EXPECT_DOUBLE_EQ(rows[1].variance_m2, 0.09);
+    EXPECT_DOUBLE_EQ(rows[2].system_bias_m, 6.0);
+    EXPECT_DOUBLE_EQ(rows[2].target_m, 4.0);
+    EXPECT_DOUBLE_EQ(rows[2].residual_m, 0.0);
+    EXPECT_DOUBLE_EQ(rows[2].variance_m2, 0.16);
+}
+
+TEST(PPPMadocaL6dConstraints, MatchesAgeStdAndPositionAdmissionBoundaries) {
+    const auto gps = SatelliteId(GNSSSystem::GPS, 1);
+    const std::vector<ppp_internal::MadocaIonoConstraintInput> inputs = {
+        {gps, 10, 1.0, 3.0, 1.0, 300.0},
+        {SatelliteId(GNSSSystem::GPS, 2), 11, 2.0, 5.0, 0.2, 300.001},
+        {SatelliteId(GNSSSystem::GPS, 3), 12, 3.0, 6.0, 1.001, 30.0},
+        {SatelliteId(GNSSSystem::GPS, 4), -1, 4.0, 7.0, 0.2, 30.0},
+        {SatelliteId(GNSSSystem::GPS, 5), 14, 5.0, 8.0, 0.0, 30.0},
+    };
+
+    const auto boundary_rows =
+        ppp_internal::buildMadocaIonoConstraintRows(inputs, 2.0, 3.0);
+    ASSERT_EQ(boundary_rows.size(), 2U);
+    EXPECT_EQ(boundary_rows.front().satellite, gps);
+    EXPECT_DOUBLE_EQ(boundary_rows.front().system_bias_m, 2.5);
+    EXPECT_DOUBLE_EQ(boundary_rows.front().variance_m2, 1.0);
+    EXPECT_EQ(
+        boundary_rows[1].satellite,
+        SatelliteId(GNSSSystem::GPS, 5));
+    EXPECT_DOUBLE_EQ(boundary_rows[1].system_bias_m, 2.5);
+    EXPECT_DOUBLE_EQ(boundary_rows[1].variance_m2, 0.0);
+
+    EXPECT_TRUE(ppp_internal::buildMadocaIonoConstraintRows(
+        inputs, 1.999, 2.999).empty());
+    EXPECT_EQ(
+        ppp_internal::buildMadocaIonoConstraintRows(
+            inputs, 0.0, 2.999).size(),
+        2U);
+    EXPECT_EQ(
+        ppp_internal::buildMadocaIonoConstraintRows(
+            inputs, 1.999, 0.0).size(),
+        2U);
+}
+
 TEST(PPPCycleSlips, MadocaPerFrequencyUsesMadocalibGeometryFreeThreshold) {
     EXPECT_DOUBLE_EQ(
         ppp_internal::geometryFreeSlipThresholdMeters(true, 0.05),


### PR DESCRIPTION
## Summary
- add opt-in native `--madoca-l6d` STEC constraints for coherent MADOCA per-frequency PPP
- match MADOCALIB row admission, constellation bias removal, previous-solution covariance gate, and postfit exclusion
- preserve shadow telemetry and keep the existing M2 path unchanged unless active L6D constraints remove its unconstrained-STEC premise
- pin one-hour `pppar-ion` row, gate, status-safety, and trajectory evidence in required CI

## Root causes resolved
- MADOCA gates `const_iono_corr()` with the previous published solution covariance, not the current predicted covariance; using the latter applied 1,890 rows instead of the oracle's 9
- the second precise-correction pass replaced the constraint telemetry collected during prefit formation
- the M2 one-child lookahead addresses an unconstrained STEC gauge and produced wrong Fix classifications after active L6D rows removed that premise

## Evidence
- native constraint application: 1 epoch / 9 rows, followed by 117 covariance-gated epochs (oracle: 9 rows at the first valid epoch)
- native/oracle statuses: native 89 Fix / 29 Float; oracle 97 Fix / 21 Float; 0 wrong Fix and 8 conservative missed Fix
- native/oracle 3D delta: 0.244372 m RMS, 0.459645 m maximum
- absolute reference RMS improves from M2 for both oracle (4.49578 -> 4.44821 m) and native (4.51256 -> 4.44202 m)
- default M2 remains exact: 108 Fix / 10 Float, 0 wrong/missed Fix, 0.186378 m RMS delta

## Validation
- Windows focused unit tests: 5/5
- Ubuntu full unit suite: 725 passed, 56 expected skipped
- MADOCALIB-linked L6D oracle tests: 3/3
- authoritative Ubuntu 120-epoch M2 and M3 parity runs
- `git diff --check`

The remaining eight conservative missed Fix epochs and component convergence are explicitly tracked as M4; this PR does not close the tracker.

Refs #148