### PR TITLE
Gate ambiguity reacquisition with DDPR anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,26 @@ Full-run A/B replays added only correct fixes:
 | Tokyo run2 | 6339 → **6357** | **314 → 314** |
 | Tokyo run3 | 9963 → **9969** | **1002 → 1002** |
 
+`--anchor-gated-unfix-reset` adds a fail-closed ambiguity-reacquisition
+policy for sustained fresh-AR outages. The existing satellite-count, GDOP,
+and FDE-fraction gates still apply; at each surviving trigger, a current-epoch
+DD-code anchor must also have enough factors, pass its residual gate, remain
+within 20 m of the IMU prediction, and disagree with the optimized antenna
+position by at least 1 m. Only then are live ambiguity generations renewed.
+The reset does not engage CP hold, break the IMU chain, or label its trigger
+epoch FIXED. Full Tokyo replays combined it with the anchor reprieve above:
+
+| Run | Anchor-only correct/wrong FIX | Anchor-gated reset correct/wrong FIX | Resets allowed / skipped |
+|---|---:|---:|---:|
+| Tokyo run1 | 5144 / 978 | **5469 / 649** | 4 / 5 |
+| Tokyo run2 | **6357 / 314** | **6357 / 314** | 0 / 3 |
+| Tokyo run3 | **9969 / 1002** | **9969 / 1002** | 0 / 4 |
+
+Across the three courses, distance-weighted correct FIX improved from
+57.0731% at the pre-reprieve baseline to **57.9735%**, while
+distance-weighted wrong FIX fell from 7.7043% to **7.0089%**. The policy is
+opt-in and leaves the default library behavior unchanged.
+
 The rescue remains opt-in at the library API level; the command above is the
 validated shipping preset. Separately, counterfactual auditing of the
 fixed-lag-QR configuration moved its `--fix-demote-res` from 25 to 40 (25

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -97,6 +97,7 @@ struct Args {
     bool residual_par = false;
     bool variance_par = false;
     bool gici_par = false;          // GICI-style strict PAR + continuous-unfix reacquisition profile
+    bool anchor_gated_unfix_reset = false;
     double par_max_std = -1.0;
     double hold_ratio = 0.0;       // >0: override ambiguity_hold_ratio_threshold
     int hold_min = 0;              // >0: override ambiguity_hold_min_fixed
@@ -239,6 +240,10 @@ Args parseArgs(int argc, char** argv) {
         }
         if (a == "--gici-par") {
             args.gici_par = true;
+            continue;
+        }
+        if (a == "--anchor-gated-unfix-reset") {
+            args.anchor_gated_unfix_reset = true;
             continue;
         }
         if (a == "--integer-constrained-reoptimization") {
@@ -963,6 +968,10 @@ libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
         if (args.ratio_threshold <= 0.0) config.lambda_ratio_threshold = 3.0;
         if (args.min_fixed <= 0) config.min_fixed_ambiguities = 6;
         if (args.par_max_std < 0.0) config.partial_ar_max_std_cycles = 0.25;
+    }
+    if (args.anchor_gated_unfix_reset) {
+        config.use_continuous_unfix_ambiguity_reset = true;
+        config.continuous_unfix_require_ddpr_anchor_disagreement = true;
     }
     if (args.par_max_std >= 0.0) {
         config.partial_ar_max_std_cycles = args.par_max_std;
@@ -2473,7 +2482,18 @@ int main(int argc, char** argv) {
                   << ", min_sat=" << config.continuous_unfix_min_satellites
                   << ", max_gdop=" << config.continuous_unfix_max_gdop
                   << ", max_fde_fraction="
-                  << config.continuous_unfix_max_fde_reject_fraction << ")\n"
+                  << config.continuous_unfix_max_fde_reject_fraction
+                  << ", anchor_gate="
+                  << (config.continuous_unfix_require_ddpr_anchor_disagreement
+                          ? "on"
+                          : "off")
+                  << ", anchor_min_gap_m="
+                  << config.continuous_unfix_anchor_min_gap_m
+                  << ", anchor_allows="
+                  << fl.diagnostics.ambiguity_continuous_unfix_anchor_allows
+                  << ", anchor_skips="
+                  << fl.diagnostics.ambiguity_continuous_unfix_anchor_skips
+                  << ")\n"
                   << "  CMC screening: " << (args.cmc ? "on" : "off")
                   << " (jump_resets=" << fl.diagnostics.code_minus_carrier_jump_resets
                   << ", level_exclusions=" << fl.diagnostics.code_minus_carrier_level_exclusions

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -394,6 +394,11 @@ public:
         int continuous_unfix_min_satellites = 10;
         double continuous_unfix_max_gdop = 2.0;
         double continuous_unfix_max_fde_reject_fraction = 0.1;
+        // Fail-closed variant: reset live ambiguities only when a trusted
+        // current-epoch DDPR anchor also disagrees with the optimized
+        // antenna position.
+        bool continuous_unfix_require_ddpr_anchor_disagreement = false;
+        double continuous_unfix_anchor_min_gap_m = 1.0;
         int min_fixed_ambiguities = 4;
         int max_lambda_ambiguities = 12;
         // --- Surplus-satellite independent integrity validation ---
@@ -1788,6 +1793,8 @@ public:
         std::size_t ambiguity_generation_bumps_reset = 0;
         std::size_t ambiguity_generation_bumps_warm_reset = 0;
         std::size_t ambiguity_continuous_unfix_resets = 0;
+        std::size_t ambiguity_continuous_unfix_anchor_allows = 0;
+        std::size_t ambiguity_continuous_unfix_anchor_skips = 0;
         std::size_t ambiguity_generation_bumps_stale_pin = 0;
         // --- Stale-pin invalidation diagnostics (use_stale_pin_invalidation) ---
         std::size_t stale_pin_invalidations = 0;  ///< pinned arcs released per-arc at a trigger epoch

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -4514,8 +4514,51 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             if (continuous_unfix_streak >
                     std::max(0, config.continuous_unfix_reset_epochs) &&
                 !live_ambiguity_indices.empty()) {
-                resetAmbiguitiesWithCpHold(i, /*engage_cp_hold=*/false);
-                ++result.diagnostics.ambiguity_continuous_unfix_resets;
+                bool reset_allowed = true;
+                if (config
+                        .continuous_unfix_require_ddpr_anchor_disagreement) {
+                    ++result.diagnostics.ddpr_anchor_solves;
+                    const DdprAnchorResult anchor =
+                        solveDdprAnchor(i, pose_seed);
+                    const double anchor_seed_gap =
+                        anchor.ok
+                            ? (antennaOf(anchor.pose) -
+                               antennaOf(pose_seed))
+                                  .norm()
+                            : std::numeric_limits<double>::infinity();
+                    const bool trusted =
+                        anchor.ok &&
+                        anchor.n_active >= config.ddpr_anchor_min_factors &&
+                        anchor.res_rms <=
+                            config.ddpr_anchor_max_residual_m &&
+                        anchor_seed_gap <=
+                            config.ddpr_anchor_imu_max_gap_m;
+                    const double state_gap =
+                        trusted
+                            ? (antennaOf(anchor.pose) - antennaOf(pose_i))
+                                  .norm()
+                            : 0.0;
+                    reset_allowed =
+                        trusted && std::isfinite(state_gap) &&
+                        state_gap >=
+                            config.continuous_unfix_anchor_min_gap_m;
+                    if (trusted) {
+                        ++result.diagnostics.ddpr_anchor_successes;
+                    }
+                    if (reset_allowed) {
+                        ++result.diagnostics
+                              .ambiguity_continuous_unfix_anchor_allows;
+                    } else {
+                        ++result.diagnostics
+                              .ambiguity_continuous_unfix_anchor_skips;
+                    }
+                }
+                if (reset_allowed) {
+                    resetAmbiguitiesWithCpHold(
+                        i, /*engage_cp_hold=*/false);
+                    ++result.diagnostics
+                          .ambiguity_continuous_unfix_resets;
+                }
                 continuous_unfix_streak = 0;
             }
         }

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -1864,6 +1864,9 @@ TEST(FGOImuIntegrationCovarianceTest, DefaultsMatchPortedReferenceMapping) {
     EXPECT_EQ(config.integer_constrained_max_iterations, 1);
     EXPECT_TRUE(config.report_held_ambiguities_as_fixed);
     EXPECT_FALSE(config.use_continuous_unfix_ambiguity_reset);
+    EXPECT_FALSE(
+        config.continuous_unfix_require_ddpr_anchor_disagreement);
+    EXPECT_DOUBLE_EQ(config.continuous_unfix_anchor_min_gap_m, 1.0);
     EXPECT_DOUBLE_EQ(config.fixed_postfit_normal_ratio_ceiling, 0.0);
     EXPECT_DOUBLE_EQ(config.surplus_validation_veto_ratio_ceiling, 0.0);
     EXPECT_DOUBLE_EQ(config.surplus_validation_veto_min_ddpr_rms_m, 0.0);


### PR DESCRIPTION
## What changed

- add an opt-in `continuous_unfix_require_ddpr_anchor_disagreement` gate to ambiguity reacquisition
- require a trusted current-epoch DDPR anchor and at least 1 m anchor/state disagreement before resetting live ambiguity generations
- expose allow/skip diagnostics and `--anchor-gated-unfix-reset` in the parity harness
- document full Tokyo validation and default-off behavior

## Why

The existing GICI-style continuous-UNFIX reset can recover stale ambiguity states, but a streak alone is not proof that the state is stale. The ungated experiment improved Tokyo1 and Tokyo2 integrity but regressed Tokyo3. The new gate requires independent current-epoch code geometry to confirm state inconsistency before mutation; otherwise it fails closed.

## Validation

- MSVC Release `gnss_fgo_parity` build passed
- focused GTest: 3/3 passed (`FGOImuIntegrationCovarianceTest` default semantics and `FGOSurplusValidationTest.*`)
- Tokyo1 clean rerun was deterministic: 0 status differences and 0 m maximum ECEF difference

3D FIX correctness threshold: 0.5 m.

| Run | Baseline correct/wrong | Anchor-only correct/wrong | Candidate correct/wrong | Reset allow/skip |
|---|---:|---:|---:|---:|
| Tokyo1 | 4955 / 978 | 5144 / 978 | 5469 / 649 | 4 / 5 |
| Tokyo2 | 6339 / 314 | 6357 / 314 | 6357 / 314 | 0 / 3 |
| Tokyo3 | 9963 / 1002 | 9969 / 1002 | 9969 / 1002 | 0 / 4 |

Across Tokyo1/2/3, distance-weighted correct FIX improves 57.0731% -> 57.9735% and distance-weighted wrong FIX falls 7.7043% -> 7.0089%. Tokyo1 fixed H-RMS/H-P95/Up-P95 improve 0.662/0.963/1.605 m -> 0.630/0.604/0.585 m; Tokyo2/3 are improved or unchanged.

The repository-wide MSVC aggregate target still has the pre-existing C1061 failures in `gnss_fuse.cpp` and `gnss_solve.cpp`; this PR does not modify those files.

Related to #389.