### PR TITLE
Preserve terminal ambiguity outcomes

### DIFF
--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -3137,6 +3137,10 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 is_low_count_attempt && config.use_low_count_ambiguity_resolution &&
                 config.use_surplus_satellite_validation &&
                 n >= std::max(1, config.low_count_min_candidates);
+            if (n > 0 && is_low_count_attempt && !low_count_entry_allowed) {
+                epoch_diagnostics[i].ar_outcome =
+                    FGOProcessor::AmbiguityResolutionOutcome::InsufficientCandidates;
+            }
             if (n >= min_candidates || low_count_entry_allowed) {
                 if (is_low_count_attempt) {
                     ++result.diagnostics.low_count_ambiguity_attempts;
@@ -4299,9 +4303,6 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                         amb_fixed_cycles[idx] = static_cast<int>(std::lround(v));
                     }
                 }
-            } else {
-                epoch_diagnostics[i].ar_outcome =
-                    FGOProcessor::AmbiguityResolutionOutcome::InsufficientCandidates;
             }
         }
 

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -2087,6 +2087,70 @@ TEST(FGOStalePinTest, DefaultOffIsNoOp) {
     EXPECT_EQ(result.solution.solutions.size(), problem.epochs.size());
 }
 
+TEST(FGOAmbiguityOutcomeTelemetryTest, HoldFallbackPreservesRatioRejection) {
+    CpHoldTestOptions opt;
+    opt.satellites = lambdaCapableSatelliteGeometry();
+    opt.num_epochs = 12;
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig config = makeStalePinBaseConfig();
+    config.lambda_ratio_threshold = 1.0e200;
+    config.ambiguity_hold_ratio_threshold = 1.0e200;
+    config.use_cp_hold_recovery = false;
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(problem);
+
+    ASSERT_EQ(result.epoch_diagnostics.size(), problem.epochs.size());
+    EXPECT_TRUE(std::any_of(
+        result.epoch_diagnostics.begin(), result.epoch_diagnostics.end(),
+        [](const FGOProcessor::FGOEpochDiagnostics& diagnostics) {
+            return diagnostics.ar_outcome ==
+                   FGOProcessor::AmbiguityResolutionOutcome::RatioRejected;
+        }))
+        << "the held-ambiguity fallback must not overwrite a terminal ratio-test rejection";
+}
+
+TEST(FGOAmbiguityOutcomeTelemetryTest, NoCarrierCandidatesRemainNoCandidates) {
+    CpHoldTestOptions opt;
+    opt.satellites = lambdaCapableSatelliteGeometry();
+    opt.num_epochs = 4;
+    auto problem = makeCpHoldFixedLagProblem(opt);
+    problem.double_difference_carrier_factors.clear();
+
+    FGOProcessor::FGOConfig config = makeStalePinBaseConfig();
+    config.use_cp_hold_recovery = false;
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(problem);
+
+    ASSERT_EQ(result.epoch_diagnostics.size(), problem.epochs.size());
+    for (const auto& diagnostics : result.epoch_diagnostics) {
+        EXPECT_EQ(diagnostics.ar_outcome,
+                  FGOProcessor::AmbiguityResolutionOutcome::NoCandidates);
+    }
+}
+
+TEST(FGOAmbiguityOutcomeTelemetryTest, BelowFloorCandidatesAreInsufficient) {
+    CpHoldTestOptions opt;
+    opt.satellites = gtsamParitySatelliteGeometry();
+    opt.num_epochs = 4;
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig config = makeStalePinBaseConfig();
+    config.use_cp_hold_recovery = false;
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(problem);
+
+    ASSERT_EQ(result.epoch_diagnostics.size(), problem.epochs.size());
+    for (const auto& diagnostics : result.epoch_diagnostics) {
+        ASSERT_EQ(diagnostics.ambiguity_candidates, 5);
+        EXPECT_EQ(diagnostics.ar_outcome,
+                  FGOProcessor::AmbiguityResolutionOutcome::InsufficientCandidates);
+    }
+}
+
 TEST(FGOStalePinTest, ReleasesOnlyOffendingPinAtTrigger) {
     const auto problem = makeStalePinProblem();
 


### PR DESCRIPTION
## What changed

- Preserve terminal ambiguity-resolution outcomes when hold fallback runs.
- Distinguish no candidates, insufficient candidates, and ratio rejection.
- Add focused regression coverage for all three outcomes.

## Why

The hold fallback path overwrote the actual terminal reason with `InsufficientCandidates`, hiding whether reacquisition failed because no candidates existed or because LAMBDA rejected them. Accurate telemetry is required before tuning FIX-rate changes.

## Impact

Diagnostics only. A full Tokyo1 replay matched the accepted solution exactly: 11,905 statuses unchanged, maximum ECEF delta 0 m, and maximum ratio delta 0.

## Checks

- `FGOAmbiguityOutcomeTelemetryTest.*` (3/3 passed)
- MSVC backend and test target build
- Full Tokyo1 behavior-neutral replay