### PR TITLE
Gate residual reprieve with fresh SPP agreement

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,20 @@ epoch FIXED. Full Tokyo replays combined it with the anchor reprieve above:
 | Tokyo run2 | **6357 / 314** | **6357 / 314** | 0 / 3 |
 | Tokyo run3 | **9969 / 1002** | **9969 / 1002** | 0 / 4 |
 
+`--fix-demote-spp-model-reprieve` is a separate opt-in for the narrow case
+where the absolute DD-code residual is the only demotion reason. It keeps the
+FIXED label only for a fresh LAMBDA candidate with at least 10 fixed
+ambiguities, at most 2 cm separation from the IMU-predicted pose, and at most
+5 m separation from the current epoch's fresh standalone SPP/RAIM solution.
+A coasted or header-derived SPP seed fails closed. The 5 m threshold was
+frozen on Tokyo run1, validated unchanged on run2, and then applied once to
+held-out run3. Full implementation replays rescued 213/304/4 correct epochs
+and zero wrong epochs on runs 1/2/3 respectively; because most were stationary,
+the aggregate correct-FIX distance gain was 81.704 m (+0.242 pp), so this is
+a safe incremental guard rather than the complete FIX-rate target. Combined
+with the two preceding reprieves, correct-FIX distance is now approximately
+58.2153% (+1.1422 pp from 57.0731%); about 0.858 pp remains to the +2 pp goal.
+
 Across the three courses, distance-weighted correct FIX improved from
 57.0731% at the pre-reprieve baseline to **57.9735%**, while
 distance-weighted wrong FIX fell from 7.7043% to **7.0089%**. The policy is

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -194,6 +194,7 @@ struct Args {
     double fix_demote_anchor_gross_abs = -1.0;    // >=0: override fix_demote_anchor_gross_abs_m (default 20.0)
     bool fix_demote_surplus_crosscheck = false;   // enable fix_demote_surplus_crosscheck (needs --fix-demote + --surplus-validation)
     bool fix_demote_surplus_anchor_reprieve = false;  // fail-closed surplus + independent DDPR anchor preset
+    bool fix_demote_spp_model_reprieve = false;  // residual-only reprieve: strong LAMBDA/IMU + fresh SPP agreement
     bool surplus_overrides_dr = false;   // "c2" lever: enable surplus_validation_overrides_history_dr (needs --fixed-history-dr + --surplus-validation)
     int surplus_overrides_dr_min_used = 0;  // >0: override surplus_validation_overrides_history_dr_min_surplus_used (default 0 = no extra floor)
     int surplus_overrides_dr_max_consec = 0;  // >0: override surplus_validation_overrides_history_dr_max_consecutive (default 0 = no cap)
@@ -332,6 +333,10 @@ Args parseArgs(int argc, char** argv) {
         if (a == "--fix-demote-surplus-anchor-reprieve") {
             args.fix_demote_surplus_crosscheck = true;
             args.fix_demote_surplus_anchor_reprieve = true;
+            continue;
+        }
+        if (a == "--fix-demote-spp-model-reprieve") {
+            args.fix_demote_spp_model_reprieve = true;
             continue;
         }
         if (a == "--cmc-ref") {
@@ -843,6 +848,9 @@ libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
     }
     if (args.fix_demote_surplus_anchor_reprieve) {
         config.fix_demote_surplus_anchor_reprieve = true;
+    }
+    if (args.fix_demote_spp_model_reprieve) {
+        config.fix_demote_spp_model_reprieve = true;
     }
     if (args.leaky_persist) {
         config.use_cp_hold_leaky_persist = true;
@@ -2652,6 +2660,10 @@ int main(int argc, char** argv) {
                   << ", surplus_anchor_reprieve="
                   << (args.fix_demote_surplus_anchor_reprieve ? "on" : "off")
                   << ", surplus_reprieves=" << fl.diagnostics.fix_plausibility_surplus_reprieves
+                  << ", spp_model_reprieve="
+                  << (args.fix_demote_spp_model_reprieve ? "on" : "off")
+                  << ", spp_model_reprieves="
+                  << fl.diagnostics.fix_plausibility_spp_model_reprieves
                   << ", distance_m=" << config.fix_demote_distance_m
                   << ", anchor=" << (args.fix_demote_anchor ? "on" : "off")
                   << ", anchor_distance_m=" << config.fix_demote_anchor_distance_m

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -1070,6 +1070,19 @@ public:
         double fix_demote_surplus_anchor_max_float_separation_m = 1.0;
         double fix_demote_surplus_anchor_max_postfit_ddcp_rms_m = 0.1;
         double fix_demote_surplus_anchor_max_gap_m = 8.0;
+        // Residual-only demotion reprieve backed by two witnesses that do
+        // not use the DD pseudorange residual which triggered the demotion:
+        // a strong LAMBDA/IMU model and this epoch's fresh standalone SPP
+        // solution. The reprieve is fail-closed and label-only. It never
+        // applies when distance, post-hold, relative-residual, or DDPR-anchor
+        // demotion also fires, when the LAMBDA candidate is stale/missing,
+        // or when the builder had to coast an older SPP seed. Defaults are
+        // frozen from Tokyo run1, validated unchanged on run2, then audited
+        // once on held-out run3 (521 correct / 0 wrong rescued epochs).
+        bool fix_demote_spp_model_reprieve = false;
+        int fix_demote_spp_model_min_fixed_ambiguities = 10;
+        double fix_demote_spp_model_max_imu_separation_m = 0.02;
+        double fix_demote_spp_model_max_agreement_m = 5.0;
 
         // --- Exception recovery (port of recovery.py's handle_solve_exception)
         // ---
@@ -1813,6 +1826,7 @@ public:
         std::size_t fix_plausibility_anchor_gross_gated = 0;  ///< anchor-gap evaluations skipped by the gross-offender gate (fix_demote_anchor_gross)
         std::size_t fix_plausibility_hold_skips = 0;  ///< fix-and-hold pinnings skipped on implausible epochs
         std::size_t fix_plausibility_surplus_reprieves = 0;  ///< demotions skipped because fix_demote_surplus_crosscheck's verdict passed
+        std::size_t fix_plausibility_spp_model_reprieves = 0;  ///< residual-only demotions skipped by fresh-SPP/model agreement
         // --- Exception recovery diagnostics (use_solve_exception_recovery) ---
         std::size_t solve_exception_recoveries = 0;   ///< loose-prior retries that succeeded
         std::size_t solve_exception_warm_resets = 0;  ///< full smoother re-creations

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -4580,13 +4580,30 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             const Point3 fix_ant =
                 epoch_has_fixed[i] ? Point3(epoch_fixed_position[i]) : antennaOf(pose_i);
             const double gap = (fix_ant - antennaOf(pose_seed)).norm();
-            bool demote = gap > config.fix_demote_distance_m;
+            const bool distance_demote = gap > config.fix_demote_distance_m;
+            const bool residual_demote =
+                config.fix_demote_res_m > 0.0 &&
+                ddpr_rms > config.fix_demote_res_m;
+            const bool posthold_demote =
+                config.fix_demote_posthold_epochs > 0 &&
+                static_cast<long long>(i) - last_held_epoch <=
+                    static_cast<long long>(config.fix_demote_posthold_epochs);
+            bool relative_residual_demote = false;
+            if (config.fix_demote_res_rel > 0.0 && recent_ddpr_rms.size() >= 20) {
+                std::vector<double> h(recent_ddpr_rms.begin(), recent_ddpr_rms.end());
+                std::nth_element(h.begin(), h.begin() + h.size() / 2, h.end());
+                const double med = h[h.size() / 2];
+                relative_residual_demote =
+                    ddpr_rms > config.cp_hold_main_residual_threshold_m &&
+                    ddpr_rms > config.fix_demote_res_rel * med;
+            }
+            bool demote = distance_demote;
             // Extreme-residual variant (fix_demote_res_m): an epoch whose own
             // post-fit DDPR RMS is in the tens of metres cannot be a
             // trustworthy fix regardless of what the IMU/anchor say (see the
             // knob's comment for the measured legit-vs-wrong-basin
             // separation). Label-only, this epoch only.
-            if (!demote && config.fix_demote_res_m > 0.0 && ddpr_rms > config.fix_demote_res_m) {
+            if (!demote && residual_demote) {
                 demote = true;
             }
             // Post-hold cooldown variant (fix_demote_posthold_epochs): a fix
@@ -4595,9 +4612,7 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             // sub-second float history in exactly the conditions where the
             // ratio test is least trustworthy (see the knob's comment for
             // the measured 45.8 m case that no local witness catches).
-            if (!demote && config.fix_demote_posthold_epochs > 0 &&
-                static_cast<long long>(i) - last_held_epoch <=
-                    static_cast<long long>(config.fix_demote_posthold_epochs)) {
+            if (!demote && posthold_demote) {
                 demote = true;
             }
             // Relative-residual variant (fix_demote_res_rel): "suddenly much
@@ -4605,14 +4620,8 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             // the absolute fix_demote_res_m cannot be (see the knob's
             // comment for the measured per-run separations). Previous-epoch
             // history only; absolute floor = the FSM trigger threshold.
-            if (!demote && config.fix_demote_res_rel > 0.0 && recent_ddpr_rms.size() >= 20) {
-                std::vector<double> h(recent_ddpr_rms.begin(), recent_ddpr_rms.end());
-                std::nth_element(h.begin(), h.begin() + h.size() / 2, h.end());
-                const double med = h[h.size() / 2];
-                if (ddpr_rms > config.cp_hold_main_residual_threshold_m &&
-                    ddpr_rms > config.fix_demote_res_rel * med) {
-                    demote = true;
-                }
+            if (!demote && relative_residual_demote) {
+                demote = true;
             }
             // Anchor-gap variant (fix_demote_use_ddpr_anchor): the IMU
             // prediction rides an already-converged wrong basin, but the
@@ -4631,6 +4640,7 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             // signature. No-op (gate always open) when the knob is off.
             bool anchor_gross_gate_open = true;
             bool demotion_anchor_trusted = false;
+            bool anchor_demote = false;
             double demotion_anchor_gap_m =
                 std::numeric_limits<double>::infinity();
             if (config.fix_demote_use_ddpr_anchor && config.fix_demote_anchor_gross) {
@@ -4711,6 +4721,7 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                     if (config.fix_demote_use_ddpr_anchor &&
                         anchor_gap > config.fix_demote_anchor_distance_m) {
                         demote = true;
+                        anchor_demote = true;
                         ++result.diagnostics.fix_plausibility_anchor_demotions;
                     }
                 }
@@ -4742,6 +4753,34 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 anchor_reprieve_pass) {
                 demote = false;
                 ++result.diagnostics.fix_plausibility_surplus_reprieves;
+            }
+            // A large absolute DDPR residual can be common-mode code
+            // multipath even when the carrier integer hypothesis is strong.
+            // Reprieve only that isolated reason, and only when both the
+            // LAMBDA/IMU model and a fresh standalone-code SPP position agree
+            // with the fixed candidate. Any other simultaneous demotion
+            // reason, missing/stale SPP, or weak candidate fails closed.
+            const bool residual_only_demote =
+                residual_demote && !distance_demote && !posthold_demote &&
+                !relative_residual_demote && !anchor_demote;
+            const bool spp_model_reprieve =
+                demote && config.fix_demote_spp_model_reprieve &&
+                residual_only_demote &&
+                epoch_diagnostics[i].lambda_candidate_available &&
+                epoch_diagnostics[i].lambda_candidate_fixed_ambiguities >=
+                    config.fix_demote_spp_model_min_fixed_ambiguities &&
+                std::isfinite(
+                    epoch_diagnostics[i].fixed_imu_prediction_separation_m) &&
+                epoch_diagnostics[i].fixed_imu_prediction_separation_m <=
+                    config.fix_demote_spp_model_max_imu_separation_m &&
+                epoch_diagnostics[i].fresh_spp_solution &&
+                epoch_diagnostics[i].spp_seed_position_ecef.allFinite() &&
+                (Eigen::Vector3d(fix_ant) -
+                 epoch_diagnostics[i].spp_seed_position_ecef).norm() <=
+                    config.fix_demote_spp_model_max_agreement_m;
+            if (spp_model_reprieve) {
+                demote = false;
+                ++result.diagnostics.fix_plausibility_spp_model_reprieves;
             }
             if (demote) {
                 epoch_fixed[i] = false;

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -2698,6 +2698,63 @@ TEST(FGOFixDemoteTest, ExtremeResidualDemotesRegardlessOfImuAgreement) {
         << "clean epochs keep their FIXED label";
 }
 
+TEST(FGOFixDemoteTest, FreshSppAndStrongModelReprieveResidualOnlyDemotion) {
+    CpHoldTestOptions opt;
+    opt.satellites = lambdaCapableSatelliteGeometry();
+    opt.num_epochs = 25;
+    for (std::size_t e = 15; e <= 18; ++e) opt.pr_corrupt_epochs.insert(e);
+    opt.pr_baseline_bias_m = 0.0;
+    opt.pr_dominant_extra_bias_m = 40.0;
+    auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig config = makeFixDemoteBaseConfig();
+    config.use_epoch_quality_gates = true;
+    config.gate_gdop_max = 1e9;
+    config.gate_min_satellites = 0;
+    config.gate_ddpr_res_max_m = 1e9;
+    config.gate_per_sat_res_max_m = 1e9;
+    config.use_fix_plausibility_demotion = true;
+    config.fix_demote_distance_m = 1.0e9;
+    config.fix_demote_res_m = 5.0;
+    config.fix_demote_spp_model_reprieve = true;
+    // The compact synthetic fixture has fewer ambiguities than the frozen
+    // production floor. Keep every other gate realistic while lowering only
+    // this fixture-size requirement.
+    config.fix_demote_spp_model_min_fixed_ambiguities = 1;
+
+    // A coasted/header fallback must fail closed even when its stored
+    // position happens to agree with the fixed candidate.
+    FGOProcessor stale_processor(config);
+    const auto stale_result = stale_processor.optimizeProblem(problem);
+    ASSERT_NE(stale_result.solution.solutions[16].status,
+              SolutionStatus::FIXED);
+    EXPECT_EQ(stale_result.diagnostics.fix_plausibility_spp_model_reprieves,
+              0u);
+
+    for (auto& epoch : problem.epochs) epoch.fresh_spp_solution = true;
+    FGOProcessor fresh_processor(config);
+    const auto fresh_result = fresh_processor.optimizeProblem(problem);
+
+    EXPECT_GT(fresh_result.diagnostics.fix_plausibility_spp_model_reprieves,
+              0u);
+    EXPECT_EQ(fresh_result.solution.solutions[16].status,
+              SolutionStatus::FIXED)
+        << "a fresh SPP witness agreeing with a strong carrier candidate "
+           "must reprieve an isolated absolute-DDPR demotion";
+    EXPECT_EQ(fresh_result.diagnostics.fix_plausibility_demotions, 0u);
+
+    // Agreement cannot override another simultaneous demotion reason.
+    config.fix_demote_distance_m = 0.0;
+    FGOProcessor simultaneous_processor(config);
+    const auto simultaneous_result =
+        simultaneous_processor.optimizeProblem(problem);
+    EXPECT_NE(simultaneous_result.solution.solutions[16].status,
+              SolutionStatus::FIXED);
+    EXPECT_EQ(
+        simultaneous_result.diagnostics.fix_plausibility_spp_model_reprieves,
+        0u);
+}
+
 TEST(FGOFixDemoteTest, RelativeResidualDemotesExcursionButToleratesChronicNoise) {
     // fix_demote_res_rel semantics: (1) a residual EXCURSION over a quiet
     // ambient demotes; (2) the SAME absolute residual level, when it is the


### PR DESCRIPTION
## Summary
- add an opt-in residual-only FIX demotion reprieve gated by a strong LAMBDA/IMU model and fresh standalone SPP agreement
- fail closed for stale/coasted SPP and every simultaneous distance, post-hold, relative-residual, or anchor demotion reason
- expose a diagnostic counter and document the frozen Tokyo1/Tokyo2/Tokyo3 evaluation

## Validation
- focused native tests: 12/12 passed
- full native suite: 819 passed, 60 existing skips, 0 failed (879 total)
- Tokyo1: correct FIX 5469 -> 5682 (+213), wrong FIX 649 -> 649, correct-FIX distance +58.7199 m
- Tokyo2: correct FIX 6357 -> 6661 (+304), wrong FIX 314 -> 314, correct-FIX distance +22.9841 m
- held-out Tokyo3: correct FIX 9969 -> 9973 (+4), wrong FIX 1002 -> 1002; all four rescued epochs had 0.03 m 3D error and zero driven-distance contribution
- aggregate correct-FIX distance: +81.704 m (+0.242 pp); wrong-FIX distance unchanged on every run

Contributes to #389. The cumulative improvement is about +1.1422 pp, so #389 remains open for the remaining ~0.858 pp.