### PR TITLE
Add anchor-gated FIX demotion reprieve

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,20 @@ above 0.5 m:
 | Tokyo run2 | 6336 → **6339** | **314 → 314** | 0.21668 → **0.21663 m** | **7130 → 7130** |
 | Tokyo run3 | 9961 → **9963** | **1002 → 1002** | 0.25744 → **0.25742 m** | **10407 → 10407** |
 
+`--fix-demote-surplus-anchor-reprieve` is an additional opt-in, fail-closed
+recovery for otherwise demoted fixes. It requires the surplus test to pass,
+at least 12 observed satellites, fixed/float separation at most 1 m, carrier
+post-fit RMS at most 0.1 m, and a trusted independently solved DD-code anchor
+within 8 m of the fixed candidate. The anchor is used only to validate the
+reprieve; this switch does not enable additional anchor-based demotions.
+Full-run A/B replays added only correct fixes:
+
+| Run | Correct FIX | Wrong FIX |
+|---|---:|---:|
+| Tokyo run1 | 4955 → **5144** | **978 → 978** |
+| Tokyo run2 | 6339 → **6357** | **314 → 314** |
+| Tokyo run3 | 9963 → **9969** | **1002 → 1002** |
+
 The rescue remains opt-in at the library API level; the command above is the
 validated shipping preset. Separately, counterfactual auditing of the
 fixed-lag-QR configuration moved its `--fix-demote-res` from 25 to 40 (25

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -30,7 +30,6 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
-#include <limits>
 #include <map>
 #include <sstream>
 #include <string>
@@ -323,7 +322,6 @@ Args parseArgs(int argc, char** argv) {
         if (a == "--fix-demote-surplus-anchor-reprieve") {
             args.fix_demote_surplus_crosscheck = true;
             args.fix_demote_surplus_anchor_reprieve = true;
-            args.fix_demote_anchor = true;
             continue;
         }
         if (a == "--cmc-ref") {
@@ -835,10 +833,6 @@ libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
     }
     if (args.fix_demote_surplus_anchor_reprieve) {
         config.fix_demote_surplus_anchor_reprieve = true;
-        if (args.fix_demote_anchor_dist < 0.0) {
-            config.fix_demote_anchor_distance_m =
-                std::numeric_limits<double>::infinity();
-        }
     }
     if (args.leaky_persist) {
         config.use_cp_hold_leaky_persist = true;

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -30,6 +30,7 @@
 #include <filesystem>
 #include <fstream>
 #include <iostream>
+#include <limits>
 #include <map>
 #include <sstream>
 #include <string>
@@ -191,6 +192,7 @@ struct Args {
     double fix_demote_anchor_gross_ratio = -1.0;  // >=0: override fix_demote_anchor_gross_ratio (default 10.0)
     double fix_demote_anchor_gross_abs = -1.0;    // >=0: override fix_demote_anchor_gross_abs_m (default 20.0)
     bool fix_demote_surplus_crosscheck = false;   // enable fix_demote_surplus_crosscheck (needs --fix-demote + --surplus-validation)
+    bool fix_demote_surplus_anchor_reprieve = false;  // fail-closed surplus + independent DDPR anchor preset
     bool surplus_overrides_dr = false;   // "c2" lever: enable surplus_validation_overrides_history_dr (needs --fixed-history-dr + --surplus-validation)
     int surplus_overrides_dr_min_used = 0;  // >0: override surplus_validation_overrides_history_dr_min_surplus_used (default 0 = no extra floor)
     int surplus_overrides_dr_max_consec = 0;  // >0: override surplus_validation_overrides_history_dr_max_consecutive (default 0 = no cap)
@@ -316,6 +318,12 @@ Args parseArgs(int argc, char** argv) {
         }
         if (a == "--fix-demote-surplus-crosscheck") {
             args.fix_demote_surplus_crosscheck = true;
+            continue;
+        }
+        if (a == "--fix-demote-surplus-anchor-reprieve") {
+            args.fix_demote_surplus_crosscheck = true;
+            args.fix_demote_surplus_anchor_reprieve = true;
+            args.fix_demote_anchor = true;
             continue;
         }
         if (a == "--cmc-ref") {
@@ -824,6 +832,13 @@ libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
     }
     if (args.fix_demote_surplus_crosscheck) {
         config.fix_demote_surplus_crosscheck = true;
+    }
+    if (args.fix_demote_surplus_anchor_reprieve) {
+        config.fix_demote_surplus_anchor_reprieve = true;
+        if (args.fix_demote_anchor_dist < 0.0) {
+            config.fix_demote_anchor_distance_m =
+                std::numeric_limits<double>::infinity();
+        }
     }
     if (args.leaky_persist) {
         config.use_cp_hold_leaky_persist = true;
@@ -2499,6 +2514,8 @@ int main(int argc, char** argv) {
                   << ", anchor_demotions=" << fl.diagnostics.fix_plausibility_anchor_demotions
                   << ", hold_skips=" << fl.diagnostics.fix_plausibility_hold_skips
                   << ", surplus_crosscheck=" << (args.fix_demote_surplus_crosscheck ? "on" : "off")
+                  << ", surplus_anchor_reprieve="
+                  << (args.fix_demote_surplus_anchor_reprieve ? "on" : "off")
                   << ", surplus_reprieves=" << fl.diagnostics.fix_plausibility_surplus_reprieves
                   << ", distance_m=" << config.fix_demote_distance_m
                   << ", anchor=" << (args.fix_demote_anchor ? "on" : "off")

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -1051,6 +1051,14 @@ public:
         // both use_fix_plausibility_demotion and
         // use_surplus_satellite_validation are also on).
         bool fix_demote_surplus_crosscheck = false;
+        // Fail-closed reprieve preset: a surplus PASS may cancel a demotion
+        // only when an independently solved DDPR anchor also agrees with the
+        // fixed candidate and the frozen observation-quality floors pass.
+        bool fix_demote_surplus_anchor_reprieve = false;
+        int fix_demote_surplus_anchor_min_satellites = 12;
+        double fix_demote_surplus_anchor_max_float_separation_m = 1.0;
+        double fix_demote_surplus_anchor_max_postfit_ddcp_rms_m = 0.1;
+        double fix_demote_surplus_anchor_max_gap_m = 8.0;
 
         // --- Exception recovery (port of recovery.py's handle_solve_exception)
         // ---

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -4394,8 +4394,10 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                     ++result.diagnostics.fix_plausibility_anchor_gross_gated;
                 }
             }
-            if (config.fix_demote_use_ddpr_anchor && config.use_ddpr_anchor &&
-                anchor_gross_gate_open) {
+            const bool evaluate_demotion_anchor =
+                config.fix_demote_surplus_anchor_reprieve ||
+                (config.fix_demote_use_ddpr_anchor && config.use_ddpr_anchor);
+            if (evaluate_demotion_anchor && anchor_gross_gate_open) {
                 ++result.diagnostics.ddpr_anchor_solves;
                 const double trust_res = config.fix_demote_anchor_trust_res_m > 0.0
                                              ? config.fix_demote_anchor_trust_res_m
@@ -4444,7 +4446,8 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                     const double anchor_gap = (fix_ant - antennaOf(anchor.pose)).norm();
                     demotion_anchor_trusted = true;
                     demotion_anchor_gap_m = anchor_gap;
-                    if (anchor_gap > config.fix_demote_anchor_distance_m) {
+                    if (config.fix_demote_use_ddpr_anchor &&
+                        anchor_gap > config.fix_demote_anchor_distance_m) {
                         demote = true;
                         ++result.diagnostics.fix_plausibility_anchor_demotions;
                     }

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -4368,6 +4368,9 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             // wrong-basin bands from run1's diffuse-multipath false-veto
             // signature. No-op (gate always open) when the knob is off.
             bool anchor_gross_gate_open = true;
+            bool demotion_anchor_trusted = false;
+            double demotion_anchor_gap_m =
+                std::numeric_limits<double>::infinity();
             if (config.fix_demote_use_ddpr_anchor && config.fix_demote_anchor_gross) {
                 anchor_gross_gate_open = false;
                 if (!per_sat_res.empty()) {
@@ -4391,7 +4394,7 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                     ++result.diagnostics.fix_plausibility_anchor_gross_gated;
                 }
             }
-            if (!demote && config.fix_demote_use_ddpr_anchor && config.use_ddpr_anchor &&
+            if (config.fix_demote_use_ddpr_anchor && config.use_ddpr_anchor &&
                 anchor_gross_gate_open) {
                 ++result.diagnostics.ddpr_anchor_solves;
                 const double trust_res = config.fix_demote_anchor_trust_res_m > 0.0
@@ -4428,10 +4431,19 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                         }
                     }
                 }
+                epoch_diagnostics[i].ddpr_anchor_evaluated = true;
+                epoch_diagnostics[i].ddpr_anchor_active_factors = anchor.n_active;
+                epoch_diagnostics[i].ddpr_anchor_residual_rms_m = anchor.res_rms;
+                if (anchor.ok) {
+                    epoch_diagnostics[i].ddpr_anchor_position_ecef =
+                        antennaOf(anchor.pose);
+                }
                 if (anchor.ok && anchor.n_active >= config.ddpr_anchor_min_factors &&
                     anchor.res_rms <= trust_res) {
                     ++result.diagnostics.ddpr_anchor_successes;
                     const double anchor_gap = (fix_ant - antennaOf(anchor.pose)).norm();
+                    demotion_anchor_trusted = true;
+                    demotion_anchor_gap_m = anchor_gap;
                     if (anchor_gap > config.fix_demote_anchor_distance_m) {
                         demote = true;
                         ++result.diagnostics.fix_plausibility_anchor_demotions;
@@ -4445,9 +4457,24 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             // vouches for the fix. Fail-safe: no verdict or a failing
             // verdict demotes exactly as before. See the knob's comment in
             // fgo.hpp for the measured false-alarm/discrimination numbers.
+            const bool anchor_reprieve_pass =
+                !config.fix_demote_surplus_anchor_reprieve ||
+                (demotion_anchor_trusted &&
+                 demotion_anchor_gap_m <=
+                     config.fix_demote_surplus_anchor_max_gap_m &&
+                 nsat >= config.fix_demote_surplus_anchor_min_satellites &&
+                 std::isfinite(epoch_diagnostics[i].fixed_float_separation_m) &&
+                 epoch_diagnostics[i].fixed_float_separation_m <=
+                     config.fix_demote_surplus_anchor_max_float_separation_m &&
+                 std::isfinite(
+                     epoch_diagnostics[i].fixed_postfit_ddcp_rms_m) &&
+                 epoch_diagnostics[i].fixed_postfit_ddcp_rms_m <=
+                     config
+                         .fix_demote_surplus_anchor_max_postfit_ddcp_rms_m);
             if (demote && config.fix_demote_surplus_crosscheck &&
                 epoch_diagnostics[i].surplus_validation_evaluated &&
-                epoch_diagnostics[i].surplus_validation_pass) {
+                epoch_diagnostics[i].surplus_validation_pass &&
+                anchor_reprieve_pass) {
                 demote = false;
                 ++result.diagnostics.fix_plausibility_surplus_reprieves;
             }


### PR DESCRIPTION
## What changed

- add one opt-in `--fix-demote-surplus-anchor-reprieve` preset
- evaluate the existing robust DDPR anchor even for candidates already scheduled for plausibility demotion
- reprieve only when surplus-carrier validation passes, `nsat >= 12`, fixed/float separation is at most 1 m, carrier post-fit RMS is at most 0.1 m, the DDPR anchor is trusted, and fixed/anchor gap is at most 8 m
- keep anchor-based additional demotion disabled for this preset
- expose demotion-anchor telemetry through the existing CSV fields and document the switch

## Why

The earlier surplus-only reprieve passed Tokyo1 but admitted an internally consistent ~3.4 m wrong basin on Tokyo2. Ratio, carrier post-fit, fixed/float/IMU agreement, and surplus-carrier checks all passed there. The independent robust DDPR anchor separated those failures with 8.61–49.41 m disagreement, so the reprieve now fails closed unless the code anchor also agrees.

## Validation

Correct FIX means 3D error < 0.5 m. Same-binary full-run A/B:

| Run | Baseline correct / wrong | Candidate correct / wrong | Delta |
|---|---:|---:|---:|
| Tokyo1 | 4,955 / 978 | 5,144 / 978 | +189 correct, +0 wrong |
| Tokyo2 | 6,339 / 314 | 6,357 / 314 | +18 correct, +0 wrong |
| Tokyo3 frozen holdout | 9,963 / 1,002 | 9,969 / 1,002 | +6 correct, +0 wrong |

All 213 added FIX epochs are correct. Status-unchanged epochs have byte-identical ECEF CSV outputs. Focused `FGOSurplusValidationTest.*`: 2/2 pass. Default remains off.

Relates to #389.