### PR TITLE
ci: add MADOCA release parity matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,7 +540,7 @@ jobs:
     needs: [changes, hygiene]
     if: needs.changes.outputs.run_heavy == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v4
 
@@ -764,6 +764,35 @@ jobs:
           ion_missed_fixes="$(awk -F, 'NR > 1 && $5 == 1 && $6 != 6 {n++} END {print n+0}' madoca_pppar_ion_solution_matches.csv)"
           test "$ion_missed_fixes" -eq 8
           python3 -c 'import json; m2=json.load(open("madoca_pppar_solution_diff.json")); ion=json.load(open("madoca_pppar_ion_solution_diff.json")); assert ion["base"]["reference_rms_3d_m"] <= m2["base"]["reference_rms_3d_m"]; assert ion["candidate"]["reference_rms_3d_m"] <= m2["candidate"]["reference_rms_3d_m"]; assert ion["comparison"]["delta_rms_3d_m"] <= 0.25; assert ion["events"]["max_delta_3d"]["delta_3d_m"] <= 1.0'
+
+    - name: Run required MADOCA release matrix
+      run: |
+        python3 scripts/ci/run_madoca_release_matrix.py \
+          --binary build-madoca-parity/apps/gnss_ppp \
+          --data-root external/madocalib/sample_data/data \
+          --output-dir output/madoca_release_matrix_required \
+          --hours 1,6 \
+          --baseline docs/madoca_release_baseline.json
+
+    - name: Run optional 24-hour MADOCA release matrix
+      if: github.event_name == 'workflow_dispatch'
+      run: |
+        python3 scripts/ci/run_madoca_release_matrix.py \
+          --binary build-madoca-parity/apps/gnss_ppp \
+          --data-root external/madocalib/sample_data/data \
+          --output-dir output/madoca_release_matrix_24h \
+          --hours 24 \
+          --baseline docs/madoca_release_baseline.json
+
+    - name: Upload MADOCA release matrix
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: madoca-release-matrix
+        path: |
+          output/madoca_release_matrix_required
+          output/madoca_release_matrix_24h
+        if-no-files-found: warn
 
     - name: Upload MADOCA PPP-AR baseline
       if: always()

--- a/docs/madoca_release_baseline.json
+++ b/docs/madoca_release_baseline.json
@@ -1,0 +1,505 @@
+{
+  "cases": {
+    "alic.ppp.1h": {
+      "base_only_epochs": 0,
+      "base_status_counts": {
+        "6": 118
+      },
+      "boundary_max_delta_3d_m": 3.4893895548867557,
+      "candidate_only_epochs": 0,
+      "candidate_status_counts": {
+        "5": 118
+      },
+      "delta_max_3d_m": 3.4893895548867557,
+      "delta_rms_3d_m": 1.2890065263482149,
+      "matched_epochs": 118,
+      "missed_fixes": 0,
+      "native_row_counts": {
+        "madoca_l6d_constraint_epochs": 0,
+        "madoca_l6d_constraint_position_gate_epochs": 0,
+        "madoca_l6d_constraint_rows": 0
+      },
+      "native_runtime_s": 11.436742382000034,
+      "status_pair_counts": {
+        "6->5": 118
+      },
+      "wrong_fixes": 0
+    },
+    "alic.ppp.24h": {
+      "base_only_epochs": 23,
+      "base_status_counts": {
+        "6": 2878
+      },
+      "boundary_max_delta_3d_m": 3.4893895548867557,
+      "candidate_only_epochs": 0,
+      "candidate_status_counts": {
+        "5": 2855
+      },
+      "delta_max_3d_m": 3.4893895548867557,
+      "delta_rms_3d_m": 0.8051494758745736,
+      "matched_epochs": 2855,
+      "missed_fixes": 0,
+      "native_row_counts": {
+        "madoca_l6d_constraint_epochs": 0,
+        "madoca_l6d_constraint_position_gate_epochs": 0,
+        "madoca_l6d_constraint_rows": 0
+      },
+      "native_runtime_s": 131.36953157799996,
+      "status_pair_counts": {
+        "6->5": 2855
+      },
+      "wrong_fixes": 0
+    },
+    "alic.ppp.6h": {
+      "base_only_epochs": 5,
+      "base_status_counts": {
+        "6": 718
+      },
+      "boundary_max_delta_3d_m": 3.4893895548867557,
+      "candidate_only_epochs": 0,
+      "candidate_status_counts": {
+        "5": 713
+      },
+      "delta_max_3d_m": 3.4893895548867557,
+      "delta_rms_3d_m": 0.8830304718044313,
+      "matched_epochs": 713,
+      "missed_fixes": 0,
+      "native_row_counts": {
+        "madoca_l6d_constraint_epochs": 0,
+        "madoca_l6d_constraint_position_gate_epochs": 0,
+        "madoca_l6d_constraint_rows": 0
+      },
+      "native_runtime_s": 30.89363381999999,
+      "status_pair_counts": {
+        "6->5": 713
+      },
+      "wrong_fixes": 0
+    },
+    "alic.pppar-ion.1h": {
+      "base_only_epochs": 0,
+      "base_status_counts": {
+        "1": 108,
+        "6": 10
+      },
+      "boundary_max_delta_3d_m": 0.049686039760109706,
+      "candidate_only_epochs": 0,
+      "candidate_status_counts": {
+        "5": 11,
+        "6": 107
+      },
+      "delta_max_3d_m": 0.4679434691068333,
+      "delta_rms_3d_m": 0.06480974657394407,
+      "matched_epochs": 118,
+      "missed_fixes": 1,
+      "native_row_counts": {
+        "madoca_l6d_constraint_epochs": 1,
+        "madoca_l6d_constraint_position_gate_epochs": 117,
+        "madoca_l6d_constraint_rows": 10
+      },
+      "native_runtime_s": 9.629612201999407,
+      "status_pair_counts": {
+        "1->5": 1,
+        "1->6": 107,
+        "6->5": 10
+      },
+      "wrong_fixes": 0
+    },
+    "alic.pppar-ion.24h": {
+      "base_only_epochs": 23,
+      "base_status_counts": {
+        "1": 2868,
+        "6": 10
+      },
+      "boundary_max_delta_3d_m": 0.25449669666628116,
+      "candidate_only_epochs": 0,
+      "candidate_status_counts": {
+        "5": 589,
+        "6": 2266
+      },
+      "delta_max_3d_m": 0.4679434691068333,
+      "delta_rms_3d_m": 0.0988556114378096,
+      "matched_epochs": 2855,
+      "missed_fixes": 579,
+      "native_row_counts": {
+        "madoca_l6d_constraint_epochs": 1,
+        "madoca_l6d_constraint_position_gate_epochs": 2854,
+        "madoca_l6d_constraint_rows": 10
+      },
+      "native_runtime_s": 142.66633428399837,
+      "status_pair_counts": {
+        "1->5": 579,
+        "1->6": 2266,
+        "6->5": 10
+      },
+      "wrong_fixes": 0
+    },
+    "alic.pppar-ion.6h": {
+      "base_only_epochs": 5,
+      "base_status_counts": {
+        "1": 708,
+        "6": 10
+      },
+      "boundary_max_delta_3d_m": 0.07188465649969084,
+      "candidate_only_epochs": 0,
+      "candidate_status_counts": {
+        "5": 11,
+        "6": 702
+      },
+      "delta_max_3d_m": 0.4679434691068333,
+      "delta_rms_3d_m": 0.06788443368825045,
+      "matched_epochs": 713,
+      "missed_fixes": 1,
+      "native_row_counts": {
+        "madoca_l6d_constraint_epochs": 1,
+        "madoca_l6d_constraint_position_gate_epochs": 712,
+        "madoca_l6d_constraint_rows": 10
+      },
+      "native_runtime_s": 38.80786048999926,
+      "status_pair_counts": {
+        "1->5": 1,
+        "1->6": 702,
+        "6->5": 10
+      },
+      "wrong_fixes": 0
+    },
+    "alic.pppar.1h": {
+      "base_only_epochs": 0,
+      "base_status_counts": {
+        "1": 99,
+        "6": 19
+      },
+      "boundary_max_delta_3d_m": 0.06386913021118062,
+      "candidate_only_epochs": 0,
+      "candidate_status_counts": {
+        "5": 9,
+        "6": 109
+      },
+      "delta_max_3d_m": 0.5414620290120746,
+      "delta_rms_3d_m": 0.125636073390556,
+      "matched_epochs": 118,
+      "missed_fixes": 1,
+      "native_row_counts": {
+        "madoca_l6d_constraint_epochs": 0,
+        "madoca_l6d_constraint_position_gate_epochs": 0,
+        "madoca_l6d_constraint_rows": 0
+      },
+      "native_runtime_s": 10.679893317999813,
+      "status_pair_counts": {
+        "1->5": 1,
+        "1->6": 98,
+        "6->5": 8,
+        "6->6": 11
+      },
+      "wrong_fixes": 11
+    },
+    "alic.pppar.24h": {
+      "base_only_epochs": 23,
+      "base_status_counts": {
+        "1": 2859,
+        "6": 19
+      },
+      "boundary_max_delta_3d_m": 0.25462907181110384,
+      "candidate_only_epochs": 0,
+      "candidate_status_counts": {
+        "5": 562,
+        "6": 2293
+      },
+      "delta_max_3d_m": 0.5414620290120746,
+      "delta_rms_3d_m": 0.10158191517621844,
+      "matched_epochs": 2855,
+      "missed_fixes": 554,
+      "native_row_counts": {
+        "madoca_l6d_constraint_epochs": 0,
+        "madoca_l6d_constraint_position_gate_epochs": 0,
+        "madoca_l6d_constraint_rows": 0
+      },
+      "native_runtime_s": 139.58109996999974,
+      "status_pair_counts": {
+        "1->5": 554,
+        "1->6": 2282,
+        "6->5": 8,
+        "6->6": 11
+      },
+      "wrong_fixes": 11
+    },
+    "alic.pppar.6h": {
+      "base_only_epochs": 5,
+      "base_status_counts": {
+        "1": 699,
+        "6": 19
+      },
+      "boundary_max_delta_3d_m": 0.0740519076073963,
+      "candidate_only_epochs": 0,
+      "candidate_status_counts": {
+        "5": 9,
+        "6": 704
+      },
+      "delta_max_3d_m": 0.5414620290120746,
+      "delta_rms_3d_m": 0.08203649874343641,
+      "matched_epochs": 713,
+      "missed_fixes": 1,
+      "native_row_counts": {
+        "madoca_l6d_constraint_epochs": 0,
+        "madoca_l6d_constraint_position_gate_epochs": 0,
+        "madoca_l6d_constraint_rows": 0
+      },
+      "native_runtime_s": 41.08398776000013,
+      "status_pair_counts": {
+        "1->5": 1,
+        "1->6": 693,
+        "6->5": 8,
+        "6->6": 11
+      },
+      "wrong_fixes": 11
+    },
+    "mizu.ppp.1h": {
+      "base_only_epochs": 0,
+      "base_status_counts": {
+        "6": 118
+      },
+      "boundary_max_delta_3d_m": 4.284246515935533,
+      "candidate_only_epochs": 0,
+      "candidate_status_counts": {
+        "5": 118
+      },
+      "delta_max_3d_m": 4.284246515935533,
+      "delta_rms_3d_m": 1.6156750831405513,
+      "matched_epochs": 118,
+      "missed_fixes": 0,
+      "native_row_counts": {
+        "madoca_l6d_constraint_epochs": 0,
+        "madoca_l6d_constraint_position_gate_epochs": 0,
+        "madoca_l6d_constraint_rows": 0
+      },
+      "native_runtime_s": 16.425533881999996,
+      "status_pair_counts": {
+        "6->5": 118
+      },
+      "wrong_fixes": 0
+    },
+    "mizu.ppp.24h": {
+      "base_only_epochs": 281,
+      "base_status_counts": {
+        "6": 2878
+      },
+      "boundary_max_delta_3d_m": 4.284246515935533,
+      "candidate_only_epochs": 0,
+      "candidate_status_counts": {
+        "5": 2597
+      },
+      "delta_max_3d_m": 4.284246515935533,
+      "delta_rms_3d_m": 1.3352679575116697,
+      "matched_epochs": 2597,
+      "missed_fixes": 0,
+      "native_row_counts": {
+        "madoca_l6d_constraint_epochs": 0,
+        "madoca_l6d_constraint_position_gate_epochs": 0,
+        "madoca_l6d_constraint_rows": 0
+      },
+      "native_runtime_s": 172.97892152600002,
+      "status_pair_counts": {
+        "6->5": 2597
+      },
+      "wrong_fixes": 0
+    },
+    "mizu.ppp.6h": {
+      "base_only_epochs": 5,
+      "base_status_counts": {
+        "6": 718
+      },
+      "boundary_max_delta_3d_m": 4.284246515935533,
+      "candidate_only_epochs": 0,
+      "candidate_status_counts": {
+        "5": 713
+      },
+      "delta_max_3d_m": 4.284246515935533,
+      "delta_rms_3d_m": 1.2209054962011483,
+      "matched_epochs": 713,
+      "missed_fixes": 0,
+      "native_row_counts": {
+        "madoca_l6d_constraint_epochs": 0,
+        "madoca_l6d_constraint_position_gate_epochs": 0,
+        "madoca_l6d_constraint_rows": 0
+      },
+      "native_runtime_s": 36.26635522999999,
+      "status_pair_counts": {
+        "6->5": 713
+      },
+      "wrong_fixes": 0
+    },
+    "mizu.pppar-ion.1h": {
+      "base_only_epochs": 0,
+      "base_status_counts": {
+        "1": 97,
+        "6": 21
+      },
+      "boundary_max_delta_3d_m": 0.2759272510010001,
+      "candidate_only_epochs": 0,
+      "candidate_status_counts": {
+        "5": 29,
+        "6": 89
+      },
+      "delta_max_3d_m": 0.4826277238332499,
+      "delta_rms_3d_m": 0.25659075945906673,
+      "matched_epochs": 118,
+      "missed_fixes": 8,
+      "native_row_counts": {
+        "madoca_l6d_constraint_epochs": 1,
+        "madoca_l6d_constraint_position_gate_epochs": 117,
+        "madoca_l6d_constraint_rows": 9
+      },
+      "native_runtime_s": 10.386064764000366,
+      "status_pair_counts": {
+        "1->5": 8,
+        "1->6": 89,
+        "6->5": 21
+      },
+      "wrong_fixes": 0
+    },
+    "mizu.pppar-ion.24h": {
+      "base_only_epochs": 23,
+      "base_status_counts": {
+        "1": 2857,
+        "6": 21
+      },
+      "boundary_max_delta_3d_m": 0.29478379262475907,
+      "candidate_only_epochs": 0,
+      "candidate_status_counts": {
+        "5": 939,
+        "6": 1916
+      },
+      "delta_max_3d_m": 0.4826277238332499,
+      "delta_rms_3d_m": 0.10718095823174646,
+      "matched_epochs": 2855,
+      "missed_fixes": 918,
+      "native_row_counts": {
+        "madoca_l6d_constraint_epochs": 1,
+        "madoca_l6d_constraint_position_gate_epochs": 2854,
+        "madoca_l6d_constraint_rows": 9
+      },
+      "native_runtime_s": 148.60230188199967,
+      "status_pair_counts": {
+        "1->5": 918,
+        "1->6": 1916,
+        "6->5": 21
+      },
+      "wrong_fixes": 0
+    },
+    "mizu.pppar-ion.6h": {
+      "base_only_epochs": 5,
+      "base_status_counts": {
+        "1": 697,
+        "6": 21
+      },
+      "boundary_max_delta_3d_m": 0.29478379262475907,
+      "candidate_only_epochs": 0,
+      "candidate_status_counts": {
+        "5": 105,
+        "6": 608
+      },
+      "delta_max_3d_m": 0.4826277238332499,
+      "delta_rms_3d_m": 0.1826056177591525,
+      "matched_epochs": 713,
+      "missed_fixes": 84,
+      "native_row_counts": {
+        "madoca_l6d_constraint_epochs": 1,
+        "madoca_l6d_constraint_position_gate_epochs": 712,
+        "madoca_l6d_constraint_rows": 9
+      },
+      "native_runtime_s": 38.12038253399987,
+      "status_pair_counts": {
+        "1->5": 84,
+        "1->6": 608,
+        "6->5": 21
+      },
+      "wrong_fixes": 0
+    },
+    "mizu.pppar.1h": {
+      "base_only_epochs": 0,
+      "base_status_counts": {
+        "1": 108,
+        "6": 10
+      },
+      "boundary_max_delta_3d_m": 0.2597104677024002,
+      "candidate_only_epochs": 0,
+      "candidate_status_counts": {
+        "5": 10,
+        "6": 108
+      },
+      "delta_max_3d_m": 0.47406375508602866,
+      "delta_rms_3d_m": 0.196377796388336,
+      "matched_epochs": 118,
+      "missed_fixes": 0,
+      "native_row_counts": {
+        "madoca_l6d_constraint_epochs": 0,
+        "madoca_l6d_constraint_position_gate_epochs": 0,
+        "madoca_l6d_constraint_rows": 0
+      },
+      "native_runtime_s": 9.705306623999604,
+      "status_pair_counts": {
+        "1->6": 108,
+        "6->5": 10
+      },
+      "wrong_fixes": 0
+    },
+    "mizu.pppar.24h": {
+      "base_only_epochs": 23,
+      "base_status_counts": {
+        "1": 2868,
+        "6": 10
+      },
+      "boundary_max_delta_3d_m": 0.2940535550794953,
+      "candidate_only_epochs": 0,
+      "candidate_status_counts": {
+        "5": 931,
+        "6": 1924
+      },
+      "delta_max_3d_m": 0.47406375508602866,
+      "delta_rms_3d_m": 0.09848191265734747,
+      "matched_epochs": 2855,
+      "missed_fixes": 921,
+      "native_row_counts": {
+        "madoca_l6d_constraint_epochs": 0,
+        "madoca_l6d_constraint_position_gate_epochs": 0,
+        "madoca_l6d_constraint_rows": 0
+      },
+      "native_runtime_s": 152.86657481400016,
+      "status_pair_counts": {
+        "1->5": 921,
+        "1->6": 1924,
+        "6->5": 10
+      },
+      "wrong_fixes": 0
+    },
+    "mizu.pppar.6h": {
+      "base_only_epochs": 5,
+      "base_status_counts": {
+        "1": 708,
+        "6": 10
+      },
+      "boundary_max_delta_3d_m": 0.2940535550794953,
+      "candidate_only_epochs": 0,
+      "candidate_status_counts": {
+        "5": 86,
+        "6": 627
+      },
+      "delta_max_3d_m": 0.47406375508602866,
+      "delta_rms_3d_m": 0.16204316868841126,
+      "matched_epochs": 713,
+      "missed_fixes": 76,
+      "native_row_counts": {
+        "madoca_l6d_constraint_epochs": 0,
+        "madoca_l6d_constraint_position_gate_epochs": 0,
+        "madoca_l6d_constraint_rows": 0
+      },
+      "native_runtime_s": 36.12640814400038,
+      "status_pair_counts": {
+        "1->5": 76,
+        "1->6": 627,
+        "6->5": 10
+      },
+      "wrong_fixes": 0
+    }
+  },
+  "schema_version": "madoca_release_baseline.v1"
+}

--- a/docs/madocalib_native_migration.md
+++ b/docs/madocalib_native_migration.md
@@ -575,6 +575,56 @@ Exit: all six solver/dataset profiles have pinned baselines; required lanes fail
 on missing artifacts, status regression, trajectory regression, or runtime over
 2x their accepted native baseline; default builds still run without MADOCALIB.
 
+#### M5 implementation evidence (2026-07-30)
+
+`scripts/ci/run_madoca_release_matrix.py` now owns the versioned
+`madoca_release_matrix.v1`, `madoca_release_commands.v1`, and
+`madoca_release_baseline.v1` contracts.  Every case preserves the exact bridge
+and native argv, both summaries and logs, both solution files, the solution
+diff, matched epochs, L6D constraint-row counters, and wall runtimes.  The
+checked-in `docs/madoca_release_baseline.json` contains all 18 combinations of
+MIZU/ALIC, `ppp`/`pppar`/`pppar-ion`, and 1 h/6 h/24 h.
+
+The native `ppp` command deliberately uses the CLI's static motion model.  That
+is the historical Issue #148 native contract for these stationary receivers;
+an initial matrix draft incorrectly forced `--kinematic` on every profile and
+produced 24-hour deltas of 5.93 m (MIZU) and 4.50 m (ALIC).  Restoring the
+profile-specific command gives MIZU 1 h/6 h/24 h RMS of
+1.538738/1.162767/1.271684 m, consistent with the earlier tracker evidence.
+The AR profiles remain kinematic, matching the M2--M4 commands.
+
+Selected measured results before the declared trajectory margin are:
+
+| Station/profile | Window | matched | oracle-only | wrong Fix | missed Fix | RMS 3D | max 3D |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| MIZU PPP | 24 h | 2,597 | 281 | 0 | 0 | 1.271684 m | 4.080235 m |
+| MIZU PPP-AR | 1 h | 118 | 0 | 0 | 0 | 0.186378 m | 0.451489 m |
+| MIZU PPP-AR | 24 h | 2,855 | 23 | 0 | 921 | 0.088482 m | 0.451489 m |
+| MIZU PPP-AR-ion | 24 h | 2,855 | 23 | 0 | 918 | 0.097181 m | 0.459645 m |
+| ALIC PPP | 24 h | 2,855 | 23 | 0 | 0 | 0.766809 m | 3.323228 m |
+| ALIC PPP-AR | 1 h | 118 | 0 | 11 | 1 | 0.115636 m | 0.515678 m |
+| ALIC PPP-AR | 24 h | 2,855 | 23 | 11 | 554 | 0.091582 m | 0.515678 m |
+| ALIC PPP-AR-ion | 24 h | 2,855 | 23 | 0 | 579 | 0.088856 m | 0.445660 m |
+
+Here `wrong Fix` means oracle non-Fix/native Fix, not a truth-labeled position
+blunder.  The 11 ALIC PPP-AR epochs were investigated before accepting the
+baseline.  Disabling the M2 canonical one-removal lookahead reduces them to
+seven but does not remove the later cluster; the oracle's float/covariance
+trajectory assigns low candidate agreement and rejects it, while native assigns
+94--95% agreement near ratio 1.23--1.27.  A 1.30 ratio floor would also remove
+at least 23 correct low-ratio MIZU fixes, and fixed-position shift does not
+separate the stations.  No station- or time-specific solver guard was accepted.
+The mismatch remains explicit and any increase fails the status baseline.
+
+Trajectory ceilings are the larger of 5% or 1 cm above the measured value.
+Native wall runtime is capped at twice its accepted measurement.  Bridge runtime
+is still recorded but is not a production-runtime gate.  The ordinary
+`madoca-parity` lane runs every 1 h and 6 h case; a manual
+`workflow_dispatch` additionally runs all 24 h cases.  Both lanes upload the
+complete matrix and append schema, metric, and exact-command artifact links to
+the GitHub job summary.  Default CMake builds retain
+`MADOCALIB_PARITY_LINK=OFF`.
+
 ### M6 -- Complete the migration
 
 - Promote native behavior only after M2--M5 pass with an explicit opt-out for

--- a/scripts/ci/run_madoca_release_matrix.py
+++ b/scripts/ci/run_madoca_release_matrix.py
@@ -1,0 +1,614 @@
+#!/usr/bin/env python3
+"""Run the MADOCALIB/native MADOCA release-gate matrix."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import os
+import subprocess
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Sequence
+
+
+ROOT_DIR = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT_DIR / "scripts" / "analysis"))
+
+import madoca_solution_diff as solution_diff  # noqa: E402
+
+
+SCHEMA_VERSION = "madoca_release_matrix.v1"
+BASELINE_SCHEMA_VERSION = "madoca_release_baseline.v1"
+COMMAND_SCHEMA_VERSION = "madoca_release_commands.v1"
+PROFILE_NAMES = ("ppp", "pppar", "pppar-ion")
+TRAJECTORY_RELATIVE_MARGIN = 0.05
+TRAJECTORY_ABSOLUTE_MARGIN_M = 0.01
+RUNTIME_MULTIPLIER = 2.0
+NATIVE_ROW_FIELDS = (
+    "madoca_l6d_constraint_epochs",
+    "madoca_l6d_constraint_rows",
+    "madoca_l6d_constraint_position_gate_epochs",
+)
+
+
+@dataclass(frozen=True)
+class Station:
+    key: str
+    observation_name: str
+    reference_ecef_m: tuple[float, float, float]
+
+
+STATIONS = {
+    "mizu": Station(
+        "mizu",
+        "MIZU00JPN_R_20250910000_01D_30S_MO.rnx",
+        (-3857167.6484, 3108694.9138, 4004041.6876),
+    ),
+    "alic": Station(
+        "alic",
+        "ALIC00AUS_R_20250910000_01D_30S_MO.rnx",
+        (-4052052.7249, 4212835.9727, -2545104.5766),
+    ),
+}
+
+
+def case_key(station: str, profile: str, hours: int) -> str:
+    return f"{station}.{profile}.{hours}h"
+
+
+def hourly_letters(hours: int) -> str:
+    if hours < 1 or hours > 24:
+        raise ValueError("hours must be in the range 1..24")
+    return "".join(chr(ord("A") + index) for index in range(hours))
+
+
+def end_time(hours: int) -> str:
+    hourly_letters(hours)
+    return f"2025/04/01 {hours - 1:02d}:59:30"
+
+
+def repeated_option(option: str, paths: Iterable[Path]) -> list[str]:
+    result: list[str] = []
+    for path in paths:
+        result.extend((option, str(path)))
+    return result
+
+
+def l6_paths(
+    data_root: Path,
+    hours: int,
+    prns: Sequence[int],
+    *,
+    ionosphere: bool,
+) -> list[Path]:
+    tree = "l6" if ionosphere else "l6_is-qzss-mdc-004"
+    day_root = data_root / tree / "2025" / "091"
+    return [
+        day_root / f"2025091{letter}.{prn}.l6"
+        for letter in hourly_letters(hours)
+        for prn in prns
+    ]
+
+
+def common_paths(data_root: Path, station: Station) -> tuple[Path, Path, Path]:
+    return (
+        data_root / "rinex" / station.observation_name,
+        data_root / "rinex" / "BRDM00DLR_S_20250910000_01D_MN.rnx",
+        data_root / "igs20.atx",
+    )
+
+
+def bridge_command(
+    binary: Path,
+    data_root: Path,
+    station: Station,
+    profile: str,
+    hours: int,
+    output_pos: Path,
+    summary_json: Path,
+) -> list[str]:
+    if profile not in PROFILE_NAMES:
+        raise ValueError(f"unknown profile: {profile}")
+    obs, nav, antex = common_paths(data_root, station)
+    command = [
+        str(binary),
+        "--madocalib-bridge",
+        "--madocalib-profile",
+        profile,
+        "--obs",
+        str(obs),
+        "--nav",
+        str(nav),
+        "--antex",
+        str(antex),
+        "--madocalib-start",
+        "2025/04/01 00:00:00",
+        "--madocalib-end",
+        end_time(hours),
+        "--madocalib-ti",
+        "30",
+        "--out",
+        str(output_pos),
+        "--summary-json",
+        str(summary_json),
+        "--quiet",
+    ]
+    command += repeated_option(
+        "--madocalib-l6",
+        l6_paths(data_root, hours, (204, 206), ionosphere=False),
+    )
+    if profile == "pppar-ion":
+        command += repeated_option(
+            "--madocalib-mdciono",
+            l6_paths(data_root, hours, (200, 201), ionosphere=True),
+        )
+    return command
+
+
+def native_command(
+    binary: Path,
+    data_root: Path,
+    station: Station,
+    profile: str,
+    hours: int,
+    output_pos: Path,
+    summary_json: Path,
+) -> list[str]:
+    if profile not in PROFILE_NAMES:
+        raise ValueError(f"unknown profile: {profile}")
+    obs, nav, antex = common_paths(data_root, station)
+    command = [
+        str(binary),
+        "--static" if profile == "ppp" else "--kinematic",
+        "--obs",
+        str(obs),
+        "--nav",
+        str(nav),
+        "--antex",
+        str(antex),
+        "--max-epochs",
+        str(hours * 120),
+        "--emit-epoch-time",
+        "--out",
+        str(output_pos),
+        "--summary-json",
+        str(summary_json),
+        "--quiet",
+    ]
+    command += repeated_option(
+        "--madoca-l6",
+        l6_paths(data_root, hours, (204, 206), ionosphere=False),
+    )
+    if profile != "ppp":
+        command += [
+            "--enable-ar",
+            "--ar-method",
+            "per-freq",
+            "--ar-ratio-threshold",
+            "1.5",
+            "--convergence-policy",
+            "local-enu",
+            "--convergence-threshold-horizontal",
+            "0.75",
+            "--convergence-threshold-vertical",
+            "1.25",
+        ]
+    if profile == "pppar-ion":
+        command += repeated_option(
+            "--madoca-l6d",
+            l6_paths(data_root, hours, (200, 201), ionosphere=True),
+        )
+    return command
+
+
+def require_inputs(command: Sequence[str]) -> None:
+    path_options = {
+        "--obs",
+        "--nav",
+        "--antex",
+        "--madocalib-l6",
+        "--madocalib-mdciono",
+        "--madoca-l6",
+        "--madoca-l6d",
+    }
+    for index, token in enumerate(command[:-1]):
+        if token in path_options:
+            path = Path(command[index + 1])
+            if not path.is_file():
+                raise FileNotFoundError(f"{token}: missing input: {path}")
+
+
+def run_command(command: Sequence[str], stdout_path: Path, stderr_path: Path) -> float:
+    require_inputs(command)
+    started = time.perf_counter()
+    with (
+        stdout_path.open("w", encoding="utf-8") as stdout_handle,
+        stderr_path.open("w", encoding="utf-8") as stderr_handle,
+    ):
+        completed = subprocess.run(
+            command,
+            cwd=ROOT_DIR,
+            stdout=stdout_handle,
+            stderr=stderr_handle,
+            check=False,
+        )
+    elapsed = time.perf_counter() - started
+    if completed.returncode != 0:
+        raise RuntimeError(
+            f"command failed with exit {completed.returncode}; see {stderr_path}"
+        )
+    return elapsed
+
+
+def status_summary(matches: Sequence[solution_diff.MatchedPair]) -> dict[str, Any]:
+    pair_counts: dict[str, int] = {}
+    wrong_fixes = 0
+    missed_fixes = 0
+    for pair in matches:
+        pair_key = f"{pair.base.status}->{pair.candidate.status}"
+        pair_counts[pair_key] = pair_counts.get(pair_key, 0) + 1
+        if pair.base.status != 1 and pair.candidate.status == 6:
+            wrong_fixes += 1
+        if pair.base.status == 1 and pair.candidate.status != 6:
+            missed_fixes += 1
+    return {
+        "pair_counts": dict(sorted(pair_counts.items())),
+        "wrong_fixes": wrong_fixes,
+        "missed_fixes": missed_fixes,
+    }
+
+
+def hourly_boundary_summary(
+    matches: Sequence[solution_diff.MatchedPair],
+    window_seconds: float = 120.0,
+) -> dict[str, Any]:
+    selected: list[tuple[float, solution_diff.MatchedPair]] = []
+    for pair in matches:
+        seconds_from_day_start = pair.base.tow - 172800.0
+        if seconds_from_day_start <= 0.0:
+            continue
+        remainder = seconds_from_day_start % 3600.0
+        distance = min(remainder, 3600.0 - remainder)
+        if distance <= window_seconds:
+            delta_3d = math.sqrt(sum(value * value for value in pair.delta_enu_m))
+            selected.append((delta_3d, pair))
+    if not selected:
+        return {
+            "window_seconds": window_seconds,
+            "matched_epochs": 0,
+            "max_delta_3d_m": None,
+            "max_week": None,
+            "max_tow": None,
+        }
+    delta, pair = max(selected, key=lambda item: item[0])
+    return {
+        "window_seconds": window_seconds,
+        "matched_epochs": len(selected),
+        "max_delta_3d_m": delta,
+        "max_week": pair.base.week,
+        "max_tow": pair.base.tow,
+    }
+
+
+def make_reference(station: Station) -> solution_diff.ReferenceFrame:
+    lat, lon, height = solution_diff.ecef_to_llh(*station.reference_ecef_m)
+    return solution_diff.ReferenceFrame(*station.reference_ecef_m, lat, lon, height)
+
+
+def evaluate_baseline(measured: dict[str, Any], baseline: dict[str, Any]) -> list[str]:
+    failures: list[str] = []
+
+    for field in (
+        "base_status_counts",
+        "candidate_status_counts",
+        "status_pair_counts",
+        "native_row_counts",
+    ):
+        if measured.get(field) != baseline.get(field):
+            failures.append(
+                f"{field}: measured={measured.get(field)!r} "
+                f"expected={baseline.get(field)!r}"
+            )
+    if measured.get("matched_epochs", 0) < baseline.get("matched_epochs", 0):
+        failures.append(
+            f"matched_epochs: measured={measured.get('matched_epochs')!r} "
+            f"minimum={baseline.get('matched_epochs')!r}"
+        )
+    for field in (
+        "base_only_epochs",
+        "candidate_only_epochs",
+        "wrong_fixes",
+        "missed_fixes",
+        "delta_rms_3d_m",
+        "delta_max_3d_m",
+        "boundary_max_delta_3d_m",
+        "native_runtime_s",
+    ):
+        expected = baseline.get(field)
+        measured_value = measured.get(field)
+        if (
+            expected is not None
+            and measured_value is not None
+            and measured_value > expected
+        ):
+            failures.append(
+                f"{field}: measured={measured_value!r} maximum={expected!r}"
+            )
+    return failures
+
+
+def trajectory_ceiling(value: float | None) -> float | None:
+    if value is None:
+        return None
+    return max(
+        value * (1.0 + TRAJECTORY_RELATIVE_MARGIN),
+        value + TRAJECTORY_ABSOLUTE_MARGIN_M,
+    )
+
+
+def measured_baseline(case: dict[str, Any]) -> dict[str, Any]:
+    fields = (
+        "matched_epochs",
+        "base_only_epochs",
+        "candidate_only_epochs",
+        "base_status_counts",
+        "candidate_status_counts",
+        "status_pair_counts",
+        "native_row_counts",
+        "wrong_fixes",
+        "missed_fixes",
+    )
+    baseline = {field: case[field] for field in fields}
+    for field in (
+        "delta_rms_3d_m",
+        "delta_max_3d_m",
+        "boundary_max_delta_3d_m",
+    ):
+        baseline[field] = trajectory_ceiling(case[field])
+    baseline["native_runtime_s"] = case["native_runtime_s"] * RUNTIME_MULTIPLIER
+    return baseline
+
+
+def append_github_summary(payload: dict[str, Any]) -> None:
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    with Path(summary_path).open("a", encoding="utf-8") as handle:
+        handle.write("### MADOCA release matrix\n\n")
+        handle.write(
+            f"- Result schema: `{payload['schema_version']}`\n"
+            f"- Command schema: `{payload['command_schema_version']}`\n"
+            f"- Baseline schema: `{payload['baseline_schema_version']}`\n"
+            f"- Status: `{payload['status']}`\n\n"
+        )
+        handle.write(
+            "| Case | Matched | Wrong Fix | Missed Fix | RMS 3D (m) | "
+            "Max 3D (m) | Native runtime (s) | Commands |\n"
+        )
+        handle.write("| --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |\n")
+        for case in payload["cases"]:
+            handle.write(
+                f"| `{case['key']}` | {case['matched_epochs']} | "
+                f"{case['wrong_fixes']} | {case['missed_fixes']} | "
+                f"{case['delta_rms_3d_m']:.6f} | "
+                f"{case['delta_max_3d_m']:.6f} | "
+                f"{case['native_runtime_s']:.2f} | "
+                f"`{case['artifact_dir']}/commands.json` |\n"
+            )
+        handle.write("\n")
+
+
+def run_case(
+    binary: Path,
+    data_root: Path,
+    output_dir: Path,
+    station: Station,
+    profile: str,
+    hours: int,
+) -> dict[str, Any]:
+    key = case_key(station.key, profile, hours)
+    case_dir = output_dir / key
+    case_dir.mkdir(parents=True, exist_ok=True)
+    bridge_pos = case_dir / "bridge.pos"
+    native_pos = case_dir / "native.pos"
+    bridge_summary = case_dir / "bridge_summary.json"
+    native_summary = case_dir / "native_summary.json"
+    bridge = bridge_command(
+        binary, data_root, station, profile, hours, bridge_pos, bridge_summary
+    )
+    native = native_command(
+        binary, data_root, station, profile, hours, native_pos, native_summary
+    )
+    (case_dir / "commands.json").write_text(
+        json.dumps(
+            {
+                "schema_version": COMMAND_SCHEMA_VERSION,
+                "bridge": bridge,
+                "native": native,
+            },
+            indent=2,
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+    bridge_runtime = run_command(
+        bridge, case_dir / "bridge.stdout.log", case_dir / "bridge.stderr.log"
+    )
+    native_runtime = run_command(
+        native, case_dir / "native.stdout.log", case_dir / "native.stderr.log"
+    )
+    report, matches = solution_diff.build_report(
+        bridge_pos,
+        native_pos,
+        make_reference(station),
+        tolerance_s=0.001,
+        tail_seconds=1800.0,
+        base_label="bridge",
+        candidate_label="native",
+    )
+    (case_dir / "solution_diff.json").write_text(
+        json.dumps(report, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    solution_diff.write_matches_csv(case_dir / "solution_matches.csv", matches)
+    statuses = status_summary(matches)
+    boundary = hourly_boundary_summary(matches)
+    comparison = report["comparison"]
+    native_summary_payload = json.loads(native_summary.read_text(encoding="utf-8"))
+    return {
+        "key": key,
+        "station": station.key,
+        "profile": profile,
+        "hours": hours,
+        "bridge_runtime_s": bridge_runtime,
+        "native_runtime_s": native_runtime,
+        "matched_epochs": comparison["matched_epochs"],
+        "base_only_epochs": report["base_only_epochs"],
+        "candidate_only_epochs": report["candidate_only_epochs"],
+        "base_status_counts": report["base"]["status_counts"],
+        "candidate_status_counts": report["candidate"]["status_counts"],
+        "status_pair_counts": statuses["pair_counts"],
+        "native_row_counts": {
+            field: native_summary_payload.get(field, 0) for field in NATIVE_ROW_FIELDS
+        },
+        "wrong_fixes": statuses["wrong_fixes"],
+        "missed_fixes": statuses["missed_fixes"],
+        "delta_rms_3d_m": comparison["delta_rms_3d_m"],
+        "delta_max_3d_m": report["events"]["max_delta_3d"]["delta_3d_m"],
+        "boundary_max_delta_3d_m": boundary["max_delta_3d_m"],
+        "boundary": boundary,
+        "artifact_dir": str(case_dir),
+    }
+
+
+def parse_csv_values(value: str) -> list[str]:
+    return [item.strip().lower() for item in value.split(",") if item.strip()]
+
+
+def parse_hours(value: str) -> list[int]:
+    return [int(item) for item in parse_csv_values(value)]
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--binary", type=Path, required=True)
+    parser.add_argument("--data-root", type=Path, required=True)
+    parser.add_argument("--output-dir", type=Path, required=True)
+    parser.add_argument("--stations", default="mizu,alic")
+    parser.add_argument("--profiles", default="ppp,pppar,pppar-ion")
+    parser.add_argument("--hours", default="1,6")
+    parser.add_argument("--baseline", type=Path)
+    parser.add_argument("--write-measured-baseline", type=Path)
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    binary = args.binary.resolve()
+    data_root = args.data_root.resolve()
+    output_dir = args.output_dir.resolve()
+    output_dir.mkdir(parents=True, exist_ok=True)
+    if not binary.is_file():
+        raise FileNotFoundError(f"missing gnss_ppp binary: {binary}")
+
+    station_names = parse_csv_values(args.stations)
+    profile_names = parse_csv_values(args.profiles)
+    hours_values = parse_hours(args.hours)
+    for station_name in station_names:
+        if station_name not in STATIONS:
+            raise ValueError(f"unknown station: {station_name}")
+    for profile_name in profile_names:
+        if profile_name not in PROFILE_NAMES:
+            raise ValueError(f"unknown profile: {profile_name}")
+
+    baseline_payload: dict[str, Any] | None = None
+    if args.baseline is not None:
+        baseline_payload = json.loads(args.baseline.read_text(encoding="utf-8"))
+        if baseline_payload.get("schema_version") != BASELINE_SCHEMA_VERSION:
+            raise ValueError("unsupported MADOCA release baseline schema")
+
+    cases: list[dict[str, Any]] = []
+    failures: list[str] = []
+    for station_name in station_names:
+        for profile_name in profile_names:
+            for hours in hours_values:
+                case = run_case(
+                    binary,
+                    data_root,
+                    output_dir,
+                    STATIONS[station_name],
+                    profile_name,
+                    hours,
+                )
+                if baseline_payload is not None:
+                    expected = baseline_payload.get("cases", {}).get(case["key"])
+                    case_failures = (
+                        ["missing baseline"]
+                        if expected is None
+                        else evaluate_baseline(case, expected)
+                    )
+                    case["baseline_failures"] = case_failures
+                    failures.extend(
+                        f"{case['key']}: {failure}" for failure in case_failures
+                    )
+                cases.append(case)
+                print(
+                    f"{case['key']}: matched={case['matched_epochs']} "
+                    f"rms={case['delta_rms_3d_m']:.6f} "
+                    f"max={case['delta_max_3d_m']:.6f} "
+                    f"wrong_fix={case['wrong_fixes']} "
+                    f"missed_fix={case['missed_fixes']}"
+                )
+
+    payload = {
+        "schema_version": SCHEMA_VERSION,
+        "command_schema_version": COMMAND_SCHEMA_VERSION,
+        "baseline_schema_version": BASELINE_SCHEMA_VERSION,
+        "status": "failed"
+        if failures
+        else ("passed" if baseline_payload else "measured"),
+        "binary": str(binary),
+        "data_root": str(data_root),
+        "cases": cases,
+        "failures": failures,
+    }
+    (output_dir / "summary.json").write_text(
+        json.dumps(payload, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    append_github_summary(payload)
+    if args.write_measured_baseline is not None:
+        baseline_cases: dict[str, Any] = {}
+        if args.write_measured_baseline.is_file():
+            existing_baseline = json.loads(
+                args.write_measured_baseline.read_text(encoding="utf-8")
+            )
+            if existing_baseline.get("schema_version") != BASELINE_SCHEMA_VERSION:
+                raise ValueError("unsupported existing MADOCA release baseline schema")
+            baseline_cases.update(existing_baseline.get("cases", {}))
+        for baseline_case in baseline_cases.values():
+            baseline_case.pop("bridge_runtime_s", None)
+        baseline_cases.update({case["key"]: measured_baseline(case) for case in cases})
+        measured = {
+            "schema_version": BASELINE_SCHEMA_VERSION,
+            "cases": baseline_cases,
+        }
+        args.write_measured_baseline.parent.mkdir(parents=True, exist_ok=True)
+        args.write_measured_baseline.write_text(
+            json.dumps(measured, indent=2, sort_keys=True) + "\n",
+            encoding="utf-8",
+        )
+
+    if failures:
+        for failure in failures:
+            print(f"FAIL: {failure}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -221,6 +221,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_madoca_solution_diff.py
     )
     add_test(
+        NAME python_madoca_release_matrix_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_madoca_release_matrix.py
+    )
+    add_test(
         NAME python_madoca_residual_component_diff_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_madoca_residual_component_diff.py
     )

--- a/tests/test_madoca_release_matrix.py
+++ b/tests/test_madoca_release_matrix.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Tests for the MADOCA release-matrix runner."""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+MODULE_PATH = ROOT_DIR / "scripts" / "ci" / "run_madoca_release_matrix.py"
+SPEC = importlib.util.spec_from_file_location("run_madoca_release_matrix", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+matrix = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = matrix
+SPEC.loader.exec_module(matrix)
+
+
+class MadocaReleaseMatrixTest(unittest.TestCase):
+    def test_hourly_paths_cover_requested_window_and_streams(self) -> None:
+        paths = matrix.l6_paths(Path("/data"), 2, (200, 201), ionosphere=True)
+        self.assertEqual(
+            [path.name for path in paths],
+            [
+                "2025091A.200.l6",
+                "2025091A.201.l6",
+                "2025091B.200.l6",
+                "2025091B.201.l6",
+            ],
+        )
+        self.assertEqual(matrix.end_time(1), "2025/04/01 00:59:30")
+        self.assertEqual(matrix.end_time(24), "2025/04/01 23:59:30")
+        with self.assertRaises(ValueError):
+            matrix.hourly_letters(25)
+
+    def test_bridge_and_native_commands_select_profile_contracts(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            root = Path(temp_dir)
+            output = root / "out.pos"
+            summary = root / "summary.json"
+            station = matrix.STATIONS["mizu"]
+            bridge = matrix.bridge_command(
+                Path("gnss_ppp"), root, station, "pppar-ion", 2, output, summary
+            )
+            native = matrix.native_command(
+                Path("gnss_ppp"), root, station, "pppar-ion", 2, output, summary
+            )
+
+        self.assertEqual(bridge.count("--madocalib-l6"), 4)
+        self.assertEqual(bridge.count("--madocalib-mdciono"), 4)
+        self.assertIn("--madocalib-profile", bridge)
+        self.assertEqual(native.count("--madoca-l6"), 4)
+        self.assertEqual(native.count("--madoca-l6d"), 4)
+        self.assertIn("--ar-method", native)
+        self.assertIn("local-enu", native)
+
+        ppp_native = matrix.native_command(
+            Path("gnss_ppp"),
+            Path("/data"),
+            matrix.STATIONS["alic"],
+            "ppp",
+            1,
+            Path("out.pos"),
+            Path("summary.json"),
+        )
+        self.assertIn("--static", ppp_native)
+        self.assertNotIn("--kinematic", ppp_native)
+        self.assertNotIn("--enable-ar", ppp_native)
+        self.assertNotIn("--madoca-l6d", ppp_native)
+
+        pppar_native = matrix.native_command(
+            Path("gnss_ppp"),
+            Path("/data"),
+            matrix.STATIONS["alic"],
+            "pppar",
+            1,
+            Path("out.pos"),
+            Path("summary.json"),
+        )
+        self.assertIn("--kinematic", pppar_native)
+        self.assertNotIn("--static", pppar_native)
+
+    def test_baseline_evaluation_checks_status_trajectory_and_runtime(self) -> None:
+        measured = {
+            "matched_epochs": 118,
+            "base_only_epochs": 0,
+            "candidate_only_epochs": 0,
+            "base_status_counts": {"1": 108, "6": 10},
+            "candidate_status_counts": {"5": 10, "6": 108},
+            "status_pair_counts": {"1->6": 108, "6->5": 10},
+            "native_row_counts": {
+                "madoca_l6d_constraint_epochs": 1,
+                "madoca_l6d_constraint_rows": 9,
+                "madoca_l6d_constraint_position_gate_epochs": 117,
+            },
+            "wrong_fixes": 0,
+            "missed_fixes": 0,
+            "delta_rms_3d_m": 0.1,
+            "delta_max_3d_m": 0.5,
+            "boundary_max_delta_3d_m": 0.3,
+            "native_runtime_s": 2.0,
+            "bridge_runtime_s": 3.0,
+        }
+        baseline = dict(measured)
+        baseline["matched_epochs"] = 100
+        baseline["native_runtime_s"] = 4.0
+        self.assertEqual(matrix.evaluate_baseline(measured, baseline), [])
+
+        regressed = dict(measured)
+        regressed["wrong_fixes"] = 1
+        regressed["delta_max_3d_m"] = 0.6
+        regressed["native_runtime_s"] = 4.1
+        failures = matrix.evaluate_baseline(regressed, baseline)
+        self.assertTrue(any("wrong_fixes" in failure for failure in failures))
+        self.assertTrue(any("delta_max_3d_m" in failure for failure in failures))
+        self.assertTrue(any("native_runtime_s" in failure for failure in failures))
+
+    def test_measured_baseline_adds_declared_margins(self) -> None:
+        case = {
+            "matched_epochs": 118,
+            "base_only_epochs": 0,
+            "candidate_only_epochs": 0,
+            "base_status_counts": {"1": 108, "6": 10},
+            "candidate_status_counts": {"5": 10, "6": 108},
+            "status_pair_counts": {"1->6": 108, "6->5": 10},
+            "native_row_counts": {
+                "madoca_l6d_constraint_epochs": 1,
+                "madoca_l6d_constraint_rows": 9,
+                "madoca_l6d_constraint_position_gate_epochs": 117,
+            },
+            "wrong_fixes": 0,
+            "missed_fixes": 0,
+            "delta_rms_3d_m": 0.1,
+            "delta_max_3d_m": 0.5,
+            "boundary_max_delta_3d_m": None,
+            "native_runtime_s": 2.0,
+            "bridge_runtime_s": 3.0,
+        }
+        baseline = matrix.measured_baseline(case)
+        self.assertAlmostEqual(baseline["delta_rms_3d_m"], 0.11)
+        self.assertAlmostEqual(baseline["delta_max_3d_m"], 0.525)
+        self.assertIsNone(baseline["boundary_max_delta_3d_m"])
+        self.assertEqual(baseline["native_runtime_s"], 4.0)
+        self.assertNotIn("bridge_runtime_s", baseline)
+
+    def test_github_summary_exposes_schemas_case_and_commands_artifact(self) -> None:
+        payload = {
+            "schema_version": matrix.SCHEMA_VERSION,
+            "command_schema_version": matrix.COMMAND_SCHEMA_VERSION,
+            "baseline_schema_version": matrix.BASELINE_SCHEMA_VERSION,
+            "status": "passed",
+            "cases": [
+                {
+                    "key": "mizu.pppar.1h",
+                    "matched_epochs": 118,
+                    "wrong_fixes": 0,
+                    "missed_fixes": 0,
+                    "delta_rms_3d_m": 0.1,
+                    "delta_max_3d_m": 0.5,
+                    "native_runtime_s": 2.0,
+                    "artifact_dir": "output/matrix/mizu.pppar.1h",
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory() as temp_dir:
+            summary_path = Path(temp_dir) / "step-summary.md"
+            with mock.patch.dict(
+                os.environ, {"GITHUB_STEP_SUMMARY": str(summary_path)}
+            ):
+                matrix.append_github_summary(payload)
+            summary = summary_path.read_text(encoding="utf-8")
+
+        self.assertIn(matrix.SCHEMA_VERSION, summary)
+        self.assertIn(matrix.COMMAND_SCHEMA_VERSION, summary)
+        self.assertIn(matrix.BASELINE_SCHEMA_VERSION, summary)
+        self.assertIn("mizu.pppar.1h", summary)
+        self.assertIn(
+            "output/matrix/mizu.pppar.1h/commands.json",
+            summary,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add a versioned 18-case MADOCALIB/native release baseline for MIZU and ALIC across PPP, PPP-AR, and PPP-AR-ion
- gate exact solution-status and L6D row artifacts, bounded trajectory drift, and native runtime
- run 1 h and 6 h cases in required CI, retain 24 h as workflow-dispatch evidence, and upload reproducible commands/logs/solutions

## Investigation
- preserve static motion for the historical stationary PPP contract; AR profiles remain kinematic
- retain the 11 ALIC oracle-nonFix/native-Fix status mismatches as an explicit non-increasing baseline after ratio/candidate/fixed-position analysis found no station-independent guard
- keep MADOCALIB linking isolated to the parity lane

## Validation
- python -m unittest tests/test_madoca_release_matrix.py
- ruff check scripts/ci/run_madoca_release_matrix.py tests/test_madoca_release_matrix.py
- ruff format --check scripts/ci/run_madoca_release_matrix.py tests/test_madoca_release_matrix.py
- ctest --test-dir build-wsl-madoca-make -R madoca.*tests --output-on-failure (12/12 passed)
- baseline schema/completeness check (18/18 cases)
- git diff --check

Part of #148; this completes M5 but intentionally does not close the tracker because M6 remains.