### PR TITLE
build: isolate MADOCALIB oracle CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -575,8 +575,8 @@ jobs:
           -DMADOCALIB_PARITY_LINK=ON \
           -DMADOCALIB_ROOT_DIR="${GITHUB_WORKSPACE}/external/madocalib"
 
-    - name: Build MadocaParity tests and bridge tool
-      run: cmake --build build-madoca-parity --config Release --parallel --target gnss_madoca_parity_tests gnss_ppp
+    - name: Build MadocaParity tests and oracle tool
+      run: cmake --build build-madoca-parity --config Release --parallel --target gnss_madoca_parity_tests gnss_madocalib_oracle
 
     - name: Show MADOCA ccache stats
       run: ccache -s
@@ -589,7 +589,8 @@ jobs:
       working-directory: build-madoca-parity
       run: |
         ROOT="${GITHUB_WORKSPACE}/external/madocalib"
-        ./apps/gnss_ppp \
+        ./apps/gnss_madocalib_oracle --help | grep -q -- "--madocalib-bridge"
+        ./apps/gnss_madocalib_oracle \
           --madocalib-bridge \
           --obs "$ROOT/sample_data/data/rinex/MIZU00JPN_R_20250910000_01D_30S_MO.rnx" \
           --nav "$ROOT/sample_data/data/rinex/BRDM00DLR_S_20250910000_01D_MN.rnx" \
@@ -607,7 +608,7 @@ jobs:
         test "$rows" -eq 118
         non_q6="$(awk '$0 !~ /^%/ && NF > 0 && $6 != 6 {n++} END {print n+0}' madocalib_bridge_smoke.pos)"
           test "$non_q6" -eq 0
-          ./apps/gnss_ppp \
+          ./apps/gnss_madocalib_oracle \
             --madocalib-bridge \
             --madocalib-profile pppar \
             --obs "$ROOT/sample_data/data/rinex/MIZU00JPN_R_20250910000_01D_30S_MO.rnx" \
@@ -624,7 +625,7 @@ jobs:
           grep -q '"madocalib_profile": "pppar"' madocalib_pppar_smoke.json
           fixed="$(awk '$0 !~ /^%/ && NF > 0 && $6 == 1 {n++} END {print n+0}' madocalib_pppar_smoke.pos)"
           test "$fixed" -gt 0
-          ./apps/gnss_ppp \
+          ./apps/gnss_madocalib_oracle \
             --kinematic \
             --enable-ar \
             --ar-method per-freq \
@@ -651,7 +652,7 @@ jobs:
           grep -q '"convergence_policy": "legacy-3d"' native_pppar_smoke.json
           grep -q '"ar_stage_last":' native_pppar_smoke.json
           grep -q '"ar_per_frequency_attempts":' native_pppar_smoke.json
-          ./apps/gnss_ppp \
+          ./apps/gnss_madocalib_oracle \
             --kinematic \
             --enable-ar \
             --ar-method per-freq \
@@ -706,7 +707,7 @@ jobs:
           status_mismatches="$(awk -F, 'NR > 1 && !(($5 == 1 && $6 == 6) || ($5 == 6 && $6 == 5)) {n++} END {print n+0}' madoca_pppar_solution_matches.csv)"
           test "$status_mismatches" -eq 0
           python3 -c 'import json; d=json.load(open("madoca_pppar_solution_diff.json")); assert d["comparison"]["delta_rms_3d_m"] <= 0.2; assert d["events"]["max_delta_3d"]["delta_3d_m"] <= 1.0'
-          ./apps/gnss_ppp \
+          ./apps/gnss_madocalib_oracle \
             --madocalib-bridge \
             --madocalib-profile pppar-ion \
             --obs "$ROOT/sample_data/data/rinex/MIZU00JPN_R_20250910000_01D_30S_MO.rnx" \
@@ -722,7 +723,7 @@ jobs:
             --out madocalib_pppar_ion_smoke.pos \
             --summary-json madocalib_pppar_ion_smoke.json \
             --quiet
-          ./apps/gnss_ppp \
+          ./apps/gnss_madocalib_oracle \
             --kinematic \
             --enable-ar \
             --ar-method per-freq \
@@ -768,7 +769,7 @@ jobs:
     - name: Run required MADOCA release matrix
       run: |
         python3 scripts/ci/run_madoca_release_matrix.py \
-          --binary build-madoca-parity/apps/gnss_ppp \
+          --binary build-madoca-parity/apps/gnss_madocalib_oracle \
           --data-root external/madocalib/sample_data/data \
           --output-dir output/madoca_release_matrix_required \
           --hours 1,6 \
@@ -778,7 +779,7 @@ jobs:
       if: github.event_name == 'workflow_dispatch'
       run: |
         python3 scripts/ci/run_madoca_release_matrix.py \
-          --binary build-madoca-parity/apps/gnss_ppp \
+          --binary build-madoca-parity/apps/gnss_madocalib_oracle \
           --data-root external/madocalib/sample_data/data \
           --output-dir output/madoca_release_matrix_24h \
           --hours 24 \

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -70,6 +70,16 @@ target_link_libraries(gnss_solve PRIVATE gnss_lib gnss_lib_noopt Threads::Thread
 add_executable(gnss_ppp ${GNSS_NATIVE_DIR}/gnss_ppp.cpp)
 target_link_libraries(gnss_ppp PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)
 
+if(MADOCALIB_PARITY_LINK)
+    # The linked MADOCALIB runtime is an oracle-only CI surface. Keep its
+    # command-line selector out of the installed production gnss_ppp binary.
+    add_executable(gnss_madocalib_oracle ${GNSS_NATIVE_DIR}/gnss_ppp.cpp)
+    target_compile_definitions(
+        gnss_madocalib_oracle PRIVATE GNSSPP_MADOCALIB_ORACLE_CLI=1)
+    target_link_libraries(
+        gnss_madocalib_oracle PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)
+endif()
+
 add_executable(gnss_visibility ${GNSS_NATIVE_DIR}/gnss_visibility.cpp)
 target_link_libraries(gnss_visibility PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)
 

--- a/apps/native/gnss_ppp.cpp
+++ b/apps/native/gnss_ppp.cpp
@@ -17,6 +17,10 @@
 #include <libgnss++/io/madoca_l6.hpp>
 #include <libgnss++/io/rinex.hpp>
 
+#ifndef GNSSPP_MADOCALIB_ORACLE_CLI
+#define GNSSPP_MADOCALIB_ORACLE_CLI 0
+#endif
+
 namespace {
 
 struct Options {
@@ -164,6 +168,7 @@ void printUsage(const char* program_name) {
         << "                          CLAS atmosphere token selection policy (default: grid-first)\n"
         << "  --clas-atmos-stale-after-seconds <seconds>\n"
         << "                          Balanced policy stale threshold (default: 15.0)\n"
+#if GNSSPP_MADOCALIB_ORACLE_CLI
         << "  --madocalib-bridge      Delegate this run to linked MADOCALIB postpos()\n"
         << "                          (requires CMake -DMADOCALIB_PARITY_LINK=ON)\n"
         << "  --madocalib-l6 <file>   Extra MADOCA L6 input file; repeat for two-channel L6E\n"
@@ -183,6 +188,7 @@ void printUsage(const char* program_name) {
         << "                          MADOCALIB trace level (default: 0)\n"
         << "  --madocalib-trace-ar   Include MADOCALIB ambiguity means, covariance,\n"
         << "                          LAMBDA candidates, and partial-AR decisions in trace\n"
+#endif
         << "  --static                Use a static PPP motion model (default)\n"
         << "  --kinematic             Use a kinematic PPP motion model\n"
         << "  --use-dynamics-model    Continuous pos/vel dynamics (MRTKLIB accel model)\n"
@@ -346,6 +352,7 @@ Options parseArguments(int argc, char* argv[]) {
             options.clas_atmos_selection = argv[++i];
         } else if (arg == "--clas-atmos-stale-after-seconds" && i + 1 < argc) {
             options.clas_atmos_stale_after_seconds = std::stod(argv[++i]);
+#if GNSSPP_MADOCALIB_ORACLE_CLI
         } else if (arg == "--madocalib-bridge") {
             options.madocalib_bridge = true;
         } else if (arg == "--madocalib-l6" && i + 1 < argc) {
@@ -366,6 +373,7 @@ Options parseArguments(int argc, char* argv[]) {
             options.madocalib_trace_level = std::stoi(argv[++i]);
         } else if (arg == "--madocalib-trace-ar") {
             options.madocalib_trace_ar = true;
+#endif
         } else if (arg == "--no-ionosphere-free") {
             options.use_ionosphere_free = false;
         } else if (arg == "--ionosphere-free") {
@@ -497,6 +505,7 @@ Options parseArguments(int argc, char* argv[]) {
     if (options.ssr_step_seconds <= 0.0) {
         argumentError("--ssr-step-seconds must be positive", argv[0]);
     }
+#if GNSSPP_MADOCALIB_ORACLE_CLI
     if (options.madocalib_time_interval_seconds < 0.0) {
         argumentError("--madocalib-ti must be non-negative", argv[0]);
     }
@@ -514,6 +523,7 @@ Options parseArguments(int argc, char* argv[]) {
     if (options.madocalib_profile == "pppar-ion" && options.madocalib_mdciono_paths.empty()) {
         argumentError("--madocalib-profile pppar-ion requires --madocalib-mdciono", argv[0]);
     }
+#endif
     if (options.clas_epoch_policy != "strict-osr" &&
         options.clas_epoch_policy != "hybrid-standard-ppp") {
         argumentError(
@@ -752,6 +762,7 @@ int main(int argc, char* argv[]) {
     try {
         const Options options = parseArguments(argc, argv);
 
+#if GNSSPP_MADOCALIB_ORACLE_CLI
         if (options.madocalib_bridge) {
             namespace madocalib = libgnss::external::madocalib;
             if (!madocalib::isAvailable()) {
@@ -889,6 +900,7 @@ int main(int argc, char* argv[]) {
             }
             return 0;
         }
+#endif
 
         libgnss::io::RINEXReader obs_reader;
         const auto& ppp_env_overrides = libgnss::pppEnvOverrides();

--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -518,13 +518,15 @@ Future oracle modules, test-only and opt-in:
 The first whole-run oracle path is an opt-in static-link delegate:
 
 - Configure with `-DMADOCALIB_PARITY_LINK=ON`.
-- Run `gnss_ppp --madocalib-bridge` to delegate the whole run to MADOCALIB
-  `postpos()`.
+- Build and run the non-installed
+  `gnss_madocalib_oracle --madocalib-bridge` tool to delegate the whole run to
+  MADOCALIB `postpos()`.
 - Pass MADOCA L6E files with repeated `--madocalib-l6 <file>` arguments.
 - Pass L6D ionosphere files with repeated `--madocalib-mdciono <file>`
   arguments when using the ionosphere scenario.
-- The default build does not link MADOCALIB and rejects `--madocalib-bridge`
-  before producing output.
+- The normal `gnss_ppp` command never exposes the oracle arguments, including
+  in a linked parity build.  The default build does not link MADOCALIB or
+  create `gnss_madocalib_oracle`.
 
 The public sample-data smoke case uses the `exec_ppp.bat` MIZU scenario with
 the two L6E channels from the `is-qzss-mdc-004` tree:
@@ -532,7 +534,7 @@ the two L6E channels from the `is-qzss-mdc-004` tree:
 ```sh
 ROOT=${MADOCALIB_ROOT}
 
-./build_iter4_madocalib/apps/gnss_ppp \
+./build_iter4_madocalib/apps/gnss_madocalib_oracle \
   --madocalib-bridge \
   --obs "$ROOT/sample_data/data/rinex/MIZU00JPN_R_20250910000_01D_30S_MO.rnx" \
   --nav "$ROOT/sample_data/data/rinex/BRDM00DLR_S_20250910000_01D_MN.rnx" \
@@ -746,8 +748,8 @@ Deferred large slices:
 - PPP-AR parity against MADOCALIB sample windows.
 - L6D ionosphere integration into PPP.
 - Triple/quad-frequency PPP-AR behavior.
-- First-class production MADOCALIB bridge behavior beyond the opt-in oracle
-  path.
+- Keep the linked MADOCALIB bridge confined to the non-installed oracle tool
+  and labeled parity CI; it is intentionally not a production workflow.
 
 ## MADOCALIB License Notes
 

--- a/docs/madocalib_native_migration.md
+++ b/docs/madocalib_native_migration.md
@@ -88,7 +88,7 @@ does not yet match end-to-end behavior; **open** has no accepted native parity.
 | MADOCALIB `exec_pppar` | Windows and authoritative Ubuntu Release both match the oracle's 108 Fix / 10 Float over all 118 epochs | native | Keep exact status agreement, no wrong/missed Fix, RMS at most 0.20 m, and maximum at most 1.0 m |
 | MADOCALIB `exec_pppar-ion` | Bridge and native opt-in profiles run in the required parity lane | partial | M4 closes eight missed Fix and M5 expands the dataset/duration matrix |
 | Triple/quad-frequency PPP-AR | Upstream 2.0 behavior has not been fully audited or signed off | open | Dedicated fixtures and ambiguity/state parity after dual-frequency M2 |
-| Linked `postpos()` bridge | `madocalib_bridge` | oracle-only | Retain until M6; never select it in production runtime |
+| Linked `postpos()` bridge | Non-installed `gnss_madocalib_oracle` | oracle-only | Available only in `MADOCALIB_PARITY_LINK=ON` builds; absent from normal `gnss_ppp` help and parsing |
 
 ## Current Numerical Baselines
 
@@ -633,6 +633,17 @@ the GitHub job summary.  Default CMake builds retain
   retaining the opt-in oracle build and tests.
 - Remove superseded preview knobs and guards after proving their replacements.
 - Update user documentation and close issue #148 with the final matrix.
+
+#### M6 oracle CLI isolation (2026-07-30)
+
+The linked `postpos()` selector is no longer part of the normal `gnss_ppp`
+command surface.  Production and installed builds neither list nor accept any
+`--madocalib-*` options.  An opt-in `MADOCALIB_PARITY_LINK=ON` configure creates
+the separate, non-installed `gnss_madocalib_oracle` executable; only that
+executable accepts `--madocalib-bridge` and the accompanying oracle arguments.
+The labeled parity lane uses the oracle executable for both sides of the
+comparison so exact commands remain reproducible without making the external
+runtime a user-facing solver choice.
 
 Exit: production code, installed targets, and default CI have no MADOCALIB
 dependency; the linked checkout is used only by the labeled oracle lane; native

--- a/tests/test_cli_tools.py
+++ b/tests/test_cli_tools.py
@@ -4029,19 +4029,19 @@ class CLIToolsTest(unittest.TestCase):
         self.assertIn("--window-size", result.stdout)
         self.assertIn("--output-csv", result.stdout)
 
-    def test_ppp_help_lists_madocalib_bridge_options(self) -> None:
+    def test_ppp_help_hides_madocalib_oracle_options(self) -> None:
         result = self.run_gnss("ppp", "--help")
         self.assertEqual(result.returncode, 0, msg=result.stderr)
-        self.assertIn("--madocalib-bridge", result.stdout)
-        self.assertIn("--madocalib-trace-ar", result.stdout)
-        self.assertIn("--madocalib-l6", result.stdout)
-        self.assertIn("--madocalib-mdciono", result.stdout)
-        self.assertIn("--madocalib-profile", result.stdout)
+        self.assertNotIn("--madocalib-bridge", result.stdout)
+        self.assertNotIn("--madocalib-trace-ar", result.stdout)
+        self.assertNotIn("--madocalib-l6", result.stdout)
+        self.assertNotIn("--madocalib-mdciono", result.stdout)
+        self.assertNotIn("--madocalib-profile", result.stdout)
         self.assertIn("--madoca-l6d-shadow", result.stdout)
         self.assertIn("--madoca-materialization-dump", result.stdout)
         self.assertIn("--madoca-materialization-dump-only", result.stdout)
 
-    def test_ppp_cli_rejects_unknown_madocalib_profile(self) -> None:
+    def test_ppp_cli_rejects_madocalib_oracle_selector(self) -> None:
         result = self.run_gnss(
             "ppp",
             "--obs",
@@ -4055,7 +4055,10 @@ class CLIToolsTest(unittest.TestCase):
             "unknown",
         )
         self.assertNotEqual(result.returncode, 0)
-        self.assertIn("--madocalib-profile must be one of", result.stderr)
+        self.assertIn(
+            "unknown or incomplete argument: --madocalib-bridge",
+            result.stderr,
+        )
 
     def test_ppp_cli_accepts_more_than_three_hourly_madoca_l6d_inputs(self) -> None:
         result = self.run_gnss(


### PR DESCRIPTION
## Summary
- remove every `--madocalib-*` selector from normal `gnss_ppp` help and parsing
- create `gnss_madocalib_oracle` only when `MADOCALIB_PARITY_LINK=ON`; keep it outside install targets
- move the labeled parity smoke and M5 release matrix to the oracle-only executable
- update the migration ledger and historical reproduction command

## Validation
- default Windows Release `gnss_ppp` build
- linked WSL Release `gnss_ppp` and `gnss_madocalib_oracle` builds
- normal CLI hides/rejects oracle selectors; oracle CLI lists/accepts them
- MIZU 1 h PPP and PPP-AR-ion release matrix through the new oracle executable (2/2 passed)
- MADOCA CTest selection (12/12 passed)
- focused CLI tests, Python lint/compile, YAML parse, and `git diff --check`
- default and linked install scripts contain no `gnss_madocalib_oracle` install rule

Part of #148 M6. This PR isolates the oracle runtime; preview/guard retirement and final tracker closure remain separate slices.