### PR TITLE
Add fail-closed safe library FIX promotion

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,6 +155,34 @@ set(GNSS_SOURCES_NO_OPTIMIZATION
     src/core/observation.cpp
 )
 
+# Production RTK applications must not inherit the historical -O0 workaround
+# used by the monolithic FGO/test support archive.  Keep FGO in
+# gnss_lib_noopt, while compiling the online RTK/SPP/LAMBDA path as its own
+# optimized archive so the documented per-epoch runtime budget is meaningful.
+set(GNSS_RTK_RUNTIME_SOURCES
+    src/algorithms/rtk_ar_selection.cpp
+    src/algorithms/rtk_ar_evaluation.cpp
+    src/algorithms/nlos_weights.cpp
+    src/algorithms/float_trust_policy.cpp
+    src/algorithms/rtk_adaptive_noise.cpp
+    src/algorithms/rtk_measurement.cpp
+    src/algorithms/rtk_selection.cpp
+    src/algorithms/rtk_cmc_reference.cpp
+    src/algorithms/rtk_cp_pr_gate.cpp
+    src/algorithms/rtk_ddpr_anchor.cpp
+    src/algorithms/rtk_update.cpp
+    src/algorithms/rtk_ins_time_update.cpp
+    src/algorithms/rtk_tdcp_diagnostics.cpp
+    src/algorithms/rtk_validation.cpp
+    src/algorithms/integrity_consensus.cpp
+    src/algorithms/rtk.cpp
+    src/algorithms/spp.cpp
+    src/algorithms/spp_velocity.cpp
+    src/algorithms/lambda.cpp
+    src/core/navigation.cpp
+    src/core/observation.cpp
+)
+
 # Create the main library
 add_library(gnss_lib STATIC ${GNSS_SOURCES})
 target_include_directories(gnss_lib PUBLIC
@@ -288,6 +316,18 @@ if(CHOLMOD_INCLUDE_DIR AND CHOLMOD_LIBRARY)
     target_compile_definitions(gnss_lib_noopt PRIVATE GNSSPP_HAS_CHOLMOD=1)
     target_link_libraries(gnss_lib_noopt PRIVATE ${CHOLMOD_LIBRARY})
 endif()
+
+add_library(gnss_rtk_runtime STATIC ${GNSS_RTK_RUNTIME_SOURCES})
+target_include_directories(gnss_rtk_runtime PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
+)
+target_link_libraries(gnss_rtk_runtime PUBLIC Eigen3::Eigen)
+if(MSVC)
+    target_compile_options(gnss_rtk_runtime PRIVATE /O2)
+else()
+    target_compile_options(gnss_rtk_runtime PRIVATE -O2)
+endif()
 if(GTSAM_FOUND)
     # fgo.cpp (FGOProcessor::optimizeProblem) lives in gnss_lib_noopt, so the
     # GTSAM backend TU and the gtsam link dependency must live here too, not
@@ -311,7 +351,12 @@ if(GTSAM_FOUND)
     endif()
 endif()
 
-set(GNSS_INSTALL_TARGETS gnss_lib gnss_lib_noopt sofa ginan_iers2010)
+set(GNSS_INSTALL_TARGETS
+    gnss_lib
+    gnss_lib_noopt
+    gnss_rtk_runtime
+    sofa
+    ginan_iers2010)
 if(MADOCALIB_PARITY_LINK)
     list(APPEND GNSS_INSTALL_TARGETS madocalib)
 endif()

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -44,7 +44,10 @@ add_executable(gnss_fuse
     ${GNSS_NATIVE_DIR}/gnss_fuse.cpp
     ${GNSS_NATIVE_DIR}/cli_toml_config.cpp
 )
-target_link_libraries(gnss_fuse PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)
+target_link_libraries(gnss_fuse PRIVATE gnss_lib gnss_rtk_runtime Threads::Threads)
+
+add_executable(gnss_safe_bridge gnss_safe_bridge.cpp)
+target_link_libraries(gnss_safe_bridge PRIVATE gnss_lib)
 
 add_executable(gnss_vel_d ${GNSS_NATIVE_DIR}/gnss_vel_d.cpp)
 target_link_libraries(gnss_vel_d PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)
@@ -65,7 +68,7 @@ add_executable(gnss_solve
     ${GNSS_NATIVE_DIR}/gnss_solve.cpp
     ${GNSS_NATIVE_DIR}/cli_toml_config.cpp
 )
-target_link_libraries(gnss_solve PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)
+target_link_libraries(gnss_solve PRIVATE gnss_lib gnss_rtk_runtime Threads::Threads)
 
 add_executable(gnss_ppp ${GNSS_NATIVE_DIR}/gnss_ppp.cpp)
 target_link_libraries(gnss_ppp PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)

--- a/apps/gnss_safe_bridge.cpp
+++ b/apps/gnss_safe_bridge.cpp
@@ -1,0 +1,174 @@
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <sstream>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+#include <Eigen/Dense>
+
+#include <libgnss++/core/solution.hpp>
+#include <libgnss++/fusion/fusion_processor.hpp>
+#include <libgnss++/io/imu.hpp>
+
+namespace {
+
+struct AnchorEpoch {
+    double tow = 0.0;
+    bool anchor = false;
+    Eigen::Vector3d ecef = Eigen::Vector3d::Zero();
+};
+
+std::vector<std::string> splitCsv(const std::string& line) {
+    std::vector<std::string> fields;
+    std::stringstream stream(line);
+    std::string field;
+    while (std::getline(stream, field, ',')) fields.push_back(field);
+    return fields;
+}
+
+int column(const std::vector<std::string>& header, const std::string& name) {
+    for (std::size_t i = 0; i < header.size(); ++i) {
+        if (header[i] == name) return static_cast<int>(i);
+    }
+    throw std::runtime_error("missing CSV column: " + name);
+}
+
+std::vector<AnchorEpoch> loadAnchors(const std::string& path) {
+    std::ifstream input(path);
+    if (!input) throw std::runtime_error("cannot open union CSV: " + path);
+    std::string line;
+    if (!std::getline(input, line)) throw std::runtime_error("empty union CSV");
+    const auto header = splitCsv(line);
+    const int tow_col = column(header, "tow");
+    const int fix_col = column(header, "union_fix");
+    const int x_col = column(header, "union_ecef_x");
+    const int y_col = column(header, "union_ecef_y");
+    const int z_col = column(header, "union_ecef_z");
+    const int max_col = std::max({tow_col, fix_col, x_col, y_col, z_col});
+
+    std::vector<AnchorEpoch> epochs;
+    while (std::getline(input, line)) {
+        const auto fields = splitCsv(line);
+        if (static_cast<int>(fields.size()) <= max_col) continue;
+        AnchorEpoch epoch;
+        epoch.tow = std::stod(fields[tow_col]);
+        epoch.anchor = fields[fix_col] == "1" && !fields[x_col].empty() &&
+                       !fields[y_col].empty() && !fields[z_col].empty();
+        if (epoch.anchor) {
+            epoch.ecef = Eigen::Vector3d(std::stod(fields[x_col]),
+                                         std::stod(fields[y_col]),
+                                         std::stod(fields[z_col]));
+            epoch.anchor = epoch.ecef.allFinite();
+        }
+        epochs.push_back(epoch);
+    }
+    return epochs;
+}
+
+}  // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 5) {
+        std::cerr << "Usage: gnss_safe_bridge UNION.csv IMU.csv GPS_WEEK OUT.csv\n";
+        return 2;
+    }
+    try {
+        const auto started = std::chrono::steady_clock::now();
+        const auto epochs = loadAnchors(argv[1]);
+        libgnss::ImuSeries imu;
+        const auto imu_result = libgnss::loadImuCsv(argv[2], imu);
+        if (!imu_result.ok) throw std::runtime_error(imu_result.error);
+        const int gps_week = std::stoi(argv[3]);
+
+        libgnss::LooseCouplingProcessor::Config config;
+        config.nhc_enable = true;
+        config.max_position_update_nis_per_observation = 0.0;
+        config.max_velocity_update_nis_per_observation = 0.0;
+        libgnss::LooseCouplingProcessor processor(config);
+        const libgnss::ImuAxisConvention axes;
+
+        std::ofstream output(argv[4]);
+        if (!output) throw std::runtime_error("cannot open output CSV");
+        output << "tow,anchor,anchor_age_s,bridge_ecef_x,bridge_ecef_y,bridge_ecef_z,"
+                  "initialized,heading_converged,speed_mps,position_sigma_max_m\n";
+        output << std::setprecision(15);
+
+        std::size_t imu_cursor = 0;
+        bool have_anchor = false;
+        double last_anchor_tow = -std::numeric_limits<double>::infinity();
+        double previous_anchor_tow = -std::numeric_limits<double>::infinity();
+        Eigen::Vector3d previous_anchor = Eigen::Vector3d::Zero();
+        for (const auto& epoch : epochs) {
+            while (imu_cursor < imu.samples.size() &&
+                   imu.samples[imu_cursor].time.tow <= epoch.tow) {
+                auto sample = imu.samples[imu_cursor++];
+                sample.accel_raw = axes.apply(sample.accel_raw);
+                sample.gyro_raw_radps = axes.apply(sample.gyro_raw_radps);
+                processor.processImuSample(sample);
+            }
+
+            if (epoch.anchor) {
+                libgnss::PositionSolution solution;
+                solution.time = libgnss::GNSSTime(gps_week, epoch.tow);
+                solution.status = libgnss::SolutionStatus::FIXED;
+                solution.position_ecef = epoch.ecef;
+                solution.position_covariance =
+                    Eigen::Matrix3d::Identity() * 0.0025;
+                solution.num_satellites = 4;
+                const double velocity_dt = epoch.tow - previous_anchor_tow;
+                if (velocity_dt > 0.0 && velocity_dt <= 1.0) {
+                    solution.velocity_ecef =
+                        (epoch.ecef - previous_anchor) / velocity_dt;
+                    solution.velocity_covariance =
+                        Eigen::Matrix3d::Identity() * 0.04;
+                    solution.has_velocity = true;
+                }
+                processor.processGnssSolution(solution);
+                previous_anchor_tow = epoch.tow;
+                previous_anchor = epoch.ecef;
+                last_anchor_tow = epoch.tow;
+                have_anchor = true;
+            }
+
+            output << epoch.tow << ',' << (epoch.anchor ? 1 : 0) << ',';
+            if (have_anchor) output << epoch.tow - last_anchor_tow;
+            output << ',';
+            if (processor.isOriginSet()) {
+                const auto solution = processor.toPositionSolution();
+                output << solution.position_ecef.x() << ','
+                       << solution.position_ecef.y() << ','
+                       << solution.position_ecef.z();
+            } else {
+                output << ",,";
+            }
+            output << ',' << (processor.isInitialized() ? 1 : 0)
+                   << ',' << (processor.isHeadingConverged() ? 1 : 0) << ',';
+            if (processor.isInitialized()) {
+                const auto& state = processor.state();
+                output << state.nominal.velocity_enu.norm() << ','
+                       << std::sqrt(state.covariance.block<3, 3>(0, 0)
+                                        .diagonal().maxCoeff());
+            } else {
+                output << ',';
+            }
+            output << '\n';
+        }
+        const double elapsed_ms =
+            std::chrono::duration<double, std::milli>(
+                std::chrono::steady_clock::now() - started).count();
+        std::cerr << "epochs=" << epochs.size()
+                  << " imu_samples=" << imu.samples.size()
+                  << " elapsed_ms=" << elapsed_ms
+                  << " ms_per_epoch=" << elapsed_ms / epochs.size() << '\n';
+        return 0;
+    } catch (const std::exception& error) {
+        std::cerr << "Error: " << error.what() << '\n';
+        return 1;
+    }
+}

--- a/apps/native/gnss_fuse.cpp
+++ b/apps/native/gnss_fuse.cpp
@@ -1,10 +1,14 @@
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstdlib>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
 #include <limits>
+#include <map>
+#include <memory>
+#include <set>
 #include <sstream>
 #include <stdexcept>
 #include <string>
@@ -36,6 +40,13 @@ Eigen::Matrix3d ecefToEnuRotation(double lat, double lon) {
     return rotation;
 }
 
+enum class DisjointPartitionScheme {
+    GRJ_EC,
+    GEJ_RC,
+    GCJ_RE,
+    GJ_ERC,
+};
+
 struct FuseOptions {
     std::string data_dir;
     std::string rover_path;
@@ -50,6 +61,8 @@ struct FuseOptions {
     std::string kml_path;
     bool write_kml = false;
     std::string attitude_csv_path;  ///< optional roll/pitch/yaw debug export (validation-only)
+    std::string sse_par_csv_path;
+    std::string library_fix_integrity_csv_path;
 
     // RTK tuning (only consulted when --base is provided; see
     // docs/design.md 5 -- "same defaults/presets" as the `solve` command).
@@ -59,6 +72,14 @@ struct FuseOptions {
     double max_baseline_length_m = 20000.0;
     double ratio_threshold = 3.0;
     bool ratio_threshold_set = false;
+    libgnss::RTKProcessor::RTKConfig::ARPolicy ar_policy =
+        libgnss::RTKProcessor::RTKConfig::ARPolicy::EXTENDED;
+    libgnss::RTKProcessor::RTKConfig::GlonassARMode glonass_ar_mode =
+        libgnss::RTKProcessor::RTKConfig::GlonassARMode::OFF;
+    double max_position_jump_m = 5.0;
+    double rtk_update_outlier_threshold = 0.0;
+    bool prefer_trusted_seed = false;
+    std::string rover_seed_pos_path;
     double elevation_mask_deg = 15.0;
     bool enable_base_interpolation = true;
     // Off by default: see runRtkFusion's doc comment. RTKProcessor/SPPProcessor
@@ -73,8 +94,46 @@ struct FuseOptions {
     // (fusion_initialization::tryAlignHeading is a one-shot, ungated
     // correction).
     bool derive_velocity_from_fixed = false;
+    bool integrity_fixed_velocity = false;
     bool tightly_coupled_dd_imu = false;
     bool tightly_coupled_dd_code_only = false;
+    bool library_fix_integrity_gate = false;
+    double integrity_anchor_max_age_s = 2.0;
+    DisjointPartitionScheme disjoint_partition_scheme =
+        DisjointPartitionScheme::GRJ_EC;
+    bool disjoint_partition_ensemble = false;
+    bool integrity_disjoint_evaluate_all = false;
+    bool integrity_student_t_front_end = false;
+    bool integrity_student_t_all_measurements = false;
+    bool integrity_laplacian_all_measurements = false;
+    bool integrity_huber_all_measurements = false;
+    double integrity_student_t_degrees_of_freedom = 4.0;
+    std::string integrity_disjoint_heavy_tail_model = "inherit";
+    double integrity_heavy_tail_activation_sigma = 2.5;
+    double integrity_validator_runtime_budget_ms = 0.0;
+    double integrity_max_statistical_separation_m = 1.0;
+    int integrity_disjoint_acquisition_streak = 3;
+    double integrity_disjoint_correction_jump_m = 0.02;
+    bool integrity_disjoint_selected_pair_ratio = false;
+    bool integrity_causal_arc_readiness_shadow = false;
+    bool integrity_causal_arc_smoothed_search = false;
+    int integrity_causal_arc_smoothed_max_pairs = 0;
+    bool integrity_causal_arc_promotion = false;
+    bool integrity_satellite_par_consensus_shadow = false;
+    bool integrity_satellite_par_consensus_promotion = false;
+    bool integrity_src_par_consensus_shadow = false;
+    bool integrity_src_par_consensus_promotion = false;
+    bool integrity_inertial_referenced_consensus_shadow = false;
+    bool integrity_inertial_referenced_consensus_promotion = false;
+    bool integrity_satellite_par_quality_diverse = false;
+    bool integrity_satellite_par_persistent_subset = false;
+    bool integrity_disjoint_satellite_par = false;
+    int integrity_satellite_par_max_drop_steps = 8;
+    bool integrity_wide_lane_front_end = false;
+    bool integrity_l1_l2_wlnl_cascade = false;
+    bool integrity_l2_l5_wlnl_cascade = false;
+    bool integrity_multifrequency_consensus_shadow = false;
+    bool integrity_multifrequency_consensus_promotion = false;
 
     // Phase 1 GNSS/IMU coupling (docs/design.md): feed the ESKF's INS-
     // mechanization-predicted antenna ECEF position back into RTKProcessor
@@ -278,6 +337,112 @@ void transformImuSample(libgnss::ImuSample& sample, const FuseOptions& options,
     sample.gyro_raw_radps = axis_convention.apply(sample.gyro_raw_radps);
 }
 
+bool belongsToDisjointPartitionA(
+    libgnss::GNSSSystem system,
+    DisjointPartitionScheme scheme) {
+    using libgnss::GNSSSystem;
+    switch (scheme) {
+        case DisjointPartitionScheme::GRJ_EC:
+            return system == GNSSSystem::GPS ||
+                   system == GNSSSystem::GLONASS ||
+                   system == GNSSSystem::QZSS;
+        case DisjointPartitionScheme::GEJ_RC:
+            return system == GNSSSystem::GPS ||
+                   system == GNSSSystem::Galileo ||
+                   system == GNSSSystem::QZSS;
+        case DisjointPartitionScheme::GCJ_RE:
+            return system == GNSSSystem::GPS ||
+                   system == GNSSSystem::BeiDou ||
+                   system == GNSSSystem::QZSS;
+        case DisjointPartitionScheme::GJ_ERC:
+            return system == GNSSSystem::GPS ||
+                   system == GNSSSystem::QZSS;
+    }
+    return false;
+}
+
+bool belongsToDisjointPartitionB(
+    libgnss::GNSSSystem system,
+    DisjointPartitionScheme scheme) {
+    return !belongsToDisjointPartitionA(system, scheme) &&
+           system != libgnss::GNSSSystem::UNKNOWN &&
+           system != libgnss::GNSSSystem::SBAS &&
+           system != libgnss::GNSSSystem::NavIC;
+}
+
+libgnss::ObservationData filterDisjointPartition(
+    const libgnss::ObservationData& input,
+    bool partition_a,
+    DisjointPartitionScheme scheme) {
+    libgnss::ObservationData filtered(input.time);
+    filtered.receiver_position = input.receiver_position;
+    filtered.receiver_clock_bias = input.receiver_clock_bias;
+    filtered.observations.reserve(input.observations.size());
+    for (const auto& observation : input.observations) {
+        const bool keep =
+            partition_a
+                ? belongsToDisjointPartitionA(
+                      observation.satellite.system, scheme)
+                : belongsToDisjointPartitionB(
+                      observation.satellite.system, scheme);
+        if (keep) {
+            filtered.observations.push_back(observation);
+        }
+    }
+    return filtered;
+}
+
+bool observationInputsAreDisjoint(
+    const libgnss::ObservationData& partition_a,
+    const libgnss::ObservationData& partition_b) {
+    std::set<libgnss::SatelliteId> satellites_a;
+    for (const auto& observation : partition_a.observations) {
+        satellites_a.insert(observation.satellite);
+    }
+    for (const auto& observation : partition_b.observations) {
+        if (satellites_a.count(observation.satellite) != 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+double roundedTowKey(double tow) {
+    return std::round(tow * 10.0) / 10.0;
+}
+
+std::map<double, Eigen::Vector3d> loadSeedPositions(
+    const std::string& path) {
+    std::ifstream input(path);
+    if (!input.is_open()) {
+        throw std::runtime_error(
+            "failed to open rover seed .pos: " + path);
+    }
+    std::map<double, Eigen::Vector3d> output;
+    std::string line;
+    while (std::getline(input, line)) {
+        if (line.empty() || line[0] == '%') continue;
+        std::istringstream stream(line);
+        double week = 0.0;
+        double tow = 0.0;
+        Eigen::Vector3d position = Eigen::Vector3d::Zero();
+        if (!(stream >> week >> tow >> position.x() >>
+              position.y() >> position.z())) {
+            continue;
+        }
+        if (std::isfinite(tow) && position.allFinite() &&
+            position.norm() > 1e6) {
+            output[roundedTowKey(tow)] = position;
+        }
+    }
+    if (output.empty()) {
+        throw std::runtime_error(
+            "rover seed .pos contained no usable ECEF rows: " +
+            path);
+    }
+    return output;
+}
+
 void applyImuGradePreset(const std::string& grade, libgnss::ProcessNoiseConfig& cfg) {
     // Continuous-time spectral-density presets, matching
     // reference_notes.md 7's IMU_PRESETS table (same names/values as the
@@ -379,6 +544,124 @@ void printAdvancedUsage(const char* program_name) {
         << "  --kml <fused.kml>            Optional KML trajectory output\n"
         << "  --attitude-csv <path>        Optional roll/pitch/yaw (deg) debug CSV, one row per\n"
         << "                                fused epoch (validation against reference.csv attitude)\n"
+        << "  --tight-dd-sse-csv <path>    Optional truth-free per-epoch SSE-PAR audit CSV\n"
+        << "  --library-fix-integrity-gate Require primary FFRT plus an independent\n"
+        << "                                L1/L5 or causal pre-update INS source before\n"
+        << "                                emitting library Status=4 (default: off)\n"
+        << "  --library-fix-integrity-csv <path>\n"
+        << "                                Optional truth-free per-epoch gate audit CSV\n"
+        << "  --integrity-anchor-max-age-s <s>\n"
+        << "                                Maximum causal age of an independently accepted\n"
+        << "                                FIX anchor for INS separation (default: 2)\n"
+        << "  --integrity-disjoint-partition <grj-ec|gej-rc|gcj-re|gj-erc>\n"
+        << "                                Fixed non-overlapping GNSS-system split\n"
+        << "                                used by independent RTK validators\n"
+        << "  --integrity-disjoint-ensemble Evaluate all four fixed splits and\n"
+        << "                                select the available split with the\n"
+        << "                                smallest truth-free A/B separation\n"
+        << "  --integrity-disjoint-evaluate-all\n"
+        << "                                Do not early-stop after a hard A/B match\n"
+        << "  --integrity-student-t-front-end\n"
+        << "                                Enable code-only Student-t covariance\n"
+        << "                                inflation before FLOAT updates; it has\n"
+        << "                                no direct integer/FIX authority\n"
+        << "  --integrity-student-t-all-measurements\n"
+        << "                                Apply Student-t inflation to code and\n"
+        << "                                carrier rows (implies front-end enable)\n"
+        << "  --integrity-student-t-degrees-of-freedom <nu>\n"
+        << "                                Student-t tail parameter (default: 4)\n"
+        << "  --integrity-laplacian-all-measurements\n"
+        << "                                Use an L1/Laplacian IRLS front-end on\n"
+        << "                                code and carrier rows\n"
+        << "  --integrity-huber-all-measurements\n"
+        << "                                Use a continuous Huber IRLS front-end on\n"
+        << "                                code and carrier rows\n"
+        << "  --integrity-heavy-tail-activation-sigma <sigma>\n"
+        << "                                Residual threshold for heavy-tail\n"
+        << "                                covariance inflation (default: 2.5)\n"
+        << "  --integrity-disjoint-heavy-tail-model <inherit|student-t|laplacian|huber>\n"
+        << "                                Optional robust model override for\n"
+        << "                                disjoint validators (default: inherit)\n"
+        << "  --integrity-validator-runtime-budget-ms <ms>\n"
+        << "                                Stop before another fallback validator\n"
+        << "                                pair once this epoch budget is reached\n"
+        << "  --integrity-max-statistical-separation-m <m>\n"
+        << "                                Gross three-solution bound used before\n"
+        << "                                causal consensus (default: 1.0)\n"
+        << "  --integrity-disjoint-acquisition-streak <n>\n"
+        << "                                Consecutive stable consensus epochs\n"
+        << "                                required for declaration (default: 3)\n"
+        << "  --integrity-disjoint-correction-jump-m <m>\n"
+        << "                                Maximum correction change within that\n"
+        << "                                streak (default: 0.02)\n"
+        << "  --integrity-disjoint-selected-pair-ratio\n"
+        << "                                Apply the unchanged absolute ratio gate\n"
+        << "                                to both estimators in the selected pair\n"
+        << "  --integrity-causal-arc-readiness-shadow\n"
+        << "                                Audit reference-generation-aware float\n"
+        << "                                ambiguity arc readiness; no FIX authority\n"
+        << "  --integrity-causal-arc-smoothed-search-shadow\n"
+        << "                                Search ready arcs with their causal float\n"
+        << "                                means/covariance; no FIX authority\n"
+        << "  --integrity-causal-arc-smoothed-max-pairs <n>\n"
+        << "                                Covariance-only PAR cap for smoothed\n"
+        << "                                search (0=all, minimum 12)\n"
+        << "  --integrity-causal-arc-promotion\n"
+        << "                                Promote only a declared arc/disjoint\n"
+        << "                                causal consensus (implies shadow)\n"
+        << "  --integrity-satellite-par-consensus-shadow\n"
+        << "                                Audit FFRT satellite-PAR against both\n"
+        << "                                disjoint validators; no FIX authority\n"
+        << "  --integrity-satellite-par-consensus-promotion\n"
+        << "                                Promote only declared PAR/disjoint\n"
+        << "                                causal consensus (implies shadow)\n"
+        << "  --integrity-src-par-consensus-shadow\n"
+        << "                                Audit covariance-scale-16 SRC-PAR\n"
+        << "                                against both disjoint validators\n"
+        << "  --integrity-src-par-consensus-promotion\n"
+        << "                                Promote only declared SRC/disjoint\n"
+        << "                                causal consensus (implies shadow)\n"
+        << "  --integrity-inertial-referenced-consensus-shadow\n"
+        << "                                Audit primary FFRT candidate against\n"
+        << "                                prior-anchor causal INS over 3 epochs\n"
+        << "  --integrity-inertial-referenced-consensus-promotion\n"
+        << "                                Promote only declared FFRT/INS causal\n"
+        << "                                consensus (implies shadow)\n"
+        << "  --integrity-satellite-par-quality-diverse\n"
+        << "                                Rank PAR drop subsets by covariance,\n"
+        << "                                elevation, SNR, residual, and azimuth\n"
+        << "  --integrity-satellite-par-persistent-subset-shadow\n"
+        << "                                Re-evaluate the prior accepted satellite\n"
+        << "                                IDs first with fresh LAMBDA/FFRT\n"
+        << "  --integrity-disjoint-satellite-par-shadow\n"
+        << "                                Allow each non-overlapping validator to\n"
+        << "                                use its own fresh FFRT PAR fallback\n"
+        << "  --integrity-satellite-par-max-drop-steps <n>\n"
+        << "                                Maximum satellite subsets tried by main\n"
+        << "                                and partition PAR (default: 8)\n"
+        << "  --integrity-wide-lane-front-end\n"
+        << "                                Enable L1/L2 Melbourne-Wubbena wide-lane\n"
+        << "                                conditioning before main integer search\n"
+        << "  --integrity-l1-l2-wlnl-cascade-shadow\n"
+        << "                                Run the two-stage FFRT WL/NL cascade on\n"
+        << "                                L1/L2 instead of sparse L1/L5\n"
+        << "  --integrity-l2-l5-wlnl-cascade-shadow\n"
+        << "                                Add the long-wide-lane L2/L5 two-stage\n"
+        << "                                FFRT cascade as the same fault family\n"
+        << "  --integrity-multifrequency-consensus-shadow\n"
+        << "                                Audit dual WL/NL candidates against both\n"
+        << "                                disjoint validators; no FIX authority\n"
+        << "  --integrity-multifrequency-consensus-promotion\n"
+        << "                                Promote only declared WL/NL/disjoint\n"
+        << "                                causal consensus (implies shadow)\n"
+        << "  --ar-policy <extended|demo5-continuous>\n"
+        << "  --glonass-ar <off|on|autocal>\n"
+        << "  --max-pos-jump <m>           RTK absolute position jump bound\n"
+        << "  --rtk-update-outlier-threshold <sigma>\n"
+        << "  --prefer-trusted-seed        Prefer trusted/current rover seed\n"
+        << "  --rover-seed-pos <file>      Per-epoch ECEF seed .pos\n"
+        << "  --integrity-fixed-velocity   Feed causal velocity from consecutive\n"
+        << "                                independently accepted FIX positions to INS\n"
         << "  --lever-arm x,y,z            IMU -> antenna lever arm, body FLU, meters (default 0,0,0)\n"
         << "  --zupt / --no-zupt           Enable/disable zero-velocity updates (default: enabled)\n"
         << "  --nhc / --no-nhc             Enable/disable the non-holonomic constraint (default: disabled)\n"
@@ -626,6 +909,553 @@ private:
     std::ofstream file_;
 };
 
+class SSEPartialARCsvWriter {
+public:
+    bool open(const std::string& path) {
+        if (path.empty()) {
+            return true;
+        }
+        file_.open(path);
+        if (!file_.is_open()) {
+            return false;
+        }
+        file_ << "gps_week,tow,available,attempted,subsets_evaluated,"
+                 "ratio_passed_subsets,separation_rejected_subsets,passed,"
+                 "fixed_count,dropped_count,ratio,bsr_qscale16,"
+                 "ffrt_min_ratio,sse_statistic_per_dof,"
+                 "position_separation_m,candidate_ecef_x,candidate_ecef_y,"
+                 "candidate_ecef_z\n";
+        return true;
+    }
+
+    void write(
+        const libgnss::GNSSTime& time,
+        const libgnss::dd_imu_bridge::SSEPartialARResult& result,
+        const Eigen::Vector3d& candidate_ecef) {
+        if (!file_.is_open()) {
+            return;
+        }
+        file_ << time.week << "," << std::fixed << std::setprecision(3)
+              << time.tow << "," << result.available << ","
+              << result.attempted << "," << result.subsets_evaluated
+              << "," << result.ratio_passed_subsets << ","
+              << result.separation_rejected_subsets << ","
+              << result.passed << "," << result.fixed_count << ","
+              << result.dropped_count << "," << std::setprecision(9)
+              << result.ratio << ","
+              << result.bootstrapped_success_rate << ","
+              << result.ffrt_minimum_ratio << ","
+              << result.statistic_per_dof << ","
+              << result.position_separation_m << ",";
+        if (result.passed && candidate_ecef.allFinite()) {
+            file_ << std::setprecision(4) << candidate_ecef.x() << ","
+                  << candidate_ecef.y() << "," << candidate_ecef.z();
+        } else {
+            file_ << ",,";
+        }
+        file_ << "\n";
+    }
+
+private:
+    std::ofstream file_;
+};
+
+class LibraryFixIntegrityCsvWriter {
+public:
+    bool open(const std::string& path) {
+        if (path.empty()) return true;
+        file_.open(path);
+        if (!file_.is_open()) return false;
+        file_ << "gps_week,tow,library_status,primary_fixed_applied,"
+                 "independent_families,joint_failure_probability,"
+                 "failure_budget_passed,inertial_available,"
+                 "primary_ffrt_passed,primary_pair_count,"
+                 "primary_full_ratio,"
+                 "causal_arc_total_pairs,causal_arc_ready_pairs,"
+                 "causal_arc_subset_pair_count,"
+                 "causal_arc_resets,"
+                 "causal_arc_subset_ratio,"
+                 "causal_arc_subset_bsr,"
+                 "causal_arc_subset_variance_min,"
+                 "causal_arc_subset_variance_max,"
+                 "causal_arc_subset_ffrt_min_ratio,"
+                 "causal_arc_subset_ffrt_passed,"
+                 "causal_arc_subset_primary_separation_m,"
+                 "causal_arc_subset_second_position_delta_m,"
+                 "causal_arc_subset_partition_a_separation_m,"
+                 "causal_arc_subset_partition_b_separation_m,"
+                 "causal_arc_disjoint_evidence_passed,"
+                 "causal_arc_consensus_declared_fixed,"
+                 "causal_arc_consensus_state,"
+                 "causal_arc_consensus_acquisition_streak,"
+                 "causal_arc_candidate_ecef_x,"
+                 "causal_arc_candidate_ecef_y,"
+                 "causal_arc_candidate_ecef_z,"
+                 "satellite_par_ffrt_passed,"
+                 "satellite_par_subset_size,"
+                 "satellite_par_persistent_subset_attempted,"
+                 "satellite_par_persistent_subset_used,"
+                 "satellite_par_ratio,"
+                 "satellite_par_disjoint_evidence_passed,"
+                 "satellite_par_consensus_declared_fixed,"
+                 "satellite_par_consensus_state,"
+                 "satellite_par_consensus_acquisition_streak,"
+                 "satellite_par_candidate_ecef_x,"
+                 "satellite_par_candidate_ecef_y,"
+                 "satellite_par_candidate_ecef_z,"
+                 "src_par_ffrt_passed,"
+                 "src_par_subset_size,"
+                 "src_par_ratio,"
+                 "src_par_second_position_delta_m,"
+                 "src_par_disjoint_evidence_passed,"
+                 "src_par_partition_a_separation_m,"
+                 "src_par_partition_b_separation_m,"
+                 "src_par_consensus_declared_fixed,"
+                 "src_par_consensus_state,"
+                 "src_par_consensus_acquisition_streak,"
+                 "src_par_candidate_ecef_x,"
+                 "src_par_candidate_ecef_y,"
+                 "src_par_candidate_ecef_z,"
+                 "float_update_nis_per_observation,"
+                 "float_update_prefit_residual_rms_m,"
+                 "safe_shadow_declared_fixed,"
+                 "inertial_healthy_anchor,inertial_passed,"
+                 "inertial_time_error_s,inertial_position_delta_m,"
+                 "inertial_nis_per_dimension,"
+                 "inertial_referenced_consensus_declared_fixed,"
+                 "inertial_referenced_consensus_state,"
+                 "inertial_referenced_consensus_acquisition_streak,"
+                 "inertial_referenced_correction_x,"
+                 "inertial_referenced_correction_y,"
+                 "inertial_referenced_correction_z,"
+                 "disjoint_available,"
+                 "disjoint_inputs_verified,disjoint_a_ffrt_passed,"
+                 "disjoint_b_ffrt_passed,disjoint_passed,"
+                 "disjoint_partition_separation_m,"
+                 "disjoint_a_primary_separation_m,"
+                 "disjoint_b_primary_separation_m,"
+                 "disjoint_hard_separation_passed,"
+                 "disjoint_statistical_separation_passed,"
+                 "disjoint_partition_nis_per_dimension,"
+                 "disjoint_a_primary_nis_per_dimension,"
+                 "disjoint_b_primary_nis_per_dimension,"
+                 "disjoint_consensus_declared_fixed,"
+                 "disjoint_consensus_state,"
+                 "disjoint_consensus_acquisition_streak,"
+                 "disjoint_consensus_selected_pair,"
+                 "disjoint_consensus_selected_pair_min_ratio,"
+                 "multifrequency_wl_ffrt_passed,"
+                 "multifrequency_nl_ffrt_passed,"
+                 "multifrequency_candidate_pair_count,"
+                 "multifrequency_primary_separation_m,"
+                 "multifrequency_disjoint_evidence_passed,"
+                 "multifrequency_consensus_declared_fixed,"
+                 "multifrequency_consensus_state,"
+                 "multifrequency_consensus_acquisition_streak,"
+                 "multifrequency_candidate_ecef_x,"
+                 "multifrequency_candidate_ecef_y,"
+                 "multifrequency_candidate_ecef_z,"
+                 "l1_l2_multifrequency_wl_ffrt_passed,"
+                 "l1_l2_multifrequency_nl_ffrt_passed,"
+                 "l1_l2_multifrequency_candidate_pair_count,"
+                 "l1_l2_multifrequency_primary_separation_m,"
+                 "l1_l2_multifrequency_disjoint_evidence_passed,"
+                 "l1_l2_multifrequency_consensus_declared_fixed,"
+                 "l1_l2_multifrequency_consensus_state,"
+                 "l1_l2_multifrequency_consensus_acquisition_streak,"
+                 "l1_l2_multifrequency_candidate_ecef_x,"
+                 "l1_l2_multifrequency_candidate_ecef_y,"
+                 "l1_l2_multifrequency_candidate_ecef_z,"
+                 "l2_l5_multifrequency_wl_ffrt_passed,"
+                 "l2_l5_multifrequency_nl_ffrt_passed,"
+                 "l2_l5_multifrequency_pair_count,"
+                 "l2_l5_multifrequency_wl_ratio,"
+                 "l2_l5_multifrequency_wl_ffrt_min_ratio,"
+                 "l2_l5_multifrequency_mw_disagreements,"
+                 "l2_l5_multifrequency_nl_ratio,"
+                 "l2_l5_multifrequency_nl_ffrt_min_ratio,"
+                 "l2_l5_multifrequency_candidate_pair_count,"
+                 "l2_l5_multifrequency_candidate_ecef_x,"
+                 "l2_l5_multifrequency_candidate_ecef_y,"
+                 "l2_l5_multifrequency_candidate_ecef_z,"
+                 "quality_gate_passed,"
+                 "quality_gate_promoted,"
+                 "quality_gate_disjoint_consensus_promoted,"
+                 "quality_gate_causal_arc_promoted,"
+                 "quality_gate_satellite_par_promoted,"
+                 "quality_gate_src_par_promoted,"
+                 "quality_gate_inertial_referenced_promoted,"
+                 "quality_gate_multifrequency_promoted,"
+                 "quality_gate_raw_partition_conflict,"
+                 "quality_gate_demoted,"
+                 "disjoint_validators_evaluated,"
+                 "processing_runtime_ms\n";
+        return true;
+    }
+
+    void write(
+        const libgnss::PositionSolution& solution,
+        const libgnss::RTKProcessor::EpochDebugTelemetry& telemetry,
+        int disjoint_validators_evaluated,
+        double processing_runtime_ms) {
+        if (!file_.is_open()) return;
+        auto number = [&](double value) {
+            if (std::isfinite(value)) file_ << std::setprecision(12) << value;
+        };
+        const Eigen::Vector3d multifrequency_candidate(
+            telemetry.lambda_l1_l5_wlnl_shadow_best_ecef_x,
+            telemetry.lambda_l1_l5_wlnl_shadow_best_ecef_y,
+            telemetry.lambda_l1_l5_wlnl_shadow_best_ecef_z);
+        const Eigen::Vector3d l1_l2_multifrequency_candidate(
+            telemetry.lambda_l1_l2_wlnl_shadow_best_ecef_x,
+            telemetry.lambda_l1_l2_wlnl_shadow_best_ecef_y,
+            telemetry.lambda_l1_l2_wlnl_shadow_best_ecef_z);
+        const Eigen::Vector3d l2_l5_multifrequency_candidate(
+            telemetry.lambda_l2_l5_wlnl_shadow_best_ecef_x,
+            telemetry.lambda_l2_l5_wlnl_shadow_best_ecef_y,
+            telemetry.lambda_l2_l5_wlnl_shadow_best_ecef_z);
+        const Eigen::Vector3d primary_candidate(
+            telemetry.lambda_shadow_best_ecef_x,
+            telemetry.lambda_shadow_best_ecef_y,
+            telemetry.lambda_shadow_best_ecef_z);
+        const Eigen::Vector3d causal_arc_candidate(
+            telemetry.lambda_causal_arc_subset_best_ecef_x,
+            telemetry.lambda_causal_arc_subset_best_ecef_y,
+            telemetry.lambda_causal_arc_subset_best_ecef_z);
+        file_ << solution.time.week << "," << std::fixed
+              << std::setprecision(3) << solution.time.tow << ","
+              << static_cast<int>(solution.status) << ","
+              << telemetry.final_fixed_applied << ","
+              << telemetry.safe_fix_shadow_independent_source_families
+              << ",";
+        number(telemetry.safe_fix_shadow_joint_failure_probability);
+        file_ << "," << telemetry.safe_fix_shadow_failure_budget_passed
+              << "," << telemetry.inertial_fix_evidence_available
+              << "," << telemetry.lambda_shadow_ffrt_passed
+              << "," << telemetry.pair_count << ",";
+        number(telemetry.full_ratio);
+        file_ << ","
+              << telemetry.lambda_causal_arc_total_pairs
+              << ","
+              << telemetry.lambda_causal_arc_ready_pairs
+              << ","
+              << telemetry.lambda_causal_arc_subset_pair_count
+              << ","
+              << telemetry.lambda_causal_arc_resets
+              << ",";
+        number(telemetry.lambda_causal_arc_subset_ratio);
+        file_ << ",";
+        number(telemetry.lambda_causal_arc_subset_bsr);
+        file_ << ",";
+        number(telemetry.lambda_causal_arc_subset_variance_min);
+        file_ << ",";
+        number(telemetry.lambda_causal_arc_subset_variance_max);
+        file_ << ",";
+        number(
+            telemetry
+                .lambda_causal_arc_subset_ffrt_min_ratio);
+        file_ << ","
+              << telemetry.lambda_causal_arc_subset_ffrt_passed
+              << ",";
+        number(
+            causal_arc_candidate.allFinite() &&
+                    primary_candidate.allFinite()
+                ? (causal_arc_candidate - primary_candidate).norm()
+                : std::numeric_limits<double>::quiet_NaN());
+        file_ << ",";
+        number(
+            telemetry
+                .lambda_causal_arc_subset_second_position_delta_m);
+        file_ << ",";
+        number(
+            telemetry
+                .lambda_causal_arc_subset_partition_a_separation_m);
+        file_ << ",";
+        number(
+            telemetry
+                .lambda_causal_arc_subset_partition_b_separation_m);
+        file_ << ","
+              << telemetry.causal_arc_disjoint_evidence_passed
+              << ","
+              << telemetry.causal_arc_consensus_declared_fixed
+              << ","
+              << telemetry.causal_arc_consensus_state
+              << ","
+              << telemetry
+                     .causal_arc_consensus_acquisition_streak
+              << ",";
+        number(causal_arc_candidate.x());
+        file_ << ",";
+        number(causal_arc_candidate.y());
+        file_ << ",";
+        number(causal_arc_candidate.z());
+        file_ << ",";
+        file_ << telemetry.lambda_satellite_par_shadow_ffrt_passed
+              << ","
+              << telemetry.lambda_satellite_par_shadow_subset_size
+              << ","
+              << telemetry
+                     .lambda_satellite_par_persistent_subset_attempted
+              << ","
+              << telemetry
+                     .lambda_satellite_par_persistent_subset_used
+              << ",";
+        number(telemetry.lambda_satellite_par_shadow_ratio);
+        file_ << ","
+              << telemetry.satellite_par_disjoint_evidence_passed
+              << ","
+              << telemetry.satellite_par_consensus_declared_fixed
+              << ","
+              << telemetry.satellite_par_consensus_state
+              << ","
+              << telemetry
+                     .satellite_par_consensus_acquisition_streak
+              << ",";
+        number(telemetry.lambda_satellite_par_shadow_best_ecef_x);
+        file_ << ",";
+        number(telemetry.lambda_satellite_par_shadow_best_ecef_y);
+        file_ << ",";
+        number(telemetry.lambda_satellite_par_shadow_best_ecef_z);
+        file_ << ",";
+        file_ << telemetry.lambda_src_par_shadow_ffrt_passed
+              << ","
+              << telemetry.lambda_src_par_shadow_subset_size
+              << ",";
+        number(telemetry.lambda_src_par_shadow_ratio);
+        file_ << ",";
+        number(
+            telemetry.lambda_src_par_shadow_second_position_delta_m);
+        file_ << ","
+              << telemetry.src_par_disjoint_evidence_passed
+              << ",";
+        number(telemetry.src_par_partition_a_separation_m);
+        file_ << ",";
+        number(telemetry.src_par_partition_b_separation_m);
+        file_ << ","
+              << telemetry.src_par_consensus_declared_fixed
+              << ","
+              << telemetry.src_par_consensus_state
+              << ","
+              << telemetry.src_par_consensus_acquisition_streak
+              << ",";
+        number(telemetry.lambda_src_par_shadow_best_ecef_x);
+        file_ << ",";
+        number(telemetry.lambda_src_par_shadow_best_ecef_y);
+        file_ << ",";
+        number(telemetry.lambda_src_par_shadow_best_ecef_z);
+        file_ << ",";
+        number(telemetry.float_update_nis_per_observation);
+        file_ << ",";
+        number(telemetry.float_update_prefit_residual_rms_m);
+        file_ << "," << telemetry.safe_fix_shadow_declared_fixed
+              << "," << telemetry.inertial_fix_evidence_healthy_anchor
+              << "," << telemetry.inertial_fix_evidence_passed << ",";
+        number(telemetry.inertial_fix_evidence_time_error_s);
+        file_ << ",";
+        number(telemetry.inertial_fix_evidence_position_delta_m);
+        file_ << ",";
+        number(telemetry.inertial_fix_evidence_nis_per_dimension);
+        file_ << ","
+              << telemetry
+                     .inertial_referenced_consensus_declared_fixed
+              << ","
+              << telemetry.inertial_referenced_consensus_state
+              << ","
+              << telemetry
+                     .inertial_referenced_consensus_acquisition_streak
+              << ",";
+        number(telemetry.inertial_referenced_correction_x);
+        file_ << ",";
+        number(telemetry.inertial_referenced_correction_y);
+        file_ << ",";
+        number(telemetry.inertial_referenced_correction_z);
+        file_ << ","
+              << telemetry.disjoint_satellite_fix_evidence_available
+              << ","
+              << telemetry.disjoint_satellite_fix_inputs_verified
+              << ","
+              << telemetry
+                     .disjoint_satellite_fix_partition_a_ffrt_passed
+              << ","
+              << telemetry
+                     .disjoint_satellite_fix_partition_b_ffrt_passed
+              << ","
+              << telemetry.disjoint_satellite_fix_evidence_passed
+              << ",";
+        number(
+            telemetry
+                .disjoint_satellite_fix_partition_separation_m);
+        file_ << ",";
+        number(
+            telemetry
+                .disjoint_satellite_fix_partition_a_primary_separation_m);
+        file_ << ",";
+        number(
+            telemetry
+                .disjoint_satellite_fix_partition_b_primary_separation_m);
+        file_ << ","
+              << telemetry
+                     .disjoint_satellite_fix_hard_separation_passed
+              << ","
+              << telemetry
+                     .disjoint_satellite_fix_statistical_separation_passed
+              << ",";
+        number(
+            telemetry
+                .disjoint_satellite_fix_partition_nis_per_dimension);
+        file_ << ",";
+        number(
+            telemetry
+                .disjoint_satellite_fix_partition_a_primary_nis_per_dimension);
+        file_ << ",";
+        number(
+            telemetry
+                .disjoint_satellite_fix_partition_b_primary_nis_per_dimension);
+        file_ << ","
+              << telemetry.disjoint_consensus_declared_fixed
+              << "," << telemetry.disjoint_consensus_state
+              << ","
+              << telemetry.disjoint_consensus_acquisition_streak
+              << ","
+              << telemetry.disjoint_consensus_selected_pair
+              << ",";
+        number(
+            telemetry
+                .disjoint_consensus_selected_pair_min_ratio);
+        file_
+              << ","
+              << telemetry
+                     .lambda_l1_l5_wlnl_shadow_wl_ffrt_passed
+              << ","
+              << telemetry
+                     .lambda_l1_l5_wlnl_shadow_nl_ffrt_passed
+              << ","
+              << telemetry
+                     .lambda_l1_l5_wlnl_shadow_candidate_pair_count
+              << ",";
+        number(
+            multifrequency_candidate.allFinite() &&
+                    primary_candidate.allFinite()
+                ? (multifrequency_candidate -
+                   primary_candidate)
+                      .norm()
+                : std::numeric_limits<double>::quiet_NaN());
+        file_ << ","
+              << telemetry.multifrequency_disjoint_evidence_passed
+              << ","
+              << telemetry.multifrequency_consensus_declared_fixed
+              << ","
+              << telemetry.multifrequency_consensus_state
+              << ","
+              << telemetry
+                     .multifrequency_consensus_acquisition_streak
+              << ",";
+        number(multifrequency_candidate.x());
+        file_ << ",";
+        number(multifrequency_candidate.y());
+        file_ << ",";
+        number(multifrequency_candidate.z());
+        file_
+              << ","
+              << telemetry
+                     .lambda_l1_l2_wlnl_shadow_wl_ffrt_passed
+              << ","
+              << telemetry
+                     .lambda_l1_l2_wlnl_shadow_nl_ffrt_passed
+              << ","
+              << telemetry
+                     .lambda_l1_l2_wlnl_shadow_candidate_pair_count
+              << ",";
+        number(
+            l1_l2_multifrequency_candidate.allFinite() &&
+                    primary_candidate.allFinite()
+                ? (l1_l2_multifrequency_candidate -
+                   primary_candidate)
+                      .norm()
+                : std::numeric_limits<double>::quiet_NaN());
+        file_ << ","
+              << telemetry
+                     .l1_l2_multifrequency_disjoint_evidence_passed
+              << ","
+              << telemetry
+                     .l1_l2_multifrequency_consensus_declared_fixed
+              << ","
+              << telemetry
+                     .l1_l2_multifrequency_consensus_state
+              << ","
+              << telemetry
+                     .l1_l2_multifrequency_consensus_acquisition_streak
+              << ",";
+        number(l1_l2_multifrequency_candidate.x());
+        file_ << ",";
+        number(l1_l2_multifrequency_candidate.y());
+        file_ << ",";
+        number(l1_l2_multifrequency_candidate.z());
+        file_
+              << ","
+              << telemetry
+                     .lambda_l2_l5_wlnl_shadow_wl_ffrt_passed
+              << ","
+              << telemetry
+                     .lambda_l2_l5_wlnl_shadow_nl_ffrt_passed
+              << ","
+              << telemetry.lambda_l2_l5_wlnl_shadow_pair_count
+              << ",";
+        number(telemetry.lambda_l2_l5_wlnl_shadow_wl_ratio);
+        file_ << ",";
+        number(
+            telemetry.lambda_l2_l5_wlnl_shadow_wl_ffrt_min_ratio);
+        file_ << ","
+              << telemetry
+                     .lambda_l2_l5_wlnl_shadow_mw_disagreements
+              << ",";
+        number(telemetry.lambda_l2_l5_wlnl_shadow_nl_ratio);
+        file_ << ",";
+        number(
+            telemetry.lambda_l2_l5_wlnl_shadow_nl_ffrt_min_ratio);
+        file_ << ","
+              << telemetry
+                     .lambda_l2_l5_wlnl_shadow_candidate_pair_count
+              << ",";
+        number(l2_l5_multifrequency_candidate.x());
+        file_ << ",";
+        number(l2_l5_multifrequency_candidate.y());
+        file_ << ",";
+        number(l2_l5_multifrequency_candidate.z());
+        file_ << "," << telemetry.library_fixed_quality_gate_passed
+              << ","
+              << telemetry.library_fixed_quality_gate_promoted
+              << ","
+              << telemetry
+                     .library_fixed_quality_gate_disjoint_consensus_promoted
+              << ","
+              << telemetry
+                     .library_fixed_quality_gate_causal_arc_promoted
+              << ","
+              << telemetry
+                     .library_fixed_quality_gate_satellite_par_promoted
+              << ","
+              << telemetry.library_fixed_quality_gate_src_par_promoted
+              << ","
+              << telemetry
+                     .library_fixed_quality_gate_inertial_referenced_promoted
+              << ","
+              << telemetry
+                     .library_fixed_quality_gate_multifrequency_promoted
+              << ","
+              << telemetry
+                     .library_fixed_quality_gate_raw_partition_conflict
+              << "," << telemetry.library_fixed_quality_gate_demoted
+              << "," << disjoint_validators_evaluated
+              << ",";
+        number(processing_runtime_ms);
+        file_ << "\n";
+    }
+
+private:
+    std::ofstream file_;
+};
+
 [[noreturn]] void argumentError(const std::string& message, const char* program_name) {
     std::cerr << "Argument error: " << message << "\n\n";
     printUsage(program_name);
@@ -752,6 +1582,204 @@ FuseOptions parseArguments(int argc, char* argv[]) {
             options.write_kml = true;
         } else if (arg == "--attitude-csv") {
             options.attitude_csv_path = requireValue(arg, i, argc, argv);
+        } else if (arg == "--tight-dd-sse-csv") {
+            options.sse_par_csv_path = requireValue(arg, i, argc, argv);
+        } else if (arg == "--library-fix-integrity-gate") {
+            options.library_fix_integrity_gate = true;
+        } else if (arg == "--library-fix-integrity-csv") {
+            options.library_fix_integrity_csv_path =
+                requireValue(arg, i, argc, argv);
+        } else if (arg == "--integrity-anchor-max-age-s") {
+            options.integrity_anchor_max_age_s =
+                std::stod(requireValue(arg, i, argc, argv));
+        } else if (arg == "--integrity-disjoint-partition") {
+            const auto value = requireValue(arg, i, argc, argv);
+            if (value == "grj-ec") {
+                options.disjoint_partition_scheme =
+                    DisjointPartitionScheme::GRJ_EC;
+            } else if (value == "gej-rc") {
+                options.disjoint_partition_scheme =
+                    DisjointPartitionScheme::GEJ_RC;
+            } else if (value == "gcj-re") {
+                options.disjoint_partition_scheme =
+                    DisjointPartitionScheme::GCJ_RE;
+            } else if (value == "gj-erc") {
+                options.disjoint_partition_scheme =
+                    DisjointPartitionScheme::GJ_ERC;
+            } else {
+                argumentError(
+                    "--integrity-disjoint-partition must be "
+                    "grj-ec, gej-rc, gcj-re, or gj-erc",
+                    argv[0]);
+            }
+        } else if (arg == "--integrity-disjoint-ensemble") {
+            options.disjoint_partition_ensemble = true;
+        } else if (arg == "--integrity-disjoint-evaluate-all") {
+            options.integrity_disjoint_evaluate_all = true;
+        } else if (arg == "--integrity-student-t-front-end") {
+            options.integrity_student_t_front_end = true;
+        } else if (arg ==
+                   "--integrity-student-t-all-measurements") {
+            options.integrity_student_t_front_end = true;
+            options.integrity_student_t_all_measurements = true;
+        } else if (arg ==
+                   "--integrity-student-t-degrees-of-freedom") {
+            options.integrity_student_t_degrees_of_freedom =
+                std::stod(requireValue(arg, i, argc, argv));
+            if (options.integrity_student_t_degrees_of_freedom <= 0.0) {
+                argumentError(
+                    "--integrity-student-t-degrees-of-freedom must be > 0",
+                    argv[0]);
+            }
+        } else if (arg ==
+                   "--integrity-laplacian-all-measurements") {
+            options.integrity_student_t_front_end = true;
+            options.integrity_student_t_all_measurements = true;
+            options.integrity_laplacian_all_measurements = true;
+        } else if (arg ==
+                   "--integrity-huber-all-measurements") {
+            options.integrity_student_t_front_end = true;
+            options.integrity_student_t_all_measurements = true;
+            options.integrity_huber_all_measurements = true;
+        } else if (arg ==
+                   "--integrity-heavy-tail-activation-sigma") {
+            options.integrity_heavy_tail_activation_sigma =
+                std::stod(requireValue(arg, i, argc, argv));
+            if (options.integrity_heavy_tail_activation_sigma < 0.0) {
+                argumentError(
+                    "--integrity-heavy-tail-activation-sigma must be >= 0",
+                    argv[0]);
+            }
+        } else if (arg ==
+                   "--integrity-disjoint-heavy-tail-model") {
+            options.integrity_disjoint_heavy_tail_model =
+                requireValue(arg, i, argc, argv);
+            const auto& model =
+                options.integrity_disjoint_heavy_tail_model;
+            if (model != "inherit" && model != "student-t" &&
+                model != "laplacian" && model != "huber") {
+                argumentError(
+                    "--integrity-disjoint-heavy-tail-model must be "
+                    "inherit, student-t, laplacian, or huber",
+                    argv[0]);
+            }
+        } else if (arg ==
+                   "--integrity-validator-runtime-budget-ms") {
+            options.integrity_validator_runtime_budget_ms =
+                std::stod(requireValue(arg, i, argc, argv));
+            if (options.integrity_validator_runtime_budget_ms < 0.0) {
+                argumentError(
+                    "--integrity-validator-runtime-budget-ms must be >= 0",
+                    argv[0]);
+            }
+        } else if (arg ==
+                   "--integrity-max-statistical-separation-m") {
+            options.integrity_max_statistical_separation_m =
+                std::stod(requireValue(arg, i, argc, argv));
+            if (options.integrity_max_statistical_separation_m <= 0.0) {
+                argumentError(
+                    "--integrity-max-statistical-separation-m must be > 0",
+                    argv[0]);
+            }
+        } else if (arg ==
+                   "--integrity-disjoint-acquisition-streak") {
+            options.integrity_disjoint_acquisition_streak =
+                std::stoi(requireValue(arg, i, argc, argv));
+            if (options.integrity_disjoint_acquisition_streak < 1) {
+                argumentError(
+                    "--integrity-disjoint-acquisition-streak must be >= 1",
+                    argv[0]);
+            }
+        } else if (arg ==
+                   "--integrity-disjoint-correction-jump-m") {
+            options.integrity_disjoint_correction_jump_m =
+                std::stod(requireValue(arg, i, argc, argv));
+            if (options.integrity_disjoint_correction_jump_m <= 0.0) {
+                argumentError(
+                    "--integrity-disjoint-correction-jump-m must be > 0",
+                    argv[0]);
+            }
+        } else if (arg ==
+                   "--integrity-disjoint-selected-pair-ratio") {
+            options.integrity_disjoint_selected_pair_ratio = true;
+        } else if (arg ==
+                   "--integrity-causal-arc-readiness-shadow") {
+            options.integrity_causal_arc_readiness_shadow = true;
+        } else if (arg ==
+                   "--integrity-causal-arc-smoothed-search-shadow") {
+            options.integrity_causal_arc_readiness_shadow = true;
+            options.integrity_causal_arc_smoothed_search = true;
+        } else if (arg ==
+                   "--integrity-causal-arc-smoothed-max-pairs") {
+            options.integrity_causal_arc_smoothed_max_pairs =
+                std::stoi(requireValue(arg, i, argc, argv));
+            if (options.integrity_causal_arc_smoothed_max_pairs != 0 &&
+                options.integrity_causal_arc_smoothed_max_pairs < 12) {
+                argumentError(
+                    "--integrity-causal-arc-smoothed-max-pairs must be 0 or >= 12",
+                    argv[0]);
+            }
+        } else if (arg ==
+                   "--integrity-causal-arc-promotion") {
+            options.integrity_causal_arc_readiness_shadow = true;
+            options.integrity_causal_arc_promotion = true;
+        } else if (arg ==
+                   "--integrity-satellite-par-consensus-shadow") {
+            options.integrity_satellite_par_consensus_shadow = true;
+        } else if (arg ==
+                   "--integrity-satellite-par-consensus-promotion") {
+            options.integrity_satellite_par_consensus_shadow = true;
+            options.integrity_satellite_par_consensus_promotion = true;
+        } else if (arg ==
+                   "--integrity-src-par-consensus-shadow") {
+            options.integrity_src_par_consensus_shadow = true;
+        } else if (arg ==
+                   "--integrity-src-par-consensus-promotion") {
+            options.integrity_src_par_consensus_shadow = true;
+            options.integrity_src_par_consensus_promotion = true;
+        } else if (arg ==
+                   "--integrity-inertial-referenced-consensus-shadow") {
+            options.integrity_inertial_referenced_consensus_shadow = true;
+        } else if (arg ==
+                   "--integrity-inertial-referenced-consensus-promotion") {
+            options.integrity_inertial_referenced_consensus_shadow = true;
+            options.integrity_inertial_referenced_consensus_promotion =
+                true;
+        } else if (arg ==
+                   "--integrity-satellite-par-quality-diverse") {
+            options.integrity_satellite_par_quality_diverse = true;
+        } else if (arg ==
+                   "--integrity-satellite-par-persistent-subset-shadow") {
+            options.integrity_satellite_par_persistent_subset = true;
+        } else if (arg ==
+                   "--integrity-disjoint-satellite-par-shadow") {
+            options.integrity_disjoint_satellite_par = true;
+        } else if (arg ==
+                   "--integrity-satellite-par-max-drop-steps") {
+            options.integrity_satellite_par_max_drop_steps =
+                std::stoi(requireValue(arg, i, argc, argv));
+            if (options.integrity_satellite_par_max_drop_steps < 1 ||
+                options.integrity_satellite_par_max_drop_steps > 32) {
+                argumentError(
+                    "--integrity-satellite-par-max-drop-steps must be in [1, 32]",
+                    argv[0]);
+            }
+        } else if (arg ==
+                   "--integrity-wide-lane-front-end") {
+            options.integrity_wide_lane_front_end = true;
+        } else if (arg ==
+                   "--integrity-l1-l2-wlnl-cascade-shadow") {
+            options.integrity_l1_l2_wlnl_cascade = true;
+        } else if (arg ==
+                   "--integrity-l2-l5-wlnl-cascade-shadow") {
+            options.integrity_l2_l5_wlnl_cascade = true;
+        } else if (arg ==
+                   "--integrity-multifrequency-consensus-shadow") {
+            options.integrity_multifrequency_consensus_shadow = true;
+        } else if (arg ==
+                   "--integrity-multifrequency-consensus-promotion") {
+            options.integrity_multifrequency_consensus_shadow = true;
+            options.integrity_multifrequency_consensus_promotion = true;
         } else if (arg == "--lever-arm") {
             options.fusion_config.lever_arm_body =
                 parseVector3(requireValue(arg, i, argc, argv), arg);
@@ -803,6 +1831,51 @@ FuseOptions parseArguments(int argc, char* argv[]) {
         } else if (arg == "--ratio") {
             options.ratio_threshold = std::stod(requireValue(arg, i, argc, argv));
             options.ratio_threshold_set = true;
+        } else if (arg == "--ar-policy") {
+            const auto value = requireValue(arg, i, argc, argv);
+            if (value == "extended") {
+                options.ar_policy =
+                    libgnss::RTKProcessor::RTKConfig::ARPolicy::
+                        EXTENDED;
+            } else if (value == "demo5-continuous") {
+                options.ar_policy =
+                    libgnss::RTKProcessor::RTKConfig::ARPolicy::
+                        DEMO5_CONTINUOUS;
+            } else {
+                argumentError(
+                    "unsupported --ar-policy value: " + value,
+                    argv[0]);
+            }
+        } else if (arg == "--glonass-ar") {
+            const auto value = requireValue(arg, i, argc, argv);
+            if (value == "off") {
+                options.glonass_ar_mode =
+                    libgnss::RTKProcessor::RTKConfig::
+                        GlonassARMode::OFF;
+            } else if (value == "on") {
+                options.glonass_ar_mode =
+                    libgnss::RTKProcessor::RTKConfig::
+                        GlonassARMode::ON;
+            } else if (value == "autocal") {
+                options.glonass_ar_mode =
+                    libgnss::RTKProcessor::RTKConfig::
+                        GlonassARMode::AUTOCAL;
+            } else {
+                argumentError(
+                    "unsupported --glonass-ar value: " + value,
+                    argv[0]);
+            }
+        } else if (arg == "--max-pos-jump") {
+            options.max_position_jump_m =
+                std::stod(requireValue(arg, i, argc, argv));
+        } else if (arg == "--rtk-update-outlier-threshold") {
+            options.rtk_update_outlier_threshold =
+                std::stod(requireValue(arg, i, argc, argv));
+        } else if (arg == "--prefer-trusted-seed") {
+            options.prefer_trusted_seed = true;
+        } else if (arg == "--rover-seed-pos") {
+            options.rover_seed_pos_path =
+                requireValue(arg, i, argc, argv);
         } else if (arg == "--max-baseline-m") {
             options.max_baseline_length_m = std::stod(requireValue(arg, i, argc, argv));
         } else if (arg == "--elevation-mask-deg") {
@@ -819,6 +1892,8 @@ FuseOptions parseArguments(int argc, char* argv[]) {
             options.enable_base_interpolation = false;
         } else if (arg == "--derive-velocity-from-fixed") {
             options.derive_velocity_from_fixed = true;
+        } else if (arg == "--integrity-fixed-velocity") {
+            options.integrity_fixed_velocity = true;
         } else if (arg == "--tight-dd-imu") {
             options.tightly_coupled_dd_imu = true;
         } else if (arg == "--tight-dd-carrier-experimental") {
@@ -979,6 +2054,24 @@ FuseOptions parseArguments(int argc, char* argv[]) {
     if (options.tightly_coupled_dd_imu && options.base_path.empty()) {
         argumentError("--tight-dd-imu requires --base", argv[0]);
     }
+    if (options.library_fix_integrity_gate &&
+        options.base_path.empty()) {
+        argumentError(
+            "--library-fix-integrity-gate requires --base",
+            argv[0]);
+    }
+    if (options.tightly_coupled_dd_imu ||
+        options.library_fix_integrity_gate) {
+        options.fusion_config.position_updates_require_fixed = true;
+    }
+    if (!std::isfinite(options.integrity_anchor_max_age_s) ||
+        options.integrity_anchor_max_age_s <= 0.0) {
+        argumentError(
+            "--integrity-anchor-max-age-s must be finite and positive",
+            argv[0]);
+    }
+    options.fusion_config.tight_dd_sse_fixed_anchor_max_age_s =
+        options.integrity_anchor_max_age_s;
     if (options.max_epochs < 0) argumentError("--max-epochs must be non-negative", argv[0]);
     if (options.imu_time_offset_score_start_epoch < 0) {
         argumentError("--imu-time-offset-score-start-epoch must be non-negative",
@@ -1076,7 +2169,6 @@ int runSppFusion(const FuseOptions& options, libgnss::ImuSeries& imu_series,
         std::cerr << "Error: failed to open attitude CSV: " << options.attitude_csv_path << "\n";
         return 1;
     }
-
     size_t imu_cursor = 0;
     int processed_epochs = 0;
     int valid_solutions = 0;
@@ -1295,6 +2387,19 @@ int runRtkFusion(const FuseOptions& options, libgnss::ImuSeries& imu_series,
     libgnss::RTKProcessor::RTKConfig rtk_config;
     rtk_config.max_baseline_length = options.max_baseline_length_m;
     rtk_config.ar_mode = libgnss::RTKProcessor::RTKConfig::AmbiguityResolutionMode::CONTINUOUS;
+    rtk_config.ar_policy = options.ar_policy;
+    rtk_config.glonass_ar_mode = options.glonass_ar_mode;
+    rtk_config.max_position_jump_m =
+        options.max_position_jump_m;
+    rtk_config.prefer_trusted_position_seed =
+        options.prefer_trusted_seed;
+    rtk_config.prefer_rover_position_seed =
+        options.prefer_trusted_seed ||
+        !options.rover_seed_pos_path.empty();
+    if (options.rtk_update_outlier_threshold > 0.0) {
+        rtk_config.outlier_threshold =
+            options.rtk_update_outlier_threshold;
+    }
     if (options.ratio_threshold_set) {
         rtk_config.ratio_threshold = options.ratio_threshold;
         rtk_config.ambiguity_ratio_threshold = options.ratio_threshold;
@@ -1365,8 +2470,236 @@ int runRtkFusion(const FuseOptions& options, libgnss::ImuSeries& imu_series,
         rtk_config.ratio_threshold = options.ratio_threshold;
         rtk_config.ambiguity_ratio_threshold = options.ratio_threshold;
     }
+    if (options.library_fix_integrity_gate) {
+        rtk_config.lambda_candidate_shadow_count = 2;
+        rtk_config.lambda_satellite_par_shadow_max_drop_steps =
+            options.integrity_satellite_par_max_drop_steps;
+        rtk_config.lambda_l1_l5_wlnl_shadow = true;
+        rtk_config.lambda_l1_l5_wlnl_causal_arc_smoothing = true;
+        rtk_config.safe_fix_shadow_state_machine.enabled = true;
+        rtk_config.safe_fix_shadow_state_machine
+            .require_independent_failure_budget = true;
+        rtk_config.safe_fix_shadow_state_machine
+            .acquisition_streak_epochs = 3;
+        rtk_config.safe_fix_shadow_state_machine
+            .maximum_acquisition_correction_jump_m = 0.02;
+        rtk_config.safe_fix_shadow_state_machine.maximum_hold_epochs = 0;
+        rtk_config.safe_fix_shadow_state_machine.minimum_absolute_ratio =
+            1.4;
+        rtk_config.safe_fix_shadow_state_machine
+            .maximum_independent_consensus_delta_m = 0.10;
+        rtk_config.safe_fix_shadow_state_machine
+            .allow_strong_instant_acquisition = true;
+        rtk_config.safe_fix_shadow_state_machine
+            .allow_change_point_acquisition = true;
+        rtk_config.safe_fix_shadow_minimum_pairs = 12;
+        rtk_config.safe_fix_shadow_maximum_second_position_delta_m =
+            0.25;
+        rtk_config.library_fixed_quality_gate.enabled = true;
+        rtk_config.library_fixed_quality_gate
+            .require_independent_failure_budget = true;
+        rtk_config.library_fixed_quality_gate
+            .allow_safe_shadow_promotion = true;
+        rtk_config.library_fixed_quality_gate
+            .allow_failure_budget_candidate_promotion = false;
+        rtk_config.disjoint_consensus_state_machine =
+            rtk_config.safe_fix_shadow_state_machine;
+        rtk_config.disjoint_consensus_state_machine
+            .maximum_independent_consensus_delta_m = 1.0;
+        rtk_config.disjoint_consensus_state_machine
+            .acquisition_streak_epochs =
+            options.integrity_disjoint_acquisition_streak;
+        rtk_config.disjoint_consensus_state_machine
+            .maximum_acquisition_correction_jump_m =
+            options.integrity_disjoint_correction_jump_m;
+        rtk_config.disjoint_consensus_state_machine
+            .allow_strong_instant_acquisition = false;
+        rtk_config.disjoint_consensus_state_machine
+            .allow_change_point_acquisition = false;
+        rtk_config.disjoint_consensus_use_selected_pair_ratio =
+            options.integrity_disjoint_selected_pair_ratio;
+        rtk_config.lambda_causal_arc_readiness_shadow =
+            options.integrity_causal_arc_readiness_shadow;
+        rtk_config.lambda_causal_arc_smoothed_search =
+            options.integrity_causal_arc_smoothed_search;
+        rtk_config.lambda_causal_arc_smoothed_max_pairs =
+            options.integrity_causal_arc_smoothed_max_pairs;
+        rtk_config.causal_arc_consensus_state_machine =
+            rtk_config.disjoint_consensus_state_machine;
+        rtk_config.causal_arc_consensus_state_machine.enabled =
+            options.integrity_causal_arc_readiness_shadow;
+        rtk_config.causal_arc_consensus_promotion =
+            options.integrity_causal_arc_promotion;
+        rtk_config.satellite_par_consensus_state_machine =
+            rtk_config.disjoint_consensus_state_machine;
+        rtk_config.satellite_par_consensus_state_machine.enabled =
+            options.integrity_satellite_par_consensus_shadow;
+        rtk_config.satellite_par_consensus_promotion =
+            options.integrity_satellite_par_consensus_promotion;
+        rtk_config.lambda_src_par_shadow_success_rate =
+            options.integrity_src_par_consensus_shadow ? 0.999 : 0.0;
+        rtk_config.lambda_src_par_shadow_covariance_scale = 16.0;
+        rtk_config.src_par_consensus_state_machine =
+            rtk_config.disjoint_consensus_state_machine;
+        rtk_config.src_par_consensus_state_machine.enabled =
+            options.integrity_src_par_consensus_shadow;
+        // SRC-PAR already applies a dimension/BSR-specific FFRT at a
+        // 1e-3 fixed-failure-rate target. Do not stack the unrelated
+        // legacy absolute-ratio 1.4 threshold on top of that calibrated
+        // test; all temporal and solution-separation gates remain active.
+        rtk_config.src_par_consensus_state_machine.minimum_absolute_ratio =
+            0.0;
+        rtk_config.src_par_consensus_promotion =
+            options.integrity_src_par_consensus_promotion;
+        rtk_config.inertial_referenced_consensus_state_machine =
+            rtk_config.disjoint_consensus_state_machine;
+        rtk_config.inertial_referenced_consensus_state_machine.enabled =
+            options.integrity_inertial_referenced_consensus_shadow;
+        rtk_config.inertial_referenced_consensus_promotion =
+            options.integrity_inertial_referenced_consensus_promotion;
+        rtk_config.lambda_satellite_par_shadow_quality_diverse =
+            options.integrity_satellite_par_quality_diverse;
+        rtk_config.lambda_satellite_par_persistent_subset =
+            options.integrity_satellite_par_persistent_subset;
+        rtk_config.enable_wide_lane_ar =
+            options.integrity_wide_lane_front_end;
+        rtk_config.lambda_l1_l2_wlnl_shadow =
+            options.integrity_l1_l2_wlnl_cascade;
+        rtk_config.lambda_l2_l5_wlnl_shadow =
+            options.integrity_l2_l5_wlnl_cascade;
+        rtk_config.multifrequency_consensus_state_machine =
+            rtk_config.disjoint_consensus_state_machine;
+        rtk_config.multifrequency_consensus_state_machine.enabled =
+            options.integrity_multifrequency_consensus_shadow;
+        rtk_config.multifrequency_consensus_promotion =
+            options.integrity_multifrequency_consensus_promotion;
+        rtk_config
+            .disjoint_satellite_fix_max_statistical_separation_m =
+            options.integrity_max_statistical_separation_m;
+        rtk_config.student_t_front_end.enabled =
+            options.integrity_student_t_front_end;
+        rtk_config.student_t_front_end.code_only =
+            !options.integrity_student_t_all_measurements;
+        rtk_config.student_t_front_end.degrees_of_freedom =
+            options.integrity_student_t_degrees_of_freedom;
+        rtk_config.student_t_front_end.activation_threshold_sigma =
+            options.integrity_heavy_tail_activation_sigma;
+        if (options.integrity_laplacian_all_measurements) {
+            rtk_config.student_t_front_end.weight_model =
+                libgnss::rtk_update::HeavyTailWeightModel::
+                    LAPLACIAN;
+        } else if (options.integrity_huber_all_measurements) {
+            rtk_config.student_t_front_end.weight_model =
+                libgnss::rtk_update::HeavyTailWeightModel::
+                    HUBER;
+        }
+    }
     rtk_processor.setRTKConfig(rtk_config);
     rtk_processor.setBasePosition(base_position);
+    struct DisjointValidator {
+        DisjointPartitionScheme scheme;
+        std::unique_ptr<libgnss::RTKProcessor> partition_a;
+        std::unique_ptr<libgnss::RTKProcessor> partition_b;
+    };
+    std::vector<DisjointValidator> disjoint_validators;
+    if (options.library_fix_integrity_gate) {
+        std::vector<DisjointPartitionScheme> schemes{
+            options.disjoint_partition_scheme};
+        if (options.disjoint_partition_ensemble) {
+            const std::vector<DisjointPartitionScheme> remaining{
+                DisjointPartitionScheme::GRJ_EC,
+                DisjointPartitionScheme::GEJ_RC,
+                DisjointPartitionScheme::GCJ_RE,
+                DisjointPartitionScheme::GJ_ERC,
+            };
+            for (const auto scheme : remaining) {
+                if (scheme != options.disjoint_partition_scheme) {
+                    schemes.push_back(scheme);
+                }
+            }
+        }
+        for (const auto scheme : schemes) {
+            auto disjoint_config = rtk_config;
+            if (options.integrity_disjoint_heavy_tail_model !=
+                "inherit") {
+                disjoint_config.student_t_front_end.enabled = true;
+                disjoint_config.student_t_front_end.code_only = false;
+                if (options.integrity_disjoint_heavy_tail_model ==
+                    "laplacian") {
+                    disjoint_config.student_t_front_end.weight_model =
+                        libgnss::rtk_update::HeavyTailWeightModel::
+                            LAPLACIAN;
+                } else if (
+                    options.integrity_disjoint_heavy_tail_model ==
+                    "huber") {
+                    disjoint_config.student_t_front_end.weight_model =
+                        libgnss::rtk_update::HeavyTailWeightModel::
+                            HUBER;
+                } else {
+                    disjoint_config.student_t_front_end.weight_model =
+                        libgnss::rtk_update::HeavyTailWeightModel::
+                            STUDENT_T;
+                }
+            }
+            disjoint_config.library_fixed_quality_gate.enabled = false;
+            disjoint_config.library_fixed_quality_gate
+                .require_independent_failure_budget = false;
+            disjoint_config.safe_fix_shadow_state_machine.enabled = false;
+            disjoint_config.lambda_satellite_par_shadow_max_drop_steps =
+                options.integrity_disjoint_satellite_par
+                    ? options.integrity_satellite_par_max_drop_steps
+                    : 0;
+            disjoint_config
+                .lambda_satellite_par_only_after_full_ffrt_failure =
+                options.integrity_disjoint_satellite_par;
+            disjoint_config.enable_wide_lane_ar = false;
+            disjoint_config.lambda_l1_l5_wlnl_shadow = false;
+            disjoint_config.lambda_l1_l2_wlnl_shadow = false;
+            disjoint_config.lambda_l1_l5_wlnl_causal_arc_smoothing =
+                false;
+            disjoint_config.lambda_causal_arc_readiness_shadow = false;
+            disjoint_config.lambda_candidate_shadow_count = 2;
+            disjoint_config.prefer_trusted_position_seed = false;
+            disjoint_config.prefer_rover_position_seed = false;
+            // Every partition must produce a fresh FFRT decision; it must
+            // never gain authority from held integers.
+            disjoint_config.min_hold_count =
+                std::numeric_limits<int>::max();
+            if (!belongsToDisjointPartitionA(
+                    libgnss::GNSSSystem::GLONASS, scheme)) {
+                disjoint_config.enable_glonass = false;
+                disjoint_config.glonass_ar_mode =
+                    libgnss::RTKProcessor::RTKConfig::
+                        GlonassARMode::OFF;
+            }
+            auto partition_b_config = disjoint_config;
+            if (belongsToDisjointPartitionB(
+                    libgnss::GNSSSystem::GLONASS, scheme)) {
+                partition_b_config.enable_glonass =
+                    rtk_config.enable_glonass;
+                partition_b_config.glonass_ar_mode =
+                    rtk_config.glonass_ar_mode;
+            } else {
+                partition_b_config.enable_glonass = false;
+                partition_b_config.glonass_ar_mode =
+                    libgnss::RTKProcessor::RTKConfig::
+                        GlonassARMode::OFF;
+            }
+            DisjointValidator validator{
+                scheme,
+                std::make_unique<libgnss::RTKProcessor>(),
+                std::make_unique<libgnss::RTKProcessor>()};
+            validator.partition_a->setRTKConfig(disjoint_config);
+            validator.partition_a->setBasePosition(base_position);
+            validator.partition_b->setRTKConfig(partition_b_config);
+            validator.partition_b->setBasePosition(base_position);
+            disjoint_validators.push_back(std::move(validator));
+        }
+    }
+    const auto rover_seed_positions =
+        options.rover_seed_pos_path.empty()
+            ? std::map<double, Eigen::Vector3d>{}
+            : loadSeedPositions(options.rover_seed_pos_path);
 
     libgnss::LooseCouplingProcessor fusion_processor(options.fusion_config);
     libgnss::ImuPreintegrationConfig tc_preintegration_config;
@@ -1416,6 +2749,19 @@ int runRtkFusion(const FuseOptions& options, libgnss::ImuSeries& imu_series,
         std::cerr << "Error: failed to open attitude CSV: " << options.attitude_csv_path << "\n";
         return 1;
     }
+    SSEPartialARCsvWriter sse_par_writer;
+    if (!sse_par_writer.open(options.sse_par_csv_path)) {
+        std::cerr << "Error: failed to open SSE-PAR CSV: "
+                  << options.sse_par_csv_path << "\n";
+        return 1;
+    }
+    LibraryFixIntegrityCsvWriter integrity_writer;
+    if (!integrity_writer.open(
+            options.library_fix_integrity_csv_path)) {
+        std::cerr << "Error: failed to open library FIX integrity CSV: "
+                  << options.library_fix_integrity_csv_path << "\n";
+        return 1;
+    }
 
     libgnss::ObservationData rover_obs;
     libgnss::ObservationData base_obs;
@@ -1453,6 +2799,13 @@ int runRtkFusion(const FuseOptions& options, libgnss::ImuSeries& imu_series,
     int tight_dd_rows = 0;
     int tight_dd_partial_ar_epochs = 0;
     int tight_dd_fixed_ambiguities = 0;
+    int tight_dd_sse_par_available_epochs = 0;
+    int tight_dd_sse_par_eligible_epochs = 0;
+    int tight_dd_sse_par_passed_epochs = 0;
+    int tight_dd_sse_par_fixed_ambiguities = 0;
+    int tight_dd_sse_par_subsets_evaluated = 0;
+    int tight_dd_sse_par_ratio_passed_subsets = 0;
+    int tight_dd_sse_par_separation_rejected_subsets = 0;
     int tight_dd_soft_resets = 0;
     int tight_dd_nis_samples = 0;
     double tight_dd_nis_sum = 0.0;
@@ -1512,6 +2865,13 @@ int runRtkFusion(const FuseOptions& options, libgnss::ImuSeries& imu_series,
         if (options.max_epochs > 0 && processed_epochs >= options.max_epochs) {
             break;
         }
+        if (!rover_seed_positions.empty()) {
+            const auto seed = rover_seed_positions.find(
+                roundedTowKey(rover_obs.time.tow));
+            if (seed != rover_seed_positions.end()) {
+                rover_obs.receiver_position = seed->second;
+            }
+        }
 
         libgnss::ObservationData lower_base_obs = previous_base_obs;
         bool have_lower_base = has_previous_base;
@@ -1562,6 +2922,8 @@ int runRtkFusion(const FuseOptions& options, libgnss::ImuSeries& imu_series,
             continue;
         }
 
+        const auto epoch_processing_started =
+            std::chrono::steady_clock::now();
         while (imu_cursor < imu_series.samples.size() &&
                imu_series.samples[imu_cursor].time <= rover_obs.time) {
             libgnss::ImuSample sample = imu_series.samples[imu_cursor];
@@ -1686,7 +3048,227 @@ int runRtkFusion(const FuseOptions& options, libgnss::ImuSeries& imu_series,
             }
         }
 
-        auto pos_solution = rtk_processor.processRTKEpoch(rover_obs, aligned_base_obs, nav_data);
+        if (options.library_fix_integrity_gate &&
+            fusion_processor.isInitialized() &&
+            fusion_processor.isOriginSet()) {
+            const auto prediction =
+                fusion_processor.toPositionSolution();
+            libgnss::RTKProcessor::ExternalInertialFixEvidence
+                inertial_evidence;
+            inertial_evidence.available =
+                prediction.position_ecef.allFinite() &&
+                prediction.position_covariance.allFinite();
+            inertial_evidence.healthy_independent_anchor =
+                fusion_processor.hasHealthyFixedAnchor();
+            inertial_evidence.time = prediction.time;
+            inertial_evidence.position_ecef =
+                prediction.position_ecef;
+            inertial_evidence.position_covariance_ecef =
+                prediction.position_covariance;
+            rtk_processor.setExternalInertialFixEvidence(
+                inertial_evidence);
+        }
+
+        int disjoint_validators_evaluated = 0;
+        if (options.library_fix_integrity_gate) {
+            libgnss::RTKProcessor::
+                ExternalDisjointSatelliteFixEvidence
+                    selected_evidence;
+            double selected_partition_separation =
+                std::numeric_limits<double>::infinity();
+            bool selected_evidence_eligible = false;
+            bool selected_ratio_qualified = false;
+            for (auto& validator : disjoint_validators) {
+                if (disjoint_validators_evaluated > 0 &&
+                    options.integrity_validator_runtime_budget_ms > 0.0) {
+                    const double elapsed_ms =
+                        std::chrono::duration<double, std::milli>(
+                            std::chrono::steady_clock::now() -
+                            epoch_processing_started)
+                            .count();
+                    if (elapsed_ms >=
+                        options.integrity_validator_runtime_budget_ms) {
+                        break;
+                    }
+                }
+                const auto rover_partition_a =
+                    filterDisjointPartition(
+                        rover_obs, true, validator.scheme);
+                const auto base_partition_a =
+                    filterDisjointPartition(
+                        aligned_base_obs, true, validator.scheme);
+                const auto rover_partition_b =
+                    filterDisjointPartition(
+                        rover_obs, false, validator.scheme);
+                const auto base_partition_b =
+                    filterDisjointPartition(
+                        aligned_base_obs, false, validator.scheme);
+                const auto partition_a_solution =
+                    validator.partition_a->processRTKEpoch(
+                        rover_partition_a, base_partition_a, nav_data);
+                const auto partition_b_solution =
+                    validator.partition_b->processRTKEpoch(
+                        rover_partition_b, base_partition_b, nav_data);
+                ++disjoint_validators_evaluated;
+                const auto& partition_a_telemetry =
+                    validator.partition_a->getLastDebugTelemetry();
+                const auto& partition_b_telemetry =
+                    validator.partition_b->getLastDebugTelemetry();
+                libgnss::RTKProcessor::
+                    ExternalDisjointSatelliteFixEvidence evidence;
+                evidence.available = true;
+                evidence.inputs_verified_disjoint =
+                    observationInputsAreDisjoint(
+                        rover_partition_a, rover_partition_b) &&
+                    observationInputsAreDisjoint(
+                        base_partition_a, base_partition_b);
+                const Eigen::Vector3d partition_a_full_candidate(
+                        partition_a_telemetry
+                            .lambda_shadow_best_ecef_x,
+                        partition_a_telemetry
+                            .lambda_shadow_best_ecef_y,
+                        partition_a_telemetry
+                            .lambda_shadow_best_ecef_z);
+                const Eigen::Vector3d partition_b_full_candidate(
+                        partition_b_telemetry
+                            .lambda_shadow_best_ecef_x,
+                        partition_b_telemetry
+                            .lambda_shadow_best_ecef_y,
+                        partition_b_telemetry
+                            .lambda_shadow_best_ecef_z);
+                const Eigen::Vector3d partition_a_par_candidate(
+                        partition_a_telemetry
+                            .lambda_satellite_par_shadow_best_ecef_x,
+                        partition_a_telemetry
+                            .lambda_satellite_par_shadow_best_ecef_y,
+                        partition_a_telemetry
+                            .lambda_satellite_par_shadow_best_ecef_z);
+                const Eigen::Vector3d partition_b_par_candidate(
+                        partition_b_telemetry
+                            .lambda_satellite_par_shadow_best_ecef_x,
+                        partition_b_telemetry
+                            .lambda_satellite_par_shadow_best_ecef_y,
+                        partition_b_telemetry
+                            .lambda_satellite_par_shadow_best_ecef_z);
+                const bool partition_a_full_passed =
+                    partition_a_telemetry.lambda_shadow_ffrt_passed &&
+                    partition_a_full_candidate.allFinite();
+                const bool partition_b_full_passed =
+                    partition_b_telemetry.lambda_shadow_ffrt_passed &&
+                    partition_b_full_candidate.allFinite();
+                const bool partition_a_par_passed =
+                    options.integrity_disjoint_satellite_par &&
+                    partition_a_telemetry
+                        .lambda_satellite_par_shadow_ffrt_passed &&
+                    partition_a_par_candidate.allFinite();
+                const bool partition_b_par_passed =
+                    options.integrity_disjoint_satellite_par &&
+                    partition_b_telemetry
+                        .lambda_satellite_par_shadow_ffrt_passed &&
+                    partition_b_par_candidate.allFinite();
+                evidence.partition_a_ffrt_passed =
+                    partition_a_full_passed ||
+                    partition_a_par_passed;
+                evidence.partition_b_ffrt_passed =
+                    partition_b_full_passed ||
+                    partition_b_par_passed;
+                evidence.partition_a_ratio =
+                    partition_a_full_passed
+                        ? partition_a_telemetry.full_ratio
+                        : partition_a_telemetry
+                              .lambda_satellite_par_shadow_ratio;
+                evidence.partition_b_ratio =
+                    partition_b_full_passed
+                        ? partition_b_telemetry.full_ratio
+                        : partition_b_telemetry
+                              .lambda_satellite_par_shadow_ratio;
+                evidence.partition_a_candidate_ecef =
+                    partition_a_full_passed
+                        ? partition_a_full_candidate
+                        : partition_a_par_candidate;
+                evidence.partition_b_candidate_ecef =
+                    partition_b_full_passed
+                        ? partition_b_full_candidate
+                        : partition_b_par_candidate;
+                evidence.partition_a_covariance_ecef =
+                    partition_a_solution.position_covariance;
+                evidence.partition_b_covariance_ecef =
+                    partition_b_solution.position_covariance;
+                const double separation =
+                    (evidence.partition_a_candidate_ecef -
+                     evidence.partition_b_candidate_ecef)
+                        .norm();
+                const bool eligible =
+                    evidence.inputs_verified_disjoint &&
+                    evidence.partition_a_ffrt_passed &&
+                    evidence.partition_b_ffrt_passed &&
+                    std::isfinite(separation);
+                const bool ratio_qualified =
+                    std::isfinite(evidence.partition_a_ratio) &&
+                    evidence.partition_a_ratio >=
+                        rtk_config.disjoint_consensus_state_machine
+                            .minimum_absolute_ratio &&
+                    std::isfinite(evidence.partition_b_ratio) &&
+                    evidence.partition_b_ratio >=
+                        rtk_config.disjoint_consensus_state_machine
+                            .minimum_absolute_ratio;
+                const bool prefer_ratio_qualified =
+                    options.integrity_disjoint_selected_pair_ratio &&
+                    ratio_qualified &&
+                    !selected_ratio_qualified;
+                const bool same_ratio_class =
+                    !options.integrity_disjoint_selected_pair_ratio ||
+                    ratio_qualified == selected_ratio_qualified;
+                if ((!selected_evidence.available) ||
+                    (eligible && !selected_evidence_eligible) ||
+                    (eligible && selected_evidence_eligible &&
+                     prefer_ratio_qualified) ||
+                    (eligible && selected_evidence_eligible &&
+                     same_ratio_class &&
+                     separation < selected_partition_separation)) {
+                    selected_evidence = evidence;
+                    selected_evidence_eligible = eligible;
+                    selected_ratio_qualified =
+                        eligible && ratio_qualified;
+                    selected_partition_separation =
+                        eligible
+                            ? separation
+                            : std::numeric_limits<double>::
+                                  infinity();
+                }
+                // A physically tight A/B agreement already satisfies the
+                // strongest partition-only separation condition. Preserve
+                // the configured split priority and avoid running further
+                // validators unless this split is unavailable or only
+                // covariance-normalized agreement is possible.
+                if (!options.integrity_disjoint_evaluate_all &&
+                    eligible &&
+                    (!options.integrity_disjoint_selected_pair_ratio ||
+                     ratio_qualified) &&
+                    separation <=
+                        rtk_config
+                            .disjoint_satellite_fix_max_partition_separation_m) {
+                    break;
+                }
+            }
+            rtk_processor.setExternalDisjointSatelliteFixEvidence(
+                selected_evidence);
+        }
+
+        auto pos_solution = rtk_processor.processRTKEpoch(
+            rover_obs, aligned_base_obs, nav_data);
+        if (options.library_fix_integrity_gate) {
+            const double processing_runtime_ms =
+                std::chrono::duration<double, std::milli>(
+                    std::chrono::steady_clock::now() -
+                    epoch_processing_started)
+                    .count();
+            integrity_writer.write(
+                pos_solution,
+                rtk_processor.getLastDebugTelemetry(),
+                disjoint_validators_evaluated,
+                processing_runtime_ms);
+        }
         if (options.tc_cp_pr_gate || options.tc_closed_loop) {
             const auto& telemetry = rtk_processor.getLastDebugTelemetry();
             tc_cp_pr_evaluated_count += telemetry.cp_pr_gate_evaluated ? 1 : 0;
@@ -1711,30 +3293,85 @@ int runRtkFusion(const FuseOptions& options, libgnss::ImuSeries& imu_series,
             }
         }
         if (pos_solution.isValid()) {
-            if (options.derive_velocity_from_fixed && !pos_solution.has_velocity &&
-                pos_solution.isFixed() && have_previous_fixed_solution &&
-                pos_solution.ratio >= kMinDerivedVelocityRatio &&
+            auto fusion_solution = pos_solution;
+            const auto& epoch_telemetry =
+                rtk_processor.getLastDebugTelemetry();
+            const bool causal_candidate_promoted =
+                epoch_telemetry
+                    .library_fixed_quality_gate_causal_arc_promoted ||
+                epoch_telemetry
+                    .library_fixed_quality_gate_satellite_par_promoted ||
+                epoch_telemetry
+                    .library_fixed_quality_gate_src_par_promoted ||
+                epoch_telemetry
+                    .library_fixed_quality_gate_inertial_referenced_promoted ||
+                epoch_telemetry
+                    .library_fixed_quality_gate_multifrequency_promoted;
+            if (causal_candidate_promoted) {
+                const Eigen::Vector3d original_ecef(
+                    epoch_telemetry
+                        .library_fixed_quality_gate_original_ecef_x,
+                    epoch_telemetry
+                        .library_fixed_quality_gate_original_ecef_y,
+                    epoch_telemetry
+                        .library_fixed_quality_gate_original_ecef_z);
+                if (original_ecef.allFinite()) {
+                    fusion_solution.position_ecef = original_ecef;
+                    fusion_solution.position_geodetic =
+                        libgnss::spp_utils::ecefToGeodetic(
+                            original_ecef);
+                }
+                fusion_solution.status =
+                    static_cast<libgnss::SolutionStatus>(
+                        epoch_telemetry
+                            .library_fixed_quality_gate_original_status);
+                fusion_solution.ratio =
+                    epoch_telemetry
+                        .library_fixed_quality_gate_original_ratio;
+            }
+            const bool use_fixed_velocity =
+                (options.derive_velocity_from_fixed &&
+                 !fusion_solution.has_velocity) ||
+                (options.library_fix_integrity_gate &&
+                 options.integrity_fixed_velocity);
+            if (use_fixed_velocity &&
+                fusion_solution.isFixed() && have_previous_fixed_solution &&
+                fusion_solution.ratio >= kMinDerivedVelocityRatio &&
                 previous_fixed_solution.ratio >= kMinDerivedVelocityRatio) {
-                const double dt = pos_solution.time - previous_fixed_solution.time;
+                const double dt =
+                    fusion_solution.time -
+                    previous_fixed_solution.time;
                 if (dt > 0.0 && dt <= kMaxVelocityDerivationGapSeconds) {
                     const Eigen::Vector3d candidate_velocity =
-                        (pos_solution.position_ecef - previous_fixed_solution.position_ecef) / dt;
+                        (fusion_solution.position_ecef -
+                         previous_fixed_solution.position_ecef) /
+                        dt;
                     if (candidate_velocity.norm() <= kMaxPlausibleSpeedMps) {
-                        pos_solution.velocity_ecef = candidate_velocity;
-                        pos_solution.velocity_covariance =
-                            (pos_solution.position_covariance + previous_fixed_solution.position_covariance) /
+                        fusion_solution.velocity_ecef =
+                            candidate_velocity;
+                        fusion_solution.velocity_covariance =
+                            (fusion_solution.position_covariance +
+                             previous_fixed_solution.position_covariance) /
                             (dt * dt);
-                        pos_solution.has_velocity = true;
+                        fusion_solution.has_velocity = true;
                         ++derived_velocity_updates;
                     }
                 }
             }
-            if (pos_solution.isFixed()) {
-                previous_fixed_solution = pos_solution;
+
+            fusion_processor.processGnssSolution(fusion_solution);
+            if (fusion_solution.isFixed()) {
+                previous_fixed_solution = fusion_solution;
                 have_previous_fixed_solution = true;
             }
-
-            fusion_processor.processGnssSolution(pos_solution);
+            if (!causal_candidate_promoted) {
+                pos_solution.velocity_ecef =
+                    fusion_solution.velocity_ecef;
+                pos_solution.velocity_covariance =
+                    fusion_solution.velocity_covariance;
+                pos_solution.has_velocity =
+                    fusion_solution.has_velocity;
+            }
             if (options.tightly_coupled_dd_imu && fusion_processor.isOriginSet()) {
                 const auto propagated_solution = fusion_processor.toPositionSolution();
                 const auto rotation = fusion_processor.ecefToLocalEnuRotation();
@@ -1770,6 +3407,44 @@ int runRtkFusion(const FuseOptions& options, libgnss::ImuSeries& imu_series,
                         ++tight_dd_partial_ar_epochs;
                         tight_dd_fixed_ambiguities += dd_result.partial_ar.fixed_count;
                     }
+                    if (dd_result.sse_partial_ar.available) {
+                        ++tight_dd_sse_par_available_epochs;
+                    }
+                    if (dd_result.sse_partial_ar.subsets_evaluated > 0) {
+                        ++tight_dd_sse_par_eligible_epochs;
+                    }
+                    tight_dd_sse_par_subsets_evaluated +=
+                        dd_result.sse_partial_ar.subsets_evaluated;
+                    tight_dd_sse_par_ratio_passed_subsets +=
+                        dd_result.sse_partial_ar.ratio_passed_subsets;
+                    tight_dd_sse_par_separation_rejected_subsets +=
+                        dd_result.sse_partial_ar
+                            .separation_rejected_subsets;
+                    if (dd_result.sse_partial_ar.passed) {
+                        ++tight_dd_sse_par_passed_epochs;
+                        tight_dd_sse_par_fixed_ambiguities +=
+                            dd_result.sse_partial_ar.fixed_count;
+                    }
+                    Eigen::Vector3d sse_candidate_ecef =
+                        Eigen::Vector3d::Constant(
+                            std::numeric_limits<double>::quiet_NaN());
+                    if (dd_result.sse_partial_ar.passed) {
+                        const auto fused_now =
+                            fusion_processor.toPositionSolution();
+                        sse_candidate_ecef =
+                            fused_now.position_ecef +
+                            fusion_processor
+                                .ecefToLocalEnuRotation()
+                                .transpose() *
+                                (dd_result.sse_partial_ar
+                                     .fixed_position_enu -
+                                 fusion_processor.state()
+                                     .nominal.position_enu);
+                    }
+                    sse_par_writer.write(
+                        pos_solution.time,
+                        dd_result.sse_partial_ar,
+                        sse_candidate_ecef);
                     if (dd_result.reset_action !=
                         libgnss::dd_imu_bridge::SoftResetAction::REJECTED) {
                         ++tight_dd_soft_resets;
@@ -1886,8 +3561,16 @@ int runRtkFusion(const FuseOptions& options, libgnss::ImuSeries& imu_series,
             }
         }
 
+        if (options.library_fix_integrity_gate &&
+            pos_solution.isValid()) {
+            // The authoritative integrity product must preserve the library
+            // solution denominator even during the IMU alignment prefix.
+            fused_solution.addSolution(pos_solution);
+        } else if (fusion_processor.isOriginSet()) {
+            fused_solution.addSolution(
+                fusion_processor.toPositionSolution());
+        }
         if (fusion_processor.isOriginSet()) {
-            fused_solution.addSolution(fusion_processor.toPositionSolution());
             attitude_writer.write(fusion_processor.state().nominal.time,
                                   fusion_processor.state().nominal.attitude_body_to_enu);
         }
@@ -2087,6 +3770,16 @@ int runRtkFusion(const FuseOptions& options, libgnss::ImuSeries& imu_series,
             std::cout << "Partial-AR epochs/fixed ambiguities: "
                       << tight_dd_partial_ar_epochs << "/"
                       << tight_dd_fixed_ambiguities << "\n";
+            std::cout << "SSE-PAR available/passed/fixed ambiguities: "
+                      << tight_dd_sse_par_available_epochs << "/"
+                      << tight_dd_sse_par_passed_epochs << "/"
+                      << tight_dd_sse_par_fixed_ambiguities << "\n";
+            std::cout << "SSE-PAR eligible/subsets/ratio-pass/SSE-reject: "
+                      << tight_dd_sse_par_eligible_epochs << "/"
+                      << tight_dd_sse_par_subsets_evaluated << "/"
+                      << tight_dd_sse_par_ratio_passed_subsets << "/"
+                      << tight_dd_sse_par_separation_rejected_subsets
+                      << "\n";
             std::cout << "Innovation-gated soft resets: " << tight_dd_soft_resets << "\n";
         }
         std::cout << "Fused epochs written: " << fused_solution.size() << "\n";

--- a/apps/native/gnss_solve.cpp
+++ b/apps/native/gnss_solve.cpp
@@ -1,4 +1,5 @@
 #include <Eigen/Dense>
+#include <algorithm>
 #include <cmath>
 #include <cstdlib>
 #include <exception>
@@ -9,6 +10,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <set>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -103,6 +105,7 @@ struct SolveConfig {
     std::string rover_seed_pos_path;
     std::string diagnostics_csv_path;
     double rtk_update_outlier_threshold = 0.0;
+    bool student_t_rtk_front_end = false;
     double ratio_threshold = 3.0;
     bool enable_satellite_count_ratio_threshold = false;
     bool enable_ar_filter = false;
@@ -266,6 +269,25 @@ struct SolveConfig {
     bool enable_bsr_guided_decimation = false;
     int bsr_guided_worst_axes = 3;
     int bsr_guided_max_drop_steps = 6;
+    int lambda_candidate_shadow_count = 0;
+    double lambda_src_par_shadow_success_rate = 0.0;
+    double lambda_src_par_shadow_covariance_scale = 1.0;
+    int lambda_satellite_par_shadow_max_drop_steps = 0;
+    double lambda_satellite_par_shadow_covariance_scale = 16.0;
+    bool enable_lambda_satellite_par_shadow_quality_diverse = false;
+    bool enable_lambda_l1_l5_wlnl_shadow = false;
+    bool enable_lambda_l1_l5_wlnl_causal_arcs = false;
+    bool enable_safe_fix_shadow_state_machine = false;
+    bool enable_safe_fix_robust_consensus_shadow = false;
+    bool require_safe_fix_independent_failure_budget = false;
+    bool enable_library_fixed_quality_gate = false;
+    double library_fixed_quality_max_covariance_trace_m2 = 0.00025;
+    double library_fixed_quality_max_nis_per_observation = 10.0;
+    int library_fixed_quality_min_strong_observations = 28;
+    double library_fixed_quality_strong_max_nis_per_observation = 1.0;
+    bool enable_safe_float_continuity = false;
+    double safe_float_continuity_max_age_s = 6.0;
+    bool enable_safe_availability_fallback = false;
     // WP7: NLOS/multipath measurement weighting. Empty path / OFF mode
     // (both defaults) mean the feature is entirely inert.
     std::string nlos_weights_csv_path;
@@ -883,12 +905,119 @@ public:
               << "bsr_guided_candidates_evaluated,bsr_guided_candidates_accepted,"
               << "wide_lane_total,wide_lane_fixed,"
               << "wide_lane_rejected,wide_lane_min_distance,wide_lane_max_distance,"
-              << "gf_slip_count,doppler_slip_l1_count,doppler_slip_l2_count,"
-              << "code_slip_l1_count,code_slip_l2_count,lli_slip_l1_count,"
-              << "lli_slip_l2_count,ambiguity_reset_l1_count,ambiguity_reset_l2_count,"
+              << "gf_slip_count,gf_slip_l1l5_count,"
+              << "doppler_slip_l1_count,doppler_slip_l2_count,doppler_slip_l5_count,"
+              << "code_slip_l1_count,code_slip_l2_count,code_slip_l5_count,"
+              << "lli_slip_l1_count,lli_slip_l2_count,lli_slip_l5_count,"
+              << "ambiguity_reset_l1_count,ambiguity_reset_l2_count,"
+              << "ambiguity_reset_l5_count,"
               << "adaptive_dynamic_slip_active,consecutive_nonfix_before_bias_update,"
               << "adaptive_dynamic_slip_hold_remaining,"
-              << "full_lambda_solved,full_ratio,selected_fixed,selected_ratio,"
+              << "full_lambda_solved,full_ratio,"
+              << "lambda_shadow_attempted,lambda_shadow_solved,"
+              << "lambda_shadow_runtime_ms,"
+              << "lambda_shadow_candidate_count,lambda_shadow_bsr,"
+              << "lambda_shadow_bsr_qscale2,lambda_shadow_bsr_qscale4,"
+              << "lambda_shadow_bsr_qscale8,lambda_shadow_bsr_qscale16,"
+              << "lambda_shadow_best_cost,lambda_shadow_second_cost,"
+              << "lambda_shadow_best_mass,lambda_shadow_effective_candidates,"
+              << "lambda_shadow_best_second_disagreements,"
+              << "lambda_shadow_ffrt_table_supported,"
+              << "lambda_shadow_ffrt_accepts_any,lambda_shadow_ffrt_passed,"
+              << "lambda_shadow_ffrt_min_ratio,"
+              << "lambda_shadow_best_ecef_x,lambda_shadow_best_ecef_y,"
+              << "lambda_shadow_best_ecef_z,"
+              << "lambda_shadow_best_correction_x,"
+              << "lambda_shadow_best_correction_y,"
+              << "lambda_shadow_best_correction_z,"
+              << "lambda_shadow_second_ecef_x,lambda_shadow_second_ecef_y,"
+              << "lambda_shadow_second_ecef_z,"
+              << "lambda_shadow_second_correction_x,"
+              << "lambda_shadow_second_correction_y,"
+              << "lambda_shadow_second_correction_z,";
+        for (int candidate = 0; candidate < 8; ++candidate) {
+            const int ordinal = candidate + 1;
+            file_ << "lambda_shadow_candidate_" << ordinal << "_cost,"
+                  << "lambda_shadow_candidate_" << ordinal << "_ecef_x,"
+                  << "lambda_shadow_candidate_" << ordinal << "_ecef_y,"
+                  << "lambda_shadow_candidate_" << ordinal << "_ecef_z,";
+        }
+        file_ << "lambda_shadow_second_position_delta_m,"
+              << "lambda_shadow_position_spread_max_m,"
+              << "lambda_src_par_shadow_attempted,"
+              << "lambda_src_par_shadow_solved,"
+              << "lambda_src_par_shadow_subset_size,"
+              << "lambda_src_par_shadow_bsr,"
+              << "lambda_src_par_shadow_ratio,"
+              << "lambda_src_par_shadow_ffrt_min_ratio,"
+              << "lambda_src_par_shadow_ffrt_passed,"
+              << "lambda_src_par_shadow_best_ecef_x,"
+              << "lambda_src_par_shadow_best_ecef_y,"
+              << "lambda_src_par_shadow_best_ecef_z,"
+              << "lambda_src_par_shadow_best_correction_x,"
+              << "lambda_src_par_shadow_best_correction_y,"
+              << "lambda_src_par_shadow_best_correction_z,"
+              << "lambda_src_par_shadow_second_position_delta_m,"
+              << "lambda_src_par_shadow_runtime_ms,"
+              << "lambda_satellite_par_shadow_attempted,"
+              << "lambda_satellite_par_shadow_subsets_evaluated,"
+              << "lambda_satellite_par_shadow_solved,"
+              << "lambda_satellite_par_shadow_subset_size,"
+              << "lambda_satellite_par_shadow_dropped_satellites,"
+              << "lambda_satellite_par_shadow_bsr,"
+              << "lambda_satellite_par_shadow_ratio,"
+              << "lambda_satellite_par_shadow_ffrt_min_ratio,"
+              << "lambda_satellite_par_shadow_ffrt_passed,"
+              << "lambda_satellite_par_shadow_best_ecef_x,"
+              << "lambda_satellite_par_shadow_best_ecef_y,"
+              << "lambda_satellite_par_shadow_best_ecef_z,"
+              << "lambda_satellite_par_shadow_best_correction_x,"
+              << "lambda_satellite_par_shadow_best_correction_y,"
+              << "lambda_satellite_par_shadow_best_correction_z,"
+              << "lambda_satellite_par_shadow_second_position_delta_m,"
+              << "lambda_satellite_par_shadow_runtime_ms,"
+              << "lambda_l1_l5_wlnl_shadow_attempted,"
+              << "lambda_l1_l5_wlnl_shadow_pair_count,"
+              << "lambda_l1_l5_wlnl_shadow_wl_bsr,"
+              << "lambda_l1_l5_wlnl_shadow_wl_ratio,"
+              << "lambda_l1_l5_wlnl_shadow_wl_ffrt_min_ratio,"
+              << "lambda_l1_l5_wlnl_shadow_wl_ffrt_passed,"
+              << "lambda_l1_l5_wlnl_shadow_mw_disagreements,"
+              << "lambda_l1_l5_wlnl_shadow_raw_mw_disagreements,"
+              << "lambda_l1_l5_wlnl_shadow_causal_arc_ready_pairs,"
+              << "lambda_l1_l5_wlnl_shadow_causal_arc_resets,"
+              << "lambda_l1_l5_wlnl_shadow_nl_bsr,"
+              << "lambda_l1_l5_wlnl_shadow_nl_ratio,"
+              << "lambda_l1_l5_wlnl_shadow_nl_ffrt_min_ratio,"
+              << "lambda_l1_l5_wlnl_shadow_nl_ffrt_passed,"
+              << "lambda_l1_l5_wlnl_shadow_best_ecef_x,"
+              << "lambda_l1_l5_wlnl_shadow_best_ecef_y,"
+              << "lambda_l1_l5_wlnl_shadow_best_ecef_z,"
+              << "lambda_l1_l5_wlnl_shadow_runtime_ms,"
+              << "safe_fix_shadow_enabled,safe_fix_shadow_state,"
+              << "safe_fix_shadow_declared_fixed,"
+              << "safe_fix_shadow_candidate_accepted,"
+              << "safe_fix_shadow_held,safe_fix_shadow_revoked,"
+              << "safe_fix_shadow_strong_acquisition,"
+              << "safe_fix_shadow_change_point_acquisition,"
+              << "safe_fix_shadow_acquisition_streak,"
+              << "safe_fix_shadow_hold_epochs,"
+              << "safe_fix_shadow_independent_consensus_delta_m,"
+              << "safe_fix_shadow_independent_source_families,"
+              << "safe_fix_shadow_joint_failure_probability,"
+              << "safe_fix_shadow_failure_budget_passed,"
+              << "inertial_fix_evidence_available,"
+              << "inertial_fix_evidence_healthy_anchor,"
+              << "inertial_fix_evidence_passed,"
+              << "inertial_fix_evidence_time_error_s,"
+              << "inertial_fix_evidence_position_delta_m,"
+              << "inertial_fix_evidence_nis_per_dimension,"
+              << "safe_float_continuity_attempted,"
+              << "safe_float_continuity_used,"
+              << "safe_float_continuity_solver_gap_anchor,"
+              << "safe_float_continuity_anchor_age_s,"
+              << "safe_float_continuity_velocity_age_s,"
+              << "selected_fixed,selected_ratio,"
               << "selected_pair_count,selected_distinct_sats,selected_distinct_systems,"
               << "selected_distinct_frequencies,selected_dual_frequency_sats,"
               << "selected_fixed_ambiguities,selected_used_subset,"
@@ -908,10 +1037,19 @@ public:
               << "final_fixed_applied,hold_fix_attempted,hold_fix_applied,"
               << "hold_fix_candidate_pairs,hold_fix_matched_pairs,hold_fix_jump_m,"
               << "hold_fix_float_divergence_m,hold_fix_reject_reason,"
+              << "library_fixed_quality_gate_enabled,"
+              << "library_fixed_quality_gate_passed,"
+              << "library_fixed_quality_gate_safe_shadow_branch,"
+              << "library_fixed_quality_gate_covariance_branch,"
+              << "library_fixed_quality_gate_strong_innovation_branch,"
+              << "library_fixed_quality_gate_demoted,"
               << "reject_reason,ar_skip_reason,"
               << "float_update_observation_count,float_update_prefit_residual_rms_m,"
               << "float_update_post_suppression_residual_rms_m,"
               << "float_update_nis_per_observation,float_update_suppressed_outliers,"
+              << "float_update_student_t_downweighted_rows,"
+              << "float_update_student_t_minimum_weight,"
+              << "float_update_student_t_mean_weight,"
               << "float_position_covariance_trace_m2\n";
         return true;
     }
@@ -952,19 +1090,234 @@ public:
         writeNumber(telemetry.wide_lane_max_distance);
         file_ << ","
               << telemetry.gf_slip_count << ","
+              << telemetry.gf_slip_l1l5_count << ","
               << telemetry.doppler_slip_l1_count << ","
               << telemetry.doppler_slip_l2_count << ","
+              << telemetry.doppler_slip_l5_count << ","
               << telemetry.code_slip_l1_count << ","
               << telemetry.code_slip_l2_count << ","
+              << telemetry.code_slip_l5_count << ","
               << telemetry.lli_slip_l1_count << ","
               << telemetry.lli_slip_l2_count << ","
+              << telemetry.lli_slip_l5_count << ","
               << telemetry.ambiguity_reset_l1_count << ","
               << telemetry.ambiguity_reset_l2_count << ","
+              << telemetry.ambiguity_reset_l5_count << ","
               << telemetry.adaptive_dynamic_slip_active << ","
               << telemetry.consecutive_nonfix_before_bias_update << ","
               << telemetry.adaptive_dynamic_slip_hold_remaining << ","
               << telemetry.full_lambda_solved << ",";
         writeNumber(telemetry.full_ratio);
+        file_ << ","
+              << telemetry.lambda_shadow_attempted << ","
+              << telemetry.lambda_shadow_solved << ",";
+        writeNumber(telemetry.lambda_shadow_runtime_ms);
+        file_ << ","
+              << telemetry.lambda_shadow_candidate_count << ",";
+        writeNumber(telemetry.lambda_shadow_bsr);
+        file_ << ",";
+        writeNumber(telemetry.lambda_shadow_bsr_qscale2);
+        file_ << ",";
+        writeNumber(telemetry.lambda_shadow_bsr_qscale4);
+        file_ << ",";
+        writeNumber(telemetry.lambda_shadow_bsr_qscale8);
+        file_ << ",";
+        writeNumber(telemetry.lambda_shadow_bsr_qscale16);
+        file_ << ",";
+        writeNumber(telemetry.lambda_shadow_best_cost);
+        file_ << ",";
+        writeNumber(telemetry.lambda_shadow_second_cost);
+        file_ << ",";
+        writeNumber(telemetry.lambda_shadow_best_mass);
+        file_ << ",";
+        writeNumber(telemetry.lambda_shadow_effective_candidates);
+        file_ << ","
+              << telemetry.lambda_shadow_best_second_disagreements << ","
+              << telemetry.lambda_shadow_ffrt_table_supported << ","
+              << telemetry.lambda_shadow_ffrt_accepts_any << ","
+              << telemetry.lambda_shadow_ffrt_passed << ",";
+        writeNumber(telemetry.lambda_shadow_ffrt_min_ratio);
+        file_ << ",";
+        writeNumber(telemetry.lambda_shadow_best_ecef_x);
+        file_ << ",";
+        writeNumber(telemetry.lambda_shadow_best_ecef_y);
+        file_ << ",";
+        writeNumber(telemetry.lambda_shadow_best_ecef_z);
+        file_ << ",";
+        writeNumber(telemetry.lambda_shadow_best_correction_x);
+        file_ << ",";
+        writeNumber(telemetry.lambda_shadow_best_correction_y);
+        file_ << ",";
+        writeNumber(telemetry.lambda_shadow_best_correction_z);
+        file_ << ",";
+        writeNumber(telemetry.lambda_shadow_second_ecef_x);
+        file_ << ",";
+        writeNumber(telemetry.lambda_shadow_second_ecef_y);
+        file_ << ",";
+        writeNumber(telemetry.lambda_shadow_second_ecef_z);
+        file_ << ",";
+        writeNumber(telemetry.lambda_shadow_second_correction_x);
+        file_ << ",";
+        writeNumber(telemetry.lambda_shadow_second_correction_y);
+        file_ << ",";
+        writeNumber(telemetry.lambda_shadow_second_correction_z);
+        file_ << ",";
+        for (int candidate = 0; candidate < 8; ++candidate) {
+            writeNumber(
+                telemetry.lambda_shadow_candidate_costs(candidate));
+            file_ << ",";
+            for (int axis = 0; axis < 3; ++axis) {
+                writeNumber(
+                    telemetry.lambda_shadow_candidate_ecef_m(
+                        axis, candidate));
+                file_ << ",";
+            }
+        }
+        writeNumber(telemetry.lambda_shadow_second_position_delta_m);
+        file_ << ",";
+        writeNumber(telemetry.lambda_shadow_position_spread_max_m);
+        file_ << ","
+              << telemetry.lambda_src_par_shadow_attempted << ","
+              << telemetry.lambda_src_par_shadow_solved << ","
+              << telemetry.lambda_src_par_shadow_subset_size << ",";
+        writeNumber(telemetry.lambda_src_par_shadow_bsr);
+        file_ << ",";
+        writeNumber(telemetry.lambda_src_par_shadow_ratio);
+        file_ << ",";
+        writeNumber(telemetry.lambda_src_par_shadow_ffrt_min_ratio);
+        file_ << ","
+              << telemetry.lambda_src_par_shadow_ffrt_passed << ",";
+        writeNumber(telemetry.lambda_src_par_shadow_best_ecef_x);
+        file_ << ",";
+        writeNumber(telemetry.lambda_src_par_shadow_best_ecef_y);
+        file_ << ",";
+        writeNumber(telemetry.lambda_src_par_shadow_best_ecef_z);
+        file_ << ",";
+        writeNumber(telemetry.lambda_src_par_shadow_best_correction_x);
+        file_ << ",";
+        writeNumber(telemetry.lambda_src_par_shadow_best_correction_y);
+        file_ << ",";
+        writeNumber(telemetry.lambda_src_par_shadow_best_correction_z);
+        file_ << ",";
+        writeNumber(
+            telemetry.lambda_src_par_shadow_second_position_delta_m);
+        file_ << ",";
+        writeNumber(telemetry.lambda_src_par_shadow_runtime_ms);
+        file_ << ","
+              << telemetry.lambda_satellite_par_shadow_attempted << ","
+              << telemetry.lambda_satellite_par_shadow_subsets_evaluated << ","
+              << telemetry.lambda_satellite_par_shadow_solved << ","
+              << telemetry.lambda_satellite_par_shadow_subset_size << ","
+              << telemetry.lambda_satellite_par_shadow_dropped_satellites
+              << ",";
+        writeNumber(telemetry.lambda_satellite_par_shadow_bsr);
+        file_ << ",";
+        writeNumber(telemetry.lambda_satellite_par_shadow_ratio);
+        file_ << ",";
+        writeNumber(telemetry.lambda_satellite_par_shadow_ffrt_min_ratio);
+        file_ << ","
+              << telemetry.lambda_satellite_par_shadow_ffrt_passed << ",";
+        writeNumber(telemetry.lambda_satellite_par_shadow_best_ecef_x);
+        file_ << ",";
+        writeNumber(telemetry.lambda_satellite_par_shadow_best_ecef_y);
+        file_ << ",";
+        writeNumber(telemetry.lambda_satellite_par_shadow_best_ecef_z);
+        file_ << ",";
+        writeNumber(
+            telemetry.lambda_satellite_par_shadow_best_correction_x);
+        file_ << ",";
+        writeNumber(
+            telemetry.lambda_satellite_par_shadow_best_correction_y);
+        file_ << ",";
+        writeNumber(
+            telemetry.lambda_satellite_par_shadow_best_correction_z);
+        file_ << ",";
+        writeNumber(
+            telemetry
+                .lambda_satellite_par_shadow_second_position_delta_m);
+        file_ << ",";
+        writeNumber(telemetry.lambda_satellite_par_shadow_runtime_ms);
+        file_ << ","
+              << telemetry.lambda_l1_l5_wlnl_shadow_attempted << ","
+              << telemetry.lambda_l1_l5_wlnl_shadow_pair_count << ",";
+        writeNumber(telemetry.lambda_l1_l5_wlnl_shadow_wl_bsr);
+        file_ << ",";
+        writeNumber(telemetry.lambda_l1_l5_wlnl_shadow_wl_ratio);
+        file_ << ",";
+        writeNumber(
+            telemetry.lambda_l1_l5_wlnl_shadow_wl_ffrt_min_ratio);
+        file_ << ","
+              << telemetry.lambda_l1_l5_wlnl_shadow_wl_ffrt_passed << ","
+              << telemetry.lambda_l1_l5_wlnl_shadow_mw_disagreements << ","
+              << telemetry
+                     .lambda_l1_l5_wlnl_shadow_raw_mw_disagreements
+              << ","
+              << telemetry
+                     .lambda_l1_l5_wlnl_shadow_causal_arc_ready_pairs
+              << ","
+              << telemetry.lambda_l1_l5_wlnl_shadow_causal_arc_resets
+              << ",";
+        writeNumber(telemetry.lambda_l1_l5_wlnl_shadow_nl_bsr);
+        file_ << ",";
+        writeNumber(telemetry.lambda_l1_l5_wlnl_shadow_nl_ratio);
+        file_ << ",";
+        writeNumber(
+            telemetry.lambda_l1_l5_wlnl_shadow_nl_ffrt_min_ratio);
+        file_ << ","
+              << telemetry.lambda_l1_l5_wlnl_shadow_nl_ffrt_passed << ",";
+        writeNumber(telemetry.lambda_l1_l5_wlnl_shadow_best_ecef_x);
+        file_ << ",";
+        writeNumber(telemetry.lambda_l1_l5_wlnl_shadow_best_ecef_y);
+        file_ << ",";
+        writeNumber(telemetry.lambda_l1_l5_wlnl_shadow_best_ecef_z);
+        file_ << ",";
+        writeNumber(telemetry.lambda_l1_l5_wlnl_shadow_runtime_ms);
+        file_ << ","
+              << telemetry.safe_fix_shadow_enabled << ","
+              << telemetry.safe_fix_shadow_state << ","
+              << telemetry.safe_fix_shadow_declared_fixed << ","
+              << telemetry.safe_fix_shadow_candidate_accepted << ","
+              << telemetry.safe_fix_shadow_held << ","
+              << telemetry.safe_fix_shadow_revoked << ","
+              << telemetry.safe_fix_shadow_strong_acquisition << ","
+              << telemetry.safe_fix_shadow_change_point_acquisition
+              << ","
+              << telemetry.safe_fix_shadow_acquisition_streak << ","
+              << telemetry.safe_fix_shadow_hold_epochs << ",";
+        writeNumber(
+            telemetry
+                .safe_fix_shadow_independent_consensus_delta_m);
+        file_ << ","
+              << telemetry
+                     .safe_fix_shadow_independent_source_families
+              << ",";
+        writeNumber(
+            telemetry.safe_fix_shadow_joint_failure_probability);
+        file_ << ","
+              << telemetry.safe_fix_shadow_failure_budget_passed
+              << ","
+              << telemetry.inertial_fix_evidence_available
+              << ","
+              << telemetry.inertial_fix_evidence_healthy_anchor
+              << ","
+              << telemetry.inertial_fix_evidence_passed
+              << ",";
+        writeNumber(telemetry.inertial_fix_evidence_time_error_s);
+        file_ << ",";
+        writeNumber(
+            telemetry.inertial_fix_evidence_position_delta_m);
+        file_ << ",";
+        writeNumber(
+            telemetry.inertial_fix_evidence_nis_per_dimension);
+        file_
+              << ","
+              << telemetry.safe_float_continuity_attempted << ","
+              << telemetry.safe_float_continuity_used << ","
+              << telemetry.safe_float_continuity_solver_gap_anchor
+              << ",";
+        writeNumber(telemetry.safe_float_continuity_anchor_age_s);
+        file_ << ",";
+        writeNumber(telemetry.safe_float_continuity_velocity_age_s);
         file_ << ","
               << telemetry.selected_fixed << ",";
         writeNumber(telemetry.selected_ratio);
@@ -1030,6 +1383,17 @@ public:
         writeNumber(telemetry.hold_fix_float_divergence_m);
         file_ << ","
               << telemetry.hold_fix_reject_reason << ","
+              << telemetry.library_fixed_quality_gate_enabled << ","
+              << telemetry.library_fixed_quality_gate_passed << ","
+              << telemetry
+                     .library_fixed_quality_gate_safe_shadow_branch
+              << ","
+              << telemetry.library_fixed_quality_gate_covariance_branch
+              << ","
+              << telemetry
+                     .library_fixed_quality_gate_strong_innovation_branch
+              << ","
+              << telemetry.library_fixed_quality_gate_demoted << ","
               << telemetry.reject_reason << ","
               << libgnss::RTKProcessor::arSkipReasonToString(telemetry.ar_skip_reason) << ","
               << telemetry.float_update_observation_count << ",";
@@ -1039,7 +1403,14 @@ public:
         file_ << ",";
         writeNumber(telemetry.float_update_nis_per_observation);
         file_ << ","
-              << telemetry.float_update_suppressed_outliers << ",";
+              << telemetry.float_update_suppressed_outliers << ","
+              << telemetry.float_update_student_t_downweighted_rows
+              << ",";
+        writeNumber(
+            telemetry.float_update_student_t_minimum_weight);
+        file_ << ",";
+        writeNumber(telemetry.float_update_student_t_mean_weight);
+        file_ << ",";
         writeNumber(telemetry.float_position_covariance_trace_m2);
         file_ << "\n";
         file_.flush();
@@ -1274,6 +1645,70 @@ void printAdvancedUsage(const char* program_name) {
         << "                             (eigendecomposition-driven drop subsets)\n"
         << "                             alongside the variance-based progressive\n"
         << "                             drop family. Default: off.\n"
+        << "  --lambda-shadow-candidates <n>\n"
+        << "                             Record top-K MLAMBDA/BSR diagnostics without\n"
+        << "                             changing FIX decisions (0=off, 2..32)\n"
+        << "  --lambda-src-par-shadow-success-rate <p>\n"
+        << "                             Shadow-only SRC partial-AR success threshold\n"
+        << "                             (0=off; requires lambda shadow candidates)\n"
+        << "  --lambda-src-par-shadow-covariance-scale <s>\n"
+        << "                             Positive SRC/FFRT covariance inflation\n"
+        << "                             (default: 1)\n"
+        << "  --lambda-satellite-par-shadow-max-drops <n>\n"
+        << "                             Shadow-only satellite-group sequential PAR\n"
+        << "                             (0=off; requires lambda shadow candidates)\n"
+        << "  --lambda-satellite-par-shadow-covariance-scale <s>\n"
+        << "                             Positive satellite-PAR FFRT covariance\n"
+        << "                             inflation (default: 16)\n"
+        << "  --lambda-satellite-par-shadow-quality-diverse\n"
+        << "                             Add deduplicated variance/residual/fractional/\n"
+        << "                             elevation/SNR/azimuth satellite-drop paths\n"
+        << "  --lambda-l1-l5-wlnl-shadow\n"
+        << "                             Shadow-only L1/L5 WL->NL cascade with\n"
+        << "                             per-stage scale-16 FFRT and MW agreement;\n"
+        << "                             never changes filter/output decisions\n"
+        << "  --lambda-l1-l5-wlnl-causal-arcs\n"
+        << "                             Validate fresh WL searches with causal MW\n"
+        << "                             arc smoothing keyed by satellite, frequency,\n"
+        << "                             and reference generation (default: off)\n"
+        << "  --safe-fix-shadow-state-machine\n"
+        << "                             Run default-off FIX/hold/revoke telemetry;\n"
+        << "                             never changes output status or filter state\n"
+        << "  --safe-fix-robust-consensus-shadow\n"
+        << "                             Enable the experimental default-off robust\n"
+        << "                             full/satellite-PAR consensus state machine\n"
+        << "                             (ratio>=1.4, pairs>=12, 3x/2cm acquisition,\n"
+        << "                             strong/change-point shortcuts, no hold)\n"
+        << "  --safe-fix-independent-failure-budget\n"
+        << "                             Require >=2 distinct source families and\n"
+        << "                             joint fixed-failure probability <=2e-6;\n"
+        << "                             full and satellite-PAR count as one family\n"
+        << "  --library-fixed-quality-gate\n"
+        << "                             Demote library FIX unless safe-shadow or a\n"
+        << "                             structural quality branch passes (default: off)\n"
+        << "  --library-fixed-quality-max-cov-trace <m^2>\n"
+        << "                             Covariance-branch float ECEF trace ceiling\n"
+        << "                             (default: 0.00025)\n"
+        << "  --library-fixed-quality-max-nis <v>\n"
+        << "                             Covariance-branch NIS/observation ceiling\n"
+        << "                             (default: 10)\n"
+        << "  --library-fixed-quality-min-observations <n>\n"
+        << "                             Strong-innovation observation floor\n"
+        << "                             (default: 28)\n"
+        << "  --library-fixed-quality-strong-max-nis <v>\n"
+        << "                             Strong-innovation NIS/observation ceiling\n"
+        << "                             (default: 1)\n"
+        << "  --safe-float-continuity\n"
+        << "                             Emit bounded Doppler-propagated FLOAT output\n"
+        << "                             during short no-solution gaps (default: off)\n"
+        << "  --safe-float-continuity-max-age <seconds>\n"
+        << "                             Trusted-anchor and velocity age limit\n"
+        << "                             (default: 6)\n"
+        << "  --safe-availability-fallback\n"
+        << "                             Preserve epoch availability after fail-closed\n"
+        << "                             RTK rejection using independent SPP, then an\n"
+        << "                             explicit PROPAGATED estimate with inflated\n"
+        << "                             covariance; never supplies FIX authority\n"
         << "  --bsr-worst-axes <n>       Number of largest-eigenvalue Qb axes to score\n"
         << "                             per-pair loadings against (default: 3)\n"
         << "  --bsr-max-drops <n>        Max pairs to drop progressively in BSR-guided\n"
@@ -1533,6 +1968,7 @@ void printAdvancedUsage(const char* program_name) {
         << "  --integrity-log <file>     Write real-time integrity decisions and latency CSV\n"
         << "  --rtk-update-outlier-threshold <v>\n"
         << "                             Outlier rejection threshold for RTK measurement update (default: 30.0)\n"
+        << "  --student-t-rtk-front-end  Enable Student-t(nu=4) DD covariance inflation (default: off)\n"
         << "  --no-kinematic-post-filter Disable the kinematic output post-filter\n"
         << "  --no-base-interp           Require exact rover/base epoch alignment\n"
         << "  --verbose                  Print per-epoch progress summary\n"
@@ -2273,6 +2709,82 @@ SolveConfig parseArguments(int argc, char* argv[]) {
             config.spp_height_step_guard_min_m = std::stod(argv[++i]);
         } else if (arg == "--spp-height-step-rate" && i + 1 < argc) {
             config.spp_height_step_guard_max_rate_mps = std::stod(argv[++i]);
+        } else if (arg == "--lambda-shadow-candidates" && i + 1 < argc) {
+            config.lambda_candidate_shadow_count = std::stoi(argv[++i]);
+        } else if (arg == "--lambda-src-par-shadow-success-rate" &&
+                   i + 1 < argc) {
+            config.lambda_src_par_shadow_success_rate =
+                std::stod(argv[++i]);
+        } else if (arg == "--lambda-src-par-shadow-covariance-scale" &&
+                   i + 1 < argc) {
+            config.lambda_src_par_shadow_covariance_scale =
+                std::stod(argv[++i]);
+        } else if (arg == "--lambda-satellite-par-shadow-max-drops" &&
+                   i + 1 < argc) {
+            config.lambda_satellite_par_shadow_max_drop_steps =
+                std::stoi(argv[++i]);
+        } else if (
+            arg == "--lambda-satellite-par-shadow-covariance-scale" &&
+            i + 1 < argc) {
+            config.lambda_satellite_par_shadow_covariance_scale =
+                std::stod(argv[++i]);
+        } else if (
+            arg ==
+            "--lambda-satellite-par-shadow-quality-diverse") {
+            config
+                .enable_lambda_satellite_par_shadow_quality_diverse =
+                true;
+        } else if (arg == "--lambda-l1-l5-wlnl-shadow") {
+            config.enable_lambda_l1_l5_wlnl_shadow = true;
+        } else if (arg == "--lambda-l1-l5-wlnl-causal-arcs") {
+            config.enable_lambda_l1_l5_wlnl_causal_arcs = true;
+        } else if (arg == "--safe-fix-shadow-state-machine") {
+            config.enable_safe_fix_shadow_state_machine = true;
+        } else if (arg == "--safe-fix-robust-consensus-shadow") {
+            config.enable_safe_fix_shadow_state_machine = true;
+            config.enable_safe_fix_robust_consensus_shadow = true;
+            config.lambda_candidate_shadow_count =
+                std::max(config.lambda_candidate_shadow_count, 2);
+            config.lambda_satellite_par_shadow_max_drop_steps =
+                std::max(
+                    config.lambda_satellite_par_shadow_max_drop_steps,
+                    8);
+        } else if (
+            arg == "--safe-fix-independent-failure-budget") {
+            config.require_safe_fix_independent_failure_budget =
+                true;
+        } else if (arg == "--library-fixed-quality-gate") {
+            config.enable_library_fixed_quality_gate = true;
+        } else if (
+            arg == "--library-fixed-quality-max-cov-trace" &&
+            i + 1 < argc) {
+            config.library_fixed_quality_max_covariance_trace_m2 =
+                std::stod(argv[++i]);
+        } else if (
+            arg == "--library-fixed-quality-max-nis" &&
+            i + 1 < argc) {
+            config.library_fixed_quality_max_nis_per_observation =
+                std::stod(argv[++i]);
+        } else if (
+            arg == "--library-fixed-quality-min-observations" &&
+            i + 1 < argc) {
+            config.library_fixed_quality_min_strong_observations =
+                std::stoi(argv[++i]);
+        } else if (
+            arg == "--library-fixed-quality-strong-max-nis" &&
+            i + 1 < argc) {
+            config
+                .library_fixed_quality_strong_max_nis_per_observation =
+                std::stod(argv[++i]);
+        } else if (arg == "--safe-float-continuity") {
+            config.enable_safe_float_continuity = true;
+        } else if (
+            arg == "--safe-float-continuity-max-age" &&
+            i + 1 < argc) {
+            config.safe_float_continuity_max_age_s =
+                std::stod(argv[++i]);
+        } else if (arg == "--safe-availability-fallback") {
+            config.enable_safe_availability_fallback = true;
         } else if (arg == "--prefer-trusted-seed") {
             config.prefer_trusted_seed = true;
         } else if (arg == "--doppler-float-seed") {
@@ -2285,6 +2797,8 @@ SolveConfig parseArguments(int argc, char* argv[]) {
             config.diagnostics_csv_path = argv[++i];
         } else if (arg == "--rtk-update-outlier-threshold" && i + 1 < argc) {
             config.rtk_update_outlier_threshold = std::stod(argv[++i]);
+        } else if (arg == "--student-t-rtk-front-end") {
+            config.student_t_rtk_front_end = true;
         } else if (arg == "--no-kinematic-post-filter") {
             config.enable_kinematic_post_filter = false;
         } else if (arg == "--no-base-interp") {
@@ -2643,6 +3157,127 @@ SolveConfig parseArguments(int argc, char* argv[]) {
     if (config.skip_epochs < 0) {
         argumentError("--skip-epochs must be >= 0", argv[0]);
     }
+    if (config.lambda_candidate_shadow_count != 0 &&
+        (config.lambda_candidate_shadow_count < 2 ||
+         config.lambda_candidate_shadow_count > 32)) {
+        argumentError(
+            "--lambda-shadow-candidates must be 0 or in [2, 32]",
+            argv[0]);
+    }
+    if (!std::isfinite(config.lambda_src_par_shadow_success_rate) ||
+        config.lambda_src_par_shadow_success_rate < 0.0 ||
+        config.lambda_src_par_shadow_success_rate > 1.0) {
+        argumentError(
+            "--lambda-src-par-shadow-success-rate must be in [0, 1]",
+            argv[0]);
+    }
+    if (!std::isfinite(config.lambda_src_par_shadow_covariance_scale) ||
+        config.lambda_src_par_shadow_covariance_scale <= 0.0) {
+        argumentError(
+            "--lambda-src-par-shadow-covariance-scale must be > 0",
+            argv[0]);
+    }
+    if (config.lambda_src_par_shadow_success_rate > 0.0 &&
+        config.lambda_candidate_shadow_count < 2) {
+        argumentError(
+            "--lambda-src-par-shadow-success-rate requires "
+            "--lambda-shadow-candidates >= 2",
+            argv[0]);
+    }
+    if (config.lambda_satellite_par_shadow_max_drop_steps < 0 ||
+        config.lambda_satellite_par_shadow_max_drop_steps > 32) {
+        argumentError(
+            "--lambda-satellite-par-shadow-max-drops must be in [0, 32]",
+            argv[0]);
+    }
+    if (!std::isfinite(
+            config.lambda_satellite_par_shadow_covariance_scale) ||
+        config.lambda_satellite_par_shadow_covariance_scale <= 0.0) {
+        argumentError(
+            "--lambda-satellite-par-shadow-covariance-scale must be > 0",
+            argv[0]);
+    }
+    if (config.lambda_satellite_par_shadow_max_drop_steps > 0 &&
+        config.lambda_candidate_shadow_count < 2) {
+        argumentError(
+            "--lambda-satellite-par-shadow-max-drops requires "
+            "--lambda-shadow-candidates >= 2",
+            argv[0]);
+    }
+    if (
+        config.enable_lambda_satellite_par_shadow_quality_diverse &&
+        config.lambda_satellite_par_shadow_max_drop_steps <= 0) {
+        argumentError(
+            "--lambda-satellite-par-shadow-quality-diverse requires "
+            "--lambda-satellite-par-shadow-max-drops > 0",
+            argv[0]);
+    }
+    if (config.enable_lambda_l1_l5_wlnl_causal_arcs &&
+        !config.enable_lambda_l1_l5_wlnl_shadow) {
+        argumentError(
+            "--lambda-l1-l5-wlnl-causal-arcs requires "
+            "--lambda-l1-l5-wlnl-shadow",
+            argv[0]);
+    }
+    if (config.enable_safe_fix_shadow_state_machine &&
+        config.lambda_candidate_shadow_count < 2) {
+        argumentError(
+            "--safe-fix-shadow-state-machine requires "
+            "--lambda-shadow-candidates >= 2",
+            argv[0]);
+    }
+    if (config.enable_library_fixed_quality_gate &&
+        !config.enable_safe_fix_robust_consensus_shadow) {
+        argumentError(
+            "--library-fixed-quality-gate requires "
+            "--safe-fix-robust-consensus-shadow",
+            argv[0]);
+    }
+    if (config.require_safe_fix_independent_failure_budget &&
+        (!config.enable_safe_fix_robust_consensus_shadow ||
+         !config.enable_lambda_l1_l5_wlnl_shadow)) {
+        argumentError(
+            "--safe-fix-independent-failure-budget requires "
+            "--safe-fix-robust-consensus-shadow and "
+            "--lambda-l1-l5-wlnl-shadow",
+            argv[0]);
+    }
+    if (!std::isfinite(
+            config.library_fixed_quality_max_covariance_trace_m2) ||
+        config.library_fixed_quality_max_covariance_trace_m2 <= 0.0) {
+        argumentError(
+            "--library-fixed-quality-max-cov-trace must be > 0",
+            argv[0]);
+    }
+    if (!std::isfinite(
+            config.library_fixed_quality_max_nis_per_observation) ||
+        config.library_fixed_quality_max_nis_per_observation <= 0.0) {
+        argumentError(
+            "--library-fixed-quality-max-nis must be > 0",
+            argv[0]);
+    }
+    if (config.library_fixed_quality_min_strong_observations < 1) {
+        argumentError(
+            "--library-fixed-quality-min-observations must be >= 1",
+            argv[0]);
+    }
+    if (!std::isfinite(
+            config
+                .library_fixed_quality_strong_max_nis_per_observation) ||
+        config
+                .library_fixed_quality_strong_max_nis_per_observation <=
+            0.0) {
+        argumentError(
+            "--library-fixed-quality-strong-max-nis must be > 0",
+            argv[0]);
+    }
+    if (
+        !std::isfinite(config.safe_float_continuity_max_age_s) ||
+        config.safe_float_continuity_max_age_s <= 0.0) {
+        argumentError(
+            "--safe-float-continuity-max-age must be > 0",
+            argv[0]);
+    }
     if (!std::isfinite(config.doppler_float_seed_max_age_s) ||
         config.doppler_float_seed_max_age_s <= 0.0) {
         argumentError("--doppler-float-seed-max-age must be > 0", argv[0]);
@@ -2919,6 +3554,8 @@ int main(int argc, char* argv[]) {
         rtk_config.fixed_prefit_reset_streak = config.fixed_prefit_reset_streak;
         rtk_config.fixed_prefit_quarantine_only = config.fixed_prefit_quarantine_only;
         rtk_config.max_update_nis_per_observation = config.max_update_nis_per_observation;
+        rtk_config.student_t_front_end.enabled =
+            config.student_t_rtk_front_end;
         rtk_config.max_fixed_update_nis_per_observation =
             config.max_fixed_update_nis_per_observation;
         rtk_config.max_fixed_update_post_residual_rms_m =
@@ -2951,6 +3588,74 @@ int main(int argc, char* argv[]) {
         rtk_config.enable_bsr_guided_decimation = config.enable_bsr_guided_decimation;
         rtk_config.bsr_guided_worst_axes = config.bsr_guided_worst_axes;
         rtk_config.bsr_guided_max_drop_steps = config.bsr_guided_max_drop_steps;
+        rtk_config.lambda_candidate_shadow_count =
+            config.lambda_candidate_shadow_count;
+        rtk_config.lambda_src_par_shadow_success_rate =
+            config.lambda_src_par_shadow_success_rate;
+        rtk_config.lambda_src_par_shadow_covariance_scale =
+            config.lambda_src_par_shadow_covariance_scale;
+        rtk_config.lambda_satellite_par_shadow_max_drop_steps =
+            config.lambda_satellite_par_shadow_max_drop_steps;
+        rtk_config.lambda_satellite_par_shadow_covariance_scale =
+            config.lambda_satellite_par_shadow_covariance_scale;
+        rtk_config.lambda_satellite_par_shadow_quality_diverse =
+            config
+                .enable_lambda_satellite_par_shadow_quality_diverse;
+        rtk_config.lambda_l1_l5_wlnl_shadow =
+            config.enable_lambda_l1_l5_wlnl_shadow;
+        rtk_config.lambda_l1_l5_wlnl_causal_arc_smoothing =
+            config.enable_lambda_l1_l5_wlnl_causal_arcs;
+        rtk_config.safe_fix_shadow_state_machine.enabled =
+            config.enable_safe_fix_shadow_state_machine;
+        rtk_config.safe_fix_shadow_state_machine
+            .require_independent_failure_budget =
+            config.require_safe_fix_independent_failure_budget;
+        rtk_config.library_fixed_quality_gate.enabled =
+            config.enable_library_fixed_quality_gate;
+        rtk_config.library_fixed_quality_gate
+            .require_independent_failure_budget =
+            config.require_safe_fix_independent_failure_budget;
+        rtk_config.library_fixed_quality_gate
+            .maximum_float_position_covariance_trace_m2 =
+            config.library_fixed_quality_max_covariance_trace_m2;
+        rtk_config.library_fixed_quality_gate
+            .maximum_covariance_branch_nis_per_observation =
+            config.library_fixed_quality_max_nis_per_observation;
+        rtk_config.library_fixed_quality_gate
+            .minimum_strong_innovation_observations =
+            config.library_fixed_quality_min_strong_observations;
+        rtk_config.library_fixed_quality_gate
+            .maximum_strong_innovation_nis_per_observation =
+            config
+                .library_fixed_quality_strong_max_nis_per_observation;
+        if (config.enable_safe_fix_robust_consensus_shadow) {
+            rtk_config.safe_fix_shadow_state_machine
+                .acquisition_streak_epochs = 3;
+            rtk_config.safe_fix_shadow_state_machine
+                .maximum_acquisition_correction_jump_m = 0.02;
+            rtk_config.safe_fix_shadow_state_machine
+                .maximum_hold_epochs = 0;
+            rtk_config.safe_fix_shadow_state_machine
+                .minimum_absolute_ratio = 1.4;
+            rtk_config.safe_fix_shadow_state_machine
+                .maximum_independent_consensus_delta_m = 0.10;
+            rtk_config.safe_fix_shadow_state_machine
+                .allow_strong_instant_acquisition = true;
+            rtk_config.safe_fix_shadow_state_machine
+                .allow_change_point_acquisition = true;
+            rtk_config.safe_fix_shadow_minimum_pairs = 12;
+            rtk_config
+                .safe_fix_shadow_maximum_second_position_delta_m =
+                0.25;
+            rtk_config.safe_fix_shadow_maximum_nis_per_observation =
+                3.0;
+        }
+        rtk_config.safe_float_continuity.enabled =
+            config.enable_safe_float_continuity;
+        rtk_config.safe_float_continuity.maximum_anchor_age_s =
+            config.safe_float_continuity_max_age_s;
+        rtk_config.safe_float_continuity.maximum_velocity_age_s =
+            config.safe_float_continuity_max_age_s;
         if (!config.nlos_weights_csv_path.empty()) {
             auto table = std::make_shared<libgnss::nlos_weights::NlosWeightTable>(
                 libgnss::nlos_weights::loadNlosWeightsCsv(config.nlos_weights_csv_path));
@@ -3158,6 +3863,11 @@ int main(int argc, char* argv[]) {
         int fixed_bridge_burst_guard_inspected_segments = 0;
         int fixed_bridge_burst_guard_rejected_segments = 0;
         int fixed_bridge_burst_guard_rejected_epochs = 0;
+        int kinematic_postfilter_continuity_epochs = 0;
+        int immediate_guard_continuity_epochs = 0;
+        int availability_spp_fallback_epochs = 0;
+        int availability_propagated_fallback_epochs = 0;
+        int availability_postfilter_reinserted_epochs = 0;
         libgnss::PositionSolution last_fixed_output;
         bool have_last_fixed_output = false;
         libgnss::PositionSolution last_guard_output;
@@ -3186,6 +3896,8 @@ int main(int argc, char* argv[]) {
                 record_output(emission.solution);
             }
         };
+        libgnss::PositionSolution last_real_output;
+        bool have_last_real_output = false;
 
         while (rover_ok) {
             if (config.max_epochs > 0 && processed_rover_epochs >= config.max_epochs) {
@@ -3251,6 +3963,97 @@ int main(int argc, char* argv[]) {
             const libgnss::PositionSolution* last_output =
                 have_last_guard_output ? &last_guard_output : nullptr;
             const bool have_last_output = last_output != nullptr;
+            bool immediate_guard_continuity_used = false;
+            bool availability_fallback_used = false;
+            const auto replace_rejected_with_continuity =
+                [&](const libgnss::PositionSolution& rejected) {
+                    if (!rtk_config.safe_float_continuity.enabled) {
+                        return false;
+                    }
+                    libgnss::safe_float_continuity::Result continuity;
+                    Eigen::Vector3d velocity = Eigen::Vector3d::Zero();
+                    auto continuity_config =
+                        rtk_config.safe_float_continuity;
+                    const auto try_anchor =
+                        [&](const libgnss::PositionSolution& anchor,
+                            double maximum_age_s) {
+                            const double anchor_age_s =
+                                rejected.time - anchor.time;
+                            const bool use_current_velocity =
+                                rejected.has_velocity &&
+                                rejected.velocity_ecef.allFinite();
+                            if (!use_current_velocity &&
+                                !anchor.has_velocity) {
+                                return false;
+                            }
+                            velocity =
+                                use_current_velocity
+                                    ? rejected.velocity_ecef
+                                    : anchor.velocity_ecef;
+                            auto candidate_config =
+                                rtk_config.safe_float_continuity;
+                            candidate_config.maximum_anchor_age_s =
+                                std::min(
+                                    candidate_config
+                                        .maximum_anchor_age_s,
+                                    maximum_age_s);
+                            continuity =
+                                libgnss::safe_float_continuity::propagate(
+                                    candidate_config,
+                                    anchor.position_ecef,
+                                    anchor_age_s,
+                                    velocity,
+                                    use_current_velocity
+                                        ? 0.0
+                                        : anchor_age_s);
+                            if (continuity.valid) {
+                                continuity_config = candidate_config;
+                            }
+                            return continuity.valid;
+                        };
+                    // Prefer a validated FIXED anchor for the configured
+                    // outage horizon. Fall back to a real solver output only
+                    // for an isolated sub-second guard rejection.
+                    bool propagated =
+                        have_last_fixed_output &&
+                        try_anchor(
+                            last_fixed_output,
+                            continuity_config.maximum_anchor_age_s);
+                    if (!propagated && have_last_real_output) {
+                        propagated = try_anchor(
+                            last_real_output,
+                            continuity_config
+                                .maximum_solver_gap_anchor_age_s);
+                    }
+                    if (!propagated) {
+                        return false;
+                    }
+                    pos_solution = libgnss::PositionSolution{};
+                    pos_solution.time = rejected.time;
+                    pos_solution.status =
+                        libgnss::SolutionStatus::FLOAT;
+                    pos_solution.position_ecef =
+                        continuity.position_ecef;
+                    pos_solution.position_geodetic =
+                        libgnss::spp_utils::ecefToGeodetic(
+                            pos_solution.position_ecef);
+                    pos_solution.position_covariance =
+                        Eigen::Matrix3d::Identity() *
+                        continuity.position_variance_m2;
+                    pos_solution.velocity_ecef = velocity;
+                    pos_solution.velocity_covariance =
+                        Eigen::Matrix3d::Identity() *
+                        std::pow(
+                            continuity_config.velocity_sigma_mps,
+                            2.0);
+                    pos_solution.has_velocity = true;
+                    pos_solution.num_satellites = 4;
+                    pos_solution.ratio = 0.0;
+                    pos_solution.num_fixed_ambiguities = 0;
+                    immediate_guard_continuity_used = true;
+                    ++immediate_guard_continuity_epochs;
+                    return true;
+                };
             const auto jump_from_last_output = [&](const libgnss::PositionSolution& candidate) {
                 if (!have_last_output || !candidate.isValid()) {
                     return std::numeric_limits<double>::infinity();
@@ -3267,6 +4070,148 @@ int main(int argc, char* argv[]) {
                 }
                 return std::max(kDefaultNonFixedJumpGuardMeters, 25.0 * dt);
             };
+            // A raw solver gap used to bypass the same bounded FLOAT-only
+            // continuity path that handles rejected jumps and height steps.
+            // Route it through that fail-closed path as well: propagation
+            // still requires a trusted finite anchor, recent velocity, and
+            // the configured maximum age, and can never declare FIX.
+            if (!pos_solution.isValid()) {
+                auto rejected = pos_solution;
+                rejected.time = rover_obs.time;
+                replace_rejected_with_continuity(rejected);
+            }
+            if (
+                !pos_solution.isValid() &&
+                config.enable_safe_availability_fallback) {
+                auto spp_fallback =
+                    spp_processor.processEpoch(rover_obs, nav_data);
+                if (spp_fallback.isValid() &&
+                    spp_fallback.position_ecef.allFinite()) {
+                    spp_fallback.status =
+                        libgnss::SolutionStatus::SPP;
+                    pos_solution = spp_fallback;
+                    availability_fallback_used = true;
+                    ++availability_spp_fallback_epochs;
+                } else {
+                    const libgnss::PositionSolution*
+                        availability_anchor =
+                            last_output != nullptr &&
+                                    last_output
+                                        ->position_ecef
+                                        .allFinite()
+                                ? last_output
+                                : nullptr;
+                    Eigen::Vector3d anchor_position =
+                        Eigen::Vector3d::Zero();
+                    double anchor_variance_m2 = 1e6;
+                    double dt = 0.2;
+                    if (availability_anchor != nullptr) {
+                        anchor_position =
+                            availability_anchor->position_ecef;
+                        const double candidate_dt =
+                            rover_obs.time -
+                            availability_anchor->time;
+                        if (
+                            std::isfinite(candidate_dt) &&
+                            candidate_dt > 0.0) {
+                            dt = candidate_dt;
+                        }
+                        const double candidate_variance =
+                            availability_anchor
+                                ->position_covariance
+                                .trace() /
+                            3.0;
+                        if (
+                            std::isfinite(candidate_variance) &&
+                            candidate_variance >= 25.0) {
+                            anchor_variance_m2 =
+                                candidate_variance;
+                        } else {
+                            anchor_variance_m2 = 25.0;
+                        }
+                    } else if (
+                        rover_obs.receiver_position.allFinite() &&
+                        rover_obs.receiver_position.norm() > 1e6) {
+                        // This is an input/header or explicitly supplied
+                        // runtime seed, never audit truth. It is exposed only
+                        // as high-variance PROPAGATED availability.
+                        anchor_position =
+                            rover_obs.receiver_position;
+                    } else {
+                        anchor_position =
+                            Eigen::Vector3d::Constant(
+                                std::numeric_limits<double>::quiet_NaN());
+                    }
+
+                    Eigen::Vector3d velocity =
+                        Eigen::Vector3d::Zero();
+                    bool have_bounded_velocity = false;
+                    if (
+                        availability_anchor != nullptr &&
+                        availability_anchor->has_velocity &&
+                        availability_anchor
+                            ->velocity_ecef.allFinite() &&
+                        availability_anchor
+                                ->velocity_ecef.norm() <= 60.0) {
+                        velocity =
+                            availability_anchor->velocity_ecef;
+                        have_bounded_velocity = true;
+                    } else if (
+                        availability_anchor == last_output &&
+                        last_output != nullptr &&
+                        solution.solutions.size() >= 2) {
+                        const auto& previous =
+                            solution.solutions[
+                                solution.solutions.size() - 2];
+                        const double velocity_dt =
+                            last_output->time - previous.time;
+                        if (
+                            previous.position_ecef.allFinite() &&
+                            std::isfinite(velocity_dt) &&
+                            velocity_dt > 0.0 &&
+                            velocity_dt <= 2.0) {
+                            const Eigen::Vector3d candidate_velocity =
+                                (last_output->position_ecef -
+                                 previous.position_ecef) /
+                                velocity_dt;
+                            if (
+                                candidate_velocity.allFinite() &&
+                                candidate_velocity.norm() <= 60.0) {
+                                velocity = candidate_velocity;
+                                have_bounded_velocity = true;
+                            }
+                        }
+                    }
+                    pos_solution =
+                        libgnss::PositionSolution{};
+                    pos_solution.time = rover_obs.time;
+                    pos_solution.status =
+                        libgnss::SolutionStatus::PROPAGATED;
+                    pos_solution.position_ecef =
+                        anchor_position + velocity * dt;
+                    pos_solution.position_geodetic =
+                        libgnss::spp_utils::ecefToGeodetic(
+                            pos_solution.position_ecef);
+                    const double growth_sigma_m = 25.0 * dt;
+                    pos_solution.position_covariance =
+                        Eigen::Matrix3d::Identity() *
+                        (anchor_variance_m2 +
+                         growth_sigma_m * growth_sigma_m);
+                    pos_solution.velocity_ecef = velocity;
+                    pos_solution.velocity_covariance =
+                        Eigen::Matrix3d::Identity() * 625.0;
+                    pos_solution.has_velocity =
+                        have_bounded_velocity;
+                    pos_solution.num_satellites = 0;
+                    pos_solution.ratio = 0.0;
+                    pos_solution.num_fixed_ambiguities = 0;
+                    availability_fallback_used =
+                        pos_solution.isValid();
+                    if (availability_fallback_used) {
+                        ++availability_propagated_fallback_epochs;
+                    }
+                }
+            }
             if (used_interpolated_base && pos_solution.status == libgnss::SolutionStatus::FLOAT) {
                 auto spp_solution = spp_processor.processEpoch(rover_obs, nav_data);
                 if (spp_solution.isValid()) {
@@ -3287,18 +4232,24 @@ int main(int argc, char* argv[]) {
                 }
             }
 
-            if (pos_solution.isValid() &&
+            if (!availability_fallback_used &&
+                pos_solution.isValid() &&
                 pos_solution.status != libgnss::SolutionStatus::FIXED) {
                 const double candidate_jump = jump_from_last_output(pos_solution);
                 if (std::isfinite(candidate_jump) && candidate_jump > max_nonfixed_jump()) {
-                    pos_solution = libgnss::PositionSolution{};
-                    pos_solution.time = rover_obs.time;
-                    pos_solution.status = libgnss::SolutionStatus::NONE;
+                    const auto rejected = pos_solution;
+                    if (!replace_rejected_with_continuity(rejected)) {
+                        pos_solution = libgnss::PositionSolution{};
+                        pos_solution.time = rover_obs.time;
+                        pos_solution.status = libgnss::SolutionStatus::NONE;
+                    }
                 }
             }
 
-            if (pos_solution.isValid() &&
+            if (!availability_fallback_used &&
+                pos_solution.isValid() &&
                 pos_solution.status != libgnss::SolutionStatus::FIXED &&
+                !immediate_guard_continuity_used &&
                 have_last_fixed_output) {
                 double dt_since_fixed = pos_solution.time - last_fixed_output.time;
                 if (std::isfinite(dt_since_fixed) && dt_since_fixed > 0.0 && dt_since_fixed <= 5.0) {
@@ -3311,14 +4262,84 @@ int main(int argc, char* argv[]) {
                     const double max_height_drift = std::max(6.0, 3.0 * dt_since_fixed);
                     if (drift_from_fixed > max_fixed_drift ||
                         height_from_fixed > max_height_drift) {
-                        pos_solution = libgnss::PositionSolution{};
-                        pos_solution.time = rover_obs.time;
-                        pos_solution.status = libgnss::SolutionStatus::NONE;
+                        const auto rejected = pos_solution;
+                        if (!replace_rejected_with_continuity(rejected)) {
+                            pos_solution =
+                                libgnss::PositionSolution{};
+                            pos_solution.time = rover_obs.time;
+                            pos_solution.status =
+                                libgnss::SolutionStatus::NONE;
+                        }
                     }
                 }
             }
 
+            // A solver result can be valid at the raw boundary and then be
+            // rejected by the jump/height guards above. Preserve the same
+            // no-FIX availability contract at this final boundary as well.
+            if (
+                !pos_solution.isValid() &&
+                config.enable_safe_availability_fallback) {
+                Eigen::Vector3d anchor_position =
+                    Eigen::Vector3d::Constant(
+                        std::numeric_limits<double>::quiet_NaN());
+                double dt = 0.2;
+                double anchor_variance_m2 = 1e6;
+                if (
+                    last_output != nullptr &&
+                    last_output->position_ecef.allFinite()) {
+                    anchor_position = last_output->position_ecef;
+                    const double candidate_dt =
+                        rover_obs.time - last_output->time;
+                    if (
+                        std::isfinite(candidate_dt) &&
+                        candidate_dt > 0.0) {
+                        dt = candidate_dt;
+                    }
+                    const double candidate_variance =
+                        last_output->position_covariance.trace() /
+                        3.0;
+                    if (
+                        std::isfinite(candidate_variance) &&
+                        candidate_variance >= 25.0) {
+                        anchor_variance_m2 =
+                            candidate_variance;
+                    }
+                } else if (
+                    rover_obs.receiver_position.allFinite() &&
+                    rover_obs.receiver_position.norm() > 1e6) {
+                    anchor_position =
+                        rover_obs.receiver_position;
+                }
+                if (anchor_position.allFinite()) {
+                    pos_solution =
+                        libgnss::PositionSolution{};
+                    pos_solution.time = rover_obs.time;
+                    pos_solution.status =
+                        libgnss::SolutionStatus::PROPAGATED;
+                    pos_solution.position_ecef =
+                        anchor_position;
+                    pos_solution.position_geodetic =
+                        libgnss::spp_utils::ecefToGeodetic(
+                            anchor_position);
+                    const double growth_sigma_m = 25.0 * dt;
+                    pos_solution.position_covariance =
+                        Eigen::Matrix3d::Identity() *
+                        (anchor_variance_m2 +
+                         growth_sigma_m * growth_sigma_m);
+                    pos_solution.velocity_covariance =
+                        Eigen::Matrix3d::Identity() * 625.0;
+                    pos_solution.has_velocity = false;
+                    pos_solution.num_satellites = 0;
+                    pos_solution.ratio = 0.0;
+                    pos_solution.num_fixed_ambiguities = 0;
+                    availability_fallback_used = true;
+                    ++availability_propagated_fallback_epochs;
+                }
+            }
+
             const auto feedback_solution = pos_solution;
+            rtk_processor.applyLibraryFixedQualityGate(pos_solution);
             if (shouldDemoteFixedStatus(config, pos_solution)) {
                 pos_solution.status = libgnss::SolutionStatus::FLOAT;
             }
@@ -3382,6 +4403,14 @@ int main(int argc, char* argv[]) {
                 have_last_guard_output = true;
                 if (gated_feedback_solution.isFixed()) {
                     last_fixed_output = gated_feedback_solution;
+                if (!immediate_guard_continuity_used &&
+                    !availability_fallback_used &&
+                    !rtk_processor.getLastDebugTelemetry()
+                         .safe_float_continuity_used) {
+                    last_real_output = feedback_solution;
+                    have_last_real_output =
+                        feedback_solution.isValid();
+                }
                     have_last_fixed_output = true;
                 }
             }
@@ -3406,6 +4435,11 @@ int main(int argc, char* argv[]) {
         if (integrity_gate) {
             record_integrity_emissions(integrity_gate->flush());
         }
+        const std::vector<libgnss::PositionSolution>
+            availability_source_solutions =
+                config.enable_safe_availability_fallback
+                    ? solution.solutions
+                    : std::vector<libgnss::PositionSolution>{};
 
         if (config.enable_nonfix_drift_guard &&
             rtk_config.position_mode != libgnss::RTKProcessor::RTKConfig::PositionMode::STATIC &&
@@ -3510,8 +4544,36 @@ int main(int argc, char* argv[]) {
                     const double max_height_step =
                         std::max(kDefaultVerticalStepGuardMeters, 4.0 * dt);
                     if (height_step > max_height_step) {
-                        // Drop this single epoch only; do not advance the
-                        // anchor or trigger a multi-epoch suppression.
+                        const auto continuity =
+                            libgnss::safe_float_continuity::propagate(
+                                rtk_config.safe_float_continuity,
+                                last_kept->position_ecef,
+                                dt,
+                                last_kept->velocity_ecef,
+                                dt);
+                        if (
+                            last_kept->has_velocity &&
+                            continuity.valid) {
+                            auto replacement = *last_kept;
+                            replacement.time = epoch_solution.time;
+                            replacement.status =
+                                libgnss::SolutionStatus::FLOAT;
+                            replacement.position_ecef =
+                                continuity.position_ecef;
+                            replacement.position_geodetic =
+                                libgnss::spp_utils::ecefToGeodetic(
+                                    replacement.position_ecef);
+                            replacement.position_covariance =
+                                Eigen::Matrix3d::Identity() *
+                                continuity.position_variance_m2;
+                            replacement.num_satellites = 4;
+                            replacement.ratio = 0.0;
+                            replacement.num_fixed_ambiguities = 0;
+                            filtered_solution.addSolution(replacement);
+                            ++kinematic_postfilter_continuity_epochs;
+                        }
+                        // Never advance the trusted post-filter anchor with a
+                        // propagated replacement.
                         continue;
                     }
                 }
@@ -3523,6 +4585,58 @@ int main(int argc, char* argv[]) {
                 }
             }
             solution = std::move(filtered_solution);
+        }
+
+        if (
+            config.enable_safe_availability_fallback &&
+            !availability_source_solutions.empty()) {
+            const auto epoch_key =
+                [](const libgnss::PositionSolution& epoch_solution) {
+                    return std::make_pair(
+                        epoch_solution.time.week,
+                        static_cast<long long>(std::llround(
+                            epoch_solution.time.tow * 1000.0)));
+                };
+            std::set<std::pair<int, long long>> kept_epochs;
+            for (const auto& epoch_solution : solution.solutions) {
+                kept_epochs.insert(epoch_key(epoch_solution));
+            }
+            for (const auto& source : availability_source_solutions) {
+                if (kept_epochs.count(epoch_key(source)) != 0) {
+                    continue;
+                }
+                auto degraded = source;
+                degraded.status =
+                    source.status ==
+                            libgnss::SolutionStatus::PROPAGATED
+                        ? libgnss::SolutionStatus::PROPAGATED
+                        : libgnss::SolutionStatus::SPP;
+                degraded.position_covariance +=
+                    Eigen::Matrix3d::Identity() * 10000.0;
+                degraded.ratio = 0.0;
+                degraded.num_fixed_ambiguities = 0;
+                if (
+                    degraded.status ==
+                    libgnss::SolutionStatus::PROPAGATED) {
+                    degraded.num_satellites = 0;
+                } else {
+                    degraded.num_satellites =
+                        std::max(4, degraded.num_satellites);
+                }
+                solution.addSolution(degraded);
+                kept_epochs.insert(epoch_key(degraded));
+                ++availability_postfilter_reinserted_epochs;
+            }
+            std::sort(
+                solution.solutions.begin(),
+                solution.solutions.end(),
+                [](const libgnss::PositionSolution& left,
+                   const libgnss::PositionSolution& right) {
+                    if (left.time.week != right.time.week) {
+                        return left.time.week < right.time.week;
+                    }
+                    return left.time.tow < right.time.tow;
+                });
         }
 
         if (solution.isEmpty()) {
@@ -3587,12 +4701,24 @@ int main(int argc, char* argv[]) {
                       << " rejected_segments=" << float_bridge_tail_guard_rejected_segments
                       << " rejected_epochs=" << float_bridge_tail_guard_rejected_epochs
                       << std::endl;
-            std::cout << "  fixed bridge-burst guard: "
+        std::cout << "  fixed bridge-burst guard: "
                       << (config.enable_fixed_bridge_burst_guard ? "enabled" : "disabled")
                       << " inspected_segments=" << fixed_bridge_burst_guard_inspected_segments
                       << " rejected_segments=" << fixed_bridge_burst_guard_rejected_segments
-                      << " rejected_epochs=" << fixed_bridge_burst_guard_rejected_epochs
-                      << std::endl;
+                  << " rejected_epochs=" << fixed_bridge_burst_guard_rejected_epochs
+                  << std::endl;
+        std::cout << "  kinematic post-filter FLOAT continuity epochs: "
+                  << kinematic_postfilter_continuity_epochs << std::endl;
+        std::cout << "  immediate guard FLOAT continuity epochs: "
+                  << immediate_guard_continuity_epochs << std::endl;
+        std::cout << "  safe availability SPP fallback epochs: "
+                  << availability_spp_fallback_epochs << std::endl;
+        std::cout << "  safe availability propagated epochs: "
+                  << availability_propagated_fallback_epochs
+                  << std::endl;
+        std::cout << "  safe availability post-filter reinsertions: "
+                  << availability_postfilter_reinserted_epochs
+                  << std::endl;
         }
         if (rtk_config.position_mode == libgnss::RTKProcessor::RTKConfig::PositionMode::STATIC &&
             rover_header.approximate_position.norm() > 0.0 && mean_count > 0) {

--- a/include/libgnss++/algorithms/causal_ambiguity_arc.hpp
+++ b/include/libgnss++/algorithms/causal_ambiguity_arc.hpp
@@ -1,0 +1,271 @@
+#pragma once
+
+#include "../core/types.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <map>
+#include <tuple>
+
+namespace libgnss::causal_ambiguity_arc {
+
+struct Config {
+    int minimum_samples = 5;
+    int maximum_effective_samples = 50;
+    double maximum_gap_s = 1.0;
+};
+
+struct Result {
+    bool valid = false;
+    bool ready = false;
+    bool reset = false;
+    int samples = 0;
+    std::uint64_t reference_generation = 0;
+    double smoothed_value = NAN;
+    double smoothed_value_variance = INFINITY;
+};
+
+/// A causal, reference-generation-aware bank for ambiguity-domain observables.
+///
+/// Values are never held as fixed integers.  The bank only smooths the
+/// current/past floating observable used to validate a fresh integer search.
+class Bank {
+public:
+    explicit Bank(Config config = {}) : config_(config) {}
+
+    Result update(const SatelliteId& satellite,
+                  const SatelliteId& reference,
+                  int frequency_pair,
+                  double time_s,
+                  double value,
+                  bool slip) {
+        Result result;
+        if (!std::isfinite(time_s) || !std::isfinite(value) ||
+            satellite == reference) {
+            return result;
+        }
+        const std::uint64_t generation =
+            observeReference(
+                satellite, frequency_pair, reference);
+        const Key key{
+            satellite, reference, frequency_pair, generation};
+        auto& state = states_[key];
+        const double gap_s =
+            state.initialized ? time_s - state.last_time_s : NAN;
+        const bool discontinuity =
+            slip || !state.initialized || !std::isfinite(gap_s) ||
+            gap_s <= 0.0 || gap_s > config_.maximum_gap_s;
+        if (discontinuity) {
+            state = State{};
+            state.initialized = true;
+            state.samples = 1;
+            state.mean = value;
+            state.observation_variance = 0.0;
+            state.rounded_integer =
+                static_cast<long long>(std::llround(value));
+            state.stable_integer_samples = 1;
+            state.last_time_s = time_s;
+            result.reset = true;
+        } else {
+            state.samples++;
+            const int effective_samples = std::clamp(
+                state.samples, 1,
+                std::max(1, config_.maximum_effective_samples));
+            const double alpha =
+                1.0 / static_cast<double>(effective_samples);
+            const double delta = value - state.mean;
+            state.mean += alpha * delta;
+            state.observation_variance =
+                (1.0 - alpha) *
+                (state.observation_variance + alpha * delta * delta);
+            const auto rounded =
+                static_cast<long long>(std::llround(state.mean));
+            if (rounded == state.rounded_integer) {
+                state.stable_integer_samples++;
+            } else {
+                state.rounded_integer = rounded;
+                state.stable_integer_samples = 1;
+            }
+            state.last_time_s = time_s;
+        }
+        result.valid = true;
+        result.samples = state.samples;
+        result.reference_generation = generation;
+        result.smoothed_value = state.mean;
+        if (state.samples >= 2) {
+            const int effective_samples = std::clamp(
+                state.samples, 1,
+                std::max(1, config_.maximum_effective_samples));
+            result.smoothed_value_variance =
+                state.observation_variance /
+                static_cast<double>(effective_samples);
+        }
+        result.ready =
+            state.samples >= std::max(1, config_.minimum_samples) &&
+            state.stable_integer_samples >=
+                std::max(1, config_.minimum_samples);
+        return result;
+    }
+
+    /// Update a reference-invariant single-difference signal arc.  A current
+    /// DD validation can be formed by subtracting two ready SD results; no DD
+    /// integer or past reference relation is retained.
+    Result updateSignal(const SatelliteId& satellite,
+                        int frequency_pair,
+                        double time_s,
+                        double value,
+                        bool slip) {
+        Result result;
+        if (!std::isfinite(time_s) || !std::isfinite(value)) {
+            return result;
+        }
+        const TrackKey key{satellite, frequency_pair};
+        auto& state = signal_states_[key];
+        if (state.initialized &&
+            std::abs(time_s - state.last_time_s) <= 1e-9) {
+            result.valid = true;
+            result.samples = state.samples;
+            result.smoothed_value = state.mean;
+            if (state.samples >= 2) {
+                const int effective_samples = std::clamp(
+                    state.samples, 1,
+                    std::max(1, config_.maximum_effective_samples));
+                result.smoothed_value_variance =
+                    state.observation_variance /
+                    static_cast<double>(effective_samples);
+            }
+            result.ready =
+                state.samples >= std::max(1, config_.minimum_samples) &&
+                state.stable_integer_samples >=
+                    std::max(1, config_.minimum_samples);
+            return result;
+        }
+        const double gap_s =
+            state.initialized ? time_s - state.last_time_s : NAN;
+        const bool discontinuity =
+            slip || !state.initialized || !std::isfinite(gap_s) ||
+            gap_s <= 0.0 || gap_s > config_.maximum_gap_s;
+        if (discontinuity) {
+            state = State{};
+            state.initialized = true;
+            state.samples = 1;
+            state.mean = value;
+            state.observation_variance = 0.0;
+            state.rounded_integer =
+                static_cast<long long>(std::llround(value));
+            state.stable_integer_samples = 1;
+            state.last_time_s = time_s;
+            result.reset = true;
+        } else {
+            state.samples++;
+            const int effective_samples = std::clamp(
+                state.samples, 1,
+                std::max(1, config_.maximum_effective_samples));
+            const double alpha =
+                1.0 / static_cast<double>(effective_samples);
+            const double delta = value - state.mean;
+            state.mean += alpha * delta;
+            state.observation_variance =
+                (1.0 - alpha) *
+                (state.observation_variance + alpha * delta * delta);
+            const auto rounded =
+                static_cast<long long>(std::llround(state.mean));
+            if (rounded == state.rounded_integer) {
+                state.stable_integer_samples++;
+            } else {
+                state.rounded_integer = rounded;
+                state.stable_integer_samples = 1;
+            }
+            state.last_time_s = time_s;
+        }
+        result.valid = true;
+        result.samples = state.samples;
+        result.smoothed_value = state.mean;
+        if (state.samples >= 2) {
+            const int effective_samples = std::clamp(
+                state.samples, 1,
+                std::max(1, config_.maximum_effective_samples));
+            result.smoothed_value_variance =
+                state.observation_variance /
+                static_cast<double>(effective_samples);
+        }
+        result.ready =
+            state.samples >= std::max(1, config_.minimum_samples) &&
+            state.stable_integer_samples >=
+                std::max(1, config_.minimum_samples);
+        return result;
+    }
+
+    void reset() {
+        states_.clear();
+        signal_states_.clear();
+        references_.clear();
+        generations_.clear();
+    }
+
+    std::size_t size() const {
+        return states_.size() + signal_states_.size();
+    }
+
+private:
+    struct Key {
+        SatelliteId satellite;
+        SatelliteId reference;
+        int frequency_pair = 0;
+        std::uint64_t reference_generation = 0;
+
+        bool operator<(const Key& other) const {
+            return std::tie(
+                       satellite, reference, frequency_pair,
+                       reference_generation) <
+                   std::tie(
+                       other.satellite, other.reference,
+                       other.frequency_pair,
+                       other.reference_generation);
+        }
+    };
+
+    struct State {
+        bool initialized = false;
+        int samples = 0;
+        int stable_integer_samples = 0;
+        long long rounded_integer = 0;
+        double mean = 0.0;
+        double observation_variance = 0.0;
+        double last_time_s = NAN;
+    };
+
+    struct TrackKey {
+        SatelliteId satellite;
+        int frequency_pair = 0;
+
+        bool operator<(const TrackKey& other) const {
+            return std::tie(satellite, frequency_pair) <
+                   std::tie(
+                       other.satellite, other.frequency_pair);
+        }
+    };
+
+    std::uint64_t observeReference(
+        const SatelliteId& satellite,
+        int frequency_pair,
+        const SatelliteId& reference) {
+        const TrackKey track{satellite, frequency_pair};
+        auto current = references_.find(track);
+        if (current == references_.end() ||
+            current->second != reference) {
+            references_[track] = reference;
+            return ++generations_[track];
+        }
+        return generations_[track];
+    }
+
+    Config config_;
+    std::map<Key, State> states_;
+    std::map<TrackKey, State> signal_states_;
+    std::map<TrackKey, SatelliteId> references_;
+    std::map<TrackKey, std::uint64_t> generations_;
+};
+
+}  // namespace libgnss::causal_ambiguity_arc

--- a/include/libgnss++/algorithms/disjoint_satellite_fix_evidence.hpp
+++ b/include/libgnss++/algorithms/disjoint_satellite_fix_evidence.hpp
@@ -1,0 +1,247 @@
+#pragma once
+
+#include <cmath>
+#include <limits>
+
+#include <Eigen/Dense>
+
+namespace libgnss::disjoint_satellite_fix_evidence {
+
+// Two independently propagated RTK processors receive disjoint GNSS-system
+// partitions.  Neither partition may share a satellite (including a DD
+// reference satellite) with the other.  This evaluator only checks the
+// declaration-time solution-separation contract; the caller owns and
+// enforces the disjoint input construction.
+struct Config {
+    double maximum_partition_separation_m = 0.25;
+    double maximum_primary_separation_m = 0.25;
+    double covariance_scale = 16.0;
+    // chi-square(3 dof, 0.999) / 3.
+    double maximum_nis_per_dimension = 5.422;
+    double maximum_statistical_separation_m = 2.0;
+};
+
+struct Evidence {
+    bool available = false;
+    bool inputs_verified_disjoint = false;
+    bool primary_ffrt_passed = false;
+    bool partition_a_ffrt_passed = false;
+    bool partition_b_ffrt_passed = false;
+    Eigen::Vector3d partition_a_candidate_ecef =
+        Eigen::Vector3d::Constant(
+            std::numeric_limits<double>::quiet_NaN());
+    Eigen::Vector3d partition_b_candidate_ecef =
+        Eigen::Vector3d::Constant(
+            std::numeric_limits<double>::quiet_NaN());
+    Eigen::Vector3d primary_candidate_ecef =
+        Eigen::Vector3d::Constant(
+            std::numeric_limits<double>::quiet_NaN());
+    Eigen::Matrix3d partition_a_covariance_ecef =
+        Eigen::Matrix3d::Constant(
+            std::numeric_limits<double>::quiet_NaN());
+    Eigen::Matrix3d partition_b_covariance_ecef =
+        Eigen::Matrix3d::Constant(
+            std::numeric_limits<double>::quiet_NaN());
+    Eigen::Matrix3d primary_covariance_ecef =
+        Eigen::Matrix3d::Constant(
+            std::numeric_limits<double>::quiet_NaN());
+};
+
+struct Decision {
+    bool passed = false;
+    double partition_separation_m =
+        std::numeric_limits<double>::quiet_NaN();
+    double partition_a_primary_separation_m =
+        std::numeric_limits<double>::quiet_NaN();
+    double partition_b_primary_separation_m =
+        std::numeric_limits<double>::quiet_NaN();
+    bool hard_separation_passed = false;
+    bool statistical_separation_passed = false;
+    double partition_nis_per_dimension =
+        std::numeric_limits<double>::quiet_NaN();
+    double partition_a_primary_nis_per_dimension =
+        std::numeric_limits<double>::quiet_NaN();
+    double partition_b_primary_nis_per_dimension =
+        std::numeric_limits<double>::quiet_NaN();
+};
+
+enum class SelectedPair {
+    NONE = 0,
+    PRIMARY_A = 1,
+    PRIMARY_B = 2,
+    A_B = 3,
+};
+
+struct ThreeCandidateConsensus {
+    bool valid = false;
+    SelectedPair selected_pair = SelectedPair::NONE;
+    Eigen::Vector3d position_ecef =
+        Eigen::Vector3d::Constant(
+            std::numeric_limits<double>::quiet_NaN());
+    double selected_pair_separation_m =
+        std::numeric_limits<double>::quiet_NaN();
+};
+
+// Under the solution-separation single-fault model, select the mutually
+// closest two of primary, partition A, and partition B. This avoids moving
+// halfway toward a lone estimator whose covariance is merely diffuse enough
+// to pass the statistical separation test.
+inline ThreeCandidateConsensus closestPairConsensus(
+    const Eigen::Vector3d& primary,
+    const Eigen::Vector3d& partition_a,
+    const Eigen::Vector3d& partition_b) {
+    ThreeCandidateConsensus result;
+    if (!primary.allFinite() ||
+        !partition_a.allFinite() ||
+        !partition_b.allFinite()) {
+        return result;
+    }
+    const double primary_a = (primary - partition_a).norm();
+    const double primary_b = (primary - partition_b).norm();
+    const double partition_ab = (partition_a - partition_b).norm();
+    if (primary_a <= primary_b && primary_a <= partition_ab) {
+        result.position_ecef = 0.5 * (primary + partition_a);
+        result.selected_pair_separation_m = primary_a;
+        result.selected_pair = SelectedPair::PRIMARY_A;
+    } else if (primary_b <= partition_ab) {
+        result.position_ecef = 0.5 * (primary + partition_b);
+        result.selected_pair_separation_m = primary_b;
+        result.selected_pair = SelectedPair::PRIMARY_B;
+    } else {
+        result.position_ecef = 0.5 * (partition_a + partition_b);
+        result.selected_pair_separation_m = partition_ab;
+        result.selected_pair = SelectedPair::A_B;
+    }
+    result.valid =
+        result.position_ecef.allFinite() &&
+        std::isfinite(result.selected_pair_separation_m);
+    return result;
+}
+
+inline double separationNisPerDimension(
+    const Eigen::Vector3d& separation,
+    const Eigen::Matrix3d& covariance_a,
+    const Eigen::Matrix3d& covariance_b,
+    double covariance_scale) {
+    if (!separation.allFinite() ||
+        !covariance_a.allFinite() ||
+        !covariance_b.allFinite() ||
+        !std::isfinite(covariance_scale) ||
+        covariance_scale <= 0.0) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    Eigen::Matrix3d covariance =
+        covariance_scale * 0.5 *
+            (covariance_a + covariance_a.transpose() +
+             covariance_b + covariance_b.transpose()) +
+        Eigen::Matrix3d::Identity() * 0.01;
+    Eigen::LDLT<Eigen::Matrix3d> solver(covariance);
+    if (solver.info() != Eigen::Success || !solver.isPositive()) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    const auto solved = solver.solve(separation);
+    return separation.dot(solved) / 3.0;
+}
+
+inline Decision evaluate(
+    const Config& config,
+    const Evidence& evidence) {
+    Decision decision;
+    if (!evidence.available ||
+        !evidence.inputs_verified_disjoint ||
+        !evidence.primary_ffrt_passed ||
+        !evidence.partition_a_ffrt_passed ||
+        !evidence.partition_b_ffrt_passed ||
+        !evidence.partition_a_candidate_ecef.allFinite() ||
+        !evidence.partition_b_candidate_ecef.allFinite() ||
+        !evidence.primary_candidate_ecef.allFinite() ||
+        !std::isfinite(config.maximum_partition_separation_m) ||
+        config.maximum_partition_separation_m <= 0.0 ||
+        !std::isfinite(config.maximum_primary_separation_m) ||
+        config.maximum_primary_separation_m <= 0.0 ||
+        !std::isfinite(config.covariance_scale) ||
+        config.covariance_scale <= 0.0 ||
+        !std::isfinite(config.maximum_nis_per_dimension) ||
+        config.maximum_nis_per_dimension <= 0.0 ||
+        !std::isfinite(
+            config.maximum_statistical_separation_m) ||
+        config.maximum_statistical_separation_m <= 0.0) {
+        return decision;
+    }
+
+    decision.partition_separation_m =
+        (evidence.partition_a_candidate_ecef -
+         evidence.partition_b_candidate_ecef)
+            .norm();
+    decision.partition_a_primary_separation_m =
+        (evidence.partition_a_candidate_ecef -
+         evidence.primary_candidate_ecef)
+            .norm();
+    decision.partition_b_primary_separation_m =
+        (evidence.partition_b_candidate_ecef -
+         evidence.primary_candidate_ecef)
+            .norm();
+    decision.hard_separation_passed =
+        std::isfinite(decision.partition_separation_m) &&
+        decision.partition_separation_m <=
+            config.maximum_partition_separation_m &&
+        std::isfinite(
+            decision.partition_a_primary_separation_m) &&
+        decision.partition_a_primary_separation_m <=
+            config.maximum_primary_separation_m &&
+        std::isfinite(
+            decision.partition_b_primary_separation_m) &&
+        decision.partition_b_primary_separation_m <=
+            config.maximum_primary_separation_m;
+    const Eigen::Vector3d partition_separation =
+        evidence.partition_a_candidate_ecef -
+        evidence.partition_b_candidate_ecef;
+    const Eigen::Vector3d partition_a_primary_separation =
+        evidence.partition_a_candidate_ecef -
+        evidence.primary_candidate_ecef;
+    const Eigen::Vector3d partition_b_primary_separation =
+        evidence.partition_b_candidate_ecef -
+        evidence.primary_candidate_ecef;
+    decision.partition_nis_per_dimension =
+        separationNisPerDimension(
+            partition_separation,
+            evidence.partition_a_covariance_ecef,
+            evidence.partition_b_covariance_ecef,
+            config.covariance_scale);
+    decision.partition_a_primary_nis_per_dimension =
+        separationNisPerDimension(
+            partition_a_primary_separation,
+            evidence.partition_a_covariance_ecef,
+            evidence.primary_covariance_ecef,
+            config.covariance_scale);
+    decision.partition_b_primary_nis_per_dimension =
+        separationNisPerDimension(
+            partition_b_primary_separation,
+            evidence.partition_b_covariance_ecef,
+            evidence.primary_covariance_ecef,
+            config.covariance_scale);
+    decision.statistical_separation_passed =
+        decision.partition_separation_m <=
+            config.maximum_statistical_separation_m &&
+        decision.partition_a_primary_separation_m <=
+            config.maximum_statistical_separation_m &&
+        decision.partition_b_primary_separation_m <=
+            config.maximum_statistical_separation_m &&
+        std::isfinite(decision.partition_nis_per_dimension) &&
+        decision.partition_nis_per_dimension <=
+            config.maximum_nis_per_dimension &&
+        std::isfinite(
+            decision.partition_a_primary_nis_per_dimension) &&
+        decision.partition_a_primary_nis_per_dimension <=
+            config.maximum_nis_per_dimension &&
+        std::isfinite(
+            decision.partition_b_primary_nis_per_dimension) &&
+        decision.partition_b_primary_nis_per_dimension <=
+            config.maximum_nis_per_dimension;
+    decision.passed =
+        decision.hard_separation_passed ||
+        decision.statistical_separation_passed;
+    return decision;
+}
+
+}  // namespace libgnss::disjoint_satellite_fix_evidence

--- a/include/libgnss++/algorithms/fix_failure_budget.hpp
+++ b/include/libgnss++/algorithms/fix_failure_budget.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstddef>
+#include <limits>
+
+namespace libgnss::fix_failure_budget {
+
+// Sources in one family may share observations, models, or ambiguity states.
+// Multiple algorithms from the same family therefore consume one fault domain.
+enum class SourceFamily : std::size_t {
+    PRIMARY_CARRIER_AR = 0,
+    MULTIFREQUENCY_CASCADE = 1,
+    INERTIAL_SOLUTION_SEPARATION = 2,
+    DISJOINT_SATELLITE_PARTITION_A = 3,
+    DISJOINT_SATELLITE_PARTITION_B = 4,
+    COUNT = 5,
+};
+
+struct Evidence {
+    SourceFamily family = SourceFamily::PRIMARY_CARRIER_AR;
+    bool accepted = false;
+    double fixed_failure_probability =
+        std::numeric_limits<double>::quiet_NaN();
+};
+
+struct Config {
+    int minimum_independent_families = 2;
+    double maximum_joint_failure_probability = 2e-6;
+};
+
+struct Decision {
+    bool passed = false;
+    int independent_families = 0;
+    double joint_failure_probability = 1.0;
+};
+
+template <std::size_t N>
+Decision evaluate(
+    const Config& config,
+    const std::array<Evidence, N>& evidence) {
+    Decision decision;
+    constexpr std::size_t family_count =
+        static_cast<std::size_t>(SourceFamily::COUNT);
+    std::array<double, family_count> best;
+    best.fill(std::numeric_limits<double>::infinity());
+    for (const auto& source : evidence) {
+        const auto family = static_cast<std::size_t>(source.family);
+        if (!source.accepted || family >= family_count ||
+            !std::isfinite(source.fixed_failure_probability) ||
+            source.fixed_failure_probability <= 0.0 ||
+            source.fixed_failure_probability > 1.0) {
+            continue;
+        }
+        best[family] =
+            std::min(best[family], source.fixed_failure_probability);
+    }
+    for (const double probability : best) {
+        if (!std::isfinite(probability)) {
+            continue;
+        }
+        ++decision.independent_families;
+        decision.joint_failure_probability *= probability;
+    }
+    decision.passed =
+        config.minimum_independent_families >= 2 &&
+        decision.independent_families >=
+            config.minimum_independent_families &&
+        std::isfinite(config.maximum_joint_failure_probability) &&
+        config.maximum_joint_failure_probability > 0.0 &&
+        decision.joint_failure_probability <=
+            config.maximum_joint_failure_probability;
+    return decision;
+}
+
+}  // namespace libgnss::fix_failure_budget

--- a/include/libgnss++/algorithms/fixed_quality_gate.hpp
+++ b/include/libgnss++/algorithms/fixed_quality_gate.hpp
@@ -1,0 +1,81 @@
+#pragma once
+
+#include <cmath>
+
+namespace libgnss::fixed_quality_gate {
+
+struct Config {
+    bool enabled = false;
+    // When enabled, ordinary quality evidence is necessary but no longer
+    // sufficient: a separately computed two-family failure budget must also
+    // pass.  Kept default-off so the established quality gate remains
+    // byte-for-byte opt-in compatible.
+    bool require_independent_failure_budget = false;
+    // Permit an exported FLOAT to become FIXED only when the causal shadow
+    // state has declared the current-epoch LAMBDA candidate and the
+    // independent failure budget passes. This never commits held integers
+    // to the RTK filter and remains default-off.
+    bool allow_safe_shadow_promotion = false;
+    // Also permit a current-epoch FFRT candidate with a passing independent
+    // failure budget to be evaluated by the ordinary covariance/innovation
+    // quality branches. A failed quality branch immediately demotes it.
+    bool allow_failure_budget_candidate_promotion = false;
+    double maximum_float_position_covariance_trace_m2 = 0.00025;
+    double maximum_covariance_branch_nis_per_observation = 10.0;
+    int minimum_strong_innovation_observations = 28;
+    double maximum_strong_innovation_nis_per_observation = 1.0;
+    double maximum_strong_innovation_suppressed_fraction = 0.5;
+};
+
+struct Evidence {
+    bool safe_fix_shadow_declared_fixed = false;
+    bool independent_failure_budget_passed = false;
+    double float_position_covariance_trace_m2 = NAN;
+    int update_observations = 0;
+    int suppressed_outliers = 0;
+    double update_nis_per_observation = NAN;
+};
+
+struct Decision {
+    bool passed = false;
+    bool independent_failure_budget_passed = false;
+    bool safe_shadow_branch = false;
+    bool covariance_branch = false;
+    bool strong_innovation_branch = false;
+};
+
+inline Decision evaluate(const Config& config, const Evidence& evidence) {
+    Decision decision;
+    decision.independent_failure_budget_passed =
+        evidence.independent_failure_budget_passed;
+    decision.safe_shadow_branch =
+        evidence.safe_fix_shadow_declared_fixed;
+    decision.covariance_branch =
+        std::isfinite(evidence.float_position_covariance_trace_m2) &&
+        evidence.float_position_covariance_trace_m2 <=
+            config.maximum_float_position_covariance_trace_m2 &&
+        std::isfinite(evidence.update_nis_per_observation) &&
+        evidence.update_nis_per_observation <=
+            config.maximum_covariance_branch_nis_per_observation;
+    decision.strong_innovation_branch =
+        evidence.update_observations >=
+            config.minimum_strong_innovation_observations &&
+        evidence.suppressed_outliers >= 0 &&
+        static_cast<double>(evidence.suppressed_outliers) /
+                evidence.update_observations <=
+            config.maximum_strong_innovation_suppressed_fraction &&
+        std::isfinite(evidence.update_nis_per_observation) &&
+        evidence.update_nis_per_observation <=
+            config.maximum_strong_innovation_nis_per_observation;
+    const bool quality_passed =
+        decision.safe_shadow_branch ||
+        decision.covariance_branch ||
+        decision.strong_innovation_branch;
+    decision.passed =
+        quality_passed &&
+        (!config.require_independent_failure_budget ||
+         decision.independent_failure_budget_passed);
+    return decision;
+}
+
+}  // namespace libgnss::fixed_quality_gate

--- a/include/libgnss++/algorithms/inertial_fix_evidence.hpp
+++ b/include/libgnss++/algorithms/inertial_fix_evidence.hpp
@@ -1,0 +1,74 @@
+#pragma once
+
+#include <cmath>
+#include <limits>
+
+#include <Eigen/Dense>
+
+namespace libgnss::inertial_fix_evidence {
+
+struct Config {
+    double maximum_time_error_s = 0.05;
+    double covariance_scale = 16.0;
+    // chi-square(3 dof, 0.999) / 3.
+    double maximum_nis_per_dimension = 5.422;
+    double maximum_position_delta_m = 2.0;
+};
+
+struct Evidence {
+    bool available = false;
+    bool healthy_independent_anchor = false;
+    double time_error_s = std::numeric_limits<double>::quiet_NaN();
+    Eigen::Vector3d predicted_position_ecef = Eigen::Vector3d::Zero();
+    Eigen::Matrix3d predicted_position_covariance_ecef =
+        Eigen::Matrix3d::Zero();
+    Eigen::Vector3d primary_candidate_ecef = Eigen::Vector3d::Zero();
+};
+
+struct Decision {
+    bool passed = false;
+    double position_delta_m = std::numeric_limits<double>::quiet_NaN();
+    double nis_per_dimension = std::numeric_limits<double>::quiet_NaN();
+};
+
+inline Decision evaluate(const Config& config, const Evidence& evidence) {
+    Decision decision;
+    if (!evidence.available ||
+        !evidence.healthy_independent_anchor ||
+        !std::isfinite(evidence.time_error_s) ||
+        !evidence.predicted_position_ecef.allFinite() ||
+        !evidence.predicted_position_covariance_ecef.allFinite() ||
+        !evidence.primary_candidate_ecef.allFinite() ||
+        !std::isfinite(config.covariance_scale) ||
+        config.covariance_scale <= 0.0) {
+        return decision;
+    }
+
+    const Eigen::Vector3d separation =
+        evidence.primary_candidate_ecef -
+        evidence.predicted_position_ecef;
+    decision.position_delta_m = separation.norm();
+    Eigen::Matrix3d covariance =
+        config.covariance_scale * 0.5 *
+            (evidence.predicted_position_covariance_ecef +
+             evidence.predicted_position_covariance_ecef.transpose()) +
+        Eigen::Matrix3d::Identity() * 0.01;
+    Eigen::LDLT<Eigen::Matrix3d> solver(covariance);
+    if (solver.info() != Eigen::Success || !solver.isPositive()) {
+        return decision;
+    }
+    const Eigen::Vector3d solved = solver.solve(separation);
+    decision.nis_per_dimension = separation.dot(solved) / 3.0;
+    decision.passed =
+        evidence.time_error_s <= config.maximum_time_error_s &&
+        std::isfinite(decision.position_delta_m) &&
+        decision.position_delta_m <=
+            config.maximum_position_delta_m &&
+        std::isfinite(decision.nis_per_dimension) &&
+        decision.nis_per_dimension >= 0.0 &&
+        decision.nis_per_dimension <=
+            config.maximum_nis_per_dimension;
+    return decision;
+}
+
+}  // namespace libgnss::inertial_fix_evidence

--- a/include/libgnss++/algorithms/lambda.hpp
+++ b/include/libgnss++/algorithms/lambda.hpp
@@ -39,4 +39,72 @@ bool lambdaSearchCandidates(const VectorXd& float_amb, const MatrixXd& Q_amb,
                             VectorXd& best_amb, VectorXd& second_amb,
                             double& ratio);
 
+/**
+ * LAMBDA search diagnostics for FFRT/PAR and multi-hypothesis shadowing.
+ *
+ * Candidate integer vectors are returned as columns, ordered by increasing
+ * squared ILS residual. conditional_variances contains the diagonal D after
+ * LAMBDA reduction. bootstrapped_success_rate is
+ * product_i(2 Phi(1/(2 sqrt(D_i))) - 1), evaluated without position truth.
+ */
+struct LambdaCandidateDiagnostics {
+    MatrixXd candidates;
+    VectorXd squared_residuals;
+    VectorXd conditional_variances;
+    // z = decorrelation_transform.transpose() * float ambiguities.
+    MatrixXd decorrelation_transform;
+    VectorXd decorrelated_float;
+    MatrixXd decorrelated_covariance;
+    double bootstrapped_success_rate = 0.0;
+};
+
+/**
+ * Fixed failure-rate ratio-test threshold from Hou et al. (2016).
+ *
+ * The paper defines mu = best_squared_residual / second_squared_residual,
+ * whereas lambdaSearch() reports the reciprocal ratio. The converted
+ * threshold below is therefore 1 / mu. A zero mu means reject all candidates.
+ *
+ * The initial implementation intentionally supports only the published
+ * Pf_tol=0.001 coefficient table and ambiguity dimensions 1..66. Unsupported
+ * requests fail closed rather than interpolating or extrapolating.
+ */
+struct FixedFailureRateRatioThreshold {
+    // Conservative covariance-derived proxy: 1 - bootstrapped success rate.
+    double ils_failure_rate_proxy = 1.0;
+    double mu = 0.0;
+    double minimum_second_to_best_ratio = 0.0;
+    bool accepts_any_candidate = false;
+};
+
+bool fixedFailureRateRatioThreshold(
+    int ambiguity_count, double bootstrapped_success_rate,
+    double tolerable_failure_rate,
+    FixedFailureRateRatioThreshold& threshold);
+
+/**
+ * Re-evaluate the bootstrapped success-rate lower bound after multiplying the
+ * ambiguity covariance by a positive scalar. Returns NaN on invalid input.
+ */
+double bootstrappedSuccessRate(const VectorXd& conditional_variances,
+                               double covariance_scale = 1.0);
+
+/**
+ * Number of trailing decorrelated ambiguities meeting an SRC success-rate
+ * threshold. LAMBDA reduction orders the trailing entries as the preferred
+ * conditional-precision subset. Returns zero on invalid input or when even the
+ * most precise ambiguity misses the threshold.
+ */
+int successRateCriterionSubsetSize(
+    const VectorXd& conditional_variances, double covariance_scale,
+    double minimum_success_rate);
+
+/**
+ * Return the best candidate_count integer vectors and covariance-only quality
+ * diagnostics. This API does not apply a ratio threshold or declare FIX.
+ */
+bool lambdaSearchTopK(const VectorXd& float_amb, const MatrixXd& Q_amb,
+                      int candidate_count,
+                      LambdaCandidateDiagnostics& diagnostics);
+
 } // namespace libgnss

--- a/include/libgnss++/algorithms/rtk.hpp
+++ b/include/libgnss++/algorithms/rtk.hpp
@@ -9,10 +9,16 @@
 #include "rtk_adaptive_noise.hpp"
 #include "rtk_float_stabilizer.hpp"
 #include "rtk_cmc_reference.hpp"
+#include "fixed_quality_gate.hpp"
+#include "inertial_fix_evidence.hpp"
+#include "causal_ambiguity_arc.hpp"
 #include "rtk_measurement.hpp"
 #include "rtk_selection.hpp"
 #include "rtk_slip_detection.hpp"
+#include "rtk_update.hpp"
 #include "rtk_validation.hpp"
+#include "safe_float_continuity.hpp"
+#include "safe_fix_state_machine.hpp"
 #include "spp.hpp"
 #include <libgnss++/fusion/dd_imu_bridge.hpp>
 #include <Eigen/Dense>
@@ -325,6 +331,10 @@ public:
         /// squared divided by active observations exceeds this threshold.
         /// 0 (default) disables the update gate.
         double max_update_nis_per_observation = 0.0;
+        /// Optional heavy-tailed measurement front end. It only inflates
+        /// measurement covariance before the float update and has no direct
+        /// integer/FIX authority.
+        rtk_update::StudentTFrontEndConfig student_t_front_end;
 
         /// Reject only FIXED ambiguity candidates when the preceding RTK DD
         /// update NIS divided by active observations exceeds this threshold.
@@ -409,6 +419,100 @@ public:
 
         /// Max pairs to drop progressively in BSR-guided decimation.
         int bsr_guided_max_drop_steps = 6;
+
+        /// Number of MLAMBDA integer candidates recorded by the full-set
+        /// shadow diagnostic. 0 (default) disables the extra search and is
+        /// output-identical to the pre-WP174 solver. The shadow result never
+        /// changes a FIX decision or filter state.
+        int lambda_candidate_shadow_count = 0;
+
+        /// Optional success-rate-criterion partial-AR shadow. A threshold of
+        /// 0 (default) disables it. Positive values select the largest trailing
+        /// decorrelated subset meeting the covariance-only success rate. This
+        /// diagnostic never changes a FIX decision or filter state.
+        double lambda_src_par_shadow_success_rate = 0.0;
+        double lambda_src_par_shadow_covariance_scale = 1.0;
+
+        /// Shadow-only satellite-group sequential PAR. A positive value drops
+        /// at most this many worst-ranked satellites (all frequency legs
+        /// together), stopping at the first subset that passes covariance-
+        /// scaled FFRT. 0 (default) is output-identical to the legacy path.
+        int lambda_satellite_par_shadow_max_drop_steps = 0;
+        double lambda_satellite_par_shadow_covariance_scale = 16.0;
+        bool lambda_satellite_par_shadow_quality_diverse = false;
+        bool lambda_satellite_par_persistent_subset = false;
+        bool lambda_satellite_par_only_after_full_ffrt_failure = false;
+
+        /// Shadow-only two-stage L1/L5 ambiguity diagnostic. L5 observations
+        /// are collected without adding L5 states or measurements to the
+        /// production filter. Wide-lane and subsequent L1 narrow-lane
+        /// searches must each pass covariance-scale-16 FFRT. The result never
+        /// changes a FIX decision, filter state, or PositionSolution.
+        bool lambda_l1_l5_wlnl_shadow = false;
+        bool lambda_l1_l2_wlnl_shadow = false;
+        bool lambda_l2_l5_wlnl_shadow = false;
+        double lambda_l1_l5_wlnl_shadow_covariance_scale = 16.0;
+        bool lambda_l1_l5_wlnl_causal_arc_smoothing = false;
+        causal_ambiguity_arc::Config
+            lambda_l1_l5_wlnl_causal_arc_config;
+        bool lambda_causal_arc_readiness_shadow = false;
+        causal_ambiguity_arc::Config
+            lambda_causal_arc_readiness_config;
+        double lambda_causal_arc_readiness_covariance_scale = 16.0;
+        bool lambda_causal_arc_smoothed_search = false;
+        int lambda_causal_arc_smoothed_max_pairs = 0;
+
+        /// Runtime shadow-only FIX/hold/revoke state machine. Disabled by
+        /// default and never changes PositionSolution or filter state.
+        safe_fix::Config safe_fix_shadow_state_machine;
+        /// Separate causal certificate for the closest-pair consensus of
+        /// primary and two disjoint-satellite validators. Default-off.
+        safe_fix::Config disjoint_consensus_state_machine;
+        safe_fix::Config causal_arc_consensus_state_machine;
+        bool causal_arc_consensus_promotion = false;
+        safe_fix::Config satellite_par_consensus_state_machine;
+        bool satellite_par_consensus_promotion = false;
+        safe_fix::Config src_par_consensus_state_machine;
+        bool src_par_consensus_promotion = false;
+        safe_fix::Config inertial_referenced_consensus_state_machine;
+        bool inertial_referenced_consensus_promotion = false;
+        safe_fix::Config multifrequency_consensus_state_machine;
+        bool multifrequency_consensus_promotion = false;
+        bool disjoint_consensus_use_selected_pair_ratio = false;
+        fixed_quality_gate::Config library_fixed_quality_gate;
+        int safe_fix_shadow_covariance_scale = 16;
+        int safe_fix_shadow_minimum_pairs = 16;
+        double safe_fix_shadow_maximum_second_position_delta_m = 0.05;
+        double safe_fix_shadow_maximum_nis_per_observation = 3.0;
+        double safe_fix_shadow_maximum_prefit_residual_rms_m = 50.0;
+        // Optional causal INS solution-separation source.  Evidence is
+        // supplied before processRTKEpoch(), must be propagated to the
+        // current epoch without that epoch's GNSS position update, and is
+        // accepted only when it descends from a prior independently-budgeted
+        // FIX anchor.
+        double inertial_fix_evidence_max_time_error_s = 0.05;
+        double inertial_fix_evidence_covariance_scale = 16.0;
+        // chi-square(3 dof, 0.999) / 3 = 5.422. The absolute bound is only
+        // a gross-corruption guard; statistical acceptance is governed by
+        // the covariance-normalized threshold.
+        double inertial_fix_evidence_max_nis_per_dimension = 5.422;
+        double inertial_fix_evidence_max_position_delta_m = 2.0;
+        double inertial_fix_evidence_failure_probability = 0.001;
+        // Optional pair of independently propagated RTK solutions built
+        // from disjoint GNSS-system partitions. Both partitions must pass
+        // their own FFRT and agree with each other and the primary
+        // declaration-time candidate.
+        double disjoint_satellite_fix_max_partition_separation_m = 0.25;
+        double disjoint_satellite_fix_max_primary_separation_m = 0.25;
+        double disjoint_satellite_fix_covariance_scale = 16.0;
+        double disjoint_satellite_fix_max_nis_per_dimension = 5.422;
+        double disjoint_satellite_fix_max_statistical_separation_m = 2.0;
+        double disjoint_satellite_fix_failure_probability = 0.001;
+
+        /// Optional FLOAT-only continuity for short observation outages.
+        /// Disabled by default, never declares FIX, and fails closed without
+        /// a finite trusted anchor and recent bounded Doppler velocity.
+        safe_float_continuity::Config safe_float_continuity;
 
         /// WP7: NLOS/multipath measurement-weighting sigma-inflation mapping.
         /// OFF (default) preserves pre-WP7 behavior bit-for-bit — the lookup
@@ -748,6 +852,322 @@ public:
 
         bool full_lambda_solved = false;
         double full_ratio = std::numeric_limits<double>::quiet_NaN();
+        bool lambda_shadow_attempted = false;
+        bool lambda_shadow_solved = false;
+        double lambda_shadow_runtime_ms =
+            std::numeric_limits<double>::quiet_NaN();
+        int lambda_shadow_candidate_count = 0;
+        double lambda_shadow_bsr = std::numeric_limits<double>::quiet_NaN();
+        double lambda_shadow_bsr_qscale2 =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_shadow_bsr_qscale4 =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_shadow_bsr_qscale8 =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_shadow_bsr_qscale16 =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_shadow_best_cost = std::numeric_limits<double>::quiet_NaN();
+        double lambda_shadow_second_cost = std::numeric_limits<double>::quiet_NaN();
+        double lambda_shadow_best_mass = std::numeric_limits<double>::quiet_NaN();
+        double lambda_shadow_effective_candidates =
+            std::numeric_limits<double>::quiet_NaN();
+        int lambda_shadow_best_second_disagreements = 0;
+        bool lambda_shadow_ffrt_table_supported = false;
+        bool lambda_shadow_ffrt_accepts_any = false;
+        bool lambda_shadow_ffrt_passed = false;
+        double lambda_shadow_ffrt_min_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_shadow_best_ecef_x =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_shadow_best_ecef_y =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_shadow_best_ecef_z =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_shadow_best_correction_x =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_shadow_best_correction_y =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_shadow_best_correction_z =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_shadow_second_ecef_x =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_shadow_second_ecef_y =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_shadow_second_ecef_z =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_shadow_second_correction_x =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_shadow_second_correction_y =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_shadow_second_correction_z =
+            std::numeric_limits<double>::quiet_NaN();
+        Eigen::Matrix<double, 8, 1> lambda_shadow_candidate_costs =
+            Eigen::Matrix<double, 8, 1>::Constant(
+                std::numeric_limits<double>::quiet_NaN());
+        Eigen::Matrix<double, 3, 8> lambda_shadow_candidate_ecef_m =
+            Eigen::Matrix<double, 3, 8>::Constant(
+                std::numeric_limits<double>::quiet_NaN());
+        double lambda_shadow_second_position_delta_m =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_shadow_position_spread_max_m =
+            std::numeric_limits<double>::quiet_NaN();
+        bool lambda_src_par_shadow_attempted = false;
+        bool lambda_src_par_shadow_solved = false;
+        int lambda_src_par_shadow_subset_size = 0;
+        double lambda_src_par_shadow_bsr =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_src_par_shadow_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_src_par_shadow_ffrt_min_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        bool lambda_src_par_shadow_ffrt_passed = false;
+        double lambda_src_par_shadow_best_ecef_x =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_src_par_shadow_best_ecef_y =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_src_par_shadow_best_ecef_z =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_src_par_shadow_best_correction_x =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_src_par_shadow_best_correction_y =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_src_par_shadow_best_correction_z =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_src_par_shadow_second_position_delta_m =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_src_par_shadow_runtime_ms =
+            std::numeric_limits<double>::quiet_NaN();
+        bool lambda_satellite_par_shadow_attempted = false;
+        int lambda_satellite_par_shadow_subsets_evaluated = 0;
+        bool lambda_satellite_par_shadow_solved = false;
+        int lambda_satellite_par_shadow_subset_size = 0;
+        int lambda_satellite_par_shadow_dropped_satellites = 0;
+        double lambda_satellite_par_shadow_bsr =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_satellite_par_shadow_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_satellite_par_shadow_ffrt_min_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        bool lambda_satellite_par_shadow_ffrt_passed = false;
+        double lambda_satellite_par_shadow_best_ecef_x =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_satellite_par_shadow_best_ecef_y =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_satellite_par_shadow_best_ecef_z =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_satellite_par_shadow_best_correction_x =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_satellite_par_shadow_best_correction_y =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_satellite_par_shadow_best_correction_z =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_satellite_par_shadow_second_position_delta_m =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_satellite_par_shadow_runtime_ms =
+            std::numeric_limits<double>::quiet_NaN();
+        bool lambda_satellite_par_persistent_subset_attempted = false;
+        bool lambda_satellite_par_persistent_subset_used = false;
+        bool lambda_l1_l5_wlnl_shadow_attempted = false;
+        int lambda_l1_l5_wlnl_shadow_pair_count = 0;
+        double lambda_l1_l5_wlnl_shadow_wl_bsr =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_l1_l5_wlnl_shadow_wl_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_l1_l5_wlnl_shadow_wl_ffrt_min_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        bool lambda_l1_l5_wlnl_shadow_wl_ffrt_passed = false;
+        int lambda_l1_l5_wlnl_shadow_mw_disagreements = 0;
+        int lambda_l1_l5_wlnl_shadow_raw_mw_disagreements = 0;
+        int lambda_l1_l5_wlnl_shadow_causal_arc_ready_pairs = 0;
+        int lambda_l1_l5_wlnl_shadow_causal_arc_resets = 0;
+        double lambda_l1_l5_wlnl_shadow_nl_bsr =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_l1_l5_wlnl_shadow_nl_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_l1_l5_wlnl_shadow_nl_ffrt_min_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        bool lambda_l1_l5_wlnl_shadow_nl_ffrt_passed = false;
+        double lambda_l1_l5_wlnl_shadow_best_ecef_x =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_l1_l5_wlnl_shadow_best_ecef_y =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_l1_l5_wlnl_shadow_best_ecef_z =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_l1_l5_wlnl_shadow_runtime_ms =
+            std::numeric_limits<double>::quiet_NaN();
+        int lambda_l1_l5_wlnl_shadow_candidate_pair_count = 0;
+        bool lambda_l1_l2_wlnl_shadow_attempted = false;
+        int lambda_l1_l2_wlnl_shadow_pair_count = 0;
+        double lambda_l1_l2_wlnl_shadow_wl_bsr =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_l1_l2_wlnl_shadow_wl_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_l1_l2_wlnl_shadow_wl_ffrt_min_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        bool lambda_l1_l2_wlnl_shadow_wl_ffrt_passed = false;
+        int lambda_l1_l2_wlnl_shadow_mw_disagreements = 0;
+        int lambda_l1_l2_wlnl_shadow_raw_mw_disagreements = 0;
+        int lambda_l1_l2_wlnl_shadow_causal_arc_ready_pairs = 0;
+        int lambda_l1_l2_wlnl_shadow_causal_arc_resets = 0;
+        double lambda_l1_l2_wlnl_shadow_nl_bsr =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_l1_l2_wlnl_shadow_nl_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_l1_l2_wlnl_shadow_nl_ffrt_min_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        bool lambda_l1_l2_wlnl_shadow_nl_ffrt_passed = false;
+        double lambda_l1_l2_wlnl_shadow_best_ecef_x =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_l1_l2_wlnl_shadow_best_ecef_y =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_l1_l2_wlnl_shadow_best_ecef_z =
+            std::numeric_limits<double>::quiet_NaN();
+        int lambda_l1_l2_wlnl_shadow_candidate_pair_count = 0;
+        bool lambda_l2_l5_wlnl_shadow_attempted = false;
+        int lambda_l2_l5_wlnl_shadow_pair_count = 0;
+        double lambda_l2_l5_wlnl_shadow_wl_bsr =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_l2_l5_wlnl_shadow_wl_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_l2_l5_wlnl_shadow_wl_ffrt_min_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        bool lambda_l2_l5_wlnl_shadow_wl_ffrt_passed = false;
+        int lambda_l2_l5_wlnl_shadow_mw_disagreements = 0;
+        int lambda_l2_l5_wlnl_shadow_raw_mw_disagreements = 0;
+        int lambda_l2_l5_wlnl_shadow_causal_arc_ready_pairs = 0;
+        int lambda_l2_l5_wlnl_shadow_causal_arc_resets = 0;
+        double lambda_l2_l5_wlnl_shadow_nl_bsr =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_l2_l5_wlnl_shadow_nl_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_l2_l5_wlnl_shadow_nl_ffrt_min_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        bool lambda_l2_l5_wlnl_shadow_nl_ffrt_passed = false;
+        double lambda_l2_l5_wlnl_shadow_best_ecef_x =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_l2_l5_wlnl_shadow_best_ecef_y =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_l2_l5_wlnl_shadow_best_ecef_z =
+            std::numeric_limits<double>::quiet_NaN();
+        int lambda_l2_l5_wlnl_shadow_candidate_pair_count = 0;
+        bool lambda_causal_arc_readiness_attempted = false;
+        int lambda_causal_arc_ready_pairs = 0;
+        int lambda_causal_arc_resets = 0;
+        int lambda_causal_arc_total_pairs = 0;
+        int lambda_causal_arc_subset_pair_count = 0;
+        bool lambda_causal_arc_subset_solved = false;
+        double lambda_causal_arc_subset_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_causal_arc_subset_bsr =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_causal_arc_subset_variance_min =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_causal_arc_subset_variance_max =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_causal_arc_subset_ffrt_min_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        bool lambda_causal_arc_subset_ffrt_passed = false;
+        double lambda_causal_arc_subset_best_ecef_x =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_causal_arc_subset_best_ecef_y =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_causal_arc_subset_best_ecef_z =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_causal_arc_subset_second_position_delta_m =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_causal_arc_subset_partition_a_separation_m =
+            std::numeric_limits<double>::quiet_NaN();
+        double lambda_causal_arc_subset_partition_b_separation_m =
+            std::numeric_limits<double>::quiet_NaN();
+        bool safe_fix_shadow_enabled = false;
+        int safe_fix_shadow_state = 0;
+        bool safe_fix_shadow_declared_fixed = false;
+        bool safe_fix_shadow_candidate_accepted = false;
+        bool safe_fix_shadow_held = false;
+        bool safe_fix_shadow_revoked = false;
+        bool safe_fix_shadow_strong_acquisition = false;
+        bool safe_fix_shadow_change_point_acquisition = false;
+        int safe_fix_shadow_acquisition_streak = 0;
+        int safe_fix_shadow_hold_epochs = 0;
+        bool disjoint_consensus_declared_fixed = false;
+        int disjoint_consensus_state = 0;
+        int disjoint_consensus_acquisition_streak = 0;
+        int disjoint_consensus_selected_pair = 0;
+        double disjoint_consensus_selected_pair_min_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        bool causal_arc_consensus_declared_fixed = false;
+        int causal_arc_consensus_state = 0;
+        int causal_arc_consensus_acquisition_streak = 0;
+        bool causal_arc_disjoint_evidence_passed = false;
+        bool satellite_par_disjoint_evidence_passed = false;
+        bool satellite_par_consensus_declared_fixed = false;
+        int satellite_par_consensus_state = 0;
+        int satellite_par_consensus_acquisition_streak = 0;
+        bool src_par_disjoint_evidence_passed = false;
+        double src_par_partition_a_separation_m =
+            std::numeric_limits<double>::quiet_NaN();
+        double src_par_partition_b_separation_m =
+            std::numeric_limits<double>::quiet_NaN();
+        bool src_par_consensus_declared_fixed = false;
+        int src_par_consensus_state = 0;
+        int src_par_consensus_acquisition_streak = 0;
+        bool inertial_referenced_consensus_declared_fixed = false;
+        int inertial_referenced_consensus_state = 0;
+        int inertial_referenced_consensus_acquisition_streak = 0;
+        double inertial_referenced_correction_x =
+            std::numeric_limits<double>::quiet_NaN();
+        double inertial_referenced_correction_y =
+            std::numeric_limits<double>::quiet_NaN();
+        double inertial_referenced_correction_z =
+            std::numeric_limits<double>::quiet_NaN();
+        bool multifrequency_disjoint_evidence_passed = false;
+        bool multifrequency_consensus_declared_fixed = false;
+        int multifrequency_consensus_state = 0;
+        int multifrequency_consensus_acquisition_streak = 0;
+        bool l1_l2_multifrequency_disjoint_evidence_passed = false;
+        bool l1_l2_multifrequency_consensus_declared_fixed = false;
+        int l1_l2_multifrequency_consensus_state = 0;
+        int l1_l2_multifrequency_consensus_acquisition_streak = 0;
+        double safe_fix_shadow_independent_consensus_delta_m =
+            std::numeric_limits<double>::quiet_NaN();
+        int safe_fix_shadow_independent_source_families = 0;
+        double safe_fix_shadow_joint_failure_probability = 1.0;
+        bool safe_fix_shadow_failure_budget_passed = false;
+        bool inertial_fix_evidence_available = false;
+        bool inertial_fix_evidence_healthy_anchor = false;
+        bool inertial_fix_evidence_passed = false;
+        double inertial_fix_evidence_time_error_s =
+            std::numeric_limits<double>::quiet_NaN();
+        double inertial_fix_evidence_position_delta_m =
+            std::numeric_limits<double>::quiet_NaN();
+        double inertial_fix_evidence_nis_per_dimension =
+            std::numeric_limits<double>::quiet_NaN();
+        bool disjoint_satellite_fix_evidence_available = false;
+        bool disjoint_satellite_fix_inputs_verified = false;
+        bool disjoint_satellite_fix_partition_a_ffrt_passed = false;
+        bool disjoint_satellite_fix_partition_b_ffrt_passed = false;
+        bool disjoint_satellite_fix_evidence_passed = false;
+        double disjoint_satellite_fix_partition_separation_m =
+            std::numeric_limits<double>::quiet_NaN();
+        double disjoint_satellite_fix_partition_a_primary_separation_m =
+            std::numeric_limits<double>::quiet_NaN();
+        double disjoint_satellite_fix_partition_b_primary_separation_m =
+            std::numeric_limits<double>::quiet_NaN();
+        bool disjoint_satellite_fix_hard_separation_passed = false;
+        bool disjoint_satellite_fix_statistical_separation_passed = false;
+        double disjoint_satellite_fix_partition_nis_per_dimension =
+            std::numeric_limits<double>::quiet_NaN();
+        double disjoint_satellite_fix_partition_a_primary_nis_per_dimension =
+            std::numeric_limits<double>::quiet_NaN();
+        double disjoint_satellite_fix_partition_b_primary_nis_per_dimension =
+            std::numeric_limits<double>::quiet_NaN();
+        bool safe_float_continuity_attempted = false;
+        bool safe_float_continuity_used = false;
+        bool safe_float_continuity_solver_gap_anchor = false;
+        double safe_float_continuity_anchor_age_s =
+            std::numeric_limits<double>::quiet_NaN();
+        double safe_float_continuity_velocity_age_s =
+            std::numeric_limits<double>::quiet_NaN();
         bool selected_fixed = false;
         double selected_ratio = std::numeric_limits<double>::quiet_NaN();
         int selected_pair_count = 0;
@@ -812,6 +1232,30 @@ public:
         int tdcp_rejected_invalid = 0;
         double tdcp_residual_rms_m = std::numeric_limits<double>::quiet_NaN();
         double tdcp_residual_max_abs_m = std::numeric_limits<double>::quiet_NaN();
+        bool library_fixed_quality_gate_enabled = false;
+        int library_fixed_quality_gate_original_status = 0;
+        double library_fixed_quality_gate_original_ecef_x =
+            std::numeric_limits<double>::quiet_NaN();
+        double library_fixed_quality_gate_original_ecef_y =
+            std::numeric_limits<double>::quiet_NaN();
+        double library_fixed_quality_gate_original_ecef_z =
+            std::numeric_limits<double>::quiet_NaN();
+        double library_fixed_quality_gate_original_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        bool library_fixed_quality_gate_passed = false;
+        bool library_fixed_quality_gate_safe_shadow_branch = false;
+        bool library_fixed_quality_gate_covariance_branch = false;
+        bool library_fixed_quality_gate_strong_innovation_branch = false;
+        bool library_fixed_quality_gate_promoted = false;
+        bool library_fixed_quality_gate_disjoint_consensus_promoted = false;
+        bool library_fixed_quality_gate_causal_arc_promoted = false;
+        bool library_fixed_quality_gate_satellite_par_promoted = false;
+        bool library_fixed_quality_gate_src_par_promoted = false;
+        bool library_fixed_quality_gate_inertial_referenced_promoted =
+            false;
+        bool library_fixed_quality_gate_multifrequency_promoted = false;
+        bool library_fixed_quality_gate_raw_partition_conflict = false;
+        bool library_fixed_quality_gate_demoted = false;
         std::string reject_reason;
         ARSkipReason ar_skip_reason{ARSkipReason::NONE};
 
@@ -827,6 +1271,11 @@ public:
             std::numeric_limits<double>::quiet_NaN();
         double float_update_nis_per_observation = std::numeric_limits<double>::quiet_NaN();
         int float_update_suppressed_outliers = 0;
+        int float_update_student_t_downweighted_rows = 0;
+        double float_update_student_t_minimum_weight =
+            std::numeric_limits<double>::quiet_NaN();
+        double float_update_student_t_mean_weight =
+            std::numeric_limits<double>::quiet_NaN();
         // Trace (sum of diagonal) of the float filter's 3x3 ECEF position
         // covariance block, sampled just after this epoch's measurement
         // update -- a direct, model-based answer to "is the float position
@@ -862,6 +1311,56 @@ public:
     PositionSolution processRTKEpoch(const ObservationData& rover_obs,
                                    const ObservationData& base_obs,
                                    const NavigationData& nav);
+
+    struct ExternalInertialFixEvidence {
+        bool available = false;
+        bool healthy_independent_anchor = false;
+        GNSSTime time;
+        Vector3d position_ecef = Vector3d::Zero();
+        Matrix3d position_covariance_ecef = Matrix3d::Zero();
+    };
+
+    struct ExternalDisjointSatelliteFixEvidence {
+        bool available = false;
+        bool inputs_verified_disjoint = false;
+        bool partition_a_ffrt_passed = false;
+        bool partition_b_ffrt_passed = false;
+        double partition_a_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        double partition_b_ratio =
+            std::numeric_limits<double>::quiet_NaN();
+        Vector3d partition_a_candidate_ecef =
+            Vector3d::Constant(
+                std::numeric_limits<double>::quiet_NaN());
+        Vector3d partition_b_candidate_ecef =
+            Vector3d::Constant(
+                std::numeric_limits<double>::quiet_NaN());
+        Matrix3d partition_a_covariance_ecef =
+            Matrix3d::Constant(
+                std::numeric_limits<double>::quiet_NaN());
+        Matrix3d partition_b_covariance_ecef =
+            Matrix3d::Constant(
+                std::numeric_limits<double>::quiet_NaN());
+    };
+
+    /// Install a one-epoch, pre-GNSS-update INS prediction. It is consumed by
+    /// the next processRTKEpoch() call and then cleared.
+    void setExternalInertialFixEvidence(
+        const ExternalInertialFixEvidence& evidence) {
+        external_inertial_fix_evidence_ = evidence;
+    }
+
+    /// Install one-epoch candidates from RTK processors whose input
+    /// satellite sets were verified disjoint by the caller.
+    void setExternalDisjointSatelliteFixEvidence(
+        const ExternalDisjointSatelliteFixEvidence& evidence) {
+        external_disjoint_satellite_fix_evidence_ = evidence;
+    }
+
+    /// Apply the default-off FIX quality policy to the exported solution.
+    /// With the independent-budget option enabled, the same policy is also
+    /// enforced before ambiguity/hold state is committed.
+    void applyLibraryFixedQualityGate(PositionSolution& solution);
 
     /**
      * @brief Doppler observation sigma (1-sigma, m/s at zenith) used by the
@@ -1019,6 +1518,19 @@ private:
     RTKConfig rtk_config_;
     SPPProcessor spp_processor_;
     EpochDebugTelemetry debug_telemetry_;
+    safe_fix::StateMachine safe_fix_shadow_state_machine_;
+    safe_fix::StateMachine disjoint_consensus_state_machine_;
+    safe_fix::StateMachine causal_arc_consensus_state_machine_;
+    safe_fix::StateMachine satellite_par_consensus_state_machine_;
+    safe_fix::StateMachine src_par_consensus_state_machine_;
+    safe_fix::StateMachine inertial_referenced_consensus_state_machine_;
+    safe_fix::StateMachine multifrequency_consensus_state_machine_;
+    safe_fix::StateMachine l1_l2_multifrequency_consensus_state_machine_;
+    std::set<SatelliteId> satellite_par_persistent_satellites_;
+    bool independent_failure_budget_evaluated_this_epoch_ = false;
+    ExternalInertialFixEvidence external_inertial_fix_evidence_;
+    ExternalDisjointSatelliteFixEvidence
+        external_disjoint_satellite_fix_evidence_;
     double doppler_velocity_sigma_mps_ = 0.5;
     Vector3d last_doppler_velocity_ecef_ = Vector3d::Zero();
     GNSSTime last_doppler_velocity_time_;
@@ -1039,6 +1551,8 @@ private:
     PositionSolution processRTKEpochInternal(const ObservationData& rover_obs,
                                              const ObservationData& base_obs,
                                              const NavigationData& nav);
+    void updateIndependentFailureBudgetTelemetry();
+    void updateSafeFixShadowStateMachine(const GNSSTime& time);
 
     Vector3d base_position_;
     bool base_position_known_ = false;
@@ -1333,6 +1847,11 @@ private:
     std::map<SatelliteId, double> code_phase_history_l1_m_;
     std::map<SatelliteId, double> code_phase_history_l2_m_;
     std::map<SatelliteId, double> code_phase_history_l5_m_;  // Phase 18 Step 5
+    std::set<SatelliteId> current_epoch_slips_l1_;
+    std::set<SatelliteId> current_epoch_slips_l2_;
+    std::set<SatelliteId> current_epoch_slips_l5_;
+    causal_ambiguity_arc::Bank l1_l5_mw_arc_bank_;
+    causal_ambiguity_arc::Bank ambiguity_arc_bank_;
 
     struct TdcpHistory {
         double phase_m = 0.0;
@@ -1493,6 +2012,7 @@ private:
                                     SolutionStatus status,
                                     int num_satellites);
     void rememberSolution(const PositionSolution& solution);
+    PositionSolution makeSafeFloatContinuity(const GNSSTime& time);
 
     void updateStatistics(SolutionStatus status) const;
 

--- a/include/libgnss++/algorithms/rtk_ar_selection.hpp
+++ b/include/libgnss++/algorithms/rtk_ar_selection.hpp
@@ -3,6 +3,7 @@
 #include "../core/observation.hpp"
 
 #include <Eigen/Dense>
+#include <limits>
 #include <vector>
 
 namespace libgnss {
@@ -11,6 +12,20 @@ namespace rtk_ar_selection {
 struct PairDescriptor {
     GNSSSystem system = GNSSSystem::GPS;
     double variance = 0.0;
+    SatelliteId satellite;
+    double elevation_rad = std::numeric_limits<double>::quiet_NaN();
+    double snr_dbhz = std::numeric_limits<double>::quiet_NaN();
+    double fractional_distance_cycles =
+        std::numeric_limits<double>::quiet_NaN();
+    // Absolute posterior distance from the nearest integer, expressed in
+    // range units. This avoids comparing cycle residuals across frequencies
+    // with different wavelengths.
+    double posterior_abs_residual_m =
+        std::numeric_limits<double>::quiet_NaN();
+    // Earth-local azimuth is used only to identify geometrically redundant
+    // (crowded) satellites. Body-frame azimuth can replace it once a causal
+    // runtime attitude is available.
+    double azimuth_rad = std::numeric_limits<double>::quiet_NaN();
 };
 
 std::vector<int> filterPairsByRelativeVariance(const std::vector<PairDescriptor>& pairs,
@@ -53,6 +68,48 @@ std::vector<std::vector<int>> buildBSRGuidedDropSubsets(
     int minimum_pairs = 4,
     int max_drop_steps = 6,
     int worst_axes = 3);
+
+// Satellite-group sequential PAR for urban conditions. All frequencies of a
+// target satellite are removed together, avoiding mixed subsets that retain a
+// contaminated L1 or L2 leg. Satellites are ranked without position truth by
+// equal-weight ordinal ranks of ambiguity variance, posterior integer
+// residual in metres, distance to the nearest integer, low elevation, low
+// SNR, and azimuth crowding. The returned sequence is largest-first: one
+// additional satellite is removed at each step until minimum_pairs or
+// max_drop_steps is reached.
+std::vector<std::vector<int>> buildSatelliteQualityDropSubsets(
+    const std::vector<PairDescriptor>& pairs,
+    int minimum_pairs = 4,
+    int max_drop_steps = 6);
+
+// Quality-diverse satellite PAR. The combined ordinal ranking above is
+// evaluated first for backward compatibility, followed by deduplicated
+// nested drop paths driven separately by variance, posterior residual,
+// fractional distance, elevation, SNR, and azimuth crowding. This prevents
+// one compromised metric from averaging away a useful exclusion path.
+std::vector<std::vector<int>> buildSatelliteQualityDiverseDropSubsets(
+    const std::vector<PairDescriptor>& pairs,
+    int minimum_pairs = 4,
+    int max_drop_steps = 6,
+    int maximum_subsets = 32);
+
+// Condition the narrow-lane (N1) float state on an independently fixed
+// wide-lane relation w = N1 - N5. Q_w must include the uncertainty of both
+// N1 and the independently derived N5 term. The cross-covariances with w are
+// conservatively taken as Cov(N1,w)=Q_n1 and Cov(head,w)=Q_head_n1.
+// Returns false on non-finite, singular, or dimensionally inconsistent input.
+bool conditionNarrowLaneOnFixedWideLane(
+    const Eigen::VectorXd& head_state,
+    const Eigen::MatrixXd& Q_head_n1,
+    const Eigen::VectorXd& n1_float,
+    const Eigen::MatrixXd& Q_n1,
+    const Eigen::VectorXd& wide_lane_float,
+    const Eigen::MatrixXd& Q_wide_lane,
+    const Eigen::VectorXd& fixed_wide_lane,
+    Eigen::VectorXd& conditioned_head_state,
+    Eigen::MatrixXd& conditioned_Q_head_n1,
+    Eigen::VectorXd& conditioned_n1_float,
+    Eigen::MatrixXd& conditioned_Q_n1);
 
 }  // namespace rtk_ar_selection
 }  // namespace libgnss

--- a/include/libgnss++/algorithms/rtk_measurement.hpp
+++ b/include/libgnss++/algorithms/rtk_measurement.hpp
@@ -53,6 +53,7 @@ struct MeasurementSystem {
     // live in the m/s domain and must not be judged by the metre-domain
     // threshold.
     std::vector<double> row_outlier_thresholds;
+    std::vector<MeasurementKind> row_kinds;
 };
 
 struct MeasurementDiagnostics {

--- a/include/libgnss++/algorithms/rtk_update.hpp
+++ b/include/libgnss++/algorithms/rtk_update.hpp
@@ -9,6 +9,29 @@
 namespace libgnss {
 namespace rtk_update {
 
+enum class HeavyTailWeightModel {
+    STUDENT_T,
+    LAPLACIAN,
+    HUBER,
+};
+
+struct StudentTFrontEndConfig {
+    bool enabled = false;
+    bool code_only = true;
+    HeavyTailWeightModel weight_model =
+        HeavyTailWeightModel::STUDENT_T;
+    double degrees_of_freedom = 4.0;
+    double minimum_weight = 0.05;
+    double activation_threshold_sigma = 2.5;
+};
+
+struct StudentTFrontEndResult {
+    bool applied = false;
+    int downweighted_rows = 0;
+    double minimum_weight = 1.0;
+    double mean_weight = 1.0;
+};
+
 struct FilterUpdateResult {
     bool ok = false;
     bool rejected_by_innovation_gate = false;
@@ -28,7 +51,18 @@ struct FilterUpdateResult {
     // innovation-based adaptive measurement noise tracker.
     Eigen::VectorXd row_innovations;
     Eigen::VectorXd row_hph_diagonal;
+    StudentTFrontEndResult student_t;
 };
+
+StudentTFrontEndResult applyStudentTMeasurementWeights(
+    const Eigen::VectorXd& residuals,
+    Eigen::MatrixXd& measurement_covariance,
+    const StudentTFrontEndConfig& config);
+StudentTFrontEndResult applyStudentTMeasurementWeights(
+    const Eigen::VectorXd& residuals,
+    const Eigen::VectorXd& innovation_variances,
+    Eigen::MatrixXd& measurement_covariance,
+    const StudentTFrontEndConfig& config);
 
 FilterUpdateResult applyMeasurementUpdate(Eigen::VectorXd& state,
                                           Eigen::MatrixXd& covariance,
@@ -38,7 +72,8 @@ FilterUpdateResult applyMeasurementUpdate(Eigen::VectorXd& state,
                                           double max_normalized_innovation_squared_per_observation = 0.0,
                                           const std::vector<bool>& force_active = {},
                                           bool compute_row_stats = false,
-                                          bool reuse_kalman_factorization_for_nis = false);
+                                          bool reuse_kalman_factorization_for_nis = false,
+                                          const StudentTFrontEndConfig& student_t_config = {});
 
 }  // namespace rtk_update
 }  // namespace libgnss

--- a/include/libgnss++/algorithms/safe_fix_state_machine.hpp
+++ b/include/libgnss++/algorithms/safe_fix_state_machine.hpp
@@ -1,0 +1,296 @@
+#pragma once
+
+#include <Eigen/Core>
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace libgnss::safe_fix {
+
+enum class State {
+    DISABLED = 0,
+    IDLE = 1,
+    ACQUIRING = 2,
+    FIXED = 3,
+    HELD = 4,
+    REVOKED = 5,
+};
+
+struct Config {
+    bool enabled = false;
+    bool require_independent_failure_budget = false;
+    int acquisition_streak_epochs = 12;
+    double maximum_epoch_gap_s = 0.21;
+    double maximum_acquisition_correction_jump_m = 0.03;
+    int maximum_hold_epochs = 100;
+    double maximum_hold_correction_jump_m = 0.06;
+    double maximum_hold_nis_per_observation = 50.0;
+    double maximum_hold_prefit_residual_rms_m = 50.0;
+    int minimum_hold_pairs = 16;
+    double minimum_absolute_ratio = 0.0;
+    double maximum_independent_consensus_delta_m =
+        std::numeric_limits<double>::infinity();
+    bool allow_strong_instant_acquisition = false;
+    bool allow_change_point_acquisition = false;
+    double minimum_change_point_jump_m = 0.40;
+    double maximum_change_point_stable_jump_m = 0.02;
+    int change_point_streak_epochs = 3;
+};
+
+struct Candidate {
+    double time_s = 0.0;
+    bool acquisition_eligible = false;
+    Eigen::Vector3d correction_m =
+        Eigen::Vector3d::Constant(std::numeric_limits<double>::quiet_NaN());
+    double nis_per_observation = std::numeric_limits<double>::quiet_NaN();
+    double prefit_residual_rms_m =
+        std::numeric_limits<double>::quiet_NaN();
+    int pair_count = 0;
+    double ambiguity_ratio = std::numeric_limits<double>::quiet_NaN();
+    double independent_consensus_delta_m =
+        std::numeric_limits<double>::quiet_NaN();
+    bool strong_acquisition_eligible = false;
+    bool change_point_acquisition_eligible = false;
+    bool independent_failure_budget_passed = false;
+};
+
+struct Decision {
+    State state = State::DISABLED;
+    bool declared_fixed = false;
+    bool candidate_accepted = false;
+    bool held = false;
+    bool revoked = false;
+    bool strong_acquisition = false;
+    bool change_point_acquisition = false;
+    bool independent_failure_budget_passed = false;
+    int acquisition_streak = 0;
+    int hold_epochs = 0;
+};
+
+class StateMachine {
+public:
+    Decision update(const Config& config, const Candidate& candidate) {
+        if (!config.enabled) {
+            reset();
+            return {};
+        }
+        const bool finite_time = std::isfinite(candidate.time_s);
+        const bool finite_correction = candidate.correction_m.allFinite();
+        const bool eligible =
+            finite_time && finite_correction &&
+            candidate.acquisition_eligible &&
+            (!config.require_independent_failure_budget ||
+             candidate.independent_failure_budget_passed) &&
+            (config.minimum_absolute_ratio <= 0.0 ||
+             (std::isfinite(candidate.ambiguity_ratio) &&
+              candidate.ambiguity_ratio >=
+                  config.minimum_absolute_ratio)) &&
+            (!std::isfinite(
+                 config.maximum_independent_consensus_delta_m) ||
+             (std::isfinite(
+                  candidate.independent_consensus_delta_m) &&
+              candidate.independent_consensus_delta_m <=
+                  config.maximum_independent_consensus_delta_m));
+        const bool hold_quality =
+            finite_time && finite_correction &&
+            std::isfinite(candidate.nis_per_observation) &&
+            candidate.nis_per_observation <=
+                config.maximum_hold_nis_per_observation &&
+            std::isfinite(candidate.prefit_residual_rms_m) &&
+            candidate.prefit_residual_rms_m <=
+                config.maximum_hold_prefit_residual_rms_m &&
+            candidate.pair_count >= config.minimum_hold_pairs;
+        const bool change_point_candidate_eligible =
+            candidate.change_point_acquisition_eligible &&
+            (!config.require_independent_failure_budget ||
+             candidate.independent_failure_budget_passed);
+
+        Decision decision;
+        decision.independent_failure_budget_passed =
+            candidate.independent_failure_budget_passed;
+        const bool was_declared =
+            state_ == State::FIXED || state_ == State::HELD;
+        bool change_point_ready = false;
+        if (!was_declared && config.allow_change_point_acquisition &&
+            finite_time && finite_correction) {
+            const bool contiguous =
+                have_change_point_previous_ &&
+                candidate.time_s > change_point_previous_time_s_ &&
+                candidate.time_s - change_point_previous_time_s_ <=
+                    config.maximum_epoch_gap_s;
+            const double jump =
+                have_change_point_previous_
+                    ? (candidate.correction_m -
+                       change_point_previous_correction_)
+                          .norm()
+                    : 0.0;
+            if (have_change_point_previous_ && contiguous &&
+                jump >= config.minimum_change_point_jump_m) {
+                change_point_armed_ = true;
+                change_point_streak_ =
+                    change_point_candidate_eligible ? 1 : 0;
+            } else if (
+                change_point_candidate_eligible &&
+                change_point_armed_ && contiguous &&
+                jump <= config.maximum_change_point_stable_jump_m) {
+                ++change_point_streak_;
+            } else if (!change_point_candidate_eligible) {
+                change_point_streak_ = 0;
+            } else {
+                // A time gap or an unstable correction breaks the evidence
+                // chain.  Keep the detector armed, but require a new fully
+                // contiguous stable streak before declaring FIX.
+                change_point_streak_ = 0;
+            }
+            change_point_previous_time_s_ = candidate.time_s;
+            change_point_previous_correction_ = candidate.correction_m;
+            have_change_point_previous_ = true;
+            change_point_ready =
+                change_point_armed_ &&
+                change_point_streak_ >=
+                    std::max(1, config.change_point_streak_epochs);
+        } else if (was_declared) {
+            clearChangePoint();
+        }
+        if (was_declared) {
+            const bool fixed_continuity =
+                eligible &&
+                candidate.time_s > last_declared_time_s_ &&
+                candidate.time_s - last_declared_time_s_ <=
+                    config.maximum_epoch_gap_s &&
+                (candidate.correction_m - last_fixed_correction_).norm() <=
+                    config.maximum_acquisition_correction_jump_m;
+            if (fixed_continuity) {
+                state_ = State::FIXED;
+                hold_epochs_ = 0;
+                last_fixed_correction_ = candidate.correction_m;
+                last_declared_time_s_ = candidate.time_s;
+                decision.declared_fixed = true;
+                decision.candidate_accepted = true;
+            } else if (
+                hold_quality && config.maximum_hold_epochs > 0 &&
+                hold_epochs_ < config.maximum_hold_epochs &&
+                candidate.time_s > last_declared_time_s_ &&
+                candidate.time_s - last_declared_time_s_ <=
+                    config.maximum_epoch_gap_s &&
+                (candidate.correction_m - last_fixed_correction_).norm() <=
+                    config.maximum_hold_correction_jump_m) {
+                state_ = State::HELD;
+                ++hold_epochs_;
+                last_fixed_correction_ = candidate.correction_m;
+                last_declared_time_s_ = candidate.time_s;
+                decision.declared_fixed = true;
+                decision.held = true;
+            } else {
+                state_ = State::REVOKED;
+                decision.revoked = true;
+                clearAcquisition();
+                hold_epochs_ = 0;
+            }
+        } else if (
+            change_point_ready &&
+            (!config.require_independent_failure_budget ||
+             candidate.independent_failure_budget_passed)) {
+            state_ = State::FIXED;
+            acquisition_streak_ = change_point_streak_;
+            last_fixed_correction_ = candidate.correction_m;
+            last_declared_time_s_ = candidate.time_s;
+            hold_epochs_ = 0;
+            decision.declared_fixed = true;
+            decision.candidate_accepted = true;
+            decision.change_point_acquisition = true;
+            clearChangePoint();
+        } else if (eligible) {
+            if (config.allow_strong_instant_acquisition &&
+                candidate.strong_acquisition_eligible) {
+                state_ = State::FIXED;
+                acquisition_streak_ = 1;
+                previous_candidate_time_s_ = candidate.time_s;
+                previous_candidate_correction_ = candidate.correction_m;
+                have_previous_candidate_ = true;
+                last_fixed_correction_ = candidate.correction_m;
+                last_declared_time_s_ = candidate.time_s;
+                hold_epochs_ = 0;
+                decision.declared_fixed = true;
+                decision.candidate_accepted = true;
+                decision.strong_acquisition = true;
+                decision.state = state_;
+                decision.acquisition_streak = acquisition_streak_;
+                decision.hold_epochs = hold_epochs_;
+                return decision;
+            }
+            const bool contiguous =
+                have_previous_candidate_ &&
+                candidate.time_s > previous_candidate_time_s_ &&
+                candidate.time_s - previous_candidate_time_s_ <=
+                    config.maximum_epoch_gap_s &&
+                (candidate.correction_m - previous_candidate_correction_)
+                        .norm() <=
+                    config.maximum_acquisition_correction_jump_m;
+            acquisition_streak_ = contiguous ? acquisition_streak_ + 1 : 1;
+            previous_candidate_time_s_ = candidate.time_s;
+            previous_candidate_correction_ = candidate.correction_m;
+            have_previous_candidate_ = true;
+            if (acquisition_streak_ >=
+                std::max(1, config.acquisition_streak_epochs)) {
+                state_ = State::FIXED;
+                last_fixed_correction_ = candidate.correction_m;
+                last_declared_time_s_ = candidate.time_s;
+                hold_epochs_ = 0;
+                decision.declared_fixed = true;
+                decision.candidate_accepted = true;
+            } else {
+                state_ = State::ACQUIRING;
+            }
+        } else {
+            state_ = State::IDLE;
+            clearAcquisition();
+        }
+        decision.state = state_;
+        decision.acquisition_streak = acquisition_streak_;
+        decision.hold_epochs = hold_epochs_;
+        return decision;
+    }
+
+    void reset() {
+        state_ = State::DISABLED;
+        clearAcquisition();
+        hold_epochs_ = 0;
+        last_fixed_correction_.setZero();
+        last_declared_time_s_ = 0.0;
+        clearChangePoint();
+    }
+
+private:
+    void clearAcquisition() {
+        acquisition_streak_ = 0;
+        have_previous_candidate_ = false;
+        previous_candidate_time_s_ = 0.0;
+        previous_candidate_correction_.setZero();
+    }
+
+    void clearChangePoint() {
+        change_point_armed_ = false;
+        change_point_streak_ = 0;
+        have_change_point_previous_ = false;
+        change_point_previous_time_s_ = 0.0;
+        change_point_previous_correction_.setZero();
+    }
+
+    State state_ = State::DISABLED;
+    int acquisition_streak_ = 0;
+    int hold_epochs_ = 0;
+    bool have_previous_candidate_ = false;
+    double previous_candidate_time_s_ = 0.0;
+    Eigen::Vector3d previous_candidate_correction_ = Eigen::Vector3d::Zero();
+    Eigen::Vector3d last_fixed_correction_ = Eigen::Vector3d::Zero();
+    double last_declared_time_s_ = 0.0;
+    bool change_point_armed_ = false;
+    int change_point_streak_ = 0;
+    bool have_change_point_previous_ = false;
+    double change_point_previous_time_s_ = 0.0;
+    Eigen::Vector3d change_point_previous_correction_ =
+        Eigen::Vector3d::Zero();
+};
+
+}  // namespace libgnss::safe_fix

--- a/include/libgnss++/algorithms/safe_float_continuity.hpp
+++ b/include/libgnss++/algorithms/safe_float_continuity.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <Eigen/Core>
+#include <cmath>
+
+namespace libgnss::safe_float_continuity {
+
+struct Config {
+    bool enabled = false;
+    double maximum_anchor_age_s = 6.0;
+    double maximum_velocity_age_s = 6.0;
+    // A last solver output may bridge only an isolated sub-second gap.  A
+    // generated continuity output is never remembered as another anchor.
+    double maximum_solver_gap_anchor_age_s = 0.5;
+    double maximum_speed_mps = 80.0;
+    double velocity_sigma_mps = 3.0;
+};
+
+struct Result {
+    bool valid = false;
+    Eigen::Vector3d position_ecef = Eigen::Vector3d::Zero();
+    double position_variance_m2 = 0.0;
+};
+
+inline Result propagate(
+    const Config& config,
+    const Eigen::Vector3d& anchor_position_ecef,
+    double anchor_age_s,
+    const Eigen::Vector3d& velocity_ecef,
+    double velocity_age_s) {
+    Result result;
+    if (
+        !config.enabled ||
+        !anchor_position_ecef.allFinite() ||
+        !velocity_ecef.allFinite() ||
+        !std::isfinite(anchor_age_s) ||
+        anchor_age_s <= 0.0 ||
+        anchor_age_s > config.maximum_anchor_age_s ||
+        !std::isfinite(velocity_age_s) ||
+        velocity_age_s < 0.0 ||
+        velocity_age_s > config.maximum_velocity_age_s ||
+        !std::isfinite(config.maximum_speed_mps) ||
+        config.maximum_speed_mps <= 0.0 ||
+        velocity_ecef.norm() > config.maximum_speed_mps ||
+        !std::isfinite(config.velocity_sigma_mps) ||
+        config.velocity_sigma_mps <= 0.0) {
+        return result;
+    }
+    result.position_ecef =
+        anchor_position_ecef + velocity_ecef * anchor_age_s;
+    result.position_variance_m2 =
+        25.0 + std::pow(config.velocity_sigma_mps * anchor_age_s, 2.0);
+    result.valid =
+        result.position_ecef.allFinite() &&
+        std::isfinite(result.position_variance_m2);
+    return result;
+}
+
+}  // namespace libgnss::safe_float_continuity

--- a/include/libgnss++/core/solution.hpp
+++ b/include/libgnss++/core/solution.hpp
@@ -105,6 +105,9 @@ struct PositionSolution {
      * @brief Check if solution is valid
      */
     bool isValid() const {
+        if (status == SolutionStatus::PROPAGATED) {
+            return position_ecef.allFinite();
+        }
         return status != SolutionStatus::NONE && num_satellites >= 4;
     }
     

--- a/include/libgnss++/core/types.hpp
+++ b/include/libgnss++/core/types.hpp
@@ -82,7 +82,8 @@ enum class SolutionStatus {
     FLOAT,      ///< RTK float solution
     FIXED,      ///< RTK fixed solution
     PPP_FLOAT,  ///< PPP float solution
-    PPP_FIXED   ///< PPP fixed solution
+    PPP_FIXED,  ///< PPP fixed solution
+    PROPAGATED  ///< Causal dead-reckoned position without a current GNSS fix
 };
 
 /**

--- a/include/libgnss++/fusion/dd_imu_bridge.hpp
+++ b/include/libgnss++/fusion/dd_imu_bridge.hpp
@@ -72,7 +72,11 @@ struct BridgeConfig {
     double lambda_ratio_threshold = 3.0;
     int partial_ar_min_ambiguities = 3;
     int partial_ar_min_lock_count = 300;
+    int sse_min_fixed_ambiguities = 10;
     double fixed_ambiguity_sigma_cycles = 0.01;
+    double sse_ffrt_covariance_scale = 16.0;
+    /// Chi-square(3) 99.9% quantile divided by three position DOF.
+    double sse_max_statistic_per_dof = 5.422;
     double soft_reset_max_innovation_m = 30.0;
     double soft_reset_position_sigma_m = 5.0;
     double rejected_reset_covariance_scale = 4.0;
@@ -97,6 +101,23 @@ struct PartialARResult {
     double ratio = 0.0;
 };
 
+struct SSEPartialARResult {
+    bool available = false;
+    bool passed = false;
+    int attempted = 0;
+    int subsets_evaluated = 0;
+    int ratio_passed_subsets = 0;
+    int separation_rejected_subsets = 0;
+    int fixed_count = 0;
+    int dropped_count = 0;
+    double ratio = 0.0;
+    double bootstrapped_success_rate = 0.0;
+    double ffrt_minimum_ratio = 0.0;
+    double statistic_per_dof = 0.0;
+    double position_separation_m = 0.0;
+    Eigen::Vector3d fixed_position_enu = Eigen::Vector3d::Zero();
+};
+
 enum class SoftResetAction { REJECTED, MEASUREMENT_UPDATE, COVARIANCE_INFLATION };
 
 class DDIMUBridge {
@@ -115,6 +136,12 @@ public:
     /// Quality-ordered sequential partial AR; never holds a subset that fails LAMBDA ratio.
     PartialARResult resolvePartialAmbiguities(const std::vector<DDObservation>& observations);
 
+    /// Evaluate a fresh joint carrier posterior against the independent INS
+    /// prediction. This never commits a carrier update or holds integers.
+    SSEPartialARResult evaluateSSEPartialAmbiguities(
+        const std::vector<DDObservation>& observations,
+        bool external_solution_healthy = true) const;
+
     /// Preserve a valid propagated state during reacquisition; never hard-overwrite position.
     SoftResetAction softResetPosition(const Eigen::Vector3d& spp_position_enu,
                                       bool propagated_state_valid);
@@ -131,6 +158,9 @@ private:
     void inject(const Eigen::VectorXd& correction);
 
     TightlyCoupledState state_;
+    TightlyCoupledState last_joint_posterior_;
+    TightlyCoupledState last_ins_prediction_;
+    bool last_joint_posterior_valid_ = false;
     BridgeConfig config_;
     int consecutive_innovation_rejections_ = 0;
 };

--- a/include/libgnss++/fusion/fusion_processor.hpp
+++ b/include/libgnss++/fusion/fusion_processor.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <deque>
+#include <limits>
 #include <memory>
 #include <vector>
 
@@ -131,6 +132,11 @@ public:
         // found apparently accepted carrier updates could make the augmented
         // covariance indefinite. Enable only for explicit research ablation.
         bool tight_dd_commit_carrier_updates = false;
+        // SSE-PAR external-solution contract: do not feed FLOAT positions
+        // back into the independent INS predictor.
+        bool position_updates_require_fixed = false;
+        double tight_dd_sse_fixed_anchor_max_age_s = 2.0;
+        double tight_dd_sse_fixed_anchor_max_nis_per_observation = 10.0;
 
         // Recovery from a gate "lockout spiral": a hard NIS gate is only
         // safe against an *isolated* bad epoch. If the true state has
@@ -163,6 +169,7 @@ public:
     struct TightlyCoupledDDResult {
         dd_imu_bridge::UpdateResult update;
         dd_imu_bridge::PartialARResult partial_ar;
+        dd_imu_bridge::SSEPartialARResult sse_partial_ar;
         dd_imu_bridge::SoftResetAction reset_action =
             dd_imu_bridge::SoftResetAction::REJECTED;
     };
@@ -179,6 +186,7 @@ public:
 
     bool isInitialized() const { return initialized_; }
     bool isOriginSet() const { return origin_set_; }
+    bool hasHealthyFixedAnchor() const;
     Eigen::Matrix3d ecefToLocalEnuRotation() const;
     /** @brief True once a heading latch has been made (see class doc: this alone does NOT mean the
      *  latch is trustworthy -- use isHeadingConverged() for a real health signal). */
@@ -273,6 +281,10 @@ private:
     double velocity_nis_ema_ = 0.0;
     int consecutive_bad_heading_epochs_ = 0;
     int recovery_cooldown_remaining_epochs_ = 0;
+    bool has_fixed_anchor_ = false;
+    GNSSTime last_fixed_anchor_time_;
+    double last_fixed_anchor_nis_per_observation_ =
+        std::numeric_limits<double>::infinity();
 
     void initializeFromStaticWindow();
     bool detectStationary() const;

--- a/python/libgnsspp/artifacts.py
+++ b/python/libgnsspp/artifacts.py
@@ -185,6 +185,7 @@ def pos_status_name(record: PosRecord) -> str:
         4: "FIXED",
         5: "PPP_FLOAT",
         6: "PPP_FIXED",
+        7: "PROPAGATED",
     }.get(record.status, f"STATUS_{record.status}")
 
 

--- a/python/libgnsspp/bindings.cpp
+++ b/python/libgnsspp/bindings.cpp
@@ -33,6 +33,8 @@ std::string solutionStatusName(libgnss::SolutionStatus status) {
             return "PPP_FLOAT";
         case libgnss::SolutionStatus::PPP_FIXED:
             return "PPP_FIXED";
+        case libgnss::SolutionStatus::PROPAGATED:
+            return "PROPAGATED";
         default:
             return "UNKNOWN";
     }
@@ -361,7 +363,8 @@ PYBIND11_MODULE(_libgnsspp, m) {
         .value("FLOAT", libgnss::SolutionStatus::FLOAT)
         .value("FIXED", libgnss::SolutionStatus::FIXED)
         .value("PPP_FLOAT", libgnss::SolutionStatus::PPP_FLOAT)
-        .value("PPP_FIXED", libgnss::SolutionStatus::PPP_FIXED);
+        .value("PPP_FIXED", libgnss::SolutionStatus::PPP_FIXED)
+        .value("PROPAGATED", libgnss::SolutionStatus::PROPAGATED);
 
     py::class_<libgnss::GNSSTime>(m, "GNSSTime")
         .def(py::init<int, double>(), py::arg("week"), py::arg("tow"))

--- a/src/algorithms/lambda.cpp
+++ b/src/algorithms/lambda.cpp
@@ -8,6 +8,7 @@
 #include <cmath>
 #include <cstring>
 #include <algorithm>
+#include <limits>
 
 namespace libgnss {
 
@@ -176,9 +177,191 @@ bool lambdaSearch(const VectorXd& float_amb, const MatrixXd& Q_amb,
 bool lambdaSearchCandidates(const VectorXd& float_amb, const MatrixXd& Q_amb,
                             VectorXd& best_amb, VectorXd& second_amb,
                             double& ratio) {
+    LambdaCandidateDiagnostics diagnostics;
+    if (!lambdaSearchTopK(float_amb, Q_amb, 2, diagnostics)) {
+        return false;
+    }
+    best_amb = diagnostics.candidates.col(0);
+    second_amb = diagnostics.candidates.col(1);
+    const double best_residual = diagnostics.squared_residuals(0);
+    const double second_residual = diagnostics.squared_residuals(1);
+    ratio = (best_residual > 0.0) ? second_residual / best_residual : 0.0;
+    return true;
+}
+
+bool fixedFailureRateRatioThreshold(
+    int ambiguity_count, double bootstrapped_success_rate,
+    double tolerable_failure_rate,
+    FixedFailureRateRatioThreshold& threshold) {
+    // CoefficientMu.csv, Pf_tol=0.001, from the supplementary material for:
+    // Hou, Verhagen, Wu, Sensors 2016, 16, 945, doi:10.3390/s16070945.
+    // mu(Pf_ILS) = p1 * Pf_ILS^p2 + p3 for Pf_tol < Pf_ILS < 0.2.
+    static constexpr double coefficients[66][3] = {
+        {0.0549, -0.4626, -0.1968},
+        {0.0507, -0.4739, -0.1450},
+        {0.0838, -0.3960, -0.1556},
+        {0.1343, -0.3225, -0.1755},
+        {0.1946, -0.2672, -0.1980},
+        {0.1876, -0.2651, -0.1429},
+        {0.1645, -0.2750, -0.0755},
+        {0.1751, -0.2605, -0.0404},
+        {0.1229, -0.3011, 0.0634},
+        {0.1133, -0.3065, 0.1151},
+        {0.0938, -0.3238, 0.1795},
+        {0.0636, -0.3737, 0.2505},
+        {0.0630, -0.3670, 0.2833},
+        {0.0522, -0.3879, 0.3263},
+        {0.0512, -0.3843, 0.3543},
+        {0.0498, -0.3824, 0.3789},
+        {0.0483, -0.3801, 0.4054},
+        {0.0489, -0.3726, 0.4257},
+        {0.0492, -0.3659, 0.4450},
+        {0.0454, -0.3699, 0.4690},
+        {0.0443, -0.3689, 0.4880},
+        {0.0419, -0.3721, 0.5072},
+        {0.0347, -0.3933, 0.5322},
+        {0.0321, -0.3999, 0.5500},
+        {0.0318, -0.3958, 0.5613},
+        {0.0273, -0.4144, 0.5805},
+        {0.0261, -0.4147, 0.5928},
+        {0.0242, -0.4219, 0.6072},
+        {0.0226, -0.4288, 0.6193},
+        {0.0208, -0.4348, 0.6309},
+        {0.0172, -0.4602, 0.6431},
+        {0.0189, -0.4421, 0.6524},
+        {0.0212, -0.4206, 0.6574},
+        {0.0197, -0.4278, 0.6673},
+        {0.0206, -0.4178, 0.6716},
+        {0.0174, -0.4399, 0.6852},
+        {0.0182, -0.4294, 0.6901},
+        {0.0161, -0.4431, 0.7004},
+        {0.0132, -0.4681, 0.7071},
+        {0.0137, -0.4613, 0.7155},
+        {0.0117, -0.4808, 0.7232},
+        {0.0118, -0.4736, 0.7286},
+        {0.0103, -0.4912, 0.7351},
+        {0.0111, -0.4773, 0.7402},
+        {0.0095, -0.4982, 0.7474},
+        {0.0095, -0.4969, 0.7525},
+        {0.0085, -0.5058, 0.7578},
+        {0.0098, -0.4837, 0.7602},
+        {0.0105, -0.4706, 0.7633},
+        {0.0108, -0.4651, 0.7673},
+        {0.0072, -0.5210, 0.7757},
+        {0.0079, -0.5051, 0.7767},
+        {0.0082, -0.4956, 0.7819},
+        {0.0094, -0.4744, 0.7840},
+        {0.0077, -0.5017, 0.7885},
+        {0.0056, -0.5433, 0.7956},
+        {0.0057, -0.5400, 0.7998},
+        {0.0086, -0.4742, 0.7975},
+        {0.0070, -0.4977, 0.7998},
+        {0.0085, -0.4741, 0.8039},
+        {0.0107, -0.4327, 0.8016},
+        {0.0058, -0.5173, 0.8121},
+        {0.0050, -0.5369, 0.8181},
+        {0.0081, -0.4521, 0.8137},
+        {0.0015, -0.7293, 0.8205},
+        {0.0016, -0.7571, 0.8317},
+    };
+
+    threshold = {};
+    if (ambiguity_count < 1 || ambiguity_count > 66 ||
+        !std::isfinite(bootstrapped_success_rate) ||
+        bootstrapped_success_rate < 0.0 ||
+        bootstrapped_success_rate > 1.0 ||
+        !std::isfinite(tolerable_failure_rate) ||
+        std::abs(tolerable_failure_rate - 0.001) > 1e-12) {
+        return false;
+    }
+
+    threshold.ils_failure_rate_proxy = 1.0 - bootstrapped_success_rate;
+    if (threshold.ils_failure_rate_proxy >= 0.2 - 1e-12) {
+        threshold.minimum_second_to_best_ratio =
+            std::numeric_limits<double>::infinity();
+        return true;
+    }
+
+    if (threshold.ils_failure_rate_proxy <= tolerable_failure_rate) {
+        threshold.mu = 1.0;
+    } else {
+        const double* c = coefficients[ambiguity_count - 1];
+        threshold.mu =
+            std::clamp(c[0] * std::pow(
+                           threshold.ils_failure_rate_proxy, c[1]) + c[2],
+                       0.0, 1.0);
+    }
+    if (!(threshold.mu > 0.0) || !std::isfinite(threshold.mu)) {
+        threshold.minimum_second_to_best_ratio =
+            std::numeric_limits<double>::infinity();
+        return true;
+    }
+    threshold.minimum_second_to_best_ratio = 1.0 / threshold.mu;
+    threshold.accepts_any_candidate = true;
+    return true;
+}
+
+double bootstrappedSuccessRate(const VectorXd& conditional_variances,
+                               double covariance_scale) {
+    if (conditional_variances.size() <= 0 ||
+        !conditional_variances.array().isFinite().all() ||
+        (conditional_variances.array() <= 0.0).any() ||
+        !std::isfinite(covariance_scale) || covariance_scale <= 0.0) {
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+    double success_rate = 1.0;
+    for (int i = 0; i < conditional_variances.size(); ++i) {
+        const double scaled_variance =
+            covariance_scale * conditional_variances(i);
+        const double argument = 0.5 / std::sqrt(2.0 * scaled_variance);
+        success_rate *=
+            std::clamp(std::erf(argument), 0.0, 1.0);
+    }
+    return std::clamp(success_rate, 0.0, 1.0);
+}
+
+int successRateCriterionSubsetSize(
+    const VectorXd& conditional_variances, double covariance_scale,
+    double minimum_success_rate) {
+    if (conditional_variances.size() <= 0 ||
+        !conditional_variances.array().isFinite().all() ||
+        (conditional_variances.array() <= 0.0).any() ||
+        !std::isfinite(covariance_scale) || covariance_scale <= 0.0 ||
+        !std::isfinite(minimum_success_rate) ||
+        minimum_success_rate <= 0.0 || minimum_success_rate > 1.0) {
+        return 0;
+    }
+    double success_rate = 1.0;
+    int selected = 0;
+    for (int i = conditional_variances.size() - 1; i >= 0; --i) {
+        const double scaled_variance =
+            covariance_scale * conditional_variances(i);
+        const double conditional_success =
+            std::clamp(
+                std::erf(0.5 / std::sqrt(2.0 * scaled_variance)),
+                0.0, 1.0);
+        const double extended_success_rate =
+            success_rate * conditional_success;
+        if (extended_success_rate < minimum_success_rate) {
+            break;
+        }
+        success_rate = extended_success_rate;
+        ++selected;
+    }
+    return selected;
+}
+
+bool lambdaSearchTopK(const VectorXd& float_amb, const MatrixXd& Q_amb,
+                      int candidate_count,
+                      LambdaCandidateDiagnostics& diagnostics) {
     int n = float_amb.size();
-    int m = 2;  // find 2 best solutions for ratio test
-    if (n <= 0) return false;
+    const int m = candidate_count;
+    if (n <= 0 || m <= 0 ||
+        Q_amb.rows() != n || Q_amb.cols() != n ||
+        !float_amb.array().isFinite().all() ||
+        !Q_amb.array().isFinite().all()) {
+        return false;
+    }
 
     // Convert to column-major flat arrays (RTKLIB convention)
     std::vector<double> Q(n * n), L(n * n, 0.0), D(n), Z(n * n, 0.0);
@@ -211,24 +394,37 @@ bool lambdaSearchCandidates(const VectorXd& float_amb, const MatrixXd& Q_amb,
     info = search(n, m, L.data(), D.data(), z.data(), E.data(), s.data());
     if (info != 0) return false;
 
-    // Back-transform both candidates.  Their component-wise disagreement is
-    // the satellite exclusion signal used by MADOCALIB partial AR.
+    // Back-transform all candidates. Their component-wise disagreement is
+    // available to partial-AR and temporal multi-hypothesis shadow policies.
     for (int candidate = 0; candidate < m; ++candidate) {
         info = solveZt(n, Z.data(), E.data() + candidate * n,
                        F.data() + candidate * n);
         if (info != 0) return false;
     }
 
-    best_amb.resize(n);
-    second_amb.resize(n);
-    for (int i = 0; i < n; ++i) {
-        best_amb(i) = F[i];
-        second_amb(i) = F[i + n];
+    diagnostics.candidates.resize(n, m);
+    diagnostics.squared_residuals.resize(m);
+    diagnostics.conditional_variances.resize(n);
+    const Eigen::Map<const Eigen::MatrixXd> decorrelation_transform(
+        Z.data(), n, n);
+    diagnostics.decorrelation_transform = decorrelation_transform;
+    diagnostics.decorrelated_float =
+        Eigen::Map<const Eigen::VectorXd>(z.data(), n);
+    diagnostics.decorrelated_covariance =
+        decorrelation_transform.transpose() * Q_amb *
+        decorrelation_transform;
+    for (int candidate = 0; candidate < m; ++candidate) {
+        diagnostics.squared_residuals(candidate) = s[candidate];
+        for (int i = 0; i < n; ++i) {
+            diagnostics.candidates(i, candidate) = F[i + candidate * n];
+        }
     }
 
-    // Ratio test
-    ratio = (s[0] > 0.0) ? s[1] / s[0] : 0.0;
-
+    for (int i = 0; i < n; ++i) {
+        diagnostics.conditional_variances(i) = D[i];
+    }
+    diagnostics.bootstrapped_success_rate =
+        bootstrappedSuccessRate(diagnostics.conditional_variances);
     return true;
 }
 

--- a/src/algorithms/rtk.cpp
+++ b/src/algorithms/rtk.cpp
@@ -1,6 +1,8 @@
 #include <libgnss++/algorithms/rtk.hpp>
 #include <libgnss++/algorithms/rtk_ar_evaluation.hpp>
 #include <libgnss++/algorithms/rtk_ar_selection.hpp>
+#include <libgnss++/algorithms/disjoint_satellite_fix_evidence.hpp>
+#include <libgnss++/algorithms/fix_failure_budget.hpp>
 #include <libgnss++/algorithms/lambda.hpp>
 #include <libgnss++/algorithms/rtk_cp_pr_gate.hpp>
 #include <libgnss++/algorithms/rtk_ddpr_anchor.hpp>
@@ -18,6 +20,7 @@
 #include <iostream>
 #include <iterator>
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <limits>
 #include <map>
@@ -289,12 +292,30 @@ static inline double geodist_range(const Vector3d& rs, const Vector3d& rr) {
     return geodist(rs, rr);
 }
 
-RTKProcessor::RTKProcessor() : spp_processor_(makeRTKSppProcessor(rtk_config_)) { filter_initialized_ = false; }
+RTKProcessor::RTKProcessor()
+    : spp_processor_(makeRTKSppProcessor(rtk_config_)),
+      l1_l5_mw_arc_bank_(
+          rtk_config_.lambda_l1_l5_wlnl_causal_arc_config),
+      ambiguity_arc_bank_(
+          rtk_config_.lambda_causal_arc_readiness_config) {
+    filter_initialized_ = false;
+}
 RTKProcessor::RTKProcessor(const RTKConfig& rtk_config)
-    : rtk_config_(rtk_config), spp_processor_(makeRTKSppProcessor(rtk_config_)) { filter_initialized_ = false; }
+    : rtk_config_(rtk_config),
+      spp_processor_(makeRTKSppProcessor(rtk_config_)),
+      l1_l5_mw_arc_bank_(
+          rtk_config_.lambda_l1_l5_wlnl_causal_arc_config),
+      ambiguity_arc_bank_(
+          rtk_config_.lambda_causal_arc_readiness_config) {
+    filter_initialized_ = false;
+}
 
 void RTKProcessor::setRTKConfig(const RTKConfig& config) {
     rtk_config_ = config;
+    l1_l5_mw_arc_bank_ = causal_ambiguity_arc::Bank(
+        rtk_config_.lambda_l1_l5_wlnl_causal_arc_config);
+    ambiguity_arc_bank_ = causal_ambiguity_arc::Bank(
+        rtk_config_.lambda_causal_arc_readiness_config);
     syncSPPConfig();
     // Phase 2a: cmc_suspect_tracker_ is lazily constructed with the
     // cmc_ref_level_m threshold captured at construction time; drop it so a
@@ -330,6 +351,16 @@ void RTKProcessor::reset() {
         static_cast<int>(lock_count_l1_.size() +
                          lock_count_l2_.size() +
                          lock_count_l5_.size());
+    safe_fix_shadow_state_machine_.reset();
+    disjoint_consensus_state_machine_.reset();
+    causal_arc_consensus_state_machine_.reset();
+    satellite_par_consensus_state_machine_.reset();
+    src_par_consensus_state_machine_.reset();
+    inertial_referenced_consensus_state_machine_.reset();
+    multifrequency_consensus_state_machine_.reset();
+    l1_l2_multifrequency_consensus_state_machine_.reset();
+    satellite_par_persistent_satellites_.clear();
+    l1_l5_mw_arc_bank_.reset();
     filter_state_ = RTKState{};
     filter_state_.next_state_idx = REAL_STATES + IONO_STATES;
     ambiguity_states_.clear();
@@ -353,8 +384,10 @@ void RTKProcessor::reset() {
     current_epoch_nlos_fraction_ = std::numeric_limits<double>::quiet_NaN();
     current_sat_data_.clear();
     gf_l1l2_history_.clear();
+    gf_l1l5_history_.clear();
     doppler_phase_history_l1_m_.clear();
     doppler_phase_history_l2_m_.clear();
+    doppler_phase_history_l5_m_.clear();
     code_phase_history_l1_m_.clear();
     code_phase_history_l2_m_.clear();
     tdcp_history_l1_.clear();
@@ -374,6 +407,11 @@ void RTKProcessor::reset() {
     position_correction_sum_sq_m2_ = 0.0;
     consecutive_cp_pr_gate_rejections_ = 0;
     has_last_ddpr_anchor_ = false;
+    code_phase_history_l5_m_.clear();
+    current_epoch_slips_l1_.clear();
+    current_epoch_slips_l2_.clear();
+    current_epoch_slips_l5_.clear();
+    ambiguity_arc_bank_.reset();
     consecutive_fix_count_ = 0;
     consecutive_float_count_ = 0;
     consecutive_nonfix_count_ = 0;
@@ -593,9 +631,14 @@ std::map<SatelliteId, RTKProcessor::SatelliteData> RTKProcessor::collectSatellit
     const ObservationData& rover_obs, const ObservationData& base_obs, const NavigationData& nav) {
     std::map<SatelliteId, SatelliteData> result;
     std::map<SatelliteId, std::vector<const Observation*>> rover_l1, rover_l2, base_l1, base_l2;
-    // Phase 18 Step 3: L5 collection (only populated when enable_l5=true).
+    // L5 may also be collected for the shadow-only L1/L5 WL->NL diagnostic.
+    // In that mode L5 remains available as independent evidence but is not
+    // added to the production filter's states or measurement blocks.
     std::map<SatelliteId, std::vector<const Observation*>> rover_l5, base_l5;
-    const bool l5_enabled = rtk_config_.enable_l5;
+    const bool l5_collection_enabled =
+        rtk_config_.enable_l5 ||
+        rtk_config_.lambda_l1_l5_wlnl_shadow ||
+        rtk_config_.lambda_l2_l5_wlnl_shadow;
     for (const auto& obs : rover_obs.observations) {
         if (!isEnabledRTKSystem(rtk_config_, obs.satellite.system)) continue;
         if (!isUsableRTKSatellite(obs.satellite)) continue;
@@ -607,8 +650,13 @@ std::map<SatelliteId, RTKProcessor::SatelliteData> RTKProcessor::collectSatellit
             obs.has_carrier_phase && obs.has_pseudorange) {
             // When L5 enabled, exclude L5-class obs from L2 slot so they don't
             // displace true L2C signals or pollute the L2 wavelength.
-            if (l5_enabled && isL5RTKSignal(obs.satellite.system, obs.signal)) {
+            if (l5_collection_enabled &&
+                isL5RTKSignal(obs.satellite.system, obs.signal)) {
                 rover_l5[obs.satellite].push_back(&obs);
+                if (!rtk_config_.enable_l5) {
+                    // Preserve the legacy L5-off signal-selection inputs.
+                    rover_l2[obs.satellite].push_back(&obs);
+                }
             } else {
                 rover_l2[obs.satellite].push_back(&obs);
             }
@@ -623,8 +671,12 @@ std::map<SatelliteId, RTKProcessor::SatelliteData> RTKProcessor::collectSatellit
         }
         if (isSecondaryRTKSignal(obs.satellite.system, obs.signal) &&
             obs.has_carrier_phase && obs.has_pseudorange) {
-            if (l5_enabled && isL5RTKSignal(obs.satellite.system, obs.signal)) {
+            if (l5_collection_enabled &&
+                isL5RTKSignal(obs.satellite.system, obs.signal)) {
                 base_l5[obs.satellite].push_back(&obs);
+                if (!rtk_config_.enable_l5) {
+                    base_l2[obs.satellite].push_back(&obs);
+                }
             } else {
                 base_l2[obs.satellite].push_back(&obs);
             }
@@ -728,7 +780,7 @@ std::map<SatelliteId, RTKProcessor::SatelliteData> RTKProcessor::collectSatellit
             }
         }
         // Phase 18 Step 3: L5 pairing (no-op until rtk_config_.enable_l5 is set).
-        if (l5_enabled) {
+        if (l5_collection_enabled) {
             auto r_l5 = rover_l5.find(sat); auto b_l5 = base_l5.find(sat);
             if (r_l5 != rover_l5.end() && b_l5 != base_l5.end()) {
                 const Observation* r_l5_obs = nullptr;
@@ -1154,6 +1206,9 @@ void RTKProcessor::updateTdcpDiagnostics(
 
 void RTKProcessor::updateBias(const std::map<SatelliteId, SatelliteData>& sat_data, double dt_s) {
     updateTdcpDiagnostics(sat_data, dt_s);
+    current_epoch_slips_l1_.clear();
+    current_epoch_slips_l2_.clear();
+    current_epoch_slips_l5_.clear();
     std::vector<SatelliteId> sats_to_remove;
     for (const auto& [sat, idx] : filter_state_.n1_indices) {
         if (sat_data.find(sat) == sat_data.end()) sats_to_remove.push_back(sat);
@@ -1448,6 +1503,44 @@ void RTKProcessor::updateBias(const std::map<SatelliteId, SatelliteData>& sat_da
                        gf_slips_l1l5.find(sat) != gf_slips_l1l5.end() ||
                        code_slips_l5.find(sat) != code_slips_l5.end() ||
                        doppler_slips_l5.find(sat) != doppler_slips_l5.end();
+            }
+            const int detector_votes =
+                (freq == 0
+                     ? static_cast<int>(
+                           gf_slips.find(sat) != gf_slips.end() ||
+                           gf_slips_l1l5.find(sat) !=
+                               gf_slips_l1l5.end())
+                     : freq == 2
+                           ? static_cast<int>(
+                                 gf_slips_l1l5.find(sat) !=
+                                 gf_slips_l1l5.end())
+                           : 0) +
+                (freq == 0
+                     ? static_cast<int>(
+                           code_slips_l1.find(sat) !=
+                           code_slips_l1.end())
+                     : freq == 2
+                           ? static_cast<int>(
+                                 code_slips_l5.find(sat) !=
+                                 code_slips_l5.end())
+                           : 0) +
+                (freq == 0
+                     ? static_cast<int>(
+                           doppler_slips_l1.find(sat) !=
+                           doppler_slips_l1.end())
+                     : freq == 2
+                           ? static_cast<int>(
+                                 doppler_slips_l5.find(sat) !=
+                                 doppler_slips_l5.end())
+                           : 0);
+            const bool confirmed_arc_slip =
+                lli_slip || detector_votes >= 2;
+            if (confirmed_arc_slip && freq == 0) {
+                current_epoch_slips_l1_.insert(sat);
+            } else if (confirmed_arc_slip && freq == 1) {
+                current_epoch_slips_l2_.insert(sat);
+            } else if (confirmed_arc_slip && freq == 2) {
+                current_epoch_slips_l5_.insert(sat);
             }
             auto idx_it = indices.find(sat);
             if (idx_it != indices.end() && slip) {
@@ -2077,6 +2170,8 @@ PositionSolution RTKProcessor::processRTKEpoch(const ObservationData& rover_obs,
         }
     }
     PositionSolution solution = processRTKEpochInternal(rover_obs, base_obs, nav);
+    updateSafeFixShadowStateMachine(rover_obs.time);
+    applyLibraryFixedQualityGate(solution);
 
     // Doppler-derived velocity: SPPProcessor now populates has_velocity on
     // its own solutions (spp.cpp), so the fallback-to-SPP paths inside
@@ -2119,12 +2214,1362 @@ PositionSolution RTKProcessor::processRTKEpoch(const ObservationData& rover_obs,
         has_doppler_continuity_position_ = true;
     }
 
+    // A nominal DD path can still finish with an invalid generated FLOAT
+    // (for example after a rank-deficient update) without taking
+    // fallback_spp() or throwing. Apply the same bounded FLOAT-only bridge
+    // here so every no-solution exit is governed by one fail-closed policy.
+    if (solution.status == SolutionStatus::NONE ||
+        !solution.isValid()) {
+        auto continuity = makeSafeFloatContinuity(rover_obs.time);
+        if (continuity.isValid()) {
+            recordFallbackEpoch(rover_obs, nav);
+            external_inertial_fix_evidence_ =
+                ExternalInertialFixEvidence{};
+            external_disjoint_satellite_fix_evidence_ =
+                ExternalDisjointSatelliteFixEvidence{};
+            return continuity;
+        }
+    }
+    external_inertial_fix_evidence_ = ExternalInertialFixEvidence{};
+    external_disjoint_satellite_fix_evidence_ =
+        ExternalDisjointSatelliteFixEvidence{};
     return solution;
+}
+
+void RTKProcessor::applyLibraryFixedQualityGate(
+    PositionSolution& solution) {
+    const auto& config = rtk_config_.library_fixed_quality_gate;
+    debug_telemetry_.library_fixed_quality_gate_enabled = config.enabled;
+    if (!config.enabled) {
+        return;
+    }
+    const PositionSolution original_solution = solution;
+    debug_telemetry_.library_fixed_quality_gate_original_status =
+        static_cast<int>(original_solution.status);
+    debug_telemetry_.library_fixed_quality_gate_original_ecef_x =
+        original_solution.position_ecef.x();
+    debug_telemetry_.library_fixed_quality_gate_original_ecef_y =
+        original_solution.position_ecef.y();
+    debug_telemetry_.library_fixed_quality_gate_original_ecef_z =
+        original_solution.position_ecef.z();
+    debug_telemetry_.library_fixed_quality_gate_original_ratio =
+        original_solution.ratio;
+    bool promoted_current_epoch_candidate = false;
+    const Vector3d primary_candidate_position(
+        debug_telemetry_.lambda_shadow_best_ecef_x,
+        debug_telemetry_.lambda_shadow_best_ecef_y,
+        debug_telemetry_.lambda_shadow_best_ecef_z);
+    const auto disjoint_consensus =
+        disjoint_satellite_fix_evidence::closestPairConsensus(
+            primary_candidate_position,
+            external_disjoint_satellite_fix_evidence_
+                .partition_a_candidate_ecef,
+            external_disjoint_satellite_fix_evidence_
+                .partition_b_candidate_ecef);
+    double selected_pair_min_ratio =
+        std::numeric_limits<double>::quiet_NaN();
+    const auto finite_min_ratio = [](double first, double second) {
+        return std::isfinite(first) && std::isfinite(second)
+                   ? std::min(first, second)
+                   : std::numeric_limits<double>::quiet_NaN();
+    };
+    switch (disjoint_consensus.selected_pair) {
+        case disjoint_satellite_fix_evidence::SelectedPair::PRIMARY_A:
+            selected_pair_min_ratio = finite_min_ratio(
+                debug_telemetry_.full_ratio,
+                external_disjoint_satellite_fix_evidence_
+                    .partition_a_ratio);
+            break;
+        case disjoint_satellite_fix_evidence::SelectedPair::PRIMARY_B:
+            selected_pair_min_ratio = finite_min_ratio(
+                debug_telemetry_.full_ratio,
+                external_disjoint_satellite_fix_evidence_
+                    .partition_b_ratio);
+            break;
+        case disjoint_satellite_fix_evidence::SelectedPair::A_B:
+            selected_pair_min_ratio = finite_min_ratio(
+                external_disjoint_satellite_fix_evidence_
+                    .partition_a_ratio,
+                external_disjoint_satellite_fix_evidence_
+                    .partition_b_ratio);
+            break;
+        case disjoint_satellite_fix_evidence::SelectedPair::NONE:
+            break;
+    }
+    debug_telemetry_.disjoint_consensus_selected_pair =
+        static_cast<int>(disjoint_consensus.selected_pair);
+    debug_telemetry_.disjoint_consensus_selected_pair_min_ratio =
+        selected_pair_min_ratio;
+    safe_fix::Candidate disjoint_state_candidate;
+    disjoint_state_candidate.time_s =
+        static_cast<double>(solution.time.week) * 604800.0 +
+        solution.time.tow;
+    if (solution.isValid() && disjoint_consensus.valid) {
+        disjoint_state_candidate.correction_m =
+            disjoint_consensus.position_ecef -
+            primary_candidate_position;
+    }
+    disjoint_state_candidate.nis_per_observation =
+        debug_telemetry_.float_update_nis_per_observation;
+    disjoint_state_candidate.prefit_residual_rms_m =
+        debug_telemetry_.float_update_prefit_residual_rms_m;
+    disjoint_state_candidate.pair_count =
+        debug_telemetry_.pair_count;
+    disjoint_state_candidate.ambiguity_ratio =
+        rtk_config_.disjoint_consensus_use_selected_pair_ratio
+            ? selected_pair_min_ratio
+            : debug_telemetry_.full_ratio;
+    disjoint_state_candidate.independent_consensus_delta_m =
+        debug_telemetry_
+            .disjoint_satellite_fix_partition_separation_m;
+    disjoint_state_candidate.independent_failure_budget_passed =
+        debug_telemetry_.safe_fix_shadow_failure_budget_passed;
+    disjoint_state_candidate.acquisition_eligible =
+        solution.isValid() &&
+        disjoint_consensus.valid &&
+        debug_telemetry_.disjoint_satellite_fix_evidence_passed &&
+        debug_telemetry_.lambda_shadow_ffrt_passed &&
+        debug_telemetry_.pair_count >=
+            rtk_config_.safe_fix_shadow_minimum_pairs &&
+        std::isfinite(
+            disjoint_state_candidate.nis_per_observation) &&
+        disjoint_state_candidate.nis_per_observation <=
+            rtk_config_
+                .safe_fix_shadow_maximum_nis_per_observation &&
+        std::isfinite(
+            disjoint_state_candidate.prefit_residual_rms_m) &&
+        disjoint_state_candidate.prefit_residual_rms_m <=
+            rtk_config_
+                .safe_fix_shadow_maximum_prefit_residual_rms_m;
+    const auto disjoint_state_decision =
+        disjoint_consensus_state_machine_.update(
+            rtk_config_.disjoint_consensus_state_machine,
+            disjoint_state_candidate);
+    debug_telemetry_.disjoint_consensus_declared_fixed =
+        disjoint_state_decision.declared_fixed;
+    debug_telemetry_.disjoint_consensus_state =
+        static_cast<int>(disjoint_state_decision.state);
+    debug_telemetry_.disjoint_consensus_acquisition_streak =
+        disjoint_state_decision.acquisition_streak;
+    const Vector3d causal_arc_candidate_position(
+        debug_telemetry_.lambda_causal_arc_subset_best_ecef_x,
+        debug_telemetry_.lambda_causal_arc_subset_best_ecef_y,
+        debug_telemetry_.lambda_causal_arc_subset_best_ecef_z);
+    disjoint_satellite_fix_evidence::Config
+        causal_arc_disjoint_config;
+    causal_arc_disjoint_config.maximum_partition_separation_m =
+        rtk_config_
+            .disjoint_satellite_fix_max_partition_separation_m;
+    causal_arc_disjoint_config.maximum_primary_separation_m =
+        rtk_config_
+            .disjoint_satellite_fix_max_primary_separation_m;
+    causal_arc_disjoint_config.covariance_scale =
+        rtk_config_.disjoint_satellite_fix_covariance_scale;
+    causal_arc_disjoint_config.maximum_nis_per_dimension =
+        rtk_config_
+            .disjoint_satellite_fix_max_nis_per_dimension;
+    causal_arc_disjoint_config.maximum_statistical_separation_m =
+        rtk_config_
+            .disjoint_satellite_fix_max_statistical_separation_m;
+    disjoint_satellite_fix_evidence::Evidence
+        causal_arc_disjoint_evidence;
+    causal_arc_disjoint_evidence.available =
+        external_disjoint_satellite_fix_evidence_.available;
+    causal_arc_disjoint_evidence.inputs_verified_disjoint =
+        external_disjoint_satellite_fix_evidence_
+            .inputs_verified_disjoint;
+    causal_arc_disjoint_evidence.primary_ffrt_passed =
+        debug_telemetry_.lambda_causal_arc_subset_ffrt_passed &&
+        std::isfinite(
+            debug_telemetry_.lambda_causal_arc_subset_ratio) &&
+        debug_telemetry_.lambda_causal_arc_subset_ratio >=
+            rtk_config_.causal_arc_consensus_state_machine
+                .minimum_absolute_ratio;
+    causal_arc_disjoint_evidence.partition_a_ffrt_passed =
+        external_disjoint_satellite_fix_evidence_
+            .partition_a_ffrt_passed;
+    causal_arc_disjoint_evidence.partition_b_ffrt_passed =
+        external_disjoint_satellite_fix_evidence_
+            .partition_b_ffrt_passed;
+    causal_arc_disjoint_evidence.primary_candidate_ecef =
+        causal_arc_candidate_position;
+    causal_arc_disjoint_evidence.partition_a_candidate_ecef =
+        external_disjoint_satellite_fix_evidence_
+            .partition_a_candidate_ecef;
+    causal_arc_disjoint_evidence.partition_b_candidate_ecef =
+        external_disjoint_satellite_fix_evidence_
+            .partition_b_candidate_ecef;
+    causal_arc_disjoint_evidence.partition_a_covariance_ecef =
+        external_disjoint_satellite_fix_evidence_
+            .partition_a_covariance_ecef;
+    causal_arc_disjoint_evidence.partition_b_covariance_ecef =
+        external_disjoint_satellite_fix_evidence_
+            .partition_b_covariance_ecef;
+    if (std::isfinite(
+            debug_telemetry_.float_position_covariance_trace_m2) &&
+        debug_telemetry_.float_position_covariance_trace_m2 > 0.0) {
+        causal_arc_disjoint_evidence.primary_covariance_ecef =
+            Matrix3d::Identity() *
+            (debug_telemetry_.float_position_covariance_trace_m2 /
+             3.0);
+    }
+    const auto causal_arc_disjoint_decision =
+        disjoint_satellite_fix_evidence::evaluate(
+            causal_arc_disjoint_config,
+            causal_arc_disjoint_evidence);
+    debug_telemetry_.causal_arc_disjoint_evidence_passed =
+        causal_arc_disjoint_decision.passed;
+    safe_fix::Candidate causal_arc_state_candidate;
+    causal_arc_state_candidate.time_s =
+        disjoint_state_candidate.time_s;
+    if (solution.isValid() &&
+        causal_arc_candidate_position.allFinite()) {
+        causal_arc_state_candidate.correction_m =
+            causal_arc_candidate_position -
+            solution.position_ecef;
+    }
+    causal_arc_state_candidate.nis_per_observation =
+        debug_telemetry_.float_update_nis_per_observation;
+    causal_arc_state_candidate.prefit_residual_rms_m =
+        debug_telemetry_.float_update_prefit_residual_rms_m;
+    causal_arc_state_candidate.pair_count =
+        debug_telemetry_.lambda_causal_arc_subset_pair_count;
+    causal_arc_state_candidate.ambiguity_ratio =
+        debug_telemetry_.lambda_causal_arc_subset_ratio;
+    causal_arc_state_candidate.independent_consensus_delta_m =
+        std::max(
+            causal_arc_disjoint_decision
+                .partition_a_primary_separation_m,
+            causal_arc_disjoint_decision
+                .partition_b_primary_separation_m);
+    causal_arc_state_candidate.independent_failure_budget_passed =
+        causal_arc_disjoint_decision.passed;
+    causal_arc_state_candidate.acquisition_eligible =
+        solution.isValid() &&
+        causal_arc_disjoint_decision.passed &&
+        debug_telemetry_.lambda_causal_arc_subset_pair_count >=
+            rtk_config_.safe_fix_shadow_minimum_pairs &&
+        std::isfinite(
+            causal_arc_state_candidate.nis_per_observation) &&
+        causal_arc_state_candidate.nis_per_observation <=
+            rtk_config_
+                .safe_fix_shadow_maximum_nis_per_observation &&
+        std::isfinite(
+            causal_arc_state_candidate.prefit_residual_rms_m) &&
+        causal_arc_state_candidate.prefit_residual_rms_m <=
+            rtk_config_
+                .safe_fix_shadow_maximum_prefit_residual_rms_m;
+    const auto causal_arc_state_decision =
+        causal_arc_consensus_state_machine_.update(
+            rtk_config_.causal_arc_consensus_state_machine,
+            causal_arc_state_candidate);
+    debug_telemetry_.causal_arc_consensus_declared_fixed =
+        causal_arc_state_decision.declared_fixed;
+    debug_telemetry_.causal_arc_consensus_state =
+        static_cast<int>(causal_arc_state_decision.state);
+    debug_telemetry_.causal_arc_consensus_acquisition_streak =
+        causal_arc_state_decision.acquisition_streak;
+    const Vector3d satellite_par_candidate_position(
+        debug_telemetry_.lambda_satellite_par_shadow_best_ecef_x,
+        debug_telemetry_.lambda_satellite_par_shadow_best_ecef_y,
+        debug_telemetry_.lambda_satellite_par_shadow_best_ecef_z);
+    auto satellite_par_disjoint_evidence =
+        causal_arc_disjoint_evidence;
+    satellite_par_disjoint_evidence.primary_ffrt_passed =
+        debug_telemetry_.lambda_satellite_par_shadow_ffrt_passed;
+    satellite_par_disjoint_evidence.primary_candidate_ecef =
+        satellite_par_candidate_position;
+    const auto satellite_par_disjoint_decision =
+        disjoint_satellite_fix_evidence::evaluate(
+            causal_arc_disjoint_config,
+            satellite_par_disjoint_evidence);
+    debug_telemetry_.satellite_par_disjoint_evidence_passed =
+        satellite_par_disjoint_decision.passed;
+    safe_fix::Candidate satellite_par_state_candidate;
+    satellite_par_state_candidate.time_s =
+        disjoint_state_candidate.time_s;
+    if (solution.isValid() &&
+        satellite_par_candidate_position.allFinite()) {
+        satellite_par_state_candidate.correction_m =
+            satellite_par_candidate_position -
+            solution.position_ecef;
+    }
+    satellite_par_state_candidate.nis_per_observation =
+        debug_telemetry_.float_update_nis_per_observation;
+    satellite_par_state_candidate.prefit_residual_rms_m =
+        debug_telemetry_.float_update_prefit_residual_rms_m;
+    satellite_par_state_candidate.pair_count =
+        debug_telemetry_.lambda_satellite_par_shadow_subset_size;
+    satellite_par_state_candidate.ambiguity_ratio =
+        debug_telemetry_.lambda_satellite_par_shadow_ratio;
+    satellite_par_state_candidate.independent_consensus_delta_m =
+        std::max(
+            satellite_par_disjoint_decision
+                .partition_a_primary_separation_m,
+            satellite_par_disjoint_decision
+                .partition_b_primary_separation_m);
+    satellite_par_state_candidate
+        .independent_failure_budget_passed =
+        satellite_par_disjoint_decision.passed;
+    satellite_par_state_candidate.acquisition_eligible =
+        solution.isValid() &&
+        satellite_par_disjoint_decision.passed &&
+        debug_telemetry_.lambda_satellite_par_shadow_subset_size >=
+            rtk_config_.safe_fix_shadow_minimum_pairs &&
+        std::isfinite(
+            satellite_par_state_candidate.nis_per_observation) &&
+        satellite_par_state_candidate.nis_per_observation <=
+            rtk_config_
+                .safe_fix_shadow_maximum_nis_per_observation &&
+        std::isfinite(
+            satellite_par_state_candidate
+                .prefit_residual_rms_m) &&
+        satellite_par_state_candidate.prefit_residual_rms_m <=
+            rtk_config_
+                .safe_fix_shadow_maximum_prefit_residual_rms_m;
+    const auto satellite_par_state_decision =
+        satellite_par_consensus_state_machine_.update(
+            rtk_config_.satellite_par_consensus_state_machine,
+            satellite_par_state_candidate);
+    debug_telemetry_.satellite_par_consensus_declared_fixed =
+        satellite_par_state_decision.declared_fixed;
+    debug_telemetry_.satellite_par_consensus_state =
+        static_cast<int>(satellite_par_state_decision.state);
+    debug_telemetry_.satellite_par_consensus_acquisition_streak =
+        satellite_par_state_decision.acquisition_streak;
+    const Vector3d src_par_candidate_position(
+        debug_telemetry_.lambda_src_par_shadow_best_ecef_x,
+        debug_telemetry_.lambda_src_par_shadow_best_ecef_y,
+        debug_telemetry_.lambda_src_par_shadow_best_ecef_z);
+    auto src_par_disjoint_evidence =
+        causal_arc_disjoint_evidence;
+    src_par_disjoint_evidence.primary_ffrt_passed =
+        debug_telemetry_.lambda_src_par_shadow_ffrt_passed;
+    src_par_disjoint_evidence.primary_candidate_ecef =
+        src_par_candidate_position;
+    const auto src_par_disjoint_decision =
+        disjoint_satellite_fix_evidence::evaluate(
+            causal_arc_disjoint_config,
+            src_par_disjoint_evidence);
+    debug_telemetry_.src_par_disjoint_evidence_passed =
+        src_par_disjoint_decision.passed;
+    debug_telemetry_.src_par_partition_a_separation_m =
+        src_par_disjoint_decision.partition_a_primary_separation_m;
+    debug_telemetry_.src_par_partition_b_separation_m =
+        src_par_disjoint_decision.partition_b_primary_separation_m;
+    safe_fix::Candidate src_par_state_candidate;
+    src_par_state_candidate.time_s =
+        disjoint_state_candidate.time_s;
+    if (solution.isValid() && src_par_candidate_position.allFinite()) {
+        src_par_state_candidate.correction_m =
+            src_par_candidate_position - solution.position_ecef;
+    }
+    src_par_state_candidate.nis_per_observation =
+        debug_telemetry_.float_update_nis_per_observation;
+    src_par_state_candidate.prefit_residual_rms_m =
+        debug_telemetry_.float_update_prefit_residual_rms_m;
+    src_par_state_candidate.pair_count =
+        debug_telemetry_.lambda_src_par_shadow_subset_size;
+    src_par_state_candidate.ambiguity_ratio =
+        debug_telemetry_.lambda_src_par_shadow_ratio;
+    src_par_state_candidate.independent_consensus_delta_m =
+        std::max(
+            src_par_disjoint_decision
+                .partition_a_primary_separation_m,
+            src_par_disjoint_decision
+                .partition_b_primary_separation_m);
+    src_par_state_candidate.independent_failure_budget_passed =
+        src_par_disjoint_decision.passed;
+    const bool src_par_hard_primary_separation_passed =
+        std::isfinite(
+            src_par_disjoint_decision
+                .partition_a_primary_separation_m) &&
+        std::isfinite(
+            src_par_disjoint_decision
+                .partition_b_primary_separation_m) &&
+        src_par_disjoint_decision
+                .partition_a_primary_separation_m <=
+            rtk_config_
+                .disjoint_satellite_fix_max_primary_separation_m &&
+        src_par_disjoint_decision
+                .partition_b_primary_separation_m <=
+            rtk_config_
+                .disjoint_satellite_fix_max_primary_separation_m;
+    const bool src_par_current_epoch_eligible =
+        solution.isValid() &&
+        src_par_disjoint_decision.passed &&
+        src_par_hard_primary_separation_passed &&
+        debug_telemetry_.lambda_src_par_shadow_ffrt_passed &&
+        std::isfinite(
+            debug_telemetry_
+                .lambda_src_par_shadow_second_position_delta_m) &&
+        debug_telemetry_
+                .lambda_src_par_shadow_second_position_delta_m <=
+            rtk_config_
+                .safe_fix_shadow_maximum_second_position_delta_m &&
+        debug_telemetry_.lambda_src_par_shadow_subset_size >=
+            rtk_config_.safe_fix_shadow_minimum_pairs &&
+        std::isfinite(src_par_state_candidate.nis_per_observation) &&
+        src_par_state_candidate.nis_per_observation <=
+            rtk_config_
+                .safe_fix_shadow_maximum_nis_per_observation &&
+        std::isfinite(
+            src_par_state_candidate.prefit_residual_rms_m) &&
+        src_par_state_candidate.prefit_residual_rms_m <=
+            rtk_config_
+                .safe_fix_shadow_maximum_prefit_residual_rms_m;
+    src_par_state_candidate.acquisition_eligible =
+        src_par_current_epoch_eligible;
+    const auto src_par_state_decision =
+        src_par_consensus_state_machine_.update(
+            rtk_config_.src_par_consensus_state_machine,
+            src_par_state_candidate);
+    debug_telemetry_.src_par_consensus_declared_fixed =
+        src_par_state_decision.declared_fixed;
+    debug_telemetry_.src_par_consensus_state =
+        static_cast<int>(src_par_state_decision.state);
+    debug_telemetry_.src_par_consensus_acquisition_streak =
+        src_par_state_decision.acquisition_streak;
+    safe_fix::Candidate inertial_referenced_state_candidate;
+    inertial_referenced_state_candidate.time_s =
+        disjoint_state_candidate.time_s;
+    if (primary_candidate_position.allFinite() &&
+        external_inertial_fix_evidence_.position_ecef.allFinite()) {
+        inertial_referenced_state_candidate.correction_m =
+            primary_candidate_position -
+            external_inertial_fix_evidence_.position_ecef;
+        debug_telemetry_.inertial_referenced_correction_x =
+            inertial_referenced_state_candidate.correction_m.x();
+        debug_telemetry_.inertial_referenced_correction_y =
+            inertial_referenced_state_candidate.correction_m.y();
+        debug_telemetry_.inertial_referenced_correction_z =
+            inertial_referenced_state_candidate.correction_m.z();
+    }
+    inertial_referenced_state_candidate.nis_per_observation =
+        debug_telemetry_.float_update_nis_per_observation;
+    inertial_referenced_state_candidate.prefit_residual_rms_m =
+        debug_telemetry_.float_update_prefit_residual_rms_m;
+    inertial_referenced_state_candidate.pair_count =
+        debug_telemetry_.pair_count;
+    inertial_referenced_state_candidate.ambiguity_ratio =
+        debug_telemetry_.full_ratio;
+    inertial_referenced_state_candidate
+        .independent_consensus_delta_m =
+        debug_telemetry_.inertial_fix_evidence_position_delta_m;
+    inertial_referenced_state_candidate
+        .independent_failure_budget_passed =
+        debug_telemetry_.inertial_fix_evidence_passed &&
+        debug_telemetry_.safe_fix_shadow_failure_budget_passed;
+    inertial_referenced_state_candidate.acquisition_eligible =
+        solution.isValid() &&
+        debug_telemetry_.lambda_shadow_ffrt_passed &&
+        debug_telemetry_.inertial_fix_evidence_passed &&
+        debug_telemetry_.pair_count >=
+            rtk_config_.safe_fix_shadow_minimum_pairs &&
+        std::isfinite(
+            inertial_referenced_state_candidate
+                .nis_per_observation) &&
+        inertial_referenced_state_candidate.nis_per_observation <=
+            rtk_config_
+                .safe_fix_shadow_maximum_nis_per_observation &&
+        std::isfinite(
+            inertial_referenced_state_candidate
+                .prefit_residual_rms_m) &&
+        inertial_referenced_state_candidate.prefit_residual_rms_m <=
+            rtk_config_
+                .safe_fix_shadow_maximum_prefit_residual_rms_m;
+    const auto inertial_referenced_state_decision =
+        inertial_referenced_consensus_state_machine_.update(
+            rtk_config_.inertial_referenced_consensus_state_machine,
+            inertial_referenced_state_candidate);
+    debug_telemetry_
+        .inertial_referenced_consensus_declared_fixed =
+        inertial_referenced_state_decision.declared_fixed;
+    debug_telemetry_.inertial_referenced_consensus_state =
+        static_cast<int>(inertial_referenced_state_decision.state);
+    debug_telemetry_
+        .inertial_referenced_consensus_acquisition_streak =
+        inertial_referenced_state_decision.acquisition_streak;
+    const Vector3d multifrequency_candidate_position(
+        debug_telemetry_.lambda_l1_l5_wlnl_shadow_best_ecef_x,
+        debug_telemetry_.lambda_l1_l5_wlnl_shadow_best_ecef_y,
+        debug_telemetry_.lambda_l1_l5_wlnl_shadow_best_ecef_z);
+    auto multifrequency_disjoint_evidence =
+        causal_arc_disjoint_evidence;
+    multifrequency_disjoint_evidence.primary_ffrt_passed =
+        debug_telemetry_.lambda_l1_l5_wlnl_shadow_wl_ffrt_passed &&
+        debug_telemetry_.lambda_l1_l5_wlnl_shadow_nl_ffrt_passed;
+    multifrequency_disjoint_evidence.primary_candidate_ecef =
+        multifrequency_candidate_position;
+    const auto multifrequency_disjoint_decision =
+        disjoint_satellite_fix_evidence::evaluate(
+            causal_arc_disjoint_config,
+            multifrequency_disjoint_evidence);
+    debug_telemetry_.multifrequency_disjoint_evidence_passed =
+        multifrequency_disjoint_decision.passed;
+    safe_fix::Candidate multifrequency_state_candidate;
+    multifrequency_state_candidate.time_s =
+        disjoint_state_candidate.time_s;
+    if (solution.isValid() &&
+        multifrequency_candidate_position.allFinite()) {
+        multifrequency_state_candidate.correction_m =
+            multifrequency_candidate_position -
+            solution.position_ecef;
+    }
+    multifrequency_state_candidate.nis_per_observation =
+        debug_telemetry_.float_update_nis_per_observation;
+    multifrequency_state_candidate.prefit_residual_rms_m =
+        debug_telemetry_.float_update_prefit_residual_rms_m;
+    multifrequency_state_candidate.pair_count =
+        debug_telemetry_
+            .lambda_l1_l5_wlnl_shadow_candidate_pair_count;
+    multifrequency_state_candidate.ambiguity_ratio =
+        debug_telemetry_.lambda_l1_l5_wlnl_shadow_nl_ratio;
+    multifrequency_state_candidate.independent_consensus_delta_m =
+        std::max(
+            multifrequency_disjoint_decision
+                .partition_a_primary_separation_m,
+            multifrequency_disjoint_decision
+                .partition_b_primary_separation_m);
+    multifrequency_state_candidate
+        .independent_failure_budget_passed =
+        multifrequency_disjoint_decision.passed;
+    multifrequency_state_candidate.acquisition_eligible =
+        solution.isValid() &&
+        multifrequency_disjoint_decision.passed &&
+        multifrequency_state_candidate.pair_count >=
+            rtk_config_.safe_fix_shadow_minimum_pairs &&
+        std::isfinite(
+            multifrequency_state_candidate.nis_per_observation) &&
+        multifrequency_state_candidate.nis_per_observation <=
+            rtk_config_
+                .safe_fix_shadow_maximum_nis_per_observation &&
+        std::isfinite(
+            multifrequency_state_candidate.prefit_residual_rms_m) &&
+        multifrequency_state_candidate.prefit_residual_rms_m <=
+            rtk_config_
+                .safe_fix_shadow_maximum_prefit_residual_rms_m;
+    const auto multifrequency_state_decision =
+        multifrequency_consensus_state_machine_.update(
+            rtk_config_.multifrequency_consensus_state_machine,
+            multifrequency_state_candidate);
+    debug_telemetry_.multifrequency_consensus_declared_fixed =
+        multifrequency_state_decision.declared_fixed;
+    debug_telemetry_.multifrequency_consensus_state =
+        static_cast<int>(multifrequency_state_decision.state);
+    debug_telemetry_.multifrequency_consensus_acquisition_streak =
+        multifrequency_state_decision.acquisition_streak;
+    const Vector3d l1_l2_multifrequency_candidate_position(
+        debug_telemetry_.lambda_l1_l2_wlnl_shadow_best_ecef_x,
+        debug_telemetry_.lambda_l1_l2_wlnl_shadow_best_ecef_y,
+        debug_telemetry_.lambda_l1_l2_wlnl_shadow_best_ecef_z);
+    auto l1_l2_multifrequency_disjoint_evidence =
+        causal_arc_disjoint_evidence;
+    l1_l2_multifrequency_disjoint_evidence.primary_ffrt_passed =
+        debug_telemetry_.lambda_l1_l2_wlnl_shadow_wl_ffrt_passed &&
+        debug_telemetry_.lambda_l1_l2_wlnl_shadow_nl_ffrt_passed;
+    l1_l2_multifrequency_disjoint_evidence.primary_candidate_ecef =
+        l1_l2_multifrequency_candidate_position;
+    const auto l1_l2_multifrequency_disjoint_decision =
+        disjoint_satellite_fix_evidence::evaluate(
+            causal_arc_disjoint_config,
+            l1_l2_multifrequency_disjoint_evidence);
+    debug_telemetry_.l1_l2_multifrequency_disjoint_evidence_passed =
+        l1_l2_multifrequency_disjoint_decision.passed;
+    safe_fix::Candidate l1_l2_multifrequency_state_candidate;
+    l1_l2_multifrequency_state_candidate.time_s =
+        disjoint_state_candidate.time_s;
+    if (solution.isValid() &&
+        l1_l2_multifrequency_candidate_position.allFinite()) {
+        l1_l2_multifrequency_state_candidate.correction_m =
+            l1_l2_multifrequency_candidate_position -
+            solution.position_ecef;
+    }
+    l1_l2_multifrequency_state_candidate.nis_per_observation =
+        debug_telemetry_.float_update_nis_per_observation;
+    l1_l2_multifrequency_state_candidate.prefit_residual_rms_m =
+        debug_telemetry_.float_update_prefit_residual_rms_m;
+    l1_l2_multifrequency_state_candidate.pair_count =
+        debug_telemetry_
+            .lambda_l1_l2_wlnl_shadow_candidate_pair_count;
+    l1_l2_multifrequency_state_candidate.ambiguity_ratio =
+        debug_telemetry_.lambda_l1_l2_wlnl_shadow_nl_ratio;
+    l1_l2_multifrequency_state_candidate
+        .independent_consensus_delta_m =
+        std::max(
+            l1_l2_multifrequency_disjoint_decision
+                .partition_a_primary_separation_m,
+            l1_l2_multifrequency_disjoint_decision
+                .partition_b_primary_separation_m);
+    l1_l2_multifrequency_state_candidate
+        .independent_failure_budget_passed =
+        l1_l2_multifrequency_disjoint_decision.passed;
+    l1_l2_multifrequency_state_candidate.acquisition_eligible =
+        solution.isValid() &&
+        l1_l2_multifrequency_disjoint_decision.passed &&
+        l1_l2_multifrequency_state_candidate.pair_count >=
+            rtk_config_.safe_fix_shadow_minimum_pairs &&
+        std::isfinite(
+            l1_l2_multifrequency_state_candidate
+                .nis_per_observation) &&
+        l1_l2_multifrequency_state_candidate
+                .nis_per_observation <=
+            rtk_config_
+                .safe_fix_shadow_maximum_nis_per_observation &&
+        std::isfinite(
+            l1_l2_multifrequency_state_candidate
+                .prefit_residual_rms_m) &&
+        l1_l2_multifrequency_state_candidate
+                .prefit_residual_rms_m <=
+            rtk_config_
+                .safe_fix_shadow_maximum_prefit_residual_rms_m;
+    const auto l1_l2_multifrequency_state_decision =
+        l1_l2_multifrequency_consensus_state_machine_.update(
+            rtk_config_.multifrequency_consensus_state_machine,
+            l1_l2_multifrequency_state_candidate);
+    debug_telemetry_
+        .l1_l2_multifrequency_consensus_declared_fixed =
+        l1_l2_multifrequency_state_decision.declared_fixed;
+    debug_telemetry_.l1_l2_multifrequency_consensus_state =
+        static_cast<int>(l1_l2_multifrequency_state_decision.state);
+    debug_telemetry_
+        .l1_l2_multifrequency_consensus_acquisition_streak =
+        l1_l2_multifrequency_state_decision.acquisition_streak;
+    const bool safe_shadow_candidate =
+        config.allow_safe_shadow_promotion &&
+        debug_telemetry_.safe_fix_shadow_declared_fixed;
+    const bool disjoint_state_safe_candidate =
+        config.allow_safe_shadow_promotion &&
+        disjoint_state_decision.declared_fixed &&
+        disjoint_consensus.valid;
+    fixed_quality_gate::Evidence original_quality_evidence;
+    original_quality_evidence.safe_fix_shadow_declared_fixed =
+        debug_telemetry_.safe_fix_shadow_declared_fixed ||
+        disjoint_state_decision.declared_fixed;
+    original_quality_evidence.independent_failure_budget_passed =
+        debug_telemetry_.safe_fix_shadow_failure_budget_passed;
+    original_quality_evidence.float_position_covariance_trace_m2 =
+        debug_telemetry_.float_position_covariance_trace_m2;
+    original_quality_evidence.update_observations =
+        debug_telemetry_.float_update_observation_count;
+    original_quality_evidence.suppressed_outliers =
+        debug_telemetry_.float_update_suppressed_outliers;
+    original_quality_evidence.update_nis_per_observation =
+        debug_telemetry_.float_update_nis_per_observation;
+    const bool replace_rejected_original_fixed_candidate =
+        solution.isFixed() &&
+        !fixed_quality_gate::evaluate(
+             config, original_quality_evidence).passed;
+    const bool causal_arc_state_safe_candidate =
+        rtk_config_.causal_arc_consensus_promotion &&
+        causal_arc_state_decision.declared_fixed &&
+        causal_arc_disjoint_decision.passed &&
+        causal_arc_candidate_position.allFinite();
+    const bool causal_arc_promotion_candidate =
+        causal_arc_state_safe_candidate &&
+        (!solution.isFixed() ||
+         replace_rejected_original_fixed_candidate);
+    const bool satellite_par_state_safe_candidate =
+        rtk_config_.satellite_par_consensus_promotion &&
+        satellite_par_state_decision.declared_fixed &&
+        satellite_par_disjoint_decision.passed &&
+        satellite_par_candidate_position.allFinite();
+    const bool satellite_par_promotion_candidate =
+        satellite_par_state_safe_candidate &&
+        (!solution.isFixed() ||
+         replace_rejected_original_fixed_candidate) &&
+        !causal_arc_promotion_candidate;
+    const bool src_par_state_safe_candidate =
+        rtk_config_.src_par_consensus_promotion &&
+        src_par_state_decision.declared_fixed &&
+        src_par_current_epoch_eligible &&
+        src_par_candidate_position.allFinite();
+    const bool src_par_promotion_candidate =
+        src_par_state_safe_candidate &&
+        (!solution.isFixed() ||
+         replace_rejected_original_fixed_candidate) &&
+        !causal_arc_promotion_candidate &&
+        !satellite_par_promotion_candidate;
+    const bool inertial_referenced_state_safe_candidate =
+        rtk_config_.inertial_referenced_consensus_promotion &&
+        inertial_referenced_state_decision.declared_fixed &&
+        debug_telemetry_.inertial_fix_evidence_passed &&
+        primary_candidate_position.allFinite();
+    const bool inertial_referenced_promotion_candidate =
+        inertial_referenced_state_safe_candidate &&
+        (!solution.isFixed() ||
+         replace_rejected_original_fixed_candidate) &&
+        !causal_arc_promotion_candidate &&
+        !satellite_par_promotion_candidate &&
+        !src_par_promotion_candidate;
+    const bool multifrequency_state_safe_candidate =
+        rtk_config_.multifrequency_consensus_promotion &&
+        multifrequency_state_decision.declared_fixed &&
+        multifrequency_disjoint_decision.passed &&
+        multifrequency_candidate_position.allFinite();
+    const bool multifrequency_promotion_candidate =
+        multifrequency_state_safe_candidate &&
+        (!solution.isFixed() ||
+         replace_rejected_original_fixed_candidate) &&
+        !causal_arc_promotion_candidate &&
+        !satellite_par_promotion_candidate &&
+        !src_par_promotion_candidate &&
+        !inertial_referenced_promotion_candidate;
+    const bool l1_l2_multifrequency_state_safe_candidate =
+        rtk_config_.multifrequency_consensus_promotion &&
+        l1_l2_multifrequency_state_decision.declared_fixed &&
+        l1_l2_multifrequency_disjoint_decision.passed &&
+        l1_l2_multifrequency_candidate_position.allFinite();
+    const bool l1_l2_multifrequency_promotion_candidate =
+        l1_l2_multifrequency_state_safe_candidate &&
+        (!solution.isFixed() ||
+         replace_rejected_original_fixed_candidate) &&
+        !causal_arc_promotion_candidate &&
+        !satellite_par_promotion_candidate &&
+        !src_par_promotion_candidate &&
+        !inertial_referenced_promotion_candidate &&
+        !multifrequency_promotion_candidate;
+    const bool disjoint_consensus_candidate =
+        config.allow_failure_budget_candidate_promotion &&
+        debug_telemetry_.disjoint_satellite_fix_evidence_passed;
+    const bool independent_replacement_candidate =
+        causal_arc_promotion_candidate ||
+        satellite_par_promotion_candidate ||
+        src_par_promotion_candidate ||
+        inertial_referenced_promotion_candidate ||
+        multifrequency_promotion_candidate ||
+        l1_l2_multifrequency_promotion_candidate;
+    if ((!solution.isFixed() ||
+         independent_replacement_candidate ||
+         disjoint_state_safe_candidate) &&
+        (safe_shadow_candidate ||
+         disjoint_state_safe_candidate ||
+         causal_arc_promotion_candidate ||
+         satellite_par_promotion_candidate ||
+         src_par_promotion_candidate ||
+         inertial_referenced_promotion_candidate ||
+         multifrequency_promotion_candidate ||
+         l1_l2_multifrequency_promotion_candidate ||
+         disjoint_consensus_candidate) &&
+        solution.isValid() &&
+        ((causal_arc_promotion_candidate &&
+          causal_arc_disjoint_decision.passed) ||
+         (satellite_par_promotion_candidate &&
+          satellite_par_disjoint_decision.passed) ||
+         (src_par_promotion_candidate &&
+          src_par_disjoint_decision.passed) ||
+         (inertial_referenced_promotion_candidate &&
+          debug_telemetry_.inertial_fix_evidence_passed) ||
+         (multifrequency_promotion_candidate &&
+          multifrequency_disjoint_decision.passed) ||
+         (l1_l2_multifrequency_promotion_candidate &&
+          l1_l2_multifrequency_disjoint_decision.passed) ||
+         (debug_telemetry_.safe_fix_shadow_failure_budget_passed &&
+          debug_telemetry_.lambda_shadow_ffrt_passed)) &&
+        (safe_shadow_candidate ||
+         disjoint_state_safe_candidate ||
+         causal_arc_promotion_candidate ||
+         satellite_par_promotion_candidate ||
+         src_par_promotion_candidate ||
+         inertial_referenced_promotion_candidate ||
+         multifrequency_promotion_candidate ||
+         l1_l2_multifrequency_promotion_candidate ||
+         disjoint_consensus_candidate)) {
+        Vector3d promoted_position = primary_candidate_position;
+        if (causal_arc_promotion_candidate) {
+            promoted_position = causal_arc_candidate_position;
+            debug_telemetry_
+                .library_fixed_quality_gate_causal_arc_promoted = true;
+            debug_telemetry_
+                .safe_fix_shadow_failure_budget_passed = true;
+            debug_telemetry_
+                .safe_fix_shadow_independent_source_families = 2;
+            debug_telemetry_
+                .safe_fix_shadow_joint_failure_probability = 1e-6;
+        } else if (satellite_par_promotion_candidate) {
+            promoted_position = satellite_par_candidate_position;
+            debug_telemetry_
+                .library_fixed_quality_gate_satellite_par_promoted =
+                true;
+            debug_telemetry_
+                .safe_fix_shadow_failure_budget_passed = true;
+            debug_telemetry_
+                .safe_fix_shadow_independent_source_families = 2;
+            debug_telemetry_
+                .safe_fix_shadow_joint_failure_probability = 1e-6;
+        } else if (src_par_promotion_candidate) {
+            promoted_position = src_par_candidate_position;
+            debug_telemetry_
+                .library_fixed_quality_gate_src_par_promoted = true;
+            debug_telemetry_
+                .safe_fix_shadow_failure_budget_passed = true;
+            debug_telemetry_
+                .safe_fix_shadow_independent_source_families = 2;
+            debug_telemetry_
+                .safe_fix_shadow_joint_failure_probability = 1e-6;
+        } else if (inertial_referenced_promotion_candidate) {
+            promoted_position = primary_candidate_position;
+            debug_telemetry_
+                .library_fixed_quality_gate_inertial_referenced_promoted =
+                true;
+            debug_telemetry_
+                .safe_fix_shadow_failure_budget_passed = true;
+            debug_telemetry_
+                .safe_fix_shadow_independent_source_families = 2;
+            debug_telemetry_
+                .safe_fix_shadow_joint_failure_probability = 1e-6;
+        } else if (multifrequency_promotion_candidate) {
+            promoted_position = multifrequency_candidate_position;
+            debug_telemetry_
+                .library_fixed_quality_gate_multifrequency_promoted =
+                true;
+            debug_telemetry_
+                .safe_fix_shadow_failure_budget_passed = true;
+            debug_telemetry_
+                .safe_fix_shadow_independent_source_families = 2;
+            debug_telemetry_
+                .safe_fix_shadow_joint_failure_probability = 1e-6;
+        } else if (l1_l2_multifrequency_promotion_candidate) {
+            promoted_position =
+                l1_l2_multifrequency_candidate_position;
+            debug_telemetry_
+                .library_fixed_quality_gate_multifrequency_promoted =
+                true;
+            debug_telemetry_
+                .safe_fix_shadow_failure_budget_passed = true;
+            debug_telemetry_
+                .safe_fix_shadow_independent_source_families = 2;
+            debug_telemetry_
+                .safe_fix_shadow_joint_failure_probability = 1e-6;
+        } else if (disjoint_state_safe_candidate ||
+            (!safe_shadow_candidate &&
+             disjoint_consensus_candidate)) {
+            promoted_position = disjoint_consensus.position_ecef;
+            debug_telemetry_
+                .library_fixed_quality_gate_disjoint_consensus_promoted =
+                disjoint_consensus.valid;
+        }
+        if (promoted_position.allFinite()) {
+            solution.position_ecef = promoted_position;
+            solution.position_geodetic =
+                spp_utils::ecefToGeodetic(promoted_position);
+            solution.status = SolutionStatus::FIXED;
+            solution.ratio =
+                causal_arc_promotion_candidate
+                    ? debug_telemetry_
+                          .lambda_causal_arc_subset_ratio
+                    : satellite_par_promotion_candidate
+                        ? debug_telemetry_
+                              .lambda_satellite_par_shadow_ratio
+                    : src_par_promotion_candidate
+                        ? debug_telemetry_
+                              .lambda_src_par_shadow_ratio
+                    : inertial_referenced_promotion_candidate
+                        ? debug_telemetry_.full_ratio
+                    : multifrequency_promotion_candidate
+                        ? debug_telemetry_
+                              .lambda_l1_l5_wlnl_shadow_nl_ratio
+                    : l1_l2_multifrequency_promotion_candidate
+                        ? debug_telemetry_
+                              .lambda_l1_l2_wlnl_shadow_nl_ratio
+                    : debug_telemetry_.full_ratio;
+            solution.num_fixed_ambiguities =
+                causal_arc_promotion_candidate
+                    ? debug_telemetry_
+                          .lambda_causal_arc_ready_pairs
+                    : satellite_par_promotion_candidate
+                        ? debug_telemetry_
+                              .lambda_satellite_par_shadow_subset_size
+                    : src_par_promotion_candidate
+                        ? debug_telemetry_
+                              .lambda_src_par_shadow_subset_size
+                    : inertial_referenced_promotion_candidate
+                        ? debug_telemetry_.pair_count
+                    : multifrequency_promotion_candidate
+                        ? debug_telemetry_
+                              .lambda_l1_l5_wlnl_shadow_candidate_pair_count
+                    : l1_l2_multifrequency_promotion_candidate
+                        ? debug_telemetry_
+                              .lambda_l1_l2_wlnl_shadow_candidate_pair_count
+                    : debug_telemetry_.pair_count;
+            debug_telemetry_
+                .library_fixed_quality_gate_promoted = true;
+            promoted_current_epoch_candidate = true;
+        }
+    }
+    if (!solution.isFixed()) {
+        return;
+    }
+    fixed_quality_gate::Evidence evidence;
+    evidence.safe_fix_shadow_declared_fixed =
+        debug_telemetry_.safe_fix_shadow_declared_fixed ||
+        disjoint_state_decision.declared_fixed ||
+        debug_telemetry_
+            .library_fixed_quality_gate_causal_arc_promoted ||
+        debug_telemetry_
+            .library_fixed_quality_gate_satellite_par_promoted;
+    evidence.safe_fix_shadow_declared_fixed =
+        evidence.safe_fix_shadow_declared_fixed ||
+        debug_telemetry_
+            .library_fixed_quality_gate_src_par_promoted ||
+        debug_telemetry_
+            .library_fixed_quality_gate_inertial_referenced_promoted ||
+        debug_telemetry_
+            .library_fixed_quality_gate_multifrequency_promoted;
+    evidence.independent_failure_budget_passed =
+        debug_telemetry_.safe_fix_shadow_failure_budget_passed;
+    evidence.float_position_covariance_trace_m2 =
+        debug_telemetry_.float_position_covariance_trace_m2;
+    evidence.update_observations =
+        debug_telemetry_.float_update_observation_count;
+    evidence.suppressed_outliers =
+        debug_telemetry_.float_update_suppressed_outliers;
+    evidence.update_nis_per_observation =
+        debug_telemetry_.float_update_nis_per_observation;
+    const auto decision = fixed_quality_gate::evaluate(config, evidence);
+    const bool unresolved_raw_partition_conflict =
+        original_solution.isFixed() &&
+        !causal_arc_promotion_candidate &&
+        !satellite_par_promotion_candidate &&
+        !src_par_promotion_candidate &&
+        !inertial_referenced_promotion_candidate &&
+        !multifrequency_promotion_candidate &&
+        !l1_l2_multifrequency_promotion_candidate &&
+        !debug_telemetry_.safe_fix_shadow_declared_fixed &&
+        !debug_telemetry_.inertial_fix_evidence_healthy_anchor &&
+        disjoint_state_decision.state == safe_fix::State::IDLE &&
+        debug_telemetry_.disjoint_satellite_fix_evidence_passed &&
+        !debug_telemetry_
+             .disjoint_satellite_fix_hard_separation_passed &&
+        std::isfinite(
+            debug_telemetry_
+                .disjoint_satellite_fix_partition_separation_m) &&
+        debug_telemetry_
+                .disjoint_satellite_fix_partition_separation_m <
+            debug_telemetry_
+                .disjoint_satellite_fix_partition_a_primary_separation_m &&
+        debug_telemetry_
+                .disjoint_satellite_fix_partition_separation_m <
+            debug_telemetry_
+                .disjoint_satellite_fix_partition_b_primary_separation_m;
+    debug_telemetry_.library_fixed_quality_gate_raw_partition_conflict =
+        unresolved_raw_partition_conflict;
+    const bool quality_passed =
+        decision.passed && !unresolved_raw_partition_conflict;
+    debug_telemetry_.library_fixed_quality_gate_passed =
+        quality_passed;
+    debug_telemetry_.library_fixed_quality_gate_safe_shadow_branch =
+        decision.safe_shadow_branch;
+    debug_telemetry_.library_fixed_quality_gate_covariance_branch =
+        decision.covariance_branch;
+    debug_telemetry_
+        .library_fixed_quality_gate_strong_innovation_branch =
+        decision.strong_innovation_branch;
+    if (!quality_passed) {
+        if (promoted_current_epoch_candidate) {
+            // A provisional current-epoch integer candidate must not leak into
+            // the exported FLOAT solution or become an inertial/filter seed
+            // after the ordinary quality gate rejects it.
+            solution = original_solution;
+        }
+        solution.status = SolutionStatus::FLOAT;
+        debug_telemetry_.library_fixed_quality_gate_demoted = true;
+    }
+}
+
+void RTKProcessor::updateIndependentFailureBudgetTelemetry() {
+    double bsr = std::numeric_limits<double>::quiet_NaN();
+    switch (rtk_config_.safe_fix_shadow_covariance_scale) {
+        case 1: bsr = debug_telemetry_.lambda_shadow_bsr; break;
+        case 2: bsr = debug_telemetry_.lambda_shadow_bsr_qscale2; break;
+        case 4: bsr = debug_telemetry_.lambda_shadow_bsr_qscale4; break;
+        case 8: bsr = debug_telemetry_.lambda_shadow_bsr_qscale8; break;
+        case 16: bsr = debug_telemetry_.lambda_shadow_bsr_qscale16; break;
+        default: break;
+    }
+    FixedFailureRateRatioThreshold threshold;
+    const bool ffrt_passed =
+        debug_telemetry_.lambda_shadow_solved &&
+        fixedFailureRateRatioThreshold(
+            debug_telemetry_.pair_count, bsr, 0.001, threshold) &&
+        threshold.accepts_any_candidate &&
+        std::isfinite(debug_telemetry_.full_ratio) &&
+        debug_telemetry_.full_ratio >=
+            threshold.minimum_second_to_best_ratio;
+
+    const auto& inertial = external_inertial_fix_evidence_;
+    debug_telemetry_.inertial_fix_evidence_available =
+        inertial.available;
+    debug_telemetry_.inertial_fix_evidence_healthy_anchor =
+        inertial.healthy_independent_anchor;
+    const Vector3d primary_candidate_ecef(
+        debug_telemetry_.lambda_shadow_best_ecef_x,
+        debug_telemetry_.lambda_shadow_best_ecef_y,
+        debug_telemetry_.lambda_shadow_best_ecef_z);
+    bool inertial_passed = false;
+    if (inertial.available &&
+        inertial.healthy_independent_anchor &&
+        inertial.position_ecef.allFinite() &&
+        inertial.position_covariance_ecef.allFinite() &&
+        primary_candidate_ecef.allFinite()) {
+        const double time_error_s =
+            std::abs(inertial.time - current_epoch_time_);
+        debug_telemetry_.inertial_fix_evidence_time_error_s =
+            time_error_s;
+        inertial_fix_evidence::Config monitor_config;
+        monitor_config.maximum_time_error_s =
+            rtk_config_.inertial_fix_evidence_max_time_error_s;
+        monitor_config.covariance_scale =
+            rtk_config_.inertial_fix_evidence_covariance_scale;
+        monitor_config.maximum_nis_per_dimension =
+            rtk_config_
+                .inertial_fix_evidence_max_nis_per_dimension;
+        monitor_config.maximum_position_delta_m =
+            rtk_config_
+                .inertial_fix_evidence_max_position_delta_m;
+        inertial_fix_evidence::Evidence monitor_evidence;
+        monitor_evidence.available = inertial.available;
+        monitor_evidence.healthy_independent_anchor =
+            inertial.healthy_independent_anchor;
+        monitor_evidence.time_error_s = time_error_s;
+        monitor_evidence.predicted_position_ecef =
+            inertial.position_ecef;
+        monitor_evidence.predicted_position_covariance_ecef =
+            inertial.position_covariance_ecef;
+        monitor_evidence.primary_candidate_ecef =
+            primary_candidate_ecef;
+        const auto monitor_decision =
+            inertial_fix_evidence::evaluate(
+                monitor_config, monitor_evidence);
+        debug_telemetry_
+            .inertial_fix_evidence_position_delta_m =
+            monitor_decision.position_delta_m;
+        debug_telemetry_
+            .inertial_fix_evidence_nis_per_dimension =
+            monitor_decision.nis_per_dimension;
+        inertial_passed = monitor_decision.passed;
+    }
+    debug_telemetry_.inertial_fix_evidence_passed =
+        inertial_passed;
+
+    const auto& disjoint =
+        external_disjoint_satellite_fix_evidence_;
+    debug_telemetry_.disjoint_satellite_fix_evidence_available =
+        disjoint.available;
+    debug_telemetry_.disjoint_satellite_fix_inputs_verified =
+        disjoint.inputs_verified_disjoint;
+    debug_telemetry_
+        .disjoint_satellite_fix_partition_a_ffrt_passed =
+        disjoint.partition_a_ffrt_passed;
+    debug_telemetry_
+        .disjoint_satellite_fix_partition_b_ffrt_passed =
+        disjoint.partition_b_ffrt_passed;
+    disjoint_satellite_fix_evidence::Config disjoint_config;
+    disjoint_config.maximum_partition_separation_m =
+        rtk_config_
+            .disjoint_satellite_fix_max_partition_separation_m;
+    disjoint_config.maximum_primary_separation_m =
+        rtk_config_
+            .disjoint_satellite_fix_max_primary_separation_m;
+    disjoint_config.covariance_scale =
+        rtk_config_.disjoint_satellite_fix_covariance_scale;
+    disjoint_config.maximum_nis_per_dimension =
+        rtk_config_
+            .disjoint_satellite_fix_max_nis_per_dimension;
+    disjoint_config.maximum_statistical_separation_m =
+        rtk_config_
+            .disjoint_satellite_fix_max_statistical_separation_m;
+    disjoint_satellite_fix_evidence::Evidence disjoint_evidence;
+    disjoint_evidence.available = disjoint.available;
+    disjoint_evidence.inputs_verified_disjoint =
+        disjoint.inputs_verified_disjoint;
+    disjoint_evidence.primary_ffrt_passed = ffrt_passed;
+    disjoint_evidence.partition_a_ffrt_passed =
+        disjoint.partition_a_ffrt_passed;
+    disjoint_evidence.partition_b_ffrt_passed =
+        disjoint.partition_b_ffrt_passed;
+    disjoint_evidence.partition_a_candidate_ecef =
+        disjoint.partition_a_candidate_ecef;
+    disjoint_evidence.partition_b_candidate_ecef =
+        disjoint.partition_b_candidate_ecef;
+    disjoint_evidence.primary_candidate_ecef =
+        primary_candidate_ecef;
+    disjoint_evidence.partition_a_covariance_ecef =
+        disjoint.partition_a_covariance_ecef;
+    disjoint_evidence.partition_b_covariance_ecef =
+        disjoint.partition_b_covariance_ecef;
+    if (std::isfinite(
+            debug_telemetry_
+                .float_position_covariance_trace_m2) &&
+        debug_telemetry_
+                .float_position_covariance_trace_m2 > 0.0) {
+        disjoint_evidence.primary_covariance_ecef =
+            Matrix3d::Identity() *
+            (debug_telemetry_
+                 .float_position_covariance_trace_m2 /
+             3.0);
+    }
+    const auto disjoint_decision =
+        disjoint_satellite_fix_evidence::evaluate(
+            disjoint_config, disjoint_evidence);
+    debug_telemetry_.disjoint_satellite_fix_evidence_passed =
+        disjoint_decision.passed;
+    debug_telemetry_
+        .disjoint_satellite_fix_partition_separation_m =
+        disjoint_decision.partition_separation_m;
+    debug_telemetry_
+        .disjoint_satellite_fix_partition_a_primary_separation_m =
+        disjoint_decision.partition_a_primary_separation_m;
+    debug_telemetry_
+        .disjoint_satellite_fix_partition_b_primary_separation_m =
+        disjoint_decision.partition_b_primary_separation_m;
+    debug_telemetry_
+        .disjoint_satellite_fix_hard_separation_passed =
+        disjoint_decision.hard_separation_passed;
+    debug_telemetry_
+        .disjoint_satellite_fix_statistical_separation_passed =
+        disjoint_decision.statistical_separation_passed;
+    debug_telemetry_
+        .disjoint_satellite_fix_partition_nis_per_dimension =
+        disjoint_decision.partition_nis_per_dimension;
+    debug_telemetry_
+        .disjoint_satellite_fix_partition_a_primary_nis_per_dimension =
+        disjoint_decision
+            .partition_a_primary_nis_per_dimension;
+    debug_telemetry_
+        .disjoint_satellite_fix_partition_b_primary_nis_per_dimension =
+        disjoint_decision
+            .partition_b_primary_nis_per_dimension;
+
+    // When two genuinely disjoint partitions both pass, they provide the
+    // two independent fault domains themselves. Do not also count the
+    // overlapping all-satellite primary solution as an independent family.
+    const bool use_disjoint_partitions =
+        disjoint_decision.passed;
+    const std::array<fix_failure_budget::Evidence, 6>
+        failure_evidence{{
+            {
+                fix_failure_budget::SourceFamily::
+                    PRIMARY_CARRIER_AR,
+                ffrt_passed && !use_disjoint_partitions,
+                0.001,
+            },
+            {
+                // Full and satellite-PAR share carrier observations and
+                // ambiguity states, so they deliberately occupy the same
+                // fault domain.
+                fix_failure_budget::SourceFamily::
+                    PRIMARY_CARRIER_AR,
+                debug_telemetry_
+                        .lambda_satellite_par_shadow_ffrt_passed &&
+                    debug_telemetry_
+                        .lambda_satellite_par_shadow_solved &&
+                    !use_disjoint_partitions,
+                0.001,
+            },
+            {
+                fix_failure_budget::SourceFamily::
+                    MULTIFREQUENCY_CASCADE,
+                (debug_telemetry_
+                         .lambda_l1_l5_wlnl_shadow_wl_ffrt_passed &&
+                 debug_telemetry_
+                         .lambda_l1_l5_wlnl_shadow_nl_ffrt_passed &&
+                 std::isfinite(
+                     debug_telemetry_
+                         .lambda_l1_l5_wlnl_shadow_best_ecef_x) &&
+                 std::isfinite(
+                     debug_telemetry_
+                         .lambda_l1_l5_wlnl_shadow_best_ecef_y) &&
+                 std::isfinite(
+                     debug_telemetry_
+                         .lambda_l1_l5_wlnl_shadow_best_ecef_z)) ||
+                    (debug_telemetry_
+                         .lambda_l1_l2_wlnl_shadow_wl_ffrt_passed &&
+                     debug_telemetry_
+                         .lambda_l1_l2_wlnl_shadow_nl_ffrt_passed &&
+                     std::isfinite(
+                         debug_telemetry_
+                             .lambda_l1_l2_wlnl_shadow_best_ecef_x) &&
+                     std::isfinite(
+                         debug_telemetry_
+                             .lambda_l1_l2_wlnl_shadow_best_ecef_y) &&
+                     std::isfinite(
+                         debug_telemetry_
+                             .lambda_l1_l2_wlnl_shadow_best_ecef_z)) ||
+                    (debug_telemetry_
+                         .lambda_l2_l5_wlnl_shadow_wl_ffrt_passed &&
+                     debug_telemetry_
+                         .lambda_l2_l5_wlnl_shadow_nl_ffrt_passed &&
+                     std::isfinite(
+                         debug_telemetry_
+                             .lambda_l2_l5_wlnl_shadow_best_ecef_x) &&
+                     std::isfinite(
+                         debug_telemetry_
+                             .lambda_l2_l5_wlnl_shadow_best_ecef_y) &&
+                     std::isfinite(
+                         debug_telemetry_
+                             .lambda_l2_l5_wlnl_shadow_best_ecef_z)),
+                0.002,
+            },
+            {
+                fix_failure_budget::SourceFamily::
+                    INERTIAL_SOLUTION_SEPARATION,
+                inertial_passed,
+                rtk_config_
+                    .inertial_fix_evidence_failure_probability,
+            },
+            {
+                fix_failure_budget::SourceFamily::
+                    DISJOINT_SATELLITE_PARTITION_A,
+                use_disjoint_partitions,
+                rtk_config_
+                    .disjoint_satellite_fix_failure_probability,
+            },
+            {
+                fix_failure_budget::SourceFamily::
+                    DISJOINT_SATELLITE_PARTITION_B,
+                use_disjoint_partitions,
+                rtk_config_
+                    .disjoint_satellite_fix_failure_probability,
+            },
+        }};
+    const auto failure_budget =
+        fix_failure_budget::evaluate(
+            fix_failure_budget::Config{}, failure_evidence);
+    debug_telemetry_
+        .safe_fix_shadow_independent_source_families =
+        failure_budget.independent_families;
+    debug_telemetry_
+        .safe_fix_shadow_joint_failure_probability =
+        failure_budget.joint_failure_probability;
+    debug_telemetry_
+        .safe_fix_shadow_failure_budget_passed =
+        failure_budget.passed;
+    independent_failure_budget_evaluated_this_epoch_ = true;
+}
+
+void RTKProcessor::updateSafeFixShadowStateMachine(const GNSSTime& time) {
+    const auto& config = rtk_config_.safe_fix_shadow_state_machine;
+    debug_telemetry_.safe_fix_shadow_enabled = config.enabled;
+
+    safe_fix::Candidate candidate;
+    candidate.time_s =
+        static_cast<double>(time.week) * 604800.0 + time.tow;
+    candidate.correction_m = Vector3d(
+        debug_telemetry_.lambda_shadow_best_correction_x,
+        debug_telemetry_.lambda_shadow_best_correction_y,
+        debug_telemetry_.lambda_shadow_best_correction_z);
+    candidate.nis_per_observation =
+        debug_telemetry_.float_update_nis_per_observation;
+    candidate.prefit_residual_rms_m =
+        debug_telemetry_.float_update_prefit_residual_rms_m;
+    candidate.pair_count = debug_telemetry_.pair_count;
+    candidate.ambiguity_ratio = debug_telemetry_.full_ratio;
+    const Vector3d satellite_candidate_ecef(
+        debug_telemetry_.lambda_satellite_par_shadow_best_ecef_x,
+        debug_telemetry_.lambda_satellite_par_shadow_best_ecef_y,
+        debug_telemetry_.lambda_satellite_par_shadow_best_ecef_z);
+    const Vector3d full_candidate_ecef(
+        debug_telemetry_.lambda_shadow_best_ecef_x,
+        debug_telemetry_.lambda_shadow_best_ecef_y,
+        debug_telemetry_.lambda_shadow_best_ecef_z);
+    if (satellite_candidate_ecef.allFinite() &&
+        full_candidate_ecef.allFinite()) {
+        candidate.independent_consensus_delta_m =
+            (satellite_candidate_ecef - full_candidate_ecef).norm();
+    }
+    debug_telemetry_
+        .safe_fix_shadow_independent_consensus_delta_m =
+        candidate.independent_consensus_delta_m;
+
+    double bsr = std::numeric_limits<double>::quiet_NaN();
+    switch (rtk_config_.safe_fix_shadow_covariance_scale) {
+        case 1: bsr = debug_telemetry_.lambda_shadow_bsr; break;
+        case 2: bsr = debug_telemetry_.lambda_shadow_bsr_qscale2; break;
+        case 4: bsr = debug_telemetry_.lambda_shadow_bsr_qscale4; break;
+        case 8: bsr = debug_telemetry_.lambda_shadow_bsr_qscale8; break;
+        case 16: bsr = debug_telemetry_.lambda_shadow_bsr_qscale16; break;
+        default: break;
+    }
+    FixedFailureRateRatioThreshold threshold;
+    const bool ffrt_passed =
+        debug_telemetry_.lambda_shadow_solved &&
+        fixedFailureRateRatioThreshold(
+            candidate.pair_count, bsr, 0.001, threshold) &&
+        threshold.accepts_any_candidate &&
+        std::isfinite(debug_telemetry_.full_ratio) &&
+        debug_telemetry_.full_ratio >=
+            threshold.minimum_second_to_best_ratio;
+    if (!independent_failure_budget_evaluated_this_epoch_) {
+        updateIndependentFailureBudgetTelemetry();
+    }
+    candidate.independent_failure_budget_passed =
+        debug_telemetry_.safe_fix_shadow_failure_budget_passed;
+    candidate.acquisition_eligible =
+        ffrt_passed &&
+        candidate.pair_count >= rtk_config_.safe_fix_shadow_minimum_pairs &&
+        std::isfinite(
+            debug_telemetry_.lambda_shadow_second_position_delta_m) &&
+        debug_telemetry_.lambda_shadow_second_position_delta_m <=
+            rtk_config_
+                .safe_fix_shadow_maximum_second_position_delta_m &&
+        std::isfinite(candidate.nis_per_observation) &&
+        candidate.nis_per_observation <=
+            rtk_config_.safe_fix_shadow_maximum_nis_per_observation &&
+        std::isfinite(candidate.prefit_residual_rms_m) &&
+        candidate.prefit_residual_rms_m <=
+            rtk_config_
+                .safe_fix_shadow_maximum_prefit_residual_rms_m;
+    candidate.strong_acquisition_eligible =
+        candidate.acquisition_eligible &&
+        std::isfinite(candidate.ambiguity_ratio) &&
+        candidate.ambiguity_ratio >= 10.0 &&
+        candidate.pair_count >= 20 &&
+        std::isfinite(
+            debug_telemetry_.lambda_shadow_second_position_delta_m) &&
+        debug_telemetry_.lambda_shadow_second_position_delta_m <= 0.05 &&
+        std::isfinite(candidate.independent_consensus_delta_m) &&
+        candidate.independent_consensus_delta_m <= 0.01 &&
+        candidate.correction_m.norm() <= 0.05;
+    candidate.change_point_acquisition_eligible =
+        ffrt_passed &&
+        std::isfinite(candidate.ambiguity_ratio) &&
+        candidate.ambiguity_ratio >= 1.10 &&
+        candidate.pair_count >= 20 &&
+        std::isfinite(
+            debug_telemetry_.lambda_shadow_second_position_delta_m) &&
+        debug_telemetry_.lambda_shadow_second_position_delta_m <= 0.07 &&
+        std::isfinite(candidate.nis_per_observation) &&
+        candidate.nis_per_observation <= 3.0 &&
+        std::isfinite(candidate.prefit_residual_rms_m) &&
+        candidate.prefit_residual_rms_m <= 50.0 &&
+        std::isfinite(candidate.independent_consensus_delta_m) &&
+        candidate.independent_consensus_delta_m <= 0.05;
+
+    const auto decision =
+        safe_fix_shadow_state_machine_.update(config, candidate);
+    debug_telemetry_.safe_fix_shadow_state =
+        static_cast<int>(decision.state);
+    debug_telemetry_.safe_fix_shadow_declared_fixed =
+        decision.declared_fixed;
+    debug_telemetry_.safe_fix_shadow_candidate_accepted =
+        decision.candidate_accepted;
+    debug_telemetry_.safe_fix_shadow_held = decision.held;
+    debug_telemetry_.safe_fix_shadow_revoked = decision.revoked;
+    debug_telemetry_.safe_fix_shadow_strong_acquisition =
+        decision.strong_acquisition;
+    debug_telemetry_.safe_fix_shadow_change_point_acquisition =
+        decision.change_point_acquisition;
+    debug_telemetry_.safe_fix_shadow_acquisition_streak =
+        decision.acquisition_streak;
+    debug_telemetry_.safe_fix_shadow_hold_epochs =
+        decision.hold_epochs;
 }
 
 PositionSolution RTKProcessor::processRTKEpochInternal(const ObservationData& rover_obs,
     const ObservationData& base_obs, const NavigationData& nav) {
     debug_telemetry_ = EpochDebugTelemetry{};
+    independent_failure_budget_evaluated_this_epoch_ = false;
     PositionSolution solution;
     solution.time = rover_obs.time;
     solution.status = SolutionStatus::NONE;
@@ -2175,8 +3620,17 @@ PositionSolution RTKProcessor::processRTKEpochInternal(const ObservationData& ro
                     spp.status = SolutionStatus::NONE;
                 }
             }
-            if (spp.isValid()) spp.status = SolutionStatus::SPP;
-            rememberSolution(spp);
+            if (!spp.isValid()) {
+                spp = makeSafeFloatContinuity(rover_obs.time);
+            }
+            if (
+                spp.isValid() &&
+                !debug_telemetry_.safe_float_continuity_used) {
+                spp.status = SolutionStatus::SPP;
+            }
+            if (!debug_telemetry_.safe_float_continuity_used) {
+                rememberSolution(spp);
+            }
             recordFallbackEpoch(rover_obs, nav);
             return spp;
         };
@@ -2380,6 +3834,9 @@ PositionSolution RTKProcessor::processRTKEpochInternal(const ObservationData& ro
                 std::vector<DDPair> dd_pairs;
                 std::vector<int> best_subset;
                 VectorXd dd_fixed;
+                bool independent_failure_budget_passed = false;
+                int independent_source_families = 0;
+                double joint_failure_probability = 1.0;
             };
 
             auto capture_candidate = [&]() {
@@ -2394,6 +3851,15 @@ PositionSolution RTKProcessor::processRTKEpochInternal(const ObservationData& ro
                 candidate.dd_pairs = last_dd_pairs_;
                 candidate.best_subset = last_best_subset_;
                 candidate.dd_fixed = last_dd_fixed_;
+                candidate.independent_failure_budget_passed =
+                    debug_telemetry_
+                        .safe_fix_shadow_failure_budget_passed;
+                candidate.independent_source_families =
+                    debug_telemetry_
+                        .safe_fix_shadow_independent_source_families;
+                candidate.joint_failure_probability =
+                    debug_telemetry_
+                        .safe_fix_shadow_joint_failure_probability;
                 return candidate;
             };
 
@@ -2405,6 +3871,15 @@ PositionSolution RTKProcessor::processRTKEpochInternal(const ObservationData& ro
                 last_dd_pairs_ = candidate.dd_pairs;
                 last_best_subset_ = candidate.best_subset;
                 last_dd_fixed_ = candidate.dd_fixed;
+                debug_telemetry_
+                    .safe_fix_shadow_failure_budget_passed =
+                    candidate.independent_failure_budget_passed;
+                debug_telemetry_
+                    .safe_fix_shadow_independent_source_families =
+                    candidate.independent_source_families;
+                debug_telemetry_
+                    .safe_fix_shadow_joint_failure_probability =
+                    candidate.joint_failure_probability;
             };
 
             const int min_lock = std::max(1, rtk_config_.min_lock_count);
@@ -2428,6 +3903,7 @@ PositionSolution RTKProcessor::processRTKEpochInternal(const ObservationData& ro
                     has_fixed_solution_;
                 ARCandidate candidate;
                 if (resolved) {
+                    updateIndependentFailureBudgetTelemetry();
                     candidate = capture_candidate();
                 }
                 rtk_config_.glonass_ar_mode = saved_mode;
@@ -2483,6 +3959,30 @@ PositionSolution RTKProcessor::processRTKEpochInternal(const ObservationData& ro
                 }
             } else if (resolveAmbiguities() && has_fixed_solution_) {
                 have_fix_candidate = true;
+            }
+
+            // A declaration-time independent-budget gate must run before
+            // validate/apply/hold mutates any trusted-FIX state.  A later
+            // output-only demotion would still let a rejected integer
+            // candidate seed hold ambiguities and future trusted positions.
+            const bool require_independent_budget =
+                rtk_config_.library_fixed_quality_gate.enabled &&
+                rtk_config_.library_fixed_quality_gate
+                    .require_independent_failure_budget;
+            if (require_independent_budget) {
+                if (rtk_config_.glonass_ar_mode !=
+                    RTKConfig::GlonassARMode::AUTOCAL) {
+                    updateIndependentFailureBudgetTelemetry();
+                }
+                if (!debug_telemetry_
+                         .safe_fix_shadow_failure_budget_passed) {
+                    have_fix_candidate = false;
+                    has_fixed_solution_ = false;
+                    if (debug_telemetry_.reject_reason.empty()) {
+                        debug_telemetry_.reject_reason =
+                            "independent_failure_budget";
+                    }
+                }
             }
 
             bool applied_fix_solution = false;
@@ -2578,6 +4078,9 @@ PositionSolution RTKProcessor::processRTKEpochInternal(const ObservationData& ro
                 !applied_fix_solution &&
                 !forced_fixed_reacquisition_reset &&
                 !fixed_prefit_quarantine &&
+                (!require_independent_budget ||
+                 debug_telemetry_
+                     .safe_fix_shadow_failure_budget_passed) &&
                 rtk_config_.ar_policy != RTKConfig::ARPolicy::DEMO5_CONTINUOUS &&
                 rtk_validation::canAttemptHoldFix(consecutive_fix_count_,
                                                   rtk_config_.min_hold_count,
@@ -2635,7 +4138,15 @@ PositionSolution RTKProcessor::processRTKEpochInternal(const ObservationData& ro
     } catch (const std::exception& e) {
         std::cerr << "RTK exception: " << e.what() << std::endl;
         auto spp = spp_processor_.processEpoch(rover_obs, nav);
-        rememberSolution(spp);
+        if (!spp.isValid()) {
+            spp = makeSafeFloatContinuity(rover_obs.time);
+        }
+        if (spp.isValid() &&
+            !debug_telemetry_.safe_float_continuity_used) {
+            spp.status = SolutionStatus::SPP;
+            rememberSolution(spp);
+        }
+        recordFallbackEpoch(rover_obs, nav);
         consecutive_fix_count_ = 0;
         consecutive_float_count_ = 0;
         consecutive_nonfix_count_ = 0;
@@ -3029,7 +4540,6 @@ bool RTKProcessor::updateFilter(const std::map<SatelliteId, SatelliteData>& sat_
     const auto measurement_diagnostics = rtk_measurement::summarizeMeasurementBlocks(blocks);
     auto measurement_system = rtk_measurement::assembleMeasurementSystem(
         blocks, filter_state_.state.size());
-
     // navi.776 B2: Doppler rows live in the m/s domain -- give them their
     // own outlier threshold instead of the metre-domain scalar.
     debug_telemetry_.float_update_doppler_observation_count =
@@ -3149,7 +4659,8 @@ bool RTKProcessor::updateFilter(const std::map<SatelliteId, SatelliteData>& sat_
             0.0,
             force_active,
             adaptive_noise_active,
-            rtk_config_.reuse_kalman_factorization_for_nis);
+            rtk_config_.reuse_kalman_factorization_for_nis,
+            rtk_config_.student_t_front_end);
         rtk_update::FilterUpdateResult doppler_result;
         if (position_result.ok) {
             const VectorXd state_correction =
@@ -3165,7 +4676,8 @@ bool RTKProcessor::updateFilter(const std::map<SatelliteId, SatelliteData>& sat_
                 0.0,
                 force_active,
                 adaptive_noise_active,
-                rtk_config_.reuse_kalman_factorization_for_nis);
+                rtk_config_.reuse_kalman_factorization_for_nis,
+                rtk_config_.student_t_front_end);
         }
         update_result.ok = position_result.ok && doppler_result.ok;
         if (!update_result.ok) {
@@ -3223,7 +4735,8 @@ bool RTKProcessor::updateFilter(const std::map<SatelliteId, SatelliteData>& sat_
             force_active,
             adaptive_noise_active,
             rtk_config_.reuse_kalman_factorization_for_nis &&
-                nis_gates_disabled);
+                nis_gates_disabled,
+            rtk_config_.student_t_front_end);
         feed_adaptive_tracker(blocks, measurement_system, update_result);
     }
 
@@ -3284,6 +4797,14 @@ bool RTKProcessor::updateFilter(const std::map<SatelliteId, SatelliteData>& sat_
     debug_telemetry_.float_update_nis_per_observation =
         update_result.normalized_innovation_squared_per_observation;
     debug_telemetry_.float_update_suppressed_outliers = update_result.suppressed_outliers;
+    debug_telemetry_.float_update_student_t_downweighted_rows =
+        update_result.student_t.downweighted_rows;
+    if (update_result.student_t.applied) {
+        debug_telemetry_.float_update_student_t_minimum_weight =
+            update_result.student_t.minimum_weight;
+        debug_telemetry_.float_update_student_t_mean_weight =
+            update_result.student_t.mean_weight;
+    }
     debug_telemetry_.float_position_covariance_trace_m2 =
         filter_state_.covariance.rows() >= 3 && filter_state_.covariance.cols() >= 3
             ? filter_state_.covariance(0, 0) + filter_state_.covariance(1, 1) +
@@ -3437,6 +4958,76 @@ bool RTKProcessor::resolveAmbiguities(std::vector<DDPair> dd_pairs) {
                 debug_telemetry_.ar_skip_reason = ARSkipReason::DD_PAIRS_LT_4_AFTER_VAR_FILTER;
             }
         }
+    }
+
+    std::vector<int> causal_arc_ready_subset;
+    std::vector<double> causal_arc_smoothed_dd(
+        nb, std::numeric_limits<double>::quiet_NaN());
+    std::vector<double> causal_arc_satellite_variance(
+        nb, std::numeric_limits<double>::infinity());
+    std::vector<double> causal_arc_reference_variance(
+        nb, std::numeric_limits<double>::infinity());
+    if (rtk_config_.lambda_causal_arc_readiness_shadow) {
+        debug_telemetry_.lambda_causal_arc_readiness_attempted = true;
+        debug_telemetry_.lambda_causal_arc_total_pairs = nb;
+        causal_arc_ready_subset.reserve(nb);
+        const double time_s =
+            static_cast<double>(current_epoch_time_.week) * 604800.0 +
+            current_epoch_time_.tow;
+        const auto slipped = [&](const SatelliteId& sat, int freq) {
+            if (freq == 0) {
+                return current_epoch_slips_l1_.count(sat) > 0;
+            }
+            if (freq == 1) {
+                return current_epoch_slips_l2_.count(sat) > 0;
+            }
+            return current_epoch_slips_l5_.count(sat) > 0;
+        };
+        for (int index = 0; index < nb; ++index) {
+            const auto& pair = dd_pairs[index];
+            if (pair.sat_idx < 0 ||
+                pair.sat_idx >= filter_state_.state.size() ||
+                pair.ref_idx < 0 ||
+                pair.ref_idx >= filter_state_.state.size()) {
+                continue;
+            }
+            const auto satellite_arc =
+                ambiguity_arc_bank_.updateSignal(
+                    pair.sat, pair.freq, time_s,
+                    filter_state_.state(pair.sat_idx),
+                    slipped(pair.sat, pair.freq));
+            const auto reference_arc =
+                ambiguity_arc_bank_.updateSignal(
+                    pair.ref_sat, pair.freq, time_s,
+                    filter_state_.state(pair.ref_idx),
+                    slipped(pair.ref_sat, pair.freq));
+            if (satellite_arc.reset) {
+                ++debug_telemetry_.lambda_causal_arc_resets;
+            }
+            if (reference_arc.reset) {
+                ++debug_telemetry_.lambda_causal_arc_resets;
+            }
+            if (satellite_arc.ready && reference_arc.ready &&
+                std::isfinite(satellite_arc.smoothed_value) &&
+                std::isfinite(reference_arc.smoothed_value) &&
+                std::isfinite(
+                    satellite_arc.smoothed_value_variance) &&
+                std::isfinite(
+                    reference_arc.smoothed_value_variance) &&
+                satellite_arc.smoothed_value_variance >= 0.0 &&
+                reference_arc.smoothed_value_variance >= 0.0) {
+                causal_arc_ready_subset.push_back(index);
+                causal_arc_smoothed_dd[index] =
+                    reference_arc.smoothed_value -
+                    satellite_arc.smoothed_value;
+                causal_arc_satellite_variance[index] =
+                    satellite_arc.smoothed_value_variance;
+                causal_arc_reference_variance[index] =
+                    reference_arc.smoothed_value_variance;
+            }
+        }
+        debug_telemetry_.lambda_causal_arc_ready_pairs =
+            static_cast<int>(causal_arc_ready_subset.size());
     }
 
     // Try full set first
@@ -3648,6 +5239,555 @@ bool RTKProcessor::resolveAmbiguities(std::vector<DDPair> dd_pairs) {
         return std::isfinite(wide_lane_float);
     };
 
+    // Shadow-only L1/L5 WL->NL cascade. Unlike enable_l5, this path does not
+    // add L5 ambiguity states or L5 measurements to the production KF. It
+    // derives an independent L5 DD ambiguity from the carrier observation and
+    // current float geometry, resolves N1-N5 first, then resolves N1 on the
+    // matching L1 subset. Both integer searches must independently pass
+    // covariance-inflated FFRT, and the WL integer must agree with MW.
+    if (rtk_config_.lambda_l1_l5_wlnl_shadow ||
+        rtk_config_.lambda_l1_l2_wlnl_shadow ||
+        rtk_config_.lambda_l2_l5_wlnl_shadow) {
+        // 0=L1/L5, 1=L1/L2, 2=L2/L5.
+        std::vector<int> wlnl_modes;
+        if (rtk_config_.lambda_l1_l5_wlnl_shadow) {
+            wlnl_modes.push_back(0);
+        }
+        if (rtk_config_.lambda_l1_l2_wlnl_shadow) {
+            wlnl_modes.push_back(1);
+        }
+        if (rtk_config_.lambda_l2_l5_wlnl_shadow) {
+            wlnl_modes.push_back(2);
+        }
+        const auto wlnl_started = std::chrono::steady_clock::now();
+        for (const int wlnl_mode : wlnl_modes) {
+        const bool use_l2_wlnl = wlnl_mode == 1;
+        const bool use_l2_primary = wlnl_mode == 2;
+        auto& wlnl_attempted = use_l2_wlnl
+            ? debug_telemetry_.lambda_l1_l2_wlnl_shadow_attempted
+            : use_l2_primary
+                ? debug_telemetry_.lambda_l2_l5_wlnl_shadow_attempted
+                : debug_telemetry_.lambda_l1_l5_wlnl_shadow_attempted;
+        auto& wlnl_pair_count = use_l2_wlnl
+            ? debug_telemetry_.lambda_l1_l2_wlnl_shadow_pair_count
+            : use_l2_primary
+                ? debug_telemetry_.lambda_l2_l5_wlnl_shadow_pair_count
+                : debug_telemetry_.lambda_l1_l5_wlnl_shadow_pair_count;
+        auto& wlnl_wl_bsr = use_l2_wlnl
+            ? debug_telemetry_.lambda_l1_l2_wlnl_shadow_wl_bsr
+            : use_l2_primary
+                ? debug_telemetry_.lambda_l2_l5_wlnl_shadow_wl_bsr
+                : debug_telemetry_.lambda_l1_l5_wlnl_shadow_wl_bsr;
+        auto& wlnl_wl_ratio = use_l2_wlnl
+            ? debug_telemetry_.lambda_l1_l2_wlnl_shadow_wl_ratio
+            : use_l2_primary
+                ? debug_telemetry_.lambda_l2_l5_wlnl_shadow_wl_ratio
+                : debug_telemetry_.lambda_l1_l5_wlnl_shadow_wl_ratio;
+        auto& wlnl_wl_ffrt_min_ratio = use_l2_wlnl
+            ? debug_telemetry_
+                  .lambda_l1_l2_wlnl_shadow_wl_ffrt_min_ratio
+            : use_l2_primary
+                ? debug_telemetry_
+                      .lambda_l2_l5_wlnl_shadow_wl_ffrt_min_ratio
+                : debug_telemetry_
+                      .lambda_l1_l5_wlnl_shadow_wl_ffrt_min_ratio;
+        auto& wlnl_wl_ffrt_passed = use_l2_wlnl
+            ? debug_telemetry_.lambda_l1_l2_wlnl_shadow_wl_ffrt_passed
+            : use_l2_primary
+                ? debug_telemetry_
+                      .lambda_l2_l5_wlnl_shadow_wl_ffrt_passed
+                : debug_telemetry_
+                      .lambda_l1_l5_wlnl_shadow_wl_ffrt_passed;
+        auto& wlnl_mw_disagreements = use_l2_wlnl
+            ? debug_telemetry_.lambda_l1_l2_wlnl_shadow_mw_disagreements
+            : use_l2_primary
+                ? debug_telemetry_
+                      .lambda_l2_l5_wlnl_shadow_mw_disagreements
+                : debug_telemetry_
+                      .lambda_l1_l5_wlnl_shadow_mw_disagreements;
+        auto& wlnl_raw_mw_disagreements = use_l2_wlnl
+            ? debug_telemetry_
+                  .lambda_l1_l2_wlnl_shadow_raw_mw_disagreements
+            : use_l2_primary
+                ? debug_telemetry_
+                      .lambda_l2_l5_wlnl_shadow_raw_mw_disagreements
+                : debug_telemetry_
+                      .lambda_l1_l5_wlnl_shadow_raw_mw_disagreements;
+        auto& wlnl_causal_arc_ready_pairs = use_l2_wlnl
+            ? debug_telemetry_
+                  .lambda_l1_l2_wlnl_shadow_causal_arc_ready_pairs
+            : use_l2_primary
+                ? debug_telemetry_
+                      .lambda_l2_l5_wlnl_shadow_causal_arc_ready_pairs
+                : debug_telemetry_
+                      .lambda_l1_l5_wlnl_shadow_causal_arc_ready_pairs;
+        auto& wlnl_causal_arc_resets = use_l2_wlnl
+            ? debug_telemetry_.lambda_l1_l2_wlnl_shadow_causal_arc_resets
+            : use_l2_primary
+                ? debug_telemetry_
+                      .lambda_l2_l5_wlnl_shadow_causal_arc_resets
+                : debug_telemetry_
+                      .lambda_l1_l5_wlnl_shadow_causal_arc_resets;
+        auto& wlnl_nl_bsr = use_l2_wlnl
+            ? debug_telemetry_.lambda_l1_l2_wlnl_shadow_nl_bsr
+            : use_l2_primary
+                ? debug_telemetry_.lambda_l2_l5_wlnl_shadow_nl_bsr
+                : debug_telemetry_.lambda_l1_l5_wlnl_shadow_nl_bsr;
+        auto& wlnl_nl_ratio = use_l2_wlnl
+            ? debug_telemetry_.lambda_l1_l2_wlnl_shadow_nl_ratio
+            : use_l2_primary
+                ? debug_telemetry_.lambda_l2_l5_wlnl_shadow_nl_ratio
+                : debug_telemetry_.lambda_l1_l5_wlnl_shadow_nl_ratio;
+        auto& wlnl_nl_ffrt_min_ratio = use_l2_wlnl
+            ? debug_telemetry_
+                  .lambda_l1_l2_wlnl_shadow_nl_ffrt_min_ratio
+            : use_l2_primary
+                ? debug_telemetry_
+                      .lambda_l2_l5_wlnl_shadow_nl_ffrt_min_ratio
+                : debug_telemetry_
+                      .lambda_l1_l5_wlnl_shadow_nl_ffrt_min_ratio;
+        auto& wlnl_nl_ffrt_passed = use_l2_wlnl
+            ? debug_telemetry_.lambda_l1_l2_wlnl_shadow_nl_ffrt_passed
+            : use_l2_primary
+                ? debug_telemetry_
+                      .lambda_l2_l5_wlnl_shadow_nl_ffrt_passed
+                : debug_telemetry_
+                      .lambda_l1_l5_wlnl_shadow_nl_ffrt_passed;
+        auto& wlnl_candidate_pair_count = use_l2_wlnl
+            ? debug_telemetry_
+                  .lambda_l1_l2_wlnl_shadow_candidate_pair_count
+            : use_l2_primary
+                ? debug_telemetry_
+                      .lambda_l2_l5_wlnl_shadow_candidate_pair_count
+                : debug_telemetry_
+                      .lambda_l1_l5_wlnl_shadow_candidate_pair_count;
+        auto& wlnl_best_ecef_x = use_l2_wlnl
+            ? debug_telemetry_.lambda_l1_l2_wlnl_shadow_best_ecef_x
+            : use_l2_primary
+                ? debug_telemetry_.lambda_l2_l5_wlnl_shadow_best_ecef_x
+                : debug_telemetry_.lambda_l1_l5_wlnl_shadow_best_ecef_x;
+        auto& wlnl_best_ecef_y = use_l2_wlnl
+            ? debug_telemetry_.lambda_l1_l2_wlnl_shadow_best_ecef_y
+            : use_l2_primary
+                ? debug_telemetry_.lambda_l2_l5_wlnl_shadow_best_ecef_y
+                : debug_telemetry_.lambda_l1_l5_wlnl_shadow_best_ecef_y;
+        auto& wlnl_best_ecef_z = use_l2_wlnl
+            ? debug_telemetry_.lambda_l1_l2_wlnl_shadow_best_ecef_z
+            : use_l2_primary
+                ? debug_telemetry_.lambda_l2_l5_wlnl_shadow_best_ecef_z
+                : debug_telemetry_.lambda_l1_l5_wlnl_shadow_best_ecef_z;
+        const auto has_secondary =
+            [&](const SatelliteData& data) {
+                return use_l2_wlnl ? data.has_l2 : data.has_l5;
+            };
+        const auto primary_wavelength =
+            [&](const SatelliteData& data) {
+                return use_l2_primary
+                    ? data.l2_wavelength
+                    : data.l1_wavelength;
+            };
+        const auto primary_frequency =
+            [&](const SatelliteData& data) {
+                return use_l2_primary
+                    ? data.l2_frequency_hz
+                    : data.l1_frequency_hz;
+            };
+        const auto primary_phase_sd_m =
+            [&](const SatelliteData& data) {
+                return use_l2_primary
+                    ? (data.rover_l2_phase - data.base_l2_phase) *
+                          data.l2_wavelength
+                    : (data.rover_l1_phase - data.base_l1_phase) *
+                          data.l1_wavelength;
+            };
+        const auto primary_code_sd =
+            [&](const SatelliteData& data) {
+                return use_l2_primary
+                    ? data.rover_l2_code - data.base_l2_code
+                    : data.rover_l1_code - data.base_l1_code;
+            };
+        const auto secondary_wavelength =
+            [&](const SatelliteData& data) {
+                return use_l2_wlnl
+                    ? data.l2_wavelength
+                    : data.l5_wavelength;
+            };
+        const auto secondary_frequency =
+            [&](const SatelliteData& data) {
+                return use_l2_wlnl
+                    ? data.l2_frequency_hz
+                    : data.l5_frequency_hz;
+            };
+        const auto secondary_phase_sd_m =
+            [&](const SatelliteData& data) {
+                return use_l2_wlnl
+                    ? (data.rover_l2_phase - data.base_l2_phase) *
+                          data.l2_wavelength
+                    : (data.rover_l5_phase - data.base_l5_phase) *
+                          data.l5_wavelength;
+            };
+        const auto secondary_code_sd =
+            [&](const SatelliteData& data) {
+                return use_l2_wlnl
+                    ? data.rover_l2_code - data.base_l2_code
+                    : data.rover_l5_code - data.base_l5_code;
+            };
+        wlnl_attempted = true;
+        std::vector<int> l1_indices;
+        std::vector<double> n5_float_values;
+        std::vector<double> mw_values;
+        std::vector<double> raw_mw_values;
+        std::vector<double> causal_reference_variances;
+        std::vector<double> causal_satellite_variances;
+        std::vector<SatelliteId> causal_references;
+        const Vector3d shadow_rover_position =
+            base_position_ + base_head_state.head<3>();
+        for (int i = 0; i < nb; ++i) {
+            const auto& pair = dd_pairs[i];
+            if (pair.freq != (use_l2_primary ? 1 : 0) ||
+                pair.ref_sat.system == GNSSSystem::GLONASS) {
+                continue;
+            }
+            const auto ref_it = sat_data.find(pair.ref_sat);
+            const auto sat_it = sat_data.find(pair.sat);
+            if (ref_it == sat_data.end() || sat_it == sat_data.end()) {
+                continue;
+            }
+            const auto& ref_sd = ref_it->second;
+            const auto& sd = sat_it->second;
+            if (!has_secondary(ref_sd) || !has_secondary(sd) ||
+                secondary_wavelength(ref_sd) <= 0.0 ||
+                secondary_wavelength(sd) <= 0.0 ||
+                std::abs(
+                    secondary_wavelength(ref_sd) -
+                    secondary_wavelength(sd)) > 1e-6) {
+                continue;
+            }
+            const double rr_ref =
+                geodist_range(ref_sd.sat_pos, shadow_rover_position) +
+                tropModel(shadow_rover_position, ref_sd.elevation);
+            const double br_ref =
+                geodist_range(ref_sd.sat_pos_base, base_position_) +
+                tropModel(base_position_, ref_sd.base_elevation);
+            const double rr =
+                geodist_range(sd.sat_pos, shadow_rover_position) +
+                tropModel(shadow_rover_position, sd.elevation);
+            const double br =
+                geodist_range(sd.sat_pos_base, base_position_) +
+                tropModel(base_position_, sd.base_elevation);
+            const double geometry_dd = (rr_ref - br_ref) - (rr - br);
+            const double phase_dd_m =
+                secondary_phase_sd_m(ref_sd) -
+                secondary_phase_sd_m(sd);
+            const double n5_float =
+                (phase_dd_m - geometry_dd) /
+                secondary_wavelength(ref_sd);
+
+            // Reuse the observation-domain MW implementation by pairing the
+            // L1 entry with a synthetic index only for validation. The helper
+            // requires an L5 DDPair, which is intentionally absent in shadow
+            // mode, so calculate the identical L1/L5 MW expression directly.
+            const double f1 = primary_frequency(ref_sd);
+            const double f5 = secondary_frequency(ref_sd);
+            const double lambda_wl_m = wideLaneWavelength(f1, f5);
+            if (!std::isfinite(n5_float) || f1 <= 0.0 || f5 <= 0.0 ||
+                lambda_wl_m <= 0.0) {
+                continue;
+            }
+            auto single_difference_mw = [&](const SatelliteData& data) {
+                const double phi1_m = primary_phase_sd_m(data);
+                const double phi5_m =
+                    secondary_phase_sd_m(data);
+                const double code_term =
+                    (f1 * primary_code_sd(data) +
+                     f5 * secondary_code_sd(data)) /
+                    (f1 + f5);
+                return ((f1 * phi1_m - f5 * phi5_m) / (f1 - f5) -
+                        code_term) /
+                       lambda_wl_m;
+            };
+            const double reference_mw =
+                single_difference_mw(ref_sd);
+            const double satellite_mw =
+                single_difference_mw(sd);
+            const double mw = reference_mw - satellite_mw;
+            if (!std::isfinite(mw)) {
+                continue;
+            }
+            double validation_mw = mw;
+            double causal_reference_variance =
+                std::numeric_limits<double>::infinity();
+            double causal_satellite_variance =
+                std::numeric_limits<double>::infinity();
+            if (rtk_config_
+                    .lambda_l1_l5_wlnl_causal_arc_smoothing) {
+                const bool satellite_slip =
+                    (use_l2_primary
+                         ? current_epoch_slips_l2_.count(pair.sat) > 0
+                         : current_epoch_slips_l1_.count(pair.sat) > 0) ||
+                    (use_l2_wlnl
+                         ? current_epoch_slips_l2_.count(pair.sat) > 0
+                         : current_epoch_slips_l5_.count(pair.sat) > 0);
+                const bool reference_slip =
+                    (use_l2_primary
+                         ? current_epoch_slips_l2_.count(pair.ref_sat) > 0
+                         : current_epoch_slips_l1_.count(pair.ref_sat) > 0) ||
+                    (use_l2_wlnl
+                         ? current_epoch_slips_l2_.count(pair.ref_sat) > 0
+                         : current_epoch_slips_l5_.count(pair.ref_sat) > 0);
+                const double time_s =
+                    static_cast<double>(current_epoch_time_.week) *
+                        604800.0 +
+                    current_epoch_time_.tow;
+                const auto satellite_arc =
+                    l1_l5_mw_arc_bank_.updateSignal(
+                        pair.sat,
+                        use_l2_primary ? 25 : (use_l2_wlnl ? 12 : 15),
+                        time_s, satellite_mw,
+                        satellite_slip);
+                const auto reference_arc =
+                    l1_l5_mw_arc_bank_.updateSignal(
+                        pair.ref_sat,
+                        use_l2_primary ? 25 : (use_l2_wlnl ? 12 : 15),
+                        time_s, reference_mw,
+                        reference_slip);
+                if (satellite_arc.reset) {
+                    ++wlnl_causal_arc_resets;
+                }
+                if (reference_arc.reset) {
+                    ++wlnl_causal_arc_resets;
+                }
+                if (satellite_arc.ready && reference_arc.ready) {
+                    validation_mw =
+                        reference_arc.smoothed_value -
+                        satellite_arc.smoothed_value;
+                    causal_reference_variance =
+                        reference_arc.smoothed_value_variance;
+                    causal_satellite_variance =
+                        satellite_arc.smoothed_value_variance;
+                    ++wlnl_causal_arc_ready_pairs;
+                } else {
+                    validation_mw =
+                        std::numeric_limits<double>::quiet_NaN();
+                }
+            }
+            l1_indices.push_back(i);
+            n5_float_values.push_back(n5_float);
+            mw_values.push_back(validation_mw);
+            raw_mw_values.push_back(mw);
+            causal_reference_variances.push_back(
+                causal_reference_variance);
+            causal_satellite_variances.push_back(
+                causal_satellite_variance);
+            causal_references.push_back(pair.ref_sat);
+        }
+
+        const int pair_count = static_cast<int>(l1_indices.size());
+        wlnl_pair_count = pair_count;
+        if (pair_count >= 4) {
+            VectorXd wl_float(pair_count);
+            MatrixXd wl_covariance(pair_count, pair_count);
+            VectorXd model_wl_float(pair_count);
+            MatrixXd model_wl_covariance(pair_count, pair_count);
+            for (int row = 0; row < pair_count; ++row) {
+                model_wl_float(row) =
+                    base_dd_float(l1_indices[row]) - n5_float_values[row];
+                const bool causal_observation =
+                    rtk_config_
+                        .lambda_l1_l5_wlnl_causal_arc_smoothing &&
+                    std::isfinite(mw_values[row]) &&
+                    std::isfinite(causal_reference_variances[row]) &&
+                    std::isfinite(causal_satellite_variances[row]);
+                wl_float(row) =
+                    causal_observation
+                        ? mw_values[row]
+                        : base_dd_float(l1_indices[row]) -
+                              n5_float_values[row];
+                for (int column = 0; column < pair_count; ++column) {
+                    model_wl_covariance(row, column) =
+                        base_Qb(l1_indices[row], l1_indices[column]);
+                    const bool causal_column =
+                        rtk_config_
+                            .lambda_l1_l5_wlnl_causal_arc_smoothing &&
+                        std::isfinite(mw_values[column]) &&
+                        std::isfinite(causal_reference_variances[column]) &&
+                        std::isfinite(causal_satellite_variances[column]);
+                    if (causal_observation && causal_column) {
+                        wl_covariance(row, column) =
+                            causal_references[row] ==
+                                    causal_references[column]
+                                ? std::max(
+                                      1e-6,
+                                      std::min(
+                                          causal_reference_variances[row],
+                                          causal_reference_variances[column]))
+                                : 0.0;
+                    } else {
+                        wl_covariance(row, column) =
+                            base_Qb(
+                                l1_indices[row], l1_indices[column]);
+                    }
+                }
+                if (causal_observation) {
+                    wl_covariance(row, row) += std::max(
+                        1e-6, causal_satellite_variances[row]);
+                } else {
+                    // Conservative independent L5 carrier/geometry
+                    // uncertainty.
+                    wl_covariance(row, row) += 0.0025;
+                }
+                // N1/N5-derived covariance retains the N1 cross-covariance
+                // needed by the subsequent Gaussian conditioning.  The
+                // causal MW covariance above is only for the independent WL
+                // integer search.
+                model_wl_covariance(row, row) += 0.0025;
+            }
+            wl_covariance =
+                (wl_covariance + wl_covariance.transpose()) * 0.5;
+            model_wl_covariance =
+                (model_wl_covariance +
+                 model_wl_covariance.transpose()) *
+                0.5;
+
+            LambdaCandidateDiagnostics wl_search;
+            if (lambdaSearchTopK(wl_float, wl_covariance, 2, wl_search) &&
+                wl_search.squared_residuals.size() >= 2 &&
+                wl_search.candidates.cols() >= 1) {
+                const double covariance_scale =
+                    std::max(
+                        1.0,
+                        rtk_config_
+                            .lambda_l1_l5_wlnl_shadow_covariance_scale);
+                const double wl_bsr = bootstrappedSuccessRate(
+                    wl_search.conditional_variances, covariance_scale);
+                const double wl_ratio =
+                    wl_search.squared_residuals(0) > 0.0
+                        ? wl_search.squared_residuals(1) /
+                              wl_search.squared_residuals(0)
+                        : 0.0;
+                wlnl_wl_bsr = wl_bsr;
+                wlnl_wl_ratio = wl_ratio;
+                FixedFailureRateRatioThreshold wl_ffrt;
+                const bool wl_table_supported =
+                    fixedFailureRateRatioThreshold(
+                        pair_count, wl_bsr, 0.001, wl_ffrt);
+                if (wl_table_supported) {
+                    wlnl_wl_ffrt_min_ratio =
+                        wl_ffrt.minimum_second_to_best_ratio;
+                }
+                int mw_disagreements = 0;
+                int raw_mw_disagreements = 0;
+                for (int row = 0; row < pair_count; ++row) {
+                    const double mw = mw_values[row];
+                    const double raw_mw = raw_mw_values[row];
+                    const bool causal_validation =
+                        rtk_config_
+                            .lambda_l1_l5_wlnl_causal_arc_smoothing;
+                    if (!std::isfinite(mw) ||
+                        (!causal_validation &&
+                         distanceToNearestInteger(mw) >= 0.25) ||
+                        std::abs(
+                            wl_search.candidates(row, 0) -
+                            std::round(mw)) > 0.5) {
+                        ++mw_disagreements;
+                    }
+                    if (distanceToNearestInteger(raw_mw) >= 0.25 ||
+                        std::abs(
+                            wl_search.candidates(row, 0) -
+                            std::round(raw_mw)) > 0.5) {
+                        ++raw_mw_disagreements;
+                    }
+                }
+                wlnl_mw_disagreements = mw_disagreements;
+                wlnl_raw_mw_disagreements = raw_mw_disagreements;
+                const bool wl_passed =
+                    wl_table_supported && wl_ffrt.accepts_any_candidate &&
+                    std::isfinite(wl_ratio) &&
+                    wl_ratio >= wl_ffrt.minimum_second_to_best_ratio &&
+                    mw_disagreements == 0;
+                wlnl_wl_ffrt_passed = wl_passed;
+
+                if (wl_passed) {
+                    const auto nl_problem =
+                        rtk_ar_evaluation::extractSubset(
+                            base_dd_float, base_Qb, base_Qab, l1_indices);
+                    VectorXd conditioned_head_state;
+                    MatrixXd conditioned_Qab;
+                    VectorXd conditioned_n1_float;
+                    MatrixXd conditioned_Qb;
+                    const bool conditioned =
+                        rtk_ar_selection::
+                            conditionNarrowLaneOnFixedWideLane(
+                                base_head_state,
+                                nl_problem.Qab,
+                                nl_problem.dd_float,
+                                nl_problem.Qb,
+                                model_wl_float,
+                                model_wl_covariance,
+                                wl_search.candidates.col(0),
+                                conditioned_head_state,
+                                conditioned_Qab,
+                                conditioned_n1_float,
+                                conditioned_Qb);
+                    LambdaCandidateDiagnostics nl_search;
+                    if (conditioned &&
+                        lambdaSearchTopK(
+                            conditioned_n1_float, conditioned_Qb, 2,
+                            nl_search) &&
+                        nl_search.squared_residuals.size() >= 2 &&
+                        nl_search.candidates.cols() >= 1) {
+                        const double nl_bsr = bootstrappedSuccessRate(
+                            nl_search.conditional_variances,
+                            covariance_scale);
+                        const double nl_ratio =
+                            nl_search.squared_residuals(0) > 0.0
+                                ? nl_search.squared_residuals(1) /
+                                      nl_search.squared_residuals(0)
+                                : 0.0;
+                        wlnl_nl_bsr = nl_bsr;
+                        wlnl_nl_ratio = nl_ratio;
+                        FixedFailureRateRatioThreshold nl_ffrt;
+                        const bool nl_table_supported =
+                            fixedFailureRateRatioThreshold(
+                                pair_count, nl_bsr, 0.001, nl_ffrt);
+                        if (nl_table_supported) {
+                            wlnl_nl_ffrt_min_ratio =
+                                nl_ffrt.minimum_second_to_best_ratio;
+                        }
+                        const bool nl_passed =
+                            nl_table_supported &&
+                            nl_ffrt.accepts_any_candidate &&
+                            std::isfinite(nl_ratio) &&
+                            nl_ratio >=
+                                nl_ffrt.minimum_second_to_best_ratio;
+                        wlnl_nl_ffrt_passed = nl_passed;
+                        if (nl_passed) {
+                            wlnl_candidate_pair_count = pair_count;
+                        }
+                        VectorXd best_head;
+                        if (nl_passed &&
+                            rtk_ar_evaluation::solveFixedHeadState(
+                                conditioned_head_state, conditioned_Qab,
+                                conditioned_Qb, conditioned_n1_float,
+                                nl_search.candidates.col(0), best_head) &&
+                            best_head.size() >= 3) {
+                            const Vector3d ecef =
+                                base_position_ + best_head.head<3>();
+                            wlnl_best_ecef_x = ecef.x();
+                            wlnl_best_ecef_y = ecef.y();
+                            wlnl_best_ecef_z = ecef.z();
+                        }
+                    }
+                }
+            }
+        }
+        }
+        debug_telemetry_.lambda_l1_l5_wlnl_shadow_runtime_ms =
+            std::chrono::duration<double, std::milli>(
+                std::chrono::steady_clock::now() - wlnl_started)
+                .count();
+    }
+
     if (rtk_config_.enable_wide_lane_ar) {
         const double wide_lane_threshold =
             std::max(0.0, rtk_config_.wide_lane_acceptance_threshold);
@@ -3801,6 +5941,829 @@ bool RTKProcessor::resolveAmbiguities(std::vector<DDPair> dd_pairs) {
         const bool full_solved =
             lambdaMethod(full_problem.dd_float, full_problem.Qb, dd_fixed, ratio);
         debug_telemetry_.full_lambda_solved = full_solved;
+        const int shadow_count = rtk_config_.lambda_candidate_shadow_count;
+        if (shadow_count > 0) {
+            debug_telemetry_.lambda_shadow_attempted = true;
+            const auto shadow_started = std::chrono::steady_clock::now();
+            LambdaCandidateDiagnostics shadow;
+            if (lambdaSearchTopK(
+                    full_problem.dd_float, full_problem.Qb, shadow_count, shadow)) {
+                debug_telemetry_.lambda_shadow_solved = true;
+                debug_telemetry_.lambda_shadow_candidate_count =
+                    static_cast<int>(shadow.squared_residuals.size());
+                debug_telemetry_.lambda_shadow_bsr =
+                    shadow.bootstrapped_success_rate;
+                debug_telemetry_.lambda_shadow_bsr_qscale2 =
+                    bootstrappedSuccessRate(
+                        shadow.conditional_variances, 2.0);
+                debug_telemetry_.lambda_shadow_bsr_qscale4 =
+                    bootstrappedSuccessRate(
+                        shadow.conditional_variances, 4.0);
+                debug_telemetry_.lambda_shadow_bsr_qscale8 =
+                    bootstrappedSuccessRate(
+                        shadow.conditional_variances, 8.0);
+                debug_telemetry_.lambda_shadow_bsr_qscale16 =
+                    bootstrappedSuccessRate(
+                        shadow.conditional_variances, 16.0);
+                FixedFailureRateRatioThreshold ffrt;
+                if (fixedFailureRateRatioThreshold(
+                        static_cast<int>(full_problem.dd_float.size()),
+                        shadow.bootstrapped_success_rate, 0.001, ffrt)) {
+                    debug_telemetry_.lambda_shadow_ffrt_table_supported = true;
+                    debug_telemetry_.lambda_shadow_ffrt_accepts_any =
+                        ffrt.accepts_any_candidate;
+                    debug_telemetry_.lambda_shadow_ffrt_min_ratio =
+                        ffrt.minimum_second_to_best_ratio;
+                }
+                if (shadow.squared_residuals.size() >= 1) {
+                    const double best_cost = shadow.squared_residuals(0);
+                    debug_telemetry_.lambda_shadow_best_cost = best_cost;
+                    const int logged_candidates = std::min(
+                        8, static_cast<int>(
+                               shadow.squared_residuals.size()));
+                    for (int candidate = 0;
+                         candidate < logged_candidates; ++candidate) {
+                        debug_telemetry_.lambda_shadow_candidate_costs(
+                            candidate) =
+                            shadow.squared_residuals(candidate);
+                    }
+                    double weight_sum = 0.0;
+                    double squared_weight_sum = 0.0;
+                    for (int i = 0; i < shadow.squared_residuals.size(); ++i) {
+                        const double weight = std::exp(
+                            -0.5 * (shadow.squared_residuals(i) - best_cost));
+                        weight_sum += weight;
+                        squared_weight_sum += weight * weight;
+                    }
+                    if (weight_sum > 0.0) {
+                        debug_telemetry_.lambda_shadow_best_mass =
+                            1.0 / weight_sum;
+                        debug_telemetry_.lambda_shadow_effective_candidates =
+                            weight_sum * weight_sum / squared_weight_sum;
+                    }
+                }
+                if (shadow.squared_residuals.size() >= 2) {
+                    debug_telemetry_.lambda_shadow_second_cost =
+                        shadow.squared_residuals(1);
+                    debug_telemetry_.lambda_shadow_best_second_disagreements =
+                        static_cast<int>(
+                            (shadow.candidates.col(0).array() !=
+                             shadow.candidates.col(1).array()).count());
+                    const double shadow_ratio =
+                        shadow.squared_residuals(0) > 0.0
+                            ? shadow.squared_residuals(1) /
+                                  shadow.squared_residuals(0)
+                            : 0.0;
+                    debug_telemetry_.lambda_shadow_ffrt_passed =
+                        debug_telemetry_.lambda_shadow_ffrt_accepts_any &&
+                        std::isfinite(shadow_ratio) &&
+                        shadow_ratio >=
+                            debug_telemetry_.lambda_shadow_ffrt_min_ratio;
+                }
+
+                VectorXd best_head;
+                if (shadow.candidates.cols() >= 1 &&
+                    rtk_ar_evaluation::solveFixedHeadState(
+                        full_problem.head_state, full_problem.Qab,
+                        full_problem.Qb, full_problem.dd_float,
+                        shadow.candidates.col(0), best_head) &&
+                    best_head.size() >= 3) {
+                    const Vector3d best_ecef =
+                        base_position_ + best_head.head<3>();
+                    debug_telemetry_.lambda_shadow_best_ecef_x = best_ecef.x();
+                    debug_telemetry_.lambda_shadow_best_ecef_y = best_ecef.y();
+                    debug_telemetry_.lambda_shadow_best_ecef_z = best_ecef.z();
+                    debug_telemetry_.lambda_shadow_candidate_ecef_m.col(0) =
+                        best_ecef;
+                    const Vector3d best_correction =
+                        best_head.head<3>() -
+                        full_problem.head_state.head<3>();
+                    debug_telemetry_.lambda_shadow_best_correction_x =
+                        best_correction.x();
+                    debug_telemetry_.lambda_shadow_best_correction_y =
+                        best_correction.y();
+                    debug_telemetry_.lambda_shadow_best_correction_z =
+                        best_correction.z();
+                    double max_spread_m = 0.0;
+                    for (int candidate = 1;
+                         candidate < shadow.candidates.cols(); ++candidate) {
+                        VectorXd candidate_head;
+                        if (!rtk_ar_evaluation::solveFixedHeadState(
+                                full_problem.head_state, full_problem.Qab,
+                                full_problem.Qb, full_problem.dd_float,
+                                shadow.candidates.col(candidate),
+                                candidate_head) ||
+                            candidate_head.size() < 3) {
+                            continue;
+                        }
+                        const double spread_m =
+                            (candidate_head.head<3>() -
+                             best_head.head<3>()).norm();
+                        debug_telemetry_.lambda_shadow_candidate_ecef_m
+                            .col(candidate) =
+                            base_position_ + candidate_head.head<3>();
+                        max_spread_m = std::max(max_spread_m, spread_m);
+                        if (candidate == 1) {
+                            debug_telemetry_
+                                .lambda_shadow_second_position_delta_m =
+                                spread_m;
+                            const Vector3d second_ecef =
+                                base_position_ +
+                                candidate_head.head<3>();
+                            debug_telemetry_.lambda_shadow_second_ecef_x =
+                                second_ecef.x();
+                            debug_telemetry_.lambda_shadow_second_ecef_y =
+                                second_ecef.y();
+                            debug_telemetry_.lambda_shadow_second_ecef_z =
+                                second_ecef.z();
+                            const Vector3d second_correction =
+                                candidate_head.head<3>() -
+                                full_problem.head_state.head<3>();
+                            debug_telemetry_
+                                .lambda_shadow_second_correction_x =
+                                second_correction.x();
+                            debug_telemetry_
+                                .lambda_shadow_second_correction_y =
+                                second_correction.y();
+                            debug_telemetry_
+                                .lambda_shadow_second_correction_z =
+                                second_correction.z();
+                        }
+                    }
+                    debug_telemetry_.lambda_shadow_position_spread_max_m =
+                        max_spread_m;
+                }
+
+                if (rtk_config_.lambda_causal_arc_readiness_shadow &&
+                    causal_arc_ready_subset.size() >= 4) {
+                    std::vector<int> causal_arc_search_subset =
+                        causal_arc_ready_subset;
+                    if (rtk_config_.lambda_causal_arc_smoothed_search &&
+                        rtk_config_
+                                .lambda_causal_arc_smoothed_max_pairs >
+                            0 &&
+                        static_cast<int>(
+                            causal_arc_search_subset.size()) >
+                            rtk_config_
+                                .lambda_causal_arc_smoothed_max_pairs) {
+                        std::stable_sort(
+                            causal_arc_search_subset.begin(),
+                            causal_arc_search_subset.end(),
+                            [&](int left, int right) {
+                                const double left_variance =
+                                    causal_arc_satellite_variance[left] +
+                                    causal_arc_reference_variance[left];
+                                const double right_variance =
+                                    causal_arc_satellite_variance[right] +
+                                    causal_arc_reference_variance[right];
+                                if (left_variance != right_variance) {
+                                    return left_variance < right_variance;
+                                }
+                                return left < right;
+                            });
+                        causal_arc_search_subset.resize(
+                            rtk_config_
+                                .lambda_causal_arc_smoothed_max_pairs);
+                        std::sort(
+                            causal_arc_search_subset.begin(),
+                            causal_arc_search_subset.end());
+                    }
+                    debug_telemetry_
+                        .lambda_causal_arc_subset_pair_count =
+                        static_cast<int>(
+                            causal_arc_search_subset.size());
+                    const auto arc_problem =
+                        build_search_problem(causal_arc_search_subset);
+                    VectorXd arc_search_float = arc_problem.dd_float;
+                    MatrixXd arc_search_covariance = arc_problem.Qb;
+                    if (rtk_config_.lambda_causal_arc_smoothed_search) {
+                        const int arc_count = static_cast<int>(
+                            causal_arc_search_subset.size());
+                        arc_search_float.resize(arc_count);
+                        arc_search_covariance =
+                            MatrixXd::Zero(arc_count, arc_count);
+                        const auto shared_variance =
+                            [](double left, double right) {
+                                return std::max(
+                                    1e-6, std::min(left, right));
+                            };
+                        for (int row = 0; row < arc_count; ++row) {
+                            const int source_row =
+                                causal_arc_search_subset[row];
+                            arc_search_float(row) =
+                                causal_arc_smoothed_dd[source_row];
+                            const auto& row_pair =
+                                dd_pairs[source_row];
+                            for (int column = 0;
+                                 column < arc_count; ++column) {
+                                const int source_column =
+                                    causal_arc_search_subset[column];
+                                const auto& column_pair =
+                                    dd_pairs[source_column];
+                                if (row_pair.freq != column_pair.freq) {
+                                    continue;
+                                }
+                                double covariance = 0.0;
+                                if (row_pair.ref_sat ==
+                                    column_pair.ref_sat) {
+                                    covariance += shared_variance(
+                                        causal_arc_reference_variance[
+                                            source_row],
+                                        causal_arc_reference_variance[
+                                            source_column]);
+                                }
+                                if (row_pair.ref_sat ==
+                                    column_pair.sat) {
+                                    covariance -= shared_variance(
+                                        causal_arc_reference_variance[
+                                            source_row],
+                                        causal_arc_satellite_variance[
+                                            source_column]);
+                                }
+                                if (row_pair.sat ==
+                                    column_pair.ref_sat) {
+                                    covariance -= shared_variance(
+                                        causal_arc_satellite_variance[
+                                            source_row],
+                                        causal_arc_reference_variance[
+                                            source_column]);
+                                }
+                                if (row_pair.sat ==
+                                    column_pair.sat) {
+                                    covariance += shared_variance(
+                                        causal_arc_satellite_variance[
+                                            source_row],
+                                        causal_arc_satellite_variance[
+                                            source_column]);
+                                }
+                                arc_search_covariance(row, column) =
+                                    covariance;
+                            }
+                            arc_search_covariance(row, row) =
+                                std::max(
+                                    1e-6,
+                                    arc_search_covariance(row, row));
+                        }
+                        arc_search_covariance =
+                            (arc_search_covariance +
+                             arc_search_covariance.transpose()) *
+                            0.5;
+                        // Distinct DD rows can momentarily describe the same
+                        // signal relation.  Keep the empirical shared-signal
+                        // covariance conservative and strictly positive
+                        // definite instead of allowing an exact, overconfident
+                        // zero-noise relation to enter LAMBDA/FFRT.
+                        arc_search_covariance.diagonal().array() += 1e-4;
+                        for (int row = 0;
+                             row < arc_search_covariance.rows(); ++row) {
+                            double off_diagonal_sum = 0.0;
+                            for (int column = 0;
+                                 column < arc_search_covariance.cols();
+                                 ++column) {
+                                if (column != row) {
+                                    off_diagonal_sum += std::abs(
+                                        arc_search_covariance(row, column));
+                                }
+                            }
+                            arc_search_covariance(row, row) =
+                                std::max(
+                                    arc_search_covariance(row, row),
+                                    off_diagonal_sum + 1e-4);
+                        }
+                    }
+                    LambdaCandidateDiagnostics arc_shadow;
+                    if (lambdaSearchTopK(
+                            arc_search_float, arc_search_covariance, 2,
+                            arc_shadow) &&
+                        arc_shadow.squared_residuals.size() >= 2) {
+                        debug_telemetry_
+                            .lambda_causal_arc_subset_solved = true;
+                        const double arc_ratio =
+                            arc_shadow.squared_residuals(0) > 0.0
+                                ? arc_shadow.squared_residuals(1) /
+                                      arc_shadow.squared_residuals(0)
+                                : 0.0;
+                        debug_telemetry_
+                            .lambda_causal_arc_subset_ratio = arc_ratio;
+                        VectorXd arc_ffrt_variances =
+                            arc_shadow.conditional_variances;
+                        if (arc_ffrt_variances.array()
+                                .isFinite()
+                                .all()) {
+                            arc_ffrt_variances =
+                                arc_ffrt_variances
+                                    .array()
+                                    .max(1e-4)
+                                    .matrix();
+                            debug_telemetry_
+                                .lambda_causal_arc_subset_variance_min =
+                                arc_ffrt_variances.minCoeff();
+                            debug_telemetry_
+                                .lambda_causal_arc_subset_variance_max =
+                                arc_ffrt_variances.maxCoeff();
+                        }
+                        const double arc_bsr =
+                            bootstrappedSuccessRate(
+                                arc_ffrt_variances,
+                                rtk_config_
+                                    .lambda_causal_arc_readiness_covariance_scale);
+                        debug_telemetry_.lambda_causal_arc_subset_bsr =
+                            arc_bsr;
+                        FixedFailureRateRatioThreshold arc_ffrt;
+                        if (fixedFailureRateRatioThreshold(
+                                static_cast<int>(
+                                    causal_arc_search_subset.size()),
+                                arc_bsr, 0.001, arc_ffrt)) {
+                            debug_telemetry_
+                                .lambda_causal_arc_subset_ffrt_min_ratio =
+                                arc_ffrt.minimum_second_to_best_ratio;
+                            debug_telemetry_
+                                .lambda_causal_arc_subset_ffrt_passed =
+                                arc_ffrt.accepts_any_candidate &&
+                                std::isfinite(arc_ratio) &&
+                                arc_ratio >=
+                                    arc_ffrt.minimum_second_to_best_ratio;
+                        }
+                        VectorXd arc_best_head;
+                        VectorXd arc_second_head;
+                        const bool arc_best_solved =
+                            rtk_ar_evaluation::solveFixedHeadState(
+                                arc_problem.head_state, arc_problem.Qab,
+                                arc_problem.Qb, arc_problem.dd_float,
+                                arc_shadow.candidates.col(0),
+                                arc_best_head);
+                        const bool arc_second_solved =
+                            rtk_ar_evaluation::solveFixedHeadState(
+                                arc_problem.head_state, arc_problem.Qab,
+                                arc_problem.Qb, arc_problem.dd_float,
+                                arc_shadow.candidates.col(1),
+                                arc_second_head);
+                        if (arc_best_solved &&
+                            arc_best_head.size() >= 3) {
+                            const Vector3d arc_best_ecef =
+                                base_position_ +
+                                arc_best_head.head<3>();
+                            debug_telemetry_
+                                .lambda_causal_arc_subset_best_ecef_x =
+                                arc_best_ecef.x();
+                            debug_telemetry_
+                                .lambda_causal_arc_subset_best_ecef_y =
+                                arc_best_ecef.y();
+                            debug_telemetry_
+                                .lambda_causal_arc_subset_best_ecef_z =
+                                arc_best_ecef.z();
+                            const auto& external_disjoint =
+                                external_disjoint_satellite_fix_evidence_;
+                            if (external_disjoint
+                                    .partition_a_candidate_ecef
+                                    .allFinite()) {
+                                debug_telemetry_
+                                    .lambda_causal_arc_subset_partition_a_separation_m =
+                                    (arc_best_ecef -
+                                     external_disjoint
+                                         .partition_a_candidate_ecef)
+                                        .norm();
+                            }
+                            if (external_disjoint
+                                    .partition_b_candidate_ecef
+                                    .allFinite()) {
+                                debug_telemetry_
+                                    .lambda_causal_arc_subset_partition_b_separation_m =
+                                    (arc_best_ecef -
+                                     external_disjoint
+                                         .partition_b_candidate_ecef)
+                                        .norm();
+                            }
+                        }
+                        if (arc_best_solved && arc_second_solved &&
+                            arc_best_head.size() >= 3 &&
+                            arc_second_head.size() >= 3) {
+                            debug_telemetry_
+                                .lambda_causal_arc_subset_second_position_delta_m =
+                                (arc_best_head.head<3>() -
+                                 arc_second_head.head<3>())
+                                    .norm();
+                        }
+                    }
+                }
+
+                const double src_threshold =
+                    rtk_config_.lambda_src_par_shadow_success_rate;
+                if (src_threshold > 0.0) {
+                    debug_telemetry_.lambda_src_par_shadow_attempted = true;
+                    const auto src_started =
+                        std::chrono::steady_clock::now();
+                    const double covariance_scale =
+                        rtk_config_.lambda_src_par_shadow_covariance_scale;
+                    const int subset_size = successRateCriterionSubsetSize(
+                        shadow.conditional_variances, covariance_scale,
+                        src_threshold);
+                    debug_telemetry_.lambda_src_par_shadow_subset_size =
+                        subset_size;
+                    if (subset_size >= 4) {
+                        const VectorXd src_float =
+                            shadow.decorrelated_float.tail(subset_size);
+                        const MatrixXd src_covariance =
+                            shadow.decorrelated_covariance.bottomRightCorner(
+                                subset_size, subset_size);
+                        LambdaCandidateDiagnostics src;
+                        if (lambdaSearchTopK(
+                                src_float, src_covariance, 2, src)) {
+                            debug_telemetry_.lambda_src_par_shadow_solved =
+                                true;
+                            const double src_bsr =
+                                bootstrappedSuccessRate(
+                                    src.conditional_variances,
+                                    covariance_scale);
+                            debug_telemetry_.lambda_src_par_shadow_bsr =
+                                src_bsr;
+                            const double src_ratio =
+                                src.squared_residuals(0) > 0.0
+                                    ? src.squared_residuals(1) /
+                                          src.squared_residuals(0)
+                                    : 0.0;
+                            debug_telemetry_.lambda_src_par_shadow_ratio =
+                                src_ratio;
+                            FixedFailureRateRatioThreshold src_ffrt;
+                            if (fixedFailureRateRatioThreshold(
+                                    subset_size, src_bsr, 0.001,
+                                    src_ffrt)) {
+                                debug_telemetry_
+                                    .lambda_src_par_shadow_ffrt_min_ratio =
+                                    src_ffrt
+                                        .minimum_second_to_best_ratio;
+                                debug_telemetry_
+                                    .lambda_src_par_shadow_ffrt_passed =
+                                    src_ffrt.accepts_any_candidate &&
+                                    std::isfinite(src_ratio) &&
+                                    src_ratio >=
+                                        src_ffrt
+                                            .minimum_second_to_best_ratio;
+                            }
+
+                            const MatrixXd head_z_covariance =
+                                full_problem.Qab *
+                                shadow.decorrelation_transform;
+                            const MatrixXd src_head_covariance =
+                                head_z_covariance.rightCols(subset_size);
+                            VectorXd src_best_head;
+                            VectorXd src_second_head;
+                            const bool best_solved =
+                                rtk_ar_evaluation::solveFixedHeadState(
+                                    full_problem.head_state,
+                                    src_head_covariance, src_covariance,
+                                    src_float, src.candidates.col(0),
+                                    src_best_head);
+                            const bool second_solved =
+                                rtk_ar_evaluation::solveFixedHeadState(
+                                    full_problem.head_state,
+                                    src_head_covariance, src_covariance,
+                                    src_float, src.candidates.col(1),
+                                    src_second_head);
+                            if (best_solved && src_best_head.size() >= 3) {
+                                const Vector3d src_best_ecef =
+                                    base_position_ +
+                                    src_best_head.head<3>();
+                                debug_telemetry_
+                                    .lambda_src_par_shadow_best_ecef_x =
+                                    src_best_ecef.x();
+                                debug_telemetry_
+                                    .lambda_src_par_shadow_best_ecef_y =
+                                    src_best_ecef.y();
+                                debug_telemetry_
+                                    .lambda_src_par_shadow_best_ecef_z =
+                                    src_best_ecef.z();
+                                const Vector3d src_best_correction =
+                                    src_best_head.head<3>() -
+                                    full_problem.head_state.head<3>();
+                                debug_telemetry_
+                                    .lambda_src_par_shadow_best_correction_x =
+                                    src_best_correction.x();
+                                debug_telemetry_
+                                    .lambda_src_par_shadow_best_correction_y =
+                                    src_best_correction.y();
+                                debug_telemetry_
+                                    .lambda_src_par_shadow_best_correction_z =
+                                    src_best_correction.z();
+                            }
+                            if (best_solved && second_solved &&
+                                src_best_head.size() >= 3 &&
+                                src_second_head.size() >= 3) {
+                                debug_telemetry_
+                                    .lambda_src_par_shadow_second_position_delta_m =
+                                    (src_second_head.head<3>() -
+                                     src_best_head.head<3>()).norm();
+                            }
+                        }
+                    }
+                    debug_telemetry_.lambda_src_par_shadow_runtime_ms =
+                        std::chrono::duration<double, std::milli>(
+                            std::chrono::steady_clock::now() -
+                            src_started).count();
+                }
+
+                const int satellite_par_max_drops =
+                    rtk_config_
+                        .lambda_satellite_par_shadow_max_drop_steps;
+                if (satellite_par_max_drops > 0 &&
+                    (!rtk_config_
+                          .lambda_satellite_par_only_after_full_ffrt_failure ||
+                     !debug_telemetry_.lambda_shadow_ffrt_passed)) {
+                    debug_telemetry_
+                        .lambda_satellite_par_shadow_attempted = true;
+                    const auto satellite_par_started =
+                        std::chrono::steady_clock::now();
+                    std::vector<rtk_ar_selection::PairDescriptor>
+                        satellite_descriptors;
+                    satellite_descriptors.reserve(nb);
+                    auto pair_snr = [&](const DDPair& pair) {
+                        const auto ref_it = sat_data.find(pair.ref_sat);
+                        const auto sat_it = sat_data.find(pair.sat);
+                        if (ref_it == sat_data.end() ||
+                            sat_it == sat_data.end()) {
+                            return std::numeric_limits<double>::quiet_NaN();
+                        }
+                        const auto& ref = ref_it->second;
+                        const auto& sat = sat_it->second;
+                        if (pair.freq == 0) {
+                            return std::min(
+                                {ref.rover_l1_snr, ref.base_l1_snr,
+                                 sat.rover_l1_snr, sat.base_l1_snr});
+                        }
+                        if (pair.freq == 1) {
+                            return std::min(
+                                {ref.rover_l2_snr, ref.base_l2_snr,
+                                 sat.rover_l2_snr, sat.base_l2_snr});
+                        }
+                        if (pair.freq == 2) {
+                            return std::min(
+                                {ref.rover_l5_snr, ref.base_l5_snr,
+                                 sat.rover_l5_snr, sat.base_l5_snr});
+                        }
+                        return std::numeric_limits<double>::quiet_NaN();
+                    };
+                    for (int index = 0; index < nb; ++index) {
+                        double elevation =
+                            std::numeric_limits<double>::quiet_NaN();
+                        double wavelength =
+                            std::numeric_limits<double>::quiet_NaN();
+                        double azimuth =
+                            std::numeric_limits<double>::quiet_NaN();
+                        const auto sat_it =
+                            sat_data.find(dd_pairs[index].sat);
+                        if (sat_it != sat_data.end()) {
+                            elevation = sat_it->second.elevation;
+                            if (dd_pairs[index].freq == 0) {
+                                wavelength =
+                                    sat_it->second.l1_wavelength;
+                            } else if (dd_pairs[index].freq == 1) {
+                                wavelength =
+                                    sat_it->second.l2_wavelength;
+                            } else if (dd_pairs[index].freq == 2) {
+                                wavelength =
+                                    sat_it->second.l5_wavelength;
+                            }
+                            if (full_problem.head_state.size() >= 3) {
+                                const Vector3d rover_position =
+                                    base_position_ +
+                                    full_problem.head_state.head<3>();
+                                const auto geodetic =
+                                    spp_utils::ecefToGeodetic(
+                                        rover_position);
+                                const Vector3d los_enu = ecef2enu(
+                                    sat_it->second.sat_pos -
+                                        rover_position,
+                                    geodetic.latitude,
+                                    geodetic.longitude);
+                                azimuth =
+                                    std::atan2(los_enu.x(), los_enu.y());
+                                if (azimuth < 0.0) {
+                                    azimuth += 2.0 * M_PI;
+                                }
+                            }
+                        }
+                        satellite_descriptors.push_back(
+                            {dd_pairs[index].sat.system,
+                             full_problem.Qb(index, index),
+                             dd_pairs[index].sat,
+                             elevation,
+                             pair_snr(dd_pairs[index]),
+                             distanceToNearestInteger(
+                                 full_problem.dd_float(index))});
+                        auto& descriptor =
+                            satellite_descriptors.back();
+                        if (std::isfinite(wavelength) &&
+                            wavelength > 0.0) {
+                            descriptor.posterior_abs_residual_m =
+                                wavelength *
+                                descriptor
+                                    .fractional_distance_cycles;
+                        }
+                        descriptor.azimuth_rad = azimuth;
+                    }
+                    auto satellite_subsets =
+                        rtk_config_
+                                .lambda_satellite_par_shadow_quality_diverse
+                            ? rtk_ar_selection::
+                                  buildSatelliteQualityDiverseDropSubsets(
+                                      satellite_descriptors,
+                                      min_subset_pairs_for_ar,
+                                      satellite_par_max_drops,
+                                      32)
+                            : rtk_ar_selection::
+                                  buildSatelliteQualityDropSubsets(
+                                      satellite_descriptors,
+                                  min_subset_pairs_for_ar,
+                                  satellite_par_max_drops);
+                    std::vector<int> persistent_subset;
+                    if (rtk_config_
+                            .lambda_satellite_par_persistent_subset &&
+                        !satellite_par_persistent_satellites_.empty()) {
+                        debug_telemetry_
+                            .lambda_satellite_par_persistent_subset_attempted =
+                            true;
+                        bool selected_signal_slipped = false;
+                        for (const auto& satellite :
+                             satellite_par_persistent_satellites_) {
+                            selected_signal_slipped =
+                                selected_signal_slipped ||
+                                current_epoch_slips_l1_.count(satellite) > 0 ||
+                                current_epoch_slips_l2_.count(satellite) > 0 ||
+                                current_epoch_slips_l5_.count(satellite) > 0;
+                        }
+                        if (!selected_signal_slipped) {
+                            for (int index = 0; index < nb; ++index) {
+                                if (satellite_par_persistent_satellites_
+                                        .count(dd_pairs[index].sat) > 0) {
+                                    persistent_subset.push_back(index);
+                                }
+                            }
+                        } else {
+                            satellite_par_persistent_satellites_.clear();
+                        }
+                        if (static_cast<int>(persistent_subset.size()) >=
+                            min_subset_pairs_for_ar) {
+                            const bool already_first =
+                                !satellite_subsets.empty() &&
+                                satellite_subsets.front() ==
+                                    persistent_subset;
+                            if (!already_first) {
+                                satellite_subsets.insert(
+                                    satellite_subsets.begin(),
+                                    persistent_subset);
+                            }
+                        }
+                    }
+                    std::set<SatelliteId> full_satellites;
+                    for (const auto& pair : dd_pairs) {
+                        full_satellites.insert(pair.sat);
+                    }
+                    for (const auto& subset : satellite_subsets) {
+                        debug_telemetry_
+                            .lambda_satellite_par_shadow_subsets_evaluated++;
+                        const auto satellite_problem =
+                            build_search_problem(subset);
+                        LambdaCandidateDiagnostics satellite_candidate;
+                        if (!lambdaSearchTopK(
+                                satellite_problem.dd_float,
+                                satellite_problem.Qb, 2,
+                                satellite_candidate)) {
+                            continue;
+                        }
+                        debug_telemetry_
+                            .lambda_satellite_par_shadow_solved = true;
+                        const double covariance_scale =
+                            rtk_config_
+                                .lambda_satellite_par_shadow_covariance_scale;
+                        const double satellite_bsr =
+                            bootstrappedSuccessRate(
+                                satellite_candidate.conditional_variances,
+                                covariance_scale);
+                        const double satellite_ratio =
+                            satellite_candidate.squared_residuals(0) > 0.0
+                                ? satellite_candidate.squared_residuals(1) /
+                                      satellite_candidate
+                                          .squared_residuals(0)
+                                : 0.0;
+                        FixedFailureRateRatioThreshold satellite_ffrt;
+                        if (!fixedFailureRateRatioThreshold(
+                                static_cast<int>(subset.size()),
+                                satellite_bsr, 0.001,
+                                satellite_ffrt) ||
+                            !satellite_ffrt.accepts_any_candidate ||
+                            !std::isfinite(satellite_ratio) ||
+                            satellite_ratio <
+                                satellite_ffrt
+                                    .minimum_second_to_best_ratio) {
+                            continue;
+                        }
+                        VectorXd satellite_best_head;
+                        VectorXd satellite_second_head;
+                        const bool best_solved =
+                            rtk_ar_evaluation::solveFixedHeadState(
+                                satellite_problem.head_state,
+                                satellite_problem.Qab,
+                                satellite_problem.Qb,
+                                satellite_problem.dd_float,
+                                satellite_candidate.candidates.col(0),
+                                satellite_best_head);
+                        const bool second_solved =
+                            rtk_ar_evaluation::solveFixedHeadState(
+                                satellite_problem.head_state,
+                                satellite_problem.Qab,
+                                satellite_problem.Qb,
+                                satellite_problem.dd_float,
+                                satellite_candidate.candidates.col(1),
+                                satellite_second_head);
+                        if (!best_solved ||
+                            satellite_best_head.size() < 3) {
+                            continue;
+                        }
+                        debug_telemetry_
+                            .lambda_satellite_par_shadow_subset_size =
+                            static_cast<int>(subset.size());
+                        std::set<SatelliteId> subset_satellites;
+                        for (int index : subset) {
+                            subset_satellites.insert(
+                                dd_pairs[index].sat);
+                        }
+                        debug_telemetry_
+                            .lambda_satellite_par_shadow_dropped_satellites =
+                            static_cast<int>(
+                                full_satellites.size() -
+                                subset_satellites.size());
+                        debug_telemetry_
+                            .lambda_satellite_par_shadow_bsr =
+                            satellite_bsr;
+                        debug_telemetry_
+                            .lambda_satellite_par_shadow_ratio =
+                            satellite_ratio;
+                        debug_telemetry_
+                            .lambda_satellite_par_shadow_ffrt_min_ratio =
+                            satellite_ffrt
+                                .minimum_second_to_best_ratio;
+                        debug_telemetry_
+                            .lambda_satellite_par_shadow_ffrt_passed = true;
+                        if (rtk_config_
+                                .lambda_satellite_par_persistent_subset) {
+                            debug_telemetry_
+                                .lambda_satellite_par_persistent_subset_used =
+                                subset == persistent_subset &&
+                                !persistent_subset.empty();
+                            satellite_par_persistent_satellites_.clear();
+                            for (int index : subset) {
+                                satellite_par_persistent_satellites_.insert(
+                                    dd_pairs[index].sat);
+                            }
+                        }
+                        const Vector3d satellite_best_ecef =
+                            base_position_ +
+                            satellite_best_head.head<3>();
+                        debug_telemetry_
+                            .lambda_satellite_par_shadow_best_ecef_x =
+                            satellite_best_ecef.x();
+                        debug_telemetry_
+                            .lambda_satellite_par_shadow_best_ecef_y =
+                            satellite_best_ecef.y();
+                        debug_telemetry_
+                            .lambda_satellite_par_shadow_best_ecef_z =
+                            satellite_best_ecef.z();
+                        const Vector3d satellite_correction =
+                            satellite_best_head.head<3>() -
+                            satellite_problem.head_state.head<3>();
+                        debug_telemetry_
+                            .lambda_satellite_par_shadow_best_correction_x =
+                            satellite_correction.x();
+                        debug_telemetry_
+                            .lambda_satellite_par_shadow_best_correction_y =
+                            satellite_correction.y();
+                        debug_telemetry_
+                            .lambda_satellite_par_shadow_best_correction_z =
+                            satellite_correction.z();
+                        if (second_solved &&
+                            satellite_second_head.size() >= 3) {
+                            debug_telemetry_
+                                .lambda_satellite_par_shadow_second_position_delta_m =
+                                (satellite_second_head.head<3>() -
+                                 satellite_best_head.head<3>())
+                                    .norm();
+                        }
+                        // Sequential PAR stops at the first (largest)
+                        // satellite subset passing the fail-closed FFRT.
+                        break;
+                    }
+                    debug_telemetry_
+                        .lambda_satellite_par_shadow_runtime_ms =
+                        std::chrono::duration<double, std::milli>(
+                            std::chrono::steady_clock::now() -
+                            satellite_par_started)
+                            .count();
+                }
+            }
+            debug_telemetry_.lambda_shadow_runtime_ms =
+                std::chrono::duration<double, std::milli>(
+                    std::chrono::steady_clock::now() - shadow_started).count();
+        }
         if (full_solved) {
             debug_telemetry_.full_ratio = ratio;
             // WP7 dead-knob fix: passesArFilter is a no-op AND term when
@@ -5107,6 +8070,87 @@ void RTKProcessor::rememberSolution(const PositionSolution& solution) {
         last_trusted_time_ = solution.time;
         has_last_trusted_time_ = true;
     }
+}
+
+PositionSolution RTKProcessor::makeSafeFloatContinuity(
+    const GNSSTime& time) {
+    PositionSolution solution;
+    solution.time = time;
+    solution.status = SolutionStatus::NONE;
+
+    const double trusted_anchor_age_s =
+        has_last_trusted_time_
+            ? time - last_trusted_time_
+            : std::numeric_limits<double>::quiet_NaN();
+    const double velocity_age_s =
+        has_last_doppler_velocity_
+            ? time - last_doppler_velocity_time_
+            : std::numeric_limits<double>::quiet_NaN();
+    debug_telemetry_.safe_float_continuity_attempted =
+        rtk_config_.safe_float_continuity.enabled;
+    debug_telemetry_.safe_float_continuity_anchor_age_s =
+        trusted_anchor_age_s;
+    debug_telemetry_.safe_float_continuity_velocity_age_s =
+        velocity_age_s;
+    auto continuity = safe_float_continuity::propagate(
+        rtk_config_.safe_float_continuity,
+        last_trusted_position_,
+        trusted_anchor_age_s,
+        last_doppler_velocity_ecef_,
+        velocity_age_s);
+    double anchor_age_s = trusted_anchor_age_s;
+    bool solver_gap_anchor = false;
+
+    // If the trusted anchor is too old, bridge only an isolated sub-second
+    // solver gap from the last real solver output. Continuity outputs are
+    // never remembered, so this path cannot recursively dead-reckon.
+    if (!continuity.valid &&
+        has_last_solution_position_ &&
+        has_last_epoch_) {
+        anchor_age_s = time - last_epoch_time_;
+        auto short_gap_config = rtk_config_.safe_float_continuity;
+        short_gap_config.maximum_anchor_age_s =
+            std::min(
+                short_gap_config.maximum_anchor_age_s,
+                short_gap_config.maximum_solver_gap_anchor_age_s);
+        continuity = safe_float_continuity::propagate(
+            short_gap_config,
+            last_solution_position_,
+            anchor_age_s,
+            last_doppler_velocity_ecef_,
+            velocity_age_s);
+        solver_gap_anchor = continuity.valid;
+    }
+    if (!has_last_doppler_velocity_ || !continuity.valid) {
+        return solution;
+    }
+
+    solution.status = SolutionStatus::FLOAT;
+    solution.position_ecef = continuity.position_ecef;
+    solution.position_geodetic =
+        spp_utils::ecefToGeodetic(solution.position_ecef);
+    solution.position_covariance =
+        Matrix3d::Identity() * continuity.position_variance_m2;
+    solution.velocity_ecef = last_doppler_velocity_ecef_;
+    solution.velocity_covariance =
+        Matrix3d::Identity() *
+        std::pow(
+            rtk_config_.safe_float_continuity.velocity_sigma_mps,
+            2.0);
+    solution.has_velocity = true;
+    // Four is the minimum valid FLOAT output and deliberately prevents
+    // rememberSolution() from refreshing trust.
+    solution.num_satellites = 4;
+    solution.ratio = 0.0;
+    solution.num_fixed_ambiguities = 0;
+    debug_telemetry_.safe_float_continuity_used = true;
+    debug_telemetry_.safe_float_continuity_solver_gap_anchor =
+        solver_gap_anchor;
+    debug_telemetry_.safe_float_continuity_anchor_age_s =
+        anchor_age_s;
+    debug_telemetry_.safe_float_continuity_velocity_age_s =
+        velocity_age_s;
+    return solution;
 }
 
 void RTKProcessor::updateStatistics(SolutionStatus status) const {

--- a/src/algorithms/rtk_ar_selection.cpp
+++ b/src/algorithms/rtk_ar_selection.cpp
@@ -1,6 +1,9 @@
 #include <libgnss++/algorithms/rtk_ar_selection.hpp>
 
 #include <algorithm>
+#include <cmath>
+#include <map>
+#include <set>
 
 namespace libgnss {
 namespace rtk_ar_selection {
@@ -26,6 +29,59 @@ std::vector<int> buildSubsetExcluding(const std::vector<PairDescriptor>& pairs,
 }
 
 }  // namespace
+
+bool conditionNarrowLaneOnFixedWideLane(
+    const Eigen::VectorXd& head_state,
+    const Eigen::MatrixXd& Q_head_n1,
+    const Eigen::VectorXd& n1_float,
+    const Eigen::MatrixXd& Q_n1,
+    const Eigen::VectorXd& wide_lane_float,
+    const Eigen::MatrixXd& Q_wide_lane,
+    const Eigen::VectorXd& fixed_wide_lane,
+    Eigen::VectorXd& conditioned_head_state,
+    Eigen::MatrixXd& conditioned_Q_head_n1,
+    Eigen::VectorXd& conditioned_n1_float,
+    Eigen::MatrixXd& conditioned_Q_n1) {
+    const Eigen::Index n = n1_float.size();
+    if (n == 0 || wide_lane_float.size() != n ||
+        fixed_wide_lane.size() != n || Q_n1.rows() != n ||
+        Q_n1.cols() != n || Q_wide_lane.rows() != n ||
+        Q_wide_lane.cols() != n || Q_head_n1.rows() != head_state.size() ||
+        Q_head_n1.cols() != n || !head_state.allFinite() ||
+        !Q_head_n1.allFinite() || !n1_float.allFinite() ||
+        !Q_n1.allFinite() || !wide_lane_float.allFinite() ||
+        !Q_wide_lane.allFinite() || !fixed_wide_lane.allFinite()) {
+        return false;
+    }
+    const Eigen::MatrixXd symmetric_Qw =
+        (Q_wide_lane + Q_wide_lane.transpose()) * 0.5;
+    Eigen::LDLT<Eigen::MatrixXd> decomposition(symmetric_Qw);
+    if (decomposition.info() != Eigen::Success ||
+        (decomposition.vectorD().array() <= 1e-12).any()) {
+        return false;
+    }
+    const Eigen::MatrixXd inverse_Qw =
+        decomposition.solve(Eigen::MatrixXd::Identity(n, n));
+    if (decomposition.info() != Eigen::Success ||
+        !inverse_Qw.allFinite()) {
+        return false;
+    }
+    const Eigen::MatrixXd n1_gain = Q_n1 * inverse_Qw;
+    const Eigen::MatrixXd head_gain = Q_head_n1 * inverse_Qw;
+    const Eigen::VectorXd innovation =
+        fixed_wide_lane - wide_lane_float;
+    conditioned_head_state = head_state + head_gain * innovation;
+    conditioned_n1_float = n1_float + n1_gain * innovation;
+    conditioned_Q_n1 = Q_n1 - n1_gain * Q_n1;
+    conditioned_Q_n1 =
+        (conditioned_Q_n1 + conditioned_Q_n1.transpose()) * 0.5;
+    conditioned_Q_head_n1 =
+        Q_head_n1 - head_gain * Q_n1;
+    return conditioned_head_state.allFinite() &&
+           conditioned_n1_float.allFinite() &&
+           conditioned_Q_n1.allFinite() &&
+           conditioned_Q_head_n1.allFinite();
+}
 
 std::vector<int> filterPairsByRelativeVariance(const std::vector<PairDescriptor>& pairs,
                                                double multiplier,
@@ -194,6 +250,270 @@ std::vector<std::vector<int>> buildProgressiveVarianceDropSubsets(
         current_subset = subset;
     }
     return subsets;
+}
+
+std::vector<std::vector<int>> buildSatelliteQualityDropSubsets(
+    const std::vector<PairDescriptor>& pairs,
+    int minimum_pairs,
+    int max_drop_steps) {
+    struct SatelliteQuality {
+        SatelliteId satellite;
+        std::vector<int> indices;
+        double variance = -1.0;
+        double fractional_distance = -1.0;
+        double posterior_abs_residual = -1.0;
+        double elevation = std::numeric_limits<double>::infinity();
+        double snr = std::numeric_limits<double>::infinity();
+        double azimuth = std::numeric_limits<double>::quiet_NaN();
+        double azimuth_crowding =
+            std::numeric_limits<double>::infinity();
+        bool has_fractional_distance = false;
+        bool has_posterior_abs_residual = false;
+        bool has_elevation = false;
+        bool has_snr = false;
+        bool has_azimuth = false;
+        double score = 0.0;
+    };
+
+    if (minimum_pairs < 1 || max_drop_steps < 1) return {};
+    std::map<SatelliteId, SatelliteQuality> grouped;
+    for (int index = 0; index < static_cast<int>(pairs.size()); ++index) {
+        const auto& pair = pairs[index];
+        auto [it, inserted] = grouped.try_emplace(pair.satellite);
+        auto& quality = it->second;
+        if (inserted) quality.satellite = pair.satellite;
+        quality.indices.push_back(index);
+        if (std::isfinite(pair.variance)) {
+            quality.variance = std::max(quality.variance, pair.variance);
+        }
+        if (std::isfinite(pair.fractional_distance_cycles)) {
+            quality.fractional_distance =
+                std::max(quality.fractional_distance,
+                         pair.fractional_distance_cycles);
+            quality.has_fractional_distance = true;
+        }
+        if (std::isfinite(pair.posterior_abs_residual_m)) {
+            quality.posterior_abs_residual =
+                std::max(
+                    quality.posterior_abs_residual,
+                    pair.posterior_abs_residual_m);
+            quality.has_posterior_abs_residual = true;
+        }
+        if (std::isfinite(pair.elevation_rad)) {
+            quality.elevation = std::min(quality.elevation, pair.elevation_rad);
+            quality.has_elevation = true;
+        }
+        if (std::isfinite(pair.snr_dbhz)) {
+            quality.snr = std::min(quality.snr, pair.snr_dbhz);
+            quality.has_snr = true;
+        }
+        if (std::isfinite(pair.azimuth_rad)) {
+            quality.azimuth = pair.azimuth_rad;
+            quality.has_azimuth = true;
+        }
+    }
+    if (grouped.size() < 2 || static_cast<int>(pairs.size()) <= minimum_pairs) {
+        return {};
+    }
+
+    std::vector<SatelliteQuality> ranked;
+    ranked.reserve(grouped.size());
+    for (const auto& [satellite, quality] : grouped) {
+        (void)satellite;
+        ranked.push_back(quality);
+    }
+    constexpr double kTwoPi = 2.0 * 3.14159265358979323846;
+    for (auto& quality : ranked) {
+        if (!quality.has_azimuth) continue;
+        for (const auto& other : ranked) {
+            if (!other.has_azimuth ||
+                other.satellite == quality.satellite) {
+                continue;
+            }
+            double separation =
+                std::abs(quality.azimuth - other.azimuth);
+            separation = std::min(separation, kTwoPi - separation);
+            quality.azimuth_crowding =
+                std::min(quality.azimuth_crowding, separation);
+        }
+    }
+    const double denominator =
+        static_cast<double>(std::max<std::size_t>(1, ranked.size() - 1));
+    for (auto& quality : ranked) {
+        double rank_sum = 0.0;
+        int rank_count = 0;
+        auto add_rank = [&](auto worse_than, bool available) {
+            if (!available) return;
+            int worse_rank = 0;
+            for (const auto& other : ranked) {
+                if (worse_than(quality, other)) ++worse_rank;
+            }
+            rank_sum += static_cast<double>(worse_rank) / denominator;
+            ++rank_count;
+        };
+        add_rank(
+            [](const auto& value, const auto& other) {
+                return value.variance > other.variance;
+            },
+            std::isfinite(quality.variance));
+        add_rank(
+            [](const auto& value, const auto& other) {
+                return value.fractional_distance >
+                       other.fractional_distance;
+            },
+            quality.has_fractional_distance);
+        add_rank(
+            [](const auto& value, const auto& other) {
+                return value.posterior_abs_residual >
+                       other.posterior_abs_residual;
+            },
+            quality.has_posterior_abs_residual);
+        add_rank(
+            [](const auto& value, const auto& other) {
+                return value.elevation < other.elevation;
+            },
+            quality.has_elevation);
+        add_rank(
+            [](const auto& value, const auto& other) {
+                return value.snr < other.snr;
+            },
+            quality.has_snr);
+        add_rank(
+            [](const auto& value, const auto& other) {
+                return value.azimuth_crowding <
+                       other.azimuth_crowding;
+            },
+            quality.has_azimuth &&
+                std::isfinite(quality.azimuth_crowding));
+        quality.score = rank_count > 0 ? rank_sum / rank_count : 0.0;
+    }
+    std::stable_sort(
+        ranked.begin(), ranked.end(),
+        [](const SatelliteQuality& left, const SatelliteQuality& right) {
+            if (left.score != right.score) return left.score > right.score;
+            if (left.variance != right.variance) {
+                return left.variance > right.variance;
+            }
+            return left.satellite < right.satellite;
+        });
+
+    std::vector<int> current;
+    current.reserve(pairs.size());
+    for (int index = 0; index < static_cast<int>(pairs.size()); ++index) {
+        current.push_back(index);
+    }
+    std::vector<std::vector<int>> subsets;
+    for (const auto& quality : ranked) {
+        if (static_cast<int>(subsets.size()) >= max_drop_steps) break;
+        std::vector<int> candidate;
+        candidate.reserve(current.size());
+        for (int index : current) {
+            if (pairs[index].satellite != quality.satellite) {
+                candidate.push_back(index);
+            }
+        }
+        if (candidate.size() == current.size()) continue;
+        if (static_cast<int>(candidate.size()) < minimum_pairs) continue;
+        subsets.push_back(candidate);
+        current = std::move(candidate);
+    }
+    return subsets;
+}
+
+std::vector<std::vector<int>> buildSatelliteQualityDiverseDropSubsets(
+    const std::vector<PairDescriptor>& pairs,
+    int minimum_pairs,
+    int max_drop_steps,
+    int maximum_subsets) {
+    if (maximum_subsets < 1) {
+        return {};
+    }
+    std::vector<std::vector<int>> result;
+    std::set<std::vector<int>> seen;
+    const auto append_unique =
+        [&](const std::vector<std::vector<int>>& candidates) {
+            for (const auto& candidate : candidates) {
+                if (static_cast<int>(result.size()) >= maximum_subsets) {
+                    break;
+                }
+                if (seen.insert(candidate).second) {
+                    result.push_back(candidate);
+                }
+            }
+        };
+    append_unique(buildSatelliteQualityDropSubsets(
+        pairs, minimum_pairs, max_drop_steps));
+
+    enum class Metric {
+        VARIANCE,
+        POSTERIOR_RESIDUAL,
+        FRACTIONAL_DISTANCE,
+        ELEVATION,
+        SNR,
+        AZIMUTH
+    };
+    constexpr Metric metrics[] = {
+        Metric::VARIANCE,
+        Metric::POSTERIOR_RESIDUAL,
+        Metric::FRACTIONAL_DISTANCE,
+        Metric::ELEVATION,
+        Metric::SNR,
+        Metric::AZIMUTH,
+    };
+    const double nan = std::numeric_limits<double>::quiet_NaN();
+    for (const Metric metric : metrics) {
+        if (static_cast<int>(result.size()) >= maximum_subsets) {
+            break;
+        }
+        const bool metric_available = std::any_of(
+            pairs.begin(), pairs.end(),
+            [metric](const PairDescriptor& pair) {
+                switch (metric) {
+                    case Metric::VARIANCE:
+                        return std::isfinite(pair.variance);
+                    case Metric::POSTERIOR_RESIDUAL:
+                        return std::isfinite(
+                            pair.posterior_abs_residual_m);
+                    case Metric::FRACTIONAL_DISTANCE:
+                        return std::isfinite(
+                            pair.fractional_distance_cycles);
+                    case Metric::ELEVATION:
+                        return std::isfinite(pair.elevation_rad);
+                    case Metric::SNR:
+                        return std::isfinite(pair.snr_dbhz);
+                    case Metric::AZIMUTH:
+                        return std::isfinite(pair.azimuth_rad);
+                }
+                return false;
+            });
+        if (!metric_available) {
+            continue;
+        }
+        auto metric_pairs = pairs;
+        for (auto& pair : metric_pairs) {
+            if (metric != Metric::VARIANCE) {
+                pair.variance = nan;
+            }
+            if (metric != Metric::POSTERIOR_RESIDUAL) {
+                pair.posterior_abs_residual_m = nan;
+            }
+            if (metric != Metric::FRACTIONAL_DISTANCE) {
+                pair.fractional_distance_cycles = nan;
+            }
+            if (metric != Metric::ELEVATION) {
+                pair.elevation_rad = nan;
+            }
+            if (metric != Metric::SNR) {
+                pair.snr_dbhz = nan;
+            }
+            if (metric != Metric::AZIMUTH) {
+                pair.azimuth_rad = nan;
+            }
+        }
+        append_unique(buildSatelliteQualityDropSubsets(
+            metric_pairs, minimum_pairs, max_drop_steps));
+    }
+    return result;
 }
 
 }  // namespace rtk_ar_selection

--- a/src/algorithms/rtk_measurement.cpp
+++ b/src/algorithms/rtk_measurement.cpp
@@ -44,12 +44,14 @@ MeasurementSystem assembleMeasurementSystem(const std::vector<MeasurementBlock>&
     MeasurementSystem system;
     system.design_matrix = Eigen::MatrixXd::Zero(observation_count, n_states);
     system.residuals = Eigen::VectorXd::Zero(observation_count);
+    system.row_kinds.reserve(observation_count);
     system.covariance = buildDoubleDifferenceCovariance(
         block_sizes, ref_variances, sat_variances, observation_count);
 
     int row_index = 0;
     for (const auto& block : blocks) {
         for (const auto& row : block.rows) {
+            system.row_kinds.push_back(block.kind);
             system.residuals(row_index) = row.residual;
             system.design_matrix(row_index, 0) = row.baseline_coefficients(0);
             system.design_matrix(row_index, 1) = row.baseline_coefficients(1);

--- a/src/algorithms/rtk_update.cpp
+++ b/src/algorithms/rtk_update.cpp
@@ -110,7 +110,128 @@ InnovationStats computeInnovationStats(const Eigen::VectorXd& state,
     return stats;
 }
 
+Eigen::VectorXd computeInnovationVariances(
+    const Eigen::VectorXd& state,
+    const Eigen::MatrixXd& covariance,
+    const Eigen::MatrixXd& design_matrix,
+    const Eigen::MatrixXd& measurement_covariance) {
+    const Eigen::Index measurements = design_matrix.rows();
+    Eigen::VectorXd variances =
+        measurement_covariance.diagonal();
+    if (state.size() != covariance.rows() ||
+        covariance.rows() != covariance.cols() ||
+        design_matrix.cols() != state.size() ||
+        measurement_covariance.rows() != measurements ||
+        measurement_covariance.cols() != measurements) {
+        return {};
+    }
+    std::vector<int> active_states;
+    for (int index = 0; index < state.size(); ++index) {
+        if (state(index) != 0.0 &&
+            covariance(index, index) > 0.0) {
+            active_states.push_back(index);
+        }
+    }
+    for (Eigen::Index row = 0; row < measurements; ++row) {
+        double state_variance = 0.0;
+        for (int first : active_states) {
+            for (int second : active_states) {
+                state_variance +=
+                    design_matrix(row, first) *
+                    covariance(first, second) *
+                    design_matrix(row, second);
+            }
+        }
+        variances(row) += state_variance;
+    }
+    return variances;
+}
+
 }  // namespace
+
+StudentTFrontEndResult applyStudentTMeasurementWeights(
+    const Eigen::VectorXd& residuals,
+    Eigen::MatrixXd& measurement_covariance,
+    const StudentTFrontEndConfig& config) {
+    return applyStudentTMeasurementWeights(
+        residuals, measurement_covariance.diagonal(),
+        measurement_covariance, config);
+}
+
+StudentTFrontEndResult applyStudentTMeasurementWeights(
+    const Eigen::VectorXd& residuals,
+    const Eigen::VectorXd& innovation_variances,
+    Eigen::MatrixXd& measurement_covariance,
+    const StudentTFrontEndConfig& config) {
+    StudentTFrontEndResult result;
+    const Eigen::Index count = residuals.size();
+    if (!config.enabled || count == 0 ||
+        innovation_variances.size() != count ||
+        measurement_covariance.rows() != count ||
+        measurement_covariance.cols() != count ||
+        !residuals.allFinite() ||
+        !measurement_covariance.allFinite() ||
+        !std::isfinite(config.degrees_of_freedom) ||
+        config.degrees_of_freedom <= 0.0 ||
+        !std::isfinite(config.minimum_weight) ||
+        config.minimum_weight <= 0.0 ||
+        config.minimum_weight > 1.0 ||
+        !std::isfinite(config.activation_threshold_sigma) ||
+        config.activation_threshold_sigma < 0.0) {
+        return result;
+    }
+    Eigen::VectorXd weights(count);
+    for (Eigen::Index row = 0; row < count; ++row) {
+        const double variance = innovation_variances(row);
+        if (!std::isfinite(variance) || variance <= 0.0) {
+            return StudentTFrontEndResult{};
+        }
+        const double standardized =
+            residuals(row) / std::sqrt(variance);
+        if (std::abs(standardized) <
+            config.activation_threshold_sigma) {
+            weights(row) = 1.0;
+            continue;
+        }
+        double raw_weight = 1.0;
+        if (config.weight_model ==
+            HeavyTailWeightModel::LAPLACIAN) {
+            // IRLS form of an L1/Laplacian loss. Central innovations remain
+            // byte-identical through the activation threshold above.
+            raw_weight = 1.0 / std::abs(standardized);
+        } else if (config.weight_model ==
+                   HeavyTailWeightModel::HUBER) {
+            // Continuous Huber IRLS: the weight is exactly one at the
+            // activation boundary and decays as c / |standardized| beyond it.
+            raw_weight =
+                config.activation_threshold_sigma /
+                std::abs(standardized);
+        } else {
+            raw_weight =
+                (config.degrees_of_freedom + 1.0) /
+                (config.degrees_of_freedom +
+                 standardized * standardized);
+        }
+        weights(row) = std::clamp(
+            raw_weight, config.minimum_weight, 1.0);
+    }
+    const Eigen::VectorXd inverse_sqrt_weights =
+        weights.array().sqrt().inverse();
+    measurement_covariance =
+        inverse_sqrt_weights.asDiagonal() *
+        measurement_covariance *
+        inverse_sqrt_weights.asDiagonal();
+    measurement_covariance =
+        (measurement_covariance +
+         measurement_covariance.transpose()) *
+        0.5;
+    result.applied = true;
+    result.minimum_weight = weights.minCoeff();
+    result.mean_weight = weights.mean();
+    result.downweighted_rows =
+        static_cast<int>((weights.array() < 1.0 - 1e-12).count());
+    return result;
+}
 
 FilterUpdateResult applyMeasurementUpdate(Eigen::VectorXd& state,
                                           Eigen::MatrixXd& covariance,
@@ -120,7 +241,8 @@ FilterUpdateResult applyMeasurementUpdate(Eigen::VectorXd& state,
                                           double max_normalized_innovation_squared_per_observation,
                                           const std::vector<bool>& force_active,
                                           bool compute_row_stats,
-                                          bool reuse_kalman_factorization_for_nis) {
+                                          bool reuse_kalman_factorization_for_nis,
+                                          const StudentTFrontEndConfig& student_t_config) {
     FilterUpdateResult result;
     result.observation_count = static_cast<int>(measurement_system.residuals.size());
     result.prefit_residual_rms_m = residualRms(measurement_system.residuals);
@@ -136,6 +258,28 @@ FilterUpdateResult applyMeasurementUpdate(Eigen::VectorXd& state,
         measurement_system.row_outlier_thresholds);
     result.post_suppression_residual_rms_m = residualRms(measurement_system.residuals);
     result.post_suppression_residual_max_abs_m = residualMaxAbs(measurement_system.residuals);
+    const Eigen::VectorXd innovation_variances =
+        computeInnovationVariances(
+            state, covariance, measurement_system.design_matrix,
+            measurement_system.covariance);
+    Eigen::VectorXd robust_residuals =
+        measurement_system.residuals;
+    if (student_t_config.code_only &&
+        measurement_system.row_kinds.size() ==
+            static_cast<std::size_t>(robust_residuals.size())) {
+        for (Eigen::Index row = 0;
+             row < robust_residuals.size(); ++row) {
+            if (measurement_system.row_kinds[
+                    static_cast<std::size_t>(row)] !=
+                rtk_measurement::MeasurementKind::CODE) {
+                robust_residuals(row) = 0.0;
+            }
+        }
+    }
+    result.student_t = applyStudentTMeasurementWeights(
+        robust_residuals, innovation_variances,
+        measurement_system.covariance,
+        student_t_config);
 
     const bool can_reuse_kalman_factorization =
         reuse_kalman_factorization_for_nis &&

--- a/src/fusion/dd_imu_bridge.cpp
+++ b/src/fusion/dd_imu_bridge.cpp
@@ -112,6 +112,7 @@ void DDIMUBridge::acceptPropagatedINS(
 }
 
 UpdateResult DDIMUBridge::update(const std::vector<DDObservation>& observations) {
+    last_joint_posterior_valid_ = false;
     // A DD ambiguity is only meaningful for its current satellite/reference
     // arc. Retire states that disappeared or whose reference changed before
     // augmenting the current epoch. Keeping them forever makes the covariance
@@ -179,6 +180,11 @@ UpdateResult DDIMUBridge::update(const std::vector<DDObservation>& observations)
                                     config_.max_nis_per_observation);
     result.joint_nis_per_observation = result.nis_per_observation;
     result.carrier_update_accepted = result.ok && carrier_rows > 0;
+    if (result.ok && carrier_rows > 0) {
+        last_ins_prediction_ = pre_joint_state;
+        last_joint_posterior_ = state_;
+        last_joint_posterior_valid_ = true;
+    }
 
     // A bad carrier arc must not discard an otherwise healthy code-DD update.
     // First attempt the genuinely joint update; if it fails, retain the live
@@ -207,6 +213,193 @@ UpdateResult DDIMUBridge::update(const std::vector<DDObservation>& observations)
         result.joint_nis_per_observation = joint_nis;
     }
     if (result.ok) consecutive_innovation_rejections_ = 0;
+    return result;
+}
+
+SSEPartialARResult DDIMUBridge::evaluateSSEPartialAmbiguities(
+    const std::vector<DDObservation>& observations,
+    bool external_solution_healthy) const {
+    SSEPartialARResult result;
+    if (!external_solution_healthy ||
+        !last_joint_posterior_valid_ ||
+        last_joint_posterior_.augmented_covariance.rows() <=
+            fusion_index::SIZE) {
+        return result;
+    }
+    result.available = true;
+    std::vector<int> indices;
+    for (const auto& observation : observations) {
+        const auto it = std::find_if(
+            last_joint_posterior_.ambiguities.begin(),
+            last_joint_posterior_.ambiguities.end(),
+            [&](const AmbiguityErrorState& ambiguity) {
+                return ambiguity.key == observation.key;
+            });
+        if (it == last_joint_posterior_.ambiguities.end() ||
+            observation.cycle_slip ||
+            observation.lock_count < config_.partial_ar_min_lock_count) {
+            continue;
+        }
+        indices.push_back(static_cast<int>(
+            std::distance(
+                last_joint_posterior_.ambiguities.begin(), it)));
+    }
+    std::sort(indices.begin(), indices.end(), [&](int a, int b) {
+        const auto quality = [&](int index) {
+            const auto& key =
+                last_joint_posterior_.ambiguities[index].key;
+            const auto it = std::find_if(
+                observations.begin(), observations.end(),
+                [&](const DDObservation& observation) {
+                    return observation.key == key;
+                });
+            if (it == observations.end()) {
+                return -std::numeric_limits<double>::infinity();
+            }
+            const double variance =
+                std::max(1e-9, it->carrier_variance_m2);
+            return 2.0 * it->elevation_rad +
+                   0.02 * it->lock_count -
+                   std::abs(it->posterior_abs_residual_m) /
+                       std::sqrt(variance);
+        };
+        return quality(a) > quality(b);
+    });
+    indices.erase(
+        std::unique(indices.begin(), indices.end()), indices.end());
+    result.attempted = static_cast<int>(indices.size());
+
+    const int minimum_sse_ambiguities = std::max(
+        config_.partial_ar_min_ambiguities,
+        config_.sse_min_fixed_ambiguities);
+    for (int count = static_cast<int>(indices.size());
+         count >= minimum_sse_ambiguities; --count) {
+        ++result.subsets_evaluated;
+        Eigen::VectorXd float_ambiguities(count);
+        Eigen::MatrixXd Qaa(count, count);
+        Eigen::MatrixXd Pxa(3, count);
+        for (int row = 0; row < count; ++row) {
+            const int ambiguity = indices[row];
+            float_ambiguities[row] =
+                last_joint_posterior_.ambiguities[ambiguity]
+                    .float_value_cycles;
+            Pxa.col(row) =
+                last_joint_posterior_.augmented_covariance.block(
+                    fusion_index::POSITION,
+                    fusion_index::SIZE + ambiguity, 3, 1);
+            for (int column = 0; column < count; ++column) {
+                Qaa(row, column) =
+                    last_joint_posterior_.augmented_covariance(
+                        fusion_index::SIZE + ambiguity,
+                        fusion_index::SIZE + indices[column]);
+            }
+        }
+        Qaa = (Qaa + Qaa.transpose()) * 0.5;
+        Eigen::LDLT<Eigen::MatrixXd> ambiguity_decomposition(Qaa);
+        if (ambiguity_decomposition.info() != Eigen::Success ||
+            (ambiguity_decomposition.vectorD().array() <= 1e-12).any()) {
+            continue;
+        }
+        LambdaCandidateDiagnostics search;
+        if (!lambdaSearchTopK(
+                float_ambiguities, Qaa, 2, search) ||
+            search.candidates.cols() < 1 ||
+            search.squared_residuals.size() < 2) {
+            continue;
+        }
+        const double ratio =
+            search.squared_residuals(0) > 0.0
+                ? search.squared_residuals(1) /
+                      search.squared_residuals(0)
+                : 0.0;
+        const double bsr = bootstrappedSuccessRate(
+            search.conditional_variances,
+            config_.sse_ffrt_covariance_scale);
+        FixedFailureRateRatioThreshold ffrt;
+        if (!fixedFailureRateRatioThreshold(
+                count, bsr, 0.001, ffrt)) {
+            continue;
+        }
+        result.ratio = std::max(result.ratio, ratio);
+        result.bootstrapped_success_rate =
+            std::max(result.bootstrapped_success_rate, bsr);
+        if (std::isfinite(ffrt.minimum_second_to_best_ratio)) {
+            result.ffrt_minimum_ratio =
+                ffrt.minimum_second_to_best_ratio;
+        }
+        if (!ffrt.accepts_any_candidate ||
+            !std::isfinite(ratio) ||
+            ratio < ffrt.minimum_second_to_best_ratio) {
+            continue;
+        }
+        ++result.ratio_passed_subsets;
+        const Eigen::VectorXd fixed =
+            search.candidates.col(0);
+        const Eigen::VectorXd ambiguity_innovation =
+            fixed - float_ambiguities;
+        const Eigen::VectorXd solved_innovation =
+            ambiguity_decomposition.solve(ambiguity_innovation);
+        if (ambiguity_decomposition.info() != Eigen::Success ||
+            !solved_innovation.allFinite()) {
+            continue;
+        }
+        const Eigen::Vector3d fixed_position =
+            last_joint_posterior_.eskf.nominal.position_enu +
+            Pxa * solved_innovation;
+        const Eigen::Vector3d separation =
+            fixed_position -
+            last_ins_prediction_.eskf.nominal.position_enu;
+        const Eigen::Matrix3d fixed_position_covariance =
+            last_joint_posterior_.augmented_covariance.block<3, 3>(
+                fusion_index::POSITION,
+                fusion_index::POSITION) -
+            Pxa * ambiguity_decomposition.solve(Pxa.transpose());
+        // The carrier posterior and external INS prediction are not
+        // independent: the posterior was formed from that INS prior. For a
+        // linear Kalman update Cov(x_post, x_prior) = P_post, so the
+        // solution-separation covariance is P_prior - P_post. Treating them
+        // as independent and adding the covariances makes the gate
+        // dangerously permissive.
+        Eigen::Matrix3d separation_covariance =
+            last_ins_prediction_.augmented_covariance.block<3, 3>(
+                fusion_index::POSITION,
+                fusion_index::POSITION) -
+            fixed_position_covariance;
+        separation_covariance =
+            (separation_covariance +
+             separation_covariance.transpose()) *
+            0.5;
+        Eigen::LDLT<Eigen::Matrix3d> separation_decomposition(
+            separation_covariance);
+        if (separation_decomposition.info() != Eigen::Success ||
+            (separation_decomposition.vectorD().array() <= 1e-12).any()) {
+            continue;
+        }
+        const Eigen::Vector3d normalized =
+            separation_decomposition.solve(separation);
+        if (separation_decomposition.info() != Eigen::Success ||
+            !normalized.allFinite()) {
+            continue;
+        }
+        const double statistic_per_dof =
+            separation.dot(normalized) / 3.0;
+        if (!std::isfinite(statistic_per_dof)) {
+            continue;
+        }
+        result.statistic_per_dof = statistic_per_dof;
+        result.position_separation_m = separation.norm();
+        result.fixed_position_enu = fixed_position;
+        if (statistic_per_dof >
+            config_.sse_max_statistic_per_dof) {
+            ++result.separation_rejected_subsets;
+            continue;
+        }
+        result.passed = true;
+        result.fixed_count = count;
+        result.dropped_count =
+            static_cast<int>(indices.size()) - count;
+        return result;
+    }
     return result;
 }
 

--- a/src/fusion/fusion_processor.cpp
+++ b/src/fusion/fusion_processor.cpp
@@ -356,17 +356,38 @@ void LooseCouplingProcessor::processGnssSolution(const PositionSolution& solutio
     const Eigen::Matrix3d position_covariance_enu = regularizeCovariance3x3(
         r_e2n * solution.position_covariance * r_e2n.transpose(), kDefaultPositionSigmaM);
 
-    const auto position_system = fusion_measurement::buildGnssPositionUpdate(
-        state_, antenna_position_enu, position_covariance_enu, config_.lever_arm_body);
-    const Eigen::Vector3d position_before = state_.nominal.position_enu;
-    const auto position_result =
-        applyUpdateAndInject(position_system,
-                             config_.max_position_update_nis_per_observation,
-                             position_consecutive_gate_rejections_);
-    if (position_result.ok) {
-        last_gnss_position_update_applied_ = true;
-        last_gnss_position_correction_enu_ =
-            state_.nominal.position_enu - position_before;
+    if (!config_.position_updates_require_fixed ||
+        solution.isFixed()) {
+        const auto position_system =
+            fusion_measurement::buildGnssPositionUpdate(
+                state_, antenna_position_enu,
+                position_covariance_enu,
+                config_.lever_arm_body);
+        const Eigen::Vector3d position_before =
+            state_.nominal.position_enu;
+        const auto position_result = applyUpdateAndInject(
+            position_system,
+            config_.max_position_update_nis_per_observation,
+            position_consecutive_gate_rejections_);
+        if (position_result.ok) {
+            last_gnss_position_update_applied_ = true;
+            last_gnss_position_correction_enu_ =
+                state_.nominal.position_enu - position_before;
+        }
+        if (solution.isFixed() && position_result.ok &&
+            std::isfinite(
+                position_result
+                    .normalized_innovation_squared_per_observation) &&
+            position_result
+                    .normalized_innovation_squared_per_observation <=
+                config_
+                    .tight_dd_sse_fixed_anchor_max_nis_per_observation) {
+            has_fixed_anchor_ = true;
+            last_fixed_anchor_time_ = solution.time;
+            last_fixed_anchor_nis_per_observation_ =
+                position_result
+                    .normalized_innovation_squared_per_observation;
+        }
     }
 
     if (solution.has_velocity) {
@@ -442,6 +463,9 @@ LooseCouplingProcessor::processTightlyCoupledDD(
     dd_transition_since_update_.setIdentity();
 
     result.update = dd_imu_bridge_->update(observations);
+    result.sse_partial_ar =
+        dd_imu_bridge_->evaluateSSEPartialAmbiguities(
+            observations, hasHealthyFixedAnchor());
     if (result.update.ok && result.update.carrier_update_accepted) {
         result.partial_ar = dd_imu_bridge_->resolvePartialAmbiguities(observations);
     } else if (result.update.rejected_by_innovation_gate &&
@@ -478,6 +502,21 @@ bool LooseCouplingProcessor::predictedAntennaPositionEcef(Eigen::Vector3d& ecef_
     const Eigen::Matrix3d cov_enu = h * state_.covariance * h.transpose();
     ecef_cov = r_n2e * cov_enu * r_e2n;
     return true;
+}
+
+bool LooseCouplingProcessor::hasHealthyFixedAnchor() const {
+    if (!has_fixed_anchor_ || !isHeadingConverged() ||
+        !std::isfinite(last_fixed_anchor_nis_per_observation_) ||
+        last_fixed_anchor_nis_per_observation_ >
+            config_
+                .tight_dd_sse_fixed_anchor_max_nis_per_observation) {
+        return false;
+    }
+    const double age_s =
+        state_.nominal.time - last_fixed_anchor_time_;
+    return std::isfinite(age_s) && age_s >= -1e-6 &&
+           age_s <=
+               config_.tight_dd_sse_fixed_anchor_max_age_s;
 }
 
 PositionSolution LooseCouplingProcessor::toPositionSolution() const {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,6 +32,12 @@ if(GTest_FOUND)
         test_ppp_correction_contract.cpp
         test_rtk_ar_evaluation.cpp
         test_rtk_ar_selection.cpp
+        test_safe_fix_state_machine.cpp
+          test_fixed_quality_gate.cpp
+          test_fix_failure_budget.cpp
+    test_inertial_fix_evidence.cpp
+    test_disjoint_satellite_fix_evidence.cpp
+        test_causal_ambiguity_arc.cpp
         test_nlos_weights.cpp
         test_float_trust_policy.cpp
         test_rtk_slip_detection.cpp

--- a/tests/test_causal_ambiguity_arc.cpp
+++ b/tests/test_causal_ambiguity_arc.cpp
@@ -1,0 +1,151 @@
+#include <gtest/gtest.h>
+
+#include <libgnss++/algorithms/causal_ambiguity_arc.hpp>
+
+namespace {
+
+using libgnss::GNSSSystem;
+using libgnss::SatelliteId;
+using libgnss::causal_ambiguity_arc::Bank;
+using libgnss::causal_ambiguity_arc::Config;
+
+TEST(CausalAmbiguityArc, UsesOnlyPastAndCurrentSamples) {
+    Config config;
+    config.minimum_samples = 3;
+    Bank bank(config);
+    const SatelliteId satellite(GNSSSystem::GPS, 2);
+    const SatelliteId reference(GNSSSystem::GPS, 1);
+    EXPECT_DOUBLE_EQ(
+        bank.update(satellite, reference, 15, 1.0, 10.2, false)
+            .smoothed_value,
+        10.2);
+    EXPECT_DOUBLE_EQ(
+        bank.update(satellite, reference, 15, 2.0, 9.8, false)
+            .smoothed_value,
+        10.0);
+    const auto third =
+        bank.update(satellite, reference, 15, 3.0, 10.1, false);
+    EXPECT_TRUE(third.ready);
+    EXPECT_NEAR(third.smoothed_value, 10.033333333333333, 1e-12);
+    EXPECT_TRUE(std::isfinite(third.smoothed_value_variance));
+    EXPECT_GT(third.smoothed_value_variance, 0.0);
+}
+
+TEST(CausalAmbiguityArc, ReportsVarianceOfTheCausalSmoothedMean) {
+    Config config;
+    config.minimum_samples = 3;
+    Bank bank(config);
+    const SatelliteId satellite(GNSSSystem::GPS, 2);
+    bank.updateSignal(satellite, 15, 1.0, 9.8, false);
+    bank.updateSignal(satellite, 15, 2.0, 10.0, false);
+    const auto result =
+        bank.updateSignal(satellite, 15, 3.0, 10.2, false);
+    EXPECT_TRUE(result.ready);
+    EXPECT_NEAR(result.smoothed_value, 10.0, 1e-12);
+    EXPECT_NEAR(result.smoothed_value_variance, 2.0 / 225.0, 1e-12);
+}
+
+TEST(CausalAmbiguityArc, SlipResetsOnlyTheAddressedArc) {
+    Config config;
+    config.minimum_samples = 2;
+    Bank bank(config);
+    const SatelliteId reference(GNSSSystem::GPS, 1);
+    const SatelliteId first(GNSSSystem::GPS, 2);
+    const SatelliteId second(GNSSSystem::GPS, 3);
+    bank.update(first, reference, 15, 1.0, 10.0, false);
+    bank.update(second, reference, 15, 1.0, 20.2, false);
+    const auto reset =
+        bank.update(first, reference, 15, 2.0, 30.0, true);
+    const auto unaffected =
+        bank.update(second, reference, 15, 2.0, 19.8, false);
+    EXPECT_TRUE(reset.reset);
+    EXPECT_FALSE(reset.ready);
+    EXPECT_DOUBLE_EQ(reset.smoothed_value, 30.0);
+    EXPECT_TRUE(unaffected.ready);
+    EXPECT_DOUBLE_EQ(unaffected.smoothed_value, 20.0);
+}
+
+TEST(CausalAmbiguityArc, ReferenceReturnCreatesNewGeneration) {
+    Config config;
+    config.minimum_samples = 2;
+    Bank bank(config);
+    const SatelliteId satellite(GNSSSystem::GPS, 3);
+    const SatelliteId first_reference(GNSSSystem::GPS, 1);
+    const SatelliteId second_reference(GNSSSystem::GPS, 2);
+    const auto first = bank.update(
+        satellite, first_reference, 15, 1.0, 10.0, false);
+    const auto changed = bank.update(
+        satellite, second_reference, 15, 2.0, 20.0, false);
+    const auto returned = bank.update(
+        satellite, first_reference, 15, 3.0, 30.0, false);
+    EXPECT_LT(first.reference_generation, changed.reference_generation);
+    EXPECT_LT(changed.reference_generation, returned.reference_generation);
+    EXPECT_FALSE(returned.ready);
+    EXPECT_DOUBLE_EQ(returned.smoothed_value, 30.0);
+}
+
+TEST(CausalAmbiguityArc, TracksReferenceGenerationPerSatellite) {
+    Config config;
+    config.minimum_samples = 2;
+    Bank bank(config);
+    const SatelliteId first(GNSSSystem::GPS, 3);
+    const SatelliteId second(GNSSSystem::GPS, 4);
+    const SatelliteId first_reference(GNSSSystem::GPS, 1);
+    const SatelliteId second_reference(GNSSSystem::GPS, 2);
+    bank.update(first, first_reference, 15, 1.0, 10.2, false);
+    bank.update(second, second_reference, 15, 1.0, 20.2, false);
+    const auto first_next =
+        bank.update(first, first_reference, 15, 2.0, 9.8, false);
+    const auto second_next =
+        bank.update(second, second_reference, 15, 2.0, 19.8, false);
+    EXPECT_TRUE(first_next.ready);
+    EXPECT_TRUE(second_next.ready);
+    EXPECT_EQ(
+        first_next.reference_generation,
+        second_next.reference_generation);
+}
+
+TEST(CausalAmbiguityArc, SingleDifferenceArcsSurviveReferenceChanges) {
+    Config config;
+    config.minimum_samples = 2;
+    Bank bank(config);
+    const SatelliteId satellite(GNSSSystem::GPS, 3);
+    const SatelliteId first_reference(GNSSSystem::GPS, 1);
+    const SatelliteId second_reference(GNSSSystem::GPS, 2);
+    bank.updateSignal(satellite, 15, 1.0, 30.2, false);
+    bank.updateSignal(first_reference, 15, 1.0, 10.2, false);
+    bank.updateSignal(second_reference, 15, 1.0, 20.2, false);
+    const auto satellite_next =
+        bank.updateSignal(satellite, 15, 2.0, 29.8, false);
+    const auto first_next =
+        bank.updateSignal(first_reference, 15, 2.0, 9.8, false);
+    const auto second_next =
+        bank.updateSignal(second_reference, 15, 2.0, 19.8, false);
+    EXPECT_TRUE(satellite_next.ready);
+    EXPECT_TRUE(first_next.ready);
+    EXPECT_TRUE(second_next.ready);
+    EXPECT_DOUBLE_EQ(
+        first_next.smoothed_value - satellite_next.smoothed_value,
+        -20.0);
+    EXPECT_DOUBLE_EQ(
+        second_next.smoothed_value - satellite_next.smoothed_value,
+        -10.0);
+}
+
+TEST(CausalAmbiguityArc, GapAndNonMonotonicTimeFailClosedByReset) {
+    Config config;
+    config.minimum_samples = 2;
+    config.maximum_gap_s = 1.0;
+    Bank bank(config);
+    const SatelliteId satellite(GNSSSystem::GPS, 2);
+    const SatelliteId reference(GNSSSystem::GPS, 1);
+    bank.update(satellite, reference, 15, 2.0, 10.0, false);
+    EXPECT_TRUE(
+        bank.update(satellite, reference, 15, 4.0, 20.0, false)
+            .reset);
+    EXPECT_TRUE(
+        bank.update(satellite, reference, 15, 3.0, 30.0, false)
+            .reset);
+}
+
+}  // namespace

--- a/tests/test_dd_imu_bridge.cpp
+++ b/tests/test_dd_imu_bridge.cpp
@@ -104,6 +104,88 @@ TEST(DDIMUBridge, ShadowCarrierNeverCommitsEvenWhenJointGatePasses) {
     EXPECT_NEAR(bridge.state().augmented_covariance(0, 15), 0.0, 1e-12);
 }
 
+TEST(DDIMUBridge, SSEPartialARUsesShadowPosteriorWithoutHoldingIntegers) {
+    BridgeConfig config;
+    config.commit_carrier_updates = false;
+    config.partial_ar_min_ambiguities = 3;
+    config.sse_min_fixed_ambiguities = 3;
+    config.partial_ar_min_lock_count = 100;
+    config.lambda_ratio_threshold = 2.0;
+    DDIMUBridge bridge(initialState(), config);
+    std::vector<DDObservation> observations{
+        carrier(1, Eigen::RowVector3d::UnitX(), 10.01, 400),
+        carrier(2, Eigen::RowVector3d::UnitY(), -3.01, 400),
+        carrier(3, Eigen::RowVector3d::UnitZ(), 6.01, 400)};
+    for (auto& observation : observations) {
+        observation.code_residual_m = 0.0;
+        observation.code_variance_m2 = 1e-8;
+        observation.carrier_variance_m2 = 1e-6;
+    }
+
+    const auto update = bridge.update(observations);
+    ASSERT_TRUE(update.ok);
+    EXPECT_FALSE(update.carrier_update_accepted);
+    const auto result =
+        bridge.evaluateSSEPartialAmbiguities(observations);
+    EXPECT_TRUE(result.available);
+    EXPECT_TRUE(result.passed);
+    EXPECT_EQ(result.fixed_count, 3);
+    EXPECT_GE(result.ratio, result.ffrt_minimum_ratio);
+    EXPECT_GT(result.bootstrapped_success_rate, 0.8);
+    for (const auto& ambiguity : bridge.state().ambiguities) {
+        EXPECT_FALSE(ambiguity.held);
+    }
+}
+
+TEST(DDIMUBridge, SSEPartialARFailsClosedWhenSeparationLimitRejects) {
+    BridgeConfig config;
+    config.commit_carrier_updates = false;
+    config.partial_ar_min_ambiguities = 3;
+    config.sse_min_fixed_ambiguities = 3;
+    config.partial_ar_min_lock_count = 100;
+    config.lambda_ratio_threshold = 2.0;
+    config.sse_max_statistic_per_dof = -1.0;
+    DDIMUBridge bridge(initialState(), config);
+    std::vector<DDObservation> observations{
+        carrier(1, Eigen::RowVector3d::UnitX(), 10.01, 400),
+        carrier(2, Eigen::RowVector3d::UnitY(), -3.01, 400),
+        carrier(3, Eigen::RowVector3d::UnitZ(), 6.01, 400)};
+    for (auto& observation : observations) {
+        observation.code_residual_m = 0.0;
+        observation.code_variance_m2 = 1e-8;
+        observation.carrier_variance_m2 = 1e-6;
+    }
+
+    ASSERT_TRUE(bridge.update(observations).ok);
+    const auto result =
+        bridge.evaluateSSEPartialAmbiguities(observations);
+    EXPECT_TRUE(result.available);
+    EXPECT_FALSE(result.passed);
+    EXPECT_GT(result.subsets_evaluated, 0);
+}
+
+TEST(DDIMUBridge, SSEPartialARDefaultRejectsSmallSubsets) {
+    BridgeConfig config;
+    config.commit_carrier_updates = false;
+    config.partial_ar_min_lock_count = 100;
+    DDIMUBridge bridge(initialState(), config);
+    std::vector<DDObservation> observations{
+        carrier(1, Eigen::RowVector3d::UnitX(), 10.01, 400),
+        carrier(2, Eigen::RowVector3d::UnitY(), -3.01, 400),
+        carrier(3, Eigen::RowVector3d::UnitZ(), 6.01, 400)};
+    for (auto& observation : observations) {
+        observation.code_residual_m = 0.0;
+        observation.code_variance_m2 = 0.01;
+    }
+
+    ASSERT_TRUE(bridge.update(observations).ok);
+    const auto result =
+        bridge.evaluateSSEPartialAmbiguities(observations);
+    EXPECT_TRUE(result.available);
+    EXPECT_FALSE(result.passed);
+    EXPECT_EQ(result.subsets_evaluated, 0);
+}
+
 TEST(DDIMUBridge, SlipRetiresOldAmbiguityAndCreatesFreshGeneration) {
     DDIMUBridge bridge(initialState());
     auto observation = carrier(7, Eigen::RowVector3d::UnitX(), 4.0);

--- a/tests/test_disjoint_satellite_fix_evidence.cpp
+++ b/tests/test_disjoint_satellite_fix_evidence.cpp
@@ -1,0 +1,115 @@
+#include <gtest/gtest.h>
+
+#include <libgnss++/algorithms/disjoint_satellite_fix_evidence.hpp>
+
+namespace {
+
+namespace evidence =
+    libgnss::disjoint_satellite_fix_evidence;
+
+TEST(DisjointSatelliteFixEvidence, FailsClosedWithoutDisjointInputs) {
+    evidence::Evidence input;
+    input.available = true;
+    input.primary_ffrt_passed = true;
+    input.partition_a_ffrt_passed = true;
+    input.partition_b_ffrt_passed = true;
+    input.partition_a_candidate_ecef = Eigen::Vector3d::Zero();
+    input.partition_b_candidate_ecef = Eigen::Vector3d::Zero();
+    input.primary_candidate_ecef = Eigen::Vector3d::Zero();
+
+    EXPECT_FALSE(evidence::evaluate({}, input).passed);
+}
+
+TEST(DisjointSatelliteFixEvidence, AcceptsAtSeparationBoundaries) {
+    evidence::Evidence input;
+    input.available = true;
+    input.inputs_verified_disjoint = true;
+    input.primary_ffrt_passed = true;
+    input.partition_a_ffrt_passed = true;
+    input.partition_b_ffrt_passed = true;
+    input.partition_a_candidate_ecef =
+        Eigen::Vector3d(-0.125, 0.0, 0.0);
+    input.partition_b_candidate_ecef =
+        Eigen::Vector3d(0.125, 0.0, 0.0);
+    input.primary_candidate_ecef = Eigen::Vector3d::Zero();
+
+    const auto decision = evidence::evaluate({}, input);
+    EXPECT_TRUE(decision.passed);
+    EXPECT_DOUBLE_EQ(decision.partition_separation_m, 0.25);
+}
+
+TEST(DisjointSatelliteFixEvidence, RejectsFfrtOrSeparationFailure) {
+    evidence::Evidence input;
+    input.available = true;
+    input.inputs_verified_disjoint = true;
+    input.primary_ffrt_passed = true;
+    input.partition_a_ffrt_passed = true;
+    input.partition_b_ffrt_passed = false;
+    input.partition_a_candidate_ecef = Eigen::Vector3d::Zero();
+    input.partition_b_candidate_ecef =
+        Eigen::Vector3d(0.01, 0.0, 0.0);
+    input.primary_candidate_ecef = Eigen::Vector3d::Zero();
+    EXPECT_FALSE(evidence::evaluate({}, input).passed);
+
+    input.partition_b_ffrt_passed = true;
+    input.partition_b_candidate_ecef =
+        Eigen::Vector3d(0.26, 0.0, 0.0);
+    EXPECT_FALSE(evidence::evaluate({}, input).passed);
+}
+
+TEST(DisjointSatelliteFixEvidence, AcceptsCovarianceNormalizedSeparation) {
+    evidence::Evidence input;
+    input.available = true;
+    input.inputs_verified_disjoint = true;
+    input.primary_ffrt_passed = true;
+    input.partition_a_ffrt_passed = true;
+    input.partition_b_ffrt_passed = true;
+    input.partition_a_candidate_ecef =
+        Eigen::Vector3d(-0.4, 0.0, 0.0);
+    input.partition_b_candidate_ecef =
+        Eigen::Vector3d(0.4, 0.0, 0.0);
+    input.primary_candidate_ecef = Eigen::Vector3d::Zero();
+    input.partition_a_covariance_ecef =
+        Eigen::Matrix3d::Identity() * 0.04;
+    input.partition_b_covariance_ecef =
+        Eigen::Matrix3d::Identity() * 0.04;
+    input.primary_covariance_ecef =
+        Eigen::Matrix3d::Identity() * 0.04;
+
+    const auto decision = evidence::evaluate({}, input);
+    EXPECT_FALSE(decision.hard_separation_passed);
+    EXPECT_TRUE(decision.statistical_separation_passed);
+    EXPECT_TRUE(decision.passed);
+
+    input.partition_b_candidate_ecef =
+        Eigen::Vector3d(2.1, 0.0, 0.0);
+    EXPECT_FALSE(evidence::evaluate({}, input).passed);
+}
+
+TEST(DisjointSatelliteFixEvidence, ConsensusRejectsPrimaryOutlier) {
+    const auto result = evidence::closestPairConsensus(
+        Eigen::Vector3d(1.5, 0.0, 0.0),
+        Eigen::Vector3d(0.01, 0.0, 0.0),
+        Eigen::Vector3d(-0.01, 0.0, 0.0));
+    ASSERT_TRUE(result.valid);
+    EXPECT_EQ(
+        result.selected_pair,
+        evidence::SelectedPair::A_B);
+    EXPECT_NEAR(result.position_ecef.x(), 0.0, 1e-12);
+    EXPECT_NEAR(result.selected_pair_separation_m, 0.02, 1e-12);
+}
+
+TEST(DisjointSatelliteFixEvidence, ConsensusRejectsPartitionOutlier) {
+    const auto result = evidence::closestPairConsensus(
+        Eigen::Vector3d(0.0, 0.0, 0.0),
+        Eigen::Vector3d(0.04, 0.0, 0.0),
+        Eigen::Vector3d(1.34, 0.0, 0.0));
+    ASSERT_TRUE(result.valid);
+    EXPECT_EQ(
+        result.selected_pair,
+        evidence::SelectedPair::PRIMARY_A);
+    EXPECT_NEAR(result.position_ecef.x(), 0.02, 1e-12);
+    EXPECT_NEAR(result.selected_pair_separation_m, 0.04, 1e-12);
+}
+
+}  // namespace

--- a/tests/test_fix_failure_budget.cpp
+++ b/tests/test_fix_failure_budget.cpp
@@ -1,0 +1,43 @@
+#include <gtest/gtest.h>
+
+#include <libgnss++/algorithms/fix_failure_budget.hpp>
+
+namespace {
+
+namespace budget = libgnss::fix_failure_budget;
+
+TEST(FixFailureBudget, RejectsTwoAlgorithmsInOneFaultDomain) {
+    const std::array<budget::Evidence, 2> evidence{{
+        {budget::SourceFamily::PRIMARY_CARRIER_AR, true, 1e-3},
+        {budget::SourceFamily::PRIMARY_CARRIER_AR, true, 1e-3},
+    }};
+    const auto decision = budget::evaluate(budget::Config{}, evidence);
+    EXPECT_FALSE(decision.passed);
+    EXPECT_EQ(decision.independent_families, 1);
+    EXPECT_DOUBLE_EQ(decision.joint_failure_probability, 1e-3);
+}
+
+TEST(FixFailureBudget, AcceptsTwoFamiliesAtJointBoundary) {
+    const std::array<budget::Evidence, 2> evidence{{
+        {budget::SourceFamily::PRIMARY_CARRIER_AR, true, 1e-3},
+        {budget::SourceFamily::MULTIFREQUENCY_CASCADE, true, 2e-3},
+    }};
+    const auto decision = budget::evaluate(budget::Config{}, evidence);
+    EXPECT_TRUE(decision.passed);
+    EXPECT_EQ(decision.independent_families, 2);
+    EXPECT_NEAR(decision.joint_failure_probability, 2e-6, 1e-18);
+}
+
+TEST(FixFailureBudget, RejectsMissingInvalidOrOverBudgetEvidence) {
+    const std::array<budget::Evidence, 3> evidence{{
+        {budget::SourceFamily::PRIMARY_CARRIER_AR, true, 3e-3},
+        {budget::SourceFamily::MULTIFREQUENCY_CASCADE, true, 1e-3},
+        {budget::SourceFamily::INERTIAL_SOLUTION_SEPARATION, false, 1e-4},
+    }};
+    const auto decision = budget::evaluate(budget::Config{}, evidence);
+    EXPECT_FALSE(decision.passed);
+    EXPECT_EQ(decision.independent_families, 2);
+    EXPECT_NEAR(decision.joint_failure_probability, 3e-6, 1e-18);
+}
+
+}  // namespace

--- a/tests/test_fixed_quality_gate.cpp
+++ b/tests/test_fixed_quality_gate.cpp
@@ -1,0 +1,81 @@
+#include <gtest/gtest.h>
+
+#include <libgnss++/algorithms/fixed_quality_gate.hpp>
+
+namespace {
+
+using libgnss::fixed_quality_gate::Config;
+using libgnss::fixed_quality_gate::Evidence;
+using libgnss::fixed_quality_gate::evaluate;
+
+TEST(FixedQualityGate, FailsClosedWithoutEvidence) {
+    const auto decision = evaluate(Config{}, Evidence{});
+    EXPECT_FALSE(decision.passed);
+    EXPECT_FALSE(decision.safe_shadow_branch);
+    EXPECT_FALSE(decision.covariance_branch);
+    EXPECT_FALSE(decision.strong_innovation_branch);
+}
+
+TEST(FixedQualityGate, AcceptsSafeShadowBranch) {
+    Evidence evidence;
+    evidence.safe_fix_shadow_declared_fixed = true;
+    const auto decision = evaluate(Config{}, evidence);
+    EXPECT_TRUE(decision.passed);
+    EXPECT_TRUE(decision.safe_shadow_branch);
+}
+
+TEST(FixedQualityGate, AcceptsCovarianceBranchAtBoundary) {
+    Evidence evidence;
+    evidence.float_position_covariance_trace_m2 = 0.00025;
+    evidence.update_nis_per_observation = 10.0;
+    const auto decision = evaluate(Config{}, evidence);
+    EXPECT_TRUE(decision.passed);
+    EXPECT_TRUE(decision.covariance_branch);
+}
+
+TEST(FixedQualityGate, AcceptsStrongInnovationBranchAtBoundary) {
+    Evidence evidence;
+    evidence.update_observations = 28;
+    evidence.update_nis_per_observation = 1.0;
+    const auto decision = evaluate(Config{}, evidence);
+    EXPECT_TRUE(decision.passed);
+    EXPECT_TRUE(decision.strong_innovation_branch);
+}
+
+TEST(FixedQualityGate, RejectsWeakEvidenceOutsideBoundaries) {
+    Evidence evidence;
+    evidence.float_position_covariance_trace_m2 = 0.000251;
+    evidence.update_observations = 27;
+    evidence.update_nis_per_observation = 1.001;
+    EXPECT_FALSE(evaluate(Config{}, evidence).passed);
+}
+
+TEST(FixedQualityGate, StrongInnovationRejectsMajorityOutlierSuppression) {
+    Evidence evidence;
+    evidence.update_observations = 60;
+    evidence.suppressed_outliers = 31;
+    evidence.update_nis_per_observation = 0.1;
+    EXPECT_FALSE(evaluate(Config{}, evidence).strong_innovation_branch);
+
+    evidence.suppressed_outliers = 30;
+    EXPECT_TRUE(evaluate(Config{}, evidence).strong_innovation_branch);
+}
+
+TEST(FixedQualityGate, IndependentBudgetIsFailClosedWhenRequired) {
+    Config config;
+    config.require_independent_failure_budget = true;
+    Evidence evidence;
+    evidence.safe_fix_shadow_declared_fixed = true;
+
+    const auto rejected = evaluate(config, evidence);
+    EXPECT_TRUE(rejected.safe_shadow_branch);
+    EXPECT_FALSE(rejected.independent_failure_budget_passed);
+    EXPECT_FALSE(rejected.passed);
+
+    evidence.independent_failure_budget_passed = true;
+    const auto accepted = evaluate(config, evidence);
+    EXPECT_TRUE(accepted.independent_failure_budget_passed);
+    EXPECT_TRUE(accepted.passed);
+}
+
+}  // namespace

--- a/tests/test_inertial_fix_evidence.cpp
+++ b/tests/test_inertial_fix_evidence.cpp
@@ -1,0 +1,51 @@
+#include <gtest/gtest.h>
+
+#include <libgnss++/algorithms/inertial_fix_evidence.hpp>
+
+namespace {
+
+using libgnss::inertial_fix_evidence::Config;
+using libgnss::inertial_fix_evidence::Evidence;
+using libgnss::inertial_fix_evidence::evaluate;
+
+Evidence nominalEvidence() {
+    Evidence evidence;
+    evidence.available = true;
+    evidence.healthy_independent_anchor = true;
+    evidence.time_error_s = 0.05;
+    evidence.predicted_position_covariance_ecef =
+        Eigen::Matrix3d::Identity() * 0.01;
+    evidence.primary_candidate_ecef =
+        Eigen::Vector3d(0.8, 0.0, 0.0);
+    return evidence;
+}
+
+TEST(InertialFixEvidence, FailsClosedWithoutIndependentAnchor) {
+    auto evidence = nominalEvidence();
+    evidence.healthy_independent_anchor = false;
+    EXPECT_FALSE(evaluate(Config{}, evidence).passed);
+}
+
+TEST(InertialFixEvidence, AcceptsAtCausalAndStatisticalBoundaries) {
+    const auto decision = evaluate(Config{}, nominalEvidence());
+    EXPECT_TRUE(decision.passed);
+    EXPECT_NEAR(decision.position_delta_m, 0.8, 1e-12);
+    EXPECT_LT(decision.nis_per_dimension, 5.422);
+}
+
+TEST(InertialFixEvidence, RejectsStaleGrossOrSingularEvidence) {
+    auto stale = nominalEvidence();
+    stale.time_error_s = 0.051;
+    EXPECT_FALSE(evaluate(Config{}, stale).passed);
+
+    auto gross = nominalEvidence();
+    gross.primary_candidate_ecef = Eigen::Vector3d(2.01, 0.0, 0.0);
+    EXPECT_FALSE(evaluate(Config{}, gross).passed);
+
+    auto invalid = nominalEvidence();
+    invalid.predicted_position_covariance_ecef(0, 0) =
+        std::numeric_limits<double>::quiet_NaN();
+    EXPECT_FALSE(evaluate(Config{}, invalid).passed);
+}
+
+}  // namespace

--- a/tests/test_rtk.cpp
+++ b/tests/test_rtk.cpp
@@ -518,6 +518,149 @@ TEST(LAMBDATest, ExposesBothRatioCandidates) {
     EXPECT_GT(ratio, 1.0);
 }
 
+TEST(LAMBDATest, TopKDiagnosticsPreserveBestTwoAndExposeSuccessRate) {
+    VectorXd float_amb(3);
+    float_amb << 12.04, -3.97, 6.93;
+    MatrixXd cov(3, 3);
+    cov << 0.018, 0.010, -0.004,
+           0.010, 0.025,  0.006,
+          -0.004, 0.006,  0.020;
+
+    VectorXd best;
+    VectorXd second;
+    double ratio = 0.0;
+    ASSERT_TRUE(lambdaSearchCandidates(float_amb, cov, best, second, ratio));
+
+    LambdaCandidateDiagnostics diagnostics;
+    ASSERT_TRUE(lambdaSearchTopK(float_amb, cov, 8, diagnostics));
+    ASSERT_EQ(diagnostics.candidates.rows(), 3);
+    ASSERT_EQ(diagnostics.candidates.cols(), 8);
+    ASSERT_EQ(diagnostics.squared_residuals.size(), 8);
+    ASSERT_EQ(diagnostics.conditional_variances.size(), 3);
+    ASSERT_EQ(diagnostics.decorrelation_transform.rows(), 3);
+    ASSERT_EQ(diagnostics.decorrelation_transform.cols(), 3);
+    EXPECT_TRUE(diagnostics.decorrelated_float.isApprox(
+        diagnostics.decorrelation_transform.transpose() * float_amb));
+    EXPECT_TRUE(diagnostics.decorrelated_covariance.isApprox(
+        diagnostics.decorrelation_transform.transpose() * cov *
+        diagnostics.decorrelation_transform));
+    EXPECT_TRUE(diagnostics.squared_residuals.array().isFinite().all());
+    EXPECT_TRUE(
+        (diagnostics.squared_residuals.tail(7).array() >=
+         diagnostics.squared_residuals.head(7).array()).all());
+    EXPECT_TRUE(diagnostics.candidates.col(0).isApprox(best));
+    EXPECT_TRUE(diagnostics.candidates.col(1).isApprox(second));
+    EXPECT_DOUBLE_EQ(
+        diagnostics.squared_residuals(1) /
+            diagnostics.squared_residuals(0),
+        ratio);
+    EXPECT_GT(diagnostics.bootstrapped_success_rate, 0.0);
+    EXPECT_LE(diagnostics.bootstrapped_success_rate, 1.0);
+}
+
+TEST(LAMBDATest, TopKDiagnosticsFailClosedOnInvalidRequest) {
+    VectorXd float_amb = VectorXd::Zero(2);
+    MatrixXd covariance = MatrixXd::Identity(2, 2);
+    LambdaCandidateDiagnostics diagnostics;
+
+    EXPECT_FALSE(lambdaSearchTopK(float_amb, covariance, 0, diagnostics));
+    EXPECT_FALSE(lambdaSearchTopK(
+        float_amb, MatrixXd::Identity(3, 3), 2, diagnostics));
+}
+
+TEST(LAMBDATest, FixedFailureRateThresholdConvertsPublishedMu) {
+    FixedFailureRateRatioThreshold threshold;
+    ASSERT_TRUE(fixedFailureRateRatioThreshold(8, 0.95, 0.001, threshold));
+
+    const double expected_mu =
+        0.1751 * std::pow(0.05, -0.2605) - 0.0404;
+    EXPECT_NEAR(threshold.ils_failure_rate_proxy, 0.05, 1e-12);
+    EXPECT_NEAR(threshold.mu, expected_mu, 1e-12);
+    EXPECT_NEAR(
+        threshold.minimum_second_to_best_ratio, 1.0 / expected_mu, 1e-12);
+    EXPECT_TRUE(threshold.accepts_any_candidate);
+}
+
+TEST(LAMBDATest, FixedFailureRateThresholdUsesSafePiecewiseLimits) {
+    FixedFailureRateRatioThreshold threshold;
+
+    ASSERT_TRUE(fixedFailureRateRatioThreshold(8, 0.9995, 0.001, threshold));
+    EXPECT_DOUBLE_EQ(threshold.mu, 1.0);
+    EXPECT_DOUBLE_EQ(threshold.minimum_second_to_best_ratio, 1.0);
+    EXPECT_TRUE(threshold.accepts_any_candidate);
+
+    ASSERT_TRUE(fixedFailureRateRatioThreshold(8, 0.8, 0.001, threshold));
+    EXPECT_DOUBLE_EQ(threshold.mu, 0.0);
+    EXPECT_TRUE(std::isinf(threshold.minimum_second_to_best_ratio));
+    EXPECT_FALSE(threshold.accepts_any_candidate);
+}
+
+TEST(LAMBDATest, FixedFailureRateThresholdFailsClosedOutsideTable) {
+    FixedFailureRateRatioThreshold threshold;
+    EXPECT_FALSE(fixedFailureRateRatioThreshold(0, 0.99, 0.001, threshold));
+    EXPECT_FALSE(fixedFailureRateRatioThreshold(67, 0.99, 0.001, threshold));
+    EXPECT_FALSE(fixedFailureRateRatioThreshold(8, 0.99, 0.002, threshold));
+    EXPECT_FALSE(fixedFailureRateRatioThreshold(8, -0.1, 0.001, threshold));
+}
+
+TEST(LAMBDATest, CovarianceInflationLowersBootstrappedSuccessRate) {
+    VectorXd conditional_variances(3);
+    conditional_variances << 0.01, 0.02, 0.03;
+    const double nominal = bootstrappedSuccessRate(conditional_variances);
+    const double scale2 = bootstrappedSuccessRate(conditional_variances, 2.0);
+    const double scale4 = bootstrappedSuccessRate(conditional_variances, 4.0);
+
+    EXPECT_GT(nominal, scale2);
+    EXPECT_GT(scale2, scale4);
+    EXPECT_TRUE(std::isnan(
+        bootstrappedSuccessRate(conditional_variances, 0.0)));
+    conditional_variances(0) = -1.0;
+    EXPECT_TRUE(std::isnan(
+        bootstrappedSuccessRate(conditional_variances, 1.0)));
+}
+
+TEST(LAMBDATest, SuccessRateCriterionSelectsTrailingPrecisionSubset) {
+    VectorXd conditional_variances(4);
+    conditional_variances << 0.5, 0.1, 0.01, 0.005;
+
+    const int selected = successRateCriterionSubsetSize(
+        conditional_variances, 1.0, 0.99);
+    EXPECT_GE(selected, 1);
+    EXPECT_LT(selected, conditional_variances.size());
+    EXPECT_EQ(successRateCriterionSubsetSize(
+                  conditional_variances, 0.0, 0.99),
+              0);
+    EXPECT_EQ(successRateCriterionSubsetSize(
+                  conditional_variances, 1.0, 0.0),
+              0);
+}
+
+TEST(LAMBDATest, CandidateShadowIsDefaultOffAndConfigurable) {
+    RTKProcessor processor;
+    EXPECT_EQ(processor.getRTKConfig().lambda_candidate_shadow_count, 0);
+
+    auto config = processor.getRTKConfig();
+    config.lambda_candidate_shadow_count = 8;
+    processor.setRTKConfig(config);
+    EXPECT_EQ(processor.getRTKConfig().lambda_candidate_shadow_count, 8);
+    EXPECT_FALSE(processor.getLastDebugTelemetry().lambda_shadow_attempted);
+}
+
+TEST(LAMBDATest, SafeFixStateMachineIsDefaultOffAndShadowOnly) {
+    RTKProcessor processor;
+    EXPECT_FALSE(
+        processor.getRTKConfig().safe_fix_shadow_state_machine.enabled);
+    EXPECT_FALSE(
+        processor.getLastDebugTelemetry().safe_fix_shadow_enabled);
+
+    auto config = processor.getRTKConfig();
+    config.safe_fix_shadow_state_machine.enabled = true;
+    config.lambda_candidate_shadow_count = 2;
+    processor.setRTKConfig(config);
+    EXPECT_TRUE(
+        processor.getRTKConfig().safe_fix_shadow_state_machine.enabled);
+}
+
 // ============================================================================
 // Test 9: DD formation produces correct number of differences
 // ============================================================================
@@ -1194,6 +1337,10 @@ TEST(RTKArSkipReasonTest, DefaultTelemetryHasNoneSkipReason) {
     EXPECT_FALSE(telemetry.adaptive_dynamic_slip_active);
     EXPECT_EQ(telemetry.consecutive_nonfix_before_bias_update, 0);
     EXPECT_EQ(telemetry.adaptive_dynamic_slip_hold_remaining, 0);
+    EXPECT_FALSE(
+        telemetry.lambda_shadow_candidate_costs.array().isFinite().any());
+    EXPECT_FALSE(
+        telemetry.lambda_shadow_candidate_ecef_m.array().isFinite().any());
 }
 
 TEST(RTKArSkipReasonTest, StringifyCoversAllValues) {

--- a/tests/test_rtk_ar_selection.cpp
+++ b/tests/test_rtk_ar_selection.cpp
@@ -1,5 +1,7 @@
 #include <gtest/gtest.h>
 
+#include <algorithm>
+
 #include <libgnss++/algorithms/rtk_ar_selection.hpp>
 
 using namespace libgnss;
@@ -163,4 +165,171 @@ TEST(RTKArSelectionTest, BSRGuidedDecimationRejectsNonPsdCovariance) {
     const auto subsets = rtk_ar_selection::buildBSRGuidedDropSubsets(
         pairs, Qb, 3, 2, 1);
     EXPECT_TRUE(subsets.empty());
+}
+
+TEST(RTKArSelectionTest, WideLaneConditioningReducesNarrowLaneVariance) {
+    Eigen::VectorXd head(3);
+    head << 10.0, 20.0, 30.0;
+    Eigen::MatrixXd Qab = Eigen::MatrixXd::Zero(3, 2);
+    Qab(0, 0) = 0.2;
+    Qab(1, 1) = 0.1;
+    Eigen::VectorXd n1(2);
+    n1 << 4.4, -2.3;
+    Eigen::MatrixXd Qn1 = Eigen::MatrixXd::Identity(2, 2);
+    Eigen::VectorXd wl(2);
+    wl << 1.4, -1.3;
+    Eigen::MatrixXd Qwl = 2.0 * Eigen::MatrixXd::Identity(2, 2);
+    Eigen::VectorXd fixed(2);
+    fixed << 1.0, -1.0;
+    Eigen::VectorXd conditioned_head;
+    Eigen::MatrixXd conditioned_Qab;
+    Eigen::VectorXd conditioned_n1;
+    Eigen::MatrixXd conditioned_Qn1;
+
+    ASSERT_TRUE(
+        rtk_ar_selection::conditionNarrowLaneOnFixedWideLane(
+            head, Qab, n1, Qn1, wl, Qwl, fixed, conditioned_head,
+            conditioned_Qab, conditioned_n1, conditioned_Qn1));
+
+    EXPECT_TRUE(conditioned_n1.isApprox(
+        (Eigen::VectorXd(2) << 4.2, -2.15).finished(), 1e-12));
+    EXPECT_TRUE(conditioned_Qn1.isApprox(
+        0.5 * Eigen::MatrixXd::Identity(2, 2), 1e-12));
+    EXPECT_LT(conditioned_head(0), head(0));
+    EXPECT_GT(conditioned_head(1), head(1));
+}
+
+TEST(RTKArSelectionTest, WideLaneConditioningRejectsSingularCovariance) {
+    Eigen::VectorXd head = Eigen::VectorXd::Zero(3);
+    Eigen::MatrixXd Qab = Eigen::MatrixXd::Zero(3, 1);
+    Eigen::VectorXd n1 = Eigen::VectorXd::Zero(1);
+    Eigen::MatrixXd Qn1 = Eigen::MatrixXd::Identity(1, 1);
+    Eigen::VectorXd wl = Eigen::VectorXd::Zero(1);
+    Eigen::MatrixXd Qwl = Eigen::MatrixXd::Zero(1, 1);
+    Eigen::VectorXd fixed = Eigen::VectorXd::Zero(1);
+    Eigen::VectorXd conditioned_head;
+    Eigen::MatrixXd conditioned_Qab;
+    Eigen::VectorXd conditioned_n1;
+    Eigen::MatrixXd conditioned_Qn1;
+
+    EXPECT_FALSE(
+        rtk_ar_selection::conditionNarrowLaneOnFixedWideLane(
+            head, Qab, n1, Qn1, wl, Qwl, fixed, conditioned_head,
+            conditioned_Qab, conditioned_n1, conditioned_Qn1));
+}
+
+TEST(RTKArSelectionTest, SatelliteQualityDropRemovesAllFrequenciesTogether) {
+    const SatelliteId g01(GNSSSystem::GPS, 1);
+    const SatelliteId g02(GNSSSystem::GPS, 2);
+    const SatelliteId e03(GNSSSystem::Galileo, 3);
+    const std::vector<rtk_ar_selection::PairDescriptor> pairs = {
+        {GNSSSystem::GPS, 0.01, g01, 0.8, 45.0, 0.02},
+        {GNSSSystem::GPS, 0.02, g01, 0.8, 44.0, 0.03},
+        {GNSSSystem::GPS, 0.80, g02, 0.2, 24.0, 0.48},
+        {GNSSSystem::GPS, 0.70, g02, 0.2, 23.0, 0.45},
+        {GNSSSystem::Galileo, 0.04, e03, 0.6, 40.0, 0.08},
+        {GNSSSystem::Galileo, 0.05, e03, 0.6, 39.0, 0.09},
+    };
+    const auto subsets =
+        rtk_ar_selection::buildSatelliteQualityDropSubsets(
+            pairs, /*minimum_pairs=*/2, /*max_drop_steps=*/2);
+    ASSERT_EQ(subsets.size(), 2U);
+    EXPECT_EQ(subsets[0], (std::vector<int>{0, 1, 4, 5}));
+    EXPECT_EQ(subsets[1], (std::vector<int>{0, 1}));
+}
+
+TEST(RTKArSelectionTest, SatelliteQualityDropFailsClosedAtPairFloor) {
+    const SatelliteId g01(GNSSSystem::GPS, 1);
+    const SatelliteId g02(GNSSSystem::GPS, 2);
+    const std::vector<rtk_ar_selection::PairDescriptor> pairs = {
+        {GNSSSystem::GPS, 0.01, g01},
+        {GNSSSystem::GPS, 0.02, g01},
+        {GNSSSystem::GPS, 0.80, g02},
+        {GNSSSystem::GPS, 0.70, g02},
+    };
+    EXPECT_TRUE(
+        rtk_ar_selection::buildSatelliteQualityDropSubsets(
+            pairs, /*minimum_pairs=*/3, /*max_drop_steps=*/2)
+            .empty());
+}
+
+TEST(RTKArSelectionTest, SatelliteQualityDropUsesPosteriorResidualInMeters) {
+    const SatelliteId g01(GNSSSystem::GPS, 1);
+    const SatelliteId g02(GNSSSystem::GPS, 2);
+    const SatelliteId g03(GNSSSystem::GPS, 3);
+    std::vector<rtk_ar_selection::PairDescriptor> pairs(3);
+    pairs[0].system = GNSSSystem::GPS;
+    pairs[0].satellite = g01;
+    pairs[0].variance = 0.1;
+    pairs[0].posterior_abs_residual_m = 0.01;
+    pairs[1].system = GNSSSystem::GPS;
+    pairs[1].satellite = g02;
+    pairs[1].variance = 0.1;
+    pairs[1].posterior_abs_residual_m = 0.09;
+    pairs[2].system = GNSSSystem::GPS;
+    pairs[2].satellite = g03;
+    pairs[2].variance = 0.1;
+    pairs[2].posterior_abs_residual_m = 0.02;
+
+    const auto subsets =
+        rtk_ar_selection::buildSatelliteQualityDropSubsets(
+            pairs, /*minimum_pairs=*/2, /*max_drop_steps=*/1);
+    ASSERT_EQ(subsets.size(), 1U);
+    EXPECT_EQ(subsets[0], (std::vector<int>{0, 2}));
+}
+
+TEST(RTKArSelectionTest, SatelliteQualityDropPenalizesAzimuthCrowding) {
+    std::vector<rtk_ar_selection::PairDescriptor> pairs(4);
+    const std::vector<double> azimuths = {0.0, 0.05, 2.0, 4.0};
+    for (int index = 0; index < 4; ++index) {
+        pairs[index].system = GNSSSystem::GPS;
+        pairs[index].satellite =
+            SatelliteId(GNSSSystem::GPS, index + 1);
+        pairs[index].variance = 0.1;
+        pairs[index].azimuth_rad = azimuths[index];
+    }
+
+    const auto subsets =
+        rtk_ar_selection::buildSatelliteQualityDropSubsets(
+            pairs, /*minimum_pairs=*/3, /*max_drop_steps=*/1);
+    ASSERT_EQ(subsets.size(), 1U);
+    // G01 and G02 are equally crowded; the stable satellite-id tie-break
+    // makes G01 the deterministic first drop.
+    EXPECT_EQ(subsets[0], (std::vector<int>{1, 2, 3}));
+}
+
+TEST(RTKArSelectionTest, SatelliteQualityDiverseDropKeepsDistinctMetricPaths) {
+    std::vector<rtk_ar_selection::PairDescriptor> pairs(4);
+    for (int index = 0; index < 4; ++index) {
+        pairs[index].system = GNSSSystem::GPS;
+        pairs[index].satellite =
+            SatelliteId(GNSSSystem::GPS, index + 1);
+        pairs[index].variance = 0.1;
+        pairs[index].posterior_abs_residual_m = 0.01;
+        pairs[index].snr_dbhz = 45.0;
+    }
+    pairs[1].variance = 10.0;
+    pairs[2].posterior_abs_residual_m = 0.5;
+    pairs[3].snr_dbhz = 15.0;
+
+    const auto subsets =
+        rtk_ar_selection::buildSatelliteQualityDiverseDropSubsets(
+            pairs, /*minimum_pairs=*/2, /*max_drop_steps=*/1,
+            /*maximum_subsets=*/16);
+
+    EXPECT_NE(
+        std::find(
+            subsets.begin(), subsets.end(),
+            std::vector<int>({0, 2, 3})),
+        subsets.end());
+    EXPECT_NE(
+        std::find(
+            subsets.begin(), subsets.end(),
+            std::vector<int>({0, 1, 3})),
+        subsets.end());
+    EXPECT_NE(
+        std::find(
+            subsets.begin(), subsets.end(),
+            std::vector<int>({0, 1, 2})),
+        subsets.end());
 }

--- a/tests/test_rtk_update.cpp
+++ b/tests/test_rtk_update.cpp
@@ -256,5 +256,155 @@ TEST(RTKUpdateTest, SequentialIndependentBlocksMatchJointUpdate) {
     EXPECT_TRUE(sequential_covariance.isApprox(joint_covariance, 1e-12));
 }
 
+TEST(RTKUpdateTest, StudentTInflationPreservesMeasurementCorrelation) {
+    Eigen::VectorXd residuals(2);
+    residuals << 1.0, 0.1;
+    Eigen::MatrixXd covariance(2, 2);
+    covariance << 0.04, 0.01,
+                  0.01, 0.04;
+    const double correlation_before =
+        covariance(0, 1) /
+        std::sqrt(covariance(0, 0) * covariance(1, 1));
+    rtk_update::StudentTFrontEndConfig config;
+    config.enabled = true;
+    const auto result =
+        rtk_update::applyStudentTMeasurementWeights(
+            residuals, covariance, config);
+    const double correlation_after =
+        covariance(0, 1) /
+        std::sqrt(covariance(0, 0) * covariance(1, 1));
+
+    EXPECT_TRUE(result.applied);
+    EXPECT_EQ(result.downweighted_rows, 1);
+    EXPECT_NEAR(result.minimum_weight, 5.0 / 29.0, 1e-12);
+    EXPECT_NEAR(correlation_after, correlation_before, 1e-12);
+    EXPECT_GT(covariance(0, 0), 0.04);
+    EXPECT_NEAR(covariance(1, 1), 0.04, 1e-12);
+}
+
+TEST(RTKUpdateTest, StudentTDefaultOffIsExactNoOp) {
+    Eigen::VectorXd residuals(1);
+    residuals << 100.0;
+    Eigen::MatrixXd covariance(1, 1);
+    covariance << 2.0;
+    const Eigen::MatrixXd before = covariance;
+
+    const auto result =
+        rtk_update::applyStudentTMeasurementWeights(
+            residuals, covariance, {});
+
+    EXPECT_FALSE(result.applied);
+    EXPECT_TRUE(covariance.isApprox(before, 0.0));
+}
+
+TEST(RTKUpdateTest, StudentTUsesInnovationNotOnlyMeasurementVariance) {
+    Eigen::VectorXd residuals(1);
+    residuals << 1.0;
+    Eigen::VectorXd innovation_variances(1);
+    innovation_variances << 4.0;
+    Eigen::MatrixXd covariance(1, 1);
+    covariance << 0.04;
+    rtk_update::StudentTFrontEndConfig config;
+    config.enabled = true;
+
+    const auto result =
+        rtk_update::applyStudentTMeasurementWeights(
+            residuals, innovation_variances, covariance, config);
+
+    EXPECT_TRUE(result.applied);
+    EXPECT_EQ(result.downweighted_rows, 0);
+    EXPECT_DOUBLE_EQ(result.minimum_weight, 1.0);
+    EXPECT_DOUBLE_EQ(covariance(0, 0), 0.04);
+}
+
+TEST(RTKUpdateTest, StudentTLeavesCentralInnovationExactlyUntouched) {
+    Eigen::VectorXd residuals(2);
+    residuals << 2.49, -2.5;
+    Eigen::VectorXd innovation_variances =
+        Eigen::VectorXd::Ones(2);
+    Eigen::MatrixXd covariance(2, 2);
+    covariance << 1.0, 0.25,
+                  0.25, 1.0;
+    const Eigen::MatrixXd before = covariance;
+    rtk_update::StudentTFrontEndConfig config;
+    config.enabled = true;
+
+    const auto result =
+        rtk_update::applyStudentTMeasurementWeights(
+            residuals, innovation_variances, covariance, config);
+
+    EXPECT_TRUE(result.applied);
+    EXPECT_EQ(result.downweighted_rows, 1);
+    EXPECT_DOUBLE_EQ(covariance(0, 0), before(0, 0));
+    EXPECT_GT(covariance(1, 1), before(1, 1));
+}
+
+TEST(RTKUpdateTest, StudentTDegreesOneUsesCauchyTailWeight) {
+    Eigen::VectorXd residuals(1);
+    residuals << 4.0;
+    Eigen::VectorXd innovation_variances =
+        Eigen::VectorXd::Ones(1);
+    Eigen::MatrixXd covariance =
+        Eigen::MatrixXd::Identity(1, 1);
+    rtk_update::StudentTFrontEndConfig config;
+    config.enabled = true;
+    config.degrees_of_freedom = 1.0;
+
+    const auto result =
+        rtk_update::applyStudentTMeasurementWeights(
+            residuals, innovation_variances, covariance, config);
+
+    EXPECT_TRUE(result.applied);
+    EXPECT_EQ(result.downweighted_rows, 1);
+    EXPECT_NEAR(result.minimum_weight, 2.0 / 17.0, 1e-12);
+    EXPECT_NEAR(covariance(0, 0), 8.5, 1e-12);
+}
+
+TEST(RTKUpdateTest, LaplacianModelUsesL1IrlsWeight) {
+    Eigen::VectorXd residuals(1);
+    residuals << 4.0;
+    Eigen::VectorXd innovation_variances =
+        Eigen::VectorXd::Ones(1);
+    Eigen::MatrixXd covariance =
+        Eigen::MatrixXd::Identity(1, 1);
+    rtk_update::StudentTFrontEndConfig config;
+    config.enabled = true;
+    config.weight_model =
+        rtk_update::HeavyTailWeightModel::LAPLACIAN;
+
+    const auto result =
+        rtk_update::applyStudentTMeasurementWeights(
+            residuals, innovation_variances, covariance, config);
+
+    EXPECT_TRUE(result.applied);
+    EXPECT_EQ(result.downweighted_rows, 1);
+    EXPECT_NEAR(result.minimum_weight, 0.25, 1e-12);
+    EXPECT_NEAR(covariance(0, 0), 4.0, 1e-12);
+}
+
+TEST(RTKUpdateTest, HuberModelIsContinuousAtActivationThreshold) {
+    Eigen::VectorXd residuals(2);
+    residuals << 2.5, 5.0;
+    Eigen::VectorXd innovation_variances =
+        Eigen::VectorXd::Ones(2);
+    Eigen::MatrixXd covariance =
+        Eigen::MatrixXd::Identity(2, 2);
+    rtk_update::StudentTFrontEndConfig config;
+    config.enabled = true;
+    config.weight_model =
+        rtk_update::HeavyTailWeightModel::HUBER;
+    config.activation_threshold_sigma = 2.5;
+
+    const auto result =
+        rtk_update::applyStudentTMeasurementWeights(
+            residuals, innovation_variances, covariance, config);
+
+    EXPECT_TRUE(result.applied);
+    EXPECT_EQ(result.downweighted_rows, 1);
+    EXPECT_NEAR(result.minimum_weight, 0.5, 1e-12);
+    EXPECT_NEAR(covariance(0, 0), 1.0, 1e-12);
+    EXPECT_NEAR(covariance(1, 1), 2.0, 1e-12);
+}
+
 }  // namespace
 }  // namespace libgnss

--- a/tests/test_safe_fix_state_machine.cpp
+++ b/tests/test_safe_fix_state_machine.cpp
@@ -1,0 +1,359 @@
+#include <gtest/gtest.h>
+
+#include <limits>
+
+#include <libgnss++/algorithms/safe_float_continuity.hpp>
+#include <libgnss++/algorithms/safe_fix_state_machine.hpp>
+
+namespace {
+
+using libgnss::safe_fix::Candidate;
+using libgnss::safe_fix::Config;
+using libgnss::safe_fix::State;
+using libgnss::safe_fix::StateMachine;
+
+Candidate candidate(double time_s, double x_m = 0.0) {
+    Candidate value;
+    value.time_s = time_s;
+    value.acquisition_eligible = true;
+    value.correction_m = Eigen::Vector3d(x_m, 0.0, 0.0);
+    value.nis_per_observation = 1.0;
+    value.prefit_residual_rms_m = 0.5;
+    value.pair_count = 16;
+    return value;
+}
+
+TEST(SafeFixStateMachineTest, DisabledIsAStatelessNoOp) {
+    StateMachine machine;
+    Config config;
+    const auto decision = machine.update(config, candidate(1.0));
+    EXPECT_EQ(decision.state, State::DISABLED);
+    EXPECT_FALSE(decision.declared_fixed);
+}
+
+TEST(SafeFixStateMachineTest, RequiresContiguousConsistentAcquisition) {
+    StateMachine machine;
+    Config config;
+    config.enabled = true;
+    config.acquisition_streak_epochs = 2;
+    EXPECT_EQ(machine.update(config, candidate(1.0)).state, State::ACQUIRING);
+    const auto fixed = machine.update(config, candidate(1.2, 0.01));
+    EXPECT_EQ(fixed.state, State::FIXED);
+    EXPECT_TRUE(fixed.declared_fixed);
+    EXPECT_TRUE(fixed.candidate_accepted);
+}
+
+TEST(SafeFixStateMachineTest, GapOrCorrectionJumpRestartsAcquisition) {
+    StateMachine machine;
+    Config config;
+    config.enabled = true;
+    config.acquisition_streak_epochs = 2;
+    machine.update(config, candidate(1.0));
+    EXPECT_EQ(machine.update(config, candidate(1.4)).acquisition_streak, 1);
+    EXPECT_EQ(machine.update(config, candidate(1.6, 0.10)).acquisition_streak, 1);
+}
+
+TEST(SafeFixStateMachineTest, IndependentFailureBudgetFailsClosed) {
+    StateMachine machine;
+    Config config;
+    config.enabled = true;
+    config.acquisition_streak_epochs = 1;
+    config.allow_strong_instant_acquisition = true;
+    config.require_independent_failure_budget = true;
+    auto sample = candidate(1.0);
+    sample.strong_acquisition_eligible = true;
+
+    const auto rejected = machine.update(config, sample);
+    EXPECT_FALSE(rejected.declared_fixed);
+    EXPECT_FALSE(rejected.independent_failure_budget_passed);
+
+    sample.time_s = 1.2;
+    sample.independent_failure_budget_passed = true;
+    const auto accepted = machine.update(config, sample);
+    EXPECT_TRUE(accepted.declared_fixed);
+    EXPECT_TRUE(accepted.independent_failure_budget_passed);
+}
+
+TEST(SafeFixStateMachineTest, HoldsOnlyWithFiniteBoundedQualityThenRevokes) {
+    StateMachine machine;
+    Config config;
+    config.enabled = true;
+    config.acquisition_streak_epochs = 2;
+    machine.update(config, candidate(1.0));
+    machine.update(config, candidate(1.2));
+
+    auto hold = candidate(1.4, 0.02);
+    hold.acquisition_eligible = false;
+    const auto held = machine.update(config, hold);
+    EXPECT_EQ(held.state, State::HELD);
+    EXPECT_TRUE(held.declared_fixed);
+    EXPECT_TRUE(held.held);
+
+    hold.time_s = 1.6;
+    hold.nis_per_observation = 100.0;
+    const auto revoked = machine.update(config, hold);
+    EXPECT_EQ(revoked.state, State::REVOKED);
+    EXPECT_TRUE(revoked.revoked);
+    EXPECT_FALSE(revoked.declared_fixed);
+}
+
+TEST(SafeFixStateMachineTest, NeverHoldsWithoutCandidateCorrection) {
+    StateMachine machine;
+    Config config;
+    config.enabled = true;
+    config.acquisition_streak_epochs = 2;
+    machine.update(config, candidate(1.0));
+    machine.update(config, candidate(1.2));
+    Candidate missing;
+    missing.time_s = 1.4;
+    missing.pair_count = 16;
+    missing.nis_per_observation = 1.0;
+    EXPECT_TRUE(machine.update(config, missing).revoked);
+}
+
+TEST(SafeFixStateMachineTest, NeverHoldsAcrossAnEpochGap) {
+    StateMachine machine;
+    Config config;
+    config.enabled = true;
+    config.acquisition_streak_epochs = 2;
+    machine.update(config, candidate(1.0));
+    machine.update(config, candidate(1.2));
+    auto late = candidate(2.0);
+    late.acquisition_eligible = false;
+    EXPECT_TRUE(machine.update(config, late).revoked);
+}
+
+TEST(SafeFixStateMachineTest, InsufficientPairGeometryRevokesDespiteLowNis) {
+    StateMachine machine;
+    Config config;
+    config.enabled = true;
+    config.acquisition_streak_epochs = 2;
+    machine.update(config, candidate(1.0));
+    machine.update(config, candidate(1.2));
+    auto nlos = candidate(1.4);
+    nlos.acquisition_eligible = false;
+    nlos.nis_per_observation = 0.2;
+    nlos.prefit_residual_rms_m = 22.0;
+    nlos.pair_count = 6;
+    EXPECT_TRUE(machine.update(config, nlos).revoked);
+}
+
+TEST(SafeFixStateMachineTest, ExtremePrefitResidualFailsClosed) {
+    StateMachine machine;
+    Config config;
+    config.enabled = true;
+    config.acquisition_streak_epochs = 2;
+    machine.update(config, candidate(1.0));
+    machine.update(config, candidate(1.2));
+    auto corrupt = candidate(1.4);
+    corrupt.acquisition_eligible = false;
+    corrupt.nis_per_observation = 0.2;
+    corrupt.prefit_residual_rms_m = 51.0;
+    EXPECT_TRUE(machine.update(config, corrupt).revoked);
+}
+
+TEST(SafeFixStateMachineTest, AbsoluteRatioFloorFailsClosed) {
+    StateMachine machine;
+    Config config;
+    config.enabled = true;
+    config.acquisition_streak_epochs = 1;
+    config.minimum_absolute_ratio = 1.5;
+    auto weak = candidate(1.0);
+    weak.ambiguity_ratio = 1.49;
+    EXPECT_FALSE(machine.update(config, weak).declared_fixed);
+    weak.time_s = 1.2;
+    weak.ambiguity_ratio = 1.5;
+    EXPECT_TRUE(machine.update(config, weak).declared_fixed);
+}
+
+TEST(SafeFixStateMachineTest, IndependentConsensusGateFailsClosed) {
+    StateMachine machine;
+    Config config;
+    config.enabled = true;
+    config.acquisition_streak_epochs = 1;
+    config.maximum_independent_consensus_delta_m = 0.10;
+    auto disagreeing = candidate(1.0);
+    disagreeing.independent_consensus_delta_m =
+        std::numeric_limits<double>::quiet_NaN();
+    EXPECT_FALSE(machine.update(config, disagreeing).declared_fixed);
+    disagreeing.time_s = 1.2;
+    disagreeing.independent_consensus_delta_m = 0.11;
+    EXPECT_FALSE(machine.update(config, disagreeing).declared_fixed);
+    disagreeing.time_s = 1.4;
+    disagreeing.independent_consensus_delta_m = 0.10;
+    EXPECT_TRUE(machine.update(config, disagreeing).declared_fixed);
+}
+
+TEST(SafeFixStateMachineTest, StrongInstantAcquisitionIsExplicitAndGated) {
+    StateMachine machine;
+    Config config;
+    config.enabled = true;
+    config.acquisition_streak_epochs = 3;
+    config.minimum_absolute_ratio = 1.4;
+    config.maximum_independent_consensus_delta_m = 0.10;
+    config.allow_strong_instant_acquisition = true;
+    auto strong = candidate(1.0);
+    strong.ambiguity_ratio = 10.0;
+    strong.independent_consensus_delta_m = 0.01;
+    strong.strong_acquisition_eligible = true;
+    const auto accepted = machine.update(config, strong);
+    EXPECT_TRUE(accepted.declared_fixed);
+    EXPECT_TRUE(accepted.strong_acquisition);
+
+    machine.reset();
+    strong.time_s = 1.2;
+    strong.ambiguity_ratio = 1.39;
+    const auto rejected = machine.update(config, strong);
+    EXPECT_FALSE(rejected.declared_fixed);
+    EXPECT_FALSE(rejected.strong_acquisition);
+}
+
+TEST(SafeFixStateMachineTest, ChangePointRequiresLargeJumpThenStableStreak) {
+    StateMachine machine;
+    Config config;
+    config.enabled = true;
+    config.acquisition_streak_epochs = 10;
+    config.allow_change_point_acquisition = true;
+    auto sample = candidate(1.0, 0.0);
+    sample.acquisition_eligible = false;
+    EXPECT_FALSE(machine.update(config, sample).declared_fixed);
+
+    sample.time_s = 1.2;
+    sample.correction_m.x() = 0.5;
+    EXPECT_FALSE(machine.update(config, sample).declared_fixed);
+    sample.time_s = 1.4;
+    sample.correction_m.x() = 0.505;
+    sample.change_point_acquisition_eligible = true;
+    EXPECT_FALSE(machine.update(config, sample).declared_fixed);
+    sample.time_s = 1.6;
+    sample.correction_m.x() = 0.510;
+    EXPECT_FALSE(machine.update(config, sample).declared_fixed);
+    sample.time_s = 1.8;
+    sample.correction_m.x() = 0.515;
+    const auto accepted = machine.update(config, sample);
+    EXPECT_TRUE(accepted.declared_fixed);
+    EXPECT_TRUE(accepted.change_point_acquisition);
+}
+
+TEST(SafeFixStateMachineTest, ChangePointFailsClosedAcrossGapAndNonfiniteSample) {
+    StateMachine machine;
+    Config config;
+    config.enabled = true;
+    config.acquisition_streak_epochs = 10;
+    config.allow_change_point_acquisition = true;
+    auto sample = candidate(1.0, 0.0);
+    sample.acquisition_eligible = false;
+    EXPECT_FALSE(machine.update(config, sample).declared_fixed);
+
+    sample.time_s = 1.2;
+    sample.correction_m.x() = 0.5;
+    EXPECT_FALSE(machine.update(config, sample).declared_fixed);
+    sample.change_point_acquisition_eligible = true;
+    sample.time_s = 1.4;
+    sample.correction_m.x() = 0.505;
+    EXPECT_FALSE(machine.update(config, sample).declared_fixed);
+
+    sample.time_s = 2.0;
+    sample.correction_m.x() = 0.510;
+    EXPECT_FALSE(machine.update(config, sample).declared_fixed);
+    sample.time_s = 2.2;
+    sample.correction_m.x() =
+        std::numeric_limits<double>::quiet_NaN();
+    EXPECT_FALSE(machine.update(config, sample).declared_fixed);
+
+    sample.time_s = 2.4;
+    sample.correction_m.x() = 0.515;
+    EXPECT_FALSE(machine.update(config, sample).declared_fixed);
+    sample.time_s = 2.6;
+    sample.correction_m.x() = 0.520;
+    EXPECT_FALSE(machine.update(config, sample).declared_fixed);
+    sample.time_s = 2.8;
+    sample.correction_m.x() = 0.525;
+    EXPECT_FALSE(machine.update(config, sample).declared_fixed);
+}
+
+TEST(SafeFixStateMachineTest, FixedStateRevokesOnCorrectionJumpOrEpochGap) {
+    StateMachine machine;
+    Config config;
+    config.enabled = true;
+    config.acquisition_streak_epochs = 1;
+    config.maximum_acquisition_correction_jump_m = 0.02;
+    config.maximum_hold_epochs = 0;
+    auto sample = candidate(1.0, 0.0);
+    EXPECT_TRUE(machine.update(config, sample).declared_fixed);
+
+    sample.time_s = 1.2;
+    sample.correction_m.x() = 0.03;
+    const auto jumped = machine.update(config, sample);
+    EXPECT_FALSE(jumped.declared_fixed);
+    EXPECT_TRUE(jumped.revoked);
+
+    machine.reset();
+    sample = candidate(1.0, 0.0);
+    EXPECT_TRUE(machine.update(config, sample).declared_fixed);
+    sample.time_s = 1.4;
+    const auto gapped = machine.update(config, sample);
+    EXPECT_FALSE(gapped.declared_fixed);
+    EXPECT_TRUE(gapped.revoked);
+}
+
+TEST(SafeFloatContinuityTest, DisabledFailsClosed) {
+    libgnss::safe_float_continuity::Config config;
+    EXPECT_FALSE(
+        libgnss::safe_float_continuity::propagate(
+            config,
+            Eigen::Vector3d(1.0, 2.0, 3.0),
+            1.0,
+            Eigen::Vector3d(4.0, 0.0, 0.0),
+            0.2)
+            .valid);
+}
+
+TEST(SafeFloatContinuityTest, PropagatesTrustedAnchorWithBoundedVelocity) {
+    libgnss::safe_float_continuity::Config config;
+    config.enabled = true;
+    const auto result =
+        libgnss::safe_float_continuity::propagate(
+            config,
+            Eigen::Vector3d(100.0, 200.0, 300.0),
+            2.0,
+            Eigen::Vector3d(5.0, -1.0, 0.5),
+            1.0);
+    ASSERT_TRUE(result.valid);
+    EXPECT_TRUE(
+        result.position_ecef.isApprox(
+            Eigen::Vector3d(110.0, 198.0, 301.0)));
+    EXPECT_DOUBLE_EQ(result.position_variance_m2, 61.0);
+}
+
+TEST(SafeFloatContinuityTest, StaleOrImplausibleInputsFailClosed) {
+    libgnss::safe_float_continuity::Config config;
+    config.enabled = true;
+    EXPECT_FALSE(
+        libgnss::safe_float_continuity::propagate(
+            config,
+            Eigen::Vector3d::Zero(),
+            6.1,
+            Eigen::Vector3d::Zero(),
+            0.0)
+            .valid);
+    EXPECT_FALSE(
+        libgnss::safe_float_continuity::propagate(
+            config,
+            Eigen::Vector3d::Zero(),
+            1.0,
+            Eigen::Vector3d(81.0, 0.0, 0.0),
+            0.0)
+            .valid);
+    EXPECT_FALSE(
+        libgnss::safe_float_continuity::propagate(
+            config,
+            Eigen::Vector3d::Zero(),
+            1.0,
+            Eigen::Vector3d(
+                std::numeric_limits<double>::quiet_NaN(), 0.0, 0.0),
+            0.0)
+            .valid);
+}
+
+}  // namespace

--- a/tests/test_types.cpp
+++ b/tests/test_types.cpp
@@ -3,6 +3,7 @@
 #include <libgnss++/core/types.hpp>
 #include <filesystem>
 #include <fstream>
+#include <limits>
 
 using namespace libgnss;
 
@@ -76,6 +77,20 @@ TEST_F(TypesTest, Constants) {
     EXPECT_GT(constants::WGS84_A, 6.3e6);
     EXPECT_GT(constants::WGS84_F, 0.0);
     EXPECT_LT(constants::WGS84_F, 1.0);
+}
+
+TEST_F(TypesTest, PropagatedSolutionIsValidWithoutCurrentSatellitesButNeverFixed) {
+    PositionSolution solution;
+    solution.status = SolutionStatus::PROPAGATED;
+    solution.position_ecef = Vector3d(1.0, 2.0, 3.0);
+    solution.num_satellites = 0;
+
+    EXPECT_TRUE(solution.isValid());
+    EXPECT_FALSE(solution.isFixed());
+
+    solution.position_ecef.x() =
+        std::numeric_limits<double>::quiet_NaN();
+    EXPECT_FALSE(solution.isValid());
 }
 
 TEST_F(TypesTest, SolutionFileRoundTripsFgoQualityColumns) {


### PR DESCRIPTION
## Summary
- add fail-closed safe FIX state, quality, failure-budget, causal-arc, disjoint-satellite, inertial, and SRC-PAR evidence paths
- integrate Student-t robust measurement weighting and integrity telemetry into native fuse/solve applications
- preserve default-off behavior while allowing guarded library Status=4 promotion

## Validation
- C++: 844 tests, 779 passed, 65 skipped, 0 failed
- rebased Tokyo smoke: 280/300 library FIX (93.3%), 0 observed false FIX, 0 lost epochs
- every smoke FIX passed quality, two-family failure-budget, and integrity gates
- formal full-route audit before rebase: Tokyo 50.08%, Nagoya 66.02%, 0 observed false FIX