### PR TITLE
Allow macOS CI build 120 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     needs: [changes, hygiene]
     if: needs.changes.outputs.run_heavy == 'true'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 90
+    timeout-minutes: 120
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What changed

- increase the heavy `build-and-test` matrix job timeout from 90 to 120 minutes

## Why

The current macOS runner repeatedly spends longer than 90 minutes in `Prepare build` before reaching the test step. PR #405 timed out twice at the job limit, and PR #407 was still in `Prepare build` after 67 minutes when all non-macOS checks had passed. A prior successful macOS job needed about 101 minutes for that same preparation step, so 90 minutes cannot reliably produce a macOS test result.

This does not change build commands, dependencies, or test selection; it only gives the existing job enough time to finish.

## Validation

- `git diff --check`
- one-line workflow diff reviewed against the `build-and-test` matrix job

Related to #389.