### PR TITLE
Support hourly MADOCA L6D input sequences

### DIFF
--- a/apps/native/gnss_ppp.cpp
+++ b/apps/native/gnss_ppp.cpp
@@ -104,7 +104,8 @@ void printUsage(const char* program_name) {
         << "  --madoca-l6 <file>       Native MADOCA L6E SSR channel (repeatable,\n"
         << "                          e.g. PRN 204 and 206); requires --nav\n"
         << "  --madoca-l6d <file>      Native MADOCA L6D STEC input (repeatable);\n"
-        << "                          opt-in application for per-frequency PPP\n"
+        << "                          opt-in application for per-frequency PPP;\n"
+        << "                          accepts hourly sequences for multi-hour runs\n"
         << "  --madoca-l6d-shadow <file>\n"
         << "                          Native L6D ionosphere shadow input (repeatable);\n"
         << "                          reports lookup diagnostics without changing PPP\n"
@@ -167,7 +168,8 @@ void printUsage(const char* program_name) {
         << "                          (requires CMake -DMADOCALIB_PARITY_LINK=ON)\n"
         << "  --madocalib-l6 <file>   Extra MADOCA L6 input file; repeat for two-channel L6E\n"
         << "  --madocalib-mdciono <file>\n"
-        << "                          Extra MADOCA L6D ionosphere file; repeat up to three\n"
+        << "                          Extra MADOCA L6D ionosphere file (repeatable);\n"
+        << "                          hourly sequences are condensed by stream\n"
         << "  --madocalib-config <file>\n"
         << "                          MADOCALIB rnx2rtkp config (default: sample.conf)\n"
         << "  --madocalib-profile <ppp|pppar|pppar-ion>\n"
@@ -468,12 +470,6 @@ Options parseArguments(int argc, char* argv[]) {
         options.ar_method != "per-freq") {
         argumentError(
             "--madoca-l6d requires --ar-method per-freq",
-            argv[0]);
-    }
-    if (options.madoca_l6d_paths.size() > 3 ||
-        options.madoca_l6d_shadow_paths.size() > 3) {
-        argumentError(
-            "MADOCA L6D input accepts at most three files",
             argv[0]);
     }
     if (options.max_epochs < 0) {

--- a/docs/madocalib_native_migration.md
+++ b/docs/madocalib_native_migration.md
@@ -538,6 +538,31 @@ Exit: all supported materialization and residual identities are accounted for;
 configured common component deltas pass their explicit tolerances; MIZU 24-hour
 maximum native/oracle 3D delta is at most 1.0 m with no new boundary spike.
 
+#### M4 24-hour input and boundary gate
+
+The CLI previously limited native `--madoca-l6d` and shadow input to three
+files, while the linked bridge copied only the first three
+`--madocalib-mdciono` paths into MADOCALIB's three stream slots.  That made an
+explicit A--X hourly sequence impossible even though RTKLIB time-path
+expansion supports it.  Native now accepts the complete sequence.  The bridge
+validates every explicit file, then condenses two or more files from the same
+PRN stream into `%Y/%n/%Y%n%HU.<prn>.l6`; independent L6D streams still fail
+when they exceed the three-slot limit.
+
+On the full-day MIZU `pppar-ion` run, the bridge publishes 2,878 solutions and
+native publishes 2,855, all of which match a bridge epoch.  Native/oracle 3D
+delta RMS is 0.097181 m and the maximum is 0.459645 m; no matched epoch exceeds
+1 m.  Across the 23 hourly boundaries, using the eight epochs within
+plus/minus 120 seconds of each boundary, the largest 3D delta is 0.280746 m.
+This satisfies the M4 24-hour trajectory and boundary clause without a
+time-window-specific position guard.
+
+Status remains deliberately conservative and is not hidden by that trajectory
+result: the bridge reports 2,857 Fix and 21 non-Fix solutions, while native
+reports 1,916 Fix and 939 Float solutions.  All native Fix epochs are bridge
+Fix epochs, so there are zero wrong Fix and 918 matched missed-Fix epochs.
+The status baseline and any safe convergence improvement remain M5 evidence.
+
 ### M5 -- Make parity a release gate
 
 - Run MIZU and ALIC for 1 h and 6 h on every solver-change PR.

--- a/include/libgnss++/external/madocalib_bridge.hpp
+++ b/include/libgnss++/external/madocalib_bridge.hpp
@@ -24,6 +24,16 @@ bool isAvailable();
 std::string defaultRootDir();
 std::string defaultSampleConfigPath();
 
+namespace detail {
+
+// Converts two or more explicitly listed hourly files from the same L6
+// stream into the RTKLIB time-path pattern consumed by postpos().
+std::vector<std::string> condenseHourlyL6Inputs(
+    const std::vector<std::string>& inputs,
+    bool ionosphere);
+
+}  // namespace detail
+
 int runPostpos(const PostposOptions& options, std::string* error_message = nullptr);
 
 }  // namespace libgnss::external::madocalib

--- a/src/algorithms/madocalib_bridge.cpp
+++ b/src/algorithms/madocalib_bridge.cpp
@@ -79,12 +79,12 @@ bool requireRegularFiles(const std::vector<std::string>& paths,
     return true;
 }
 
-struct L6ePatternInfo {
+struct L6PatternInfo {
     bool matched = false;
     std::string pattern;
 };
 
-L6ePatternInfo hourlyL6ePattern(const std::string& input_path) {
+L6PatternInfo hourlyL6Pattern(const std::string& input_path, bool ionosphere) {
     const std::filesystem::path path(input_path);
     const std::string filename = path.filename().string();
     const auto dot_l6 = filename.rfind('.');
@@ -100,7 +100,8 @@ L6ePatternInfo hourlyL6ePattern(const std::string& input_path) {
         return {};
     }
     const std::string prn = filename.substr(dot_prn + 1, dot_l6 - dot_prn - 1);
-    if (prn.size() != 3 || prn == "200" || prn == "201") {
+    const bool is_ionosphere = prn == "200" || prn == "201";
+    if (prn.size() != 3 || is_ionosphere != ionosphere) {
         return {};
     }
     const std::string stem = filename.substr(0, dot_prn);
@@ -130,37 +131,6 @@ L6ePatternInfo hourlyL6ePattern(const std::string& input_path) {
         pattern_path = day_dir / pattern_name;
     }
     return {true, pattern_path.string()};
-}
-
-std::vector<std::string> condenseHourlyL6eInputs(
-    const std::vector<std::string>& inputs) {
-    constexpr size_t kMadocalibL6eStreamSlots = 7;
-    std::map<std::string, size_t> pattern_counts;
-    std::vector<L6ePatternInfo> infos;
-    infos.reserve(inputs.size());
-    for (const std::string& input : inputs) {
-        L6ePatternInfo info = hourlyL6ePattern(input);
-        if (info.matched) {
-            ++pattern_counts[info.pattern];
-        }
-        infos.push_back(std::move(info));
-    }
-
-    std::vector<std::string> condensed;
-    condensed.reserve(inputs.size());
-    std::set<std::string> emitted_patterns;
-    for (size_t i = 0; i < inputs.size(); ++i) {
-        const L6ePatternInfo& info = infos[i];
-        if (!info.matched ||
-            pattern_counts[info.pattern] <= kMadocalibL6eStreamSlots) {
-            condensed.push_back(inputs[i]);
-            continue;
-        }
-        if (emitted_patterns.insert(info.pattern).second) {
-            condensed.push_back(info.pattern);
-        }
-    }
-    return condensed;
 }
 
 #if GNSSPP_HAS_MADOCALIB_BRIDGE
@@ -301,6 +271,40 @@ void applySignalSelection(const prcopt_t& prcopt) {
 
 }  // namespace
 
+namespace detail {
+
+std::vector<std::string> condenseHourlyL6Inputs(
+    const std::vector<std::string>& inputs,
+    bool ionosphere) {
+    std::map<std::string, size_t> pattern_counts;
+    std::vector<L6PatternInfo> infos;
+    infos.reserve(inputs.size());
+    for (const std::string& input : inputs) {
+        L6PatternInfo info = hourlyL6Pattern(input, ionosphere);
+        if (info.matched) {
+            ++pattern_counts[info.pattern];
+        }
+        infos.push_back(std::move(info));
+    }
+
+    std::vector<std::string> condensed;
+    condensed.reserve(inputs.size());
+    std::set<std::string> emitted_patterns;
+    for (size_t i = 0; i < inputs.size(); ++i) {
+        const L6PatternInfo& info = infos[i];
+        if (!info.matched || pattern_counts[info.pattern] == 1) {
+            condensed.push_back(inputs[i]);
+            continue;
+        }
+        if (emitted_patterns.insert(info.pattern).second) {
+            condensed.push_back(info.pattern);
+        }
+    }
+    return condensed;
+}
+
+}  // namespace detail
+
 bool isAvailable() {
     return GNSSPP_HAS_MADOCALIB_BRIDGE != 0;
 }
@@ -402,8 +406,17 @@ int runPostpos(const PostposOptions& options, std::string* error_message) {
     }
     applySignalSelection(prcopt);
 
-    for (size_t i = 0; i < options.mdciono_paths.size() && i < MIONO_MAX_PRN; ++i) {
-        prcopt.l6dpath[i] = const_cast<char*>(options.mdciono_paths[i].c_str());
+    const std::vector<std::string> mdciono_paths =
+        detail::condenseHourlyL6Inputs(options.mdciono_paths, true);
+    if (mdciono_paths.size() > MIONO_MAX_PRN) {
+        if (error_message != nullptr) {
+            *error_message =
+                "MADOCALIB accepts at most three independent L6D streams";
+        }
+        return -1;
+    }
+    for (size_t i = 0; i < mdciono_paths.size(); ++i) {
+        prcopt.l6dpath[i] = const_cast<char*>(mdciono_paths[i].c_str());
     }
 
     if (!options.antenna_path.empty()) {
@@ -413,7 +426,7 @@ int runPostpos(const PostposOptions& options, std::string* error_message) {
     solopt.trace = options.trace_level;
 
     const std::vector<std::string> auxiliary_input_paths =
-        condenseHourlyL6eInputs(options.auxiliary_input_paths);
+        detail::condenseHourlyL6Inputs(options.auxiliary_input_paths, false);
 
     std::vector<std::string> input_storage;
     input_storage.push_back(options.obs_path);

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -4057,6 +4057,29 @@ class CLIToolsTest(unittest.TestCase):
         self.assertNotEqual(result.returncode, 0)
         self.assertIn("--madocalib-profile must be one of", result.stderr)
 
+    def test_ppp_cli_accepts_more_than_three_hourly_madoca_l6d_inputs(self) -> None:
+        result = self.run_gnss(
+            "ppp",
+            "--obs",
+            "missing.obs",
+            "--nav",
+            "missing.nav",
+            "--out",
+            "unused.pos",
+            "--ar-method",
+            "per-freq",
+            "--madoca-l6",
+            "missing-l6e.l6",
+            *[
+                option
+                for hour in "ABCD"
+                for option in ("--madoca-l6d", f"2025091{hour}.200.l6")
+            ],
+        )
+
+        self.assertNotEqual(result.returncode, 0)
+        self.assertNotIn("accepts at most three files", result.stderr)
+
     def test_ppp_cli_rejects_madoca_materialization_dump_only_without_dump_path(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_ppp_madoca_materialization_dump_only_cli_") as temp_dir:
             temp_root = Path(temp_dir)

--- a/tests/test_madoca_parity.cpp
+++ b/tests/test_madoca_parity.cpp
@@ -112,6 +112,50 @@ TEST(MadocaBridgeConfig, AvailabilityMatchesBuildFlag) {
 #endif
 }
 
+TEST(MadocaBridgeConfig, CondensesHourlyFilesByL6Stream) {
+    namespace bridge = libgnss::external::madocalib;
+    const std::filesystem::path root =
+        std::filesystem::path("archive") / "2025" / "091";
+    const std::vector<std::string> inputs = {
+        (root / "2025091A.200.l6").string(),
+        (root / "2025091A.201.l6").string(),
+        (root / "2025091B.200.l6").string(),
+        (root / "2025091B.201.l6").string(),
+    };
+
+    const std::vector<std::string> condensed =
+        bridge::detail::condenseHourlyL6Inputs(inputs, true);
+
+    ASSERT_EQ(condensed.size(), 2u);
+    EXPECT_EQ(condensed[0],
+              (std::filesystem::path("archive") / "%Y" / "%n" /
+               "%Y%n%HU.200.l6").string());
+    EXPECT_EQ(condensed[1],
+              (std::filesystem::path("archive") / "%Y" / "%n" /
+               "%Y%n%HU.201.l6").string());
+
+    const std::vector<std::string> l6e_inputs = {
+        (root / "2025091A.204.l6").string(),
+        (root / "2025091B.204.l6").string(),
+    };
+    EXPECT_EQ(bridge::detail::condenseHourlyL6Inputs(l6e_inputs, false),
+              std::vector<std::string>({
+                  (std::filesystem::path("archive") / "%Y" / "%n" /
+                   "%Y%n%HU.204.l6").string(),
+              }));
+}
+
+TEST(MadocaBridgeConfig, PreservesSingleAndNonmatchingL6Inputs) {
+    namespace bridge = libgnss::external::madocalib;
+    const std::vector<std::string> inputs = {
+        "2025091A.200.l6",
+        "2025091A.204.l6",
+        "custom-ionosphere.l6",
+    };
+
+    EXPECT_EQ(bridge::detail::condenseHourlyL6Inputs(inputs, true), inputs);
+}
+
 TEST(MadocaBridgeConfig, TideOracleIsAlsoOptIn) {
 #if GNSSPP_HAS_MADOCALIB_ORACLE
     EXPECT_TRUE(libgnss::external::madocalib_oracle::tideAvailable());


### PR DESCRIPTION
## Summary
- accept complete hourly native L6D and shadow input sequences instead of imposing MADOCALIB's three-stream slot limit on files
- condense repeated hourly L6D/L6E files into RTKLIB `%Y/%n/%Y%n%HU` stream patterns before calling the linked bridge
- reject more than three genuinely independent L6D streams and pin short/full-day behavior in tests and migration evidence

## M4 evidence
- clean MIZU 24 h `pppar-ion`: oracle 2,878 rows, native 2,855 rows, 2,855 matched
- native/oracle 3D delta RMS `0.097181 m`, maximum `0.459645 m`; no epoch over `1 m`
- 23 hourly boundaries, ±120 s: maximum `0.280746 m`
- status remains conservative and is recorded explicitly: oracle 2,857 Fix / 21 non-Fix, native 1,916 Fix / 939 Float, zero wrong Fix, 918 matched missed Fix

## Verification
- `cmake --build build-wsl-madoca-make --target gnss_ppp -- -j2`
- `cmake --build build-wsl-madoca-make --target gnss_madoca_parity_tests -- -j2`
- `madoca_parity_tests --gtest_filter='*MadocaParity*:MadocaBridgeConfig.*'` (17 passed)
- targeted Python CLI regression (1 passed)
- real A/B two-hour bridge smoke with PRN 200/201 and 204/206 (exit 0)
- clean A-X full-day bridge/native run and solution diff

Refs #148 (M4). This does not close the tracker; M5/M6 remain.