### PR TITLE
Add AR candidate attrition telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,28 @@ the shipping preset:
 --surplus-validation-aperture-gt2 0.45
 ```
 
+With `--dump-csv <path>`, the epoch table includes the ambiguity-candidate
+funnel (`amb_after_hold`, `amb_final`, and `amb_excl_*`). A normalized
+satellite/signal trace is written beside it as
+`<path>.ar_candidates.csv`. Its `disposition` values are:
+
+| Value | Meaning |
+|---:|---|
+| 0 | Reached the final per-epoch LAMBDA candidate set |
+| 1 | Excluded while building the problem (currently sustained CMC level) |
+| 2 | Carrier factor suppressed by full CP hold |
+| 3 | Carrier retained as float but quarantined from AR during CP recovery |
+| 4 | Removed by one-band-per-satellite selection |
+| 5 | Removed by constellation exclusion |
+| 6 | Removed by the previous epoch's per-satellite residual gate |
+| 7 | Removed by carrier FDE |
+| 8 | Removed because its ambiguity key left the active smoother |
+| 9 | Candidate present, but the whole epoch failed the quality gate |
+| 10 | Candidate present, but ambiguity resolution was disabled |
+
+These fields only report decisions already made by the solver; enabling the
+CSV dump does not alter candidate selection or FIX/FLOAT decisions.
+
 #### Surplus-satellite rescue integrity
 
 LAMBDA candidates that fall short of the ratio gate can be rescued by an

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -1457,7 +1457,10 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
            "ddpr_anchor_h_err_m,ddpr_anchor_u_err_m,ddpr_anchor_prior,"
            "fixed_float_sep_m,fixed_imu_pred_sep_m,fixed_postfit_ddcp_rms_m,fixed_postfit_ddcp_max_norm,fixed_postfit_ddcp_chi2_dof,fixed_postfit_ddcp_n,external_dr_sep_m,external_dr_mahal2,external_dr_age,external_doppler_valid,external_doppler_vel_e_mps,external_doppler_vel_n_mps,external_doppler_vel_u_mps,external_dr_eval,external_dr_accept,external_dr_reject,cp_hold,"
            "imu_aperture_accept,imu_aperture_reject,cp_available,cp_added,"
-           "cp_suppressed_hold,gen_bump_hold,gen_bump_fde,gen_bump_reset,"
+           "cp_suppressed_hold,amb_after_hold,amb_final,amb_excl_build,"
+           "amb_excl_hold,amb_excl_one_band,amb_excl_constellation,"
+           "amb_excl_prev_residual,amb_excl_fde,amb_excl_stale,"
+           "gen_bump_hold,gen_bump_fde,gen_bump_reset,"
            "gen_bump_warm_reset,gen_bump_stale_pin,"
            "surplus_eval,surplus_pass,surplus_level,surplus_used,surplus_rescue,surplus_veto,"
            "low_count_attempted,low_count_used,"
@@ -1570,6 +1573,15 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                 << ',' << d.carrier_factors_available
                 << ',' << d.carrier_factors_added
                 << ',' << d.carrier_factors_suppressed_hold
+                << ',' << d.ambiguity_candidates_after_hold
+                << ',' << d.ambiguity_candidates_final
+                << ',' << d.ambiguity_candidates_excluded_build_time
+                << ',' << d.ambiguity_candidates_excluded_hold
+                << ',' << d.ambiguity_candidates_excluded_one_band
+                << ',' << d.ambiguity_candidates_excluded_constellation
+                << ',' << d.ambiguity_candidates_excluded_previous_residual
+                << ',' << d.ambiguity_candidates_excluded_fde
+                << ',' << d.ambiguity_candidates_excluded_stale
                 << ',' << d.ambiguity_generation_bumps_hold
                 << ',' << d.ambiguity_generation_bumps_fde
                 << ',' << d.ambiguity_generation_bumps_reset
@@ -1601,6 +1613,39 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                 << ',' << (d.dr_bypass_applied ? 1 : 0);
         }
         out << '\n';
+    }
+
+    // Normalized companion table: the epoch CSV above answers "how many",
+    // while this row-per-satellite/signal trace answers exactly which carrier
+    // row left the LAMBDA funnel and at which existing gate.  It deliberately
+    // shares --dump-csv rather than adding another command-line switch.
+    const std::string trace_path = path + ".ar_candidates.csv";
+    std::ofstream trace_out(trace_path);
+    if (!trace_out) {
+        std::cerr << "Warning: cannot open AR candidate trace output file "
+                  << trace_path << "\n";
+        return;
+    }
+    trace_out << "tow,satellite,reference_satellite,system,prn,"
+                 "reference_system,reference_prn,signal,ambiguity_index,disposition\n";
+    trace_out << std::fixed;
+    trace_out.precision(3);
+    for (const auto& epoch : r.epoch_diagnostics) {
+        for (const auto& candidate : epoch.ambiguity_candidate_trace) {
+            trace_out << epoch.time.tow << ','
+                      << candidate.satellite.toString() << ','
+                      << candidate.reference_satellite.toString() << ','
+                      << static_cast<int>(candidate.satellite.system) << ','
+                      << static_cast<int>(candidate.satellite.prn) << ','
+                      << static_cast<int>(candidate.reference_satellite.system) << ','
+                      << static_cast<int>(candidate.reference_satellite.prn) << ','
+                      << static_cast<int>(candidate.signal) << ',';
+            if (candidate.ambiguity_index !=
+                std::numeric_limits<std::size_t>::max()) {
+                trace_out << candidate.ambiguity_index;
+            }
+            trace_out << ',' << static_cast<int>(candidate.disposition) << '\n';
+        }
     }
 }
 

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -7,6 +7,7 @@
 #include <libgnss++/io/imu.hpp>
 
 #include <cstddef>
+#include <limits>
 #include <map>
 #include <set>
 #include <string>
@@ -1906,6 +1907,33 @@ public:
         IntegerConstrainedReoptimizationRejected = 15,
     };
 
+    /// Terminal reason why one satellite/signal DD carrier row did or did not
+    /// reach the per-epoch LAMBDA candidate set.  This is diagnostic-only:
+    /// the backend records decisions already made by the existing pipeline.
+    enum class AmbiguityCandidateDisposition : int {
+        LambdaEligible = 0,
+        BuildTimeExcluded = 1,
+        CarrierHoldSuppressed = 2,
+        CarrierHoldQuarantined = 3,
+        OneBandPerSatelliteExcluded = 4,
+        ConstellationExcluded = 5,
+        PreviousResidualGateExcluded = 6,
+        FdeExcluded = 7,
+        StaleSmootherKeyExcluded = 8,
+        EpochQualityGateExcluded = 9,
+        AmbiguityResolutionDisabled = 10,
+    };
+
+    /// Satellite/signal-level trace for one DD carrier row in one epoch.
+    struct AmbiguityCandidateTrace {
+        SatelliteId satellite;
+        SatelliteId reference_satellite;
+        SignalType signal = SignalType::SIGNAL_TYPE_COUNT;
+        std::size_t ambiguity_index = std::numeric_limits<std::size_t>::max();
+        AmbiguityCandidateDisposition disposition =
+            AmbiguityCandidateDisposition::LambdaEligible;
+    };
+
     /// Per-epoch fixed-lag integrity state.  These values expose why an epoch
     /// did or did not fix, rather than only reporting the final FIX/FLOAT label.
     struct FGOEpochDiagnostics {
@@ -1973,6 +2001,19 @@ public:
         int carrier_factors_available = 0;
         int carrier_factors_added = 0;
         int carrier_factors_suppressed_hold = 0;
+        // Candidate attrition funnel.  ambiguity_candidates retains its
+        // historical meaning (after one-band/constellation filtering, before
+        // runtime residual/FDE/stale-key filtering).
+        int ambiguity_candidates_after_hold = 0;
+        int ambiguity_candidates_final = 0;
+        int ambiguity_candidates_excluded_build_time = 0;
+        int ambiguity_candidates_excluded_hold = 0;
+        int ambiguity_candidates_excluded_one_band = 0;
+        int ambiguity_candidates_excluded_constellation = 0;
+        int ambiguity_candidates_excluded_previous_residual = 0;
+        int ambiguity_candidates_excluded_fde = 0;
+        int ambiguity_candidates_excluded_stale = 0;
+        std::vector<AmbiguityCandidateTrace> ambiguity_candidate_trace;
         int ambiguity_generation_bumps_hold = 0;
         int ambiguity_generation_bumps_fde = 0;
         int ambiguity_generation_bumps_reset = 0;

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -865,15 +865,12 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
     }
     // Build-time-excluded DD carrier rows (CMC level exclusion; see
     // FGOProblem::excluded_double_difference_carrier_factors), grouped the
-    // same way, ONLY consumed by the surplus-satellite independent
-    // integrity validator below (use_surplus_satellite_validation). Empty
-    // whenever the excluding feature that populates it (CMC) is off.
+    // same way.  The surplus validator consumes these rows when enabled; the
+    // diagnostic candidate trace always records them.
     std::vector<std::vector<const FGOProcessor::DoubleDifferenceCarrierFactor*>>
-        cp_excluded_by_epoch(config.use_surplus_satellite_validation ? num_epochs : 0);
-    if (config.use_surplus_satellite_validation) {
-        for (const auto& f : problem.excluded_double_difference_carrier_factors) {
-            if (f.epoch_index < num_epochs) cp_excluded_by_epoch[f.epoch_index].push_back(&f);
-        }
+        cp_excluded_by_epoch(num_epochs);
+    for (const auto& f : problem.excluded_double_difference_carrier_factors) {
+        if (f.epoch_index < num_epochs) cp_excluded_by_epoch[f.epoch_index].push_back(&f);
     }
 
     // --- DDPR-LS anchor solve (FGOConfig::use_ddpr_anchor; port of the
@@ -1976,6 +1973,32 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             : FGOProcessor::AmbiguityResolutionOutcome::Disabled;
         epoch_diagnostics[i].ambiguity_candidates =
             static_cast<int>(cp_by_epoch[i].size());
+        auto& candidate_trace = epoch_diagnostics[i].ambiguity_candidate_trace;
+        candidate_trace.reserve(cp_by_epoch[i].size() + cp_excluded_by_epoch[i].size());
+        for (const auto* fp : cp_excluded_by_epoch[i]) {
+            candidate_trace.push_back(
+                {fp->satellite, fp->reference_satellite, fp->signal,
+                 fp->ambiguity_index,
+                 FGOProcessor::AmbiguityCandidateDisposition::BuildTimeExcluded});
+            ++epoch_diagnostics[i].ambiguity_candidates_excluded_build_time;
+        }
+        const auto addCandidateTrace = [&](const auto& factor) -> std::size_t {
+            candidate_trace.push_back(
+                {factor.satellite, factor.reference_satellite, factor.signal,
+                 factor.ambiguity_index,
+                 FGOProcessor::AmbiguityCandidateDisposition::LambdaEligible});
+            return candidate_trace.size() - 1;
+        };
+        const auto setCandidateDisposition =
+            [&](std::size_t ambiguity_index,
+                FGOProcessor::AmbiguityCandidateDisposition disposition) {
+                for (auto& entry : candidate_trace) {
+                    if (entry.ambiguity_index == ambiguity_index) {
+                        entry.disposition = disposition;
+                        return;
+                    }
+                }
+            };
         gtsam::NonlinearFactorGraph new_factors;
         gtsam::Values new_values;
         gtsam::FixedLagSmoother::KeyTimestampMap ts;
@@ -2247,6 +2270,7 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
         std::vector<std::size_t> epoch_amb_indices;
         for (const auto* fp : cp_by_epoch[i]) {
             const auto& factor = *fp;
+            const std::size_t trace_index = addCandidateTrace(factor);
             ++epoch_diagnostics[i].carrier_factors_available;
             const bool selectively_bad_pair =
                 selective_cp_hold_bad_sats.count(factor.satellite) > 0 ||
@@ -2267,6 +2291,9 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 ++result.diagnostics.ambiguity_generation_bumps_hold;
                 ++epoch_diagnostics[i].ambiguity_generation_bumps_hold;
                 ++epoch_diagnostics[i].carrier_factors_suppressed_hold;
+                ++epoch_diagnostics[i].ambiguity_candidates_excluded_hold;
+                candidate_trace[trace_index].disposition =
+                    FGOProcessor::AmbiguityCandidateDisposition::CarrierHoldSuppressed;
                 pinned_ambiguities.erase(old_sid);
                 live_ambiguity_indices.erase(idx);
                 continue;
@@ -2352,6 +2379,10 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 !(config.use_cp_hold_recovery && skip_cp_now &&
                   config.use_cp_hold_float_recovery)) {
                 epoch_amb_indices.push_back(factor.ambiguity_index);
+            } else {
+                ++epoch_diagnostics[i].ambiguity_candidates_excluded_hold;
+                candidate_trace[trace_index].disposition =
+                    FGOProcessor::AmbiguityCandidateDisposition::CarrierHoldQuarantined;
             }
             // Track active arcs for every reset policy, not only the CP-hold
             // FSM. The GICI-style continuous-unfix reset also needs to bump
@@ -2360,6 +2391,8 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             live_ambiguity_indices.insert(factor.ambiguity_index);
         }
         if (dummy_created) ts[dummyAmbiguityKey()] = te;
+        epoch_diagnostics[i].ambiguity_candidates_after_hold =
+            static_cast<int>(epoch_amb_indices.size());
 
         // --- DDPR-anchor bootstrap re-seed (use_ddpr_anchor; port of
         // optimize/stage.py's BOOT_DDPR_EPOCHS translation-only re-seed).
@@ -2410,11 +2443,35 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
         // correlated multi-frequency bands don't weaken the all-or-nothing fix.
         if (config.double_difference_lambda_one_band_per_satellite &&
             epoch_amb_indices.size() > 1) {
+            const std::vector<std::size_t> candidates_before_one_band =
+                epoch_amb_indices;
             epoch_amb_indices = selectOneBandPerSatellite(epoch_amb_indices, problem);
+            const std::set<std::size_t> retained(
+                epoch_amb_indices.begin(), epoch_amb_indices.end());
+            for (const std::size_t idx : candidates_before_one_band) {
+                if (retained.count(idx) == 0) {
+                    ++epoch_diagnostics[i].ambiguity_candidates_excluded_one_band;
+                    setCandidateDisposition(
+                        idx,
+                        FGOProcessor::AmbiguityCandidateDisposition::
+                            OneBandPerSatelliteExcluded);
+                }
+            }
         }
         // MF-AR step 2 (gated): keep Galileo arcs out of the integer search /
         // fix-and-hold entirely -- their DD factors still shape the float.
         if (config.exclude_galileo_ambiguity_fixing) {
+            const std::size_t candidates_before_constellation =
+                epoch_amb_indices.size();
+            for (const std::size_t idx : epoch_amb_indices) {
+                if (problem.ambiguity_states[idx].satellite.system ==
+                    GNSSSystem::Galileo) {
+                    setCandidateDisposition(
+                        idx,
+                        FGOProcessor::AmbiguityCandidateDisposition::
+                            ConstellationExcluded);
+                }
+            }
             epoch_amb_indices.erase(
                 std::remove_if(epoch_amb_indices.begin(), epoch_amb_indices.end(),
                                [&](std::size_t idx) {
@@ -2422,6 +2479,9 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                                           GNSSSystem::Galileo;
                                }),
                 epoch_amb_indices.end());
+            epoch_diagnostics[i].ambiguity_candidates_excluded_constellation +=
+                static_cast<int>(
+                    candidates_before_constellation - epoch_amb_indices.size());
         }
         epoch_diagnostics[i].ambiguity_candidates =
             static_cast<int>(epoch_amb_indices.size());
@@ -3000,6 +3060,18 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             // out of this epoch's LAMBDA candidate set (their factors and
             // held pins are untouched).
             if (!gate_bad_sats.empty() && !epoch_amb_indices.empty()) {
+                const std::size_t candidates_before_residual_gate =
+                    epoch_amb_indices.size();
+                for (const std::size_t idx : epoch_amb_indices) {
+                    const auto& amb = problem.ambiguity_states[idx];
+                    if (gate_bad_sats.count(amb.satellite) > 0 ||
+                        gate_bad_sats.count(amb.reference_satellite) > 0) {
+                        setCandidateDisposition(
+                            idx,
+                            FGOProcessor::AmbiguityCandidateDisposition::
+                                PreviousResidualGateExcluded);
+                    }
+                }
                 epoch_amb_indices.erase(
                     std::remove_if(
                         epoch_amb_indices.begin(), epoch_amb_indices.end(),
@@ -3009,6 +3081,11 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                                    gate_bad_sats.count(amb.reference_satellite) > 0;
                         }),
                     epoch_amb_indices.end());
+                epoch_diagnostics[i]
+                    .ambiguity_candidates_excluded_previous_residual +=
+                    static_cast<int>(
+                        candidates_before_residual_gate -
+                        epoch_amb_indices.size());
             }
             gate_bad_sats.clear();
             if (config.gate_per_sat_res_max_m > 0.0) {
@@ -3066,12 +3143,25 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 // branch above, which never adds a suppressed arc to
                 // epoch_amb_indices in the first place).
                 if (!fde_rejected_amb.empty()) {
+                    for (const std::size_t idx : epoch_amb_indices) {
+                        if (fde_rejected_amb.count(idx) > 0) {
+                            setCandidateDisposition(
+                                idx,
+                                FGOProcessor::AmbiguityCandidateDisposition::
+                                    FdeExcluded);
+                        }
+                    }
+                    const std::size_t candidates_before_fde =
+                        epoch_amb_indices.size();
                     epoch_amb_indices.erase(
                         std::remove_if(epoch_amb_indices.begin(), epoch_amb_indices.end(),
                                        [&](std::size_t idx) {
                                            return fde_rejected_amb.count(idx) > 0;
                                        }),
                         epoch_amb_indices.end());
+                    epoch_diagnostics[i].ambiguity_candidates_excluded_fde +=
+                        static_cast<int>(
+                            candidates_before_fde - epoch_amb_indices.size());
                 }
                 // Refresh the post-FDE estimate: downstream LAMBDA/fix-and-
                 // hold and the REPORTED pose for this epoch must see the
@@ -3096,6 +3186,22 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             }
         }
 
+        if (!config.use_lambda_ambiguity_fix) {
+            for (const std::size_t idx : epoch_amb_indices) {
+                setCandidateDisposition(
+                    idx,
+                    FGOProcessor::AmbiguityCandidateDisposition::
+                        AmbiguityResolutionDisabled);
+            }
+        } else if (!fix_allowed) {
+            for (const std::size_t idx : epoch_amb_indices) {
+                setCandidateDisposition(
+                    idx,
+                    FGOProcessor::AmbiguityCandidateDisposition::
+                        EpochQualityGateExcluded);
+            }
+        }
+
         // --- Per-epoch LAMBDA off the bounded windowed marginals ---
         if (fix_allowed && config.use_lambda_ambiguity_fix && !epoch_amb_indices.empty()) {
             // FDE, exception recovery, or an ambiguity-generation bump can
@@ -3105,6 +3211,15 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             const gtsam::Values& lambda_linearization_point =
                 smoother.getLinearizationPoint();
             const std::size_t candidates_before_filter = epoch_amb_indices.size();
+            for (const std::size_t idx : epoch_amb_indices) {
+                if (!lambda_linearization_point.exists(
+                        ambiguityKey(ambSymbolId(idx)))) {
+                    setCandidateDisposition(
+                        idx,
+                        FGOProcessor::AmbiguityCandidateDisposition::
+                            StaleSmootherKeyExcluded);
+                }
+            }
             epoch_amb_indices.erase(
                 std::remove_if(
                     epoch_amb_indices.begin(), epoch_amb_indices.end(),
@@ -3115,6 +3230,11 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 epoch_amb_indices.end());
             result.diagnostics.lambda_stale_candidates_filtered +=
                 candidates_before_filter - epoch_amb_indices.size();
+            epoch_diagnostics[i].ambiguity_candidates_excluded_stale +=
+                static_cast<int>(
+                    candidates_before_filter - epoch_amb_indices.size());
+            epoch_diagnostics[i].ambiguity_candidates_final =
+                static_cast<int>(epoch_amb_indices.size());
 
             std::sort(epoch_amb_indices.begin(), epoch_amb_indices.end(),
                       [&](std::size_t a, std::size_t b) {

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -10,6 +10,7 @@
 #include <array>
 #include <cmath>
 #include <cstdio>
+#include <limits>
 #include <set>
 #include <vector>
 
@@ -499,6 +500,92 @@ FGOProcessor::FGOConfig makeCpHoldBaseConfig() {
 }
 
 }  // namespace
+
+TEST(FGOAmbiguityCandidateTelemetryTest, ReportsDisabledCandidateFunnel) {
+    CpHoldTestOptions opt;
+    opt.num_epochs = 3;
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+    FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
+
+    const FGOProcessor processor(config);
+    const FGOProcessor::FGOResult result = processor.optimizeProblem(problem);
+
+    ASSERT_EQ(result.epoch_diagnostics.size(), problem.epochs.size());
+    for (const auto& epoch : result.epoch_diagnostics) {
+        EXPECT_EQ(epoch.carrier_factors_available, 5);
+        EXPECT_EQ(epoch.carrier_factors_added, 5);
+        EXPECT_EQ(epoch.ambiguity_candidates_after_hold, 5);
+        EXPECT_EQ(epoch.ambiguity_candidates, 5);
+        EXPECT_EQ(epoch.ambiguity_candidates_final, 0);
+        EXPECT_EQ(epoch.ambiguity_candidates_excluded_build_time, 0);
+        EXPECT_EQ(epoch.ambiguity_candidates_excluded_hold, 0);
+        EXPECT_EQ(epoch.ambiguity_candidates_excluded_one_band, 0);
+        EXPECT_EQ(epoch.ambiguity_candidates_excluded_constellation, 0);
+        EXPECT_EQ(epoch.ambiguity_candidates_excluded_previous_residual, 0);
+        EXPECT_EQ(epoch.ambiguity_candidates_excluded_fde, 0);
+        EXPECT_EQ(epoch.ambiguity_candidates_excluded_stale, 0);
+        ASSERT_EQ(epoch.ambiguity_candidate_trace.size(), 5u);
+        for (const auto& candidate : epoch.ambiguity_candidate_trace) {
+            EXPECT_EQ(
+                candidate.disposition,
+                FGOProcessor::AmbiguityCandidateDisposition::
+                    AmbiguityResolutionDisabled);
+        }
+    }
+}
+
+TEST(FGOAmbiguityCandidateTelemetryTest,
+     ReportsFinalCandidatesBeforeInsufficientCountDecision) {
+    CpHoldTestOptions opt;
+    opt.num_epochs = 3;
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+    FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
+    config.use_lambda_ambiguity_fix = true;
+
+    const FGOProcessor processor(config);
+    const FGOProcessor::FGOResult result = processor.optimizeProblem(problem);
+
+    ASSERT_EQ(result.epoch_diagnostics.size(), problem.epochs.size());
+    for (const auto& epoch : result.epoch_diagnostics) {
+        // Preserve the existing terminal outcome semantics: without the hold
+        // reporting path enabled, a below-floor epoch retains NoCandidates.
+        // The new funnel is what disambiguates that label (five candidates
+        // did reach the count gate).
+        EXPECT_EQ(
+            epoch.ar_outcome,
+            FGOProcessor::AmbiguityResolutionOutcome::NoCandidates);
+        EXPECT_EQ(epoch.ambiguity_candidates_after_hold, 5);
+        EXPECT_EQ(epoch.ambiguity_candidates, 5);
+        EXPECT_EQ(epoch.ambiguity_candidates_final, 5);
+        ASSERT_EQ(epoch.ambiguity_candidate_trace.size(), 5u);
+        for (const auto& candidate : epoch.ambiguity_candidate_trace) {
+            EXPECT_EQ(
+                candidate.disposition,
+                FGOProcessor::AmbiguityCandidateDisposition::LambdaEligible);
+        }
+    }
+}
+
+TEST(FGOAmbiguityCandidateTelemetryTest, ReportsBuildTimeExcludedCarrierRows) {
+    CpHoldTestOptions opt;
+    opt.num_epochs = 3;
+    auto problem = makeCpHoldFixedLagProblem(opt);
+    auto excluded = problem.double_difference_carrier_factors.front();
+    excluded.ambiguity_index = std::numeric_limits<std::size_t>::max();
+    problem.excluded_double_difference_carrier_factors.push_back(excluded);
+
+    FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
+    const FGOProcessor processor(config);
+    const FGOProcessor::FGOResult result = processor.optimizeProblem(problem);
+
+    ASSERT_FALSE(result.epoch_diagnostics.empty());
+    const auto& epoch = result.epoch_diagnostics.front();
+    EXPECT_EQ(epoch.ambiguity_candidates_excluded_build_time, 1);
+    ASSERT_EQ(epoch.ambiguity_candidate_trace.size(), 6u);
+    EXPECT_EQ(
+        epoch.ambiguity_candidate_trace.front().disposition,
+        FGOProcessor::AmbiguityCandidateDisposition::BuildTimeExcluded);
+}
 
 TEST(FGOCpHoldFsmTest, DefaultOffIsNoOp) {
     CpHoldTestOptions opt;


### PR DESCRIPTION
## What changed

- add per-epoch ambiguity-candidate funnel counters to fixed-lag diagnostics
- add normalized per-satellite/signal candidate disposition traces
- write `<dump>.ar_candidates.csv` automatically alongside `--dump-csv`
- document disposition codes and add focused GTSAM fixed-lag tests

## Why

Historical Tokyo1 diagnostics show that insufficient AR candidates dominate rejection, but the existing aggregate count cannot distinguish build-time exclusion, CP-hold suppression/quarantine, one-band/constellation selection, residual/FDE rejection, or stale smoother keys. This telemetry makes the attrition source measurable before changing the fixing policy.

This PR is behavior-neutral: it records decisions already made by the solver and does not change candidate selection, LAMBDA thresholds, or FIX/FLOAT decisions.

## Validation

- built `gnss_run_tests` and `gnss_fgo_parity` in Release with MSVC/GTSAM
- focused telemetry/backend tests: 6/6 passed
- broad FGO/ambiguity/fixed-lag regression: 92 passed, 3 skipped because repository fixture data is unavailable
- Tokyo1 50-epoch shipping-profile replay: 50 epoch CSV rows, 2,000 normalized candidate rows, all required columns present, and no `amb_final > amb_after_hold` inconsistencies
