### PR TITLE
Add FGO SRC subset shadow telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,13 @@ optimism; no scale is selected until Tokyo1 development and independent
 Tokyo2 validation are complete. This follows the model/data separation
 described by the
 [two-step success-rate criterion](https://doi.org/10.1007/s10291-022-01317-0).
+The `src_*_q*` columns additionally search the trailing LAMBDA-decorrelated
+subset whose bootstrapped success rate meets 0.999. Its integer candidate is
+propagated to a shadow ECEF position through the transformed
+position/ambiguity cross-covariance. It is not treated as a subset of original
+ambiguity indices and does not create integer constraints or alter the
+shipping solution. SRC shadow evaluation is default-off in the library and is
+enabled by this parity harness only when `--dump-csv` is requested.
 
 #### Surplus-satellite rescue integrity
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,9 @@ propagated to a shadow ECEF position through the transformed
 position/ambiguity cross-covariance. It is not treated as a subset of original
 ambiguity indices and does not create integer constraints or alter the
 shipping solution. SRC shadow evaluation is default-off in the library and is
-enabled by this parity harness only when `--dump-csv` is requested.
+enabled in the parity harness with `--src-shadow`; use it together with
+`--dump-csv` to export the shadow columns. Ordinary CSV diagnostics therefore
+do not pay for the five extra subset searches per ambiguity attempt.
 
 #### Surplus-satellite rescue integrity
 

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -210,6 +210,7 @@ struct Args {
     bool low_count_ar = false;
     int low_count_ar_min = -1;        // >0: override low_count_min_candidates (default 4)
     double low_count_ar_ratio = -1.0; // >=0: override low_count_min_ratio (default 1.5); use --low-count-ratio 0 for "surplus alone"
+    bool src_shadow = false;    // opt-in SRC subset searches in attempt telemetry
     std::string dump_csv_path;  // debug: per-epoch CSV dump (tow/status/E-N-U err/position) for plotting
     // Opt-in FGOProblem cache (skips repeated RINEX parse + problem build
     // across validation runs on the SAME inputs/config). Default-off; when
@@ -234,6 +235,10 @@ Args parseArgs(int argc, char** argv) {
         }
         if (a == "--no-held-fix-label") {
             args.no_held_fix_label = true;
+            continue;
+        }
+        if (a == "--src-shadow") {
+            args.src_shadow = true;
             continue;
         }
         if (a == "--gici-par") {
@@ -686,8 +691,7 @@ libgnss::FGOProcessor::FGOConfig makeRealDataDdConfig() {
 // call, without duplicating this arg-to-config mapping logic.
 libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
     libgnss::FGOProcessor::FGOConfig config = makeRealDataDdConfig();
-    config.enable_src_shadow_telemetry =
-        !args.dump_csv_path.empty();
+    config.enable_src_shadow_telemetry = args.src_shadow;
     config.report_held_ambiguities_as_fixed = !args.no_held_fix_label;
     if (args.max_iters > 0) {
         config.max_iterations = args.max_iters;

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -686,6 +686,8 @@ libgnss::FGOProcessor::FGOConfig makeRealDataDdConfig() {
 // call, without duplicating this arg-to-config mapping logic.
 libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
     libgnss::FGOProcessor::FGOConfig config = makeRealDataDdConfig();
+    config.enable_src_shadow_telemetry =
+        !args.dump_csv_path.empty();
     config.report_held_ambiguities_as_fixed = !args.no_held_fix_label;
     if (args.max_iters > 0) {
         config.max_iterations = args.max_iters;
@@ -1668,7 +1670,15 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                      << ",ffrt_min_ratio_q" << scale
                      << ",ffrt_supported_q" << scale
                      << ",ffrt_accepts_any_candidate_q" << scale
-                     << ",ffrt_pass_q" << scale;
+                     << ",ffrt_pass_q" << scale
+                     << ",src_subset_size_q" << scale
+                     << ",src_bsr_q" << scale
+                     << ",src_search_solved_q" << scale
+                     << ",src_ratio_q" << scale
+                     << ",src_candidate_position_valid_q" << scale
+                     << ",src_candidate_x_ecef_m_q" << scale
+                     << ",src_candidate_y_ecef_m_q" << scale
+                     << ",src_candidate_z_ecef_m_q" << scale;
     }
     attempts_out
         << ",surplus_eval,surplus_pass,surplus_level,surplus_used,"
@@ -1716,7 +1726,39 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                             ? 1
                             : 0)
                     << ','
-                    << (attempt.ffrt_pass[scale_index] ? 1 : 0);
+                    << (attempt.ffrt_pass[scale_index] ? 1 : 0)
+                    << ','
+                    << attempt.src_subset_size[scale_index]
+                    << ','
+                    << attempt
+                           .src_bootstrapped_success_rate[scale_index]
+                    << ','
+                    << (attempt.src_search_solved[scale_index] ? 1 : 0)
+                    << ','
+                    << attempt.src_ratio[scale_index]
+                    << ','
+                    << (attempt
+                                .src_candidate_position_valid[scale_index]
+                            ? 1
+                            : 0)
+                    << ',';
+                if (attempt
+                        .src_candidate_position_valid[scale_index]) {
+                    attempts_out
+                        << attempt
+                               .src_candidate_position_ecef[scale_index]
+                               .x()
+                        << ','
+                        << attempt
+                               .src_candidate_position_ecef[scale_index]
+                               .y()
+                        << ','
+                        << attempt
+                               .src_candidate_position_ecef[scale_index]
+                               .z();
+                } else {
+                    attempts_out << ",,";
+                }
             }
             attempts_out
                 << ',' << (attempt.surplus_evaluated ? 1 : 0)

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -153,6 +153,10 @@ public:
         bool fix_ambiguities = false;
         bool prefer_double_difference_ambiguity_fixing = true;
         bool use_lambda_ambiguity_fix = true;
+        // Evaluate success-rate-criterion subsets and candidate positions for
+        // diagnostics only. Default OFF because the extra ILS searches are
+        // intentionally not part of the shipping decision or runtime path.
+        bool enable_src_shadow_telemetry = false;
         bool use_epoch_lambda_fixed_output = false;
         bool use_partial_lambda_ambiguity_fix = true;
         // Independently re-optimize the active fixed-lag graph with the
@@ -1943,6 +1947,7 @@ public:
     struct AmbiguityResolutionAttemptTrace {
         inline static constexpr std::array<double, 5> covariance_scales{
             1.0, 2.0, 4.0, 8.0, 16.0};
+        inline static constexpr double src_minimum_success_rate = 0.999;
 
         int attempt_index = -1;
         int subset_size = 0;
@@ -1954,6 +1959,14 @@ public:
         std::array<bool, 5> ffrt_supported{};
         std::array<bool, 5> ffrt_accepts_any_candidate{};
         std::array<bool, 5> ffrt_pass{};
+        std::array<int, 5> src_subset_size{};
+        std::array<double, 5> src_bootstrapped_success_rate{};
+        std::array<bool, 5> src_search_solved{};
+        std::array<double, 5> src_ratio{};
+        std::array<bool, 5> src_candidate_position_valid{};
+        std::array<Vector3d, 5> src_candidate_position_ecef{
+            Vector3d::Zero(), Vector3d::Zero(), Vector3d::Zero(),
+            Vector3d::Zero(), Vector3d::Zero()};
         bool candidate_position_valid = false;
         Vector3d candidate_position_ecef = Vector3d::Zero();
         double fixed_float_separation_m = 0.0;

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -3553,6 +3553,15 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                                     : 0.0;
                         attempt_trace.lambda_search_solved = true;
                         attempt_trace.ratio = ratio;
+                        struct SrcShadowCandidate {
+                            bool search_solved = false;
+                            double ratio = 0.0;
+                            bool position_valid = false;
+                            Eigen::Vector3d position_ecef =
+                                Eigen::Vector3d::Zero();
+                        };
+                        std::map<int, SrcShadowCandidate>
+                            src_shadow_candidates_by_size;
                         for (std::size_t scale_index = 0;
                              scale_index <
                              FGOProcessor::AmbiguityResolutionAttemptTrace::
@@ -3584,6 +3593,130 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                                 std::isfinite(ratio) &&
                                 ratio >=
                                     ffrt.minimum_second_to_best_ratio;
+                            if (!config.enable_src_shadow_telemetry) {
+                                continue;
+                            }
+
+                            const double covariance_scale =
+                                FGOProcessor::
+                                    AmbiguityResolutionAttemptTrace::
+                                        covariance_scales[scale_index];
+                            const int src_subset_size =
+                                successRateCriterionSubsetSize(
+                                    lambda_diagnostics
+                                        .conditional_variances,
+                                    covariance_scale,
+                                    FGOProcessor::
+                                        AmbiguityResolutionAttemptTrace::
+                                            src_minimum_success_rate);
+                            attempt_trace.src_subset_size[scale_index] =
+                                src_subset_size;
+                            if (src_subset_size <= 0) continue;
+
+                            const Eigen::VectorXd src_conditional_variances =
+                                lambda_diagnostics
+                                    .conditional_variances
+                                    .tail(src_subset_size);
+                            attempt_trace
+                                .src_bootstrapped_success_rate[scale_index] =
+                                bootstrappedSuccessRate(
+                                    src_conditional_variances,
+                                    covariance_scale);
+
+                            auto candidate_it =
+                                src_shadow_candidates_by_size.find(
+                                    src_subset_size);
+                            if (candidate_it ==
+                                src_shadow_candidates_by_size.end()) {
+                                SrcShadowCandidate candidate;
+                                const Eigen::VectorXd src_float =
+                                    lambda_diagnostics
+                                        .decorrelated_float
+                                        .tail(src_subset_size);
+                                const Eigen::MatrixXd src_q =
+                                    lambda_diagnostics
+                                        .decorrelated_covariance
+                                        .bottomRightCorner(
+                                            src_subset_size,
+                                            src_subset_size);
+                                LambdaCandidateDiagnostics
+                                    src_lambda_diagnostics;
+                                Eigen::VectorXd src_fixed;
+                                if (src_subset_size == subset) {
+                                    candidate.search_solved = true;
+                                    candidate.ratio = ratio;
+                                    src_fixed =
+                                        lambda_diagnostics
+                                            .decorrelation_transform
+                                            .transpose() *
+                                        fixed_amb;
+                                } else if (lambdaSearchTopK(
+                                               src_float, src_q, 2,
+                                               src_lambda_diagnostics)) {
+                                    candidate.search_solved = true;
+                                    const double src_best_residual =
+                                        src_lambda_diagnostics
+                                            .squared_residuals(0);
+                                    candidate.ratio =
+                                        src_best_residual > 0.0
+                                            ? src_lambda_diagnostics
+                                                      .squared_residuals(1) /
+                                                  src_best_residual
+                                            : 0.0;
+                                    src_fixed =
+                                        src_lambda_diagnostics
+                                            .candidates.col(0);
+                                }
+                                if (candidate.search_solved &&
+                                    src_fixed.size() ==
+                                        src_subset_size) {
+                                    const Eigen::VectorXd src_delta =
+                                        src_float - src_fixed;
+                                    const Eigen::LDLT<Eigen::MatrixXd>
+                                        src_ldlt(src_q);
+                                    if (src_ldlt.info() ==
+                                        Eigen::Success) {
+                                        const Eigen::VectorXd src_corr =
+                                            src_ldlt.solve(src_delta);
+                                        const Eigen::MatrixXd src_pos =
+                                            sub_pos *
+                                            lambda_diagnostics
+                                                .decorrelation_transform
+                                                .rightCols(
+                                                    src_subset_size);
+                                        const Eigen::Vector3d src_pd =
+                                            src_pos * src_corr;
+                                        if (src_corr.allFinite() &&
+                                            src_pd.allFinite()) {
+                                            candidate.position_ecef =
+                                                Eigen::Vector3d(
+                                                    antennaOf(pose_i)) -
+                                                src_pd;
+                                            candidate.position_valid =
+                                                candidate.position_ecef
+                                                    .allFinite();
+                                        }
+                                    }
+                                }
+                                candidate_it =
+                                    src_shadow_candidates_by_size
+                                        .emplace(
+                                            src_subset_size,
+                                            std::move(candidate))
+                                        .first;
+                            }
+                            const SrcShadowCandidate& src_candidate =
+                                candidate_it->second;
+                            attempt_trace.src_search_solved[scale_index] =
+                                src_candidate.search_solved;
+                            attempt_trace.src_ratio[scale_index] =
+                                src_candidate.ratio;
+                            attempt_trace
+                                .src_candidate_position_valid[scale_index] =
+                                src_candidate.position_valid;
+                            attempt_trace
+                                .src_candidate_position_ecef[scale_index] =
+                                src_candidate.position_ecef;
                         }
                         result.diagnostics.lambda_ambiguity_fix_solved = true;
                         epoch_diagnostics[i].ar_outcome =

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -598,6 +598,7 @@ TEST(FGOAmbiguityAttemptTelemetryTest,
 
     FGOProcessor::FGOConfig config = makeCpHoldBaseConfig();
     config.use_lambda_ambiguity_fix = true;
+    config.enable_src_shadow_telemetry = true;
     config.lambda_ratio_threshold =
         std::numeric_limits<double>::max();
     config.min_fixed_ambiguities = 5;
@@ -605,16 +606,52 @@ TEST(FGOAmbiguityAttemptTelemetryTest,
     const FGOProcessor processor(config);
     const FGOProcessor::FGOResult result =
         processor.optimizeProblem(problem);
+    FGOProcessor::FGOConfig disabled_config = config;
+    disabled_config.enable_src_shadow_telemetry = false;
+    const FGOProcessor disabled_processor(disabled_config);
+    const FGOProcessor::FGOResult disabled_result =
+        disabled_processor.optimizeProblem(problem);
 
     ASSERT_EQ(result.epoch_diagnostics.size(), problem.epochs.size());
+    ASSERT_EQ(
+        disabled_result.solution.solutions.size(),
+        result.solution.solutions.size());
+    ASSERT_EQ(
+        disabled_result.epoch_diagnostics.size(),
+        result.epoch_diagnostics.size());
     bool saw_solved_attempt = false;
     for (std::size_t epoch_index = 0;
          epoch_index < result.epoch_diagnostics.size();
          ++epoch_index) {
         const auto& epoch = result.epoch_diagnostics[epoch_index];
+        const auto& disabled_epoch =
+            disabled_result.epoch_diagnostics[epoch_index];
+        EXPECT_EQ(
+            disabled_result.solution.solutions[epoch_index].status,
+            result.solution.solutions[epoch_index].status);
+        EXPECT_TRUE(
+            disabled_result.solution.solutions[epoch_index]
+                .position_ecef.isApprox(
+                    result.solution.solutions[epoch_index]
+                        .position_ecef));
         EXPECT_EQ(
             epoch.ambiguity_resolution_attempt_trace.size(),
             static_cast<std::size_t>(epoch.lambda_attempts));
+        ASSERT_EQ(
+            disabled_epoch.ambiguity_resolution_attempt_trace.size(),
+            epoch.ambiguity_resolution_attempt_trace.size());
+        for (const auto& disabled_attempt :
+             disabled_epoch.ambiguity_resolution_attempt_trace) {
+            EXPECT_EQ(
+                disabled_attempt.src_subset_size,
+                (std::array<int, 5>{}));
+            EXPECT_EQ(
+                disabled_attempt.src_search_solved,
+                (std::array<bool, 5>{}));
+            EXPECT_EQ(
+                disabled_attempt.src_candidate_position_valid,
+                (std::array<bool, 5>{}));
+        }
         for (const auto& attempt :
              epoch.ambiguity_resolution_attempt_trace) {
             EXPECT_EQ(attempt.subset_size, 7);
@@ -656,11 +693,35 @@ TEST(FGOAmbiguityAttemptTelemetryTest,
                 if (!attempt.ffrt_accepts_any_candidate[scale_index]) {
                     EXPECT_FALSE(attempt.ffrt_pass[scale_index]);
                 }
+                EXPECT_GE(
+                    attempt.src_subset_size[scale_index], 0);
+                EXPECT_LE(
+                    attempt.src_subset_size[scale_index],
+                    attempt.subset_size);
+                if (attempt.src_subset_size[scale_index] > 0) {
+                    EXPECT_GE(
+                        attempt.src_bootstrapped_success_rate[scale_index],
+                        FGOProcessor::AmbiguityResolutionAttemptTrace::
+                            src_minimum_success_rate - 1e-12);
+                    EXPECT_TRUE(
+                        attempt.src_search_solved[scale_index]);
+                    EXPECT_TRUE(std::isfinite(
+                        attempt.src_ratio[scale_index]));
+                    EXPECT_TRUE(
+                        attempt.src_candidate_position_valid[scale_index]);
+                    EXPECT_TRUE(
+                        attempt
+                            .src_candidate_position_ecef[scale_index]
+                            .allFinite());
+                }
                 if (scale_index > 0) {
                     EXPECT_LE(
                         attempt.bootstrapped_success_rate[scale_index],
                         attempt.bootstrapped_success_rate[
                             scale_index - 1]);
+                    EXPECT_LE(
+                        attempt.src_subset_size[scale_index],
+                        attempt.src_subset_size[scale_index - 1]);
                 }
             }
         }


### PR DESCRIPTION
## Summary

- choose the trailing LAMBDA-decorrelated SRC subset that meets a 0.999 bootstrapped success-rate threshold
- evaluate covariance scales 1/2/4/8/16 without selecting a shipping scale
- run ILS on the transformed subset and propagate its integer candidate to an ECEF position through the transformed position/ambiguity cross-covariance
- record subset size, subset BSR, ratio, and candidate position in the attempt CSV
- keep the library feature default-off; the parity harness enables it only for `--dump-csv`

## Why

The full Tokyo1 FFRT shadow run in #397 showed that direct FFRT promotion is unsafe. Even covariance scale 16 plus the existing surplus and basic plausibility checks left 246 correct and 200 wrong candidates among existing ratio-rejected epochs.

The cited SRC/TSRC method does not simply relax the full-set ratio threshold or drop original ambiguity indices by marginal variance. It fixes the most precise trailing subset in the integer Z-transformed ambiguity domain. This PR implements that candidate computation in shadow mode so it can be evaluated before any transformed integer constraints are introduced.

The implementation follows the SRC construction and conditional baseline update described in [Hou et al. (2022)](https://doi.org/10.1007/s10291-022-01317-0). Covariance scales remain explicit because that study also reports strong sensitivity to an optimistic ambiguity covariance model.

This PR is stacked on #397. It does not promote, demote, hold, or constrain any ambiguity.

## Validation

- MSVC Release builds: `gnss_lib_noopt`, `gnss_run_tests`, and `gnss_fgo_parity`
- FGO-focused unit/integration tests: 83/83 passed
- default-off and enabled synthetic runs produce identical statuses and ECEF positions
- Tokyo1 shipping-profile replay, first 200 epochs: 199 FIXED / 1 FLOAT
- existing epoch CSV and 7,721-row candidate CSV exactly match the baseline SHA-256 hashes
- attempt ledger: 203 rows, 89 columns, zero covariance-scale subset-size monotonicity violations
- all nonempty subsets meet BSR >= 0.999 and produce finite ILS ratios and ECEF candidate positions
- whenever the SRC subset contains the full ambiguity set, its candidate position matches the existing full candidate exactly

Part of #389.
