### PR TITLE
Allow extended CI Docker smoke 120 minutes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,7 +178,7 @@ jobs:
     needs: [changes, hygiene, build-and-test]
     if: needs.changes.outputs.run_heavy == 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 120
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
## What changed

- increase the `linux-extended-tests` job timeout from 60 to 120 minutes

## Why

PR #408's extended tests passed, but the job was forcibly terminated by the
60-minute job timeout while `Docker smoke` was still running. The macOS build
on the same run completed in 96 minutes after its own timeout was raised, so
the extended Docker build needs the same headroom.

## Impact

No production or test behavior changes. The CI job can finish its existing
Docker smoke and dashboard steps instead of being cancelled mid-step.

## Validation

- `git diff --check`
- parsed `.github/workflows/ci.yml` with PyYAML
- confirmed PR #408 run 30647106999: extended tests passed; timeout occurred during Docker smoke
