### PR TITLE
Add FGO FFRT shadow telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,21 @@ satellite/signal trace is written beside it as
 These fields only report decisions already made by the solver; enabling the
 CSV dump does not alter candidate selection or FIX/FLOAT decisions.
 
+The same dump also writes `<path>.ar_attempts.csv`, with one row for every
+concrete LAMBDA subset search. It records the subset/stage, integer candidate
+position, static-ratio and existing-pipeline verdicts, surplus/post-fit
+evidence, and covariance-only bootstrapped success rate (BSR) at covariance
+scales 1/2/4/8/16. `ffrt_min_ratio_q*`,
+`ffrt_accepts_any_candidate_q*`, and `ffrt_pass_q*` are shadow results for a
+tolerable failure rate of 0.001 using the published
+[Hou–Verhagen–Wu FFRT](https://doi.org/10.3390/s16070945) coefficients.
+They never promote or demote a solution. Multiple covariance scales are
+reported because success-rate PAR is sensitive to stochastic-model
+optimism; no scale is selected until Tokyo1 development and independent
+Tokyo2 validation are complete. This follows the model/data separation
+described by the
+[two-step success-rate criterion](https://doi.org/10.1007/s10291-022-01317-0).
+
 #### Surplus-satellite rescue integrity
 
 LAMBDA candidates that fall short of the ratio gate can be rescued by an

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -1647,6 +1647,93 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
             trace_out << ',' << static_cast<int>(candidate.disposition) << '\n';
         }
     }
+
+    // One row per concrete LAMBDA subset attempt.  This is a shadow ledger:
+    // FFRT pass flags are counterfactual only and never feed the solver's
+    // existing static ratio/integrity decision.
+    const std::string attempts_path = path + ".ar_attempts.csv";
+    std::ofstream attempts_out(attempts_path);
+    if (!attempts_out) {
+        std::cerr << "Warning: cannot open AR attempt trace output file "
+                  << attempts_path << "\n";
+        return;
+    }
+    attempts_out
+        << "tow,attempt_index,subset_size,lambda_stage,lambda_search_solved,"
+           "ratio,candidate_position_valid,candidate_x_ecef_m,"
+           "candidate_y_ecef_m,candidate_z_ecef_m,fixed_float_sep_m,"
+           "fixed_imu_pred_sep_m,configured_ratio_pass,effective_ratio_pass";
+    for (const int scale : {1, 2, 4, 8, 16}) {
+        attempts_out << ",bsr_q" << scale
+                     << ",ffrt_min_ratio_q" << scale
+                     << ",ffrt_supported_q" << scale
+                     << ",ffrt_accepts_any_candidate_q" << scale
+                     << ",ffrt_pass_q" << scale;
+    }
+    attempts_out
+        << ",surplus_eval,surplus_pass,surplus_level,surplus_used,"
+           "postfit_ddcp_n,postfit_ddcp_rms_m,postfit_ddcp_max_norm,"
+           "postfit_ddcp_chi2_dof,static_fixed_decision_pass,"
+           "accepted_by_existing_pipeline\n";
+    attempts_out.precision(17);
+    for (const auto& epoch : r.epoch_diagnostics) {
+        for (const auto& attempt :
+             epoch.ambiguity_resolution_attempt_trace) {
+            attempts_out
+                << epoch.time.tow << ',' << attempt.attempt_index << ','
+                << attempt.subset_size << ',' << attempt.lambda_stage << ','
+                << (attempt.lambda_search_solved ? 1 : 0) << ','
+                << attempt.ratio << ','
+                << (attempt.candidate_position_valid ? 1 : 0) << ',';
+            if (attempt.candidate_position_valid) {
+                attempts_out
+                    << attempt.candidate_position_ecef.x() << ','
+                    << attempt.candidate_position_ecef.y() << ','
+                    << attempt.candidate_position_ecef.z();
+            } else {
+                attempts_out << ",,";
+            }
+            attempts_out
+                << ',' << attempt.fixed_float_separation_m
+                << ',' << attempt.fixed_imu_prediction_separation_m
+                << ',' << (attempt.configured_ratio_pass ? 1 : 0)
+                << ',' << (attempt.effective_ratio_pass ? 1 : 0);
+            for (std::size_t scale_index = 0;
+                 scale_index <
+                 libgnss::FGOProcessor::
+                     AmbiguityResolutionAttemptTrace::
+                         covariance_scales.size();
+                 ++scale_index) {
+                attempts_out
+                    << ','
+                    << attempt.bootstrapped_success_rate[scale_index]
+                    << ','
+                    << attempt.ffrt_minimum_ratio[scale_index]
+                    << ','
+                    << (attempt.ffrt_supported[scale_index] ? 1 : 0)
+                    << ','
+                    << (attempt.ffrt_accepts_any_candidate[scale_index]
+                            ? 1
+                            : 0)
+                    << ','
+                    << (attempt.ffrt_pass[scale_index] ? 1 : 0);
+            }
+            attempts_out
+                << ',' << (attempt.surplus_evaluated ? 1 : 0)
+                << ',' << (attempt.surplus_pass ? 1 : 0)
+                << ',' << attempt.surplus_fallback_level
+                << ',' << attempt.surplus_used
+                << ',' << attempt.postfit_ddcp_factors
+                << ',' << attempt.postfit_ddcp_rms_m
+                << ',' << attempt.postfit_ddcp_max_normalized
+                << ',' << attempt.postfit_ddcp_chi2_per_dof
+                << ','
+                << (attempt.static_fixed_decision_pass ? 1 : 0)
+                << ','
+                << (attempt.accepted_by_existing_pipeline ? 1 : 0)
+                << '\n';
+        }
+    }
 }
 
 // Populate problem.imu from an imu.csv + the already-built FGOProblem epochs.

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -6,6 +6,7 @@
 #include <libgnss++/core/types.hpp>
 #include <libgnss++/io/imu.hpp>
 
+#include <array>
 #include <cstddef>
 #include <limits>
 #include <map>
@@ -1934,6 +1935,43 @@ public:
             AmbiguityCandidateDisposition::LambdaEligible;
     };
 
+    /// Behavior-neutral trace for one concrete LAMBDA subset attempt.
+    ///
+    /// The five covariance scales deliberately match the safe-library
+    /// shadow telemetry.  They expose covariance sensitivity before any
+    /// scale is allowed to influence an FGO FIX/FLOAT decision.
+    struct AmbiguityResolutionAttemptTrace {
+        inline static constexpr std::array<double, 5> covariance_scales{
+            1.0, 2.0, 4.0, 8.0, 16.0};
+
+        int attempt_index = -1;
+        int subset_size = 0;
+        int lambda_stage = -1;  ///< PPC cascade: 0=GQEBR ... 5=GQ
+        bool lambda_search_solved = false;
+        double ratio = 0.0;
+        std::array<double, 5> bootstrapped_success_rate{};
+        std::array<double, 5> ffrt_minimum_ratio{};
+        std::array<bool, 5> ffrt_supported{};
+        std::array<bool, 5> ffrt_accepts_any_candidate{};
+        std::array<bool, 5> ffrt_pass{};
+        bool candidate_position_valid = false;
+        Vector3d candidate_position_ecef = Vector3d::Zero();
+        double fixed_float_separation_m = 0.0;
+        double fixed_imu_prediction_separation_m = 0.0;
+        bool configured_ratio_pass = false;
+        bool effective_ratio_pass = false;
+        bool surplus_evaluated = false;
+        bool surplus_pass = false;
+        int surplus_fallback_level = -1;
+        int surplus_used = 0;
+        int postfit_ddcp_factors = 0;
+        double postfit_ddcp_rms_m = 0.0;
+        double postfit_ddcp_max_normalized = 0.0;
+        double postfit_ddcp_chi2_per_dof = 0.0;
+        bool static_fixed_decision_pass = false;
+        bool accepted_by_existing_pipeline = false;
+    };
+
     /// Per-epoch fixed-lag integrity state.  These values expose why an epoch
     /// did or did not fix, rather than only reporting the final FIX/FLOAT label.
     struct FGOEpochDiagnostics {
@@ -2014,6 +2052,8 @@ public:
         int ambiguity_candidates_excluded_fde = 0;
         int ambiguity_candidates_excluded_stale = 0;
         std::vector<AmbiguityCandidateTrace> ambiguity_candidate_trace;
+        std::vector<AmbiguityResolutionAttemptTrace>
+            ambiguity_resolution_attempt_trace;
         int ambiguity_generation_bumps_hold = 0;
         int ambiguity_generation_bumps_fde = 0;
         int ambiguity_generation_bumps_reset = 0;

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -3520,14 +3520,70 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
 
                         Eigen::VectorXd fixed_amb;
                         double ratio = 0.0;
+                        auto& attempt_trace =
+                            epoch_diagnostics[i]
+                                .ambiguity_resolution_attempt_trace
+                                .emplace_back();
+                        attempt_trace.attempt_index =
+                            static_cast<int>(
+                                epoch_diagnostics[i]
+                                    .ambiguity_resolution_attempt_trace
+                                    .size()) -
+                            1;
+                        attempt_trace.subset_size = subset;
+                        attempt_trace.lambda_stage =
+                            lambda_stages[lambda_order_idx];
                         ++lambda_attempts;
                         ++result.diagnostics.lambda_ambiguity_attempts;
                         ++epoch_diagnostics[i].lambda_attempts;
                         result.diagnostics.lambda_ambiguity_candidates +=
                             static_cast<std::size_t>(subset);
-                        if (!lambdaSearch(sub_float, sub_q, fixed_amb, ratio)) {
+                        LambdaCandidateDiagnostics lambda_diagnostics;
+                        if (!lambdaSearchTopK(
+                                sub_float, sub_q, 2, lambda_diagnostics)) {
                             if (!config.use_fixed_lag_partial_lambda) break;
                             continue;
+                        }
+                        fixed_amb = lambda_diagnostics.candidates.col(0);
+                        const double best_squared_residual =
+                            lambda_diagnostics.squared_residuals(0);
+                        ratio = best_squared_residual > 0.0
+                                    ? lambda_diagnostics.squared_residuals(1) /
+                                          best_squared_residual
+                                    : 0.0;
+                        attempt_trace.lambda_search_solved = true;
+                        attempt_trace.ratio = ratio;
+                        for (std::size_t scale_index = 0;
+                             scale_index <
+                             FGOProcessor::AmbiguityResolutionAttemptTrace::
+                                 covariance_scales.size();
+                             ++scale_index) {
+                            const double bsr = bootstrappedSuccessRate(
+                                lambda_diagnostics.conditional_variances,
+                                FGOProcessor::
+                                    AmbiguityResolutionAttemptTrace::
+                                        covariance_scales[scale_index]);
+                            attempt_trace.bootstrapped_success_rate
+                                [scale_index] = bsr;
+                            FixedFailureRateRatioThreshold ffrt;
+                            const bool supported =
+                                fixedFailureRateRatioThreshold(
+                                    subset, bsr, 0.001, ffrt);
+                            attempt_trace.ffrt_supported[scale_index] =
+                                supported;
+                            attempt_trace.ffrt_accepts_any_candidate
+                                [scale_index] =
+                                supported && ffrt.accepts_any_candidate;
+                            attempt_trace.ffrt_minimum_ratio[scale_index] =
+                                supported
+                                    ? ffrt.minimum_second_to_best_ratio
+                                    : std::numeric_limits<double>::infinity();
+                            attempt_trace.ffrt_pass[scale_index] =
+                                attempt_trace.ffrt_accepts_any_candidate
+                                    [scale_index] &&
+                                std::isfinite(ratio) &&
+                                ratio >=
+                                    ffrt.minimum_second_to_best_ratio;
                         }
                         result.diagnostics.lambda_ambiguity_fix_solved = true;
                         epoch_diagnostics[i].ar_outcome =
@@ -3555,6 +3611,17 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                                         epoch_diagnostics[i].fixed_imu_prediction_separation_m =
                                             (provisional_fixed_ant - Eigen::Vector3d(
                                                  antennaOf(pose_seed))).norm();
+                                        attempt_trace.candidate_position_valid =
+                                            true;
+                                        attempt_trace.candidate_position_ecef =
+                                            provisional_fixed_ant;
+                                        attempt_trace.fixed_float_separation_m =
+                                            epoch_diagnostics[i]
+                                                .fixed_float_separation_m;
+                                        attempt_trace
+                                            .fixed_imu_prediction_separation_m =
+                                            epoch_diagnostics[i]
+                                                .fixed_imu_prediction_separation_m;
                                         if (has_antenna_position_cov) {
                                             provisional_fixed_cov =
                                                 antenna_position_cov -
@@ -3688,6 +3755,10 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                             std::isfinite(ratio) &&
                             (effective_ratio_threshold <= 0.0 ||
                              ratio > effective_ratio_threshold);
+                        attempt_trace.configured_ratio_pass =
+                            configured_ratio_pass;
+                        attempt_trace.effective_ratio_pass =
+                            normal_ratio_pass;
                         // --- Surplus-satellite independent integrity
                         // validation (use_surplus_satellite_validation).
                         // Evaluated for EVERY attempt (both the established
@@ -3710,6 +3781,13 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                                     surplus_pool, fixed_cycles_by_index, provisional_fixed_ant, config);
                             surplus_evaluated = surplus_diag.evaluated;
                             surplus_pass = surplus_diag.pass;
+                            attempt_trace.surplus_evaluated =
+                                surplus_evaluated;
+                            attempt_trace.surplus_pass = surplus_pass;
+                            attempt_trace.surplus_fallback_level =
+                                surplus_diag.fallback_level;
+                            attempt_trace.surplus_used =
+                                surplus_diag.surplus_used;
                             epoch_diagnostics[i].surplus_validation_evaluated = surplus_evaluated;
                             epoch_diagnostics[i].surplus_validation_pass = surplus_pass;
                             epoch_diagnostics[i].surplus_validation_fallback_level =
@@ -4109,6 +4187,22 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                                  : (established_path_pass || incremental_integrity_pass)) &&
                             !defer_relaxed_fix_to_existing_hold &&
                             relaxed_plausibility_pass && fixed_amb.size() == subset;
+                        if (attempt_trace.candidate_position_valid) {
+                            attempt_trace.postfit_ddcp_factors =
+                                epoch_diagnostics[i]
+                                    .fixed_postfit_ddcp_factors;
+                            attempt_trace.postfit_ddcp_rms_m =
+                                epoch_diagnostics[i]
+                                    .fixed_postfit_ddcp_rms_m;
+                            attempt_trace.postfit_ddcp_max_normalized =
+                                epoch_diagnostics[i]
+                                    .fixed_postfit_ddcp_max_normalized;
+                            attempt_trace.postfit_ddcp_chi2_per_dof =
+                                epoch_diagnostics[i]
+                                    .fixed_postfit_ddcp_chi2_per_dof;
+                        }
+                        attempt_trace.static_fixed_decision_pass =
+                            fixed_decision_pass;
                         bool integer_constrained_pass = true;
                         if (fixed_decision_pass &&
                             config.use_integer_constrained_reoptimization) {
@@ -4192,6 +4286,8 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                         }
                         const bool fixed_epoch =
                             fixed_decision_pass && integer_constrained_pass;
+                        attempt_trace.accepted_by_existing_pipeline =
+                            fixed_epoch;
                         // Record float ambiguity values for the result mapping
                         // (full candidate set, once).
                         if (!float_cycles_recorded) {

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -587,6 +587,87 @@ TEST(FGOAmbiguityCandidateTelemetryTest, ReportsBuildTimeExcludedCarrierRows) {
         FGOProcessor::AmbiguityCandidateDisposition::BuildTimeExcluded);
 }
 
+TEST(FGOAmbiguityAttemptTelemetryTest,
+     ReportsFfrtShadowWithoutChangingStaticRatioDecision) {
+    CpHoldTestOptions opt;
+    opt.num_epochs = 8;
+    opt.satellites = gtsamParitySatelliteGeometry();
+    opt.satellites.emplace_back(-20000000.0, 10000000.0, 12000000.0);
+    opt.satellites.emplace_back(9000000.0, 20000000.0, 15000000.0);
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
+    config.use_lambda_ambiguity_fix = true;
+    config.lambda_ratio_threshold =
+        std::numeric_limits<double>::max();
+    config.min_fixed_ambiguities = 5;
+
+    const FGOProcessor processor(config);
+    const FGOProcessor::FGOResult result =
+        processor.optimizeProblem(problem);
+
+    ASSERT_EQ(result.epoch_diagnostics.size(), problem.epochs.size());
+    bool saw_solved_attempt = false;
+    for (std::size_t epoch_index = 0;
+         epoch_index < result.epoch_diagnostics.size();
+         ++epoch_index) {
+        const auto& epoch = result.epoch_diagnostics[epoch_index];
+        EXPECT_EQ(
+            epoch.ambiguity_resolution_attempt_trace.size(),
+            static_cast<std::size_t>(epoch.lambda_attempts));
+        for (const auto& attempt :
+             epoch.ambiguity_resolution_attempt_trace) {
+            EXPECT_EQ(attempt.subset_size, 7);
+            EXPECT_EQ(attempt.lambda_stage, -1);
+            if (!attempt.lambda_search_solved) continue;
+            saw_solved_attempt = true;
+            EXPECT_TRUE(std::isfinite(attempt.ratio));
+            EXPECT_TRUE(attempt.candidate_position_valid);
+            EXPECT_TRUE(
+                attempt.candidate_position_ecef.allFinite());
+            EXPECT_FALSE(attempt.configured_ratio_pass);
+            EXPECT_FALSE(attempt.effective_ratio_pass);
+            EXPECT_FALSE(attempt.static_fixed_decision_pass);
+            EXPECT_FALSE(attempt.accepted_by_existing_pipeline);
+            EXPECT_NE(
+                result.solution.solutions[epoch_index].status,
+                SolutionStatus::FIXED);
+            for (std::size_t scale_index = 0;
+                 scale_index <
+                 FGOProcessor::AmbiguityResolutionAttemptTrace::
+                     covariance_scales.size();
+                 ++scale_index) {
+                EXPECT_TRUE(std::isfinite(
+                    attempt.bootstrapped_success_rate[scale_index]));
+                EXPECT_GE(
+                    attempt.bootstrapped_success_rate[scale_index],
+                    0.0);
+                EXPECT_LE(
+                    attempt.bootstrapped_success_rate[scale_index],
+                    1.0);
+                EXPECT_TRUE(
+                    attempt.ffrt_supported[scale_index]);
+                EXPECT_EQ(
+                    attempt.ffrt_pass[scale_index],
+                    attempt.ffrt_accepts_any_candidate[scale_index] &&
+                        std::isfinite(attempt.ratio) &&
+                        attempt.ratio >=
+                            attempt.ffrt_minimum_ratio[scale_index]);
+                if (!attempt.ffrt_accepts_any_candidate[scale_index]) {
+                    EXPECT_FALSE(attempt.ffrt_pass[scale_index]);
+                }
+                if (scale_index > 0) {
+                    EXPECT_LE(
+                        attempt.bootstrapped_success_rate[scale_index],
+                        attempt.bootstrapped_success_rate[
+                            scale_index - 1]);
+                }
+            }
+        }
+    }
+    EXPECT_TRUE(saw_solved_attempt);
+}
+
 TEST(FGOCpHoldFsmTest, DefaultOffIsNoOp) {
     CpHoldTestOptions opt;
     opt.carrier_corrupt_epochs = {5, 6, 7, 8, 9, 10, 11, 12};


### PR DESCRIPTION
## Summary

- record one behavior-neutral trace row for every concrete FGO LAMBDA subset attempt
- compute bootstrapped success rate and Hou–Verhagen–Wu fixed-failure-rate ratio thresholds at covariance scales 1/2/4/8/16
- distinguish coefficient support from the low-success-rate `accepts_any_candidate=false` state
- write normalized `<dump>.ar_attempts.csv` output with candidate position, existing ratio/integrity verdicts, surplus evidence, and post-fit evidence
- document why no covariance scale is selected before Tokyo1 development and Tokyo2 validation

## Why

The candidate-attribution work in #395 showed that 1,727 Tokyo1 FLOAT epochs are actual fixed-ratio rejections, making covariance-derived BSR/FFRT the next useful read-only experiment. Existing terminal AR outcome labels alone were insufficient to compare the rejected integer candidate against the shipping decision path.

This PR is intentionally shadow-only: FFRT values never promote or demote a solution. It is stacked on #395 and should be retargeted to `develop` after #395 merges.

The FFRT calculation follows [Hou, Verhagen, and Wu (2016)](https://doi.org/10.3390/s16070945). The multi-scale, development/validation separation is motivated by the stochastic-model sensitivity discussed in the [two-step success-rate criterion study](https://doi.org/10.1007/s10291-022-01317-0).

## Validation

- MSVC Release builds: `gnss_lib_noopt`, `gnss_run_tests`, and `gnss_fgo_parity`
- FGO-focused unit/integration tests: 83/83 passed
- Tokyo1 shipping-profile replay, first 200 epochs: 199 FIXED / 1 FLOAT, 100% under 0.5 m
- existing epoch CSV: 200/200 rows and all columns exactly match the #395 baseline
- existing candidate CSV: 7,721/7,721 rows exactly match the #395 baseline
- attempt ledger: 203 rows equals the sum of per-epoch LAMBDA attempts; no attempt-index, BSR monotonicity, or FFRT-state/formula mismatches

Part of #389.
