### PR TITLE
Add GNSS-only MultiSD FGO with safe top-K validation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,10 @@ if(MSVC OR (WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
     # (MSVC is false), but the toolchain still resolves <cmath>/<math.h>
     # to the MSVC STL headers, which gate M_PI on this same macro.
     add_compile_definitions(_USE_MATH_DEFINES NOMINMAX)
+    # Ninja does not inherit Visual Studio project's exception defaults.
+    # The library and GoogleTest both use C++ exceptions, so compiling
+    # without unwind semantics can crash the focused test shards at startup.
+    add_compile_options(/EHsc)
 endif()
 include(CTest)
 include(GNUInstallDirs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ if(MSVC OR (WIN32 AND CMAKE_CXX_COMPILER_ID STREQUAL "Clang"))
     # Ninja does not inherit Visual Studio project's exception defaults.
     # The library and GoogleTest both use C++ exceptions, so compiling
     # without unwind semantics can crash the focused test shards at startup.
-    add_compile_options(/EHsc)
+    add_compile_options($<$<COMPILE_LANGUAGE:CXX>:/EHsc>)
 endif()
 include(CTest)
 include(GNUInstallDirs)
@@ -63,6 +63,15 @@ if(GNSSPP_USE_CHOLMOD)
     endif()
 else()
     message(STATUS "CHOLMOD disabled; using Eigen sparse covariance solver")
+endif()
+option(GNSSPP_ENABLE_CUDA_FGO
+    "Build the optional cuSOLVER dense backend for native FGO" OFF)
+if(GNSSPP_ENABLE_CUDA_FGO)
+    if(CMAKE_VERSION VERSION_LESS 3.18)
+        message(FATAL_ERROR "GNSSPP_ENABLE_CUDA_FGO requires CMake 3.18+")
+    endif()
+    enable_language(CUDA)
+    find_package(CUDAToolkit REQUIRED)
 endif()
 option(MADOCALIB_PARITY_LINK "Link external MADOCALIB C sources for opt-in parity oracle tests" OFF)
 option(
@@ -301,6 +310,22 @@ else()
             GNSSPP_HAS_MADOCALIB_ORACLE=0)
 endif()
 
+# Optional CUDA solver is isolated from the public API and from default builds.
+# Runtime selection is controlled by GNSSPP_FGO_CUDA_SOLVER=off|auto|on; every
+# failure returns to the Eigen reference path.
+if(GNSSPP_ENABLE_CUDA_FGO)
+    add_library(gnss_fgo_cuda_backend STATIC
+        src/algorithms/fgo_cuda_backend.cu)
+    target_include_directories(gnss_fgo_cuda_backend PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/algorithms)
+    target_link_libraries(gnss_fgo_cuda_backend PRIVATE
+        CUDA::cudart CUDA::cusolver)
+    set_target_properties(gnss_fgo_cuda_backend PROPERTIES
+        CUDA_STANDARD 20
+        CUDA_STANDARD_REQUIRED ON
+        CUDA_ARCHITECTURES "60;70;75;80;86")
+endif()
+
 # Historically -O0/-Od for debuggability; the hot solver paths in this list
 # (lambda, navigation, spp, observation) made kinematic runs ~2.3x slower.
 # -O2 output is byte-identical on the CLAS kinematic parity runs.
@@ -315,6 +340,10 @@ target_include_directories(gnss_lib_noopt PUBLIC
     $<INSTALL_INTERFACE:${CMAKE_INSTALL_INCLUDEDIR}>
 )
 target_link_libraries(gnss_lib_noopt PUBLIC Eigen3::Eigen)
+if(GNSSPP_ENABLE_CUDA_FGO)
+    target_compile_definitions(gnss_lib_noopt PRIVATE GNSSPP_HAS_CUDA_FGO=1)
+    target_link_libraries(gnss_lib_noopt PRIVATE gnss_fgo_cuda_backend)
+endif()
 if(CHOLMOD_INCLUDE_DIR AND CHOLMOD_LIBRARY)
     target_include_directories(gnss_lib_noopt PRIVATE ${CHOLMOD_INCLUDE_DIR})
     target_compile_definitions(gnss_lib_noopt PRIVATE GNSSPP_HAS_CHOLMOD=1)
@@ -361,6 +390,9 @@ set(GNSS_INSTALL_TARGETS
     gnss_rtk_runtime
     sofa
     ginan_iers2010)
+if(GNSSPP_ENABLE_CUDA_FGO)
+    list(APPEND GNSS_INSTALL_TARGETS gnss_fgo_cuda_backend)
+endif()
 if(MADOCALIB_PARITY_LINK)
     list(APPEND GNSS_INSTALL_TARGETS madocalib)
 endif()

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -68,7 +68,8 @@ add_executable(gnss_solve
     ${GNSS_NATIVE_DIR}/gnss_solve.cpp
     ${GNSS_NATIVE_DIR}/cli_toml_config.cpp
 )
-target_link_libraries(gnss_solve PRIVATE gnss_lib gnss_rtk_runtime Threads::Threads)
+target_link_libraries(
+    gnss_solve PRIVATE gnss_lib gnss_rtk_runtime gnss_lib_noopt Threads::Threads)
 
 add_executable(gnss_ppp ${GNSS_NATIVE_DIR}/gnss_ppp.cpp)
 target_link_libraries(gnss_ppp PRIVATE gnss_lib gnss_lib_noopt Threads::Threads)

--- a/apps/native/gnss_fgo.cpp
+++ b/apps/native/gnss_fgo.cpp
@@ -95,6 +95,12 @@ struct Options {
     int lambda_top_k_candidates = 2;
     double lambda_min_bootstrapped_success_rate = 0.0;
     double lambda_max_adop_cycles = 0.0;
+    bool use_multisd_disjoint_validation = false;
+    int multisd_validation_holdout_satellites = 4;
+    int multisd_validation_holdout_offset = 0;
+    double multisd_validation_aperture_cycles = 0.15;
+    double multisd_validation_min_carrier_fraction = 1.0;
+    double multisd_validation_max_ddpr_rms_m = 3.0;
     bool use_carrier_phase_factors = false;
     bool fix_ambiguities = false;
     bool fix_all_ambiguities = false;
@@ -188,6 +194,12 @@ void printUsage(const char* program_name) {
         << "  --lambda-top-k <n>            Bounded LAMBDA hypotheses, 2..32 (default: 2)\n"
         << "  --lambda-min-success <p>      Bootstrapped success-rate gate; 0 disables\n"
         << "  --lambda-max-adop <cycles>    ADOP gate in cycles; 0 disables\n"
+        << "  --multisd-disjoint-validation Reserve GNSS satellites for independent validation\n"
+        << "  --multisd-holdout-satellites <n> Holdout satellite count (default: 4)\n"
+        << "  --multisd-holdout-offset <n> Deterministic ranked-partition offset\n"
+        << "  --multisd-validation-aperture <cycles> Carrier integer aperture (default: 0.15)\n"
+        << "  --multisd-validation-min-carrier-fraction <f> Required holdout agreement (default: 1)\n"
+        << "  --multisd-validation-max-ddpr <m> DD code RMS ceiling (default: 3)\n"
         << "  --max-tdcp-gap <s>            Max adjacent epoch gap for TDCP (default: 2)\n"
         << "  --base-match-tolerance <s>    Max rover/base epoch gap for DD factors (default: 0.02)\n"
         << "  --base-interpolation-max-gap <s>\n"
@@ -541,6 +553,18 @@ Options parseArguments(int argc, char* argv[]) {
                 std::stod(argv[++i]);
         } else if (arg == "--lambda-max-adop" && i + 1 < argc) {
             options.lambda_max_adop_cycles = std::stod(argv[++i]);
+        } else if (arg == "--multisd-disjoint-validation") {
+            options.use_multisd_disjoint_validation = true;
+        } else if (arg == "--multisd-holdout-satellites" && i + 1 < argc) {
+            options.multisd_validation_holdout_satellites = std::stoi(argv[++i]);
+        } else if (arg == "--multisd-holdout-offset" && i + 1 < argc) {
+            options.multisd_validation_holdout_offset = std::stoi(argv[++i]);
+        } else if (arg == "--multisd-validation-aperture" && i + 1 < argc) {
+            options.multisd_validation_aperture_cycles = std::stod(argv[++i]);
+        } else if (arg == "--multisd-validation-min-carrier-fraction" && i + 1 < argc) {
+            options.multisd_validation_min_carrier_fraction = std::stod(argv[++i]);
+        } else if (arg == "--multisd-validation-max-ddpr" && i + 1 < argc) {
+            options.multisd_validation_max_ddpr_rms_m = std::stod(argv[++i]);
         } else if (arg == "--max-tdcp-gap" && i + 1 < argc) {
             options.max_tdcp_gap_s = std::stod(argv[++i]);
         } else if (arg == "--base-match-tolerance" && i + 1 < argc) {
@@ -751,6 +775,23 @@ Options parseArguments(int argc, char* argv[]) {
     if (options.lambda_max_adop_cycles < 0.0) {
         argumentError("--lambda-max-adop must be non-negative", argv[0]);
     }
+    if (options.multisd_validation_holdout_satellites < 1) {
+        argumentError("--multisd-holdout-satellites must be positive", argv[0]);
+    }
+    if (options.multisd_validation_holdout_offset < 0) {
+        argumentError("--multisd-holdout-offset must be non-negative", argv[0]);
+    }
+    if (options.multisd_validation_aperture_cycles < 0.0 ||
+        options.multisd_validation_aperture_cycles > 0.5) {
+        argumentError("--multisd-validation-aperture must be in [0, 0.5]", argv[0]);
+    }
+    if (options.multisd_validation_min_carrier_fraction < 0.0 ||
+        options.multisd_validation_min_carrier_fraction > 1.0) {
+        argumentError("--multisd-validation-min-carrier-fraction must be in [0, 1]", argv[0]);
+    }
+    if (options.multisd_validation_max_ddpr_rms_m < 0.0) {
+        argumentError("--multisd-validation-max-ddpr must be non-negative", argv[0]);
+    }
     if (options.max_tdcp_gap_s < 0.0) {
         argumentError("--max-tdcp-gap must be non-negative", argv[0]);
     }
@@ -829,6 +870,14 @@ std::string jsonEscape(const std::string& value) {
 
 const char* jsonBool(bool value) {
     return value ? "true" : "false";
+}
+
+void writeJsonNumber(std::ostream& output, double value) {
+    if (std::isfinite(value)) {
+        output << value;
+    } else {
+        output << "null";
+    }
 }
 
 struct SeedPosition {
@@ -1860,6 +1909,18 @@ void writeSummaryJson(const Options& options,
            << options.lambda_min_bootstrapped_success_rate << ",\n";
     output << "  \"lambda_max_adop_cycles\": "
            << options.lambda_max_adop_cycles << ",\n";
+    output << "  \"use_multisd_disjoint_validation\": "
+           << jsonBool(options.use_multisd_disjoint_validation) << ",\n";
+    output << "  \"multisd_validation_holdout_satellites\": "
+           << options.multisd_validation_holdout_satellites << ",\n";
+    output << "  \"multisd_validation_holdout_offset\": "
+           << options.multisd_validation_holdout_offset << ",\n";
+    output << "  \"multisd_validation_aperture_cycles\": "
+           << options.multisd_validation_aperture_cycles << ",\n";
+    output << "  \"multisd_validation_min_carrier_fraction\": "
+           << options.multisd_validation_min_carrier_fraction << ",\n";
+    output << "  \"multisd_validation_max_ddpr_rms_m\": "
+           << options.multisd_validation_max_ddpr_rms_m << ",\n";
     output << "  \"use_integer_constrained_reoptimization\": "
            << jsonBool(options.use_integer_constrained_reoptimization) << ",\n";
     output << "  \"integer_constrained_prior_sigma_cycles\": "
@@ -1984,10 +2045,64 @@ void writeSummaryJson(const Options& options,
            << diagnostics.lambda_ambiguity_ratio << ",\n";
     output << "  \"lambda_bootstrapped_success_rate\": "
            << diagnostics.lambda_bootstrapped_success_rate << ",\n";
-    output << "  \"lambda_adop_cycles\": "
-           << diagnostics.lambda_adop_cycles << ",\n";
+    output << "  \"lambda_adop_cycles\": ";
+    writeJsonNumber(output, diagnostics.lambda_adop_cycles);
+    output << ",\n";
     output << "  \"lambda_top_k_generated\": "
            << diagnostics.lambda_top_k_generated << ",\n";
+    output << "  \"multisd_validation_evaluated\": "
+           << jsonBool(diagnostics.multisd_validation_evaluated) << ",\n";
+    output << "  \"multisd_validation_pass\": "
+           << jsonBool(diagnostics.multisd_validation_pass) << ",\n";
+    output << "  \"multisd_validation_holdout_satellites\": "
+           << diagnostics.multisd_validation_holdout_satellites << ",\n";
+    output << "  \"multisd_validation_carrier_used\": "
+           << diagnostics.multisd_validation_carrier_used << ",\n";
+    output << "  \"multisd_validation_carrier_passed\": "
+           << diagnostics.multisd_validation_carrier_passed << ",\n";
+    output << "  \"multisd_validation_pseudorange_used\": "
+           << diagnostics.multisd_validation_pseudorange_used << ",\n";
+    output << "  \"multisd_validation_hypotheses_evaluated\": "
+           << diagnostics.multisd_validation_hypotheses_evaluated << ",\n";
+    output << "  \"multisd_validation_hypotheses_passed\": "
+           << diagnostics.multisd_validation_hypotheses_passed << ",\n";
+    output << "  \"multisd_validation_selected_rank\": "
+           << diagnostics.multisd_validation_selected_rank << ",\n";
+    output << "  \"multisd_validation_max_integer_distance_cycles\": ";
+    writeJsonNumber(
+        output,
+        diagnostics.multisd_validation_max_integer_distance_cycles);
+    output << ",\n";
+    output << "  \"multisd_validation_ddpr_rms_m\": ";
+    writeJsonNumber(output, diagnostics.multisd_validation_ddpr_rms_m);
+    output << ",\n";
+    output << "  \"multisd_validation_hypothesis_details\": [";
+    for (std::size_t i = 0;
+         i < result.multisd_validation_hypotheses.size();
+         ++i) {
+        const auto& hypothesis = result.multisd_validation_hypotheses[i];
+        if (i > 0) {
+            output << ',';
+        }
+        output << "{\"rank\":" << hypothesis.rank
+               << ",\"evaluated\":" << jsonBool(hypothesis.evaluated)
+               << ",\"pass\":" << jsonBool(hypothesis.pass)
+               << ",\"position_ecef\":["
+               << hypothesis.latest_position_ecef.x() << ','
+               << hypothesis.latest_position_ecef.y() << ','
+               << hypothesis.latest_position_ecef.z() << ']'
+               << ",\"carrier_used\":" << hypothesis.carrier_used
+               << ",\"carrier_passed\":" << hypothesis.carrier_passed
+               << ",\"pseudorange_used\":"
+               << hypothesis.pseudorange_used
+               << ",\"max_integer_distance_cycles\":";
+        writeJsonNumber(
+            output, hypothesis.maximum_integer_distance_cycles);
+        output << ",\"ddpr_rms_m\":";
+        writeJsonNumber(output, hypothesis.ddpr_rms_m);
+        output << '}';
+    }
+    output << "],\n";
     output << "  \"fixed_ambiguities\": " << diagnostics.fixed_ambiguities << ",\n";
     output << "  \"fixed_solution\": " << jsonBool(diagnostics.fixed_solution) << ",\n";
     output << "  \"tdcp_candidate_pairs\": " << diagnostics.tdcp_candidate_pairs << ",\n";
@@ -3413,6 +3528,18 @@ int main(int argc, char* argv[]) {
         config.lambda_min_bootstrapped_success_rate =
             options.lambda_min_bootstrapped_success_rate;
         config.lambda_max_adop_cycles = options.lambda_max_adop_cycles;
+        config.use_multisd_disjoint_validation =
+            options.use_multisd_disjoint_validation;
+        config.multisd_validation_holdout_satellites =
+            options.multisd_validation_holdout_satellites;
+        config.multisd_validation_holdout_offset =
+            options.multisd_validation_holdout_offset;
+        config.multisd_validation_aperture_cycles =
+            options.multisd_validation_aperture_cycles;
+        config.multisd_validation_min_carrier_fraction =
+            options.multisd_validation_min_carrier_fraction;
+        config.multisd_validation_max_ddpr_rms_m =
+            options.multisd_validation_max_ddpr_rms_m;
         config.use_epoch_lambda_fixed_output =
             options.use_epoch_lambda_fixed_output &&
             !options.use_multisd_ambiguities;
@@ -3639,6 +3766,22 @@ int main(int argc, char* argv[]) {
                       << "\n";
             std::cout << "LAMBDA ADOP (cycles): "
                       << result.diagnostics.lambda_adop_cycles << "\n";
+            std::cout << "MultiSD disjoint validation: "
+                      << (result.diagnostics.multisd_validation_pass ? "pass" : "fail")
+                      << " (evaluated="
+                      << (result.diagnostics.multisd_validation_evaluated ? "yes" : "no")
+                      << ", holdout="
+                      << result.diagnostics.multisd_validation_holdout_satellites
+                      << ", hypotheses="
+                      << result.diagnostics.multisd_validation_hypotheses_passed
+                      << "/"
+                      << result.diagnostics.multisd_validation_hypotheses_evaluated
+                      << ", selected_rank="
+                      << result.diagnostics.multisd_validation_selected_rank
+                      << ", max_integer_distance="
+                      << result.diagnostics.multisd_validation_max_integer_distance_cycles
+                      << " cycles, DDPR_RMS="
+                      << result.diagnostics.multisd_validation_ddpr_rms_m << " m)\n";
             std::cout << "Fixed ambiguities: "
                       << result.diagnostics.fixed_ambiguities << "\n";
             std::cout << "Fixed solution: "

--- a/apps/native/gnss_fgo.cpp
+++ b/apps/native/gnss_fgo.cpp
@@ -92,6 +92,9 @@ struct Options {
     double max_float_position_jump_m = 0.0;
     int min_fixed_ambiguities = 4;
     int max_lambda_ambiguities = 12;
+    int lambda_top_k_candidates = 2;
+    double lambda_min_bootstrapped_success_rate = 0.0;
+    double lambda_max_adop_cycles = 0.0;
     bool use_carrier_phase_factors = false;
     bool fix_ambiguities = false;
     bool fix_all_ambiguities = false;
@@ -110,6 +113,7 @@ struct Options {
     bool use_velocity_states = false;
     bool use_velocity_motion_factors = false;
     bool use_ambiguity_between_factors = false;
+    bool use_multisd_ambiguities = false;
     bool linearize_double_difference_factors_at_seed = false;
     bool dd_ambiguity_per_epoch = false;
     bool no_ambiguity_priors = false;
@@ -181,6 +185,9 @@ void printUsage(const char* program_name) {
         << "  --min-fixed-ambiguities <n>   Min accepted ambiguities before fixed pass (default: 4)\n"
         << "  --lambda-ratio-threshold <v>  LAMBDA ratio threshold (default: 3)\n"
         << "  --max-lambda-ambiguities <n>  Max ambiguity states passed to LAMBDA (default: 12)\n"
+        << "  --lambda-top-k <n>            Bounded LAMBDA hypotheses, 2..32 (default: 2)\n"
+        << "  --lambda-min-success <p>      Bootstrapped success-rate gate; 0 disables\n"
+        << "  --lambda-max-adop <cycles>    ADOP gate in cycles; 0 disables\n"
         << "  --max-tdcp-gap <s>            Max adjacent epoch gap for TDCP (default: 2)\n"
         << "  --base-match-tolerance <s>    Max rover/base epoch gap for DD factors (default: 0.02)\n"
         << "  --base-interpolation-max-gap <s>\n"
@@ -210,6 +217,7 @@ void printUsage(const char* program_name) {
         << "                                Keep optimized float positions in output\n"
         << "  --no-partial-lambda-ambiguity-fix\n"
         << "                                Disable partial LAMBDA retry with fewer candidates\n"
+        << "  --multisd-ambiguities         Use reference-independent SD states and BSD LAMBDA\n"
         << "  --integer-constrained-reoptimization\n"
         << "                                Re-optimize each accepted integer hypothesis and\n"
         << "                                reject it if the original active-graph cost worsens\n"
@@ -526,6 +534,13 @@ Options parseArguments(int argc, char* argv[]) {
             options.lambda_ratio_threshold = std::stod(argv[++i]);
         } else if (arg == "--max-lambda-ambiguities" && i + 1 < argc) {
             options.max_lambda_ambiguities = std::stoi(argv[++i]);
+        } else if (arg == "--lambda-top-k" && i + 1 < argc) {
+            options.lambda_top_k_candidates = std::stoi(argv[++i]);
+        } else if (arg == "--lambda-min-success" && i + 1 < argc) {
+            options.lambda_min_bootstrapped_success_rate =
+                std::stod(argv[++i]);
+        } else if (arg == "--lambda-max-adop" && i + 1 < argc) {
+            options.lambda_max_adop_cycles = std::stod(argv[++i]);
         } else if (arg == "--max-tdcp-gap" && i + 1 < argc) {
             options.max_tdcp_gap_s = std::stod(argv[++i]);
         } else if (arg == "--base-match-tolerance" && i + 1 < argc) {
@@ -579,6 +594,8 @@ Options parseArguments(int argc, char* argv[]) {
             options.integer_constrained_max_iterations = std::stoi(argv[++i]);
         } else if (arg == "--no-partial-lambda-ambiguity-fix") {
             options.use_partial_lambda_ambiguity_fix = false;
+        } else if (arg == "--multisd-ambiguities") {
+            options.use_multisd_ambiguities = true;
         } else if (arg == "--no-pseudorange-factors") {
             options.no_pseudorange_factors = true;
         } else if (arg == "--no-dd-factors") {
@@ -722,6 +739,17 @@ Options parseArguments(int argc, char* argv[]) {
     }
     if (options.max_lambda_ambiguities < 0) {
         argumentError("--max-lambda-ambiguities must be non-negative", argv[0]);
+    }
+    if (options.lambda_top_k_candidates < 2 ||
+        options.lambda_top_k_candidates > 32) {
+        argumentError("--lambda-top-k must be in [2, 32]", argv[0]);
+    }
+    if (options.lambda_min_bootstrapped_success_rate < 0.0 ||
+        options.lambda_min_bootstrapped_success_rate > 1.0) {
+        argumentError("--lambda-min-success must be in [0, 1]", argv[0]);
+    }
+    if (options.lambda_max_adop_cycles < 0.0) {
+        argumentError("--lambda-max-adop must be non-negative", argv[0]);
     }
     if (options.max_tdcp_gap_s < 0.0) {
         argumentError("--max-tdcp-gap must be non-negative", argv[0]);
@@ -1824,6 +1852,14 @@ void writeSummaryJson(const Options& options,
            << ",\n";
     output << "  \"use_epoch_lambda_fixed_output\": "
            << jsonBool(options.use_epoch_lambda_fixed_output) << ",\n";
+    output << "  \"use_multisd_ambiguities\": "
+           << jsonBool(options.use_multisd_ambiguities) << ",\n";
+    output << "  \"lambda_top_k_candidates\": "
+           << options.lambda_top_k_candidates << ",\n";
+    output << "  \"lambda_min_bootstrapped_success_rate\": "
+           << options.lambda_min_bootstrapped_success_rate << ",\n";
+    output << "  \"lambda_max_adop_cycles\": "
+           << options.lambda_max_adop_cycles << ",\n";
     output << "  \"use_integer_constrained_reoptimization\": "
            << jsonBool(options.use_integer_constrained_reoptimization) << ",\n";
     output << "  \"integer_constrained_prior_sigma_cycles\": "
@@ -1917,6 +1953,9 @@ void writeSummaryJson(const Options& options,
            << diagnostics.double_difference_pseudorange_factors << ",\n";
     output << "  \"double_difference_carrier_factors\": "
            << diagnostics.double_difference_carrier_factors << ",\n";
+    output << "  \"multisd_carrier_factors\": "
+           << diagnostics.multisd_carrier_factors
+           << ",\n";
     output << "  \"ambiguity_states\": " << diagnostics.ambiguity_states << ",\n";
     output << "  \"ambiguity_fix_candidates\": " << diagnostics.ambiguity_fix_candidates << ",\n";
     output << "  \"lambda_ambiguity_candidates\": "
@@ -1943,6 +1982,12 @@ void writeSummaryJson(const Options& options,
            << jsonBool(diagnostics.partial_lambda_ambiguity_fix_used) << ",\n";
     output << "  \"lambda_ambiguity_ratio\": "
            << diagnostics.lambda_ambiguity_ratio << ",\n";
+    output << "  \"lambda_bootstrapped_success_rate\": "
+           << diagnostics.lambda_bootstrapped_success_rate << ",\n";
+    output << "  \"lambda_adop_cycles\": "
+           << diagnostics.lambda_adop_cycles << ",\n";
+    output << "  \"lambda_top_k_generated\": "
+           << diagnostics.lambda_top_k_generated << ",\n";
     output << "  \"fixed_ambiguities\": " << diagnostics.fixed_ambiguities << ",\n";
     output << "  \"fixed_solution\": " << jsonBool(diagnostics.fixed_solution) << ",\n";
     output << "  \"tdcp_candidate_pairs\": " << diagnostics.tdcp_candidate_pairs << ",\n";
@@ -3364,8 +3409,13 @@ int main(int argc, char* argv[]) {
         config.ambiguity_fix_max_fractional_cycles =
             options.ambiguity_fix_threshold_cycles;
         config.lambda_ratio_threshold = options.lambda_ratio_threshold;
+        config.lambda_top_k_candidates = options.lambda_top_k_candidates;
+        config.lambda_min_bootstrapped_success_rate =
+            options.lambda_min_bootstrapped_success_rate;
+        config.lambda_max_adop_cycles = options.lambda_max_adop_cycles;
         config.use_epoch_lambda_fixed_output =
-            options.use_epoch_lambda_fixed_output;
+            options.use_epoch_lambda_fixed_output &&
+            !options.use_multisd_ambiguities;
         config.use_integer_constrained_reoptimization =
             options.use_integer_constrained_reoptimization;
         config.integer_constrained_prior_sigma_cycles =
@@ -3411,6 +3461,7 @@ int main(int argc, char* argv[]) {
             options.use_velocity_motion_factors && options.use_velocity_states;
         config.use_ambiguity_between_factors =
             options.use_ambiguity_between_factors;
+        config.use_multisd_ambiguities = options.use_multisd_ambiguities;
         config.linearize_double_difference_factors_at_seed =
             options.linearize_double_difference_factors_at_seed;
         config.reset_double_difference_ambiguities_each_epoch =
@@ -3581,6 +3632,13 @@ int main(int argc, char* argv[]) {
                       << "\n";
             std::cout << "LAMBDA ratio: "
                       << result.diagnostics.lambda_ambiguity_ratio << "\n";
+            std::cout << "LAMBDA top-K generated: "
+                      << result.diagnostics.lambda_top_k_generated << "\n";
+            std::cout << "LAMBDA bootstrapped success rate: "
+                      << result.diagnostics.lambda_bootstrapped_success_rate
+                      << "\n";
+            std::cout << "LAMBDA ADOP (cycles): "
+                      << result.diagnostics.lambda_adop_cycles << "\n";
             std::cout << "Fixed ambiguities: "
                       << result.diagnostics.fixed_ambiguities << "\n";
             std::cout << "Fixed solution: "

--- a/apps/native/gnss_fgo.cpp
+++ b/apps/native/gnss_fgo.cpp
@@ -2146,6 +2146,12 @@ void writeSummaryJson(const Options& options,
     output << "  \"initial_cost\": " << diagnostics.initial_cost << ",\n";
     output << "  \"final_cost\": " << diagnostics.final_cost << ",\n";
     output << "  \"processing_time_ms\": " << diagnostics.processing_time_ms << ",\n";
+    output << "  \"cuda_hypothesis_batch_attempts\": "
+           << diagnostics.cuda_hypothesis_batch_attempts << ",\n";
+    output << "  \"cuda_hypothesis_batch_successes\": "
+           << diagnostics.cuda_hypothesis_batch_successes << ",\n";
+    output << "  \"cuda_hypothesis_batch_rhs_columns\": "
+           << diagnostics.cuda_hypothesis_batch_rhs_columns << ",\n";
     output << "  \"epoch_lambda_processing_time_ms\": "
            << diagnostics.epoch_lambda_processing_time_ms << ",\n";
     output << "  \"epoch_lambda_setup_time_ms\": "

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -79,6 +79,10 @@ struct Args {
     bool no_code_align = false;  // MF hygiene ablation: disable secondary-band code alignment
     bool dd_resid = false;       // per-signal DD residuals at the reference trajectory (no solve)
     bool partial_ar = false;     // MF-AR step 2: partial AR in the fixed-lag LAMBDA
+    bool multisd = false;        // reference-independent SD ambiguity graph
+    int lambda_top_k = 0;
+    double lambda_min_success = -1.0;
+    double lambda_max_adop = -1.0;
     bool integer_constrained_reoptimization = false;
     double integer_constrained_prior_sigma_cycles = -1.0;
     double integer_constrained_cost_tolerance = -1.0;
@@ -254,6 +258,22 @@ Args parseArgs(int argc, char** argv) {
         }
         if (a == "--integer-constrained-max-iterations" && i + 1 < argc) {
             args.integer_constrained_max_iterations = std::stoi(argv[++i]);
+            continue;
+        }
+        if (a == "--multisd") {
+            args.multisd = true;
+            continue;
+        }
+        if (a == "--lambda-top-k" && i + 1 < argc) {
+            args.lambda_top_k = std::stoi(argv[++i]);
+            continue;
+        }
+        if (a == "--lambda-min-success" && i + 1 < argc) {
+            args.lambda_min_success = std::stod(argv[++i]);
+            continue;
+        }
+        if (a == "--lambda-max-adop" && i + 1 < argc) {
+            args.lambda_max_adop = std::stod(argv[++i]);
             continue;
         }
         if (a == "--cp-hold-keep-imu-chain") {
@@ -768,6 +788,19 @@ libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
     if (args.partial_ar) {
         config.use_fixed_lag_partial_lambda = true;
     }
+    if (args.multisd) {
+        config.use_multisd_ambiguities = true;
+    }
+    if (args.lambda_top_k > 0) {
+        config.lambda_top_k_candidates = args.lambda_top_k;
+    }
+    if (args.lambda_min_success >= 0.0) {
+        config.lambda_min_bootstrapped_success_rate =
+            args.lambda_min_success;
+    }
+    if (args.lambda_max_adop >= 0.0) {
+        config.lambda_max_adop_cycles = args.lambda_max_adop;
+    }
     if (args.integer_constrained_reoptimization) {
         config.use_integer_constrained_reoptimization = true;
     }
@@ -1249,7 +1282,8 @@ libgnss::FGOProcessor::FGOResult run(const libgnss::FGOProcessor::FGOProblem& pr
     // output) so the fix comparison is apples-to-apples: the native backend's
     // per-epoch fixing and the GTSAM backend's per-epoch fixing both mark
     // epochs FIXED and snap positions to the fixed ambiguities.
-    config.use_epoch_lambda_fixed_output = use_lambda;
+    config.use_epoch_lambda_fixed_output =
+        use_lambda && !config.use_multisd_ambiguities;
     config.collect_lambda_debug = false;
     if (use_pose3) {
         // Milestone 2a (docs/gtsam_backend_design.md): key the GTSAM rover

--- a/apps/native/gnss_solve.cpp
+++ b/apps/native/gnss_solve.cpp
@@ -4141,6 +4141,9 @@ int main(int argc, char* argv[]) {
                    "optimize_wall_ms,optimizer_cpu_ms,runtime_ms,"
                    "normal_state_size,cuda_selected,cuda_attempts,"
                    "cuda_successes,cuda_fallbacks,cuda_runtime_ms,"
+                   "cuda_hypothesis_batch_attempts,"
+                   "cuda_hypothesis_batch_successes,"
+                   "cuda_hypothesis_batch_rhs_columns,"
                    "fixed_float_separation_m,seed_separation_m\n";
         }
 
@@ -4587,6 +4590,9 @@ int main(int argc, char* argv[]) {
                         << ',' << diagnostics.cuda_dense_solve_successes
                         << ',' << diagnostics.cuda_dense_solve_fallbacks
                         << ',' << diagnostics.cuda_dense_solve_time_ms
+                        << ',' << diagnostics.cuda_hypothesis_batch_attempts
+                        << ',' << diagnostics.cuda_hypothesis_batch_successes
+                        << ',' << diagnostics.cuda_hypothesis_batch_rhs_columns
                         << ',';
                     writeOptionalCsvNumber(
                         multisd_shadow_csv,

--- a/apps/native/gnss_solve.cpp
+++ b/apps/native/gnss_solve.cpp
@@ -1,5 +1,6 @@
 #include <Eigen/Dense>
 #include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cstdlib>
 #include <exception>
@@ -18,6 +19,7 @@
 #include <libgnss++/algorithms/integrity_consensus.hpp>
 #include <libgnss++/algorithms/nlos_weights.hpp>
 #include <libgnss++/algorithms/float_trust_policy.hpp>
+#include <libgnss++/algorithms/fgo.hpp>
 #include <libgnss++/algorithms/rtk.hpp>
 #include <libgnss++/algorithms/rtk_validation.hpp>
 #include <libgnss++/algorithms/spp.hpp>
@@ -104,6 +106,13 @@ struct SolveConfig {
     double doppler_float_seed_max_age_s = 6.0;
     std::string rover_seed_pos_path;
     std::string diagnostics_csv_path;
+    // GNSS-only causal MultiSD FGO shadow. The rolling window ends at the
+    // current RTK epoch and never changes RTK output/filter state.
+    std::string multisd_fgo_shadow_csv_path;
+    int multisd_fgo_shadow_window_epochs = 25;
+    int multisd_fgo_shadow_min_epochs = 10;
+    int multisd_fgo_shadow_holdout_offset = 2;
+    int multisd_fgo_shadow_top_k = 4;
     double rtk_update_outlier_threshold = 0.0;
     bool student_t_rtk_front_end = false;
     double ratio_threshold = 3.0;
@@ -1925,6 +1934,16 @@ void printAdvancedUsage(const char* program_name) {
         << "                             Maximum trusted-anchor age (default: 6)\n"
         << "  --rover-seed-pos <file>    Inject ECEF seed positions from .pos file per epoch\n"
         << "  --diagnostics-csv <file>   Write per-epoch RTK candidate diagnostics CSV (PPC pipeline format)\n"
+        << "  --multisd-fgo-shadow-csv <file>\n"
+        << "                             GNSS-only causal rolling-window MultiSD shadow telemetry\n"
+        << "  --multisd-fgo-shadow-window <epochs>\n"
+        << "                             Rolling window ending at current epoch (default: 25)\n"
+        << "  --multisd-fgo-shadow-min-epochs <epochs>\n"
+        << "                             Warm-up before shadow solve (default: 10)\n"
+        << "  --multisd-fgo-shadow-holdout-offset <n>\n"
+        << "                             Deterministic disjoint partition offset (default: 2)\n"
+        << "  --multisd-fgo-shadow-top-k <n>\n"
+        << "                             Bounded integer hypotheses, 2..32 (default: 4)\n"
         << "  --realtime-fix-integrity   Gate FIX output with bounded-latency residual checks\n"
         << "                             (default: off; maximum latency: 7 epochs)\n"
         << "  --integrity-base-gate      Also enable the frozen offline low-satellite/ratio\n"
@@ -2169,6 +2188,26 @@ SolveConfig parseArguments(int argc, char* argv[]) {
         if (arg == "-h" || arg == "--help") {
             printUsage(argv[0]);
             std::exit(0);
+        }
+        if (arg == "--multisd-fgo-shadow-csv" && i + 1 < argc) {
+            config.multisd_fgo_shadow_csv_path = argv[++i];
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-window" && i + 1 < argc) {
+            config.multisd_fgo_shadow_window_epochs = std::stoi(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-min-epochs" && i + 1 < argc) {
+            config.multisd_fgo_shadow_min_epochs = std::stoi(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-holdout-offset" && i + 1 < argc) {
+            config.multisd_fgo_shadow_holdout_offset = std::stoi(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-top-k" && i + 1 < argc) {
+            config.multisd_fgo_shadow_top_k = std::stoi(argv[++i]);
+            continue;
         }
         // Phase 2a CMC-aware reference selection flags: kept as STANDALONE
         // ifs (each ending in `continue`) rather than joining the else-if
@@ -2448,74 +2487,126 @@ SolveConfig parseArguments(int argc, char* argv[]) {
         }
         if (arg == "--data-dir" && i + 1 < argc) {
             config.data_dir = argv[++i];
-        } else if (arg == "--rover" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--rover" && i + 1 < argc) {
             config.rover_obs_path = argv[++i];
-        } else if (arg == "--base" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--base" && i + 1 < argc) {
             config.base_obs_path = argv[++i];
-        } else if (arg == "--nav" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--nav" && i + 1 < argc) {
             config.nav_path = argv[++i];
-        } else if (arg == "--out" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--out" && i + 1 < argc) {
             config.output_pos_path = argv[++i];
-        } else if (arg == "--kml" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--kml" && i + 1 < argc) {
             config.output_kml_path = argv[++i];
             config.write_kml = true;
-        } else if (arg == "--no-kml") {
+            continue;
+        }
+        if (arg == "--no-kml") {
             config.write_kml = false;
-        } else if (arg == "--format" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--format" && i + 1 < argc) {
             config.output_format = parseOutputFormat(argv[++i], argv[0]);
-        } else if (arg == "--mode" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--mode" && i + 1 < argc) {
             config.mode = parseModeChoice(argv[++i], argv[0]);
-        } else if (arg == "--iono" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--iono" && i + 1 < argc) {
             config.iono = parseIonoChoice(argv[++i], argv[0]);
-        } else if (arg == "--ratio" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--ratio" && i + 1 < argc) {
             const std::string ratio_value = argv[++i];
             config.enable_satellite_count_ratio_threshold = ratio_value == "sat-count";
             config.ratio_threshold = config.enable_satellite_count_ratio_threshold
                 ? 3.0
                 : std::stod(ratio_value);
             config.ratio_threshold_set = true;
-        } else if (arg == "--preset" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--preset" && i + 1 < argc) {
             config.preset = parseRTKTuningPreset(argv[++i], argv[0]);
-        } else if (arg == "--arfilter") {
+            continue;
+        }
+        if (arg == "--arfilter") {
             config.enable_ar_filter = true;
             config.has_ar_filter_override = true;
-        } else if (arg == "--no-arfilter") {
+            continue;
+        }
+        if (arg == "--no-arfilter") {
             config.enable_ar_filter = false;
             config.has_ar_filter_override = true;
-        } else if (arg == "--arfilter-margin" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--arfilter-margin" && i + 1 < argc) {
             config.ar_filter_margin = std::stod(argv[++i]);
             config.ar_filter_margin_set = true;
-        } else if (arg == "--min-ar-sats" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--min-ar-sats" && i + 1 < argc) {
             config.min_satellites_for_ar = std::stoi(argv[++i]);
             config.min_satellites_for_ar_set = true;
-        } else if (arg == "--min-subset-ar-pairs" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--min-subset-ar-pairs" && i + 1 < argc) {
             config.min_subset_pairs_for_ar = std::stoi(argv[++i]);
-        } else if (arg == "--max-subset-ar-drop-steps" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--max-subset-ar-drop-steps" && i + 1 < argc) {
             config.max_subset_drop_steps_for_ar = std::stoi(argv[++i]);
-        } else if (arg == "--min-subset-ar-sats" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--min-subset-ar-sats" && i + 1 < argc) {
             config.min_subset_sats_for_ar = std::stoi(argv[++i]);
             config.min_subset_sats_for_ar_set = true;
-        } else if (arg == "--min-subset-ar-systems" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--min-subset-ar-systems" && i + 1 < argc) {
             config.min_subset_systems_for_ar = std::stoi(argv[++i]);
             config.min_subset_systems_for_ar_set = true;
-        } else if (arg == "--min-subset-ar-freqs" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--min-subset-ar-freqs" && i + 1 < argc) {
             config.min_subset_frequencies_for_ar = std::stoi(argv[++i]);
             config.min_subset_frequencies_for_ar_set = true;
-        } else if (arg == "--min-subset-ar-dual-freq-sats" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--min-subset-ar-dual-freq-sats" && i + 1 < argc) {
             config.min_subset_dual_frequency_sats_for_ar = std::stoi(argv[++i]);
             config.min_subset_dual_frequency_sats_for_ar_set = true;
-        } else if (arg == "--min-full-ratio-for-subset-ar" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--min-full-ratio-for-subset-ar" && i + 1 < argc) {
             config.min_full_ratio_for_subset_ar = std::stod(argv[++i]);
             config.min_full_ratio_for_subset_ar_set = true;
-        } else if (arg == "--min-hold-count" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--min-hold-count" && i + 1 < argc) {
             config.min_hold_count = std::stoi(argv[++i]);
             config.min_hold_count_set = true;
-        } else if (arg == "--hold-ratio-threshold" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--hold-ratio-threshold" && i + 1 < argc) {
             config.hold_ratio_threshold = std::stod(argv[++i]);
             config.hold_ratio_threshold_set = true;
-        } else if (arg == "--elevation-mask-deg" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--elevation-mask-deg" && i + 1 < argc) {
             config.elevation_mask_deg = std::stod(argv[++i]);
-        } else if (arg == "--process-noise-position" && i + 1 < argc) {
+            continue;
+        }
+        if (arg == "--process-noise-position" && i + 1 < argc) {
             config.process_noise_position = std::stod(argv[++i]);
             config.process_noise_position_set = true;
         } else if (arg == "--process-noise-ambiguity" && i + 1 < argc) {
@@ -3282,6 +3373,26 @@ SolveConfig parseArguments(int argc, char* argv[]) {
         config.doppler_float_seed_max_age_s <= 0.0) {
         argumentError("--doppler-float-seed-max-age must be > 0", argv[0]);
     }
+    if (config.multisd_fgo_shadow_window_epochs < 2) {
+        argumentError("--multisd-fgo-shadow-window must be >= 2", argv[0]);
+    }
+    if (config.multisd_fgo_shadow_min_epochs < 2 ||
+        config.multisd_fgo_shadow_min_epochs >
+            config.multisd_fgo_shadow_window_epochs) {
+        argumentError(
+            "--multisd-fgo-shadow-min-epochs must be in [2, window]",
+            argv[0]);
+    }
+    if (config.multisd_fgo_shadow_holdout_offset < 0) {
+        argumentError(
+            "--multisd-fgo-shadow-holdout-offset must be non-negative",
+            argv[0]);
+    }
+    if (config.multisd_fgo_shadow_top_k < 2 ||
+        config.multisd_fgo_shadow_top_k > 32) {
+        argumentError("--multisd-fgo-shadow-top-k must be in [2, 32]",
+                      argv[0]);
+    }
 
     return config;
 }
@@ -3378,6 +3489,58 @@ bool writeSolutions(const SolveConfig& config, const libgnss::Solution& solution
 
 double roundedTowKey(double tow) {
     return std::round(tow * 10.0) / 10.0;
+}
+
+libgnss::FGOProcessor::FGOConfig makeGnssOnlyMultiSdShadowConfig(
+    const SolveConfig& solve_config) {
+    libgnss::FGOProcessor::FGOConfig config;
+    config.backend = libgnss::FGOBackend::Eigen;
+    config.max_iterations = 12;
+    config.pseudorange_sigma_m = 4.0;
+    config.motion_sigma_m = 100.0;
+    config.clock_motion_sigma_m = 600.0;
+    config.tdcp_sigma_m = 0.05;
+    config.carrier_phase_sigma_m = 0.02;
+    config.double_difference_pseudorange_sigma_m = 1.0;
+    config.double_difference_carrier_sigma_m = 0.02;
+    config.ambiguity_prior_sigma_m = 2000.0;
+    config.fixed_ambiguity_sigma_m = 0.005;
+    config.pseudorange_huber_threshold_sigma = 3.0;
+    config.carrier_phase_huber_threshold_sigma = 3.0;
+    config.tdcp_huber_threshold_sigma = 3.0;
+    config.max_tdcp_gap_s = 1.5;
+    config.base_epoch_match_tolerance_s = 0.02;
+    config.base_interpolation_max_gap_s = 1.2;
+    config.tdcp_code_phase_jump_threshold_m = 6.0;
+    config.min_elevation_deg = 15.0;
+    config.use_spp_seed = false;
+    config.use_double_difference_factors = true;
+    config.use_single_difference_doppler_factors = true;
+    config.use_single_difference_tdcp_factors = true;
+    config.use_velocity_states = true;
+    config.use_velocity_motion_factors = true;
+    config.fix_ambiguities = true;
+    config.use_lambda_ambiguity_fix = true;
+    config.lambda_ratio_threshold = 1.5;
+    config.min_fixed_ambiguities = 6;
+    config.max_lambda_ambiguities = 16;
+    config.lambda_top_k_candidates = solve_config.multisd_fgo_shadow_top_k;
+    config.parallelize_lambda_hypotheses = true;
+    config.use_multisd_ambiguities = true;
+    config.use_multisd_disjoint_validation = true;
+    config.multisd_validation_holdout_satellites = 4;
+    config.multisd_validation_holdout_offset =
+        solve_config.multisd_fgo_shadow_holdout_offset;
+    config.multisd_validation_aperture_cycles = 0.15;
+    config.multisd_validation_min_carrier_fraction = 1.0;
+    config.multisd_validation_max_ddpr_rms_m = 3.0;
+    return config;
+}
+
+void writeOptionalCsvNumber(std::ostream& output, double value) {
+    if (std::isfinite(value)) {
+        output << value;
+    }
 }
 
 std::map<double, Eigen::Vector3d> loadSeedPositions(const std::string& path) {
@@ -3687,6 +3850,31 @@ int main(int argc, char* argv[]) {
             writeDiagnosticsHeader(diagnostics_csv);
         }
 
+        const libgnss::FGOProcessor multisd_shadow_processor(
+            makeGnssOnlyMultiSdShadowConfig(config));
+        std::vector<libgnss::ObservationData> multisd_shadow_rover_window;
+        std::vector<libgnss::ObservationData> multisd_shadow_base_window;
+        multisd_shadow_rover_window.reserve(
+            static_cast<std::size_t>(config.multisd_fgo_shadow_window_epochs));
+        multisd_shadow_base_window.reserve(
+            static_cast<std::size_t>(config.multisd_fgo_shadow_window_epochs));
+        std::ofstream multisd_shadow_csv;
+        if (!config.multisd_fgo_shadow_csv_path.empty()) {
+            multisd_shadow_csv.open(config.multisd_fgo_shadow_csv_path);
+            if (!multisd_shadow_csv.is_open()) {
+                std::cerr << "Error: failed to open MultiSD FGO shadow CSV: "
+                          << config.multisd_fgo_shadow_csv_path << std::endl;
+                return 1;
+            }
+            multisd_shadow_csv
+                << "epoch_index,gps_week,tow,window_epochs,rtk_status,"
+                   "shadow_status,shadow_fixed,lambda_ratio,fixed_ambiguities,"
+                   "validation_evaluated,validation_pass,holdout_satellites,"
+                   "hypotheses_passed,hypotheses_evaluated,selected_rank,"
+                   "carrier_passed,carrier_used,max_integer_distance_cycles,"
+                   "ddpr_rms_m,x,y,z,rtk_position_delta_m,runtime_ms\n";
+        }
+
         std::unique_ptr<IntegrityShadowTimeline> integrity_shadow;
         if (!config.integrity_shadow_csv_path.empty()) {
             IntegrityShadowTimeline::Config shadow_config;
@@ -3868,6 +4056,10 @@ int main(int argc, char* argv[]) {
         int availability_spp_fallback_epochs = 0;
         int availability_propagated_fallback_epochs = 0;
         int availability_postfilter_reinserted_epochs = 0;
+        std::size_t multisd_shadow_attempts = 0;
+        std::size_t multisd_shadow_valid = 0;
+        std::size_t multisd_shadow_fixed = 0;
+        double multisd_shadow_total_runtime_ms = 0.0;
         libgnss::PositionSolution last_fixed_output;
         bool have_last_fixed_output = false;
         libgnss::PositionSolution last_guard_output;
@@ -3960,6 +4152,136 @@ int main(int argc, char* argv[]) {
             }
 
             auto pos_solution = rtk_processor.processRTKEpoch(rover_obs, aligned_base_obs, nav_data);
+
+            // GNSS-only, strictly causal shadow: the window contains only
+            // observations at or before this RTK epoch, and only its latest
+            // solution is recorded. It has no authority over RTK output or
+            // state. RTK's current estimate is used solely as the geometry
+            // seed (never reference truth).
+            if (multisd_shadow_csv.is_open()) {
+                libgnss::ObservationData shadow_rover = rover_obs;
+                if (pos_solution.isValid() &&
+                    pos_solution.position_ecef.allFinite()) {
+                    shadow_rover.receiver_position =
+                        pos_solution.position_ecef;
+                    shadow_rover.receiver_clock_bias =
+                        pos_solution.receiver_clock_bias;
+                }
+                multisd_shadow_rover_window.push_back(
+                    std::move(shadow_rover));
+                multisd_shadow_base_window.push_back(aligned_base_obs);
+                const std::size_t maximum_window =
+                    static_cast<std::size_t>(
+                        config.multisd_fgo_shadow_window_epochs);
+                if (multisd_shadow_rover_window.size() > maximum_window) {
+                    multisd_shadow_rover_window.erase(
+                        multisd_shadow_rover_window.begin());
+                    multisd_shadow_base_window.erase(
+                        multisd_shadow_base_window.begin());
+                }
+
+                if (multisd_shadow_rover_window.size() >=
+                    static_cast<std::size_t>(
+                        config.multisd_fgo_shadow_min_epochs)) {
+                    const auto shadow_start =
+                        std::chrono::steady_clock::now();
+                    const auto shadow_problem =
+                        multisd_shadow_processor.buildDoubleDifferenceProblem(
+                            multisd_shadow_rover_window,
+                            multisd_shadow_base_window,
+                            nav_data,
+                            base_position);
+                    const auto shadow_result =
+                        multisd_shadow_processor.optimizeProblem(shadow_problem);
+                    const double shadow_runtime_ms =
+                        std::chrono::duration<double, std::milli>(
+                            std::chrono::steady_clock::now() - shadow_start)
+                            .count();
+                    ++multisd_shadow_attempts;
+                    multisd_shadow_total_runtime_ms += shadow_runtime_ms;
+
+                    const libgnss::PositionSolution* shadow_latest = nullptr;
+                    if (!shadow_result.solution.solutions.empty()) {
+                        const auto& candidate =
+                            shadow_result.solution.solutions.back();
+                        if (std::abs(candidate.time - rover_obs.time) <=
+                            kExactTimeToleranceSeconds) {
+                            shadow_latest = &candidate;
+                        }
+                    }
+                    if (shadow_latest && shadow_latest->isValid()) {
+                        ++multisd_shadow_valid;
+                        if (shadow_latest->isFixed()) {
+                            ++multisd_shadow_fixed;
+                        }
+                    }
+
+                    const auto& diagnostics = shadow_result.diagnostics;
+                    multisd_shadow_csv
+                        << processed_rover_epochs << ','
+                        << rover_obs.time.week << ','
+                        << std::setprecision(12) << rover_obs.time.tow << ','
+                        << multisd_shadow_rover_window.size() << ','
+                        << static_cast<int>(pos_solution.status) << ','
+                        << (shadow_latest
+                                ? static_cast<int>(shadow_latest->status)
+                                : static_cast<int>(libgnss::SolutionStatus::NONE))
+                        << ','
+                        << (shadow_latest && shadow_latest->isFixed() ? 1 : 0)
+                        << ',';
+                    writeOptionalCsvNumber(
+                        multisd_shadow_csv,
+                        shadow_latest ? shadow_latest->ratio
+                                      : diagnostics.lambda_ambiguity_ratio);
+                    multisd_shadow_csv << ','
+                        << (shadow_latest
+                                ? shadow_latest->num_fixed_ambiguities
+                                : 0)
+                        << ','
+                        << (diagnostics.multisd_validation_evaluated ? 1 : 0)
+                        << ','
+                        << (diagnostics.multisd_validation_pass ? 1 : 0)
+                        << ','
+                        << diagnostics.multisd_validation_holdout_satellites
+                        << ','
+                        << diagnostics.multisd_validation_hypotheses_passed
+                        << ','
+                        << diagnostics.multisd_validation_hypotheses_evaluated
+                        << ','
+                        << diagnostics.multisd_validation_selected_rank
+                        << ','
+                        << diagnostics.multisd_validation_carrier_passed
+                        << ','
+                        << diagnostics.multisd_validation_carrier_used
+                        << ',';
+                    writeOptionalCsvNumber(
+                        multisd_shadow_csv,
+                        diagnostics
+                            .multisd_validation_max_integer_distance_cycles);
+                    multisd_shadow_csv << ',';
+                    writeOptionalCsvNumber(
+                        multisd_shadow_csv,
+                        diagnostics.multisd_validation_ddpr_rms_m);
+                    multisd_shadow_csv << ',';
+                    if (shadow_latest) {
+                        multisd_shadow_csv
+                            << std::setprecision(12)
+                            << shadow_latest->position_ecef.x() << ','
+                            << shadow_latest->position_ecef.y() << ','
+                            << shadow_latest->position_ecef.z() << ',';
+                        if (pos_solution.isValid()) {
+                            writeOptionalCsvNumber(
+                                multisd_shadow_csv,
+                                (shadow_latest->position_ecef -
+                                 pos_solution.position_ecef)
+                                    .norm());
+                        }
+                    } else {
+                        multisd_shadow_csv << ",,,";
+                    }
+                    multisd_shadow_csv << ',' << shadow_runtime_ms << '\n';
+                }
+            }
             const libgnss::PositionSolution* last_output =
                 have_last_guard_output ? &last_guard_output : nullptr;
             const bool have_last_output = last_output != nullptr;
@@ -4736,6 +5058,19 @@ int main(int argc, char* argv[]) {
                           << "% qualified as demotion authority)";
             }
             std::cout << std::endl;
+        }
+        if (multisd_shadow_csv.is_open()) {
+            std::cout << "  GNSS-only MultiSD shadow: attempts="
+                      << multisd_shadow_attempts
+                      << " valid=" << multisd_shadow_valid
+                      << " fixed=" << multisd_shadow_fixed;
+            if (multisd_shadow_attempts > 0) {
+                std::cout << " mean_runtime_ms="
+                          << (multisd_shadow_total_runtime_ms /
+                              static_cast<double>(multisd_shadow_attempts));
+            }
+            std::cout << " csv=" << config.multisd_fgo_shadow_csv_path
+                      << std::endl;
         }
         std::cout << "  output written: " << config.output_pos_path << std::endl;
         if (config.write_kml) {

--- a/apps/native/gnss_solve.cpp
+++ b/apps/native/gnss_solve.cpp
@@ -3873,7 +3873,9 @@ int main(int argc, char* argv[]) {
                    "hypotheses_passed,hypotheses_evaluated,selected_rank,"
                    "carrier_passed,carrier_used,max_integer_distance_cycles,"
                    "ddpr_rms_m,x,y,z,rtk_position_delta_m,build_runtime_ms,"
-                   "optimize_wall_ms,optimizer_cpu_ms,runtime_ms\n";
+                   "optimize_wall_ms,optimizer_cpu_ms,runtime_ms,"
+                   "normal_state_size,cuda_selected,cuda_attempts,"
+                   "cuda_successes,cuda_fallbacks,cuda_runtime_ms\n";
         }
 
         std::unique_ptr<IntegrityShadowTimeline> integrity_shadow;
@@ -4296,7 +4298,14 @@ int main(int argc, char* argv[]) {
                         << ',' << shadow_build_runtime_ms
                         << ',' << shadow_optimize_wall_ms
                         << ',' << diagnostics.processing_time_ms
-                        << ',' << shadow_runtime_ms << '\n';
+                        << ',' << shadow_runtime_ms
+                        << ',' << diagnostics.dense_normal_state_size
+                        << ',' << (diagnostics.cuda_dense_solver_selected ? 1 : 0)
+                        << ',' << diagnostics.cuda_dense_solve_attempts
+                        << ',' << diagnostics.cuda_dense_solve_successes
+                        << ',' << diagnostics.cuda_dense_solve_fallbacks
+                        << ',' << diagnostics.cuda_dense_solve_time_ms
+                        << '\n';
                 }
             }
             const libgnss::PositionSolution* last_output =

--- a/apps/native/gnss_solve.cpp
+++ b/apps/native/gnss_solve.cpp
@@ -114,6 +114,10 @@ struct SolveConfig {
     int multisd_fgo_shadow_holdout_offset = 2;
     int multisd_fgo_shadow_top_k = 4;
     double multisd_fgo_shadow_max_seed_separation_m = 0.5;
+    int multisd_fgo_shadow_validation_history_epochs = 3;
+    double multisd_fgo_shadow_min_carrier_fraction = 0.75;
+    int multisd_fgo_shadow_min_fixed_ambiguities = 6;
+    int multisd_fgo_shadow_holdout_satellites = 4;
     double rtk_update_outlier_threshold = 0.0;
     bool student_t_rtk_front_end = false;
     double ratio_threshold = 3.0;
@@ -1947,6 +1951,14 @@ void printAdvancedUsage(const char* program_name) {
         << "                             Bounded integer hypotheses, 2..32 (default: 4)\n"
         << "  --multisd-fgo-shadow-max-seed-separation <m>\n"
         << "                             GNSS-only RTK/FGO aperture; 0 disables (default: 0.5)\n"
+        << "  --multisd-fgo-shadow-validation-history <epochs>\n"
+        << "                             Causal held-out carrier span (default: 3)\n"
+        << "  --multisd-fgo-shadow-min-carrier-fraction <0..1>\n"
+        << "                             Required held-out rows (default: 0.75)\n"
+        << "  --multisd-fgo-shadow-min-fixed-ambiguities <n>\n"
+        << "                             MultiSD PAR dimension floor (default: 6)\n"
+        << "  --multisd-fgo-shadow-holdout-satellites <n>\n"
+        << "                             Fully disjoint satellites (default: 4)\n"
         << "  --realtime-fix-integrity   Gate FIX output with bounded-latency residual checks\n"
         << "                             (default: off; maximum latency: 7 epochs)\n"
         << "  --integrity-base-gate      Also enable the frozen offline low-satellite/ratio\n"
@@ -2216,6 +2228,30 @@ SolveConfig parseArguments(int argc, char* argv[]) {
             i + 1 < argc) {
             config.multisd_fgo_shadow_max_seed_separation_m =
                 std::stod(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-validation-history" &&
+            i + 1 < argc) {
+            config.multisd_fgo_shadow_validation_history_epochs =
+                std::stoi(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-min-carrier-fraction" &&
+            i + 1 < argc) {
+            config.multisd_fgo_shadow_min_carrier_fraction =
+                std::stod(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-min-fixed-ambiguities" &&
+            i + 1 < argc) {
+            config.multisd_fgo_shadow_min_fixed_ambiguities =
+                std::stoi(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-holdout-satellites" &&
+            i + 1 < argc) {
+            config.multisd_fgo_shadow_holdout_satellites =
+                std::stoi(argv[++i]);
             continue;
         }
         // Phase 2a CMC-aware reference selection flags: kept as STANDALONE
@@ -3409,6 +3445,30 @@ SolveConfig parseArguments(int argc, char* argv[]) {
             "--multisd-fgo-shadow-max-seed-separation must be >= 0",
             argv[0]);
     }
+    if (config.multisd_fgo_shadow_validation_history_epochs < 1) {
+        argumentError(
+            "--multisd-fgo-shadow-validation-history must be >= 1",
+            argv[0]);
+    }
+    if (!std::isfinite(config.multisd_fgo_shadow_min_carrier_fraction) ||
+        config.multisd_fgo_shadow_min_carrier_fraction <= 0.0 ||
+        config.multisd_fgo_shadow_min_carrier_fraction > 1.0) {
+        argumentError(
+            "--multisd-fgo-shadow-min-carrier-fraction must be in (0, 1]",
+            argv[0]);
+    }
+    if (config.multisd_fgo_shadow_min_fixed_ambiguities < 2 ||
+        config.multisd_fgo_shadow_min_fixed_ambiguities > 16) {
+        argumentError(
+            "--multisd-fgo-shadow-min-fixed-ambiguities must be in [2, 16]",
+            argv[0]);
+    }
+    if (config.multisd_fgo_shadow_holdout_satellites < 2 ||
+        config.multisd_fgo_shadow_holdout_satellites > 16) {
+        argumentError(
+            "--multisd-fgo-shadow-holdout-satellites must be in [2, 16]",
+            argv[0]);
+    }
 
     return config;
 }
@@ -3538,17 +3598,22 @@ libgnss::FGOProcessor::FGOConfig makeGnssOnlyMultiSdShadowConfig(
     config.fix_ambiguities = true;
     config.use_lambda_ambiguity_fix = true;
     config.lambda_ratio_threshold = 1.5;
-    config.min_fixed_ambiguities = 6;
+    config.min_fixed_ambiguities =
+        solve_config.multisd_fgo_shadow_min_fixed_ambiguities;
     config.max_lambda_ambiguities = 16;
     config.lambda_top_k_candidates = solve_config.multisd_fgo_shadow_top_k;
     config.parallelize_lambda_hypotheses = true;
     config.use_multisd_ambiguities = true;
     config.use_multisd_disjoint_validation = true;
-    config.multisd_validation_holdout_satellites = 4;
+    config.multisd_validation_holdout_satellites =
+        solve_config.multisd_fgo_shadow_holdout_satellites;
     config.multisd_validation_holdout_offset =
         solve_config.multisd_fgo_shadow_holdout_offset;
     config.multisd_validation_aperture_cycles = 0.15;
-    config.multisd_validation_min_carrier_fraction = 1.0;
+    config.multisd_validation_history_epochs =
+        solve_config.multisd_fgo_shadow_validation_history_epochs;
+    config.multisd_validation_min_carrier_fraction =
+        solve_config.multisd_fgo_shadow_min_carrier_fraction;
     config.multisd_validation_max_ddpr_rms_m = 3.0;
     config.multisd_validation_max_fixed_float_separation_m = 0.0;
     config.multisd_validation_max_seed_separation_m =

--- a/apps/native/gnss_solve.cpp
+++ b/apps/native/gnss_solve.cpp
@@ -113,6 +113,7 @@ struct SolveConfig {
     int multisd_fgo_shadow_min_epochs = 10;
     int multisd_fgo_shadow_holdout_offset = 2;
     int multisd_fgo_shadow_top_k = 4;
+    double multisd_fgo_shadow_max_seed_separation_m = 0.5;
     double rtk_update_outlier_threshold = 0.0;
     bool student_t_rtk_front_end = false;
     double ratio_threshold = 3.0;
@@ -1944,6 +1945,8 @@ void printAdvancedUsage(const char* program_name) {
         << "                             Deterministic disjoint partition offset (default: 2)\n"
         << "  --multisd-fgo-shadow-top-k <n>\n"
         << "                             Bounded integer hypotheses, 2..32 (default: 4)\n"
+        << "  --multisd-fgo-shadow-max-seed-separation <m>\n"
+        << "                             GNSS-only RTK/FGO aperture; 0 disables (default: 0.5)\n"
         << "  --realtime-fix-integrity   Gate FIX output with bounded-latency residual checks\n"
         << "                             (default: off; maximum latency: 7 epochs)\n"
         << "  --integrity-base-gate      Also enable the frozen offline low-satellite/ratio\n"
@@ -2207,6 +2210,12 @@ SolveConfig parseArguments(int argc, char* argv[]) {
         }
         if (arg == "--multisd-fgo-shadow-top-k" && i + 1 < argc) {
             config.multisd_fgo_shadow_top_k = std::stoi(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-max-seed-separation" &&
+            i + 1 < argc) {
+            config.multisd_fgo_shadow_max_seed_separation_m =
+                std::stod(argv[++i]);
             continue;
         }
         // Phase 2a CMC-aware reference selection flags: kept as STANDALONE
@@ -3393,6 +3402,13 @@ SolveConfig parseArguments(int argc, char* argv[]) {
         argumentError("--multisd-fgo-shadow-top-k must be in [2, 32]",
                       argv[0]);
     }
+    if (!std::isfinite(
+            config.multisd_fgo_shadow_max_seed_separation_m) ||
+        config.multisd_fgo_shadow_max_seed_separation_m < 0.0) {
+        argumentError(
+            "--multisd-fgo-shadow-max-seed-separation must be >= 0",
+            argv[0]);
+    }
 
     return config;
 }
@@ -3534,6 +3550,9 @@ libgnss::FGOProcessor::FGOConfig makeGnssOnlyMultiSdShadowConfig(
     config.multisd_validation_aperture_cycles = 0.15;
     config.multisd_validation_min_carrier_fraction = 1.0;
     config.multisd_validation_max_ddpr_rms_m = 3.0;
+    config.multisd_validation_max_fixed_float_separation_m = 0.0;
+    config.multisd_validation_max_seed_separation_m =
+        solve_config.multisd_fgo_shadow_max_seed_separation_m;
     return config;
 }
 
@@ -3875,7 +3894,8 @@ int main(int argc, char* argv[]) {
                    "ddpr_rms_m,x,y,z,rtk_position_delta_m,build_runtime_ms,"
                    "optimize_wall_ms,optimizer_cpu_ms,runtime_ms,"
                    "normal_state_size,cuda_selected,cuda_attempts,"
-                   "cuda_successes,cuda_fallbacks,cuda_runtime_ms\n";
+                   "cuda_successes,cuda_fallbacks,cuda_runtime_ms,"
+                   "fixed_float_separation_m,seed_separation_m\n";
         }
 
         std::unique_ptr<IntegrityShadowTimeline> integrity_shadow;
@@ -4305,6 +4325,16 @@ int main(int argc, char* argv[]) {
                         << ',' << diagnostics.cuda_dense_solve_successes
                         << ',' << diagnostics.cuda_dense_solve_fallbacks
                         << ',' << diagnostics.cuda_dense_solve_time_ms
+                        << ',';
+                    writeOptionalCsvNumber(
+                        multisd_shadow_csv,
+                        diagnostics
+                            .multisd_validation_fixed_float_separation_m);
+                    multisd_shadow_csv << ',';
+                    writeOptionalCsvNumber(
+                        multisd_shadow_csv,
+                        diagnostics.multisd_validation_seed_separation_m);
+                    multisd_shadow_csv
                         << '\n';
                 }
             }

--- a/apps/native/gnss_solve.cpp
+++ b/apps/native/gnss_solve.cpp
@@ -120,6 +120,8 @@ struct SolveConfig {
     int multisd_fgo_shadow_holdout_satellites = 4;
     bool multisd_fgo_shadow_constellation_par = false;
     bool multisd_fgo_shadow_variance_ranked_par = false;
+    double multisd_fgo_shadow_candidate_ratio = 1.5;
+    int multisd_fgo_shadow_candidate_groups = 1;
     double rtk_update_outlier_threshold = 0.0;
     bool student_t_rtk_front_end = false;
     double ratio_threshold = 3.0;
@@ -1965,6 +1967,10 @@ void printAdvancedUsage(const char* program_name) {
         << "                             Full-band constellation pool PAR (default: off)\n"
         << "  --multisd-fgo-shadow-variance-ranked-par\n"
         << "                             Rank PAR candidates by float variance (default: off)\n"
+        << "  --multisd-fgo-shadow-candidate-ratio <ratio>\n"
+        << "                             Top-K generation floor before disjoint validation (default: 1.5)\n"
+        << "  --multisd-fgo-shadow-candidate-groups <n>\n"
+        << "                             Validator-aware PAR fallback groups, 1..32 (default: 1)\n"
         << "  --realtime-fix-integrity   Gate FIX output with bounded-latency residual checks\n"
         << "                             (default: off; maximum latency: 7 epochs)\n"
         << "  --integrity-base-gate      Also enable the frozen offline low-satellite/ratio\n"
@@ -2266,6 +2272,18 @@ SolveConfig parseArguments(int argc, char* argv[]) {
         }
         if (arg == "--multisd-fgo-shadow-variance-ranked-par") {
             config.multisd_fgo_shadow_variance_ranked_par = true;
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-candidate-ratio" &&
+            i + 1 < argc) {
+            config.multisd_fgo_shadow_candidate_ratio =
+                std::stod(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-candidate-groups" &&
+            i + 1 < argc) {
+            config.multisd_fgo_shadow_candidate_groups =
+                std::stoi(argv[++i]);
             continue;
         }
         // Phase 2a CMC-aware reference selection flags: kept as STANDALONE
@@ -3483,6 +3501,18 @@ SolveConfig parseArguments(int argc, char* argv[]) {
             "--multisd-fgo-shadow-holdout-satellites must be in [2, 16]",
             argv[0]);
     }
+    if (!std::isfinite(config.multisd_fgo_shadow_candidate_ratio) ||
+        config.multisd_fgo_shadow_candidate_ratio < 1.0) {
+        argumentError(
+            "--multisd-fgo-shadow-candidate-ratio must be >= 1",
+            argv[0]);
+    }
+    if (config.multisd_fgo_shadow_candidate_groups < 1 ||
+        config.multisd_fgo_shadow_candidate_groups > 32) {
+        argumentError(
+            "--multisd-fgo-shadow-candidate-groups must be in [1, 32]",
+            argv[0]);
+    }
 
     return config;
 }
@@ -3636,6 +3666,10 @@ libgnss::FGOProcessor::FGOConfig makeGnssOnlyMultiSdShadowConfig(
     config.multisd_validation_max_fixed_float_separation_m = 0.0;
     config.multisd_validation_max_seed_separation_m =
         solve_config.multisd_fgo_shadow_max_seed_separation_m;
+    config.multisd_lambda_candidate_ratio_threshold =
+        solve_config.multisd_fgo_shadow_candidate_ratio;
+    config.multisd_max_candidate_groups =
+        solve_config.multisd_fgo_shadow_candidate_groups;
     return config;
 }
 
@@ -3971,6 +4005,8 @@ int main(int argc, char* argv[]) {
             multisd_shadow_csv
                 << "epoch_index,gps_week,tow,window_epochs,rtk_status,"
                    "shadow_status,shadow_fixed,lambda_ratio,fixed_ambiguities,"
+                   "lambda_candidates,lambda_used_candidates,lambda_attempts,"
+                   "lambda_solved,partial_lambda_used,lambda_bsr,lambda_adop_cycles,"
                    "validation_evaluated,validation_pass,holdout_satellites,"
                    "hypotheses_passed,hypotheses_evaluated,selected_rank,"
                    "carrier_passed,carrier_used,max_integer_distance_cycles,"
@@ -4355,6 +4391,22 @@ int main(int argc, char* argv[]) {
                         << (shadow_latest
                                 ? shadow_latest->num_fixed_ambiguities
                                 : 0)
+                        << ',' << diagnostics.lambda_ambiguity_candidates
+                        << ',' << diagnostics.lambda_ambiguity_used_candidates
+                        << ',' << diagnostics.lambda_ambiguity_attempts
+                        << ','
+                        << (diagnostics.lambda_ambiguity_fix_solved ? 1 : 0)
+                        << ','
+                        << (diagnostics.partial_lambda_ambiguity_fix_used ? 1 : 0)
+                        << ',';
+                    writeOptionalCsvNumber(
+                        multisd_shadow_csv,
+                        diagnostics.lambda_bootstrapped_success_rate);
+                    multisd_shadow_csv << ',';
+                    writeOptionalCsvNumber(
+                        multisd_shadow_csv,
+                        diagnostics.lambda_adop_cycles);
+                    multisd_shadow_csv
                         << ','
                         << (diagnostics.multisd_validation_evaluated ? 1 : 0)
                         << ','

--- a/apps/native/gnss_solve.cpp
+++ b/apps/native/gnss_solve.cpp
@@ -118,6 +118,8 @@ struct SolveConfig {
     double multisd_fgo_shadow_min_carrier_fraction = 0.75;
     int multisd_fgo_shadow_min_fixed_ambiguities = 6;
     int multisd_fgo_shadow_holdout_satellites = 4;
+    bool multisd_fgo_shadow_constellation_par = false;
+    bool multisd_fgo_shadow_variance_ranked_par = false;
     double rtk_update_outlier_threshold = 0.0;
     bool student_t_rtk_front_end = false;
     double ratio_threshold = 3.0;
@@ -1959,6 +1961,10 @@ void printAdvancedUsage(const char* program_name) {
         << "                             MultiSD PAR dimension floor (default: 6)\n"
         << "  --multisd-fgo-shadow-holdout-satellites <n>\n"
         << "                             Fully disjoint satellites (default: 4)\n"
+        << "  --multisd-fgo-shadow-constellation-par\n"
+        << "                             Full-band constellation pool PAR (default: off)\n"
+        << "  --multisd-fgo-shadow-variance-ranked-par\n"
+        << "                             Rank PAR candidates by float variance (default: off)\n"
         << "  --realtime-fix-integrity   Gate FIX output with bounded-latency residual checks\n"
         << "                             (default: off; maximum latency: 7 epochs)\n"
         << "  --integrity-base-gate      Also enable the frozen offline low-satellite/ratio\n"
@@ -2252,6 +2258,14 @@ SolveConfig parseArguments(int argc, char* argv[]) {
             i + 1 < argc) {
             config.multisd_fgo_shadow_holdout_satellites =
                 std::stoi(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-constellation-par") {
+            config.multisd_fgo_shadow_constellation_par = true;
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-variance-ranked-par") {
+            config.multisd_fgo_shadow_variance_ranked_par = true;
             continue;
         }
         // Phase 2a CMC-aware reference selection flags: kept as STANDALONE
@@ -3603,6 +3617,10 @@ libgnss::FGOProcessor::FGOConfig makeGnssOnlyMultiSdShadowConfig(
     config.max_lambda_ambiguities = 16;
     config.lambda_top_k_candidates = solve_config.multisd_fgo_shadow_top_k;
     config.parallelize_lambda_hypotheses = true;
+    config.use_constellation_ranked_partial_ar =
+        solve_config.multisd_fgo_shadow_constellation_par;
+    config.use_variance_ranked_partial_ar =
+        solve_config.multisd_fgo_shadow_variance_ranked_par;
     config.use_multisd_ambiguities = true;
     config.use_multisd_disjoint_validation = true;
     config.multisd_validation_holdout_satellites =

--- a/apps/native/gnss_solve.cpp
+++ b/apps/native/gnss_solve.cpp
@@ -122,6 +122,9 @@ struct SolveConfig {
     bool multisd_fgo_shadow_variance_ranked_par = false;
     double multisd_fgo_shadow_candidate_ratio = 1.5;
     int multisd_fgo_shadow_candidate_groups = 1;
+    int multisd_fgo_shadow_fallback_consensus_groups = 1;
+    double multisd_fgo_shadow_fallback_consensus_separation_m = 0.0;
+    double multisd_fgo_shadow_fallback_max_seed_separation_m = 0.0;
     double rtk_update_outlier_threshold = 0.0;
     bool student_t_rtk_front_end = false;
     double ratio_threshold = 3.0;
@@ -1971,6 +1974,12 @@ void printAdvancedUsage(const char* program_name) {
         << "                             Top-K generation floor before disjoint validation (default: 1.5)\n"
         << "  --multisd-fgo-shadow-candidate-groups <n>\n"
         << "                             Validator-aware PAR fallback groups, 1..32 (default: 1)\n"
+        << "  --multisd-fgo-shadow-fallback-consensus-groups <n>\n"
+        << "                             Later PAR subsets required to agree, 1..32 (default: 1)\n"
+        << "  --multisd-fgo-shadow-fallback-consensus-separation <m>\n"
+        << "                             Maximum pairwise fallback position split (default: 0)\n"
+        << "  --multisd-fgo-shadow-fallback-max-seed-separation <m>\n"
+        << "                             Additional later-group GNSS-seed aperture (default: 0)\n"
         << "  --realtime-fix-integrity   Gate FIX output with bounded-latency residual checks\n"
         << "                             (default: off; maximum latency: 7 epochs)\n"
         << "  --integrity-base-gate      Also enable the frozen offline low-satellite/ratio\n"
@@ -2284,6 +2293,24 @@ SolveConfig parseArguments(int argc, char* argv[]) {
             i + 1 < argc) {
             config.multisd_fgo_shadow_candidate_groups =
                 std::stoi(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-fallback-consensus-groups" &&
+            i + 1 < argc) {
+            config.multisd_fgo_shadow_fallback_consensus_groups =
+                std::stoi(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-fallback-consensus-separation" &&
+            i + 1 < argc) {
+            config.multisd_fgo_shadow_fallback_consensus_separation_m =
+                std::stod(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-fallback-max-seed-separation" &&
+            i + 1 < argc) {
+            config.multisd_fgo_shadow_fallback_max_seed_separation_m =
+                std::stod(argv[++i]);
             continue;
         }
         // Phase 2a CMC-aware reference selection flags: kept as STANDALONE
@@ -3513,6 +3540,33 @@ SolveConfig parseArguments(int argc, char* argv[]) {
             "--multisd-fgo-shadow-candidate-groups must be in [1, 32]",
             argv[0]);
     }
+    if (config.multisd_fgo_shadow_fallback_consensus_groups < 1 ||
+        config.multisd_fgo_shadow_fallback_consensus_groups > 32) {
+        argumentError(
+            "--multisd-fgo-shadow-fallback-consensus-groups must be in [1, 32]",
+            argv[0]);
+    }
+    if (!std::isfinite(
+            config.multisd_fgo_shadow_fallback_consensus_separation_m) ||
+        config.multisd_fgo_shadow_fallback_consensus_separation_m < 0.0) {
+        argumentError(
+            "--multisd-fgo-shadow-fallback-consensus-separation must be >= 0",
+            argv[0]);
+    }
+    if (config.multisd_fgo_shadow_fallback_consensus_groups > 1 &&
+        config.multisd_fgo_shadow_fallback_consensus_separation_m <= 0.0) {
+        argumentError(
+            "--multisd-fgo-shadow-fallback-consensus-separation must be > 0 "
+            "when fallback consensus groups exceed 1",
+            argv[0]);
+    }
+    if (!std::isfinite(
+            config.multisd_fgo_shadow_fallback_max_seed_separation_m) ||
+        config.multisd_fgo_shadow_fallback_max_seed_separation_m < 0.0) {
+        argumentError(
+            "--multisd-fgo-shadow-fallback-max-seed-separation must be >= 0",
+            argv[0]);
+    }
 
     return config;
 }
@@ -3670,6 +3724,12 @@ libgnss::FGOProcessor::FGOConfig makeGnssOnlyMultiSdShadowConfig(
         solve_config.multisd_fgo_shadow_candidate_ratio;
     config.multisd_max_candidate_groups =
         solve_config.multisd_fgo_shadow_candidate_groups;
+    config.multisd_fallback_min_consensus_groups =
+        solve_config.multisd_fgo_shadow_fallback_consensus_groups;
+    config.multisd_fallback_max_consensus_separation_m =
+        solve_config.multisd_fgo_shadow_fallback_consensus_separation_m;
+    config.multisd_fallback_max_seed_separation_m =
+        solve_config.multisd_fgo_shadow_fallback_max_seed_separation_m;
     return config;
 }
 

--- a/apps/native/gnss_solve.cpp
+++ b/apps/native/gnss_solve.cpp
@@ -3872,7 +3872,8 @@ int main(int argc, char* argv[]) {
                    "validation_evaluated,validation_pass,holdout_satellites,"
                    "hypotheses_passed,hypotheses_evaluated,selected_rank,"
                    "carrier_passed,carrier_used,max_integer_distance_cycles,"
-                   "ddpr_rms_m,x,y,z,rtk_position_delta_m,runtime_ms\n";
+                   "ddpr_rms_m,x,y,z,rtk_position_delta_m,build_runtime_ms,"
+                   "optimize_wall_ms,optimizer_cpu_ms,runtime_ms\n";
         }
 
         std::unique_ptr<IntegrityShadowTimeline> integrity_shadow;
@@ -4191,11 +4192,23 @@ int main(int argc, char* argv[]) {
                             multisd_shadow_base_window,
                             nav_data,
                             base_position);
+                    const auto shadow_optimize_start =
+                        std::chrono::steady_clock::now();
                     const auto shadow_result =
                         multisd_shadow_processor.optimizeProblem(shadow_problem);
+                    const auto shadow_end =
+                        std::chrono::steady_clock::now();
+                    const double shadow_build_runtime_ms =
+                        std::chrono::duration<double, std::milli>(
+                            shadow_optimize_start - shadow_start)
+                            .count();
+                    const double shadow_optimize_wall_ms =
+                        std::chrono::duration<double, std::milli>(
+                            shadow_end - shadow_optimize_start)
+                            .count();
                     const double shadow_runtime_ms =
                         std::chrono::duration<double, std::milli>(
-                            std::chrono::steady_clock::now() - shadow_start)
+                            shadow_end - shadow_start)
                             .count();
                     ++multisd_shadow_attempts;
                     multisd_shadow_total_runtime_ms += shadow_runtime_ms;
@@ -4279,7 +4292,11 @@ int main(int argc, char* argv[]) {
                     } else {
                         multisd_shadow_csv << ",,,";
                     }
-                    multisd_shadow_csv << ',' << shadow_runtime_ms << '\n';
+                    multisd_shadow_csv
+                        << ',' << shadow_build_runtime_ms
+                        << ',' << shadow_optimize_wall_ms
+                        << ',' << diagnostics.processing_time_ms
+                        << ',' << shadow_runtime_ms << '\n';
                 }
             }
             const libgnss::PositionSolution* last_output =

--- a/apps/native/gnss_solve.cpp
+++ b/apps/native/gnss_solve.cpp
@@ -129,6 +129,7 @@ struct SolveConfig {
     double multisd_fgo_shadow_fallback_max_seed_separation_m = 0.0;
     double multisd_fgo_shadow_min_bootstrapped_success_rate = 0.0;
     double multisd_fgo_shadow_max_adop_cycles = 0.0;
+    double multisd_fgo_shadow_fallback_min_bootstrapped_success_rate = 0.0;
     double rtk_update_outlier_threshold = 0.0;
     bool student_t_rtk_front_end = false;
     double ratio_threshold = 3.0;
@@ -1992,6 +1993,8 @@ void printAdvancedUsage(const char* program_name) {
         << "                             Minimum LAMBDA bootstrap success rate (default: 0)\n"
         << "  --multisd-fgo-shadow-max-adop <cycles>\n"
         << "                             Maximum ambiguity dilution of precision (default: 0/off)\n"
+        << "  --multisd-fgo-shadow-fallback-min-bsr <0..1>\n"
+        << "                             Minimum BSR for later validator groups only (default: 0)\n"
         << "  --realtime-fix-integrity   Gate FIX output with bounded-latency residual checks\n"
         << "                             (default: off; maximum latency: 7 epochs)\n"
         << "  --integrity-base-gate      Also enable the frozen offline low-satellite/ratio\n"
@@ -2340,6 +2343,11 @@ SolveConfig parseArguments(int argc, char* argv[]) {
         }
         if (arg == "--multisd-fgo-shadow-max-adop" && i + 1 < argc) {
             config.multisd_fgo_shadow_max_adop_cycles =
+                std::stod(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-fallback-min-bsr" && i + 1 < argc) {
+            config.multisd_fgo_shadow_fallback_min_bootstrapped_success_rate =
                 std::stod(argv[++i]);
             continue;
         }
@@ -3608,6 +3616,14 @@ SolveConfig parseArguments(int argc, char* argv[]) {
         config.multisd_fgo_shadow_max_adop_cycles < 0.0) {
         argumentError("--multisd-fgo-shadow-max-adop must be >= 0", argv[0]);
     }
+    if (!std::isfinite(
+            config.multisd_fgo_shadow_fallback_min_bootstrapped_success_rate) ||
+        config.multisd_fgo_shadow_fallback_min_bootstrapped_success_rate < 0.0 ||
+        config.multisd_fgo_shadow_fallback_min_bootstrapped_success_rate > 1.0) {
+        argumentError(
+            "--multisd-fgo-shadow-fallback-min-bsr must be in [0, 1]",
+            argv[0]);
+    }
 
     return config;
 }
@@ -3779,6 +3795,8 @@ libgnss::FGOProcessor::FGOConfig makeGnssOnlyMultiSdShadowConfig(
         solve_config.multisd_fgo_shadow_min_bootstrapped_success_rate;
     config.lambda_max_adop_cycles =
         solve_config.multisd_fgo_shadow_max_adop_cycles;
+    config.multisd_fallback_min_bootstrapped_success_rate =
+        solve_config.multisd_fgo_shadow_fallback_min_bootstrapped_success_rate;
     return config;
 }
 

--- a/apps/native/gnss_solve.cpp
+++ b/apps/native/gnss_solve.cpp
@@ -127,6 +127,8 @@ struct SolveConfig {
     int multisd_fgo_shadow_fallback_consensus_groups = 1;
     double multisd_fgo_shadow_fallback_consensus_separation_m = 0.0;
     double multisd_fgo_shadow_fallback_max_seed_separation_m = 0.0;
+    double multisd_fgo_shadow_min_bootstrapped_success_rate = 0.0;
+    double multisd_fgo_shadow_max_adop_cycles = 0.0;
     double rtk_update_outlier_threshold = 0.0;
     bool student_t_rtk_front_end = false;
     double ratio_threshold = 3.0;
@@ -1986,6 +1988,10 @@ void printAdvancedUsage(const char* program_name) {
         << "                             Maximum pairwise fallback position split (default: 0)\n"
         << "  --multisd-fgo-shadow-fallback-max-seed-separation <m>\n"
         << "                             Additional later-group GNSS-seed aperture (default: 0)\n"
+        << "  --multisd-fgo-shadow-min-bsr <0..1>\n"
+        << "                             Minimum LAMBDA bootstrap success rate (default: 0)\n"
+        << "  --multisd-fgo-shadow-max-adop <cycles>\n"
+        << "                             Maximum ambiguity dilution of precision (default: 0/off)\n"
         << "  --realtime-fix-integrity   Gate FIX output with bounded-latency residual checks\n"
         << "                             (default: off; maximum latency: 7 epochs)\n"
         << "  --integrity-base-gate      Also enable the frozen offline low-satellite/ratio\n"
@@ -2324,6 +2330,16 @@ SolveConfig parseArguments(int argc, char* argv[]) {
         if (arg == "--multisd-fgo-shadow-fallback-max-seed-separation" &&
             i + 1 < argc) {
             config.multisd_fgo_shadow_fallback_max_seed_separation_m =
+                std::stod(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-min-bsr" && i + 1 < argc) {
+            config.multisd_fgo_shadow_min_bootstrapped_success_rate =
+                std::stod(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-max-adop" && i + 1 < argc) {
+            config.multisd_fgo_shadow_max_adop_cycles =
                 std::stod(argv[++i]);
             continue;
         }
@@ -3581,6 +3597,17 @@ SolveConfig parseArguments(int argc, char* argv[]) {
             "--multisd-fgo-shadow-fallback-max-seed-separation must be >= 0",
             argv[0]);
     }
+    if (!std::isfinite(
+            config.multisd_fgo_shadow_min_bootstrapped_success_rate) ||
+        config.multisd_fgo_shadow_min_bootstrapped_success_rate < 0.0 ||
+        config.multisd_fgo_shadow_min_bootstrapped_success_rate > 1.0) {
+        argumentError("--multisd-fgo-shadow-min-bsr must be in [0, 1]",
+                      argv[0]);
+    }
+    if (!std::isfinite(config.multisd_fgo_shadow_max_adop_cycles) ||
+        config.multisd_fgo_shadow_max_adop_cycles < 0.0) {
+        argumentError("--multisd-fgo-shadow-max-adop must be >= 0", argv[0]);
+    }
 
     return config;
 }
@@ -3748,6 +3775,10 @@ libgnss::FGOProcessor::FGOConfig makeGnssOnlyMultiSdShadowConfig(
         solve_config.multisd_fgo_shadow_fallback_consensus_separation_m;
     config.multisd_fallback_max_seed_separation_m =
         solve_config.multisd_fgo_shadow_fallback_max_seed_separation_m;
+    config.lambda_min_bootstrapped_success_rate =
+        solve_config.multisd_fgo_shadow_min_bootstrapped_success_rate;
+    config.lambda_max_adop_cycles =
+        solve_config.multisd_fgo_shadow_max_adop_cycles;
     return config;
 }
 

--- a/apps/native/gnss_solve.cpp
+++ b/apps/native/gnss_solve.cpp
@@ -119,7 +119,9 @@ struct SolveConfig {
     int multisd_fgo_shadow_min_fixed_ambiguities = 6;
     int multisd_fgo_shadow_holdout_satellites = 4;
     bool multisd_fgo_shadow_constellation_par = false;
+    bool multisd_fgo_shadow_interleave_constellation_par = false;
     bool multisd_fgo_shadow_variance_ranked_par = false;
+    bool multisd_fgo_shadow_quality_ranked_par = false;
     double multisd_fgo_shadow_candidate_ratio = 1.5;
     int multisd_fgo_shadow_candidate_groups = 1;
     int multisd_fgo_shadow_fallback_consensus_groups = 1;
@@ -1968,8 +1970,12 @@ void printAdvancedUsage(const char* program_name) {
         << "                             Fully disjoint satellites (default: 4)\n"
         << "  --multisd-fgo-shadow-constellation-par\n"
         << "                             Full-band constellation pool PAR (default: off)\n"
+        << "  --multisd-fgo-shadow-interleave-constellation-par\n"
+        << "                             Interleave validator groups across constellation pools (default: off)\n"
         << "  --multisd-fgo-shadow-variance-ranked-par\n"
         << "                             Rank PAR candidates by float variance (default: off)\n"
+        << "  --multisd-fgo-shadow-quality-ranked-par\n"
+        << "                             Rank PAR by PPC variance/integer-distance/carrier residual (default: off)\n"
         << "  --multisd-fgo-shadow-candidate-ratio <ratio>\n"
         << "                             Top-K generation floor before disjoint validation (default: 1.5)\n"
         << "  --multisd-fgo-shadow-candidate-groups <n>\n"
@@ -2279,8 +2285,16 @@ SolveConfig parseArguments(int argc, char* argv[]) {
             config.multisd_fgo_shadow_constellation_par = true;
             continue;
         }
+        if (arg == "--multisd-fgo-shadow-interleave-constellation-par") {
+            config.multisd_fgo_shadow_interleave_constellation_par = true;
+            continue;
+        }
         if (arg == "--multisd-fgo-shadow-variance-ranked-par") {
             config.multisd_fgo_shadow_variance_ranked_par = true;
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-quality-ranked-par") {
+            config.multisd_fgo_shadow_quality_ranked_par = true;
             continue;
         }
         if (arg == "--multisd-fgo-shadow-candidate-ratio" &&
@@ -3703,8 +3717,12 @@ libgnss::FGOProcessor::FGOConfig makeGnssOnlyMultiSdShadowConfig(
     config.parallelize_lambda_hypotheses = true;
     config.use_constellation_ranked_partial_ar =
         solve_config.multisd_fgo_shadow_constellation_par;
+    config.interleave_constellation_partial_ar =
+        solve_config.multisd_fgo_shadow_interleave_constellation_par;
     config.use_variance_ranked_partial_ar =
         solve_config.multisd_fgo_shadow_variance_ranked_par;
+    config.use_quality_ranked_partial_ar =
+        solve_config.multisd_fgo_shadow_quality_ranked_par;
     config.use_multisd_ambiguities = true;
     config.use_multisd_disjoint_validation = true;
     config.multisd_validation_holdout_satellites =

--- a/cmake/libgnssppConfig.cmake.in
+++ b/cmake/libgnssppConfig.cmake.in
@@ -4,5 +4,8 @@ include(CMakeFindDependencyMacro)
 
 find_dependency(Eigen3 REQUIRED)
 find_dependency(Threads REQUIRED)
+if(@GNSSPP_ENABLE_CUDA_FGO@)
+    find_dependency(CUDAToolkit REQUIRED)
+endif()
 
 include("${CMAKE_CURRENT_LIST_DIR}/libgnssppTargets.cmake")

--- a/docs/gnss_only_multisd_fgo_design.md
+++ b/docs/gnss_only_multisd_fgo_design.md
@@ -222,3 +222,52 @@ Thus the preliminary 25-epoch p95 is below 100 ms on this host even before a
 CUDA solve. This is still a 21-solve development sample, not the full latency
 contract. CUDA remains an optional scaling path for longer windows and larger
 hypothesis batches; CPU stays the reference and fallback.
+
+## Optional CUDA dense-solve checkpoint (2026-07-31)
+
+The native Eigen backend now has a build-time, default-off
+`GNSSPP_ENABLE_CUDA_FGO` option. When built with CUDA, the runtime selector is
+`GNSSPP_FGO_CUDA_SOLVER=off|auto|on`; an unset value is `off`. The backend uses
+cuSOLVER Cholesky (`potrf` followed by `potrs`) for the damped SPD normal
+equations and supports multi-right-hand-side ambiguity/output covariance
+solves. Its cuSOLVER handle and device allocations are retained per worker
+thread. Every CUDA error, non-SPD result, or unavailable device returns to the
+unchanged Eigen solver. CUDA is never needed for a normal build or deployment.
+NVIDIA documents this factor/solve ordering, stream parallelism, deterministic
+controls, and the newer generic API in the cuSOLVER manual:
+<https://docs.nvidia.com/cuda/cusolver/index.html>.
+
+The shadow CSV exposes the normal-state dimension, CUDA selection, attempted
+and successful solves, fallbacks, and measured CUDA-call time. A Tokyo run1
+100-epoch causal batch on the development GTX 1660 Ti produced:
+
+| selector | state | CUDA solves | total wall | selected FIX/rank | RTK SHA |
+|---|---:|---:|---:|---|---|
+| `off` | 735 | 0 | 439 ms | FIX / 0 | reference |
+| `auto` | 735 | 0 | 478 ms | FIX / 0 | exact match |
+| `on` | 735 | 19/19 | 551 ms | FIX / 0 | exact match |
+
+The selected shadow ECEF coordinates also matched at the emitted precision and
+there were no CUDA fallbacks. The forced GPU path spent 254 ms inside the 19
+CUDA calls. This is positive numerical/parity evidence, but not a speedup:
+repeated host dense assembly and host/device copies dominate at this size.
+Automatic dispatch therefore starts only at state dimension 2048; the
+real-time 10/25-epoch windows stay on the faster sparse CPU path. `on` remains
+available for explicit parity and large-batch experiments. The threshold is a
+host-specific conservative guard and must be calibrated on every deployment
+GPU before promotion.
+
+This result agrees with the architectural lesson from MegBA: reported large
+GPU gains come from end-to-end vectorized graph optimization and minimized
+communication, rather than copying each already-assembled normal matrix for an
+isolated factorization. MegBA is an Apache-2.0 architectural reference; no code
+is copied. <https://github.com/MegviiRobot/MegBA> and
+<https://arxiv.org/abs/2112.01349>.
+
+The next CUDA work is consequently limited to changes that remove transfer and
+launch overhead: assemble GNSS residual/Jacobian blocks and accumulate normal
+blocks on-device, retain the fixed-lag normal/factorization across epochs,
+apply top-K integer constraints as batched low-rank updates, and migrate the
+legacy typed cuSOLVER calls to the current generic API. CPU parity remains the
+authority at every checkpoint. No IMU, LiDAR, camera, map, or reference
+trajectory enters estimation; reference trajectories remain scorer-only.

--- a/docs/gnss_only_multisd_fgo_design.md
+++ b/docs/gnss_only_multisd_fgo_design.md
@@ -271,3 +271,33 @@ apply top-K integer constraints as batched low-rank updates, and migrate the
 legacy typed cuSOLVER calls to the current generic API. CPU parity remains the
 authority at every checkpoint. No IMU, LiDAR, camera, map, or reference
 trajectory enters estimation; reference trajectories remain scorer-only.
+
+## 300-epoch integrity counterexample and aperture (2026-07-31)
+
+Extending the causal window-10 smoke from 30 to 300 epochs exposed two unsafe
+fixes that the four-satellite disjoint carrier/code validator accepted. Tokyo
+run1 had 144 correct fixes plus one 2.36 m false fix; Nagoya run2 had 158
+correct fixes plus one 1.07 m false fix. Both passed all four held-out carrier
+rows and had a unique top-K hypothesis. Their LAMBDA ratios were 1.88 and 1.71,
+so the earlier 30-epoch smoke was not sufficient safety evidence.
+
+A fixed-vs-float FGO separation aperture was instrumented first. It rejected
+the counterexamples, but the holdout-excluded float graph was itself weak and
+also reduced Tokyo availability from 145 to 22 fixes. It remains default-off
+diagnostic telemetry and is not an authority gate.
+
+The shadow instead applies a configurable cross-estimator aperture between
+each constrained FGO hypothesis and the latest GNSS-only RTK position seed.
+It uses neither RTK FIX status nor reference truth; both estimators consume
+GNSS observations only. With a development value of 0.5 m, the same two
+300-epoch blocks produced Tokyo 146/300 and Nagoya 163/300 correct fixes, zero
+false fixes, maximum fixed errors 0.137 m and 0.124 m, and wall p95 40.3 ms and
+23.4 ms. The previously wrong hypotheses were rejected, while removal of
+additional inconsistent hypotheses made several correct top-K outcomes unique.
+
+The aperture is exposed as
+`--multisd-fgo-shadow-max-seed-separation`; zero disables it. The 0.5 m value
+is a development candidate, not a promoted threshold. It must be selected
+inside route/time-block nested CV and must survive faults. This cross-estimator
+agreement is also not statistically independent of the GNSS observations, so
+the disjoint satellite validator remains mandatory.

--- a/docs/gnss_only_multisd_fgo_design.md
+++ b/docs/gnss_only_multisd_fgo_design.md
@@ -372,3 +372,21 @@ of subset/top-K low-rank updates with an unchanged CPU authority and exact
 decision parity. Promotion still requires run/time-block nested CV, injected
 NLOS/outage/cycle-slip/satellite-loss faults, false/FIX at most 0.1%, no
 greater-than-1-m false fixes, and p95 latency at most 100 ms.
+
+The first native constellation-PAR checkpoint keeps every observed frequency
+but evaluates separate GQEBR, GQEB, GQER, GQB, GQR, and GQ ambiguity pools.
+Each pool retains the native quality-ranked prefix shrink down to the minimum
+dimension; skipping that shrink reduced Nagoya run1 from 45 to 12 fixes and
+was rejected. The GTSAM backend's one-band-per-satellite preprocessing was
+also tested and produced the same 12-fix regression, so it is not transferred
+to the PPC MultiSD path. Frequency diversity is valuable in this dataset even
+when the bands share satellite geometry.
+
+With full-band pool-specific prefix PAR, the six 300-epoch route probes kept
+Tokyo unchanged at 552 correct / 0 false and increased Nagoya from 238 to 252
+correct / 0 false. All 14 added Nagoya candidates were below 0.106 m error;
+the maximum route runtime p95 was 57.6 ms. The feature is exposed only by the
+default-off `--multisd-fgo-shadow-constellation-par` research switch and is a
+nested-CV candidate, not a promoted production policy. Variance ranking is a
+separate default-off switch so model-driven and data-driven selection can be
+ablated without confounding the constellation pool experiment.

--- a/docs/gnss_only_multisd_fgo_design.md
+++ b/docs/gnss_only_multisd_fgo_design.md
@@ -28,6 +28,14 @@ route-blocked PPC validation.
 - RTKLIB-demo5: operational comparison for staged subset AR, satellite
   admission/lock lifecycle, and fix-and-hold. No source is copied.
   <https://github.com/rtklibexplorer/RTKLIB>
+- Teunissen and Verhagen's integer-aperture/fixed-failure-rate work: a fixed
+  ratio is not a correctness test and its threshold should depend on model
+  strength and an explicit failure-rate contract. The implementation keeps
+  ratio/ADOP/BSSR as candidate-quality gates, not independent evidence.
+  <https://doi.org/10.1007/s10291-012-0299-z>
+- Teunissen (1998), bootstrapped ambiguity success probability: BSSR is a
+  conservative covariance-domain bound, but cannot expose unmodelled urban
+  bias. <https://doi.org/10.1007/s001900050199>
 
 ## Existing gap
 
@@ -105,6 +113,43 @@ model-bias failure. Raising the ratio to 2.0 rejected the entire bad block
 solution. This result makes a disjoint measurement-domain causal validator a
 hard promotion requirement. It also confirms the validator must detect common
 model bias rather than reusing the same ambiguity covariance evidence.
+
+## Disjoint top-K validator checkpoint (2026-07-31)
+
+The Eigen MultiSD path now deterministically reserves satellites before the
+float solve and removes every DD carrier/code factor involving them from the
+entire window. The lowest-elevation surplus satellites are reserved so the
+strongest satellite-PAR geometry remains in ILS. Each bounded LAMBDA hypothesis
+is independently constrained and re-optimized. A hypothesis is checked at the
+latest causal edge using only reserved DD carrier integer distance and DD code
+RMS. FIX authority requires sufficient evidence and exactly one passing top-K
+hypothesis; otherwise the result reverts to the untouched float solution.
+Individual hypothesis position and residual diagnostics are emitted to JSON.
+
+Synthetic coverage exercises clean acceptance, four-satellite independent
+carrier corruption rejection, and insufficient-evidence fail-closed behavior.
+Four holdout satellites are the safe default because two carrier equations do
+not overdetermine a 3-D candidate position. The feature and all thresholds
+remain default-off at the MultiSD authority level.
+
+On exploratory 100-epoch PPC windows, four holdouts, offset 2, top-K=4 and
+require-all carrier agreement produced 100/100 correct FIX with zero false
+fixes on Tokyo 0--100, Tokyo 500--600, and Nagoya 0--100. In particular, the
+Nagoya block that previously fixed 100/100 at about 0.65 m was changed by the
+disjoint graph to a correct 0.09--0.11 m solution. Nagoya 500--600 abstained,
+so this is a safety/candidate-quality breakthrough but not yet the availability
+target. The offset is exploratory and may not be promoted without nested
+route/time-block validation.
+
+A 3-of-4 carrier-majority ablation recovered Nagoya 500--600 availability but
+fixed all 100 epochs about 1.65 m wrong (100 >1 m false fixes). It is therefore
+rejected; require-all remains the default. Increasing top-K from 4 to 16 also
+made the Nagoya 0--100 window non-unique (two passing hypotheses about 4 cm
+apart), while K=4 retained a unique correct hypothesis. Position-domain
+hypothesis clustering is recorded as future research, not granted FIX
+authority. Candidate re-optimization currently costs roughly 0.3--0.8 s per
+100-epoch batch in these samples; this is still an offline batch measurement,
+not proof of causal online p95 latency.
 
 The original global LAMBDA path also skipped all large sparse-normal problems.
 MultiSD now retains the sparse normal matrix whenever global LAMBDA is enabled

--- a/docs/gnss_only_multisd_fgo_design.md
+++ b/docs/gnss_only_multisd_fgo_design.md
@@ -83,8 +83,9 @@ difference constraints for integer re-optimization are implemented. Individual
 SD states are never labelled fixed. Unit coverage verifies that a CMC-driven
 DD reference change reuses the same satellite SD state, that BSD integers are
 recovered without fixing the SD gauge, and that the legacy ambiguity path does
-not regress. The next authority gate is the disjoint causal validator; until it
-is wired into the production RTK path, MultiSD remains opt-in and experimental.
+not regress. The disjoint causal validator and a `gnss_solve` rolling-window
+shadow are now wired default-off. They have no production RTK authority, so
+MultiSD remains opt-in and experimental pending the full promotion matrix.
 
 ## Validation sequence
 
@@ -159,3 +160,38 @@ and verifies BSD/top-K fixing. The 100-epoch Tokyo sample generated 16 BSD
 candidates and four hypotheses. Total batch time ranged from about 61 to
 193 ms per 100-epoch batch on the development host; this is not yet an online
 per-epoch fixed-lag latency measurement.
+
+## Causal `gnss_solve` shadow checkpoint (2026-07-31)
+
+`gnss_solve` now has an explicit default-off GNSS-only shadow output. When
+`--multisd-fgo-shadow-csv` is supplied, it keeps a rolling observation window
+that ends at the current RTK epoch, builds the MultiSD DD code/carrier,
+single-difference Doppler, and TDCP graph, and records only the solution whose
+timestamp equals that current epoch. No future observation can enter the
+window. The RTK solution is used only as a geometry seed; the shadow never
+changes RTK state, status, or output. The path takes no IMU, LiDAR, or camera
+input.
+
+The first causal smoke used top-K=4, four disjoint holdout satellites, offset
+2, and require-all carrier agreement. These are development samples, not a
+promotion or full-run FIX-rate claim:
+
+| PPC block | window | evaluated | correct FIX | >1 m false | max FIX error | wall p95 |
+|---|---:|---:|---:|---:|---:|---:|
+| Tokyo run1 0--30 | 25 | 21 | 20 | 0 | 0.067 m | 1315 ms |
+| Tokyo run1 0--30 | 10 | 21 | 21 | 0 | 0.066 m | 201 ms |
+| Tokyo run1 500--530 | 10 | 21 | 19 | 0 | 0.034 m | 145 ms |
+| Nagoya run2 0--30 | 10 | 21 | 20 | 0 | 0.105 m | 124 ms |
+| Nagoya run2 500--530 | 10 | 21 | 8 | 0 | 0.249 m | 118 ms |
+
+The 10-epoch window preserved the safe decisions in these samples and reduced
+wall time by roughly 4x versus rebuilding 25 epochs, but it does not yet meet
+the 100 ms p95 contract. Independent fixed top-K re-solves can now run as a
+deterministic parallel batch behind `parallelize_lambda_hypotheses`; a smoke
+test requires the sequential and parallel FIX decision, selected rank, and
+latest position to match. This is the CPU fallback and intended seam for a
+future CUDA batched normal-equation/factorization backend. The remaining large
+cost is rebuilding and solving the common float graph each epoch, so GPU alone
+must not substitute for fixed-lag reuse/marginalization. Promotion still
+requires PPC run/time-block nested validation, injected fault tests, and the
+full latency distribution.

--- a/docs/gnss_only_multisd_fgo_design.md
+++ b/docs/gnss_only_multisd_fgo_design.md
@@ -1,0 +1,116 @@
+# GNSS-only MultiSD fixed-lag FGO design
+
+## Scope and acceptance contract
+
+This path uses PPC rover/base GNSS observations only. IMU, LiDAR, camera, map,
+and external-route data are excluded from both estimation and validation.
+The deployment targets are Tokyo correct FIX >= 70%, Nagoya correct FIX >= 80%,
+false/FIX <= 0.1%, zero >1 m false fixes, and p95 <= 100 ms/epoch. The feature
+is opt-in and must remain shadow-only until all integrity gates pass nested,
+route-blocked PPC validation.
+
+## Evidence used
+
+- Li et al., ION GNSS+ 2024, "Factor Graph Optimization Based Multi Epoch
+  Ambiguity Resolution for GNSS RTK": MultiSD uses ambiguity correlation over
+  multiple epochs and reports improved urban-canyon fixation and positioning.
+  <https://doi.org/10.33012/2024.19805>
+- Wen and Hsu, GraphGNSSLib: a sliding historical/current factor graph with DD
+  pseudorange, carrier phase, and Doppler, followed by LAMBDA. It is used only
+  as an architectural comparison; no source is copied because the repository
+  does not publish a recognized license.
+  <https://github.com/weisongwen/GraphGNSSLib>
+- Chi et al., GICI-LIB: its differential AR path retains SD ambiguities and
+  forms between-satellite differences at AR time, and its graph checks the
+  post-fix solution. GICI is GPL-3.0, so only the published concepts are used;
+  this implementation is independent.
+  <https://github.com/chichengcn/gici-open>
+- RTKLIB-demo5: operational comparison for staged subset AR, satellite
+  admission/lock lifecycle, and fix-and-hold. No source is copied.
+  <https://github.com/rtklibexplorer/RTKLIB>
+
+## Existing gap
+
+`RTKProcessor` already stores reference-independent, per-satellite SD
+ambiguities and converts them to DD immediately before LAMBDA. The FGO problem
+builder historically stores one ambiguity per `(satellite, reference, signal,
+arc)`. A harmless DD reference change therefore starts a new FGO ambiguity and
+discards useful temporal information. The production `gnss_fuse` RTK path also
+does not run the FGO path, so existing FGO experiments cannot improve its FIX
+rate.
+
+## Target architecture
+
+1. Build FGO ambiguity states per `(satellite, signal, rover carrier arc)`.
+   Each DD carrier factor connects two SD states as `N_sat - N_ref`; reference
+   changes do not alter either key. Only a detected slip, loss of lock, or
+   excessive observation gap starts a new satellite arc.
+2. Optimize a causal fixed-lag graph containing DD pseudorange/carrier,
+   rover-only between-satellite Doppler, and TDCP factors. Marginalize expired
+   epoch states while retaining active SD ambiguity information.
+3. At AR time only, create a full-rank between-satellite-difference projection
+   per constellation/signal/arc component. Project both the SD float vector and
+   its full covariance, including position cross-covariance. Never integer-fix
+   an individual gauge-dependent SD state.
+4. Rank decorrelated ambiguity subsets using a conservative bootstrapped
+   success-rate/ADOP criterion, then run bounded top-K LAMBDA. Re-optimize each
+   candidate with tight BSD constraints and reject it if graph cost worsens.
+5. Give FIX authority only after a disjoint causal validator passes. Validation
+   satellites/factors may not have contributed to the candidate, subset
+   selection, robust weights, or parameter tuning.
+6. Batch independent top-K/subset covariance projections on GPU only after the
+   CPU reference is bitwise/within-tolerance correct. Keep a CPU fallback and
+   enforce the p95 budget in CI.
+
+## Implementation state
+
+`FGOConfig::use_multisd_ambiguities` is default-off. When enabled, the problem
+builder now creates reference-independent SD ambiguity states, initializes them
+from rover-base carrier-minus-code, and connects DD carrier factors to the
+target and reference states. The legacy DD topology is unchanged when disabled.
+At AR time, the latest active DD edge set now projects the SD float state and
+its full covariance into gauge-free BSD combinations. Bounded top-K LAMBDA,
+bootstrapped success-rate telemetry/gating, ADOP telemetry/gating, and
+difference constraints for integer re-optimization are implemented. Individual
+SD states are never labelled fixed. Unit coverage verifies that a CMC-driven
+DD reference change reuses the same satellite SD state, that BSD integers are
+recovered without fixing the SD gauge, and that the legacy ambiguity path does
+not regress. The next authority gate is the disjoint causal validator; until it
+is wired into the production RTK path, MultiSD remains opt-in and experimental.
+
+## Validation sequence
+
+1. Structural tests: reference-switch invariance, per-satellite slip reset,
+   covariance projection symmetry/PSD, rank, and permutation invariance.
+2. Synthetic integer tests: known SD gauge, BSD truth recovery, top-K ordering,
+   and wrong-candidate post-fit rejection.
+3. PPC shadow telemetry: candidate supply, oracle-correct supply, ratio,
+   bootstrapped success rate, ADOP, graph cost delta, validator residuals, and
+   latency. No threshold selection may use the held-out route block.
+4. Nested route/time-blocked cross-validation plus cycle-slip, NLOS,
+   satellite-loss, and outage injection. The final policy is adopted only if
+   both cities meet the FIX/integrity contract without regressions.
+
+## Initial PPC shadow evidence (2026-07-31)
+
+Five non-overlapping 100-epoch run1 blocks were evaluated with the Eigen batch
+backend, MultiSD, top-4 LAMBDA, and no IMU or external sensor. Tokyo blocks
+0-100, 100-200, and 500-600 produced 300/300 correct FIX and zero false fixes;
+Nagoya 500-600 produced 100/100 correct FIX. Nagoya 0-100 exposed the required
+negative control: ratio 1.532 passed the experimental 1.5 aperture and produced
+100/100 fixes at about 0.65 m 3D error. Bootstrapped success rate was 1.0 and
+ADOP was 0.029 cycles, so covariance-only quality metrics did not detect this
+model-bias failure. Raising the ratio to 2.0 rejected the entire bad block
+(0 FIX), but threshold tightening alone is not the intended availability
+solution. This result makes a disjoint measurement-domain causal validator a
+hard promotion requirement. It also confirms the validator must detect common
+model bias rather than reusing the same ambiguity covariance evidence.
+
+The original global LAMBDA path also skipped all large sparse-normal problems.
+MultiSD now retains the sparse normal matrix whenever global LAMBDA is enabled
+and solves only the ambiguity columns through sparse LDLT; it never forms the
+full state covariance. An 80-epoch synthetic smoke test forces this sparse path
+and verifies BSD/top-K fixing. The 100-epoch Tokyo sample generated 16 BSD
+candidates and four hypotheses. Total batch time ranged from about 61 to
+193 ms per 100-epoch batch on the development host; this is not yet an online
+per-epoch fixed-lag latency measurement.

--- a/docs/gnss_only_multisd_fgo_design.md
+++ b/docs/gnss_only_multisd_fgo_design.md
@@ -195,3 +195,30 @@ cost is rebuilding and solving the common float graph each epoch, so GPU alone
 must not substitute for fixed-lag reuse/marginalization. Promotion still
 requires PPC run/time-block nested validation, injected fault tests, and the
 full latency distribution.
+
+### Covariance hot-path correction
+
+Profiling split each causal solve into graph construction, optimizer wall time,
+and accumulated optimizer CPU time. For the 10-epoch Tokyo sample, only about
+14 ms was graph construction and 8 ms was Gauss--Newton work; the dominant
+cost was two dense Jacobi-SVD full pseudo-inverses used to obtain ambiguity and
+output covariance. The optimizer had already factorized the same damped normal
+matrix with LDLT. Retaining that final factorization and solving the ambiguity
+columns as a multi-right-hand-side batch removes the duplicated decomposition
+without weakening any validator gate.
+
+After this change, FIX/FLOAT decisions, top-K validation outcomes, and emitted
+ECEF positions match the pre-change CSV values on all four development blocks.
+The causal wall-time samples are now:
+
+| PPC block | window | mean | p95 | max |
+|---|---:|---:|---:|---:|
+| Tokyo run1 0--30 | 10 | 22.6 ms | 36.6 ms | 44.2 ms |
+| Tokyo run1 0--30 | 25 | 45.2 ms | 79.1 ms | 118.9 ms |
+| Nagoya run2 0--30 | 10 | 16.3 ms | 20.8 ms | 20.9 ms |
+| Nagoya run2 500--530 | 10 | 19.6 ms | 27.1 ms | 33.5 ms |
+
+Thus the preliminary 25-epoch p95 is below 100 ms on this host even before a
+CUDA solve. This is still a 21-solve development sample, not the full latency
+contract. CUDA remains an optional scaling path for longer windows and larger
+hypothesis batches; CPU stays the reference and fallback.

--- a/docs/gnss_only_multisd_fgo_design.md
+++ b/docs/gnss_only_multisd_fgo_design.md
@@ -301,3 +301,74 @@ is a development candidate, not a promoted threshold. It must be selected
 inside route/time-block nested CV and must survive faults. This cross-estimator
 agreement is also not statistically independent of the GNSS observations, so
 the disjoint satellite validator remains mandatory.
+
+The next development arm replaces the brittle latest-only 4/4 carrier check
+with a causal three-epoch check over the same satellites that were excluded
+from the complete candidate graph. It requires at least 75% of all 12 held-out
+carrier rows while retaining the latest-epoch DD-code and GNSS-seed apertures.
+The library default remains the legacy one epoch and 100%; only the
+`gnss_solve` research shadow enables the temporal arm. Its purpose is to
+tolerate isolated carrier noise, not sustained wrong integers, and it remains
+unpromoted until the 300-epoch counterexamples and injected faults pass.
+
+## Six-route 300-epoch audit and next availability arm (2026-07-31)
+
+The causal harness now runs all Tokyo/Nagoya routes, scores five contiguous
+time blocks, supports outer leave-one-run-out selection, records the exact
+solver command and binary SHA-256, and rejects malformed, truncated, or
+duplicate-TOW shadow files. Rover, base, and navigation RINEX are the only
+estimator inputs. Reference CSV is opened after the subprocess exits and is
+scoring-only. IMU, LiDAR, camera, maps, and other-date data are excluded.
+
+The strict one-epoch/four-satellite validator exposed a useful partition
+effect. Across the three holdout offsets, truth-blind selection of the passing
+hypothesis with the smallest GNSS-seed separation produced 698 correct and
+zero false fixes in the 873 common post-warmup Tokyo epochs (77.6% if divided
+by all 900 input epochs). Nagoya produced only 231 correct and zero false
+fixes. Requiring two offsets to agree within 0.25 m was safe in this sample but
+reduced the counts to 641 Tokyo and 25 Nagoya. Thus partition diversity is a
+viable Tokyo authority arm, but agreement-only fusion cannot solve Nagoya's
+candidate-supply deficit.
+
+The temporal 3-epoch/75%-carrier arm recovered some carrier-noise epochs but
+did not change the conclusion: shadow-only counts were 552/900 Tokyo and
+238/898 Nagoya, with zero false fixes. A 25-epoch window increased latency and
+did not materially recover Nagoya. Lowering the minimum ambiguity dimension
+from six to four produced the same FIX set. Reducing the holdout from four to
+three introduced a 0.661 m Nagoya false fix. These arms are rejected rather
+than promoted.
+
+The baseline-priority union is also not an integrity authority. In the first
+300 epochs per route, the RTK baseline itself had six Tokyo false fixes
+(0.500--0.867 m). All six were rejected by the temporal and both tested strict
+FGO partitions; their candidate/RTK disagreement was 4.1--7.7 m. The audit
+harness therefore labels this output `baseline_priority_union` and selects
+policies using the disjoint FGO shadow, not that union. A future production
+gate may use FGO as confirmation/veto authority, but it must measure the
+availability cost in nested CV.
+
+The next Nagoya arm is model- and data-driven PAR rather than a looser residual
+threshold. It will reuse the existing GTSAM backend's constellation-ranked
+PAR, continuous ambiguity arcs, and surplus-satellite monitor, then evaluate
+each top-K subset with observations excluded from candidate generation. The
+design follows three primary references:
+
+* Li et al.'s MultiSD method uses soft equality constraints between persistent
+  single-difference ambiguities instead of prematurely merging ambiguity
+  parameters: <https://doi.org/10.33012/2024.19805>.
+* Triple-checked PAR combines bootstrapped success rate, a bounded
+  fixed-failure ratio test, and baseline precision impact instead of trusting
+  a fixed ratio threshold alone: <https://doi.org/10.3390/s19225034>.
+* The fixed-failure-rate ratio test makes the threshold model-dependent; a
+  single constant ratio does not preserve a fixed failure probability as the
+  ambiguity model changes: <https://doi.org/10.1007/s10291-012-0299-z>.
+
+GraphGNSSLib is retained as an OSS factor-layout reference for DD code,
+carrier, Doppler, historical epochs, and final LAMBDA, not copied code:
+<https://github.com/weisongwen/GraphGNSSLib>. RTKLIB demo5's pre-fix
+leave-one-satellite exclusion is the operational analogue for partitioned
+candidate generation. The implementation target is a deterministic GPU batch
+of subset/top-K low-rank updates with an unchanged CPU authority and exact
+decision parity. Promotion still requires run/time-block nested CV, injected
+NLOS/outage/cycle-slip/satellite-loss faults, false/FIX at most 0.1%, no
+greater-than-1-m false fixes, and p95 latency at most 100 ms.

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -166,6 +166,19 @@ public:
         // Covariance-only integer quality gates. Zero disables each gate.
         double lambda_min_bootstrapped_success_rate = 0.0;
         double lambda_max_adop_cycles = 0.0;
+        // Reserve carrier/code observations from deterministic satellites for
+        // a disjoint post-fix check. Reserved observations are removed from
+        // the complete float/fixed window before optimization, so the
+        // validator cannot reuse evidence that generated the integer
+        // candidate. MultiSD/native only; default OFF until PPC calibration.
+        bool use_multisd_disjoint_validation = false;
+        int multisd_validation_holdout_satellites = 4;
+        int multisd_validation_holdout_offset = 0;
+        double multisd_validation_aperture_cycles = 0.15;
+        // Require all held-out carrier rows by default. The 3-of-4 PPC
+        // ablation accepted a 1.65 m wrong fix for all 100 Nagoya epochs.
+        double multisd_validation_min_carrier_fraction = 1.0;
+        double multisd_validation_max_ddpr_rms_m = 3.0;
         bool use_epoch_lambda_fixed_output = false;
         bool use_partial_lambda_ambiguity_fix = true;
         // Independently re-optimize the active fixed-lag graph with the
@@ -1688,6 +1701,12 @@ public:
         // AmbiguityState for an arc that was never solved for; the surplus
         // validator looks up wavelength from `signal` instead.
         std::vector<DoubleDifferenceCarrierFactor> excluded_double_difference_carrier_factors;
+        // Factors reserved before optimization for the MultiSD disjoint
+        // validator. They are never inserted into the candidate graph.
+        std::vector<DoubleDifferencePseudorangeFactor>
+            multisd_validation_pseudorange_factors;
+        std::vector<DoubleDifferenceCarrierFactor>
+            multisd_validation_carrier_factors;
         std::vector<AmbiguityBetweenFactor> ambiguity_between_factors;
         FGOProblemDiagnostics diagnostics;
     };
@@ -1855,6 +1874,19 @@ public:
         double lambda_bootstrapped_success_rate = 0.0;
         double lambda_adop_cycles = std::numeric_limits<double>::quiet_NaN();
         std::size_t lambda_top_k_generated = 0;
+        bool multisd_validation_evaluated = false;
+        bool multisd_validation_pass = false;
+        std::size_t multisd_validation_holdout_satellites = 0;
+        std::size_t multisd_validation_carrier_used = 0;
+        std::size_t multisd_validation_carrier_passed = 0;
+        std::size_t multisd_validation_pseudorange_used = 0;
+        std::size_t multisd_validation_hypotheses_evaluated = 0;
+        std::size_t multisd_validation_hypotheses_passed = 0;
+        int multisd_validation_selected_rank = -1;
+        double multisd_validation_max_integer_distance_cycles =
+            std::numeric_limits<double>::quiet_NaN();
+        double multisd_validation_ddpr_rms_m =
+            std::numeric_limits<double>::quiet_NaN();
     };
 
     struct AmbiguityEstimate {
@@ -2000,6 +2032,17 @@ public:
     };
 
     struct FGOResult {
+        struct MultiSdValidationHypothesis {
+            int rank = -1;
+            bool evaluated = false;
+            bool pass = false;
+            Vector3d latest_position_ecef = Vector3d::Zero();
+            std::size_t carrier_used = 0;
+            std::size_t carrier_passed = 0;
+            std::size_t pseudorange_used = 0;
+            double maximum_integer_distance_cycles = 0.0;
+            double ddpr_rms_m = std::numeric_limits<double>::infinity();
+        };
         Solution solution;
         FGODiagnostics diagnostics;
         std::vector<AmbiguityEstimate> ambiguity_estimates;
@@ -2010,6 +2053,8 @@ public:
         std::vector<LambdaDebugEntry> lambda_debug_entries;
         std::vector<CostTraceEntry> cost_trace_entries;
         std::vector<FGOEpochDiagnostics> epoch_diagnostics;
+        std::vector<MultiSdValidationHypothesis>
+            multisd_validation_hypotheses;
         // Milestone 2b (populated only by the GTSAM IMU-coupled path):
         // per-epoch estimated attitude as [roll, pitch, heading] in degrees
         // (body FLU -> nav ENU; heading is clockwise from North) and estimated

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -144,6 +144,14 @@ public:
         bool use_velocity_states = false;
         bool use_velocity_motion_factors = false;
         bool use_ambiguity_between_factors = false;
+        // Represent carrier ambiguities as reference-independent rover-base
+        // single differences keyed by (satellite, signal, rover carrier arc).
+        // DD carrier factors then connect two SD states as N_sat - N_ref.
+        // This preserves ambiguity continuity when the DD reference changes
+        // and is the state topology required by multi-epoch MultiSD AR.
+        // Default OFF until the BSD covariance projection and integer
+        // validator are enabled by the production RTK integration.
+        bool use_multisd_ambiguities = false;
         bool linearize_double_difference_factors_at_seed = false;
         bool reset_double_difference_ambiguities_each_epoch = false;
         bool use_inter_system_biases = true;
@@ -151,6 +159,13 @@ public:
         bool fix_ambiguities = false;
         bool prefer_double_difference_ambiguity_fixing = true;
         bool use_lambda_ambiguity_fix = true;
+        // Request a bounded multi-hypothesis LAMBDA search. Two preserves the
+        // legacy ratio-test behavior; larger values supply candidates for the
+        // causal/post-fit validator without rerunning decorrelation.
+        int lambda_top_k_candidates = 2;
+        // Covariance-only integer quality gates. Zero disables each gate.
+        double lambda_min_bootstrapped_success_rate = 0.0;
+        double lambda_max_adop_cycles = 0.0;
         bool use_epoch_lambda_fixed_output = false;
         bool use_partial_lambda_ambiguity_fix = true;
         // Independently re-optimize the active fixed-lag graph with the
@@ -1694,6 +1709,7 @@ public:
         std::size_t carrier_phase_factors = 0;
         std::size_t double_difference_pseudorange_factors = 0;
         std::size_t double_difference_carrier_factors = 0;
+        std::size_t multisd_carrier_factors = 0;
         std::size_t ambiguity_states = 0;
         std::size_t ambiguity_fix_candidates = 0;
         std::size_t lambda_ambiguity_candidates = 0;
@@ -1836,6 +1852,9 @@ public:
         double double_difference_carrier_residual_rms_m = 0.0;
         double fixed_ambiguity_residual_rms_cycles = 0.0;
         double lambda_ambiguity_ratio = 0.0;
+        double lambda_bootstrapped_success_rate = 0.0;
+        double lambda_adop_cycles = std::numeric_limits<double>::quiet_NaN();
+        std::size_t lambda_top_k_generated = 0;
     };
 
     struct AmbiguityEstimate {

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -193,6 +193,17 @@ public:
         // Cross-estimator aperture against the latest GNSS-only position seed.
         // The seed must not contain truth or an external sensor. Zero disables.
         double multisd_validation_max_seed_separation_m = 0.0;
+        // Candidate-generation ratio floor used only when the complete
+        // disjoint MultiSD validator is enabled. Zero preserves
+        // lambda_ratio_threshold. A lower value does not grant FIX: every
+        // top-K hypothesis must still pass the excluded-observation validator
+        // and uniqueness checks.
+        double multisd_lambda_candidate_ratio_threshold = 0.0;
+        // Number of distinct PAR subset/pool candidate groups that may be
+        // offered to the disjoint validator. One preserves first-LAMBDA-group
+        // behavior. Groups are evaluated in order and later groups are tried
+        // only after an earlier group has zero passing hypotheses.
+        int multisd_max_candidate_groups = 1;
         bool use_epoch_lambda_fixed_output = false;
         bool use_partial_lambda_ambiguity_fix = true;
         // Independently re-optimize the active fixed-lag graph with the

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -215,6 +215,9 @@ public:
         // Additional GNSS-only seed aperture for later PAR groups. The first
         // group retains the ordinary validator aperture. Zero disables.
         double multisd_fallback_max_seed_separation_m = 0.0;
+        // Optional bootstrap-success aperture for validator fallback groups.
+        // The first group retains the regular LAMBDA gate.
+        double multisd_fallback_min_bootstrapped_success_rate = 0.0;
         bool use_epoch_lambda_fixed_output = false;
         bool use_partial_lambda_ambiguity_fix = true;
         // Independently re-optimize the active fixed-lag graph with the

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -1906,6 +1906,11 @@ public:
         std::size_t cuda_dense_solve_successes = 0;
         std::size_t cuda_dense_solve_fallbacks = 0;
         double cuda_dense_solve_time_ms = 0.0;
+        /// Top-K groups submitted as one common-normal, multi-RHS CUDA solve.
+        std::size_t cuda_hypothesis_batch_attempts = 0;
+        std::size_t cuda_hypothesis_batch_successes = 0;
+        /// Total hypothesis RHS columns submitted across successful or failed batches.
+        std::size_t cuda_hypothesis_batch_rhs_columns = 0;
         double epoch_lambda_processing_time_ms = 0.0;
         double epoch_lambda_setup_time_ms = 0.0;
         double epoch_lambda_factorization_time_ms = 0.0;

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -204,6 +204,17 @@ public:
         // behavior. Groups are evaluated in order and later groups are tried
         // only after an earlier group has zero passing hypotheses.
         int multisd_max_candidate_groups = 1;
+        // Later PAR groups can require corroboration from multiple independently
+        // generated subsets. The first group retains the ordinary unique top-K
+        // decision. One preserves sequential fallback behavior.
+        int multisd_fallback_min_consensus_groups = 1;
+        // Maximum pairwise latest-position separation for later-group
+        // consensus. Required when the minimum consensus group count exceeds
+        // one. Zero disables consensus acceptance in that case.
+        double multisd_fallback_max_consensus_separation_m = 0.0;
+        // Additional GNSS-only seed aperture for later PAR groups. The first
+        // group retains the ordinary validator aperture. Zero disables.
+        double multisd_fallback_max_seed_separation_m = 0.0;
         bool use_epoch_lambda_fixed_output = false;
         bool use_partial_lambda_ambiguity_fix = true;
         // Independently re-optimize the active fixed-lag graph with the

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -1856,6 +1856,14 @@ public:
         double initial_cost = 0.0;
         double final_cost = 0.0;
         double processing_time_ms = 0.0;
+        /// Native dense normal-equation dimension used for CPU/GPU dispatch.
+        std::size_t dense_normal_state_size = 0;
+        /// True when this solve selected the optional cuSOLVER dense path.
+        bool cuda_dense_solver_selected = false;
+        std::size_t cuda_dense_solve_attempts = 0;
+        std::size_t cuda_dense_solve_successes = 0;
+        std::size_t cuda_dense_solve_fallbacks = 0;
+        double cuda_dense_solve_time_ms = 0.0;
         double epoch_lambda_processing_time_ms = 0.0;
         double epoch_lambda_setup_time_ms = 0.0;
         double epoch_lambda_factorization_time_ms = 0.0;

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -179,6 +179,9 @@ public:
         int multisd_validation_holdout_satellites = 4;
         int multisd_validation_holdout_offset = 0;
         double multisd_validation_aperture_cycles = 0.15;
+        // Causal carrier validation span ending at the latest epoch. A value
+        // of one preserves the legacy latest-only check.
+        int multisd_validation_history_epochs = 1;
         // Require all held-out carrier rows by default. The 3-of-4 PPC
         // ablation accepted a 1.65 m wrong fix for all 100 Nagoya epochs.
         double multisd_validation_min_carrier_fraction = 1.0;

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -163,6 +163,10 @@ public:
         // legacy ratio-test behavior; larger values supply candidates for the
         // causal/post-fit validator without rerunning decorrelation.
         int lambda_top_k_candidates = 2;
+        // Each top-K integer hypothesis is an independent fixed re-solve.
+        // Run those re-solves concurrently when explicitly enabled. This is
+        // the deterministic CPU fallback for the future GPU batch backend.
+        bool parallelize_lambda_hypotheses = false;
         // Covariance-only integer quality gates. Zero disables each gate.
         double lambda_min_bootstrapped_success_rate = 0.0;
         double lambda_max_adop_cycles = 0.0;

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -439,6 +439,9 @@ public:
         // Try the PPC constellation partial-AR cascade as separate LAMBDA
         // pools: GQEBR -> GQEB -> GQER -> GQB -> GQR -> GQ.
         bool use_constellation_ranked_partial_ar = false;
+        // When collecting multiple validator groups, visit each constellation
+        // pool at the same PAR depth before shrinking one pool again.
+        bool interleave_constellation_partial_ar = false;
         // Remove ambiguity candidates implicated by a gross current-epoch
         // DD pseudorange residual before the PPC constellation cascade.
         bool use_residual_screened_partial_ar = false;
@@ -446,6 +449,10 @@ public:
         // variance and do not attempt a subset whose least precise member
         // exceeds this standard deviation in cycles (<=0 disables the gate).
         bool use_variance_ranked_partial_ar = false;
+        // Rank PAR candidates with an all-PPC composite of marginal float
+        // variance, distance to the nearest integer, and the windowed
+        // standardized DD carrier residual. Default off for compatibility.
+        bool use_quality_ranked_partial_ar = false;
         double partial_ar_max_std_cycles = 0.25;
         // GICI-style ambiguity reacquisition: when geometry is good and FDE
         // rejects less than the configured fraction, a long run of fresh-AR

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -183,6 +183,13 @@ public:
         // ablation accepted a 1.65 m wrong fix for all 100 Nagoya epochs.
         double multisd_validation_min_carrier_fraction = 1.0;
         double multisd_validation_max_ddpr_rms_m = 3.0;
+        // Solution-separation aperture between a constrained top-K hypothesis
+        // and the holdout-excluded float graph at the latest epoch. Zero
+        // disables it. This is truth-free and does not use the RTK seed.
+        double multisd_validation_max_fixed_float_separation_m = 0.0;
+        // Cross-estimator aperture against the latest GNSS-only position seed.
+        // The seed must not contain truth or an external sensor. Zero disables.
+        double multisd_validation_max_seed_separation_m = 0.0;
         bool use_epoch_lambda_fixed_output = false;
         bool use_partial_lambda_ambiguity_fix = true;
         // Independently re-optimize the active fixed-lag graph with the
@@ -1899,6 +1906,10 @@ public:
             std::numeric_limits<double>::quiet_NaN();
         double multisd_validation_ddpr_rms_m =
             std::numeric_limits<double>::quiet_NaN();
+        double multisd_validation_fixed_float_separation_m =
+            std::numeric_limits<double>::quiet_NaN();
+        double multisd_validation_seed_separation_m =
+            std::numeric_limits<double>::quiet_NaN();
     };
 
     struct AmbiguityEstimate {
@@ -2054,6 +2065,10 @@ public:
             std::size_t pseudorange_used = 0;
             double maximum_integer_distance_cycles = 0.0;
             double ddpr_rms_m = std::numeric_limits<double>::infinity();
+            double fixed_float_separation_m =
+                std::numeric_limits<double>::infinity();
+            double seed_separation_m =
+                std::numeric_limits<double>::infinity();
         };
         Solution solution;
         FGODiagnostics diagnostics;

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -2910,6 +2910,7 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
     struct OptimizationOutput {
         Eigen::VectorXd state;
         Eigen::MatrixXd normal_matrix;
+        Eigen::VectorXd normal_rhs;
         Eigen::SparseMatrix<double> sparse_normal_matrix;
         std::shared_ptr<SparseNormalFactorization> sparse_factorization;
         std::shared_ptr<DenseNormalFactorization> dense_factorization;
@@ -2943,14 +2944,15 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
         [&](const Eigen::VectorXd& start_state,
             const std::vector<FixedAmbiguityConstraint>& fixed_constraints,
             const std::string& phase,
-            int global_iteration_offset)
+            int global_iteration_offset,
+            int iteration_limit)
             -> OptimizationOutput {
         OptimizationOutput output;
         output.state = start_state;
 
         const auto start_time = std::chrono::high_resolution_clock::now();
         double previous_cost = std::numeric_limits<double>::infinity();
-        for (int iter = 0; iter < config_.max_iterations; ++iter) {
+        for (int iter = 0; iter < iteration_limit; ++iter) {
             const int pr_rows = static_cast<int>(problem.pseudorange_factors.size());
             const int carrier_phase_rows =
                 static_cast<int>(problem.carrier_phase_factors.size());
@@ -3666,6 +3668,7 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                 output.final_cost = weighted_residual_square_sum;
                 if (!use_sparse_normal) {
                     output.normal_matrix = normal_matrix;
+                    output.normal_rhs = normal_rhs;
                 }
                 output.robust_pseudorange_factors = robust_pseudorange_count;
                 output.robust_carrier_phase_factors = robust_carrier_phase_count;
@@ -3826,7 +3829,8 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
         return output;
     };
 
-    OptimizationOutput optimization = run_optimizer(initial_state, {}, "float", 0);
+    OptimizationOutput optimization = run_optimizer(
+        initial_state, {}, "float", 0, config_.max_iterations);
     result.cost_trace_entries = optimization.cost_trace_entries;
     int total_iterations = optimization.iterations;
     double total_processing_ms = optimization.processing_ms;
@@ -4578,7 +4582,8 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                 run_optimizer(optimization.state,
                               fixed_constraints,
                               "fixed",
-                              fixed_global_iteration_offset);
+                              fixed_global_iteration_offset,
+                              config_.max_iterations);
             total_iterations += fixed_optimization.iterations;
             total_processing_ms += fixed_optimization.processing_ms;
             result.cost_trace_entries.insert(
@@ -4788,6 +4793,144 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                         hypothesis_futures;
                     const std::size_t async_start =
                         group_start == 0 ? 1 : group_start;
+                    std::vector<Eigen::VectorXd> cuda_batch_start_states(
+                        group_end - async_start);
+                    std::vector<bool> cuda_batch_start_valid(
+                        group_end - async_start, false);
+                    // Every top-K hypothesis in one PAR group constrains the
+                    // same ambiguity columns. At the common float state its
+                    // fixed-row normal matrix is therefore identical; only
+                    // the right-hand side changes. Use one cuSOLVER POTRF and
+                    // a multi-column POTRS to precondition all hypotheses,
+                    // then retain the ordinary nonlinear reoptimization and
+                    // independent validator as final authority.
+                    if (use_cuda_dense_normal &&
+                        group_end > async_start &&
+                        float_optimization.normal_matrix.rows() == state_size) {
+                        const auto& pattern =
+                            lambda_hypothesis_constraints[async_start];
+                        bool common_pattern = !pattern.empty();
+                        for (std::size_t rank = async_start + 1;
+                             common_pattern && rank < group_end; ++rank) {
+                            const auto& constraints =
+                                lambda_hypothesis_constraints[rank];
+                            if (constraints.size() != pattern.size()) {
+                                common_pattern = false;
+                                break;
+                            }
+                            for (std::size_t row = 0;
+                                 row < pattern.size(); ++row) {
+                                if (constraints[row].ambiguity_index !=
+                                        pattern[row].ambiguity_index ||
+                                    constraints[row].reference_ambiguity_index !=
+                                        pattern[row]
+                                            .reference_ambiguity_index) {
+                                    common_pattern = false;
+                                    break;
+                                }
+                            }
+                        }
+                        if (common_pattern) {
+                            Eigen::MatrixXd batch_normal =
+                                float_optimization.normal_matrix;
+                            const int batch_columns =
+                                static_cast<int>(group_end - async_start);
+                            Eigen::MatrixXd batch_rhs = Eigen::MatrixXd::Zero(
+                                state_size, batch_columns);
+                            if (float_optimization.normal_rhs.rows() ==
+                                state_size) {
+                                batch_rhs = float_optimization.normal_rhs.replicate(
+                                    1, batch_columns);
+                            }
+                            const double fixed_sigma = std::max(
+                                1e-5, config_.fixed_ambiguity_sigma_m);
+                            const double fixed_weight = 1.0 / fixed_sigma;
+                            const double fixed_weight_squared =
+                                fixed_weight * fixed_weight;
+                            for (const auto& fixed : pattern) {
+                                const int ambiguity_col =
+                                    base_state_size + static_cast<int>(
+                                        fixed.ambiguity_index);
+                                batch_normal(ambiguity_col, ambiguity_col) +=
+                                    fixed_weight_squared;
+                                if (fixed.reference_ambiguity_index <
+                                    problem.ambiguity_states.size()) {
+                                    const int reference_col =
+                                        base_state_size + static_cast<int>(
+                                            fixed.reference_ambiguity_index);
+                                    batch_normal(reference_col, reference_col) +=
+                                        fixed_weight_squared;
+                                    batch_normal(ambiguity_col, reference_col) -=
+                                        fixed_weight_squared;
+                                    batch_normal(reference_col, ambiguity_col) -=
+                                        fixed_weight_squared;
+                                }
+                            }
+                            for (std::size_t rank = async_start;
+                                 rank < group_end; ++rank) {
+                                const auto& constraints =
+                                    lambda_hypothesis_constraints[rank];
+                                const int rhs_col =
+                                    static_cast<int>(rank - async_start);
+                                for (const auto& fixed : constraints) {
+                                    const int ambiguity_col =
+                                        base_state_size + static_cast<int>(
+                                            fixed.ambiguity_index);
+                                    const bool use_difference =
+                                        fixed.reference_ambiguity_index <
+                                        problem.ambiguity_states.size();
+                                    const int reference_col = use_difference
+                                        ? base_state_size + static_cast<int>(
+                                              fixed.reference_ambiguity_index)
+                                        : -1;
+                                    const double current_ambiguity =
+                                        float_optimization.state(ambiguity_col) -
+                                        (use_difference
+                                             ? float_optimization.state(
+                                                   reference_col)
+                                             : 0.0);
+                                    const double weighted_rhs =
+                                        (fixed.fixed_ambiguity_m -
+                                         current_ambiguity) *
+                                        fixed_weight_squared;
+                                    batch_rhs(ambiguity_col, rhs_col) +=
+                                        weighted_rhs;
+                                    if (use_difference) {
+                                        batch_rhs(reference_col, rhs_col) -=
+                                            weighted_rhs;
+                                    }
+                                }
+                            }
+                            const double max_diagonal =
+                                batch_normal.diagonal().cwiseAbs().maxCoeff();
+                            batch_normal.diagonal().array() +=
+                                std::max(1e-12, max_diagonal * 1e-12);
+                            Eigen::MatrixXd batch_delta;
+                            result.diagnostics.cuda_hypothesis_batch_attempts += 1;
+                            result.diagnostics.cuda_hypothesis_batch_rhs_columns +=
+                                static_cast<std::size_t>(batch_rhs.cols());
+                            if (tryCudaDenseSolve(
+                                    batch_normal, batch_rhs, batch_delta,
+                                    &cuda_solve_stats) &&
+                                batch_delta.cols() == batch_rhs.cols()) {
+                                result.diagnostics.cuda_hypothesis_batch_successes += 1;
+                                for (int column = 0;
+                                     column < batch_delta.cols(); ++column) {
+                                    Eigen::VectorXd start_state =
+                                        float_optimization.state +
+                                        batch_delta.col(column);
+                                    if (start_state.allFinite()) {
+                                        cuda_batch_start_states[
+                                            static_cast<std::size_t>(column)] =
+                                            std::move(start_state);
+                                        cuda_batch_start_valid[
+                                            static_cast<std::size_t>(column)] =
+                                            true;
+                                    }
+                                }
+                            }
+                        }
+                    }
                     // CUDA uses a retained thread-local cuSOLVER workspace.
                     // Keep hypotheses on this thread in CUDA mode; CPU groups
                     // retain the existing deterministic parallel batch.
@@ -4803,7 +4946,8 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                                 float_optimization.state,
                                 lambda_hypothesis_constraints[rank],
                                 "fixed-hypothesis",
-                                fixed_global_iteration_offset));
+                                fixed_global_iteration_offset,
+                                config_.max_iterations));
                         }
                     }
                     std::size_t group_passes = 0;
@@ -4819,11 +4963,21 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                             hypothesis =
                                 hypothesis_futures[rank - async_start].get();
                         } else {
+                            const std::size_t batch_index =
+                                rank - async_start;
+                            const Eigen::VectorXd& hypothesis_start =
+                                batch_index < cuda_batch_start_valid.size() &&
+                                        cuda_batch_start_valid[batch_index]
+                                    ? cuda_batch_start_states[batch_index]
+                                    : float_optimization.state;
                             hypothesis = run_optimizer(
-                                float_optimization.state,
+                                hypothesis_start,
                                 lambda_hypothesis_constraints[rank],
                                 "fixed-hypothesis",
-                                fixed_global_iteration_offset);
+                                fixed_global_iteration_offset,
+                                cuda_batch_start_valid[batch_index]
+                                    ? std::max(1, config_.max_iterations - 1)
+                                    : config_.max_iterations);
                             total_iterations += hypothesis.iterations;
                             total_processing_ms += hypothesis.processing_ms;
                         }

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -494,6 +494,8 @@ double varerrDdSigma(bool is_pseudorange, double el_pair_rad, double dt_s,
 
 struct FixedAmbiguityConstraint {
     std::size_t ambiguity_index = 0;
+    std::size_t reference_ambiguity_index =
+        std::numeric_limits<std::size_t>::max();
     double fixed_ambiguity_m = 0.0;
     int fixed_cycles = 0;
     double residual_cycles = 0.0;
@@ -547,6 +549,21 @@ struct DoubleDifferenceSegmentKey {
     bool operator<(const DoubleDifferenceSegmentKey& other) const {
         return std::tie(satellite, reference_satellite, signal) <
                std::tie(other.satellite, other.reference_satellite, other.signal);
+    }
+};
+
+struct SingleDifferenceAmbiguityKey {
+    SatelliteId satellite;
+    SignalType signal = SignalType::GPS_L1CA;
+    std::size_t rover_ambiguity_index = 0;
+    std::size_t integrity_segment_index = 0;
+
+    bool operator<(const SingleDifferenceAmbiguityKey& other) const {
+        return std::tie(satellite, signal, rover_ambiguity_index,
+                        integrity_segment_index) <
+               std::tie(other.satellite, other.signal,
+                        other.rover_ambiguity_index,
+                        other.integrity_segment_index);
     }
 };
 
@@ -1573,6 +1590,10 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
     std::map<DoubleDifferenceAmbiguityKey, ActiveCarrierSegment>
         active_dd_segments;
     std::map<DoubleDifferenceSegmentKey, std::size_t> next_dd_segment_indices;
+    std::map<SingleDifferenceAmbiguityKey, ActiveCarrierSegment>
+        active_sd_segments;
+    std::map<CarrierKey, std::size_t> next_sd_segment_indices;
+    std::map<CarrierKey, std::size_t> sd_integrity_segment_indices;
     using DdFactorKey =
         std::tuple<std::size_t, SatelliteId, SatelliteId, SignalType>;
     std::map<SingleDifferenceReferenceKey, SatelliteId> sd_reference_by_group;
@@ -1777,6 +1798,9 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
                     }
                 }
             }
+        }
+        for (const auto& key : cmc_jump_reset_this_epoch) {
+            ++sd_integrity_segment_indices[key];
         }
 
         if (rover_pseudorange_it != rover_pseudoranges_by_epoch.end()) {
@@ -2114,7 +2138,8 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
 
                 DoubleDifferenceCarrierFactor factor;
                 factor.epoch_index = epoch_index;
-                factor.use_ambiguity_difference = false;
+                factor.use_ambiguity_difference =
+                    config_.use_multisd_ambiguities;
                 factor.satellite = satellite->satellite;
                 factor.reference_satellite = reference->satellite;
                 factor.signal = satellite->signal;
@@ -2195,6 +2220,58 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
                     // gap checks above already perform (multipath jump
                     // breaks the integer ambiguity).
                     start_new_segment = true;
+                }
+
+                if (config_.use_multisd_ambiguities) {
+                    auto get_or_create_sd_ambiguity =
+                        [&](const CarrierPhaseFactor& rover,
+                            const PreparedCarrierObservation& base)
+                            -> std::size_t {
+                        const SingleDifferenceAmbiguityKey key{
+                            rover.satellite, rover.signal,
+                            rover.ambiguity_index,
+                            sd_integrity_segment_indices[CarrierKey{
+                                rover.satellite, rover.signal}]};
+                        auto it = active_sd_segments.find(key);
+                        if (it != active_sd_segments.end()) {
+                            it->second.last_epoch_index = epoch_index;
+                            return it->second.ambiguity_index;
+                        }
+
+                        AmbiguityState ambiguity;
+                        ambiguity.satellite = rover.satellite;
+                        ambiguity.reference_satellite = SatelliteId{};
+                        ambiguity.signal = rover.signal;
+                        ambiguity.is_double_difference = false;
+                        ambiguity.segment_index =
+                            next_sd_segment_indices[CarrierKey{
+                                rover.satellite, rover.signal}]++;
+                        ambiguity.wavelength_m = rover.wavelength_m;
+                        // Carrier-minus-code removes the geometric range and
+                        // clock terms from the rover-base SD seed. The noisy
+                        // code only initializes the graph; carrier factors
+                        // determine the optimized ambiguity.
+                        ambiguity.initial_ambiguity_m =
+                            (rover.corrected_carrier_m -
+                             base.corrected_carrier_m) -
+                            (rover.corrected_pseudorange_m -
+                             base.corrected_pseudorange_m);
+                        const std::size_t index =
+                            problem.ambiguity_states.size();
+                        problem.ambiguity_states.push_back(ambiguity);
+                        active_sd_segments.emplace(
+                            key, ActiveCarrierSegment{index, epoch_index});
+                        return index;
+                    };
+
+                    factor.ambiguity_index = get_or_create_sd_ambiguity(
+                        *satellite, base_satellite);
+                    factor.reference_ambiguity_index =
+                        get_or_create_sd_ambiguity(*reference,
+                                                   base_reference);
+                    problem.double_difference_carrier_factors.push_back(
+                        factor);
+                    continue;
                 }
 
                 if (start_new_segment) {
@@ -2494,6 +2571,13 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
         problem.double_difference_pseudorange_factors.size();
     result.diagnostics.double_difference_carrier_factors =
         problem.double_difference_carrier_factors.size();
+    result.diagnostics.multisd_carrier_factors =
+        static_cast<std::size_t>(std::count_if(
+            problem.double_difference_carrier_factors.begin(),
+            problem.double_difference_carrier_factors.end(),
+            [](const DoubleDifferenceCarrierFactor& factor) {
+                return factor.use_ambiguity_difference;
+            }));
     result.diagnostics.ambiguity_between_factors =
         problem.ambiguity_between_factors.size();
     result.diagnostics.ambiguity_states = problem.ambiguity_states.size();
@@ -3353,11 +3437,25 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
                     }
                     const int ambiguity_col =
                         base_state_size + static_cast<int>(fixed.ambiguity_index);
+                    const bool use_difference =
+                        fixed.reference_ambiguity_index <
+                        problem.ambiguity_states.size();
+                    const int reference_col = use_difference
+                        ? base_state_size + static_cast<int>(
+                              fixed.reference_ambiguity_index)
+                        : -1;
+                    const double current_ambiguity =
+                        output.state(ambiguity_col) -
+                        (use_difference ? output.state(reference_col) : 0.0);
                     const double weighted_residual =
-                        (fixed.fixed_ambiguity_m - output.state(ambiguity_col)) *
+                        (fixed.fixed_ambiguity_m - current_ambiguity) *
                         fixed_weight;
-                    add_weighted_row({{ambiguity_col, fixed_weight}},
-                                     weighted_residual);
+                    std::vector<std::pair<int, double>> jacobian = {
+                        {ambiguity_col, fixed_weight}};
+                    if (use_difference) {
+                        jacobian.emplace_back(reference_col, -fixed_weight);
+                    }
+                    add_weighted_row(jacobian, weighted_residual);
                 }
             }
 
@@ -3440,7 +3538,9 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
                 if (cost_converged()) {
                     store_current_linearization();
                     if (config_.collect_lambda_debug ||
-                        config_.use_epoch_lambda_fixed_output) {
+                        config_.use_epoch_lambda_fixed_output ||
+                        (config_.fix_ambiguities &&
+                         config_.use_lambda_ambiguity_fix)) {
                         output.sparse_normal_matrix = std::move(sparse_normal);
                     }
                     output.iterations = iter;
@@ -3470,7 +3570,9 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
                     damping *= 10.0;
                 }
                 if (config_.collect_lambda_debug ||
-                    config_.use_epoch_lambda_fixed_output) {
+                    config_.use_epoch_lambda_fixed_output ||
+                    (config_.fix_ambiguities &&
+                     config_.use_lambda_ambiguity_fix)) {
                     current_sparse_normal = std::move(sparse_normal);
                 }
             } else {
@@ -3510,7 +3612,9 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
             store_current_linearization();
             if (use_sparse_normal &&
                 (config_.collect_lambda_debug ||
-                 config_.use_epoch_lambda_fixed_output)) {
+                 config_.use_epoch_lambda_fixed_output ||
+                 (config_.fix_ambiguities &&
+                  config_.use_lambda_ambiguity_fix))) {
                 output.sparse_normal_matrix = std::move(current_sparse_normal);
             }
             const bool update_converged =
@@ -3553,6 +3657,16 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
                             return ambiguity.is_double_difference;
                         });
         auto is_fix_candidate = [&](const AmbiguityState& ambiguity) -> bool {
+            // A rover-base SD ambiguity contains a common receiver gauge.
+            // It is not an integer-fix candidate by itself. MultiSD fixing
+            // must first project the SD posterior to independent BSD/DD
+            // combinations; until that projection is available, keep this
+            // path float-only instead of silently applying invalid integer
+            // constraints to gauge-dependent states.
+            if (config_.use_multisd_ambiguities &&
+                !ambiguity.is_double_difference) {
+                return false;
+            }
             if (config_.prefer_double_difference_ambiguity_fixing &&
                 has_double_difference_ambiguities) {
                 return ambiguity.is_double_difference;
@@ -3593,48 +3707,143 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
         };
 
         auto build_lambda_constraints = [&]() -> bool {
-            if (!config_.use_lambda_ambiguity_fix ||
-                optimization.normal_matrix.rows() != state_size) {
+            if (!config_.use_lambda_ambiguity_fix) {
                 return false;
             }
 
-            const Eigen::MatrixXd float_covariance =
-                pseudoInverse(optimization.normal_matrix);
-            if (float_covariance.rows() != state_size) {
+            Eigen::MatrixXd ambiguity_state_covariance =
+                Eigen::MatrixXd::Zero(ambiguity_count, ambiguity_count);
+            if (optimization.normal_matrix.rows() == state_size) {
+                const Eigen::MatrixXd float_covariance =
+                    pseudoInverse(optimization.normal_matrix);
+                if (float_covariance.rows() != state_size) {
+                    return false;
+                }
+                ambiguity_state_covariance = float_covariance.block(
+                    base_state_size, base_state_size,
+                    ambiguity_count, ambiguity_count);
+            } else if (optimization.sparse_normal_matrix.rows() == state_size) {
+                Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> solver;
+                double max_diagonal = 0.0;
+                for (int i = 0; i < state_size; ++i) {
+                    max_diagonal = std::max(
+                        max_diagonal,
+                        std::abs(optimization.sparse_normal_matrix.coeff(i, i)));
+                }
+                solver.setShift(std::max(1e-12, max_diagonal * 1e-12));
+                solver.compute(optimization.sparse_normal_matrix);
+                if (solver.info() != Eigen::Success) {
+                    return false;
+                }
+                Eigen::VectorXd unit = Eigen::VectorXd::Zero(state_size);
+                for (int col = 0; col < ambiguity_count; ++col) {
+                    unit.setZero();
+                    unit(base_state_size + col) = 1.0;
+                    const Eigen::VectorXd covariance_col = solver.solve(unit);
+                    if (solver.info() != Eigen::Success ||
+                        !covariance_col.allFinite()) {
+                        return false;
+                    }
+                    ambiguity_state_covariance.col(col) =
+                        covariance_col.segment(base_state_size,
+                                               ambiguity_count);
+                }
+            } else {
                 return false;
             }
+            ambiguity_state_covariance =
+                0.5 * (ambiguity_state_covariance +
+                       ambiguity_state_covariance.transpose());
 
             struct LambdaCandidate {
                 int ambiguity_index = 0;
+                int reference_ambiguity_index = -1;
                 double variance_cycles = 0.0;
                 double fractional_cycles = 0.0;
             };
 
             std::vector<LambdaCandidate> candidates;
             candidates.reserve(problem.ambiguity_states.size());
-            for (int i = 0; i < ambiguity_count; ++i) {
-                const auto& ambiguity = problem.ambiguity_states[i];
-                if (ambiguity.wavelength_m <= 0.0 || !is_fix_candidate(ambiguity)) {
-                    continue;
+            auto append_candidate = [&](int ambiguity_index,
+                                        int reference_ambiguity_index) {
+                const auto& ambiguity =
+                    problem.ambiguity_states[ambiguity_index];
+                if (ambiguity.wavelength_m <= 0.0) {
+                    return;
                 }
-
-                const int col = base_state_size + i;
-                const double variance_m2 = float_covariance(col, col);
+                const int col = base_state_size + ambiguity_index;
+                double ambiguity_m = optimization.state(col);
+                double variance_m2 = ambiguity_state_covariance(
+                    ambiguity_index, ambiguity_index);
+                if (reference_ambiguity_index >= 0) {
+                    const auto& reference =
+                        problem.ambiguity_states[reference_ambiguity_index];
+                    if (reference.wavelength_m <= 0.0 ||
+                        std::abs(reference.wavelength_m -
+                                 ambiguity.wavelength_m) > 1e-9) {
+                        return;
+                    }
+                    const int reference_col =
+                        base_state_size + reference_ambiguity_index;
+                    ambiguity_m -= optimization.state(reference_col);
+                    variance_m2 += ambiguity_state_covariance(
+                                       reference_ambiguity_index,
+                                       reference_ambiguity_index) -
+                                   2.0 * ambiguity_state_covariance(
+                                             ambiguity_index,
+                                             reference_ambiguity_index);
+                } else if (!is_fix_candidate(ambiguity)) {
+                    return;
+                }
                 const double variance_cycles =
-                    variance_m2 / (ambiguity.wavelength_m * ambiguity.wavelength_m);
+                    variance_m2 /
+                    (ambiguity.wavelength_m * ambiguity.wavelength_m);
                 const double ambiguity_cycles =
-                    optimization.state(col) / ambiguity.wavelength_m;
-                if (!std::isfinite(variance_cycles) || variance_cycles <= 0.0 ||
+                    ambiguity_m / ambiguity.wavelength_m;
+                if (!std::isfinite(variance_cycles) ||
+                    variance_cycles <= 0.0 ||
                     !std::isfinite(ambiguity_cycles)) {
-                    continue;
+                    return;
                 }
-
-                const double nearest_cycles = std::round(ambiguity_cycles);
                 LambdaCandidate candidate;
-                candidate.ambiguity_index = i;
+                candidate.ambiguity_index = ambiguity_index;
+                candidate.reference_ambiguity_index =
+                    reference_ambiguity_index;
                 candidate.variance_cycles = variance_cycles;
-                candidate.fractional_cycles = std::abs(ambiguity_cycles - nearest_cycles);
+                candidate.fractional_cycles = std::abs(
+                    ambiguity_cycles - std::round(ambiguity_cycles));
                 candidates.push_back(candidate);
+            };
+
+            if (config_.use_multisd_ambiguities) {
+                std::size_t latest_epoch = 0;
+                for (const auto& factor :
+                     problem.double_difference_carrier_factors) {
+                    latest_epoch = std::max(latest_epoch,
+                                            factor.epoch_index);
+                }
+                std::set<std::pair<std::size_t, std::size_t>> seen;
+                for (const auto& factor :
+                     problem.double_difference_carrier_factors) {
+                    if (factor.epoch_index != latest_epoch ||
+                        !factor.use_ambiguity_difference ||
+                        factor.ambiguity_index >=
+                            problem.ambiguity_states.size() ||
+                        factor.reference_ambiguity_index >=
+                            problem.ambiguity_states.size() ||
+                        !seen.emplace(factor.ambiguity_index,
+                                      factor.reference_ambiguity_index)
+                             .second) {
+                        continue;
+                    }
+                    append_candidate(
+                        static_cast<int>(factor.ambiguity_index),
+                        static_cast<int>(factor.reference_ambiguity_index));
+                }
+            } else {
+                for (int i = 0; i < ambiguity_count; ++i) {
+                    append_candidate(i, -1);
+                }
             }
 
             std::stable_sort(candidates.begin(),
@@ -3671,13 +3880,38 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
                     const int row_col = base_state_size + ambiguity_row;
                     float_ambiguities(row) =
                         optimization.state(row_col) / row_state.wavelength_m;
+                    if (candidates[row].reference_ambiguity_index >= 0) {
+                        const int reference_row_col =
+                            base_state_size +
+                            candidates[row].reference_ambiguity_index;
+                        float_ambiguities(row) -=
+                            optimization.state(reference_row_col) /
+                            row_state.wavelength_m;
+                    }
                     for (int col = 0; col < n; ++col) {
                         const int ambiguity_col = candidates[col].ambiguity_index;
                         const auto& col_state = problem.ambiguity_states[ambiguity_col];
-                        const int state_col = base_state_size + ambiguity_col;
-                        ambiguity_covariance(row, col) =
-                            float_covariance(row_col, state_col) /
-                            (row_state.wavelength_m * col_state.wavelength_m);
+                        double covariance_m2 = ambiguity_state_covariance(
+                            ambiguity_row, ambiguity_col);
+                        const int reference_row =
+                            candidates[row].reference_ambiguity_index;
+                        const int reference_col =
+                            candidates[col].reference_ambiguity_index;
+                        if (reference_row >= 0) {
+                            covariance_m2 -= ambiguity_state_covariance(
+                                reference_row, ambiguity_col);
+                        }
+                        if (reference_col >= 0) {
+                            covariance_m2 -= ambiguity_state_covariance(
+                                ambiguity_row, reference_col);
+                        }
+                        if (reference_row >= 0 && reference_col >= 0) {
+                            covariance_m2 += ambiguity_state_covariance(
+                                reference_row, reference_col);
+                        }
+                        ambiguity_covariance(row, col) = covariance_m2 /
+                            (row_state.wavelength_m *
+                             col_state.wavelength_m);
                     }
                 }
 
@@ -3691,11 +3925,46 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
                 Eigen::VectorXd fixed_ambiguities;
                 double lambda_ratio = 0.0;
                 ++result.diagnostics.lambda_ambiguity_attempts;
-                const bool lambda_solved =
-                    lambdaSearch(float_ambiguities,
-                                 ambiguity_covariance,
-                                 fixed_ambiguities,
-                                 lambda_ratio);
+                LambdaCandidateDiagnostics lambda_diagnostics;
+                const int top_k =
+                    std::clamp(config_.lambda_top_k_candidates, 2, 32);
+                const bool lambda_solved = lambdaSearchTopK(
+                    float_ambiguities, ambiguity_covariance, top_k,
+                    lambda_diagnostics);
+                if (lambda_solved &&
+                    lambda_diagnostics.candidates.cols() >= 2 &&
+                    lambda_diagnostics.squared_residuals.size() >= 2) {
+                    fixed_ambiguities =
+                        lambda_diagnostics.candidates.col(0);
+                    const double best =
+                        lambda_diagnostics.squared_residuals(0);
+                    const double second =
+                        lambda_diagnostics.squared_residuals(1);
+                    lambda_ratio = best > 0.0
+                        ? second / best
+                        : std::numeric_limits<double>::infinity();
+                    result.diagnostics.lambda_top_k_generated =
+                        std::max(result.diagnostics.lambda_top_k_generated,
+                                 static_cast<std::size_t>(
+                                     lambda_diagnostics.candidates.cols()));
+                    result.diagnostics.lambda_bootstrapped_success_rate =
+                        std::max(
+                            result.diagnostics
+                                .lambda_bootstrapped_success_rate,
+                            lambda_diagnostics
+                                .bootstrapped_success_rate);
+                }
+                double adop_cycles =
+                    std::numeric_limits<double>::quiet_NaN();
+                Eigen::SelfAdjointEigenSolver<Eigen::MatrixXd> eigensolver(
+                    ambiguity_covariance);
+                if (eigensolver.info() == Eigen::Success &&
+                    (eigensolver.eigenvalues().array() > 0.0).all()) {
+                    adop_cycles = std::exp(
+                        eigensolver.eigenvalues().array().log().sum() /
+                        (2.0 * static_cast<double>(n)));
+                    result.diagnostics.lambda_adop_cycles = adop_cycles;
+                }
                 if (lambda_solved) {
                     result.diagnostics.lambda_ambiguity_fix_solved = true;
                 }
@@ -3704,9 +3973,16 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
                         std::max(result.diagnostics.lambda_ambiguity_ratio,
                                  lambda_ratio);
                 }
-                if (!lambda_solved || !std::isfinite(lambda_ratio) ||
+                if (!lambda_solved || fixed_ambiguities.size() != n ||
+                    !std::isfinite(lambda_ratio) ||
                     (config_.lambda_ratio_threshold > 0.0 &&
-                     lambda_ratio < config_.lambda_ratio_threshold)) {
+                     lambda_ratio < config_.lambda_ratio_threshold) ||
+                    (config_.lambda_min_bootstrapped_success_rate > 0.0 &&
+                     lambda_diagnostics.bootstrapped_success_rate <
+                         config_.lambda_min_bootstrapped_success_rate) ||
+                    (config_.lambda_max_adop_cycles > 0.0 &&
+                     (!std::isfinite(adop_cycles) ||
+                      adop_cycles > config_.lambda_max_adop_cycles))) {
                     return false;
                 }
 
@@ -3721,6 +3997,11 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
 
                     FixedAmbiguityConstraint fixed;
                     fixed.ambiguity_index = static_cast<std::size_t>(ambiguity_index);
+                    if (candidates[i].reference_ambiguity_index >= 0) {
+                        fixed.reference_ambiguity_index =
+                            static_cast<std::size_t>(
+                                candidates[i].reference_ambiguity_index);
+                    }
                     fixed.fixed_cycles = static_cast<int>(fixed_cycles_d);
                     fixed.fixed_ambiguity_m = fixed_cycles_d * ambiguity.wavelength_m;
                     fixed.residual_cycles = residual_cycles;
@@ -3763,7 +4044,8 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
 
         const bool can_attempt_lambda =
             config_.use_lambda_ambiguity_fix &&
-            optimization.normal_matrix.rows() == state_size;
+            (optimization.normal_matrix.rows() == state_size ||
+             optimization.sparse_normal_matrix.rows() == state_size);
         const bool lambda_constraints_built =
             can_attempt_lambda && build_lambda_constraints();
         if (!lambda_constraints_built &&
@@ -4293,7 +4575,9 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
             std::find_if(fixed_constraints.begin(),
                          fixed_constraints.end(),
                          [i](const FixedAmbiguityConstraint& fixed) {
-                             return fixed.ambiguity_index == i;
+                             return fixed.ambiguity_index == i &&
+                                    fixed.reference_ambiguity_index ==
+                                        std::numeric_limits<std::size_t>::max();
                          });
         if (fixed_it != fixed_constraints.end()) {
             estimate.is_fixed = true;

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -4360,6 +4360,10 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                     double maximum_integer_distance = 0.0;
                     double ddpr_rms =
                         std::numeric_limits<double>::infinity();
+                    double fixed_float_separation =
+                        std::numeric_limits<double>::infinity();
+                    double seed_separation =
+                        std::numeric_limits<double>::infinity();
                 };
                 const std::size_t latest_epoch =
                     static_cast<std::size_t>(num_epochs - 1);
@@ -4379,6 +4383,15 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                     const Vector3d fixed_position =
                         hypothesis.state.segment<3>(
                             epoch_state_col(latest_epoch));
+                    const Vector3d float_position =
+                        float_optimization.state.segment<3>(
+                            epoch_state_col(latest_epoch));
+                    outcome.fixed_float_separation =
+                        (fixed_position - float_position).norm();
+                    outcome.seed_separation =
+                        (fixed_position -
+                         problem.epochs[latest_epoch].position_ecef)
+                            .norm();
                     for (const auto& factor :
                          problem.multisd_validation_carrier_factors) {
                         if (factor.epoch_index != latest_epoch ||
@@ -4470,7 +4483,18 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                         std::isfinite(outcome.ddpr_rms) &&
                         outcome.ddpr_rms <= std::max(
                             0.0,
-                            config_.multisd_validation_max_ddpr_rms_m);
+                            config_.multisd_validation_max_ddpr_rms_m) &&
+                        std::isfinite(outcome.fixed_float_separation) &&
+                        (config_
+                                 .multisd_validation_max_fixed_float_separation_m <=
+                             0.0 ||
+                         outcome.fixed_float_separation <=
+                             config_
+                                 .multisd_validation_max_fixed_float_separation_m) &&
+                        std::isfinite(outcome.seed_separation) &&
+                        (config_.multisd_validation_max_seed_separation_m <= 0.0 ||
+                         outcome.seed_separation <=
+                             config_.multisd_validation_max_seed_separation_m);
                     return outcome;
                 };
 
@@ -4536,6 +4560,10 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                     hypothesis_record.maximum_integer_distance_cycles =
                         outcome.maximum_integer_distance;
                     hypothesis_record.ddpr_rms_m = outcome.ddpr_rms;
+                    hypothesis_record.fixed_float_separation_m =
+                        outcome.fixed_float_separation;
+                    hypothesis_record.seed_separation_m =
+                        outcome.seed_separation;
                     result.multisd_validation_hypotheses.push_back(
                         hypothesis_record);
                     if (rank == 0) {
@@ -4572,6 +4600,11 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                     reported_outcome.maximum_integer_distance;
                 result.diagnostics.multisd_validation_ddpr_rms_m =
                     reported_outcome.ddpr_rms;
+                result.diagnostics
+                    .multisd_validation_fixed_float_separation_m =
+                    reported_outcome.fixed_float_separation;
+                result.diagnostics.multisd_validation_seed_separation_m =
+                    reported_outcome.seed_separation;
 
                 if (unique_pass) {
                     optimization = std::move(selected_optimization);

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -21,6 +21,7 @@
 #include <future>
 #include <limits>
 #include <map>
+#include <memory>
 #include <numeric>
 #include <set>
 #include <string>
@@ -2841,10 +2842,15 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
         return static_cast<std::size_t>(num_epochs) * 3U;
     };
 
+    using SparseNormalFactorization =
+        Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>>;
+    using DenseNormalFactorization = Eigen::LDLT<Eigen::MatrixXd>;
     struct OptimizationOutput {
         Eigen::VectorXd state;
         Eigen::MatrixXd normal_matrix;
         Eigen::SparseMatrix<double> sparse_normal_matrix;
+        std::shared_ptr<SparseNormalFactorization> sparse_factorization;
+        std::shared_ptr<DenseNormalFactorization> dense_factorization;
         int iterations = 0;
         bool converged = false;
         double final_cost = 0.0;
@@ -3628,6 +3634,7 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                             config_.relative_cost_convergence_threshold);
             };
             if (use_sparse_normal) {
+                output.sparse_factorization.reset();
                 Eigen::SparseMatrix<double> sparse_normal(state_size, state_size);
                 sparse_normal.setFromTriplets(
                     normal_triplets.begin(), normal_triplets.end());
@@ -3654,12 +3661,14 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                 }
                 double damping = std::max(1e-12, max_diagonal * 1e-12);
                 for (int attempt = 0; attempt < 6; ++attempt) {
-                    Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> ldlt;
-                    ldlt.setShift(damping);
-                    ldlt.compute(sparse_normal);
-                    if (ldlt.info() == Eigen::Success) {
-                        dx = ldlt.solve(normal_rhs);
-                        if (ldlt.info() == Eigen::Success && dx.allFinite()) {
+                    auto ldlt =
+                        std::make_shared<SparseNormalFactorization>();
+                    ldlt->setShift(damping);
+                    ldlt->compute(sparse_normal);
+                    if (ldlt->info() == Eigen::Success) {
+                        dx = ldlt->solve(normal_rhs);
+                        if (ldlt->info() == Eigen::Success && dx.allFinite()) {
+                            output.sparse_factorization = std::move(ldlt);
                             solved = true;
                             break;
                         }
@@ -3673,6 +3682,7 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                     current_sparse_normal = std::move(sparse_normal);
                 }
             } else {
+                output.dense_factorization.reset();
                 if (cost_converged()) {
                     store_current_linearization();
                     output.iterations = iter;
@@ -3687,10 +3697,13 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                 for (int attempt = 0; attempt < 6; ++attempt) {
                     Eigen::MatrixXd damped_normal = normal_matrix;
                     damped_normal.diagonal().array() += damping;
-                    Eigen::LDLT<Eigen::MatrixXd> ldlt(damped_normal);
-                    if (ldlt.info() == Eigen::Success) {
-                        dx = ldlt.solve(normal_rhs);
+                    auto ldlt =
+                        std::make_shared<DenseNormalFactorization>(
+                            damped_normal);
+                    if (ldlt->info() == Eigen::Success) {
+                        dx = ldlt->solve(normal_rhs);
                         if (dx.allFinite()) {
+                            output.dense_factorization = std::move(ldlt);
                             solved = true;
                             break;
                         }
@@ -3813,40 +3826,69 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
             Eigen::MatrixXd ambiguity_state_covariance =
                 Eigen::MatrixXd::Zero(ambiguity_count, ambiguity_count);
             if (optimization.normal_matrix.rows() == state_size) {
-                const Eigen::MatrixXd float_covariance =
-                    pseudoInverse(optimization.normal_matrix);
-                if (float_covariance.rows() != state_size) {
-                    return false;
-                }
-                ambiguity_state_covariance = float_covariance.block(
-                    base_state_size, base_state_size,
-                    ambiguity_count, ambiguity_count);
-            } else if (optimization.sparse_normal_matrix.rows() == state_size) {
-                Eigen::SimplicialLDLT<Eigen::SparseMatrix<double>> solver;
-                double max_diagonal = 0.0;
-                for (int i = 0; i < state_size; ++i) {
-                    max_diagonal = std::max(
-                        max_diagonal,
-                        std::abs(optimization.sparse_normal_matrix.coeff(i, i)));
-                }
-                solver.setShift(std::max(1e-12, max_diagonal * 1e-12));
-                solver.compute(optimization.sparse_normal_matrix);
-                if (solver.info() != Eigen::Success) {
-                    return false;
-                }
-                Eigen::VectorXd unit = Eigen::VectorXd::Zero(state_size);
-                for (int col = 0; col < ambiguity_count; ++col) {
-                    unit.setZero();
-                    unit(base_state_size + col) = 1.0;
-                    const Eigen::VectorXd covariance_col = solver.solve(unit);
-                    if (solver.info() != Eigen::Success ||
-                        !covariance_col.allFinite()) {
+                if (optimization.dense_factorization) {
+                    Eigen::MatrixXd ambiguity_rhs = Eigen::MatrixXd::Zero(
+                        state_size, ambiguity_count);
+                    ambiguity_rhs.block(base_state_size, 0,
+                                        ambiguity_count, ambiguity_count)
+                        .setIdentity();
+                    const Eigen::MatrixXd covariance_columns =
+                        optimization.dense_factorization->solve(ambiguity_rhs);
+                    if (optimization.dense_factorization->info() !=
+                            Eigen::Success ||
+                        !covariance_columns.allFinite()) {
                         return false;
                     }
-                    ambiguity_state_covariance.col(col) =
-                        covariance_col.segment(base_state_size,
-                                               ambiguity_count);
+                    ambiguity_state_covariance = covariance_columns.block(
+                        base_state_size, 0,
+                        ambiguity_count, ambiguity_count);
+                } else {
+                    const Eigen::MatrixXd float_covariance =
+                        pseudoInverse(optimization.normal_matrix);
+                    if (float_covariance.rows() != state_size) {
+                        return false;
+                    }
+                    ambiguity_state_covariance = float_covariance.block(
+                        base_state_size, base_state_size,
+                        ambiguity_count, ambiguity_count);
                 }
+            } else if (optimization.sparse_normal_matrix.rows() == state_size) {
+                auto solver = optimization.sparse_factorization;
+                if (!solver) {
+                    solver = std::make_shared<SparseNormalFactorization>();
+                    double max_diagonal = 0.0;
+                    for (int i = 0; i < state_size; ++i) {
+                        max_diagonal = std::max(
+                            max_diagonal,
+                            std::abs(
+                                optimization.sparse_normal_matrix.coeff(i, i)));
+                    }
+                    solver->setShift(
+                        std::max(1e-12, max_diagonal * 1e-12));
+                    solver->compute(optimization.sparse_normal_matrix);
+                    if (solver->info() != Eigen::Success) {
+                        return false;
+                    }
+                }
+                // Factor once and solve every requested ambiguity covariance
+                // column as a multi-RHS batch. The previous per-column solve
+                // repeated sparse triangular-solve setup and dominated the
+                // causal 10-epoch wall time. This is also the exact operation
+                // that a CUDA sparse/dense backend can later offload.
+                Eigen::MatrixXd ambiguity_rhs = Eigen::MatrixXd::Zero(
+                    state_size, ambiguity_count);
+                ambiguity_rhs.block(base_state_size, 0,
+                                    ambiguity_count, ambiguity_count)
+                    .setIdentity();
+                const Eigen::MatrixXd covariance_columns =
+                    solver->solve(ambiguity_rhs);
+                if (solver->info() != Eigen::Success ||
+                    !covariance_columns.allFinite()) {
+                    return false;
+                }
+                ambiguity_state_covariance = covariance_columns.block(
+                    base_state_size, 0,
+                    ambiguity_count, ambiguity_count);
             } else {
                 return false;
             }
@@ -4474,7 +4516,12 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
 
     Eigen::MatrixXd covariance;
     if (optimization.normal_matrix.rows() == state_size) {
-        covariance = pseudoInverse(optimization.normal_matrix);
+        if (optimization.dense_factorization) {
+            covariance = optimization.dense_factorization->solve(
+                Eigen::MatrixXd::Identity(state_size, state_size));
+        } else {
+            covariance = pseudoInverse(optimization.normal_matrix);
+        }
     }
 
     std::vector<Vector3d> epoch_output_positions(

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -4367,6 +4367,12 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                 };
                 const std::size_t latest_epoch =
                     static_cast<std::size_t>(num_epochs - 1);
+                const std::size_t validation_history =
+                    static_cast<std::size_t>(std::clamp(
+                        config_.multisd_validation_history_epochs,
+                        1, num_epochs));
+                const std::size_t first_validation_epoch =
+                    latest_epoch + 1 - validation_history;
                 const int required_holdout =
                     std::max(1, config_.multisd_validation_holdout_satellites);
                 const double aperture =
@@ -4394,7 +4400,8 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                             .norm();
                     for (const auto& factor :
                          problem.multisd_validation_carrier_factors) {
-                        if (factor.epoch_index != latest_epoch ||
+                        if (factor.epoch_index < first_validation_epoch ||
+                            factor.epoch_index > latest_epoch ||
                             factor.ambiguity_index >=
                                 problem.ambiguity_states.size()) {
                             continue;
@@ -4407,7 +4414,9 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                         }
                         const DoubleDifferencePrediction prediction =
                             doubleDifferencePredictionAt(
-                                fixed_position, factor.base_position_ecef,
+                                hypothesis.state.segment<3>(
+                                    epoch_state_col(factor.epoch_index)),
+                                factor.base_position_ecef,
                                 factor.rover_satellite_position_ecef,
                                 factor.rover_reference_position_ecef,
                                 factor.base_satellite_position_ecef,
@@ -4466,7 +4475,8 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                     }
                     const bool enough_rows =
                         static_cast<int>(outcome.carrier_used) >=
-                            required_holdout &&
+                            required_holdout *
+                                static_cast<int>(validation_history) &&
                         static_cast<int>(outcome.pseudorange_used) >=
                             required_holdout;
                     outcome.evaluated = enough_satellites && enough_rows;

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -9,6 +9,10 @@
 #include <libgnss++/models/ionosphere.hpp>
 #include <libgnss++/models/troposphere.hpp>
 
+#ifdef GNSSPP_HAS_CUDA_FGO
+#include "fgo_cuda_backend.hpp"
+#endif
+
 #include <Eigen/Dense>
 #include <Eigen/Sparse>
 #ifdef GNSSPP_HAS_CHOLMOD
@@ -40,6 +44,57 @@ FGOProcessor::FGOResult optimizeProblemWithGtsam(
 #endif
 
 namespace {
+
+bool cudaDenseSolverEnabled(int state_size) {
+#ifdef GNSSPP_HAS_CUDA_FGO
+    return detail::fgoCudaDenseSolverEnabled(state_size);
+#else
+    (void)state_size;
+    return false;
+#endif
+}
+
+struct CudaDenseSolveStats {
+    std::size_t attempts = 0;
+    std::size_t successes = 0;
+    double processing_ms = 0.0;
+};
+
+bool tryCudaDenseSolve(const Eigen::MatrixXd& normal,
+                       const Eigen::MatrixXd& rhs,
+                       Eigen::MatrixXd& solution,
+                       CudaDenseSolveStats* stats) {
+#ifdef GNSSPP_HAS_CUDA_FGO
+    if (normal.rows() <= 0 || normal.rows() != normal.cols() ||
+        rhs.rows() != normal.rows() || rhs.cols() <= 0) {
+        return false;
+    }
+    const auto start = std::chrono::steady_clock::now();
+    if (stats != nullptr) {
+        ++stats->attempts;
+    }
+    solution.resize(rhs.rows(), rhs.cols());
+    const bool solved = detail::fgoCudaDenseSolve(
+        normal.data(), static_cast<int>(normal.rows()),
+        rhs.data(), static_cast<int>(rhs.cols()), solution.data());
+    if (stats != nullptr) {
+        stats->processing_ms +=
+            std::chrono::duration<double, std::milli>(
+                std::chrono::steady_clock::now() - start)
+                .count();
+        if (solved) {
+            ++stats->successes;
+        }
+    }
+    return solved;
+#else
+    (void)normal;
+    (void)rhs;
+    (void)solution;
+    (void)stats;
+    return false;
+#endif
+}
 
 bool isPrimaryFgoSignal(SignalType signal, bool use_multi_constellation) {
     if (!use_multi_constellation) {
@@ -2762,7 +2817,14 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
     const int ambiguity_count = static_cast<int>(problem.ambiguity_states.size());
     const int state_size = base_state_size + ambiguity_count;
     constexpr int kSparseNormalStateThreshold = 300;
-    const bool use_sparse_normal = state_size > kSparseNormalStateThreshold;
+    // cuSOLVER consumes a dense SPD normal matrix. In auto/on mode retain the
+    // dense assembly above the ordinary Eigen sparse threshold so large
+    // fixed-lag windows actually reach the GPU backend. With CUDA disabled or
+    // below its auto threshold, the historical sparse selection is unchanged.
+    const bool use_cuda_dense_normal = cudaDenseSolverEnabled(state_size);
+    const bool use_sparse_normal =
+        state_size > kSparseNormalStateThreshold && !use_cuda_dense_normal;
+    CudaDenseSolveStats cuda_solve_stats;
     Eigen::VectorXd initial_state = Eigen::VectorXd::Zero(state_size);
     for (int i = 0; i < num_epochs; ++i) {
         const int epoch_col = epoch_state_size * i;
@@ -2851,6 +2913,7 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
         Eigen::SparseMatrix<double> sparse_normal_matrix;
         std::shared_ptr<SparseNormalFactorization> sparse_factorization;
         std::shared_ptr<DenseNormalFactorization> dense_factorization;
+        double dense_damping = 0.0;
         int iterations = 0;
         bool converged = false;
         double final_cost = 0.0;
@@ -3683,6 +3746,7 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                 }
             } else {
                 output.dense_factorization.reset();
+                output.dense_damping = 0.0;
                 if (cost_converged()) {
                     store_current_linearization();
                     output.iterations = iter;
@@ -3697,6 +3761,21 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                 for (int attempt = 0; attempt < 6; ++attempt) {
                     Eigen::MatrixXd damped_normal = normal_matrix;
                     damped_normal.diagonal().array() += damping;
+                    if (cudaDenseSolverEnabled(state_size)) {
+                        Eigen::MatrixXd cuda_rhs(normal_rhs.rows(), 1);
+                        cuda_rhs.col(0) = normal_rhs;
+                        Eigen::MatrixXd cuda_solution;
+                        if (tryCudaDenseSolve(damped_normal, cuda_rhs,
+                                              cuda_solution,
+                                              &cuda_solve_stats) &&
+                            cuda_solution.cols() == 1 &&
+                            cuda_solution.allFinite()) {
+                            dx = cuda_solution.col(0);
+                            output.dense_damping = damping;
+                            solved = true;
+                            break;
+                        }
+                    }
                     auto ldlt =
                         std::make_shared<DenseNormalFactorization>(
                             damped_normal);
@@ -3704,6 +3783,7 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                         dx = ldlt->solve(normal_rhs);
                         if (dx.allFinite()) {
                             output.dense_factorization = std::move(ldlt);
+                            output.dense_damping = damping;
                             solved = true;
                             break;
                         }
@@ -3826,12 +3906,23 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
             Eigen::MatrixXd ambiguity_state_covariance =
                 Eigen::MatrixXd::Zero(ambiguity_count, ambiguity_count);
             if (optimization.normal_matrix.rows() == state_size) {
-                if (optimization.dense_factorization) {
-                    Eigen::MatrixXd ambiguity_rhs = Eigen::MatrixXd::Zero(
-                        state_size, ambiguity_count);
-                    ambiguity_rhs.block(base_state_size, 0,
-                                        ambiguity_count, ambiguity_count)
-                        .setIdentity();
+                Eigen::MatrixXd ambiguity_rhs = Eigen::MatrixXd::Zero(
+                    state_size, ambiguity_count);
+                ambiguity_rhs.block(base_state_size, 0,
+                                    ambiguity_count, ambiguity_count)
+                    .setIdentity();
+                Eigen::MatrixXd covariance_columns;
+                bool covariance_solved = false;
+                if (cudaDenseSolverEnabled(state_size)) {
+                    Eigen::MatrixXd damped_normal =
+                        optimization.normal_matrix;
+                    damped_normal.diagonal().array() +=
+                        std::max(1e-12, optimization.dense_damping);
+                    covariance_solved = tryCudaDenseSolve(
+                        damped_normal, ambiguity_rhs, covariance_columns,
+                        &cuda_solve_stats);
+                }
+                if (!covariance_solved && optimization.dense_factorization) {
                     const Eigen::MatrixXd covariance_columns =
                         optimization.dense_factorization->solve(ambiguity_rhs);
                     if (optimization.dense_factorization->info() !=
@@ -3842,7 +3933,16 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                     ambiguity_state_covariance = covariance_columns.block(
                         base_state_size, 0,
                         ambiguity_count, ambiguity_count);
-                } else {
+                    covariance_solved = true;
+                } else if (covariance_solved) {
+                    if (!covariance_columns.allFinite()) {
+                        return false;
+                    }
+                    ambiguity_state_covariance = covariance_columns.block(
+                        base_state_size, 0,
+                        ambiguity_count, ambiguity_count);
+                }
+                if (!covariance_solved) {
                     const Eigen::MatrixXd float_covariance =
                         pseudoInverse(optimization.normal_matrix);
                     if (float_covariance.rows() != state_size) {
@@ -4385,7 +4485,12 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                 ValidationOutcome first_outcome;
                 std::vector<std::future<OptimizationOutput>>
                     hypothesis_futures;
+                // CUDA uses a retained thread-local cuSOLVER workspace. Keep
+                // hypotheses on this thread so every rank reuses the same
+                // allocations/handle instead of creating one CUDA context
+                // workspace per std::async worker.
                 if (config_.parallelize_lambda_hypotheses &&
+                    !use_cuda_dense_normal &&
                     hypothesis_count > 1) {
                     hypothesis_futures.reserve(hypothesis_count - 1);
                     for (std::size_t rank = 1;
@@ -4511,15 +4616,44 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
     }
     const double processing_ms = total_processing_ms;
     result.diagnostics.processing_time_ms = processing_ms;
+    result.diagnostics.dense_normal_state_size =
+        static_cast<std::size_t>(state_size);
+    result.diagnostics.cuda_dense_solver_selected = use_cuda_dense_normal;
+    result.diagnostics.cuda_dense_solve_attempts = cuda_solve_stats.attempts;
+    result.diagnostics.cuda_dense_solve_successes = cuda_solve_stats.successes;
+    result.diagnostics.cuda_dense_solve_fallbacks =
+        cuda_solve_stats.attempts - cuda_solve_stats.successes;
+    result.diagnostics.cuda_dense_solve_time_ms =
+        cuda_solve_stats.processing_ms;
     result.diagnostics.last_update_norm_m =
         std::isfinite(optimization.last_dx_norm) ? optimization.last_dx_norm : 0.0;
 
     Eigen::MatrixXd covariance;
     if (optimization.normal_matrix.rows() == state_size) {
-        if (optimization.dense_factorization) {
+        bool covariance_solved = false;
+        if (cudaDenseSolverEnabled(state_size)) {
+            Eigen::MatrixXd damped_normal = optimization.normal_matrix;
+            damped_normal.diagonal().array() +=
+                std::max(1e-12, optimization.dense_damping);
+            covariance_solved = tryCudaDenseSolve(
+                damped_normal,
+                Eigen::MatrixXd::Identity(state_size, state_size),
+                covariance, &cuda_solve_stats);
+            result.diagnostics.cuda_dense_solve_attempts =
+                cuda_solve_stats.attempts;
+            result.diagnostics.cuda_dense_solve_successes =
+                cuda_solve_stats.successes;
+            result.diagnostics.cuda_dense_solve_fallbacks =
+                cuda_solve_stats.attempts - cuda_solve_stats.successes;
+            result.diagnostics.cuda_dense_solve_time_ms =
+                cuda_solve_stats.processing_ms;
+        }
+        if (!covariance_solved && optimization.dense_factorization) {
             covariance = optimization.dense_factorization->solve(
                 Eigen::MatrixXd::Identity(state_size, state_size));
-        } else {
+            covariance_solved = covariance.allFinite();
+        }
+        if (!covariance_solved) {
             covariance = pseudoInverse(optimization.normal_matrix);
         }
     }

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -18,6 +18,7 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <future>
 #include <limits>
 #include <map>
 #include <numeric>
@@ -4340,10 +4341,29 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                 OptimizationOutput selected_optimization;
                 ValidationOutcome selected_outcome;
                 ValidationOutcome first_outcome;
+                std::vector<std::future<OptimizationOutput>>
+                    hypothesis_futures;
+                if (config_.parallelize_lambda_hypotheses &&
+                    hypothesis_count > 1) {
+                    hypothesis_futures.reserve(hypothesis_count - 1);
+                    for (std::size_t rank = 1;
+                         rank < hypothesis_count;
+                         ++rank) {
+                        hypothesis_futures.push_back(std::async(
+                            std::launch::async,
+                            run_optimizer,
+                            float_optimization.state,
+                            lambda_hypothesis_constraints[rank],
+                            "fixed-hypothesis",
+                            fixed_global_iteration_offset));
+                    }
+                }
                 for (std::size_t rank = 0; rank < hypothesis_count; ++rank) {
                     OptimizationOutput hypothesis;
                     if (rank == 0) {
                         hypothesis = optimization;
+                    } else if (!hypothesis_futures.empty()) {
+                        hypothesis = hypothesis_futures[rank - 1].get();
                     } else {
                         hypothesis = run_optimizer(
                             float_optimization.state,

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -4005,12 +4005,15 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                 int reference_ambiguity_index = -1;
                 double variance_cycles = 0.0;
                 double fractional_cycles = 0.0;
+                double carrier_residual_rms_sigma = 0.0;
+                double quality_score = 0.0;
             };
 
             std::vector<LambdaCandidate> candidates;
             candidates.reserve(problem.ambiguity_states.size());
             auto append_candidate = [&](int ambiguity_index,
-                                        int reference_ambiguity_index) {
+                                        int reference_ambiguity_index,
+                                        double carrier_residual_rms_sigma) {
                 const auto& ambiguity =
                     problem.ambiguity_states[ambiguity_index];
                 if (ambiguity.wavelength_m <= 0.0) {
@@ -4057,6 +4060,16 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                 candidate.variance_cycles = variance_cycles;
                 candidate.fractional_cycles = std::abs(
                     ambiguity_cycles - std::round(ambiguity_cycles));
+                candidate.carrier_residual_rms_sigma =
+                    carrier_residual_rms_sigma;
+                // Each term is mapped to [0, 1) so no single quantity wins
+                // merely because of its units. Fractional distance is in
+                // [0, 0.5], hence the factor of two.
+                candidate.quality_score =
+                    variance_cycles / (1.0 + variance_cycles) +
+                    carrier_residual_rms_sigma /
+                        (1.0 + carrier_residual_rms_sigma) +
+                    2.0 * candidate.fractional_cycles;
                 candidates.push_back(candidate);
             };
 
@@ -4081,13 +4094,80 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                              .second) {
                         continue;
                     }
+                    double carrier_residual_rms_sigma = 0.0;
+                    if (config_.use_quality_ranked_partial_ar) {
+                        double residual_squared_sum = 0.0;
+                        std::size_t residual_count = 0;
+                        for (const auto& track_factor :
+                             problem.double_difference_carrier_factors) {
+                            if (!track_factor.use_ambiguity_difference ||
+                                track_factor.ambiguity_index !=
+                                    factor.ambiguity_index ||
+                                track_factor.reference_ambiguity_index !=
+                                    factor.reference_ambiguity_index ||
+                                track_factor.epoch_index >=
+                                    problem.epochs.size()) {
+                                continue;
+                            }
+                        const Vector3d position = optimization.state.segment<3>(
+                            epoch_state_col(track_factor.epoch_index));
+                        const Vector3d seed_position =
+                            problem.epochs[track_factor.epoch_index]
+                                .position_ecef;
+                        const Vector3d linearization_position =
+                            config_.linearize_double_difference_factors_at_seed
+                                ? seed_position
+                                : position;
+                        const DoubleDifferencePrediction prediction =
+                            doubleDifferencePredictionAt(
+                                linearization_position,
+                                track_factor.base_position_ecef,
+                                track_factor.rover_satellite_position_ecef,
+                                track_factor.rover_reference_position_ecef,
+                                track_factor.base_satellite_position_ecef,
+                                track_factor.base_reference_position_ecef);
+                        if (!prediction.valid) {
+                            continue;
+                        }
+                        double predicted = prediction.geometry_m +
+                            optimization.state(
+                                base_state_size +
+                                static_cast<int>(
+                                    track_factor.ambiguity_index)) -
+                            optimization.state(
+                                base_state_size +
+                                static_cast<int>(track_factor
+                                                     .reference_ambiguity_index));
+                        if (config_.linearize_double_difference_factors_at_seed) {
+                            predicted += prediction.position_jacobian.dot(
+                                position - seed_position);
+                        }
+                        const double sigma =
+                            std::max(1e-4, track_factor.sigma_m);
+                        const double standardized_residual =
+                            (track_factor.observed_dd_carrier_m - predicted) /
+                            sigma;
+                            if (std::isfinite(standardized_residual)) {
+                                residual_squared_sum += standardized_residual *
+                                                        standardized_residual;
+                                ++residual_count;
+                            }
+                        }
+                        if (residual_count == 0) {
+                            continue;
+                        }
+                        carrier_residual_rms_sigma = std::sqrt(
+                            residual_squared_sum /
+                            static_cast<double>(residual_count));
+                    }
                     append_candidate(
                         static_cast<int>(factor.ambiguity_index),
-                        static_cast<int>(factor.reference_ambiguity_index));
+                        static_cast<int>(factor.reference_ambiguity_index),
+                        carrier_residual_rms_sigma);
                 }
             } else {
                 for (int i = 0; i < ambiguity_count; ++i) {
-                    append_candidate(i, -1);
+                    append_candidate(i, -1, 0.0);
                 }
             }
 
@@ -4095,6 +4175,11 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                              candidates.end(),
                              [&](const LambdaCandidate& lhs,
                                  const LambdaCandidate& rhs) {
+                                 if (config_.use_quality_ranked_partial_ar &&
+                                     lhs.quality_score != rhs.quality_score) {
+                                     return lhs.quality_score <
+                                            rhs.quality_score;
+                                 }
                                  if (config_.use_variance_ranked_partial_ar &&
                                      lhs.variance_cycles !=
                                          rhs.variance_cycles) {
@@ -4377,22 +4462,53 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                         pools.push_back(std::move(pool));
                     }
                 }
-                for (const auto& pool : pools) {
-                    candidates = pool;
-                    for (std::size_t subset_size = candidates.size();
-                         subset_size >= min_subset_size;
-                         --subset_size) {
-                        if (solve_candidate_subset(subset_size)) {
-                            built_any_group = true;
-                            if (!collect_validator_groups ||
-                                lambda_hypothesis_group_ends.size() >=
+                if (config_.interleave_constellation_partial_ar &&
+                    collect_validator_groups) {
+                    std::size_t maximum_depth = 0;
+                    for (const auto& pool : pools) {
+                        maximum_depth = std::max(
+                            maximum_depth, pool.size() - min_subset_size);
+                    }
+                    for (std::size_t depth = 0;
+                         depth <= maximum_depth;
+                         ++depth) {
+                        for (const auto& pool : pools) {
+                            if (pool.size() < min_subset_size + depth) {
+                                continue;
+                            }
+                            candidates = pool;
+                            const std::size_t subset_size =
+                                pool.size() - depth;
+                            if (solve_candidate_subset(subset_size)) {
+                                built_any_group = true;
+                                if (lambda_hypothesis_group_ends.size() >=
                                     maximum_groups) {
-                                return true;
+                                    return true;
+                                }
                             }
                         }
-                        if (!config_.use_partial_lambda_ambiguity_fix ||
-                            subset_size == min_subset_size) {
+                        if (!config_.use_partial_lambda_ambiguity_fix) {
                             break;
+                        }
+                    }
+                } else {
+                    for (const auto& pool : pools) {
+                        candidates = pool;
+                        for (std::size_t subset_size = candidates.size();
+                             subset_size >= min_subset_size;
+                             --subset_size) {
+                            if (solve_candidate_subset(subset_size)) {
+                                built_any_group = true;
+                                if (!collect_validator_groups ||
+                                    lambda_hypothesis_group_ends.size() >=
+                                        maximum_groups) {
+                                    return true;
+                                }
+                            }
+                            if (!config_.use_partial_lambda_ambiguity_fix ||
+                                subset_size == min_subset_size) {
+                                break;
+                            }
                         }
                     }
                 }

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -3834,6 +3834,7 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
     std::vector<std::vector<FixedAmbiguityConstraint>>
         lambda_hypothesis_constraints;
     std::vector<double> lambda_hypothesis_residual_square_sums;
+    std::vector<std::size_t> lambda_hypothesis_group_ends;
     const bool has_ambiguity_measurements =
         !problem.carrier_phase_factors.empty() ||
         !problem.double_difference_carrier_factors.empty();
@@ -3902,6 +3903,9 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
             if (!config_.use_lambda_ambiguity_fix) {
                 return false;
             }
+            lambda_hypothesis_constraints.clear();
+            lambda_hypothesis_residual_square_sums.clear();
+            lambda_hypothesis_group_ends.clear();
 
             Eigen::MatrixXd ambiguity_state_covariance =
                 Eigen::MatrixXd::Zero(ambiguity_count, ambiguity_count);
@@ -4215,10 +4219,18 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                         std::max(result.diagnostics.lambda_ambiguity_ratio,
                                  lambda_ratio);
                 }
+                const double candidate_ratio_threshold =
+                    config_.use_multisd_ambiguities &&
+                            config_.use_multisd_disjoint_validation &&
+                            config_.multisd_lambda_candidate_ratio_threshold > 0.0
+                        ? std::min(
+                              config_.lambda_ratio_threshold,
+                              config_.multisd_lambda_candidate_ratio_threshold)
+                        : config_.lambda_ratio_threshold;
                 if (!lambda_solved || fixed_ambiguities.size() != n ||
                     !std::isfinite(lambda_ratio) ||
-                    (config_.lambda_ratio_threshold > 0.0 &&
-                     lambda_ratio < config_.lambda_ratio_threshold) ||
+                    (candidate_ratio_threshold > 0.0 &&
+                     lambda_ratio < candidate_ratio_threshold) ||
                     (config_.lambda_min_bootstrapped_success_rate > 0.0 &&
                      lambda_diagnostics.bootstrapped_success_rate <
                          config_.lambda_min_bootstrapped_success_rate) ||
@@ -4228,12 +4240,14 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                     return false;
                 }
 
-                lambda_hypothesis_constraints.clear();
-                lambda_hypothesis_residual_square_sums.clear();
+                const std::size_t group_start =
+                    lambda_hypothesis_constraints.size();
                 const int hypothesis_count =
                     lambda_diagnostics.candidates.cols();
-                lambda_hypothesis_constraints.reserve(hypothesis_count);
-                lambda_hypothesis_residual_square_sums.reserve(hypothesis_count);
+                lambda_hypothesis_constraints.reserve(
+                    group_start + static_cast<std::size_t>(hypothesis_count));
+                lambda_hypothesis_residual_square_sums.reserve(
+                    group_start + static_cast<std::size_t>(hypothesis_count));
                 for (int hypothesis = 0;
                      hypothesis < hypothesis_count;
                      ++hypothesis) {
@@ -4274,16 +4288,21 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                         residual_square_sum);
                 }
 
-                if (lambda_hypothesis_constraints.empty() ||
+                if (lambda_hypothesis_constraints.size() == group_start ||
                     static_cast<int>(
-                        lambda_hypothesis_constraints.front().size()) <
+                        lambda_hypothesis_constraints[group_start].size()) <
                         min_fixed_ambiguities) {
                     return false;
                 }
 
-                fixed_constraints = lambda_hypothesis_constraints.front();
-                fixed_residual_square_sum =
-                    lambda_hypothesis_residual_square_sums.front();
+                lambda_hypothesis_group_ends.push_back(
+                    lambda_hypothesis_constraints.size());
+                if (fixed_constraints.empty()) {
+                    fixed_constraints =
+                        lambda_hypothesis_constraints[group_start];
+                    fixed_residual_square_sum =
+                        lambda_hypothesis_residual_square_sums[group_start];
+                }
                 result.diagnostics.lambda_ambiguity_fix_used = true;
                 result.diagnostics.partial_lambda_ambiguity_fix_used =
                     subset_size < result.diagnostics.lambda_ambiguity_candidates;
@@ -4294,6 +4313,14 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
 
             const std::size_t min_subset_size =
                 static_cast<std::size_t>(min_fixed_ambiguities);
+            const bool collect_validator_groups =
+                config_.use_multisd_ambiguities &&
+                config_.use_multisd_disjoint_validation &&
+                config_.multisd_max_candidate_groups > 1;
+            const std::size_t maximum_groups =
+                static_cast<std::size_t>(std::max(
+                    1, config_.multisd_max_candidate_groups));
+            bool built_any_group = false;
             if (config_.use_constellation_ranked_partial_ar) {
                 const auto all_candidates = candidates;
                 const auto allowed_in_stage = [](GNSSSystem system,
@@ -4356,7 +4383,12 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                          subset_size >= min_subset_size;
                          --subset_size) {
                         if (solve_candidate_subset(subset_size)) {
-                            return true;
+                            built_any_group = true;
+                            if (!collect_validator_groups ||
+                                lambda_hypothesis_group_ends.size() >=
+                                    maximum_groups) {
+                                return true;
+                            }
                         }
                         if (!config_.use_partial_lambda_ambiguity_fix ||
                             subset_size == min_subset_size) {
@@ -4375,7 +4407,12 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                      subset_size >= min_subset_size;
                      --subset_size) {
                     if (solve_candidate_subset(subset_size)) {
-                        return true;
+                        built_any_group = true;
+                        if (!collect_validator_groups ||
+                            lambda_hypothesis_group_ends.size() >=
+                                maximum_groups) {
+                            return true;
+                        }
                     }
                     if (!config_.use_partial_lambda_ambiguity_fix ||
                         subset_size == min_subset_size) {
@@ -4384,7 +4421,7 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                 }
             }
 
-            return false;
+            return built_any_group;
         };
 
         const bool can_attempt_lambda =
@@ -4592,81 +4629,119 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                         ? 1
                         : lambda_hypothesis_constraints.size();
                 std::size_t passing_hypotheses = 0;
+                std::size_t evaluated_hypotheses = 0;
                 int selected_rank = -1;
                 OptimizationOutput selected_optimization;
                 ValidationOutcome selected_outcome;
                 ValidationOutcome first_outcome;
-                std::vector<std::future<OptimizationOutput>>
-                    hypothesis_futures;
-                // CUDA uses a retained thread-local cuSOLVER workspace. Keep
-                // hypotheses on this thread so every rank reuses the same
-                // allocations/handle instead of creating one CUDA context
-                // workspace per std::async worker.
-                if (config_.parallelize_lambda_hypotheses &&
-                    !use_cuda_dense_normal &&
-                    hypothesis_count > 1) {
-                    hypothesis_futures.reserve(hypothesis_count - 1);
-                    for (std::size_t rank = 1;
-                         rank < hypothesis_count;
-                         ++rank) {
-                        hypothesis_futures.push_back(std::async(
-                            std::launch::async,
-                            run_optimizer,
-                            float_optimization.state,
-                            lambda_hypothesis_constraints[rank],
-                            "fixed-hypothesis",
-                            fixed_global_iteration_offset));
-                    }
+                std::vector<std::size_t> group_ends =
+                    lambda_hypothesis_group_ends;
+                if (group_ends.empty()) {
+                    group_ends.push_back(hypothesis_count);
                 }
-                for (std::size_t rank = 0; rank < hypothesis_count; ++rank) {
-                    OptimizationOutput hypothesis;
-                    if (rank == 0) {
-                        hypothesis = optimization;
-                    } else if (!hypothesis_futures.empty()) {
-                        hypothesis = hypothesis_futures[rank - 1].get();
-                    } else {
-                        hypothesis = run_optimizer(
-                            float_optimization.state,
-                            lambda_hypothesis_constraints[rank],
-                            "fixed-hypothesis",
-                            fixed_global_iteration_offset);
-                        total_iterations += hypothesis.iterations;
-                        total_processing_ms += hypothesis.processing_ms;
+                std::size_t group_start = 0;
+                for (const std::size_t group_end : group_ends) {
+                    if (group_end <= group_start ||
+                        group_end > hypothesis_count) {
+                        continue;
                     }
-                    const ValidationOutcome outcome =
-                        validate_hypothesis(hypothesis);
-                    FGOResult::MultiSdValidationHypothesis hypothesis_record;
-                    hypothesis_record.rank = static_cast<int>(rank);
-                    hypothesis_record.evaluated = outcome.evaluated;
-                    hypothesis_record.pass = outcome.pass;
-                    hypothesis_record.latest_position_ecef =
-                        hypothesis.state.segment<3>(
-                            epoch_state_col(latest_epoch));
-                    hypothesis_record.carrier_used = outcome.carrier_used;
-                    hypothesis_record.carrier_passed = outcome.carrier_passed;
-                    hypothesis_record.pseudorange_used =
-                        outcome.pseudorange_used;
-                    hypothesis_record.maximum_integer_distance_cycles =
-                        outcome.maximum_integer_distance;
-                    hypothesis_record.ddpr_rms_m = outcome.ddpr_rms;
-                    hypothesis_record.fixed_float_separation_m =
-                        outcome.fixed_float_separation;
-                    hypothesis_record.seed_separation_m =
-                        outcome.seed_separation;
-                    result.multisd_validation_hypotheses.push_back(
-                        hypothesis_record);
-                    if (rank == 0) {
-                        first_outcome = outcome;
+                    std::vector<std::future<OptimizationOutput>>
+                        hypothesis_futures;
+                    const std::size_t async_start =
+                        group_start == 0 ? 1 : group_start;
+                    // CUDA uses a retained thread-local cuSOLVER workspace.
+                    // Keep hypotheses on this thread in CUDA mode; CPU groups
+                    // retain the existing deterministic parallel batch.
+                    if (config_.parallelize_lambda_hypotheses &&
+                        !use_cuda_dense_normal &&
+                        group_end > async_start) {
+                        hypothesis_futures.reserve(group_end - async_start);
+                        for (std::size_t rank = async_start;
+                             rank < group_end; ++rank) {
+                            hypothesis_futures.push_back(std::async(
+                                std::launch::async,
+                                run_optimizer,
+                                float_optimization.state,
+                                lambda_hypothesis_constraints[rank],
+                                "fixed-hypothesis",
+                                fixed_global_iteration_offset));
+                        }
                     }
-                    if (outcome.pass) {
-                        ++passing_hypotheses;
-                        selected_rank = static_cast<int>(rank);
-                        selected_optimization = std::move(hypothesis);
-                        selected_outcome = outcome;
+                    std::size_t group_passes = 0;
+                    int group_selected_rank = -1;
+                    OptimizationOutput group_selected_optimization;
+                    ValidationOutcome group_selected_outcome;
+                    for (std::size_t rank = group_start;
+                         rank < group_end; ++rank) {
+                        OptimizationOutput hypothesis;
+                        if (rank == 0) {
+                            hypothesis = optimization;
+                        } else if (!hypothesis_futures.empty()) {
+                            hypothesis =
+                                hypothesis_futures[rank - async_start].get();
+                        } else {
+                            hypothesis = run_optimizer(
+                                float_optimization.state,
+                                lambda_hypothesis_constraints[rank],
+                                "fixed-hypothesis",
+                                fixed_global_iteration_offset);
+                            total_iterations += hypothesis.iterations;
+                            total_processing_ms += hypothesis.processing_ms;
+                        }
+                        const ValidationOutcome outcome =
+                            validate_hypothesis(hypothesis);
+                        FGOResult::MultiSdValidationHypothesis
+                            hypothesis_record;
+                        hypothesis_record.rank = static_cast<int>(rank);
+                        hypothesis_record.evaluated = outcome.evaluated;
+                        hypothesis_record.pass = outcome.pass;
+                        hypothesis_record.latest_position_ecef =
+                            hypothesis.state.segment<3>(
+                                epoch_state_col(latest_epoch));
+                        hypothesis_record.carrier_used = outcome.carrier_used;
+                        hypothesis_record.carrier_passed = outcome.carrier_passed;
+                        hypothesis_record.pseudorange_used =
+                            outcome.pseudorange_used;
+                        hypothesis_record.maximum_integer_distance_cycles =
+                            outcome.maximum_integer_distance;
+                        hypothesis_record.ddpr_rms_m = outcome.ddpr_rms;
+                        hypothesis_record.fixed_float_separation_m =
+                            outcome.fixed_float_separation;
+                        hypothesis_record.seed_separation_m =
+                            outcome.seed_separation;
+                        result.multisd_validation_hypotheses.push_back(
+                            hypothesis_record);
+                        ++evaluated_hypotheses;
+                        if (rank == 0) {
+                            first_outcome = outcome;
+                        }
+                        if (outcome.pass) {
+                            ++group_passes;
+                            group_selected_rank = static_cast<int>(rank);
+                            group_selected_optimization =
+                                std::move(hypothesis);
+                            group_selected_outcome = outcome;
+                        }
                     }
+                    passing_hypotheses = group_passes;
+                    if (group_passes == 1) {
+                        selected_rank = group_selected_rank;
+                        selected_optimization =
+                            std::move(group_selected_optimization);
+                        selected_outcome = group_selected_outcome;
+                        break;
+                    }
+                    // Multiple passing hypotheses in any group are an
+                    // integrity ambiguity. Fail closed instead of searching
+                    // for a later group that happens to look unique.
+                    if (group_passes > 1) {
+                        break;
+                    }
+                    group_start = group_end;
                 }
 
-                const bool unique_pass = passing_hypotheses == 1;
+                const bool unique_pass =
+                    passing_hypotheses == 1 && selected_rank >= 0;
                 const ValidationOutcome& reported_outcome =
                     unique_pass ? selected_outcome : first_outcome;
                 result.diagnostics.multisd_validation_evaluated =
@@ -4679,7 +4754,7 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                 result.diagnostics.multisd_validation_pseudorange_used =
                     reported_outcome.pseudorange_used;
                 result.diagnostics.multisd_validation_hypotheses_evaluated =
-                    hypothesis_count;
+                    evaluated_hypotheses;
                 result.diagnostics.multisd_validation_hypotheses_passed =
                     passing_hypotheses;
                 result.diagnostics.multisd_validation_selected_rank =
@@ -4708,6 +4783,14 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                             std::sqrt(
                                 fixed_residual_square_sum /
                                 static_cast<double>(fixed_constraints.size()));
+                        result.diagnostics.fixed_ambiguities =
+                            static_cast<int>(fixed_constraints.size());
+                        result.diagnostics.lambda_ambiguity_used_candidates =
+                            static_cast<int>(fixed_constraints.size());
+                        result.diagnostics.partial_lambda_ambiguity_fix_used =
+                            fixed_constraints.size() <
+                            static_cast<std::size_t>(result.diagnostics
+                                .lambda_ambiguity_candidates);
                     }
                 } else {
                     optimization = std::move(float_optimization);

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -4089,8 +4089,14 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
 
             std::stable_sort(candidates.begin(),
                              candidates.end(),
-                             [](const LambdaCandidate& lhs,
-                                const LambdaCandidate& rhs) {
+                             [&](const LambdaCandidate& lhs,
+                                 const LambdaCandidate& rhs) {
+                                 if (config_.use_variance_ranked_partial_ar &&
+                                     lhs.variance_cycles !=
+                                         rhs.variance_cycles) {
+                                     return lhs.variance_cycles <
+                                            rhs.variance_cycles;
+                                 }
                                  if (lhs.fractional_cycles == rhs.fractional_cycles) {
                                      return lhs.variance_cycles < rhs.variance_cycles;
                                  }
@@ -4099,11 +4105,6 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
 
             const int max_lambda_ambiguities =
                 std::max(0, config_.max_lambda_ambiguities);
-            if (max_lambda_ambiguities > 0 &&
-                static_cast<int>(candidates.size()) > max_lambda_ambiguities) {
-                candidates.resize(static_cast<std::size_t>(max_lambda_ambiguities));
-            }
-
             result.diagnostics.lambda_ambiguity_candidates = candidates.size();
             result.diagnostics.ambiguity_fix_candidates = candidates.size();
             const int min_fixed_ambiguities = std::max(1, config_.min_fixed_ambiguities);
@@ -4285,7 +4286,7 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                     lambda_hypothesis_residual_square_sums.front();
                 result.diagnostics.lambda_ambiguity_fix_used = true;
                 result.diagnostics.partial_lambda_ambiguity_fix_used =
-                    subset_size < candidates.size();
+                    subset_size < result.diagnostics.lambda_ambiguity_candidates;
                 result.diagnostics.lambda_ambiguity_used_candidates = subset_size;
                 result.diagnostics.lambda_ambiguity_ratio = lambda_ratio;
                 return true;
@@ -4293,15 +4294,93 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
 
             const std::size_t min_subset_size =
                 static_cast<std::size_t>(min_fixed_ambiguities);
-            for (std::size_t subset_size = candidates.size();
-                 subset_size >= min_subset_size;
-                 --subset_size) {
-                if (solve_candidate_subset(subset_size)) {
-                    return true;
+            if (config_.use_constellation_ranked_partial_ar) {
+                const auto all_candidates = candidates;
+                const auto allowed_in_stage = [](GNSSSystem system,
+                                                 int stage) {
+                    if (system == GNSSSystem::GPS ||
+                        system == GNSSSystem::QZSS) {
+                        return true;
+                    }
+                    if (system == GNSSSystem::Galileo) {
+                        return stage <= 2;
+                    }
+                    if (system == GNSSSystem::BeiDou) {
+                        return stage == 0 || stage == 1 || stage == 3;
+                    }
+                    if (system == GNSSSystem::GLONASS) {
+                        return stage == 0 || stage == 2 || stage == 4;
+                    }
+                    return stage == 0;
+                };
+                std::vector<std::vector<LambdaCandidate>> pools;
+                for (int stage = 0; stage < 6; ++stage) {
+                    std::vector<LambdaCandidate> pool;
+                    for (const auto& candidate : all_candidates) {
+                        const auto system = problem.ambiguity_states[
+                            candidate.ambiguity_index].satellite.system;
+                        if (allowed_in_stage(system, stage)) {
+                            pool.push_back(candidate);
+                        }
+                    }
+                    if (max_lambda_ambiguities > 0 &&
+                        pool.size() > static_cast<std::size_t>(
+                                          max_lambda_ambiguities)) {
+                        pool.resize(static_cast<std::size_t>(
+                            max_lambda_ambiguities));
+                    }
+                    const bool duplicate_pool = std::any_of(
+                        pools.begin(), pools.end(),
+                        [&](const std::vector<LambdaCandidate>& existing) {
+                            if (existing.size() != pool.size()) {
+                                return false;
+                            }
+                            for (std::size_t i = 0; i < pool.size(); ++i) {
+                                if (existing[i].ambiguity_index !=
+                                        pool[i].ambiguity_index ||
+                                    existing[i].reference_ambiguity_index !=
+                                        pool[i].reference_ambiguity_index) {
+                                    return false;
+                                }
+                            }
+                            return true;
+                        });
+                    if (pool.size() >= min_subset_size &&
+                        !duplicate_pool) {
+                        pools.push_back(std::move(pool));
+                    }
                 }
-                if (!config_.use_partial_lambda_ambiguity_fix ||
-                    subset_size == min_subset_size) {
-                    break;
+                for (const auto& pool : pools) {
+                    candidates = pool;
+                    for (std::size_t subset_size = candidates.size();
+                         subset_size >= min_subset_size;
+                         --subset_size) {
+                        if (solve_candidate_subset(subset_size)) {
+                            return true;
+                        }
+                        if (!config_.use_partial_lambda_ambiguity_fix ||
+                            subset_size == min_subset_size) {
+                            break;
+                        }
+                    }
+                }
+            } else {
+                if (max_lambda_ambiguities > 0 &&
+                    candidates.size() > static_cast<std::size_t>(
+                                            max_lambda_ambiguities)) {
+                    candidates.resize(static_cast<std::size_t>(
+                        max_lambda_ambiguities));
+                }
+                for (std::size_t subset_size = candidates.size();
+                     subset_size >= min_subset_size;
+                     --subset_size) {
+                    if (solve_candidate_subset(subset_size)) {
+                        return true;
+                    }
+                    if (!config_.use_partial_lambda_ambiguity_fix ||
+                        subset_size == min_subset_size) {
+                        break;
+                    }
                 }
             }
 

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -2555,10 +2555,106 @@ FGOProcessor::FGOResult FGOProcessor::optimize(
         buildDoubleDifferenceProblem(rover_epochs, base_epochs, nav, base_position_ecef));
 }
 
-FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem) const {
+FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
+    const FGOProblem& input_problem) const {
     const auto optimize_problem_start =
         std::chrono::high_resolution_clock::now();
     FGOResult result;
+
+    // Select the validation satellites before either float or fixed
+    // optimization, then remove every factor involving those satellites from
+    // the complete window.  Selection uses only observation metadata from the
+    // latest epoch (elevation and satellite id), never a solved state or truth.
+    // The weakest-elevation ambiguities are held out, matching satellite-PAR:
+    // strong geometry remains in the ILS candidate while the unused surplus
+    // observations provide validation evidence.
+    // This makes the post-fix evidence genuinely disjoint from candidate
+    // generation, including all earlier epochs in a multi-epoch window.
+    FGOProblem disjoint_problem;
+    const FGOProblem* active_problem = &input_problem;
+    if (config_.backend == FGOBackend::Eigen &&
+        config_.use_multisd_ambiguities &&
+        config_.use_multisd_disjoint_validation &&
+        !input_problem.double_difference_carrier_factors.empty()) {
+        disjoint_problem = input_problem;
+        std::size_t latest_epoch = 0;
+        for (const auto& factor :
+             input_problem.double_difference_carrier_factors) {
+            latest_epoch = std::max(latest_epoch, factor.epoch_index);
+        }
+
+        std::map<SatelliteId, double> latest_target_elevation;
+        for (const auto& factor :
+             input_problem.double_difference_carrier_factors) {
+            if (factor.epoch_index == latest_epoch &&
+                factor.use_ambiguity_difference) {
+                auto [it, inserted] = latest_target_elevation.emplace(
+                    factor.satellite, factor.elevation_rad);
+                if (!inserted) {
+                    it->second = std::max(it->second, factor.elevation_rad);
+                }
+            }
+        }
+        std::vector<std::pair<SatelliteId, double>> ranked_targets(
+            latest_target_elevation.begin(), latest_target_elevation.end());
+        std::stable_sort(
+            ranked_targets.begin(), ranked_targets.end(),
+            [](const auto& lhs, const auto& rhs) {
+                if (lhs.second != rhs.second) {
+                    return lhs.second < rhs.second;
+                }
+                return lhs.first < rhs.first;
+            });
+        const std::size_t requested = static_cast<std::size_t>(
+            std::max(1, config_.multisd_validation_holdout_satellites));
+        std::set<SatelliteId> held_out_satellites;
+        const std::size_t offset = ranked_targets.empty()
+            ? 0
+            : static_cast<std::size_t>(
+                  std::max(0, config_.multisd_validation_holdout_offset)) %
+                  ranked_targets.size();
+        for (std::size_t i = 0;
+             i < ranked_targets.size() &&
+             held_out_satellites.size() < requested;
+             ++i) {
+            const auto& [satellite, elevation] =
+                ranked_targets[(offset + i) % ranked_targets.size()];
+            (void)elevation;
+            held_out_satellites.insert(satellite);
+        }
+        result.diagnostics.multisd_validation_holdout_satellites =
+            held_out_satellites.size();
+
+        auto involves_holdout = [&](const auto& factor) {
+            return held_out_satellites.count(factor.satellite) > 0 ||
+                   held_out_satellites.count(factor.reference_satellite) > 0;
+        };
+        auto& carriers = disjoint_problem.double_difference_carrier_factors;
+        for (const auto& factor : carriers) {
+            if (involves_holdout(factor)) {
+                disjoint_problem.multisd_validation_carrier_factors.push_back(
+                    factor);
+            }
+        }
+        carriers.erase(
+            std::remove_if(carriers.begin(), carriers.end(), involves_holdout),
+            carriers.end());
+
+        auto& pseudoranges =
+            disjoint_problem.double_difference_pseudorange_factors;
+        for (const auto& factor : pseudoranges) {
+            if (involves_holdout(factor)) {
+                disjoint_problem.multisd_validation_pseudorange_factors.push_back(
+                    factor);
+            }
+        }
+        pseudoranges.erase(
+            std::remove_if(pseudoranges.begin(), pseudoranges.end(),
+                           involves_holdout),
+            pseudoranges.end());
+        active_problem = &disjoint_problem;
+    }
+    const FGOProblem& problem = *active_problem;
     result.diagnostics.epochs = problem.epochs.size();
     result.diagnostics.pseudorange_factors = problem.pseudorange_factors.size();
     result.diagnostics.tdcp_factors = problem.tdcp_factors.size();
@@ -3641,6 +3737,9 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
     int total_iterations = optimization.iterations;
     double total_processing_ms = optimization.processing_ms;
     std::vector<FixedAmbiguityConstraint> fixed_constraints;
+    std::vector<std::vector<FixedAmbiguityConstraint>>
+        lambda_hypothesis_constraints;
+    std::vector<double> lambda_hypothesis_residual_square_sums;
     const bool has_ambiguity_measurements =
         !problem.carrier_phase_factors.empty() ||
         !problem.double_difference_carrier_factors.empty();
@@ -3660,9 +3759,8 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
             // A rover-base SD ambiguity contains a common receiver gauge.
             // It is not an integer-fix candidate by itself. MultiSD fixing
             // must first project the SD posterior to independent BSD/DD
-            // combinations; until that projection is available, keep this
-            // path float-only instead of silently applying invalid integer
-            // constraints to gauge-dependent states.
+            // combinations. Individual gauge-dependent states stay float;
+            // the MultiSD path below constrains only projected BSD edges.
             if (config_.use_multisd_ambiguities &&
                 !ambiguity.is_double_difference) {
                 return false;
@@ -3986,37 +4084,62 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
                     return false;
                 }
 
-                std::vector<FixedAmbiguityConstraint> lambda_constraints;
-                lambda_constraints.reserve(subset_size);
-                double lambda_residual_square_sum = 0.0;
-                for (int i = 0; i < n; ++i) {
-                    const int ambiguity_index = candidates[i].ambiguity_index;
-                    const auto& ambiguity = problem.ambiguity_states[ambiguity_index];
-                    const double fixed_cycles_d = std::round(fixed_ambiguities(i));
-                    const double residual_cycles = float_ambiguities(i) - fixed_cycles_d;
+                lambda_hypothesis_constraints.clear();
+                lambda_hypothesis_residual_square_sums.clear();
+                const int hypothesis_count =
+                    lambda_diagnostics.candidates.cols();
+                lambda_hypothesis_constraints.reserve(hypothesis_count);
+                lambda_hypothesis_residual_square_sums.reserve(hypothesis_count);
+                for (int hypothesis = 0;
+                     hypothesis < hypothesis_count;
+                     ++hypothesis) {
+                    std::vector<FixedAmbiguityConstraint> constraints;
+                    constraints.reserve(subset_size);
+                    double residual_square_sum = 0.0;
+                    for (int i = 0; i < n; ++i) {
+                        const int ambiguity_index =
+                            candidates[i].ambiguity_index;
+                        const auto& ambiguity =
+                            problem.ambiguity_states[ambiguity_index];
+                        const double fixed_cycles_d = std::round(
+                            lambda_diagnostics.candidates(i, hypothesis));
+                        const double residual_cycles =
+                            float_ambiguities(i) - fixed_cycles_d;
 
-                    FixedAmbiguityConstraint fixed;
-                    fixed.ambiguity_index = static_cast<std::size_t>(ambiguity_index);
-                    if (candidates[i].reference_ambiguity_index >= 0) {
-                        fixed.reference_ambiguity_index =
-                            static_cast<std::size_t>(
-                                candidates[i].reference_ambiguity_index);
+                        FixedAmbiguityConstraint fixed;
+                        fixed.ambiguity_index =
+                            static_cast<std::size_t>(ambiguity_index);
+                        if (candidates[i].reference_ambiguity_index >= 0) {
+                            fixed.reference_ambiguity_index =
+                                static_cast<std::size_t>(
+                                    candidates[i].reference_ambiguity_index);
+                        }
+                        fixed.fixed_cycles =
+                            static_cast<int>(fixed_cycles_d);
+                        fixed.fixed_ambiguity_m =
+                            fixed_cycles_d * ambiguity.wavelength_m;
+                        fixed.residual_cycles = residual_cycles;
+                        fixed.fixed_by_lambda = true;
+                        constraints.push_back(fixed);
+                        residual_square_sum +=
+                            residual_cycles * residual_cycles;
                     }
-                    fixed.fixed_cycles = static_cast<int>(fixed_cycles_d);
-                    fixed.fixed_ambiguity_m = fixed_cycles_d * ambiguity.wavelength_m;
-                    fixed.residual_cycles = residual_cycles;
-                    fixed.fixed_by_lambda = true;
-                    lambda_constraints.push_back(fixed);
-                    lambda_residual_square_sum += residual_cycles * residual_cycles;
+                    lambda_hypothesis_constraints.push_back(
+                        std::move(constraints));
+                    lambda_hypothesis_residual_square_sums.push_back(
+                        residual_square_sum);
                 }
 
-                if (static_cast<int>(lambda_constraints.size()) <
-                    min_fixed_ambiguities) {
+                if (lambda_hypothesis_constraints.empty() ||
+                    static_cast<int>(
+                        lambda_hypothesis_constraints.front().size()) <
+                        min_fixed_ambiguities) {
                     return false;
                 }
 
-                fixed_constraints = std::move(lambda_constraints);
-                fixed_residual_square_sum = lambda_residual_square_sum;
+                fixed_constraints = lambda_hypothesis_constraints.front();
+                fixed_residual_square_sum =
+                    lambda_hypothesis_residual_square_sums.front();
                 result.diagnostics.lambda_ambiguity_fix_used = true;
                 result.diagnostics.partial_lambda_ambiguity_fix_used =
                     subset_size < candidates.size();
@@ -4055,6 +4178,13 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
 
         if (static_cast<int>(fixed_constraints.size()) >=
             std::max(1, config_.min_fixed_ambiguities)) {
+            const bool run_disjoint_validation =
+                config_.use_multisd_ambiguities &&
+                config_.use_multisd_disjoint_validation;
+            OptimizationOutput float_optimization;
+            if (run_disjoint_validation) {
+                float_optimization = optimization;
+            }
             const int fixed_global_iteration_offset =
                 result.cost_trace_entries.empty()
                     ? total_iterations
@@ -4076,6 +4206,230 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
             result.diagnostics.fixed_ambiguity_residual_rms_cycles =
                 std::sqrt(fixed_residual_square_sum /
                           static_cast<double>(fixed_constraints.size()));
+
+            if (run_disjoint_validation) {
+                struct ValidationOutcome {
+                    bool evaluated = false;
+                    bool pass = false;
+                    std::size_t carrier_used = 0;
+                    std::size_t carrier_passed = 0;
+                    std::size_t pseudorange_used = 0;
+                    double maximum_integer_distance = 0.0;
+                    double ddpr_rms =
+                        std::numeric_limits<double>::infinity();
+                };
+                const std::size_t latest_epoch =
+                    static_cast<std::size_t>(num_epochs - 1);
+                const int required_holdout =
+                    std::max(1, config_.multisd_validation_holdout_satellites);
+                const double aperture =
+                    std::max(0.0,
+                             config_.multisd_validation_aperture_cycles);
+                const bool enough_satellites =
+                    static_cast<int>(result.diagnostics
+                                         .multisd_validation_holdout_satellites) >=
+                    required_holdout;
+                auto validate_hypothesis =
+                    [&](const OptimizationOutput& hypothesis)
+                        -> ValidationOutcome {
+                    ValidationOutcome outcome;
+                    const Vector3d fixed_position =
+                        hypothesis.state.segment<3>(
+                            epoch_state_col(latest_epoch));
+                    for (const auto& factor :
+                         problem.multisd_validation_carrier_factors) {
+                        if (factor.epoch_index != latest_epoch ||
+                            factor.ambiguity_index >=
+                                problem.ambiguity_states.size()) {
+                            continue;
+                        }
+                        const double wavelength =
+                            problem.ambiguity_states[factor.ambiguity_index]
+                                .wavelength_m;
+                        if (!(wavelength > 0.0)) {
+                            continue;
+                        }
+                        const DoubleDifferencePrediction prediction =
+                            doubleDifferencePredictionAt(
+                                fixed_position, factor.base_position_ecef,
+                                factor.rover_satellite_position_ecef,
+                                factor.rover_reference_position_ecef,
+                                factor.base_satellite_position_ecef,
+                                factor.base_reference_position_ecef);
+                        if (!prediction.valid) {
+                            continue;
+                        }
+                        const double ambiguity_cycles =
+                            (factor.observed_dd_carrier_m -
+                             prediction.geometry_m) /
+                            wavelength;
+                        if (!std::isfinite(ambiguity_cycles)) {
+                            continue;
+                        }
+                        const double integer_distance =
+                            std::abs(ambiguity_cycles -
+                                     std::round(ambiguity_cycles));
+                        outcome.maximum_integer_distance = std::max(
+                            outcome.maximum_integer_distance,
+                            integer_distance);
+                        if (integer_distance <= aperture) {
+                            ++outcome.carrier_passed;
+                        }
+                        ++outcome.carrier_used;
+                    }
+
+                    double ddpr_square_sum = 0.0;
+                    for (const auto& factor :
+                         problem.multisd_validation_pseudorange_factors) {
+                        if (factor.epoch_index != latest_epoch) {
+                            continue;
+                        }
+                        const DoubleDifferencePrediction prediction =
+                            doubleDifferencePredictionAt(
+                                fixed_position, factor.base_position_ecef,
+                                factor.rover_satellite_position_ecef,
+                                factor.rover_reference_position_ecef,
+                                factor.base_satellite_position_ecef,
+                                factor.base_reference_position_ecef);
+                        if (!prediction.valid) {
+                            continue;
+                        }
+                        const double residual =
+                            factor.observed_dd_pseudorange_m -
+                            prediction.geometry_m;
+                        if (!std::isfinite(residual)) {
+                            continue;
+                        }
+                        ddpr_square_sum += residual * residual;
+                        ++outcome.pseudorange_used;
+                    }
+                    if (outcome.pseudorange_used > 0) {
+                        outcome.ddpr_rms = std::sqrt(
+                            ddpr_square_sum /
+                            static_cast<double>(outcome.pseudorange_used));
+                    }
+                    const bool enough_rows =
+                        static_cast<int>(outcome.carrier_used) >=
+                            required_holdout &&
+                        static_cast<int>(outcome.pseudorange_used) >=
+                            required_holdout;
+                    outcome.evaluated = enough_satellites && enough_rows;
+                    const std::size_t required_carrier_passes =
+                        static_cast<std::size_t>(std::ceil(
+                            std::clamp(
+                                config_
+                                    .multisd_validation_min_carrier_fraction,
+                                0.0, 1.0) *
+                            static_cast<double>(outcome.carrier_used)));
+                    outcome.pass =
+                        outcome.evaluated &&
+                        outcome.carrier_passed >= required_carrier_passes &&
+                        std::isfinite(outcome.ddpr_rms) &&
+                        outcome.ddpr_rms <= std::max(
+                            0.0,
+                            config_.multisd_validation_max_ddpr_rms_m);
+                    return outcome;
+                };
+
+                const std::size_t hypothesis_count =
+                    lambda_hypothesis_constraints.empty()
+                        ? 1
+                        : lambda_hypothesis_constraints.size();
+                std::size_t passing_hypotheses = 0;
+                int selected_rank = -1;
+                OptimizationOutput selected_optimization;
+                ValidationOutcome selected_outcome;
+                ValidationOutcome first_outcome;
+                for (std::size_t rank = 0; rank < hypothesis_count; ++rank) {
+                    OptimizationOutput hypothesis;
+                    if (rank == 0) {
+                        hypothesis = optimization;
+                    } else {
+                        hypothesis = run_optimizer(
+                            float_optimization.state,
+                            lambda_hypothesis_constraints[rank],
+                            "fixed-hypothesis",
+                            fixed_global_iteration_offset);
+                        total_iterations += hypothesis.iterations;
+                        total_processing_ms += hypothesis.processing_ms;
+                    }
+                    const ValidationOutcome outcome =
+                        validate_hypothesis(hypothesis);
+                    FGOResult::MultiSdValidationHypothesis hypothesis_record;
+                    hypothesis_record.rank = static_cast<int>(rank);
+                    hypothesis_record.evaluated = outcome.evaluated;
+                    hypothesis_record.pass = outcome.pass;
+                    hypothesis_record.latest_position_ecef =
+                        hypothesis.state.segment<3>(
+                            epoch_state_col(latest_epoch));
+                    hypothesis_record.carrier_used = outcome.carrier_used;
+                    hypothesis_record.carrier_passed = outcome.carrier_passed;
+                    hypothesis_record.pseudorange_used =
+                        outcome.pseudorange_used;
+                    hypothesis_record.maximum_integer_distance_cycles =
+                        outcome.maximum_integer_distance;
+                    hypothesis_record.ddpr_rms_m = outcome.ddpr_rms;
+                    result.multisd_validation_hypotheses.push_back(
+                        hypothesis_record);
+                    if (rank == 0) {
+                        first_outcome = outcome;
+                    }
+                    if (outcome.pass) {
+                        ++passing_hypotheses;
+                        selected_rank = static_cast<int>(rank);
+                        selected_optimization = std::move(hypothesis);
+                        selected_outcome = outcome;
+                    }
+                }
+
+                const bool unique_pass = passing_hypotheses == 1;
+                const ValidationOutcome& reported_outcome =
+                    unique_pass ? selected_outcome : first_outcome;
+                result.diagnostics.multisd_validation_evaluated =
+                    reported_outcome.evaluated;
+                result.diagnostics.multisd_validation_pass = unique_pass;
+                result.diagnostics.multisd_validation_carrier_used =
+                    reported_outcome.carrier_used;
+                result.diagnostics.multisd_validation_carrier_passed =
+                    reported_outcome.carrier_passed;
+                result.diagnostics.multisd_validation_pseudorange_used =
+                    reported_outcome.pseudorange_used;
+                result.diagnostics.multisd_validation_hypotheses_evaluated =
+                    hypothesis_count;
+                result.diagnostics.multisd_validation_hypotheses_passed =
+                    passing_hypotheses;
+                result.diagnostics.multisd_validation_selected_rank =
+                    unique_pass ? selected_rank : -1;
+                result.diagnostics
+                    .multisd_validation_max_integer_distance_cycles =
+                    reported_outcome.maximum_integer_distance;
+                result.diagnostics.multisd_validation_ddpr_rms_m =
+                    reported_outcome.ddpr_rms;
+
+                if (unique_pass) {
+                    optimization = std::move(selected_optimization);
+                    if (!lambda_hypothesis_constraints.empty()) {
+                        fixed_constraints =
+                            lambda_hypothesis_constraints[
+                                static_cast<std::size_t>(selected_rank)];
+                        fixed_residual_square_sum =
+                            lambda_hypothesis_residual_square_sums[
+                                static_cast<std::size_t>(selected_rank)];
+                        result.diagnostics.fixed_ambiguity_residual_rms_cycles =
+                            std::sqrt(
+                                fixed_residual_square_sum /
+                                static_cast<double>(fixed_constraints.size()));
+                    }
+                } else {
+                    optimization = std::move(float_optimization);
+                    fixed_constraints.clear();
+                    result.diagnostics.fixed_solution = false;
+                    result.diagnostics.fixed_ambiguities = 0;
+                    result.diagnostics.lambda_ambiguity_fix_used = false;
+                    result.diagnostics.partial_lambda_ambiguity_fix_used = false;
+                    result.diagnostics.fixed_ambiguity_residual_rms_cycles = 0.0;
+                }
+            }
         } else {
             fixed_constraints.clear();
         }

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -4634,6 +4634,19 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                 OptimizationOutput selected_optimization;
                 ValidationOutcome selected_outcome;
                 ValidationOutcome first_outcome;
+                struct FallbackConsensusCandidate {
+                    int rank = -1;
+                    OptimizationOutput optimization;
+                    ValidationOutcome outcome;
+                    Eigen::Vector3d latest_position_ecef =
+                        Eigen::Vector3d::Zero();
+                };
+                std::vector<FallbackConsensusCandidate>
+                    fallback_consensus_candidates;
+                const std::size_t required_fallback_consensus =
+                    static_cast<std::size_t>(std::max(
+                        1, config_.multisd_fallback_min_consensus_groups));
+                bool ambiguous_group = false;
                 std::vector<std::size_t> group_ends =
                     lambda_hypothesis_group_ends;
                 if (group_ends.empty()) {
@@ -4688,8 +4701,15 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                             total_iterations += hypothesis.iterations;
                             total_processing_ms += hypothesis.processing_ms;
                         }
-                        const ValidationOutcome outcome =
+                        ValidationOutcome outcome =
                             validate_hypothesis(hypothesis);
+                        if (group_start > 0 && outcome.pass &&
+                            config_.multisd_fallback_max_seed_separation_m > 0.0 &&
+                            outcome.seed_separation >
+                                config_
+                                    .multisd_fallback_max_seed_separation_m) {
+                            outcome.pass = false;
+                        }
                         FGOResult::MultiSdValidationHypothesis
                             hypothesis_record;
                         hypothesis_record.rank = static_cast<int>(rank);
@@ -4725,23 +4745,77 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                     }
                     passing_hypotheses = group_passes;
                     if (group_passes == 1) {
-                        selected_rank = group_selected_rank;
-                        selected_optimization =
+                        if (group_start == 0 ||
+                            required_fallback_consensus == 1) {
+                            selected_rank = group_selected_rank;
+                            selected_optimization =
+                                std::move(group_selected_optimization);
+                            selected_outcome = group_selected_outcome;
+                            break;
+                        }
+                        FallbackConsensusCandidate candidate;
+                        candidate.rank = group_selected_rank;
+                        candidate.latest_position_ecef =
+                            group_selected_optimization.state.segment<3>(
+                                epoch_state_col(latest_epoch));
+                        candidate.optimization =
                             std::move(group_selected_optimization);
-                        selected_outcome = group_selected_outcome;
-                        break;
+                        candidate.outcome = group_selected_outcome;
+                        fallback_consensus_candidates.push_back(
+                            std::move(candidate));
                     }
                     // Multiple passing hypotheses in any group are an
                     // integrity ambiguity. Fail closed instead of searching
                     // for a later group that happens to look unique.
                     if (group_passes > 1) {
+                        ambiguous_group = true;
+                        fallback_consensus_candidates.clear();
                         break;
                     }
                     group_start = group_end;
                 }
 
+                if (selected_rank < 0 && !ambiguous_group &&
+                    !fallback_consensus_candidates.empty()) {
+                    passing_hypotheses =
+                        fallback_consensus_candidates.size();
+                }
+                if (selected_rank < 0 && !ambiguous_group &&
+                    fallback_consensus_candidates.size() >=
+                        required_fallback_consensus) {
+                    bool consensus =
+                        config_
+                            .multisd_fallback_max_consensus_separation_m > 0.0;
+                    for (std::size_t i = 0;
+                         consensus &&
+                         i < fallback_consensus_candidates.size();
+                         ++i) {
+                        for (std::size_t j = i + 1;
+                             j < fallback_consensus_candidates.size(); ++j) {
+                            if ((fallback_consensus_candidates[i]
+                                     .latest_position_ecef -
+                                 fallback_consensus_candidates[j]
+                                     .latest_position_ecef)
+                                    .norm() >
+                                config_
+                                    .multisd_fallback_max_consensus_separation_m) {
+                                consensus = false;
+                                break;
+                            }
+                        }
+                    }
+                    if (consensus) {
+                        auto& candidate =
+                            fallback_consensus_candidates.front();
+                        selected_rank = candidate.rank;
+                        selected_optimization =
+                            std::move(candidate.optimization);
+                        selected_outcome = candidate.outcome;
+                    }
+                }
+
                 const bool unique_pass =
-                    passing_hypotheses == 1 && selected_rank >= 0;
+                    selected_rank >= 0;
                 const ValidationOutcome& reported_outcome =
                     unique_pass ? selected_outcome : first_outcome;
                 result.diagnostics.multisd_validation_evaluated =

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -4312,13 +4312,23 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                               config_.lambda_ratio_threshold,
                               config_.multisd_lambda_candidate_ratio_threshold)
                         : config_.lambda_ratio_threshold;
+                const double minimum_bootstrapped_success_rate =
+                    !lambda_hypothesis_group_ends.empty() &&
+                            config_
+                                    .multisd_fallback_min_bootstrapped_success_rate >
+                                0.0
+                        ? std::max(
+                              config_.lambda_min_bootstrapped_success_rate,
+                              config_
+                                  .multisd_fallback_min_bootstrapped_success_rate)
+                        : config_.lambda_min_bootstrapped_success_rate;
                 if (!lambda_solved || fixed_ambiguities.size() != n ||
                     !std::isfinite(lambda_ratio) ||
                     (candidate_ratio_threshold > 0.0 &&
                      lambda_ratio < candidate_ratio_threshold) ||
-                    (config_.lambda_min_bootstrapped_success_rate > 0.0 &&
+                    (minimum_bootstrapped_success_rate > 0.0 &&
                      lambda_diagnostics.bootstrapped_success_rate <
-                         config_.lambda_min_bootstrapped_success_rate) ||
+                         minimum_bootstrapped_success_rate) ||
                     (config_.lambda_max_adop_cycles > 0.0 &&
                      (!std::isfinite(adop_cycles) ||
                       adop_cycles > config_.lambda_max_adop_cycles))) {

--- a/src/algorithms/fgo_cuda_backend.cu
+++ b/src/algorithms/fgo_cuda_backend.cu
@@ -1,0 +1,196 @@
+#include "fgo_cuda_backend.hpp"
+
+#include <cuda_runtime.h>
+#include <cusolverDn.h>
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+namespace libgnss::detail {
+namespace {
+
+enum class SolverMode { Off, Auto, On };
+
+SolverMode configuredMode() {
+    const char* raw = std::getenv("GNSSPP_FGO_CUDA_SOLVER");
+    if (raw == nullptr) {
+        return SolverMode::Off;
+    }
+    std::string value(raw);
+    std::transform(value.begin(), value.end(), value.begin(),
+                   [](unsigned char c) {
+                       return static_cast<char>(std::tolower(c));
+                   });
+    if (value == "1" || value == "on" || value == "true") {
+        return SolverMode::On;
+    }
+    if (value == "auto") {
+        return SolverMode::Auto;
+    }
+    return SolverMode::Off;
+}
+
+class DenseSolverWorkspace {
+public:
+    ~DenseSolverWorkspace() {
+        if (matrix_ != nullptr) cudaFree(matrix_);
+        if (rhs_ != nullptr) cudaFree(rhs_);
+        if (workspace_ != nullptr) cudaFree(workspace_);
+        if (info_ != nullptr) cudaFree(info_);
+        if (handle_ != nullptr) cusolverDnDestroy(handle_);
+    }
+
+    bool solve(const double* normal_matrix,
+               int state_size,
+               const double* rhs,
+               int rhs_columns,
+               double* solution) {
+        if (normal_matrix == nullptr || rhs == nullptr || solution == nullptr ||
+            state_size <= 0 || rhs_columns <= 0 ||
+            !ensureCapacity(state_size, rhs_columns)) {
+            return false;
+        }
+        const std::size_t matrix_bytes =
+            static_cast<std::size_t>(state_size) * state_size * sizeof(double);
+        const std::size_t rhs_bytes =
+            static_cast<std::size_t>(state_size) * rhs_columns * sizeof(double);
+        if (cudaMemcpy(matrix_, normal_matrix, matrix_bytes,
+                       cudaMemcpyHostToDevice) != cudaSuccess ||
+            cudaMemcpy(rhs_, rhs, rhs_bytes,
+                       cudaMemcpyHostToDevice) != cudaSuccess) {
+            return false;
+        }
+        if (cusolverDnDpotrf(handle_, CUBLAS_FILL_MODE_LOWER,
+                            state_size, matrix_, state_size,
+                            workspace_, workspace_elements_, info_) !=
+            CUSOLVER_STATUS_SUCCESS) {
+            return false;
+        }
+        int info = -1;
+        if (cudaMemcpy(&info, info_, sizeof(info),
+                       cudaMemcpyDeviceToHost) != cudaSuccess ||
+            info != 0) {
+            return false;
+        }
+        if (cusolverDnDpotrs(handle_, CUBLAS_FILL_MODE_LOWER,
+                            state_size, rhs_columns,
+                            matrix_, state_size,
+                            rhs_, state_size, info_) !=
+            CUSOLVER_STATUS_SUCCESS) {
+            return false;
+        }
+        if (cudaMemcpy(&info, info_, sizeof(info),
+                       cudaMemcpyDeviceToHost) != cudaSuccess ||
+            info != 0) {
+            return false;
+        }
+        return cudaMemcpy(solution, rhs_, rhs_bytes,
+                          cudaMemcpyDeviceToHost) == cudaSuccess;
+    }
+
+private:
+    bool ensureCapacity(int state_size, int rhs_columns) {
+        if (handle_ == nullptr &&
+            cusolverDnCreate(&handle_) != CUSOLVER_STATUS_SUCCESS) {
+            return false;
+        }
+        int required_workspace = 0;
+        const bool resize_matrix = state_size > matrix_capacity_;
+        const bool resize_rhs =
+            state_size > rhs_state_capacity_ ||
+            rhs_columns > rhs_column_capacity_;
+        if (resize_matrix) {
+            if (matrix_ != nullptr) cudaFree(matrix_);
+            matrix_ = nullptr;
+            if (cudaMalloc(&matrix_,
+                           static_cast<std::size_t>(state_size) * state_size *
+                               sizeof(double)) != cudaSuccess) {
+                return false;
+            }
+            matrix_capacity_ = state_size;
+        }
+        if (resize_rhs) {
+            if (rhs_ != nullptr) cudaFree(rhs_);
+            rhs_ = nullptr;
+            if (cudaMalloc(&rhs_,
+                           static_cast<std::size_t>(state_size) * rhs_columns *
+                               sizeof(double)) != cudaSuccess) {
+                return false;
+            }
+            rhs_state_capacity_ = state_size;
+            rhs_column_capacity_ = rhs_columns;
+        }
+        if (info_ == nullptr && cudaMalloc(&info_, sizeof(int)) != cudaSuccess) {
+            return false;
+        }
+        if (cusolverDnDpotrf_bufferSize(
+                handle_, CUBLAS_FILL_MODE_LOWER, state_size,
+                matrix_, state_size, &required_workspace) !=
+            CUSOLVER_STATUS_SUCCESS) {
+            return false;
+        }
+        if (required_workspace > workspace_capacity_) {
+            if (workspace_ != nullptr) cudaFree(workspace_);
+            workspace_ = nullptr;
+            if (cudaMalloc(&workspace_,
+                           static_cast<std::size_t>(required_workspace) *
+                               sizeof(double)) != cudaSuccess) {
+                return false;
+            }
+            workspace_capacity_ = required_workspace;
+        }
+        workspace_elements_ = required_workspace;
+        return matrix_ != nullptr && rhs_ != nullptr && info_ != nullptr &&
+               workspace_ != nullptr;
+    }
+
+    cusolverDnHandle_t handle_ = nullptr;
+    double* matrix_ = nullptr;
+    double* rhs_ = nullptr;
+    double* workspace_ = nullptr;
+    int* info_ = nullptr;
+    int matrix_capacity_ = 0;
+    int rhs_state_capacity_ = 0;
+    int rhs_column_capacity_ = 0;
+    int workspace_capacity_ = 0;
+    int workspace_elements_ = 0;
+};
+
+thread_local DenseSolverWorkspace workspace;
+
+}  // namespace
+
+bool fgoCudaDenseSolverEnabled(int state_size) {
+    // Dense assembly plus PCIe copies lose badly to Eigen's sparse path on the
+    // fixed-lag windows used by the real-time shadow. Keep automatic dispatch
+    // for genuinely large batches; `on` remains available for parity tests and
+    // explicit large-problem benchmarking.
+    constexpr int kAutoMinimumState = 2048;
+    const SolverMode mode = configuredMode();
+    const bool requested = mode == SolverMode::On ||
+                           (mode == SolverMode::Auto &&
+                            state_size >= kAutoMinimumState);
+    if (!requested) {
+        return false;
+    }
+    static const bool device_available = [] {
+        int device_count = 0;
+        return cudaGetDeviceCount(&device_count) == cudaSuccess &&
+               device_count > 0;
+    }();
+    return device_available;
+}
+
+bool fgoCudaDenseSolve(const double* normal_matrix,
+                       int state_size,
+                       const double* rhs,
+                       int rhs_columns,
+                       double* solution) {
+    return workspace.solve(normal_matrix, state_size, rhs,
+                           rhs_columns, solution);
+}
+
+}  // namespace libgnss::detail

--- a/src/algorithms/fgo_cuda_backend.hpp
+++ b/src/algorithms/fgo_cuda_backend.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+namespace libgnss::detail {
+
+// Optional cuSOLVER dense SPD solve used by the native FGO backend. Matrices
+// and right-hand sides use Eigen's default column-major layout. The function
+// returns false on every CUDA/configuration failure so the caller can execute
+// the reference Eigen path without changing solver authority.
+bool fgoCudaDenseSolverEnabled(int state_size);
+bool fgoCudaDenseSolve(const double* normal_matrix,
+                       int state_size,
+                       const double* rhs,
+                       int rhs_columns,
+                       double* solution);
+
+}  // namespace libgnss::detail

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -174,6 +174,36 @@ if(GTest_FOUND)
         Threads::Threads
     )
 
+    # Focused FGO shard: keeps MultiSD/reference-switch/LAMBDA development
+    # independent of the monolithic test executable and its application
+    # dependencies. This is intentionally the same source file so the shard
+    # and full CI suite cannot drift to different assertions.
+    add_executable(gnss_fgo_tests
+        test_fgo.cpp
+        ${CMAKE_SOURCE_DIR}/src/core/solution.cpp
+        ${CMAKE_SOURCE_DIR}/src/core/types.cpp
+    )
+
+    add_executable(gnss_fgo_multisd_smoke
+        fgo_multisd_smoke.cpp
+        ${CMAKE_SOURCE_DIR}/src/core/solution.cpp
+        ${CMAKE_SOURCE_DIR}/src/core/types.cpp
+    )
+    target_link_libraries(gnss_fgo_multisd_smoke
+        gnss_lib_noopt
+        Threads::Threads
+    )
+    target_compile_definitions(gnss_fgo_tests PRIVATE
+        GNSSPP_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
+        GNSSPP_BINARY_DIR="${CMAKE_BINARY_DIR}"
+    )
+    target_link_libraries(gnss_fgo_tests
+        gnss_lib_noopt
+        GTest::GTest
+        GTest::Main
+        Threads::Threads
+    )
+
     # Add test to CTest
     add_test(NAME run_tests COMMAND gnss_run_tests)
     add_test(
@@ -191,6 +221,8 @@ if(GTest_FOUND)
                 --gtest_filter=*MadocaParity*:MadocaBridgeConfig.*
     )
     add_test(NAME integrity_tests COMMAND gnss_integrity_tests)
+    add_test(NAME fgo_tests COMMAND gnss_fgo_tests)
+    add_test(NAME fgo_multisd_smoke COMMAND gnss_fgo_multisd_smoke)
     add_test(
         NAME python_benchmark_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_benchmark_scripts.py

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -193,6 +193,10 @@ if(GTest_FOUND)
         gnss_lib_noopt
         Threads::Threads
     )
+    if(GNSSPP_ENABLE_CUDA_FGO)
+        target_compile_definitions(gnss_fgo_multisd_smoke PRIVATE
+            GNSSPP_TEST_HAS_CUDA_FGO=1)
+    endif()
     target_compile_definitions(gnss_fgo_tests PRIVATE
         GNSSPP_SOURCE_DIR="${CMAKE_SOURCE_DIR}"
         GNSSPP_BINARY_DIR="${CMAKE_BINARY_DIR}"

--- a/tests/fgo_multisd_smoke.cpp
+++ b/tests/fgo_multisd_smoke.cpp
@@ -1,0 +1,156 @@
+#include <libgnss++/algorithms/fgo.hpp>
+#include <libgnss++/core/constants.hpp>
+
+#include <array>
+#include <cmath>
+#include <iostream>
+#include <vector>
+
+using namespace libgnss;
+
+namespace {
+
+double ddGeometry(const Vector3d& rover,
+                  const Vector3d& base,
+                  const Vector3d& satellite,
+                  const Vector3d& reference) {
+    return ((satellite - rover).norm() - (satellite - base).norm()) -
+           ((reference - rover).norm() - (reference - base).norm());
+}
+
+int fail(const char* message) {
+    std::cerr << "MultiSD smoke failure: " << message << '\n';
+    return 1;
+}
+
+}  // namespace
+
+int main() {
+    const std::vector<Vector3d> satellites = {
+        {15600000.0, 7540000.0, 20140000.0},
+        {-18760000.0, 2750000.0, 18610000.0},
+        {17610000.0, -14630000.0, 13480000.0},
+        {19170000.0, 610000.0, -18390000.0},
+        {-13480000.0, -15600000.0, 17760000.0},
+        {21700000.0, 13000000.0, 9000000.0},
+    };
+    std::vector<Vector3d> rover_positions;
+    rover_positions.reserve(80);
+    const Vector3d first_rover(1113194.0, -4841695.0, 3985350.0);
+    const Vector3d epoch_motion(2.5, 1.0, -0.6);
+    for (int epoch = 0; epoch < 80; ++epoch) {
+        rover_positions.push_back(first_rover + epoch * epoch_motion);
+    }
+    const Vector3d base_position =
+        first_rover + Vector3d(-320.0, 180.0, 45.0);
+    const double wavelength = constants::GPS_L1_WAVELENGTH;
+
+    FGOProcessor::FGOProblem problem;
+    for (std::size_t sat = 0; sat < satellites.size(); ++sat) {
+        FGOProcessor::AmbiguityState ambiguity;
+        ambiguity.satellite =
+            SatelliteId(GNSSSystem::GPS,
+                        static_cast<uint8_t>(sat + 1));
+        ambiguity.signal = SignalType::GPS_L1CA;
+        ambiguity.wavelength_m = wavelength;
+        ambiguity.initial_ambiguity_m =
+            wavelength * static_cast<double>(96 + sat);
+        ambiguity.is_double_difference = false;
+        problem.ambiguity_states.push_back(ambiguity);
+    }
+
+    for (std::size_t epoch = 0; epoch < rover_positions.size(); ++epoch) {
+        FGOProcessor::EpochSeed seed;
+        seed.time = GNSSTime(2300, 100000.0 + epoch);
+        seed.position_ecef =
+            rover_positions[epoch] + Vector3d(35.0, -18.0, 12.0);
+        problem.epochs.push_back(seed);
+
+        for (std::size_t sat = 1; sat < satellites.size(); ++sat) {
+            const double geometry = ddGeometry(
+                rover_positions[epoch], base_position, satellites[sat],
+                satellites[0]);
+
+            FGOProcessor::DoubleDifferencePseudorangeFactor code;
+            code.epoch_index = epoch;
+            code.satellite = SatelliteId(
+                GNSSSystem::GPS, static_cast<uint8_t>(sat + 1));
+            code.reference_satellite = SatelliteId(GNSSSystem::GPS, 1);
+            code.rover_satellite_position_ecef = satellites[sat];
+            code.rover_reference_position_ecef = satellites[0];
+            code.base_satellite_position_ecef = satellites[sat];
+            code.base_reference_position_ecef = satellites[0];
+            code.base_position_ecef = base_position;
+            code.observed_dd_pseudorange_m = geometry;
+            code.sigma_m = 0.5;
+            problem.double_difference_pseudorange_factors.push_back(code);
+
+            FGOProcessor::DoubleDifferenceCarrierFactor carrier;
+            carrier.epoch_index = epoch;
+            carrier.ambiguity_index = sat;
+            carrier.reference_ambiguity_index = 0;
+            carrier.use_ambiguity_difference = true;
+            carrier.satellite = code.satellite;
+            carrier.reference_satellite = code.reference_satellite;
+            carrier.rover_satellite_position_ecef = satellites[sat];
+            carrier.rover_reference_position_ecef = satellites[0];
+            carrier.base_satellite_position_ecef = satellites[sat];
+            carrier.base_reference_position_ecef = satellites[0];
+            carrier.base_position_ecef = base_position;
+            carrier.observed_dd_carrier_m =
+                geometry + wavelength * static_cast<double>(sat);
+            carrier.sigma_m = 0.01;
+            problem.double_difference_carrier_factors.push_back(carrier);
+        }
+    }
+
+    FGOProcessor::FGOConfig config;
+    config.max_iterations = 12;
+    config.convergence_threshold_m = 1e-8;
+    config.use_motion_factors = false;
+    config.use_multisd_ambiguities = true;
+    config.fix_ambiguities = true;
+    config.use_lambda_ambiguity_fix = true;
+    config.lambda_top_k_candidates = 4;
+    config.lambda_ratio_threshold = 1.5;
+    config.min_fixed_ambiguities = 4;
+    config.ambiguity_prior_sigma_m = 1000.0;
+    config.fixed_ambiguity_sigma_m = 1e-4;
+
+    const auto result = FGOProcessor(config).optimizeProblem(problem);
+    if (!result.diagnostics.lambda_ambiguity_fix_solved ||
+        !result.diagnostics.lambda_ambiguity_fix_used ||
+        !result.diagnostics.fixed_solution) {
+        return fail("BSD LAMBDA candidate was not accepted");
+    }
+    if (result.diagnostics.fixed_ambiguities != 5 ||
+        result.diagnostics.lambda_top_k_generated != 4) {
+        return fail("unexpected BSD/top-K candidate count");
+    }
+    if (!(result.diagnostics.lambda_bootstrapped_success_rate > 0.0) ||
+        !std::isfinite(result.diagnostics.lambda_adop_cycles) ||
+        !(result.diagnostics.lambda_adop_cycles > 0.0)) {
+        return fail("invalid success-rate or ADOP diagnostics");
+    }
+    if (result.ambiguity_estimates.size() != satellites.size()) {
+        return fail("missing SD ambiguity estimates");
+    }
+    for (const auto& estimate : result.ambiguity_estimates) {
+        if (estimate.is_fixed) {
+            return fail("gauge-dependent SD state was labelled fixed");
+        }
+    }
+    for (std::size_t sat = 1; sat < satellites.size(); ++sat) {
+        const double bsd =
+            result.ambiguity_estimates[sat].ambiguity_cycles -
+            result.ambiguity_estimates[0].ambiguity_cycles;
+        if (std::abs(bsd - static_cast<double>(sat)) > 1e-4) {
+            return fail("fixed BSD does not match integer truth");
+        }
+    }
+
+    std::cout << "MultiSD smoke passed: BSD=5 topK=4 success_rate="
+              << result.diagnostics.lambda_bootstrapped_success_rate
+              << " ADOP=" << result.diagnostics.lambda_adop_cycles << '\n';
+    return 0;
+}

--- a/tests/fgo_multisd_smoke.cpp
+++ b/tests/fgo_multisd_smoke.cpp
@@ -240,6 +240,30 @@ int main() {
         return fail("independent carrier corruption was not rejected");
     }
 
+    // A single latest-epoch carrier outlier is recoverable only when a causal
+    // history supplies enough disjoint evidence. Persistent/multi-satellite
+    // corruption above remains rejected.
+    auto isolated_outlier_problem = problem;
+    for (auto& carrier :
+         isolated_outlier_problem.double_difference_carrier_factors) {
+        if (carrier.epoch_index + 1 == rover_positions.size() &&
+            carrier.satellite == SatelliteId(GNSSSystem::GPS, 2)) {
+            carrier.observed_dd_carrier_m += 0.35 * wavelength;
+        }
+    }
+    auto temporal_config = config;
+    temporal_config.multisd_validation_history_epochs = 3;
+    temporal_config.multisd_validation_min_carrier_fraction = 0.75;
+    const auto temporal = FGOProcessor(temporal_config).optimizeProblem(
+        isolated_outlier_problem);
+    if (!temporal.diagnostics.multisd_validation_evaluated ||
+        !temporal.diagnostics.multisd_validation_pass ||
+        !temporal.diagnostics.fixed_solution ||
+        temporal.diagnostics.multisd_validation_carrier_used < 12 ||
+        temporal.diagnostics.multisd_validation_carrier_passed < 9) {
+        return fail("causal carrier history did not tolerate one outlier");
+    }
+
     auto insufficient_config = config;
     insufficient_config.multisd_validation_holdout_satellites = 20;
     const auto insufficient =

--- a/tests/fgo_multisd_smoke.cpp
+++ b/tests/fgo_multisd_smoke.cpp
@@ -3,7 +3,9 @@
 
 #include <array>
 #include <cmath>
+#include <cstdlib>
 #include <iostream>
+#include <string>
 #include <vector>
 
 using namespace libgnss;
@@ -124,6 +126,26 @@ int main() {
     config.multisd_validation_holdout_satellites = 4;
 
     const auto result = FGOProcessor(config).optimizeProblem(problem);
+#ifdef GNSSPP_TEST_HAS_CUDA_FGO
+    const char* cuda_mode = std::getenv("GNSSPP_FGO_CUDA_SOLVER");
+    const bool forced_cuda = cuda_mode != nullptr &&
+                             (std::string(cuda_mode) == "on" ||
+                              std::string(cuda_mode) == "1");
+    if (forced_cuda &&
+        (!result.diagnostics.cuda_dense_solver_selected ||
+         result.diagnostics.cuda_dense_solve_attempts == 0 ||
+         result.diagnostics.cuda_dense_solve_successes !=
+             result.diagnostics.cuda_dense_solve_attempts ||
+         result.diagnostics.cuda_dense_solve_fallbacks != 0 ||
+         !(result.diagnostics.cuda_dense_solve_time_ms > 0.0))) {
+        return fail("forced CUDA solve was not exercised successfully");
+    }
+    if (!forced_cuda &&
+        (result.diagnostics.cuda_dense_solver_selected ||
+         result.diagnostics.cuda_dense_solve_attempts != 0)) {
+        return fail("CUDA solve was unexpectedly selected");
+    }
+#endif
     if (!result.diagnostics.lambda_ambiguity_fix_solved ||
         !result.diagnostics.lambda_ambiguity_fix_used ||
         !result.diagnostics.fixed_solution) {

--- a/tests/fgo_multisd_smoke.cpp
+++ b/tests/fgo_multisd_smoke.cpp
@@ -124,6 +124,7 @@ int main() {
     config.fixed_ambiguity_sigma_m = 1e-4;
     config.use_multisd_disjoint_validation = true;
     config.multisd_validation_holdout_satellites = 4;
+    config.multisd_validation_max_fixed_float_separation_m = 0.0;
 
     const auto result = FGOProcessor(config).optimizeProblem(problem);
 #ifdef GNSSPP_TEST_HAS_CUDA_FGO
@@ -161,6 +162,12 @@ int main() {
         result.diagnostics.multisd_validation_carrier_used < 4 ||
         result.diagnostics.multisd_validation_pseudorange_used < 4) {
         return fail("disjoint validation did not pass clean holdout data");
+    }
+    if (!std::isfinite(
+            result.diagnostics
+                .multisd_validation_fixed_float_separation_m) ||
+        !(result.diagnostics.multisd_validation_fixed_float_separation_m >= 0.0)) {
+        return fail("fixed/float separation diagnostic was not recorded");
     }
     if (!(result.diagnostics.lambda_bootstrapped_success_rate > 0.0) ||
         !std::isfinite(result.diagnostics.lambda_adop_cycles) ||

--- a/tests/fgo_multisd_smoke.cpp
+++ b/tests/fgo_multisd_smoke.cpp
@@ -178,6 +178,19 @@ int main() {
         return fail("missing SD ambiguity estimates");
     }
 
+    auto constellation_config = config;
+    constellation_config.use_constellation_ranked_partial_ar = true;
+    const auto constellation_result =
+        FGOProcessor(constellation_config).optimizeProblem(problem);
+    if (!constellation_result.diagnostics.fixed_solution ||
+        !constellation_result.diagnostics.multisd_validation_pass ||
+        constellation_result.solution.solutions.empty() ||
+        result.solution.solutions.empty() ||
+        (constellation_result.solution.solutions.back().position_ecef -
+         result.solution.solutions.back().position_ecef).norm() > 1e-9) {
+        return fail("constellation PAR changed the clean all-GPS solution");
+    }
+
     auto parallel_config = config;
     parallel_config.parallelize_lambda_hypotheses = true;
     const auto parallel_result =

--- a/tests/fgo_multisd_smoke.cpp
+++ b/tests/fgo_multisd_smoke.cpp
@@ -33,6 +33,10 @@ int main() {
         {19170000.0, 610000.0, -18390000.0},
         {-13480000.0, -15600000.0, 17760000.0},
         {21700000.0, 13000000.0, 9000000.0},
+        {-21100000.0, 8100000.0, -13200000.0},
+        {9200000.0, 22400000.0, 10600000.0},
+        {-6400000.0, 17100000.0, 19300000.0},
+        {24100000.0, -7400000.0, 6300000.0},
     };
     std::vector<Vector3d> rover_positions;
     rover_positions.reserve(80);
@@ -116,6 +120,8 @@ int main() {
     config.min_fixed_ambiguities = 4;
     config.ambiguity_prior_sigma_m = 1000.0;
     config.fixed_ambiguity_sigma_m = 1e-4;
+    config.use_multisd_disjoint_validation = true;
+    config.multisd_validation_holdout_satellites = 4;
 
     const auto result = FGOProcessor(config).optimizeProblem(problem);
     if (!result.diagnostics.lambda_ambiguity_fix_solved ||
@@ -126,6 +132,13 @@ int main() {
     if (result.diagnostics.fixed_ambiguities != 5 ||
         result.diagnostics.lambda_top_k_generated != 4) {
         return fail("unexpected BSD/top-K candidate count");
+    }
+    if (!result.diagnostics.multisd_validation_evaluated ||
+        !result.diagnostics.multisd_validation_pass ||
+        result.diagnostics.multisd_validation_holdout_satellites != 4 ||
+        result.diagnostics.multisd_validation_carrier_used < 4 ||
+        result.diagnostics.multisd_validation_pseudorange_used < 4) {
+        return fail("disjoint validation did not pass clean holdout data");
     }
     if (!(result.diagnostics.lambda_bootstrapped_success_rate > 0.0) ||
         !std::isfinite(result.diagnostics.lambda_adop_cycles) ||
@@ -147,6 +160,46 @@ int main() {
         if (std::abs(bsd - static_cast<double>(sat)) > 1e-4) {
             return fail("fixed BSD does not match integer truth");
         }
+    }
+
+    // PRN 2 and 3 are the deterministic holdouts (all elevations tie, so the
+    // satellite-id tie-break decides). Corrupting only their latest carrier
+    // evidence cannot change the float/LAMBDA candidate, but must veto FIX.
+    auto corrupt_problem = problem;
+    for (auto& carrier : corrupt_problem.double_difference_carrier_factors) {
+        if (carrier.epoch_index + 1 == rover_positions.size() &&
+            carrier.satellite == SatelliteId(GNSSSystem::GPS, 2)) {
+            carrier.observed_dd_carrier_m += 0.35 * wavelength;
+        }
+        if (carrier.epoch_index + 1 == rover_positions.size() &&
+            carrier.satellite == SatelliteId(GNSSSystem::GPS, 3)) {
+            carrier.observed_dd_carrier_m -= 0.31 * wavelength;
+        }
+        if (carrier.epoch_index + 1 == rover_positions.size() &&
+            carrier.satellite == SatelliteId(GNSSSystem::GPS, 4)) {
+            carrier.observed_dd_carrier_m += 0.27 * wavelength;
+        }
+        if (carrier.epoch_index + 1 == rover_positions.size() &&
+            carrier.satellite == SatelliteId(GNSSSystem::GPS, 5)) {
+            carrier.observed_dd_carrier_m -= 0.23 * wavelength;
+        }
+    }
+    const auto rejected = FGOProcessor(config).optimizeProblem(corrupt_problem);
+    if (!rejected.diagnostics.multisd_validation_evaluated ||
+        rejected.diagnostics.multisd_validation_pass ||
+        rejected.diagnostics.fixed_solution ||
+        rejected.diagnostics.lambda_ambiguity_fix_used) {
+        return fail("independent carrier corruption was not rejected");
+    }
+
+    auto insufficient_config = config;
+    insufficient_config.multisd_validation_holdout_satellites = 20;
+    const auto insufficient =
+        FGOProcessor(insufficient_config).optimizeProblem(problem);
+    if (insufficient.diagnostics.multisd_validation_evaluated ||
+        insufficient.diagnostics.multisd_validation_pass ||
+        insufficient.diagnostics.fixed_solution) {
+        return fail("insufficient holdout evidence did not fail closed");
     }
 
     std::cout << "MultiSD smoke passed: BSD=5 topK=4 success_rate="

--- a/tests/fgo_multisd_smoke.cpp
+++ b/tests/fgo_multisd_smoke.cpp
@@ -148,6 +148,25 @@ int main() {
     if (result.ambiguity_estimates.size() != satellites.size()) {
         return fail("missing SD ambiguity estimates");
     }
+
+    auto parallel_config = config;
+    parallel_config.parallelize_lambda_hypotheses = true;
+    const auto parallel_result =
+        FGOProcessor(parallel_config).optimizeProblem(problem);
+    if (parallel_result.diagnostics.fixed_solution !=
+            result.diagnostics.fixed_solution ||
+        parallel_result.diagnostics.multisd_validation_pass !=
+            result.diagnostics.multisd_validation_pass ||
+        parallel_result.diagnostics.multisd_validation_selected_rank !=
+            result.diagnostics.multisd_validation_selected_rank ||
+        parallel_result.multisd_validation_hypotheses.size() !=
+            result.multisd_validation_hypotheses.size() ||
+        parallel_result.solution.solutions.empty() ||
+        result.solution.solutions.empty() ||
+        (parallel_result.solution.solutions.back().position_ecef -
+         result.solution.solutions.back().position_ecef).norm() > 1e-9) {
+        return fail("parallel top-K result differs from sequential result");
+    }
     for (const auto& estimate : result.ambiguity_estimates) {
         if (estimate.is_fixed) {
             return fail("gauge-dependent SD state was labelled fixed");

--- a/tests/test_fgo.cpp
+++ b/tests/test_fgo.cpp
@@ -838,6 +838,57 @@ TEST(FGOTest, DoubleDifferenceCarrierFactorsConstrainAmbiguityDifferences) {
     }
 }
 
+TEST(FGOTest, MultiSdLambdaFixesBsdDifferencesWithoutFixingSdGauge) {
+    FGOProcessor::FGOConfig config;
+    config.max_iterations = 12;
+    config.convergence_threshold_m = 1e-8;
+    config.use_motion_factors = false;
+    config.use_multisd_ambiguities = true;
+    config.fix_ambiguities = true;
+    config.use_lambda_ambiguity_fix = true;
+    config.lambda_top_k_candidates = 4;
+    config.lambda_ratio_threshold = 1.5;
+    config.min_fixed_ambiguities = 4;
+    config.double_difference_carrier_sigma_m = 0.01;
+    config.ambiguity_prior_sigma_m = 1000.0;
+    config.fixed_ambiguity_sigma_m = 1e-4;
+
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(
+        makeSyntheticDoubleDifferenceProblem(true));
+
+    ASSERT_EQ(result.solution.size(), 2u);
+    EXPECT_TRUE(result.diagnostics.lambda_ambiguity_fix_solved);
+    EXPECT_TRUE(result.diagnostics.lambda_ambiguity_fix_used);
+    EXPECT_TRUE(result.diagnostics.fixed_solution);
+    EXPECT_EQ(result.diagnostics.lambda_ambiguity_candidates, 5u);
+    EXPECT_EQ(result.diagnostics.lambda_ambiguity_used_candidates, 5u);
+    EXPECT_EQ(result.diagnostics.lambda_top_k_generated, 4u);
+    EXPECT_GT(result.diagnostics.lambda_bootstrapped_success_rate, 0.0);
+    EXPECT_TRUE(std::isfinite(result.diagnostics.lambda_adop_cycles));
+    EXPECT_GT(result.diagnostics.lambda_adop_cycles, 0.0);
+    EXPECT_EQ(result.diagnostics.fixed_ambiguities, 5u);
+    EXPECT_EQ(result.solution.solutions[0].num_fixed_ambiguities, 5);
+    EXPECT_EQ(result.solution.solutions[0].status, SolutionStatus::FIXED);
+    EXPECT_LT(result.diagnostics.fixed_ambiguity_residual_rms_cycles, 1e-4);
+
+    // The accepted integers constrain N_sat-N_ref. No individual SD state
+    // is labelled fixed because its common gauge remains unobservable.
+    ASSERT_EQ(result.ambiguity_estimates.size(), 6u);
+    for (const auto& estimate : result.ambiguity_estimates) {
+        EXPECT_FALSE(estimate.is_fixed);
+    }
+    for (std::size_t sat = 1; sat < result.ambiguity_estimates.size(); ++sat) {
+        const double fixed_bsd_cycles =
+            result.ambiguity_estimates[sat].ambiguity_cycles -
+            result.ambiguity_estimates[0].ambiguity_cycles;
+        EXPECT_NEAR(fixed_bsd_cycles,
+                    static_cast<double>(trueAmbiguityCycles(sat) -
+                                        trueAmbiguityCycles(0)),
+                    1e-4);
+    }
+}
+
 TEST(FGOTest, DoubleDifferencePseudorangeFactorsRecoverSyntheticGeometry) {
     FGOProcessor::FGOConfig config;
     config.max_iterations = 12;
@@ -1507,6 +1558,85 @@ TEST(FGOTest, CmcAwareReferenceSelectionAvoidsExcludedReference) {
         }
         EXPECT_TRUE(found_epoch3_factor);
         EXPECT_EQ(problem.diagnostics.cmc_ref_avoided_count, 2u);
+    }
+}
+
+TEST(FGOTest, MultiSdAmbiguitySurvivesDdReferenceChange) {
+    const NavigationData nav = makeSyntheticGpsNavigation(3);
+    const Vector3d rover_position(1113194.0, -4841695.0, 3985350.0);
+    const Vector3d base_position =
+        rover_position + Vector3d(-320.0, 180.0, 45.0);
+
+    const std::vector<std::array<double, 3>> zero_bias =
+        {{0.0, 0.0, 0.0}};
+    const auto probe_rover = makeCmcObservationEpochsThreeSat(
+        nav, rover_position, zero_bias, 1.0);
+    const auto probe_base = makeCmcObservationEpochsThreeSat(
+        nav, base_position, zero_bias, 1.0);
+    FGOProcessor probe_processor(makeCmcTestConfig());
+    const auto probe_problem = probe_processor.buildDoubleDifferenceProblem(
+        probe_rover, probe_base, nav, base_position);
+    ASSERT_FALSE(probe_problem.double_difference_carrier_factors.empty());
+    const SatelliteId old_reference =
+        probe_problem.double_difference_carrier_factors.front()
+            .reference_satellite;
+
+    FGOProcessor::FGOConfig config = makeCmcTestConfig();
+    config.use_multisd_ambiguities = true;
+    config.cmc_aware_reference_selection = true;
+    config.code_minus_carrier_jump_threshold_m = 1000.0;
+    config.code_minus_carrier_level_threshold_m = 0.4;
+    config.code_minus_carrier_warmup_epochs = 3;
+
+    std::vector<std::array<double, 3>> base_bias(
+        4, std::array<double, 3>{0.0, 0.0, 0.0});
+    base_bias[3][static_cast<std::size_t>(old_reference.prn) - 1] = 1.0;
+    const std::vector<std::array<double, 3>> rover_bias(
+        4, std::array<double, 3>{0.0, 0.0, 0.0});
+    const auto rover_epochs = makeCmcObservationEpochsThreeSat(
+        nav, rover_position, rover_bias, 1.0);
+    const auto base_epochs = makeCmcObservationEpochsThreeSat(
+        nav, base_position, base_bias, 1.0);
+
+    FGOProcessor processor(config);
+    const auto problem = processor.buildDoubleDifferenceProblem(
+        rover_epochs, base_epochs, nav, base_position);
+
+    const FGOProcessor::DoubleDifferenceCarrierFactor* switched = nullptr;
+    for (const auto& factor : problem.double_difference_carrier_factors) {
+        EXPECT_TRUE(factor.use_ambiguity_difference);
+        EXPECT_LT(factor.ambiguity_index, problem.ambiguity_states.size());
+        EXPECT_LT(factor.reference_ambiguity_index,
+                  problem.ambiguity_states.size());
+        EXPECT_NE(factor.ambiguity_index, factor.reference_ambiguity_index);
+        if (factor.epoch_index == 3) {
+            switched = &factor;
+        }
+    }
+    ASSERT_NE(switched, nullptr);
+    EXPECT_FALSE(switched->reference_satellite == old_reference);
+
+    // The satellite that remains the target after the reference switch must
+    // point to the exact same SD ambiguity state used in the prior epoch.
+    // A DD-keyed graph would allocate a new state here solely because the
+    // reference changed.
+    bool found_prior_state = false;
+    for (const auto& factor : problem.double_difference_carrier_factors) {
+        if (factor.epoch_index != 2) {
+            continue;
+        }
+        if (factor.satellite == switched->satellite) {
+            EXPECT_EQ(factor.ambiguity_index, switched->ambiguity_index);
+            found_prior_state = true;
+        } else if (factor.reference_satellite == switched->satellite) {
+            EXPECT_EQ(factor.reference_ambiguity_index,
+                      switched->ambiguity_index);
+            found_prior_state = true;
+        }
+    }
+    EXPECT_TRUE(found_prior_state);
+    for (const auto& ambiguity : problem.ambiguity_states) {
+        EXPECT_FALSE(ambiguity.is_double_difference);
     }
 }
 

--- a/tests/test_gnss_solve_cli.py
+++ b/tests/test_gnss_solve_cli.py
@@ -63,6 +63,18 @@ class GnssSolveCliTest(unittest.TestCase):
         self.assertIn(
             "--multisd-fgo-shadow-max-seed-separation", result.stdout
         )
+        self.assertIn(
+            "--multisd-fgo-shadow-validation-history", result.stdout
+        )
+        self.assertIn(
+            "--multisd-fgo-shadow-min-carrier-fraction", result.stdout
+        )
+        self.assertIn(
+            "--multisd-fgo-shadow-min-fixed-ambiguities", result.stdout
+        )
+        self.assertIn(
+            "--multisd-fgo-shadow-holdout-satellites", result.stdout
+        )
 
     def test_config_supplies_defaults_and_cli_always_overrides_them(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_solve_config_") as temp_dir:

--- a/tests/test_gnss_solve_cli.py
+++ b/tests/test_gnss_solve_cli.py
@@ -60,6 +60,9 @@ class GnssSolveCliTest(unittest.TestCase):
         self.assertIn("--fixed-bridge-burst-max-residual", result.stdout)
         self.assertIn("--multisd-fgo-shadow-csv", result.stdout)
         self.assertIn("--multisd-fgo-shadow-window", result.stdout)
+        self.assertIn(
+            "--multisd-fgo-shadow-max-seed-separation", result.stdout
+        )
 
     def test_config_supplies_defaults_and_cli_always_overrides_them(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_solve_config_") as temp_dir:

--- a/tests/test_gnss_solve_cli.py
+++ b/tests/test_gnss_solve_cli.py
@@ -82,6 +82,12 @@ class GnssSolveCliTest(unittest.TestCase):
             "--multisd-fgo-shadow-variance-ranked-par", result.stdout
         )
         self.assertIn(
+            "--multisd-fgo-shadow-interleave-constellation-par", result.stdout
+        )
+        self.assertIn(
+            "--multisd-fgo-shadow-quality-ranked-par", result.stdout
+        )
+        self.assertIn(
             "--multisd-fgo-shadow-candidate-ratio", result.stdout
         )
         self.assertIn(

--- a/tests/test_gnss_solve_cli.py
+++ b/tests/test_gnss_solve_cli.py
@@ -104,6 +104,7 @@ class GnssSolveCliTest(unittest.TestCase):
         )
         self.assertIn("--multisd-fgo-shadow-min-bsr", result.stdout)
         self.assertIn("--multisd-fgo-shadow-max-adop", result.stdout)
+        self.assertIn("--multisd-fgo-shadow-fallback-min-bsr", result.stdout)
 
     def test_config_supplies_defaults_and_cli_always_overrides_them(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_solve_config_") as temp_dir:
@@ -168,6 +169,10 @@ class GnssSolveCliTest(unittest.TestCase):
             "--data-dir", "missing",
             "--multisd-fgo-shadow-max-adop", "-0.01"
         )
+        fallback_bsr = self.run_solve(
+            "--data-dir", "missing",
+            "--multisd-fgo-shadow-fallback-min-bsr", "1.01"
+        )
 
         self.assertEqual(ratio.returncode, 1)
         self.assertIn("candidate-ratio must be >= 1", ratio.stderr)
@@ -181,6 +186,8 @@ class GnssSolveCliTest(unittest.TestCase):
         self.assertIn("min-bsr must be in [0, 1]", bsr.stderr)
         self.assertEqual(adop.returncode, 1)
         self.assertIn("max-adop must be >= 0", adop.stderr)
+        self.assertEqual(fallback_bsr.returncode, 1)
+        self.assertIn("fallback-min-bsr must be in [0, 1]", fallback_bsr.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_gnss_solve_cli.py
+++ b/tests/test_gnss_solve_cli.py
@@ -81,6 +81,12 @@ class GnssSolveCliTest(unittest.TestCase):
         self.assertIn(
             "--multisd-fgo-shadow-variance-ranked-par", result.stdout
         )
+        self.assertIn(
+            "--multisd-fgo-shadow-candidate-ratio", result.stdout
+        )
+        self.assertIn(
+            "--multisd-fgo-shadow-candidate-groups", result.stdout
+        )
 
     def test_config_supplies_defaults_and_cli_always_overrides_them(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_solve_config_") as temp_dir:
@@ -123,6 +129,21 @@ class GnssSolveCliTest(unittest.TestCase):
         self.assertEqual(result.returncode, 1)
         self.assertIn("unknown or incomplete argument: --this-option-does-not-exist",
                       result.stderr)
+
+    def test_multisd_candidate_controls_reject_unsafe_ranges(self) -> None:
+        ratio = self.run_solve(
+            "--data-dir", "missing",
+            "--multisd-fgo-shadow-candidate-ratio", "0.99"
+        )
+        groups = self.run_solve(
+            "--data-dir", "missing",
+            "--multisd-fgo-shadow-candidate-groups", "33"
+        )
+
+        self.assertEqual(ratio.returncode, 1)
+        self.assertIn("candidate-ratio must be >= 1", ratio.stderr)
+        self.assertEqual(groups.returncode, 1)
+        self.assertIn("candidate-groups must be in [1, 32]", groups.stderr)
 
 
 if __name__ == "__main__":

--- a/tests/test_gnss_solve_cli.py
+++ b/tests/test_gnss_solve_cli.py
@@ -87,6 +87,15 @@ class GnssSolveCliTest(unittest.TestCase):
         self.assertIn(
             "--multisd-fgo-shadow-candidate-groups", result.stdout
         )
+        self.assertIn(
+            "--multisd-fgo-shadow-fallback-consensus-groups", result.stdout
+        )
+        self.assertIn(
+            "--multisd-fgo-shadow-fallback-consensus-separation", result.stdout
+        )
+        self.assertIn(
+            "--multisd-fgo-shadow-fallback-max-seed-separation", result.stdout
+        )
 
     def test_config_supplies_defaults_and_cli_always_overrides_them(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_solve_config_") as temp_dir:
@@ -139,11 +148,19 @@ class GnssSolveCliTest(unittest.TestCase):
             "--data-dir", "missing",
             "--multisd-fgo-shadow-candidate-groups", "33"
         )
+        consensus = self.run_solve(
+            "--data-dir", "missing",
+            "--multisd-fgo-shadow-fallback-consensus-groups", "2"
+        )
 
         self.assertEqual(ratio.returncode, 1)
         self.assertIn("candidate-ratio must be >= 1", ratio.stderr)
         self.assertEqual(groups.returncode, 1)
         self.assertIn("candidate-groups must be in [1, 32]", groups.stderr)
+        self.assertEqual(consensus.returncode, 1)
+        self.assertIn(
+            "fallback-consensus-separation must be > 0", consensus.stderr
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_gnss_solve_cli.py
+++ b/tests/test_gnss_solve_cli.py
@@ -75,6 +75,12 @@ class GnssSolveCliTest(unittest.TestCase):
         self.assertIn(
             "--multisd-fgo-shadow-holdout-satellites", result.stdout
         )
+        self.assertIn(
+            "--multisd-fgo-shadow-constellation-par", result.stdout
+        )
+        self.assertIn(
+            "--multisd-fgo-shadow-variance-ranked-par", result.stdout
+        )
 
     def test_config_supplies_defaults_and_cli_always_overrides_them(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_solve_config_") as temp_dir:

--- a/tests/test_gnss_solve_cli.py
+++ b/tests/test_gnss_solve_cli.py
@@ -48,6 +48,7 @@ class GnssSolveCliTest(unittest.TestCase):
         self.assertIn("--help-advanced", result.stdout)
         self.assertNotIn("--rtk-adaptive-noise-alpha-phase", result.stdout)
         self.assertNotIn("--fixed-bridge-burst-max-residual", result.stdout)
+        self.assertNotIn("--multisd-fgo-shadow-csv", result.stdout)
         self.assertLess(len(result.stdout), 5000)
 
     def test_advanced_help_retains_research_option_discoverability(self) -> None:
@@ -57,6 +58,8 @@ class GnssSolveCliTest(unittest.TestCase):
         self.assertIn("--config <path>", result.stdout)
         self.assertIn("--rtk-adaptive-noise-alpha-phase", result.stdout)
         self.assertIn("--fixed-bridge-burst-max-residual", result.stdout)
+        self.assertIn("--multisd-fgo-shadow-csv", result.stdout)
+        self.assertIn("--multisd-fgo-shadow-window", result.stdout)
 
     def test_config_supplies_defaults_and_cli_always_overrides_them(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_solve_config_") as temp_dir:

--- a/tests/test_gnss_solve_cli.py
+++ b/tests/test_gnss_solve_cli.py
@@ -102,6 +102,8 @@ class GnssSolveCliTest(unittest.TestCase):
         self.assertIn(
             "--multisd-fgo-shadow-fallback-max-seed-separation", result.stdout
         )
+        self.assertIn("--multisd-fgo-shadow-min-bsr", result.stdout)
+        self.assertIn("--multisd-fgo-shadow-max-adop", result.stdout)
 
     def test_config_supplies_defaults_and_cli_always_overrides_them(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_solve_config_") as temp_dir:
@@ -158,6 +160,14 @@ class GnssSolveCliTest(unittest.TestCase):
             "--data-dir", "missing",
             "--multisd-fgo-shadow-fallback-consensus-groups", "2"
         )
+        bsr = self.run_solve(
+            "--data-dir", "missing",
+            "--multisd-fgo-shadow-min-bsr", "1.01"
+        )
+        adop = self.run_solve(
+            "--data-dir", "missing",
+            "--multisd-fgo-shadow-max-adop", "-0.01"
+        )
 
         self.assertEqual(ratio.returncode, 1)
         self.assertIn("candidate-ratio must be >= 1", ratio.stderr)
@@ -167,6 +177,10 @@ class GnssSolveCliTest(unittest.TestCase):
         self.assertIn(
             "fallback-consensus-separation must be > 0", consensus.stderr
         )
+        self.assertEqual(bsr.returncode, 1)
+        self.assertIn("min-bsr must be in [0, 1]", bsr.stderr)
+        self.assertEqual(adop.returncode, 1)
+        self.assertIn("max-adop must be >= 0", adop.stderr)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What changed

- adds reference-invariant single-difference ambiguity states and causal fixed-lag GNSS-only FGO factors
- validates top-K LAMBDA/PAR hypotheses with disjoint satellite and temporal evidence
- adds quality-ranked/fallback PAR controls and a fail-closed independent validator
- adds optional cuSOLVER dense solves and common-normal multi-RHS CUDA hypothesis evaluation
- exposes CLI diagnostics and adds CPU/CUDA parity, smoke, and CLI coverage

## Why

PPC urban runs need more correct ambiguity fixes without using IMU, LiDAR, camera, maps, or truth during estimation. Candidate generation previously stopped before validator-aware fallback groups and repeated each CUDA hypothesis factorization separately.

## Impact

All new acquisition paths remain opt-in/default-off. CPU behavior remains the production path for small PPC windows; CUDA `auto` retains its large-state threshold. Independent validation remains the only FIX authority.

## Validation

- CUDA CTest: `fgo_tests`, `fgo_multisd_smoke`, `python_gnss_solve_cli_tests` (3/3)
- six PPC 300-epoch CPU/CUDA decision parity: 1,047 correct FIX, 0 false, 0 >1 m
- accepted CPU/CUDA ECEF delta <=10 micrometres
- CUDA-enabled `auto` p95: 25.34–39.63 ms across six routes
- raw fault and ambiguity-arc audits are recorded in the parent repository research audit
