### PR TITLE
Expose FGO TDCP backend insertion counts

### DIFF
--- a/apps/native/gnss_fgo.cpp
+++ b/apps/native/gnss_fgo.cpp
@@ -1904,10 +1904,14 @@ void writeSummaryJson(const Options& options,
     output << "  \"float_rate_percent\": " << float_rate_percent << ",\n";
     output << "  \"pseudorange_factors\": " << diagnostics.pseudorange_factors << ",\n";
     output << "  \"tdcp_factors\": " << diagnostics.tdcp_factors << ",\n";
+    output << "  \"tdcp_factors_inserted\": "
+           << diagnostics.tdcp_factors_inserted << ",\n";
     output << "  \"single_difference_doppler_factors\": "
            << diagnostics.single_difference_doppler_factors << ",\n";
     output << "  \"single_difference_tdcp_factors\": "
            << diagnostics.single_difference_tdcp_factors << ",\n";
+    output << "  \"single_difference_tdcp_factors_inserted\": "
+           << diagnostics.single_difference_tdcp_factors_inserted << ",\n";
     output << "  \"carrier_phase_factors\": " << diagnostics.carrier_phase_factors << ",\n";
     output << "  \"double_difference_pseudorange_factors\": "
            << diagnostics.double_difference_pseudorange_factors << ",\n";
@@ -3531,11 +3535,16 @@ int main(int argc, char* argv[]) {
                       << formatPercent(float_rate) << "\n";
             std::cout << "Pseudorange factors: " << result.diagnostics.pseudorange_factors << "\n";
             std::cout << "TDCP factors: " << result.diagnostics.tdcp_factors << "\n";
+            std::cout << "TDCP factors inserted: "
+                      << result.diagnostics.tdcp_factors_inserted << "\n";
             std::cout << "SD Doppler factors: "
                       << result.diagnostics.single_difference_doppler_factors
                       << "\n";
             std::cout << "SD TDCP factors: "
                       << result.diagnostics.single_difference_tdcp_factors
+                      << "\n";
+            std::cout << "SD TDCP factors inserted: "
+                      << result.diagnostics.single_difference_tdcp_factors_inserted
                       << "\n";
             std::cout << "Carrier phase factors: "
                       << result.diagnostics.carrier_phase_factors << "\n";

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -1682,9 +1682,15 @@ public:
         bool converged = false;
         std::size_t epochs = 0;
         std::size_t pseudorange_factors = 0;
+        /// TDCP measurements present in the backend-independent problem.
         std::size_t tdcp_factors = 0;
+        /// TDCP residual rows/factors actually inserted by the selected backend.
+        std::size_t tdcp_factors_inserted = 0;
         std::size_t single_difference_doppler_factors = 0;
+        /// Satellite-single-difference TDCP measurements present in the problem.
         std::size_t single_difference_tdcp_factors = 0;
+        /// Satellite-single-difference TDCP rows/factors actually inserted by the backend.
+        std::size_t single_difference_tdcp_factors_inserted = 0;
         std::size_t carrier_phase_factors = 0;
         std::size_t double_difference_pseudorange_factors = 0;
         std::size_t double_difference_carrier_factors = 0;

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -2539,6 +2539,13 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
     }
 #endif
 
+    // The native optimizer consumes every TDCP entry in the problem as one
+    // residual row. Keep this separate from tdcp_factors (measurements built)
+    // so a backend can never silently report generated factors as inserted.
+    result.diagnostics.tdcp_factors_inserted = problem.tdcp_factors.size();
+    result.diagnostics.single_difference_tdcp_factors_inserted =
+        problem.single_difference_tdcp_factors.size();
+
     const int num_epochs = static_cast<int>(problem.epochs.size());
     std::vector<GNSSSystem> bias_groups;
     std::map<GNSSSystem, int> bias_group_columns;

--- a/tests/test_fgo.cpp
+++ b/tests/test_fgo.cpp
@@ -620,6 +620,7 @@ TEST(FGOTest, TimeDifferencedCarrierFactorsRecoverSyntheticTrajectory) {
     EXPECT_EQ(stats.fixed_solutions, 0u);
     EXPECT_EQ(result.diagnostics.pseudorange_factors, 12u);
     EXPECT_EQ(result.diagnostics.tdcp_factors, 6u);
+    EXPECT_EQ(result.diagnostics.tdcp_factors_inserted, 6u);
     EXPECT_EQ(result.diagnostics.tdcp_candidate_pairs, 6u);
     EXPECT_LT(result.diagnostics.residual_rms_m, 1e-5);
     EXPECT_LT(result.diagnostics.tdcp_residual_rms_m, 1e-5);
@@ -643,6 +644,7 @@ TEST(FGOTest, SingleDifferenceDopplerAndTdcpFactorsConstrainMotion) {
     EXPECT_TRUE(result.diagnostics.converged);
     EXPECT_EQ(result.diagnostics.single_difference_doppler_factors, 5u);
     EXPECT_EQ(result.diagnostics.single_difference_tdcp_factors, 5u);
+    EXPECT_EQ(result.diagnostics.single_difference_tdcp_factors_inserted, 5u);
     EXPECT_LT(result.diagnostics.single_difference_doppler_residual_rms_mps,
               1e-5);
     EXPECT_LT(result.diagnostics.single_difference_tdcp_residual_rms_m,

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -230,6 +230,30 @@ TEST(FGOGtsamBackendTest, FloatSolutionMatchesEigenBackendOnDoubleDifferenceProb
         << " gtsam=" << gtsam_result.diagnostics.double_difference_carrier_residual_rms_m;
 }
 
+TEST(FGOGtsamBackendTest, ReportsBuiltTdcpThatIsNotInsertedByGtsamBackend) {
+    FGOProcessor::FGOProblem problem = makeGtsamParityDoubleDifferenceProblem();
+    FGOProcessor::TimeDifferencedCarrierFactor tdcp;
+    tdcp.previous_epoch_index = 0;
+    tdcp.current_epoch_index = 1;
+    tdcp.satellite = SatelliteId(GNSSSystem::GPS, 1);
+    tdcp.signal = SignalType::GPS_L1CA;
+    tdcp.previous_satellite_position_ecef = gtsamParitySatelliteGeometry().front();
+    tdcp.current_satellite_position_ecef = gtsamParitySatelliteGeometry().front();
+    tdcp.delta_carrier_m = 0.0;
+    tdcp.sigma_m = 0.03;
+    problem.tdcp_factors.push_back(tdcp);
+
+    FGOProcessor::FGOConfig config = makeParityBaseConfig();
+    config.backend = FGOBackend::GTSAM;
+    config.use_tdcp_factors = true;
+
+    const FGOProcessor processor(config);
+    const FGOProcessor::FGOResult result = processor.optimizeProblem(problem);
+
+    EXPECT_EQ(result.diagnostics.tdcp_factors, 1u);
+    EXPECT_EQ(result.diagnostics.tdcp_factors_inserted, 0u);
+}
+
 TEST(FGOGtsamBackendTest, GtsamBackendRecoversFloatAmbiguitiesNearIntegers) {
     const FGOProcessor::FGOProblem problem = makeGtsamParityDoubleDifferenceProblem();
     FGOProcessor::FGOConfig config = makeParityBaseConfig();


### PR DESCRIPTION
## What changed

- distinguish TDCP measurements built in the backend-independent problem from factors actually inserted by the selected optimizer;
- expose insertion counts in CLI text and summary JSON;
- report native Eigen TDCP/SD-TDCP rows as inserted;
- add a GTSAM regression test documenting the current generated-but-not-inserted gap.

## Why

The FGO configuration enables TDCP and the problem builder produces TDCP factors, but the GTSAM backend used by the documented fixed-lag profile does not consume them. The existing `tdcp_factors` count therefore looked like backend usage even when it only represented generated measurements. This telemetry makes backend comparisons and later mechanism experiments attributable.

This PR does not change positioning behavior.

## Validation

- MSVC Release build: `gnss_run_tests`, `gnss_fgo`
- `FGOTest.*:FGOGtsamBackendTest.*`: 28/28 passed
- Eigen/GTSAM synthetic float parity remained at max 0.00221519 m

Part of #389.