### PR TITLE
Filter stale FGO LAMBDA marginal keys

### DIFF
--- a/apps/native/gnss_fgo.cpp
+++ b/apps/native/gnss_fgo.cpp
@@ -1925,6 +1925,10 @@ void writeSummaryJson(const Options& options,
            << diagnostics.lambda_ambiguity_used_candidates << ",\n";
     output << "  \"lambda_ambiguity_attempts\": "
            << diagnostics.lambda_ambiguity_attempts << ",\n";
+    output << "  \"lambda_stale_candidates_filtered\": "
+           << diagnostics.lambda_stale_candidates_filtered << ",\n";
+    output << "  \"lambda_joint_marginal_failures\": "
+           << diagnostics.lambda_joint_marginal_failures << ",\n";
     output << "  \"integer_constrained_reoptimization_attempts\": "
            << diagnostics.integer_constrained_reoptimization_attempts << ",\n";
     output << "  \"integer_constrained_reoptimization_accepts\": "
@@ -3562,6 +3566,10 @@ int main(int argc, char* argv[]) {
                       << result.diagnostics.lambda_ambiguity_used_candidates << "\n";
             std::cout << "LAMBDA attempts: "
                       << result.diagnostics.lambda_ambiguity_attempts << "\n";
+            std::cout << "LAMBDA stale candidates filtered: "
+                      << result.diagnostics.lambda_stale_candidates_filtered << "\n";
+            std::cout << "LAMBDA joint marginal failures: "
+                      << result.diagnostics.lambda_joint_marginal_failures << "\n";
             std::cout << "LAMBDA solved: "
                       << (result.diagnostics.lambda_ambiguity_fix_solved ? "yes" : "no")
                       << "\n";

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -2391,7 +2391,11 @@ int main(int argc, char** argv) {
                   << "  per-epoch LAMBDA: attempts=" << fl.diagnostics.lambda_ambiguity_attempts
                   << ", fixed_epochs=" << fl_fixed << "/" << ne << " ("
                   << (ne > 0 ? 100.0 * double(fl_fixed) / double(ne) : 0.0)
-                  << "% fix-rate), best_ratio=" << fl.diagnostics.lambda_ambiguity_ratio << "\n"
+                  << "% fix-rate), best_ratio=" << fl.diagnostics.lambda_ambiguity_ratio
+                  << ", stale_candidates_filtered="
+                  << fl.diagnostics.lambda_stale_candidates_filtered
+                  << ", joint_marginal_failures="
+                  << fl.diagnostics.lambda_joint_marginal_failures << "\n"
                   << "  partial AR: " << (config.use_fixed_lag_partial_lambda ? "on" : "off")
                   << " (min_fraction=" << config.fixed_lag_partial_lambda_min_fraction
                   << ", min_fixed=" << config.min_fixed_ambiguities

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -1699,6 +1699,10 @@ public:
         std::size_t lambda_ambiguity_candidates = 0;
         std::size_t lambda_ambiguity_used_candidates = 0;
         std::size_t lambda_ambiguity_attempts = 0;
+        /// Ambiguity keys removed before LAMBDA because they left the active smoother.
+        std::size_t lambda_stale_candidates_filtered = 0;
+        /// Exceptions while requesting the active pose/ambiguity joint marginal.
+        std::size_t lambda_joint_marginal_failures = 0;
         std::size_t integer_constrained_reoptimization_attempts = 0;
         std::size_t integer_constrained_reoptimization_accepts = 0;
         std::size_t integer_constrained_reoptimization_rejects = 0;

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -3098,6 +3098,24 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
 
         // --- Per-epoch LAMBDA off the bounded windowed marginals ---
         if (fix_allowed && config.use_lambda_ambiguity_fix && !epoch_amb_indices.empty()) {
+            // FDE, exception recovery, or an ambiguity-generation bump can
+            // invalidate a candidate after epoch_amb_indices was assembled.
+            // Never request a joint marginal containing a key that has
+            // already left the active smoother.
+            const gtsam::Values& lambda_linearization_point =
+                smoother.getLinearizationPoint();
+            const std::size_t candidates_before_filter = epoch_amb_indices.size();
+            epoch_amb_indices.erase(
+                std::remove_if(
+                    epoch_amb_indices.begin(), epoch_amb_indices.end(),
+                    [&](std::size_t idx) {
+                        return !lambda_linearization_point.exists(
+                            ambiguityKey(ambSymbolId(idx)));
+                    }),
+                epoch_amb_indices.end());
+            result.diagnostics.lambda_stale_candidates_filtered +=
+                candidates_before_filter - epoch_amb_indices.size();
+
             std::sort(epoch_amb_indices.begin(), epoch_amb_indices.end(),
                       [&](std::size_t a, std::size_t b) {
                           const auto& sa = problem.ambiguity_states[a];
@@ -3174,6 +3192,7 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                     }
                 } catch (const std::exception&) {
                     ok = false;
+                    ++result.diagnostics.lambda_joint_marginal_failures;
                 }
                 if (ok && float_amb.allFinite() && q_amb.allFinite()) {
                     epoch_diagnostics[i].ar_outcome =

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -228,6 +228,8 @@ TEST(FGOGtsamBackendTest, FloatSolutionMatchesEigenBackendOnDoubleDifferenceProb
                 gtsam_result.diagnostics.double_difference_carrier_residual_rms_m, 1e-3)
         << "eigen=" << eigen_result.diagnostics.double_difference_carrier_residual_rms_m
         << " gtsam=" << gtsam_result.diagnostics.double_difference_carrier_residual_rms_m;
+    EXPECT_EQ(gtsam_result.diagnostics.lambda_stale_candidates_filtered, 0u);
+    EXPECT_EQ(gtsam_result.diagnostics.lambda_joint_marginal_failures, 0u);
 }
 
 TEST(FGOGtsamBackendTest, ReportsBuiltTdcpThatIsNotInsertedByGtsamBackend) {


### PR DESCRIPTION
## What
- filter ambiguity keys that are absent from the active fixed-lag smoother before requesting a joint marginal
- expose stale-candidate and joint-marginal-failure diagnostics in JSON, CLI, and parity summaries
- cover the clean synthetic path with zero-count regression assertions

## Why
FDE recovery and ambiguity-generation changes can leave an epoch candidate list referring to keys that have already left the active smoother. Asking GTSAM for a joint marginal over such keys causes an avoidable LAMBDA marginal failure.

## Validation
- MSVC Release build: `gnss_run_tests`, `gnss_fgo`, `gnss_fgo_parity`
- `FGOTest.*:FGOGtsamBackendTest.*`: 28/28 passed
- Tokyo2, first 1499 evaluated epochs: 35 stale candidates filtered and 0 joint-marginal failures; fixed rate 86.1241%, fixed horizontal RMS 0.349269 m, and fixed horizontal <50 cm rate 83.3222%, unchanged from the matched baseline

Part of #389.