### PR TITLE
feat(fgo): trace ratio-impact exclusion trials

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,10 @@ that remain ratio-rejected. It removes each target satellite in turn, reruns
 LAMBDA, and writes the best ratio, subset size, candidate ECEF position, and
 fixed/float and fixed/IMU separations as `ratio_impact_*`. The audit is
 diagnostic-only: it cannot change the selected subset, graph, hold state, or
-reported FIX/FLOAT status.
+reported FIX/FLOAT status. A normalized row-per-exclusion trace is also
+written beside the epoch CSV as `<dump>.ratio_impact.csv`; it includes the
+excluded satellite, its ambiguity variance/fractional-cycle/DDPR-residual
+proxies, and the resulting counterfactual candidate.
 
 #### Surplus-satellite rescue integrity
 

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -1695,6 +1695,44 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
             trace_out << ',' << static_cast<int>(candidate.disposition) << '\n';
         }
     }
+
+    const bool has_ratio_impact_trials = std::any_of(
+        r.epoch_diagnostics.begin(), r.epoch_diagnostics.end(),
+        [](const auto& epoch) { return !epoch.ratio_impact_trial_trace.empty(); });
+    if (!has_ratio_impact_trials) return;
+
+    const std::string impact_path = path + ".ratio_impact.csv";
+    std::ofstream impact_out(impact_path);
+    if (!impact_out) {
+        std::cerr << "Warning: cannot open ratio-impact trial output file "
+                  << impact_path << "\n";
+        return;
+    }
+    impact_out << "tow,excluded_satellite,system,prn,excluded_ambiguities,"
+                  "excluded_max_variance_cycles2,excluded_max_fractional_cycles,"
+                  "excluded_ddpr_residual_m,candidate_available,ratio,nfixed,"
+                  "x_ecef_m,y_ecef_m,z_ecef_m,float_sep_m,imu_sep_m\n";
+    impact_out << std::fixed;
+    impact_out.precision(6);
+    for (const auto& epoch : r.epoch_diagnostics) {
+        for (const auto& trial : epoch.ratio_impact_trial_trace) {
+            impact_out << epoch.time.tow << ','
+                       << trial.excluded_satellite.toString() << ','
+                       << static_cast<int>(trial.excluded_satellite.system) << ','
+                       << static_cast<int>(trial.excluded_satellite.prn) << ','
+                       << trial.excluded_ambiguities << ','
+                       << trial.excluded_max_variance_cycles2 << ','
+                       << trial.excluded_max_fractional_cycles << ','
+                       << trial.excluded_ddpr_residual_m << ','
+                       << (trial.candidate_available ? 1 : 0) << ','
+                       << trial.ratio << ',' << trial.fixed_ambiguities << ','
+                       << trial.candidate_position_ecef.x() << ','
+                       << trial.candidate_position_ecef.y() << ','
+                       << trial.candidate_position_ecef.z() << ','
+                       << trial.float_separation_m << ','
+                       << trial.imu_separation_m << '\n';
+        }
+    }
 }
 
 // Populate problem.imu from an imu.csv + the already-built FGOProblem epochs.

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -1954,6 +1954,23 @@ public:
             AmbiguityCandidateDisposition::LambdaEligible;
     };
 
+    /// One counterfactual leave-one-target-satellite-out LAMBDA trial.
+    /// Populated only by monitor_ratio_impact_partial_ar and never consumed
+    /// by the estimator.
+    struct RatioImpactTrialTrace {
+        SatelliteId excluded_satellite;
+        int excluded_ambiguities = 0;
+        double excluded_max_variance_cycles2 = 0.0;
+        double excluded_max_fractional_cycles = 0.0;
+        double excluded_ddpr_residual_m = 0.0;
+        bool candidate_available = false;
+        double ratio = 0.0;
+        int fixed_ambiguities = 0;
+        Vector3d candidate_position_ecef = Vector3d::Zero();
+        double float_separation_m = 0.0;
+        double imu_separation_m = 0.0;
+    };
+
     /// Per-epoch fixed-lag integrity state.  These values expose why an epoch
     /// did or did not fix, rather than only reporting the final FIX/FLOAT label.
     struct FGOEpochDiagnostics {
@@ -1985,6 +2002,7 @@ public:
         Vector3d ratio_impact_best_position_ecef = Vector3d::Zero();
         double ratio_impact_best_float_separation_m = 0.0;
         double ratio_impact_best_imu_separation_m = 0.0;
+        std::vector<RatioImpactTrialTrace> ratio_impact_trial_trace;
         bool ddpr_anchor_evaluated = false;
         bool ddpr_anchor_bootstrap_prior_applied = false;
         int ddpr_anchor_active_factors = 0;

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -4417,13 +4417,24 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                                     epoch_amb_indices[candidate]].satellite);
                         }
                         for (const SatelliteId& drop_satellite : drop_satellites) {
+                            FGOProcessor::RatioImpactTrialTrace trial;
+                            trial.excluded_satellite = drop_satellite;
                             std::vector<int> pool;
                             pool.reserve(ratio_impact_order.size());
                             for (int candidate : ratio_impact_order) {
-                                if (problem.ambiguity_states[
-                                        epoch_amb_indices[candidate]].satellite !=
-                                    drop_satellite) {
+                                const auto& ambiguity = problem.ambiguity_states[
+                                    epoch_amb_indices[candidate]];
+                                if (ambiguity.satellite != drop_satellite) {
                                     pool.push_back(candidate);
+                                } else {
+                                    ++trial.excluded_ambiguities;
+                                    trial.excluded_max_variance_cycles2 = std::max(
+                                        trial.excluded_max_variance_cycles2,
+                                        q_amb(candidate, candidate));
+                                    trial.excluded_max_fractional_cycles = std::max(
+                                        trial.excluded_max_fractional_cycles,
+                                        std::abs(float_amb(candidate) -
+                                                 std::round(float_amb(candidate))));
                                 }
                             }
                             if (pool.size() < static_cast<std::size_t>(min_subset) ||
@@ -4432,6 +4443,10 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                             }
                             epoch_diagnostics[i].ratio_impact_evaluated = true;
                             ++epoch_diagnostics[i].ratio_impact_trials;
+                            const auto residual_it = per_sat_res.find(drop_satellite);
+                            if (residual_it != per_sat_res.end()) {
+                                trial.excluded_ddpr_residual_m = residual_it->second;
+                            }
                             const int monitor_n = static_cast<int>(pool.size());
                             Eigen::VectorXd monitor_float(monitor_n);
                             Eigen::MatrixXd monitor_q(monitor_n, monitor_n);
@@ -4448,24 +4463,55 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                             if (!lambdaSearch(monitor_float, monitor_q,
                                               monitor_fixed, monitor_ratio) ||
                                 !std::isfinite(monitor_ratio) ||
-                                monitor_fixed.size() != monitor_n ||
-                                monitor_ratio <=
-                                    epoch_diagnostics[i].ratio_impact_best_ratio) {
+                                monitor_fixed.size() != monitor_n) {
+                                epoch_diagnostics[i].ratio_impact_trial_trace.push_back(
+                                    std::move(trial));
                                 continue;
                             }
+                            trial.ratio = monitor_ratio;
+                            trial.fixed_ambiguities = monitor_n;
                             const Eigen::VectorXd delta =
                                 monitor_float - monitor_fixed;
                             const Eigen::LDLT<Eigen::MatrixXd> ldlt(monitor_q);
-                            if (ldlt.info() != Eigen::Success) continue;
+                            if (ldlt.info() != Eigen::Success) {
+                                epoch_diagnostics[i].ratio_impact_trial_trace.push_back(
+                                    std::move(trial));
+                                continue;
+                            }
                             const Eigen::VectorXd correction = ldlt.solve(delta);
-                            if (!correction.allFinite()) continue;
+                            if (!correction.allFinite()) {
+                                epoch_diagnostics[i].ratio_impact_trial_trace.push_back(
+                                    std::move(trial));
+                                continue;
+                            }
                             const Eigen::Vector3d position_delta =
                                 monitor_pos * correction;
-                            if (!position_delta.allFinite()) continue;
+                            if (!position_delta.allFinite()) {
+                                epoch_diagnostics[i].ratio_impact_trial_trace.push_back(
+                                    std::move(trial));
+                                continue;
+                            }
                             const Eigen::Vector3d candidate_position =
                                 Eigen::Vector3d(antennaOf(pose_i)) -
                                 position_delta;
-                            if (!candidate_position.allFinite()) continue;
+                            if (!candidate_position.allFinite()) {
+                                epoch_diagnostics[i].ratio_impact_trial_trace.push_back(
+                                    std::move(trial));
+                                continue;
+                            }
+                            trial.candidate_available = true;
+                            trial.candidate_position_ecef = candidate_position;
+                            trial.float_separation_m =
+                                (candidate_position - Eigen::Vector3d(
+                                     antennaOf(pose_i))).norm();
+                            trial.imu_separation_m =
+                                (candidate_position - Eigen::Vector3d(
+                                     antennaOf(pose_seed))).norm();
+                            epoch_diagnostics[i].ratio_impact_trial_trace.push_back(trial);
+                            if (monitor_ratio <=
+                                epoch_diagnostics[i].ratio_impact_best_ratio) {
+                                continue;
+                            }
                             epoch_diagnostics[i].ratio_impact_best_ratio =
                                 monitor_ratio;
                             epoch_diagnostics[i]
@@ -4475,12 +4521,10 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                                     candidate_position;
                             epoch_diagnostics[i]
                                 .ratio_impact_best_float_separation_m =
-                                    (candidate_position - Eigen::Vector3d(
-                                         antennaOf(pose_i))).norm();
+                                    trial.float_separation_m;
                             epoch_diagnostics[i]
                                 .ratio_impact_best_imu_separation_m =
-                                    (candidate_position - Eigen::Vector3d(
-                                         antennaOf(pose_seed))).norm();
+                                    trial.imu_separation_m;
                         }
                     }
                 } else {

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -2242,6 +2242,17 @@ TEST(FGOAmbiguityOutcomeTelemetryTest,
     EXPECT_GT(monitored->ratio_impact_trials, 0);
     EXPECT_GT(monitored->ratio_impact_best_ratio, 0.0);
     EXPECT_GT(monitored->ratio_impact_best_position_ecef.norm(), 1.0e6);
+    ASSERT_FALSE(monitored->ratio_impact_trial_trace.empty());
+    const auto available_trial = std::find_if(
+        monitored->ratio_impact_trial_trace.begin(),
+        monitored->ratio_impact_trial_trace.end(),
+        [](const FGOProcessor::RatioImpactTrialTrace& trial) {
+            return trial.candidate_available;
+        });
+    ASSERT_NE(available_trial, monitored->ratio_impact_trial_trace.end());
+    EXPECT_GT(available_trial->excluded_ambiguities, 0);
+    EXPECT_GT(available_trial->fixed_ambiguities, 0);
+    EXPECT_GT(available_trial->candidate_position_ecef.norm(), 1.0e6);
 }
 
 TEST(FGOAmbiguityOutcomeTelemetryTest, NoCarrierCandidatesRemainNoCandidates) {


### PR DESCRIPTION
## Summary
- retain every leave-one-target-satellite-out LAMBDA trial from the ratio-impact monitor
- write a normalized .ratio_impact.csv sidecar with excluded-satellite quality proxies and counterfactual candidate positions
- extend the monitor regression test and documentation

## Validation
- 877 tests: 817 passed, 60 existing skips, 0 failed
- Tokyo1 full accepted profile: 11,905 rows, zero status/tow/ECEF differences
- Tokyo2 full accepted profile: 9,147 rows, zero status/tow/ECEF differences
- smoke validation confirms sidecar max-ratio rows match epoch best-ratio telemetry within CSV rounding

## Research outcome
Max-ratio, variance, fractional-cycle, and DDPR-residual selectors all admitted wrong candidates, so this PR remains diagnostic-only and does not promote any exclusion trial.

Tracks #389; does not close it.