### PR TITLE
cleanup: retire MADOCA preview selectors

### DIFF
--- a/apps/native/gnss_ppp.cpp
+++ b/apps/native/gnss_ppp.cpp
@@ -1119,8 +1119,7 @@ int main(int argc, char* argv[]) {
             const int rows = libgnss::io::writeMadocaL6eMaterializationCsv(
                 options.madoca_l6_paths,
                 ppp_config.l6_gps_week,
-                options.madoca_materialization_dump_path,
-                ppp_env_overrides.madoca_ssr_replay);
+                options.madoca_materialization_dump_path);
             if (rows < 0) {
                 std::cerr << "Error: failed to write MADOCA materialization dump: "
                           << options.madoca_materialization_dump_path << "\n";

--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -34,10 +34,11 @@ post-fit commit-on-success gate (#146/#147) was promoted to the default
 second station (ALIC, neutral) with 1 h/6 h staying byte-exact.  The interim
 #145 boundary guard was retired (commit-on-success subsumes it; guard on/off was
 byte-identical under commit); the #144 spike guard (100 m) is kept as the
-opt-out-path safety net.  GLONASS
-phase, QZSS L5, SSR-replay, bias-identity, and pair-selection hypotheses were
-each measured.  QZSS L5 was later promoted for M2 three-frequency row parity;
-the remaining preview-only knobs stay default-off.
+opt-out-path safety net.  GLONASS phase, QZSS L5, SSR-replay, bias-identity,
+and pair-selection hypotheses were each measured.  QZSS L5 was later promoted
+for M2 three-frequency row parity.  The rejected SSR-replay selector and
+implementation were removed in M6 rather than retained as a default-off
+production path.
 The repro harness and per-slice history live in the memory note
 `madoca-ppp-frontier` and in issue #148.
 

--- a/docs/madocalib_native_migration.md
+++ b/docs/madocalib_native_migration.md
@@ -76,7 +76,7 @@ does not yet match end-to-end behavior; **open** has no accepted native parity.
 | System, signal, update-interval, URA, and bias-code helpers | `madoca_core`, `madoca_parity`, `MadocaParity` tests | native | Keep deterministic helper parity at exact integer or `1e-6` scaled tolerance |
 | L6E byte sync and subframe assembly | `MadocaL6eDecoder` | native | Byte-stepped oracle test remains green |
 | L6E mask/orbit/clock/code-bias/phase-bias/URA | `madoca_l6`, `SSRProducts` materialization | native | No missing keys; supported numeric fields match the pinned oracle |
-| Multi-file L6E replay and correction ordering | `decodeMadocaL6eFilesToProductsReplay`, correction contract | native | Materialization key, time, IOD, identity, and value diffs are zero for the pinned fixture |
+| Multi-file L6E decode and correction ordering | `decodeMadocaL6eFilesToProducts`, correction contract | native | Materialization key, time, IOD, identity, and value diffs are zero for the pinned fixture |
 | L6D coverage/correction decode | `MadocaL6dDecoder` | native | Byte-stepped region/area parity remains green |
 | L6D receiver-area selection and delay/std | `MadocaIonoStore` | native | Selected receiver correction values match the oracle |
 | L6D causal product snapshots | `MadocaIonoSnapshot`, `MadocaIonoProducts` | native | File snapshot/application sequence parity remains green |
@@ -644,6 +644,25 @@ executable accepts `--madocalib-bridge` and the accompanying oracle arguments.
 The labeled parity lane uses the oracle executable for both sides of the
 comparison so exact commands remain reproducible without making the external
 runtime a user-facing solver choice.
+
+#### M6 preview cleanup (2026-07-30)
+
+Two superseded preview selectors were removed after the M5 matrix froze their
+accepted replacements.  `GNSS_PPP_MADOCA_SSR_REPLAY` and its independent-stream
+decoder/API represented the rejected #136 replay hypothesis; production and
+materialization paths now have one `decodeMadocaL6eFilesToProducts` contract.
+The explicit `GNSS_PPP_MADOCA_GALILEO_GATE` selector was redundant after the
+Galileo admission behavior became part of default-on
+`GNSS_PPP_MADOCA_EARLY_WINDOW`; the latter remains the one-release-cycle
+opt-out.
+
+The other promoted compatibility opt-outs remain for that release cycle.
+`GNSS_PPP_MADOCA_POSTFIT_COMMIT=0` still selects the pre-promotion update
+behavior, and the 100 m spike guard remains its safety backstop.  Bias,
+frequency, constellation, and early-window opt-outs likewise remain available
+for controlled rollback.  Diagnostic dumps and measurement-neutral shadow
+inputs are retained because they observe the accepted path rather than select
+an alternative solver implementation.
 
 Exit: production code, installed targets, and default CI have no MADOCALIB
 dependency; the linked checkout is used only by the labeled oracle lane; native

--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -11,9 +11,6 @@ struct PPPEnvOverrides {
     // GNSS_PPP_MADOCA_ALLOW_PARTIAL_SSR: accept incomplete MADOCA SSR epochs
     // when set exactly to "1". Default false.
     bool madoca_allow_partial_ssr = false;
-    // GNSS_PPP_MADOCA_SSR_REPLAY: select native MADOCA L6 SSR corrections from
-    // per-PRN replay snapshots when set exactly to "1". Default false.
-    bool madoca_ssr_replay = false;
     // GNSS_PPP_REQUIRE_SSR_ORBIT: drop satellites missing SSR orbit
     // corrections when set to a value whose first char is not '0'. Default false.
     bool require_ssr_orbit = false;
@@ -84,11 +81,6 @@ struct PPPEnvOverrides {
     // GNSS_PPP_MADOCA_LOW_ELEV: admit coherent MADOCA observations down to the
     // MADOCALIB 10 degree mask unless set exactly to "0". Default true.
     bool madoca_low_elev = true;
-    // GNSS_PPP_MADOCA_GALILEO_GATE: apply MADOCALIB Galileo broadcast
-    // ephemeris admission semantics in coherent MADOCA when set exactly to "1",
-    // or when GNSS_PPP_MADOCA_EARLY_WINDOW is enabled. Default follows
-    // GNSS_PPP_MADOCA_EARLY_WINDOW.
-    bool madoca_galileo_gate = false;
     // GNSS_PPP_MADOCA_BIAS_IDENTITY: preserve MADOCA SSR code/phase-bias
     // signal identity instead of collapsed RTCM band ids unless set exactly
     // to "0". Exact identity is required for distinct BDS-3 B2a biases.

--- a/include/libgnss++/io/madoca_l6.hpp
+++ b/include/libgnss++/io/madoca_l6.hpp
@@ -151,14 +151,6 @@ int decodeMadocaL6eFilesToProducts(const std::vector<std::string>& files,
                                    int gps_week,
                                    libgnss::SSRProducts& products);
 
-// Decode MADOCA L6E files as independent PRN streams and emit full per-stream
-// snapshots whenever any SSR component timestamp changes. This mirrors
-// MADOCALIB's per-epoch update_qzssl6e() replay more closely than the legacy
-// whole-file orbit/clock snapshot loader.
-int decodeMadocaL6eFilesToProductsReplay(const std::vector<std::string>& files,
-                                         int gps_week,
-                                         libgnss::SSRProducts& products);
-
 // Write the materialized native SSRProducts view used by MADOCA PPP. This is a
 // diagnostic boundary dump: it records the satellite key, correction epoch,
 // component reference times, IODs, orbit/clock values, and code/phase bias
@@ -172,7 +164,6 @@ int writeMadocaMaterializationCsv(const libgnss::SSRProducts& products,
 // <0 means the output file could not be opened.
 int writeMadocaL6eMaterializationCsv(const std::vector<std::string>& files,
                                      int gps_week,
-                                     const std::string& output_path,
-                                     bool replay_mode);
+                                     const std::string& output_path);
 
 }  // namespace libgnss::io

--- a/src/algorithms/ppp_corrections.cpp
+++ b/src/algorithms/ppp_corrections.cpp
@@ -664,7 +664,7 @@ bool PPPProcessor::hasEnoughCoherentSsrObservations(const ObservationData& obs,
             nullptr,
             &status,
             false);
-        if (env_overrides_.madoca_galileo_gate &&
+        if (env_overrides_.madoca_early_window &&
             observation.satellite.system == GNSSSystem::Galileo &&
             !nav.hasMadocaGalileoEphemeris(
                 observation.satellite, obs.time, status.orbit_iode)) {
@@ -948,7 +948,7 @@ void PPPProcessor::applyPreciseCorrections(std::vector<IonosphereFreeObs>& obser
                 observation.valid = false;
                 continue;
             }
-            if (env_overrides_.madoca_galileo_gate &&
+            if (env_overrides_.madoca_early_window &&
                 require_coherent_ssr_ &&
                 observation.satellite.system == GNSSSystem::Galileo &&
                 !nav.hasMadocaGalileoEphemeris(

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -117,7 +117,6 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
 
     overrides.madoca_bias_subtract = envPresent("GNSS_PPP_MADOCA_BIAS_SUBTRACT");
     overrides.madoca_allow_partial_ssr = envExactOne("GNSS_PPP_MADOCA_ALLOW_PARTIAL_SSR");
-    overrides.madoca_ssr_replay = envExactOne("GNSS_PPP_MADOCA_SSR_REPLAY");
     overrides.require_ssr_orbit = envFirstCharNotZero("GNSS_PPP_REQUIRE_SSR_ORBIT");
     overrides.disable_madoca_static_anchor =
         envExactOne("GNSS_PPP_DISABLE_MADOCA_STATIC_ANCHOR");
@@ -155,9 +154,6 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
     overrides.madoca_glonass_phase =
         !envExactZero("GNSS_PPP_MADOCA_GLONASS_PHASE");
     overrides.madoca_low_elev = !envExactZero("GNSS_PPP_MADOCA_LOW_ELEV");
-    overrides.madoca_galileo_gate =
-        envExactOne("GNSS_PPP_MADOCA_GALILEO_GATE") ||
-        overrides.madoca_early_window;
     overrides.madoca_bias_identity =
         !envExactZero("GNSS_PPP_MADOCA_BIAS_IDENTITY");
     overrides.pb_add = envPresent("GNSS_PPP_PB_ADD");

--- a/src/algorithms/ppp_products.cpp
+++ b/src/algorithms/ppp_products.cpp
@@ -211,8 +211,7 @@ bool PPPProcessor::loadMadocaL6Products(const std::vector<std::string>& l6_files
     }
     const int gps_week = ppp_config_.l6_gps_week > 0 ? ppp_config_.l6_gps_week
                                                      : last_obs_gps_week_;
-    const int added = env_overrides_.madoca_ssr_replay ?
-        io::decodeMadocaL6eFilesToProductsReplay(l6_files, gps_week, ssr_products_) :
+    const int added =
         io::decodeMadocaL6eFilesToProducts(l6_files, gps_week, ssr_products_);
     ssr_products_loaded_ = added > 0;
     require_coherent_ssr_ =

--- a/src/io/madoca_l6.cpp
+++ b/src/io/madoca_l6.cpp
@@ -754,18 +754,10 @@ bool madocaTimeLess(const MadocaGtime& lhs, const MadocaGtime& rhs) {
     return lhs.sec < rhs.sec;
 }
 
-MadocaGtime latestComponentTime(const MadocaSsrCorrection& c, bool include_bias_times) {
+MadocaGtime latestComponentTime(const MadocaSsrCorrection& c) {
     MadocaGtime latest = c.t0[0];
     if (latest.time == 0 || madocaTimeLess(latest, c.t0[1])) {
         latest = c.t0[1];
-    }
-    if (include_bias_times) {
-        for (int index : {3, 4, 5}) {
-            if (c.t0[index].time != 0 &&
-                (latest.time == 0 || madocaTimeLess(latest, c.t0[index]))) {
-                latest = c.t0[index];
-            }
-        }
     }
     return latest;
 }
@@ -775,8 +767,7 @@ bool useMadocaBiasIdentityKey(libgnss::GNSSSystem system,
 
 bool buildMadocaSsrCorrection(int sat, const MadocaSsrCorrection& c,
                               const PPPEnvOverrides& env_overrides,
-                              libgnss::SSROrbitClockCorrection& out,
-                              bool include_bias_times = false) {
+                              libgnss::SSROrbitClockCorrection& out) {
     const bool has_orbit = c.t0[0].time != 0;  // t0[eph]
     const bool has_clock = c.t0[1].time != 0;  // t0[clk]
     if (!has_orbit && !has_clock) {
@@ -808,7 +799,7 @@ bool buildMadocaSsrCorrection(int sat, const MadocaSsrCorrection& c,
     out = libgnss::SSROrbitClockCorrection{};
     out.satellite = libgnss::SatelliteId(gsys, static_cast<std::uint8_t>(prn));
 
-    const MadocaGtime t0 = latestComponentTime(c, include_bias_times);
+    const MadocaGtime t0 = latestComponentTime(c);
     int week = 0;
     const double tow = time2gpst(t0, &week);
     out.time = libgnss::GNSSTime(week, tow);
@@ -1047,64 +1038,6 @@ int decodeMadocaL6eFilesToProducts(const std::vector<std::string>& files,
     return added;
 }
 
-int decodeMadocaL6eFilesToProductsReplay(const std::vector<std::string>& files,
-                                         int gps_week,
-                                         libgnss::SSRProducts& products) {
-    products.setOrbitCorrectionsAreRac(true);
-    double ref_ep[6];
-    referenceEpochForWeek(gps_week, ref_ep);
-
-    constexpr int kN = MadocaL6eDecoder::kMaxSat;
-    std::vector<libgnss::SSROrbitClockCorrection> corrections;
-    int added = 0;
-    for (const std::string& file : files) {
-        std::ifstream in(file, std::ios::binary);
-        if (!in) {
-            continue;
-        }
-
-        MadocaL6eDecoder decoder;
-        decoder.setReferenceEpoch(ref_ep);
-        std::vector<std::array<std::int64_t, 6>> last_t0(kN + 1);
-        for (auto& sat_t0 : last_t0) {
-            sat_t0.fill(-1);
-        }
-
-        char raw = 0;
-        while (in.get(raw)) {
-            if (decoder.inputByte(static_cast<std::uint8_t>(raw)) != 10) {
-                continue;
-            }
-            for (int sat = 1; sat <= kN; ++sat) {
-                const MadocaSsrCorrection& c = decoder.correction(sat);
-                bool changed = false;
-                bool has_any_component = false;
-                for (int index = 0; index < 6; ++index) {
-                    const std::int64_t t0 = c.t0[index].time;
-                    has_any_component = has_any_component || t0 != 0;
-                    if (t0 != last_t0[sat][index]) {
-                        changed = true;
-                    }
-                }
-                if (!has_any_component || !changed) {
-                    continue;
-                }
-                for (int index = 0; index < 6; ++index) {
-                    last_t0[sat][index] = c.t0[index].time;
-                }
-                libgnss::SSROrbitClockCorrection corr;
-                if (buildMadocaSsrCorrection(
-                        sat, c, decoder.envOverrides(), corr, true)) {
-                    corrections.push_back(corr);
-                    ++added;
-                }
-            }
-        }
-    }
-    products.addCorrections(corrections);
-    return added;
-}
-
 int writeMadocaMaterializationCsv(const libgnss::SSRProducts& products,
                                   std::ostream& output) {
     output
@@ -1157,14 +1090,9 @@ int writeMadocaMaterializationCsv(const libgnss::SSRProducts& products,
 
 int writeMadocaL6eMaterializationCsv(const std::vector<std::string>& files,
                                      int gps_week,
-                                     const std::string& output_path,
-                                     bool replay_mode) {
+                                     const std::string& output_path) {
     libgnss::SSRProducts products;
-    if (replay_mode) {
-        decodeMadocaL6eFilesToProductsReplay(files, gps_week, products);
-    } else {
-        decodeMadocaL6eFilesToProducts(files, gps_week, products);
-    }
+    decodeMadocaL6eFilesToProducts(files, gps_week, products);
 
     std::ofstream output(output_path);
     if (!output.is_open()) {

--- a/tests/test_ppp.cpp
+++ b/tests/test_ppp.cpp
@@ -409,6 +409,13 @@ TEST(PPPEnvOverridesTest, MadocaGlonassPhaseDefaultsToParityRows) {
     EXPECT_TRUE(PPPEnvOverrides::fromEnvironment().madoca_glonass_phase);
 }
 
+TEST(PPPEnvOverridesTest, MadocaPromotedPathRetainsReleaseCycleOptOuts) {
+    const PPPEnvOverrides overrides = PPPEnvOverrides::fromEnvironment();
+    EXPECT_TRUE(overrides.madoca_early_window);
+    EXPECT_TRUE(overrides.madoca_postfit_commit);
+    EXPECT_TRUE(overrides.madoca_spike_guard);
+}
+
 TEST(NavigationSsrIodeSelection, DoesNotFallBackWhenGpsIodeIsUnavailable) {
     NavigationData navigation;
     const SatelliteId satellite(GNSSSystem::GPS, 8);


### PR DESCRIPTION
## Summary
- remove the rejected GNSS_PPP_MADOCA_SSR_REPLAY preview and its duplicate replay decoder
- retire the redundant GNSS_PPP_MADOCA_GALILEO_GATE selector now that the promoted early-window path is canonical
- document the cleanup ledger and retain the one-release-cycle opt-outs plus the 100 m spike safety net

## Validation
- linked MADOCALIB run_tests passed
- MADOCA CTest suite: 12/12 passed
- real 1 h release matrix: 6/6 cases passed (MIZU/ALIC x PPP/PPP-AR/PPP-AR-ion)
- git diff --check passed

Part of #148.