### PR TITLE
feat(fgo): expose fresh SPP seed telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,12 @@ written beside the epoch CSV as `<dump>.ratio_impact.csv`; it includes the
 excluded satellite, its ambiguity variance/fractional-cycle/DDPR-residual
 proxies, and the resulting counterfactual candidate.
 
+The epoch CSV also records whether its builder position came from a fresh
+current-epoch SPP solution (`spp_seed_fresh`) and that seed's ECEF position.
+These diagnostic-only fields allow integer candidates to be audited against
+an independent undifferenced-code/RAIM witness; they do not feed the graph or
+change FIX/FLOAT decisions.
+
 #### Surplus-satellite rescue integrity
 
 LAMBDA candidates that fall short of the ratio gate can be rescued by an

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -1478,7 +1478,9 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
            "vel_e_mps,vel_n_mps,vel_u_mps,"
            "ratio,ratio_threshold,nfixed,ar_outcome,ddpr_rms_m,sd_doppler_rms_mps,gdop,nsat,sd_doppler_n,"
            "amb_candidates,lambda_attempts,lambda_stage,amb_var_median,amb_var_max,"
-           "imu_pose_correction_m,lambda_candidate_valid,lambda_candidate_nfixed,"
+           "imu_pose_correction_m,spp_seed_fresh,spp_seed_x_ecef_m,"
+           "spp_seed_y_ecef_m,spp_seed_z_ecef_m,"
+           "lambda_candidate_valid,lambda_candidate_nfixed,"
            "lambda_candidate_ratio,lambda_candidate_x_ecef_m,"
            "lambda_candidate_y_ecef_m,lambda_candidate_z_ecef_m,"
            "ratio_impact_eval,ratio_impact_trials,ratio_impact_best_ratio,"
@@ -1562,6 +1564,10 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                 << ',' << d.ambiguity_variance_median_cycles2
                 << ',' << d.ambiguity_variance_max_cycles2
                 << ',' << d.imu_pose_correction_m
+                << ',' << (d.fresh_spp_solution ? 1 : 0)
+                << ',' << d.spp_seed_position_ecef.x()
+                << ',' << d.spp_seed_position_ecef.y()
+                << ',' << d.spp_seed_position_ecef.z()
                 << ',' << (d.lambda_candidate_available ? 1 : 0)
                 << ',' << d.lambda_candidate_fixed_ambiguities
                 << ',' << d.lambda_candidate_ratio
@@ -2080,7 +2086,7 @@ FileId statFile(const std::string& path) {
 // vector, new factor field, ...) -- an old cache then fails the magic/version
 // check in load() below and is rebuilt instead of misread.
 constexpr uint32_t kMagic = 0x50434647u;  // "PCFG" (problem-cache fgo)
-constexpr uint32_t kVersion = 6u;
+constexpr uint32_t kVersion = 7u;
 constexpr std::size_t kBuilderFingerprintBytes = 512u;
 
 struct Fingerprint {

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -1446,6 +1446,9 @@ public:
         GNSSTime time;
         Vector3d position_ecef = Vector3d::Zero();
         double receiver_clock_bias_m = 0.0;
+        // True only when position_ecef came from a valid SPP solve at this
+        // epoch; false for last-valid/header fallbacks.
+        bool fresh_spp_solution = false;
     };
 
     struct ObservationModelDebug {
@@ -1988,6 +1991,11 @@ public:
         double ambiguity_variance_median_cycles2 = 0.0;
         double ambiguity_variance_max_cycles2 = 0.0;
         double imu_pose_correction_m = 0.0;
+        // Read-only copy of the builder's independent current-epoch SPP
+        // seed. This exposes an absolute-code witness for AR analysis while
+        // keeping all estimator and FIX/FLOAT decisions unchanged.
+        bool fresh_spp_solution = false;
+        Vector3d spp_seed_position_ecef = Vector3d::Zero();
         // Last position candidate produced by a successful LAMBDA search in
         // this epoch, even when a later integrity/ratio decision leaves the
         // epoch FLOAT. Diagnostic-only; never feeds the estimator.

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -1008,6 +1008,7 @@ FGOProcessor::FGOProblem FGOProcessor::buildPseudorangeProblem(
         if (spp_solution.isValid()) {
             seed.position_ecef = spp_solution.position_ecef;
             seed.receiver_clock_bias_m = spp_solution.receiver_clock_bias;
+            seed.fresh_spp_solution = true;
             last_valid_seed_position_ecef = seed.position_ecef;
             last_valid_seed_clock_bias_m = seed.receiver_clock_bias_m;
             have_last_valid_seed = true;

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -1968,6 +1968,10 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             }
         }
         epoch_diagnostics[i].time = problem.epochs[i].time;
+        epoch_diagnostics[i].fresh_spp_solution =
+            problem.epochs[i].fresh_spp_solution;
+        epoch_diagnostics[i].spp_seed_position_ecef =
+            problem.epochs[i].position_ecef;
         epoch_diagnostics[i].ar_outcome = config.use_lambda_ambiguity_fix
             ? FGOProcessor::AmbiguityResolutionOutcome::SmootherFailure
             : FGOProcessor::AmbiguityResolutionOutcome::Disabled;

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -2295,6 +2295,24 @@ TEST(FGOAmbiguityOutcomeTelemetryTest, BelowFloorCandidatesAreInsufficient) {
     }
 }
 
+TEST(FGOSppSeedTelemetryTest, ReportsFreshnessAndBuilderPositionReadOnly) {
+    auto problem = makeStalePinProblem();
+    for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
+        problem.epochs[i].fresh_spp_solution = (i % 2u) == 0u;
+    }
+    FGOProcessor processor(makeStalePinBaseConfig());
+    const auto result = processor.optimizeProblem(problem);
+
+    ASSERT_EQ(result.epoch_diagnostics.size(), problem.epochs.size());
+    for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
+        EXPECT_EQ(result.epoch_diagnostics[i].fresh_spp_solution,
+                  problem.epochs[i].fresh_spp_solution);
+        EXPECT_TRUE(result.epoch_diagnostics[i]
+                        .spp_seed_position_ecef.isApprox(
+                            problem.epochs[i].position_ecef, 1e-12));
+    }
+}
+
 TEST(FGOStalePinTest, ReleasesOnlyOffendingPinAtTrigger) {
     const auto problem = makeStalePinProblem();
 


### PR DESCRIPTION
## Summary
- mark whether each FGO builder seed came from a valid current-epoch SPP solve or a fallback
- expose the SPP seed ECEF in fixed-lag epoch diagnostics and parity CSV output
- bump the problem-cache version for the EpochSeed layout change
- document that the fields are diagnostic-only and do not affect FIX/FLOAT decisions

## Validation
- focused telemetry and ambiguity tests: 5 passed
- full native suite: 818 passed, 60 existing skips, 0 failed
- Tokyo1 first 200 epochs: 0 status differences and 0 ECEF differences versus the pre-change accepted replay; 200/200 fresh SPP seeds

Related to #389.