### PR TITLE
Gate surplus AR rescues on state separation

### DIFF
--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -2520,6 +2520,8 @@ int main(int argc, char** argv) {
                   << ", fails=" << fl.diagnostics.surplus_validation_fails
                   << ", insufficient_surplus=" << fl.diagnostics.surplus_validation_insufficient_surplus
                   << ", rescued_epochs=" << fl.diagnostics.surplus_validation_rescued_epochs
+                  << ", separation_rejects="
+                  << fl.diagnostics.surplus_validation_separation_rejects
                   << ", vetoed_epochs=" << fl.diagnostics.surplus_validation_vetoed_epochs
                   << ", min_n=" << config.surplus_validation_min_surplus_satellites
                   << ", aperture_cycles(lt1/1to2/gt2)=" << config.surplus_validation_aperture_pdop_lt1_cycles

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -1725,6 +1725,7 @@ public:
         std::size_t surplus_validation_fails = 0;
         std::size_t surplus_validation_insufficient_surplus = 0;  ///< too few surplus sats at every fallback level
         std::size_t surplus_validation_rescued_epochs = 0;  ///< epochs FIXED only because this test passed a relaxed-ratio candidate
+        std::size_t surplus_validation_separation_rejects = 0;  ///< surplus-pass rescues rejected by the existing fixed-vs-float/IMU separation aperture
         std::size_t surplus_validation_vetoed_epochs = 0;   ///< established-ratio fixes demoted by surplus_validation_veto_high_ratio_fails
         std::size_t surplus_validation_fallback_level_histogram[6] = {0, 0, 0, 0, 0, 0};  ///< index = deciding fallback level (0=GQEBR .. 5=GQ)
         // --- Below-floor low-count AR rescue (use_low_count_ambiguity_resolution) ---

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -3642,22 +3642,33 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                             anchorValidationAgrees(provisional_fixed_ant)) {
                             aperture_pass = true;
                         }
-                        // Stage B rescue: a candidate in the relaxed ratio
-                        // zone that independently passes the surplus-
-                        // satellite test is treated exactly like an IMU-
-                        // aperture pass (eligible for FIXED output AND,
-                        // subject to the SAME downstream holdBlockedByImu
-                        // Aperture()/plausibility checks as every other
-                        // path, fix-and-hold pinning). Monitor mode never
-                        // reaches here (decision-affecting).
+                        // Stage B rescue: require both the independent
+                        // surplus-satellite pass and the existing fixed-vs-
+                        // float / IMU-prediction separation aperture.  The
+                        // latter is correlated with this graph, so it cannot
+                        // replace the surplus test, but it prevents a
+                        // surplus pass from bypassing the same gross
+                        // consistency bound used by IMU-aided relaxed-ratio
+                        // fixes. Monitor mode never reaches here.
                         bool surplus_rescue_applied = false;
-                        if (!config.surplus_validation_monitor_only &&
+                        const bool surplus_rescue_candidate =
+                            !config.surplus_validation_monitor_only &&
                             !normal_ratio_pass && !aperture_pass &&
                             std::isfinite(ratio) &&
                             ratio > config.imu_aided_relaxed_ratio_threshold &&
-                            has_provisional_fixed_ant && surplus_evaluated && surplus_pass) {
-                            aperture_pass = true;
-                            surplus_rescue_applied = true;
+                            has_provisional_fixed_ant && surplus_evaluated && surplus_pass;
+                        if (surplus_rescue_candidate) {
+                            const bool separation_pass =
+                                epoch_diagnostics[i].fixed_float_separation_m <=
+                                    config.imu_aided_max_float_separation_m &&
+                                epoch_diagnostics[i].fixed_imu_prediction_separation_m <=
+                                    config.imu_aided_max_prediction_separation_m;
+                            if (separation_pass) {
+                                aperture_pass = true;
+                                surplus_rescue_applied = true;
+                            } else {
+                                ++result.diagnostics.surplus_validation_separation_rejects;
+                            }
                         }
                         // Integrity-aided aperture: the conventional
                         // fixed-vs-float separation is correlated because

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -2639,6 +2639,7 @@ TEST(FGOSurplusValidationTest, DefaultOffIsNoOp) {
     EXPECT_EQ(result.diagnostics.surplus_validation_fails, 0u);
     EXPECT_EQ(result.diagnostics.surplus_validation_insufficient_surplus, 0u);
     EXPECT_EQ(result.diagnostics.surplus_validation_rescued_epochs, 0u);
+    EXPECT_EQ(result.diagnostics.surplus_validation_separation_rejects, 0u);
     EXPECT_EQ(result.diagnostics.surplus_validation_vetoed_epochs, 0u);
     for (auto count : result.diagnostics.surplus_validation_fallback_level_histogram) {
         EXPECT_EQ(count, 0u);
@@ -2669,6 +2670,7 @@ TEST(FGOSurplusValidationTest, EnabledWithoutExclusionsReportsInsufficientSurplu
     EXPECT_EQ(on_result.diagnostics.surplus_validation_fails, 0u);
     EXPECT_GT(on_result.diagnostics.surplus_validation_insufficient_surplus, 0u);
     EXPECT_EQ(on_result.diagnostics.surplus_validation_rescued_epochs, 0u);
+    EXPECT_EQ(on_result.diagnostics.surplus_validation_separation_rejects, 0u);
     EXPECT_EQ(on_result.diagnostics.surplus_validation_vetoed_epochs, 0u);
 
     // With nothing to rescue or veto, the held-arc outcome must be


### PR DESCRIPTION
## What
- require opt-in surplus-satellite AR rescues to pass the existing fixed-vs-float and IMU-prediction separation aperture
- count surplus-pass candidates rejected by that consistency gate
- expose the rejection count in the parity summary

## Why
The surplus test is independent evidence, but the rescue path was able to bypass the same gross state-separation bound used by IMU-aided relaxed-ratio fixes. On the matched Tokyo2 window, the pre-change rescue added 25 correct FIX and 8 Wrong FIX relative to baseline. The gated path added 8 correct FIX with no additional Wrong FIX.

This is safety hardening for an opt-in experimental path. It does not enable surplus rescue or low-count AR in the shipping preset; full Tokyo2 validation showed those settings should remain off.

## Validation
- MSVC Release build: `gnss_run_tests`, `gnss_fgo_parity`
- 30/30 `FGOTest.*:FGOGtsamBackendTest.*:FGOSurplusValidationTest.*`
- Tokyo2 matched 1499 epochs: correct FIX 1087 -> 1095, Wrong FIX 204 -> 204, fixed-H RMS 0.3493 -> 0.3482 m
- Tokyo1 full, with relaxed ratio floor 1.5: correct FIX +201, Wrong FIX -99, fixed-H RMS 0.6866 -> 0.6662 m
- Tokyo2 full exposed a remaining preset-level non-regression, so the option stays disabled in the shipping preset

Part of #389.