### PR TITLE
docs: close out MADOCA native migration

### DIFF
--- a/docs/madoca_port_plan.md
+++ b/docs/madoca_port_plan.md
@@ -1,9 +1,11 @@
 # MADOCA Port Plan
 
-> **Active plan:** [MADOCALIB Native Migration Ledger](madocalib_native_migration.md)
-> is the current issue-#148 capability table, frozen oracle contract, milestone
-> plan, and acceptance gate.  This document retains the detailed migration
-> history and earlier design analysis.
+> **Completed migration:** [MADOCALIB Native Migration Ledger](madocalib_native_migration.md)
+> is the final issue-#148 capability table, frozen oracle contract, milestone
+> evidence, and release gate.  This document retains the detailed migration
+> history and earlier design analysis.  Future triple/quad-frequency solver
+> expansion is tracked separately in
+> [issue #387](https://github.com/rsasaki0109/gnssplusplus-library/issues/387).
 
 This plan scopes a MADOCA foundation pass.  The goal is to capture what should
 be ported from MADOCALIB, what should be shared with the existing CLAS work,
@@ -11,8 +13,8 @@ and how to build oracle parity without dragging reference code into production.
 
 > The sections from "Reference Inputs" onward are the original foundation plan
 > (through the iter4 MADOCALIB bridge baseline, 2026-06-10).  They are kept as
-> reference.  For the current state of native parity and the next architecture
-> step, read "Status (2026-06-13)" immediately below first.
+> reference.  The dated status immediately below is a historical snapshot; use
+> the migration ledger for the completed 2026-07-30 state.
 
 ## Status (2026-06-13) — Native Parity Achieved, AR/Filter Architecture Is The Wall
 
@@ -57,8 +59,10 @@ demeaned RMS, residual span, duration, and residual/elevation correlation.
 The shadow CSV header includes the signal-family, RINEX-code, and RTKLIB-code
 columns emitted by each data row so these residual fields remain aligned.
 
-Open MADOCA levers (measured, none yet a default win): PPP-AR parity
-(`exec_pppar` window); QZSS atmosphere row-set.
+The formerly open PPP-AR and QZSS-atmosphere levers were resolved or bounded by
+the M2--M5 acceptance gates.  Their intermediate measurements below remain
+historical evidence, while the versioned release matrix is the current
+regression contract.
 
 Correction-materialization snapshot: use
 `gnss ppp --madoca-l6 <file> --madoca-materialization-dump <csv>` to record the

--- a/docs/madocalib_native_migration.md
+++ b/docs/madocalib_native_migration.md
@@ -67,9 +67,11 @@ Therefore:
 
 ## Capability Ledger
 
-Status meanings: **native** is implemented without MADOCALIB; **oracle-only**
-exists only in the opt-in linked lane; **partial** has a native foundation but
-does not yet match end-to-end behavior; **open** has no accepted native parity.
+Status meanings: **native** is implemented without MADOCALIB and satisfies the
+declared #148 acceptance envelope; **native opt-in** additionally requires an
+explicit native feature input; **oracle-only** exists only in the opt-in linked
+lane; **deferred** is outside the frozen #148 solver/fixture contract and has a
+dedicated follow-up.
 
 | MADOCALIB surface | Native implementation/evidence | Status | Exit evidence |
 |---|---|---|---|
@@ -84,10 +86,10 @@ does not yet match end-to-end behavior; **open** has no accepted native parity.
 | PPP correction signs and ordering | Native correction contract plus materialization/residual diff tools | native | Default PPP parity matrix remains within the accepted MIZU/ALIC envelope |
 | PPP commit-on-success and diagnostics | Native postfit validation/shadow telemetry | native | MIZU 1 h/6 h/24 h and ALIC regression gates remain green |
 | GLONASS phase in MADOCA PPP | Native L1/L2 rows plus corrected postfit-shadow audit | native | Keep the pinned per-satellite demeaned RMS at millimetre scale and span below 4 cm |
-| MADOCALIB `exec_ppp` | Native PPP runs end to end; remaining solution delta is tracked | partial | M4/M5 matrix meets the declared trajectory thresholds |
+| MADOCALIB `exec_ppp` | Native PPP runs end to end across the MIZU/ALIC release matrix | native | Keep all 1 h/6 h/24 h trajectory and runtime baselines green |
 | MADOCALIB `exec_pppar` | Windows and authoritative Ubuntu Release both match the oracle's 108 Fix / 10 Float over all 118 epochs | native | Keep exact status agreement, no wrong/missed Fix, RMS at most 0.20 m, and maximum at most 1.0 m |
-| MADOCALIB `exec_pppar-ion` | Bridge and native opt-in profiles run in the required parity lane | partial | M4 closes eight missed Fix and M5 expands the dataset/duration matrix |
-| Triple/quad-frequency PPP-AR | Upstream 2.0 behavior has not been fully audited or signed off | open | Dedicated fixtures and ambiguity/state parity after dual-frequency M2 |
+| MADOCALIB `exec_pppar-ion` | Native opt-in L6D application runs across the MIZU/ALIC release matrix with explicit status baselines | native opt-in | Keep all 1 h/6 h/24 h trajectory, status, row, and runtime baselines green |
+| Triple/quad-frequency PPP-AR expansion | Not part of the frozen dual-frequency #148 profiles or fixtures | deferred to #387 | Add dedicated fixtures, ambiguity/state parity, and release baselines before claiming support |
 | Linked `postpos()` bridge | Non-installed `gnss_madocalib_oracle` | oracle-only | Available only in `MADOCALIB_PARITY_LINK=ON` builds; absent from normal `gnss_ppp` help and parsing |
 
 ## Current Numerical Baselines
@@ -100,12 +102,18 @@ exact 118/118 status agreement and no native-only or oracle-only Fix.
 On Windows, the native/oracle 3D delta RMS is 0.054269 m, the maximum is
 0.419804 m, and the trailing-1800-second RMS is 0.035616 m.  On Ubuntu, the
 3D delta RMS is 0.189146 m and the maximum is 0.451489 m.  These results meet
-the M2 status and trajectory exit gates.  M3--M6 remain open, so this does not
-complete the overall migration.
+the M2 status and trajectory exit gates.
+
+M3--M6 are also complete for the frozen contract.  The versioned M5 baseline
+covers all 18 combinations of MIZU/ALIC, `ppp`/`pppar`/`pppar-ion`, and
+1 h/6 h/24 h.  Required 1 h/6 h and manually dispatched 24 h matrices passed
+with their declared trajectory, status, row, artifact, and runtime gates.
+The milestone subsections below are chronological evidence: statements that a
+milestone "remains open" describe that intermediate slice, not the final state.
 
 The float-PPP history and older MIZU/ALIC/full-day measurements remain in issue
-#148 and `madoca_port_plan.md`; they are regression context, not proof that
-PPP-AR or L6D integration is complete.
+#148 and `madoca_port_plan.md` as regression context.  The versioned release
+matrix and milestone gates above are the current completion evidence.
 
 ## Migration Milestones
 
@@ -664,10 +672,27 @@ for controlled rollback.  Diagnostic dumps and measurement-neutral shadow
 inputs are retained because they observe the accepted path rather than select
 an alternative solver implementation.
 
-Exit: production code, installed targets, and default CI have no MADOCALIB
-dependency; the linked checkout is used only by the labeled oracle lane; native
-PPP, PPP-AR, and PPP-AR-ion satisfy the M5 matrix; no required migration item
-remains open.
+#### M6 closeout evidence (2026-07-30)
+
+PR #384 made the 18-case matrix a versioned release gate and passed both the
+required 1 h/6 h lane and the manually dispatched 24 h lane.  PR #385 moved all
+linked `postpos()` parsing into the non-installed oracle executable.  PR #386
+removed the rejected replay implementation and redundant Galileo preview
+selector; its Docs, hygiene, Linux GCC/Clang, macOS Clang, static analysis,
+MADOCA parity, extended-test, and optional-signoff jobs all passed.
+
+The accepted `ppp` and `pppar-ion` envelopes intentionally preserve measured
+non-zero solution/status deltas recorded by M5; #148 requires bounded,
+regression-gated native behavior rather than byte-identical whole-solver output.
+Complete MADOCALIB triple/quad-frequency solver parity was never exercised by
+the frozen profiles and is tracked separately in
+[#387](https://github.com/rsasaki0109/gnssplusplus-library/issues/387).  It is a
+capability expansion, not an unaccounted item in the supported #148 matrix.
+
+Exit (satisfied): production code, installed targets, and default CI have no
+MADOCALIB dependency; the linked checkout is used only by the labeled oracle
+lane; native PPP, PPP-AR, and PPP-AR-ion satisfy the M5 matrix; no required
+migration item remains open.
 
 ## PR and Evidence Rules
 
@@ -683,11 +708,12 @@ remains open.
   evidence.
 - Record rejected hypotheses in issue #148 and remove their runtime wiring.
 
-## Immediate Slice
+## Post-migration follow-up
 
-Begin M4 with the eight conservative `pppar-ion` missed-Fix epochs.  Compare
-materialization, satellite and row sets, residual components, then N1
-candidates without relaxing the zero-wrong-Fix gate.  In parallel, reduce the
-0.244372 m one-hour native/oracle delta RMS toward the M2 baseline and extend
-the same accounting to QZSS atmosphere admission and the 24-hour boundary.
-Keep L6D application opt-in until the M5 matrix passes.
+Issue #148 has no remaining implementation slice.  Keep the M5 matrix as the
+release regression contract, remove the compatibility opt-outs only after their
+documented one-release-cycle window, and use
+[#387](https://github.com/rsasaki0109/gnssplusplus-library/issues/387) for any
+future triple/quad-frequency solver expansion.  Such expansion must add
+fixtures and baselines rather than silently widening the completed #148
+contract.

--- a/docs/references/madocalib-gap.md
+++ b/docs/references/madocalib-gap.md
@@ -7,6 +7,11 @@ page remains the broader architectural gap analysis.
 This page compares the current `libgnss++` PPP stack against the areas where
 `MADOCALIB` is the most relevant primary reference.
 
+Issue #148 completed the supported native MADOCA migration on 2026-07-30.  The
+current release contract is the 18-case MIZU/ALIC matrix in the migration
+ledger; this page now records broader architectural follow-ups rather than
+blockers for that completed contract.
+
 Primary upstream:
 
 - [QZSS-Strategy-Office/madocalib](https://github.com/QZSS-Strategy-Office/madocalib)
@@ -45,18 +50,18 @@ Relevant code entrypoints today:
 | Precise product loading | `SP3` and `CLK` products are loaded through `PreciseProducts` |
 | RTCM SSR to PPP path | Implemented through sampled `SSRProducts` and direct RTCM SSR conversion |
 | CLAS/MADOCA transport | Implemented through compact sampled transport and raw `QZSS L6` preprocessing |
+| Native MADOCA L6 products | L6E SSR materialization and L6D causal ionosphere snapshots/application are implemented in C++ and parity-tested |
 | Atmospheric application | Factored into `ppp_atmosphere` and applied inside PPP |
 | Geophysical corrections | Solid Earth tides, ocean loading hooks, receiver ANTEX support are present |
-| Validation | Static/kinematic PPP sign-off commands and CLI regressions already exist |
+| Validation | A versioned 18-case MIZU/ALIC × PPP/PPP-AR/PPP-AR-ion × 1 h/6 h/24 h release matrix gates status, trajectory, rows, artifacts, and runtime |
 
 ## Main gaps versus a MADOCALIB-style reference stack
 
 | Gap | Current libgnss++ state | Why it matters |
 |---|---|---|
-| Native in-core `L6E/L6D -> correction object` path | Current CLAS/MADOCA transport still depends on Python-side preprocessing in `gnss_clas_ppp.py` / `gnss_qzss_l6_info.py` before the C++ PPP core sees sampled corrections | A first-class C++ path would make correction handling easier to test, replay, and profile |
 | First-class `IONEX / DCB` workflow | Native loaders and PPP hooks are implemented; production workflow and sign-off coverage remain narrower than SP3/CLK | `MADOCALIB`-style PPP studies need these products to be reproducible across normal CLI and validation workflows |
-| Explicit multi-frequency PPP beyond the current IF-centric path | Current solver structure is centered on ionosphere-free combinations and PPP ambiguity state handling in `ppp.cpp` | A wider multi-frequency story needs to be explicit before claiming parity with richer PPP references |
-| Broader PPP-AR reference matrix | Current real-data sign-off is useful but still relatively narrow compared with a dedicated upstream PPP reference stack | `PPP-AR` robustness needs more dataset coverage before it can be considered mature |
+| Triple/quad-frequency solver expansion | The completed #148 profiles use the frozen supported contract and do not claim complete MADOCALIB triple/quad-frequency PPP-AR parity | [Issue #387](https://github.com/rsasaki0109/gnssplusplus-library/issues/387) requires dedicated fixtures, ambiguity/state contracts, oracle traces, and release baselines before support is claimed |
+| Broader PPP-AR reference matrix | The MIZU/ALIC 18-case gate is the accepted #148 release baseline; additional climates, receivers, and days remain useful expansion | New datasets should extend a versioned baseline without weakening the frozen regression gates |
 | Correction ordering audit against upstream reference behavior | The native order is now an explicit, tested contract in `ppp_correction_contract.hpp`; whole-run parity still guards numerical behavior | Future reordering is reviewable because it changes a named contract rather than incidental control flow |
 
 ## What should *not* be copied directly
@@ -84,11 +89,17 @@ and **not** a direct code transplant.
    when adding new correction sources.
 2. Finish integrating the existing `IONEX` and `DCB` loaders across production
    workflows and sign-off datasets.
-3. Move more `CLAS/MADOCA` transport handling from Python preprocessing toward
-   native C++ product ingestion.
-4. Widen PPP-AR sign-off datasets and keep the results as checked artifacts.
+3. Keep native L6E/L6D materialization, row, and whole-solver release gates
+   green when adding correction sources.
+4. Use [#387](https://github.com/rsasaki0109/gnssplusplus-library/issues/387)
+   for triple/quad-frequency expansion and widen PPP-AR datasets as versioned
+   checked artifacts.
 
 ## Exit condition for this analysis
 
-This page is considered "done enough" when each of the gaps above has been
-translated into a concrete small PR or explicitly deferred with a reason.
+This analysis is complete for issue #148: its native L6/PPP gaps were
+implemented and release-gated, while triple/quad-frequency expansion is
+explicitly deferred to
+[#387](https://github.com/rsasaki0109/gnssplusplus-library/issues/387).  The
+remaining rows above are independent product and dataset breadth improvements,
+not hidden #148 exit requirements.


### PR DESCRIPTION
## Summary
- reconcile the MADOCA capability ledger with the completed M2-M6 and 18-case M5 release gate
- mark native PPP and PPP-AR-ion against their accepted regression envelopes instead of leaving stale partial/open labels
- separate unsupported triple/quad-frequency expansion into follow-up #387
- replace the obsolete immediate slice and architectural gap text with post-migration maintenance guidance

## Validation
- `python tests/test_cli_ux.py` (18/18 passed)
- `python -m mkdocs build --strict` passed
- stale closeout wording audit passed
- `git diff --check` passed

Final documentation slice for #148. The issue will be closed only after this PR merges and the tracker body/final evidence are reconciled.