### PR TITLE
Expose provisional LAMBDA candidate telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,8 +111,10 @@ the shipping preset:
 ```
 
 With `--dump-csv <path>`, the epoch table includes the ambiguity-candidate
-funnel (`amb_after_hold`, `amb_final`, and `amb_excl_*`). A normalized
-satellite/signal trace is written beside it as
+funnel (`amb_after_hold`, `amb_final`, and `amb_excl_*`) and the last
+successfully searched LAMBDA position candidate (`lambda_candidate_*`), even
+when the ratio or a later integrity decision leaves the epoch FLOAT. A
+normalized satellite/signal trace is written beside it as
 `<path>.ar_candidates.csv`. Its `disposition` values are:
 
 | Value | Meaning |

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -1470,7 +1470,10 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
            "vel_e_mps,vel_n_mps,vel_u_mps,"
            "ratio,ratio_threshold,nfixed,ar_outcome,ddpr_rms_m,sd_doppler_rms_mps,gdop,nsat,sd_doppler_n,"
            "amb_candidates,lambda_attempts,lambda_stage,amb_var_median,amb_var_max,"
-           "imu_pose_correction_m,ddpr_anchor_eval,ddpr_anchor_n,ddpr_anchor_res_m,"
+           "imu_pose_correction_m,lambda_candidate_valid,lambda_candidate_nfixed,"
+           "lambda_candidate_ratio,lambda_candidate_x_ecef_m,"
+           "lambda_candidate_y_ecef_m,lambda_candidate_z_ecef_m,"
+           "ddpr_anchor_eval,ddpr_anchor_n,ddpr_anchor_res_m,"
            "ddpr_anchor_x_ecef_m,ddpr_anchor_y_ecef_m,ddpr_anchor_z_ecef_m,"
            "ddpr_anchor_h_err_m,ddpr_anchor_u_err_m,ddpr_anchor_prior,"
            "fixed_float_sep_m,fixed_imu_pred_sep_m,fixed_postfit_ddcp_rms_m,fixed_postfit_ddcp_max_norm,fixed_postfit_ddcp_chi2_dof,fixed_postfit_ddcp_n,external_dr_sep_m,external_dr_mahal2,external_dr_age,external_doppler_valid,external_doppler_vel_e_mps,external_doppler_vel_n_mps,external_doppler_vel_u_mps,external_dr_eval,external_dr_accept,external_dr_reject,cp_hold,"
@@ -1546,7 +1549,13 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                 << ',' << d.lambda_selected_stage
                 << ',' << d.ambiguity_variance_median_cycles2
                 << ',' << d.ambiguity_variance_max_cycles2
-                << ',' << d.imu_pose_correction_m;
+                << ',' << d.imu_pose_correction_m
+                << ',' << (d.lambda_candidate_available ? 1 : 0)
+                << ',' << d.lambda_candidate_fixed_ambiguities
+                << ',' << d.lambda_candidate_ratio
+                << ',' << d.lambda_candidate_position_ecef.x()
+                << ',' << d.lambda_candidate_position_ecef.y()
+                << ',' << d.lambda_candidate_position_ecef.z();
             double anchor_horiz = -1.0;
             double anchor_up = -1.0;
             if (d.ddpr_anchor_evaluated && d.ddpr_anchor_position_ecef.norm() > 1e6) {

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -1966,6 +1966,13 @@ public:
         double ambiguity_variance_median_cycles2 = 0.0;
         double ambiguity_variance_max_cycles2 = 0.0;
         double imu_pose_correction_m = 0.0;
+        // Last position candidate produced by a successful LAMBDA search in
+        // this epoch, even when a later integrity/ratio decision leaves the
+        // epoch FLOAT. Diagnostic-only; never feeds the estimator.
+        bool lambda_candidate_available = false;
+        Vector3d lambda_candidate_position_ecef = Vector3d::Zero();
+        int lambda_candidate_fixed_ambiguities = 0;
+        double lambda_candidate_ratio = 0.0;
         bool ddpr_anchor_evaluated = false;
         bool ddpr_anchor_bootstrap_prior_applied = false;
         int ddpr_anchor_active_factors = 0;

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -3553,6 +3553,12 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                                         provisional_fixed_ant =
                                             Eigen::Vector3d(antennaOf(pose_i)) - pd;
                                         has_provisional_fixed_ant = true;
+                                        epoch_diagnostics[i].lambda_candidate_available = true;
+                                        epoch_diagnostics[i].lambda_candidate_position_ecef =
+                                            provisional_fixed_ant;
+                                        epoch_diagnostics[i]
+                                            .lambda_candidate_fixed_ambiguities = subset;
+                                        epoch_diagnostics[i].lambda_candidate_ratio = ratio;
                                         epoch_diagnostics[i].fixed_float_separation_m =
                                             (provisional_fixed_ant - Eigen::Vector3d(
                                                  antennaOf(pose_i))).norm();

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -2187,13 +2187,18 @@ TEST(FGOAmbiguityOutcomeTelemetryTest, HoldFallbackPreservesRatioRejection) {
     const auto result = processor.optimizeProblem(problem);
 
     ASSERT_EQ(result.epoch_diagnostics.size(), problem.epochs.size());
-    EXPECT_TRUE(std::any_of(
+    const auto rejected = std::find_if(
         result.epoch_diagnostics.begin(), result.epoch_diagnostics.end(),
         [](const FGOProcessor::FGOEpochDiagnostics& diagnostics) {
             return diagnostics.ar_outcome ==
                    FGOProcessor::AmbiguityResolutionOutcome::RatioRejected;
-        }))
+        });
+    ASSERT_NE(rejected, result.epoch_diagnostics.end())
         << "the held-ambiguity fallback must not overwrite a terminal ratio-test rejection";
+    EXPECT_TRUE(rejected->lambda_candidate_available);
+    EXPECT_GT(rejected->lambda_candidate_position_ecef.norm(), 1.0e6);
+    EXPECT_GT(rejected->lambda_candidate_fixed_ambiguities, 0);
+    EXPECT_TRUE(std::isfinite(rejected->lambda_candidate_ratio));
 }
 
 TEST(FGOAmbiguityOutcomeTelemetryTest, NoCarrierCandidatesRemainNoCandidates) {


### PR DESCRIPTION
## What changed

- record the last successfully searched provisional LAMBDA position candidate in per-epoch diagnostics
- include candidate validity, fixed ambiguity count, ratio, and ECEF position in the existing `--dump-csv` output
- preserve telemetry when the ratio or a later integrity gate leaves the epoch FLOAT
- add no command-line option and do not feed the telemetry back into the estimator

## Why

Tokyo1 has 1,728 ratio-rejected FLOAT epochs, but the reported FLOAT position cannot tell whether the rejected integer hypothesis itself was right or wrong. This behavior-neutral telemetry lets the development/validation runs score the actual counterfactual candidate before designing another promotion gate.

## Validation

- focused GTest: 4/4 passed (`FGOAmbiguityCandidateTelemetryTest.*` plus the ratio-rejection outcome test)
- MSVC `gnss_fgo_parity` build passed
- Tokyo1 200-epoch smoke: 200 candidate rows populated, including the ratio-rejected epoch
- behavior check against the accepted baseline over the same 200 epochs: 0 status differences and 0 m maximum ECEF difference
- aggregate MSVC test target still encounters the pre-existing C1061 failures in `gnss_fuse.cpp` and `gnss_solve.cpp`; building the test project with project references disabled succeeds

Related to #389.