### PR TITLE
feat(fgo): add ratio-impact AR telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,13 @@ normalized satellite/signal trace is written beside it as
 These fields only report decisions already made by the solver; enabling the
 CSV dump does not alter candidate selection or FIX/FLOAT decisions.
 
+`--ratio-impact-monitor` adds a counterfactual partial-AR audit for epochs
+that remain ratio-rejected. It removes each target satellite in turn, reruns
+LAMBDA, and writes the best ratio, subset size, candidate ECEF position, and
+fixed/float and fixed/IMU separations as `ratio_impact_*`. The audit is
+diagnostic-only: it cannot change the selected subset, graph, hold state, or
+reported FIX/FLOAT status.
+
 #### Surplus-satellite rescue integrity
 
 LAMBDA candidates that fall short of the ratio gate can be rescued by an

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -95,6 +95,7 @@ struct Args {
     bool anchor_aided_validation = false;
     bool constellation_par = false;
     bool residual_par = false;
+    bool ratio_impact_monitor = false;
     bool variance_par = false;
     bool gici_par = false;          // GICI-style strict PAR + continuous-unfix reacquisition profile
     bool anchor_gated_unfix_reset = false;
@@ -244,6 +245,10 @@ Args parseArgs(int argc, char** argv) {
         }
         if (a == "--anchor-gated-unfix-reset") {
             args.anchor_gated_unfix_reset = true;
+            continue;
+        }
+        if (a == "--ratio-impact-monitor") {
+            args.ratio_impact_monitor = true;
             continue;
         }
         if (a == "--integer-constrained-reoptimization") {
@@ -945,6 +950,9 @@ libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
     if (args.residual_par) {
         config.use_residual_screened_partial_ar = true;
     }
+    if (args.ratio_impact_monitor) {
+        config.monitor_ratio_impact_partial_ar = true;
+    }
     if (args.variance_par) {
         config.use_variance_ranked_partial_ar = true;
     }
@@ -1473,6 +1481,10 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
            "imu_pose_correction_m,lambda_candidate_valid,lambda_candidate_nfixed,"
            "lambda_candidate_ratio,lambda_candidate_x_ecef_m,"
            "lambda_candidate_y_ecef_m,lambda_candidate_z_ecef_m,"
+           "ratio_impact_eval,ratio_impact_trials,ratio_impact_best_ratio,"
+           "ratio_impact_best_nfixed,ratio_impact_x_ecef_m,"
+           "ratio_impact_y_ecef_m,ratio_impact_z_ecef_m,"
+           "ratio_impact_float_sep_m,ratio_impact_imu_sep_m,"
            "ddpr_anchor_eval,ddpr_anchor_n,ddpr_anchor_res_m,"
            "ddpr_anchor_x_ecef_m,ddpr_anchor_y_ecef_m,ddpr_anchor_z_ecef_m,"
            "ddpr_anchor_h_err_m,ddpr_anchor_u_err_m,ddpr_anchor_prior,"
@@ -1555,7 +1567,16 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                 << ',' << d.lambda_candidate_ratio
                 << ',' << d.lambda_candidate_position_ecef.x()
                 << ',' << d.lambda_candidate_position_ecef.y()
-                << ',' << d.lambda_candidate_position_ecef.z();
+                << ',' << d.lambda_candidate_position_ecef.z()
+                << ',' << (d.ratio_impact_evaluated ? 1 : 0)
+                << ',' << d.ratio_impact_trials
+                << ',' << d.ratio_impact_best_ratio
+                << ',' << d.ratio_impact_best_fixed_ambiguities
+                << ',' << d.ratio_impact_best_position_ecef.x()
+                << ',' << d.ratio_impact_best_position_ecef.y()
+                << ',' << d.ratio_impact_best_position_ecef.z()
+                << ',' << d.ratio_impact_best_float_separation_m
+                << ',' << d.ratio_impact_best_imu_separation_m;
             double anchor_horiz = -1.0;
             double anchor_up = -1.0;
             if (d.ddpr_anchor_evaluated && d.ddpr_anchor_position_ecef.norm() > 1e6) {
@@ -2471,7 +2492,9 @@ int main(int argc, char** argv) {
                   << "  partial AR: " << (config.use_fixed_lag_partial_lambda ? "on" : "off")
                   << " (min_fraction=" << config.fixed_lag_partial_lambda_min_fraction
                   << ", min_fixed=" << config.min_fixed_ambiguities
-                  << ", max_std_cycles=" << config.partial_ar_max_std_cycles << ")\n"
+                  << ", max_std_cycles=" << config.partial_ar_max_std_cycles
+                  << ", ratio_impact_monitor="
+                  << (config.monitor_ratio_impact_partial_ar ? "on" : "off") << ")\n"
                   << "  IMU ratio aperture: " << (args.imu_ratio_aperture ? "on" : "off")
                   << " (accepted=" << fl.diagnostics.imu_aided_ratio_accepts
                   << ", rejected=" << fl.diagnostics.imu_aided_ratio_rejects

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -379,6 +379,11 @@ public:
         // Remove ambiguity candidates implicated by a gross current-epoch
         // DD pseudorange residual before the PPC constellation cascade.
         bool use_residual_screened_partial_ar = false;
+        // Diagnostic-only RTKLIB-demo5-style satellite exclusion audit.
+        // On a ratio-rejected epoch, retry LAMBDA after removing each target
+        // satellite in turn and record the best candidate. Never changes the
+        // selected subset, FIX/FLOAT status, graph, or hold state.
+        bool monitor_ratio_impact_partial_ar = false;
         // GICI-style PAR: prefer ambiguities with the smallest marginal
         // variance and do not attempt a subset whose least precise member
         // exceeds this standard deviation in cycles (<=0 disables the gate).
@@ -1973,6 +1978,13 @@ public:
         Vector3d lambda_candidate_position_ecef = Vector3d::Zero();
         int lambda_candidate_fixed_ambiguities = 0;
         double lambda_candidate_ratio = 0.0;
+        bool ratio_impact_evaluated = false;
+        int ratio_impact_trials = 0;
+        double ratio_impact_best_ratio = 0.0;
+        int ratio_impact_best_fixed_ambiguities = 0;
+        Vector3d ratio_impact_best_position_ecef = Vector3d::Zero();
+        double ratio_impact_best_float_separation_m = 0.0;
+        double ratio_impact_best_imu_separation_m = 0.0;
         bool ddpr_anchor_evaluated = false;
         bool ddpr_anchor_bootstrap_prior_applied = false;
         int ddpr_anchor_active_factors = 0;

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -3491,6 +3491,8 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                             lambda_stages.push_back(-1);
                         }
                     }
+                    const std::vector<int> ratio_impact_order(
+                        order.begin(), order.begin() + attempt_n);
 
                     bool float_cycles_recorded = false;
                     for (std::size_t lambda_order_idx = 0;
@@ -4395,6 +4397,91 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                             }
                         }
                         break;  // validated subset found
+                    }
+
+                    // Monitor-only satellite-impact audit, modeled after
+                    // RTKLIB demo5's AR-filter/exclusion retry. Evaluate the
+                    // actual LAMBDA ratio after removing each target
+                    // satellite from the full ranked pool. This deliberately
+                    // runs only after the established pipeline left the epoch
+                    // ratio-rejected, and cannot change any estimator state
+                    // or FIX/FLOAT decision.
+                    if (config.monitor_ratio_impact_partial_ar &&
+                        !epoch_fixed[i] &&
+                        epoch_diagnostics[i].ar_outcome ==
+                            FGOProcessor::AmbiguityResolutionOutcome::RatioRejected) {
+                        std::set<SatelliteId> drop_satellites;
+                        for (int candidate : ratio_impact_order) {
+                            drop_satellites.insert(
+                                problem.ambiguity_states[
+                                    epoch_amb_indices[candidate]].satellite);
+                        }
+                        for (const SatelliteId& drop_satellite : drop_satellites) {
+                            std::vector<int> pool;
+                            pool.reserve(ratio_impact_order.size());
+                            for (int candidate : ratio_impact_order) {
+                                if (problem.ambiguity_states[
+                                        epoch_amb_indices[candidate]].satellite !=
+                                    drop_satellite) {
+                                    pool.push_back(candidate);
+                                }
+                            }
+                            if (pool.size() < static_cast<std::size_t>(min_subset) ||
+                                pool.size() == ratio_impact_order.size()) {
+                                continue;
+                            }
+                            epoch_diagnostics[i].ratio_impact_evaluated = true;
+                            ++epoch_diagnostics[i].ratio_impact_trials;
+                            const int monitor_n = static_cast<int>(pool.size());
+                            Eigen::VectorXd monitor_float(monitor_n);
+                            Eigen::MatrixXd monitor_q(monitor_n, monitor_n);
+                            Eigen::MatrixXd monitor_pos(3, monitor_n);
+                            for (int r = 0; r < monitor_n; ++r) {
+                                monitor_float(r) = float_amb(pool[r]);
+                                monitor_pos.col(r) = pos_amb.col(pool[r]);
+                                for (int c = 0; c < monitor_n; ++c) {
+                                    monitor_q(r, c) = q_amb(pool[r], pool[c]);
+                                }
+                            }
+                            Eigen::VectorXd monitor_fixed;
+                            double monitor_ratio = 0.0;
+                            if (!lambdaSearch(monitor_float, monitor_q,
+                                              monitor_fixed, monitor_ratio) ||
+                                !std::isfinite(monitor_ratio) ||
+                                monitor_fixed.size() != monitor_n ||
+                                monitor_ratio <=
+                                    epoch_diagnostics[i].ratio_impact_best_ratio) {
+                                continue;
+                            }
+                            const Eigen::VectorXd delta =
+                                monitor_float - monitor_fixed;
+                            const Eigen::LDLT<Eigen::MatrixXd> ldlt(monitor_q);
+                            if (ldlt.info() != Eigen::Success) continue;
+                            const Eigen::VectorXd correction = ldlt.solve(delta);
+                            if (!correction.allFinite()) continue;
+                            const Eigen::Vector3d position_delta =
+                                monitor_pos * correction;
+                            if (!position_delta.allFinite()) continue;
+                            const Eigen::Vector3d candidate_position =
+                                Eigen::Vector3d(antennaOf(pose_i)) -
+                                position_delta;
+                            if (!candidate_position.allFinite()) continue;
+                            epoch_diagnostics[i].ratio_impact_best_ratio =
+                                monitor_ratio;
+                            epoch_diagnostics[i]
+                                .ratio_impact_best_fixed_ambiguities = monitor_n;
+                            epoch_diagnostics[i]
+                                .ratio_impact_best_position_ecef =
+                                    candidate_position;
+                            epoch_diagnostics[i]
+                                .ratio_impact_best_float_separation_m =
+                                    (candidate_position - Eigen::Vector3d(
+                                         antennaOf(pose_i))).norm();
+                            epoch_diagnostics[i]
+                                .ratio_impact_best_imu_separation_m =
+                                    (candidate_position - Eigen::Vector3d(
+                                         antennaOf(pose_seed))).norm();
+                        }
                     }
                 } else {
                     ++marginals_failures;

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -2201,6 +2201,49 @@ TEST(FGOAmbiguityOutcomeTelemetryTest, HoldFallbackPreservesRatioRejection) {
     EXPECT_TRUE(std::isfinite(rejected->lambda_candidate_ratio));
 }
 
+TEST(FGOAmbiguityOutcomeTelemetryTest,
+     RatioImpactMonitorIsDiagnosticOnlyAndRecordsBestExclusion) {
+    CpHoldTestOptions opt;
+    opt.satellites = lambdaCapableSatelliteGeometry();
+    opt.num_epochs = 12;
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig config = makeStalePinBaseConfig();
+    config.lambda_ratio_threshold = 1.0e200;
+    config.ambiguity_hold_ratio_threshold = 1.0e200;
+    config.use_cp_hold_recovery = false;
+    config.use_fixed_lag_partial_lambda = true;
+
+    FGOProcessor baseline_processor(config);
+    const auto baseline = baseline_processor.optimizeProblem(problem);
+
+    config.monitor_ratio_impact_partial_ar = true;
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(problem);
+
+    ASSERT_EQ(result.solution.solutions.size(), baseline.solution.solutions.size());
+    for (std::size_t i = 0; i < result.solution.solutions.size(); ++i) {
+        EXPECT_EQ(result.solution.solutions[i].status,
+                  baseline.solution.solutions[i].status);
+        EXPECT_TRUE(result.solution.solutions[i].position_ecef.isApprox(
+            baseline.solution.solutions[i].position_ecef, 0.0));
+    }
+
+    const auto monitored = std::find_if(
+        result.epoch_diagnostics.begin(), result.epoch_diagnostics.end(),
+        [](const FGOProcessor::FGOEpochDiagnostics& diagnostics) {
+            return diagnostics.ratio_impact_evaluated &&
+                   diagnostics.ratio_impact_best_fixed_ambiguities > 0;
+        });
+    ASSERT_NE(monitored, result.epoch_diagnostics.end());
+    EXPECT_EQ(monitored->ar_outcome,
+              FGOProcessor::AmbiguityResolutionOutcome::RatioRejected);
+    EXPECT_GT(monitored->ratio_impact_trials, 0);
+    EXPECT_GT(monitored->ratio_impact_best_ratio, 0.0);
+    EXPECT_GT(monitored->ratio_impact_best_position_ecef.norm(), 1.0e6);
+}
+
 TEST(FGOAmbiguityOutcomeTelemetryTest, NoCarrierCandidatesRemainNoCandidates) {
     CpHoldTestOptions opt;
     opt.satellites = lambdaCapableSatelliteGeometry();


### PR DESCRIPTION
## Summary
- add opt-in, diagnostic-only leave-one-target-satellite-out LAMBDA ratio telemetry
- expose best candidate ratio, subset size, ECEF position, and float/IMU separations in parity CSV output
- document the monitor and enforce behavior neutrality in a synthetic regression test

## Motivation
RTKLIB demo5 uses satellite exclusion retries when added satellites degrade ambiguity resolution. Before changing AR behavior, this PR measures the actual counterfactual ratio impact instead of relying on residual proxies.

## Validation
- Full test binary: 877 tests; 817 passed, 60 existing skips, 0 failed
- Tokyo1 full accepted profile + monitor: 11,905 rows, zero status/tow/ECEF differences from accepted baseline
- Tokyo2 full accepted profile + monitor: 9,147 rows, zero status/tow/ECEF differences from accepted baseline
- Ordinary ratio >=2 was unsafe (Tokyo1 61 correct/157 wrong; Tokyo2 39/86), so this PR deliberately does not promote candidates

Tracks #389; does not close it.