### PR TITLE
Expose FGO BSR and FFRT telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,17 @@ a safe incremental guard rather than the complete FIX-rate target. Combined
 with the two preceding reprieves, correct-FIX distance is now approximately
 58.2153% (+1.1422 pp from 57.0731%); about 0.858 pp remains to the +2 pp goal.
 
+The FGO epoch CSV also reports monitor-only LAMBDA covariance diagnostics for
+each provisional candidate: the bootstrapped success-rate lower bound, the
+same bound after 2/4/8/16x covariance inflation, and the fixed-failure-rate
+ratio threshold and verdict for `Pf_tol=0.001`. These values come from the
+same two-candidate search used by the existing ratio test, add no CLI option,
+and do not change candidate selection or FIX/FLOAT decisions. The FFRT
+coefficient table follows [Hou, Verhagen, and Wu (2016)](https://doi.org/10.3390/s16070945)
+and unsupported ambiguity dimensions fail closed in telemetry.
+
 Across the three courses, distance-weighted correct FIX improved from
-57.0731% at the pre-reprieve baseline to **57.9735%**, while
+57.0731% at the pre-reprieve baseline to approximately **58.2153%**, while
 distance-weighted wrong FIX fell from 7.7043% to **7.0089%**. The policy is
 opt-in and leaves the default library behavior unchanged.
 

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -1491,6 +1491,11 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
            "lambda_candidate_valid,lambda_candidate_nfixed,"
            "lambda_candidate_ratio,lambda_candidate_x_ecef_m,"
            "lambda_candidate_y_ecef_m,lambda_candidate_z_ecef_m,"
+           "lambda_candidate_bsr,lambda_candidate_bsr_qscale2,"
+           "lambda_candidate_bsr_qscale4,lambda_candidate_bsr_qscale8,"
+           "lambda_candidate_bsr_qscale16,lambda_candidate_ffrt_supported,"
+           "lambda_candidate_ffrt_accepts_any,lambda_candidate_ffrt_min_ratio,"
+           "lambda_candidate_ffrt_pass,"
            "ratio_impact_eval,ratio_impact_trials,ratio_impact_best_ratio,"
            "ratio_impact_best_nfixed,ratio_impact_x_ecef_m,"
            "ratio_impact_y_ecef_m,ratio_impact_z_ecef_m,"
@@ -1582,6 +1587,15 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                 << ',' << d.lambda_candidate_position_ecef.x()
                 << ',' << d.lambda_candidate_position_ecef.y()
                 << ',' << d.lambda_candidate_position_ecef.z()
+                << ',' << d.lambda_candidate_bsr
+                << ',' << d.lambda_candidate_bsr_qscale2
+                << ',' << d.lambda_candidate_bsr_qscale4
+                << ',' << d.lambda_candidate_bsr_qscale8
+                << ',' << d.lambda_candidate_bsr_qscale16
+                << ',' << (d.lambda_candidate_ffrt_table_supported ? 1 : 0)
+                << ',' << (d.lambda_candidate_ffrt_accepts_any ? 1 : 0)
+                << ',' << d.lambda_candidate_ffrt_min_ratio
+                << ',' << (d.lambda_candidate_ffrt_pass ? 1 : 0)
                 << ',' << (d.ratio_impact_evaluated ? 1 : 0)
                 << ',' << d.ratio_impact_trials
                 << ',' << d.ratio_impact_best_ratio

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -2017,6 +2017,18 @@ public:
         Vector3d lambda_candidate_position_ecef = Vector3d::Zero();
         int lambda_candidate_fixed_ambiguities = 0;
         double lambda_candidate_ratio = 0.0;
+        // Covariance-only quality diagnostics from the same Top-K LAMBDA
+        // search that produced lambda_candidate_position_ecef. These fields
+        // are monitor-only and never participate in FIX/FLOAT decisions.
+        double lambda_candidate_bsr = 0.0;
+        double lambda_candidate_bsr_qscale2 = 0.0;
+        double lambda_candidate_bsr_qscale4 = 0.0;
+        double lambda_candidate_bsr_qscale8 = 0.0;
+        double lambda_candidate_bsr_qscale16 = 0.0;
+        bool lambda_candidate_ffrt_table_supported = false;
+        bool lambda_candidate_ffrt_accepts_any = false;
+        double lambda_candidate_ffrt_min_ratio = 0.0;
+        bool lambda_candidate_ffrt_pass = false;
         bool ratio_impact_evaluated = false;
         int ratio_impact_trials = 0;
         double ratio_impact_best_ratio = 0.0;

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -3535,10 +3535,20 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                         ++epoch_diagnostics[i].lambda_attempts;
                         result.diagnostics.lambda_ambiguity_candidates +=
                             static_cast<std::size_t>(subset);
-                        if (!lambdaSearch(sub_float, sub_q, fixed_amb, ratio)) {
+                        LambdaCandidateDiagnostics lambda_diagnostics;
+                        if (!lambdaSearchTopK(
+                                sub_float, sub_q, 2, lambda_diagnostics)) {
                             if (!config.use_fixed_lag_partial_lambda) break;
                             continue;
                         }
+                        fixed_amb = lambda_diagnostics.candidates.col(0);
+                        const double best_residual =
+                            lambda_diagnostics.squared_residuals(0);
+                        const double second_residual =
+                            lambda_diagnostics.squared_residuals(1);
+                        ratio = best_residual > 0.0
+                                    ? second_residual / best_residual
+                                    : 0.0;
                         result.diagnostics.lambda_ambiguity_fix_solved = true;
                         epoch_diagnostics[i].ar_outcome =
                             FGOProcessor::AmbiguityResolutionOutcome::RatioRejected;
@@ -3565,6 +3575,55 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                                         epoch_diagnostics[i]
                                             .lambda_candidate_fixed_ambiguities = subset;
                                         epoch_diagnostics[i].lambda_candidate_ratio = ratio;
+                                        epoch_diagnostics[i].lambda_candidate_bsr =
+                                            lambda_diagnostics
+                                                .bootstrapped_success_rate;
+                                        epoch_diagnostics[i]
+                                            .lambda_candidate_bsr_qscale2 =
+                                            bootstrappedSuccessRate(
+                                                lambda_diagnostics
+                                                    .conditional_variances,
+                                                2.0);
+                                        epoch_diagnostics[i]
+                                            .lambda_candidate_bsr_qscale4 =
+                                            bootstrappedSuccessRate(
+                                                lambda_diagnostics
+                                                    .conditional_variances,
+                                                4.0);
+                                        epoch_diagnostics[i]
+                                            .lambda_candidate_bsr_qscale8 =
+                                            bootstrappedSuccessRate(
+                                                lambda_diagnostics
+                                                    .conditional_variances,
+                                                8.0);
+                                        epoch_diagnostics[i]
+                                            .lambda_candidate_bsr_qscale16 =
+                                            bootstrappedSuccessRate(
+                                                lambda_diagnostics
+                                                    .conditional_variances,
+                                                16.0);
+                                        FixedFailureRateRatioThreshold ffrt;
+                                        if (fixedFailureRateRatioThreshold(
+                                                subset,
+                                                lambda_diagnostics
+                                                    .bootstrapped_success_rate,
+                                                0.001, ffrt)) {
+                                            epoch_diagnostics[i]
+                                                .lambda_candidate_ffrt_table_supported =
+                                                true;
+                                            epoch_diagnostics[i]
+                                                .lambda_candidate_ffrt_accepts_any =
+                                                ffrt.accepts_any_candidate;
+                                            epoch_diagnostics[i]
+                                                .lambda_candidate_ffrt_min_ratio =
+                                                ffrt.minimum_second_to_best_ratio;
+                                            epoch_diagnostics[i]
+                                                .lambda_candidate_ffrt_pass =
+                                                ffrt.accepts_any_candidate &&
+                                                std::isfinite(ratio) &&
+                                                ratio > ffrt
+                                                            .minimum_second_to_best_ratio;
+                                        }
                                         epoch_diagnostics[i].fixed_float_separation_m =
                                             (provisional_fixed_ant - Eigen::Vector3d(
                                                  antennaOf(pose_i))).norm();

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -2199,6 +2199,21 @@ TEST(FGOAmbiguityOutcomeTelemetryTest, HoldFallbackPreservesRatioRejection) {
     EXPECT_GT(rejected->lambda_candidate_position_ecef.norm(), 1.0e6);
     EXPECT_GT(rejected->lambda_candidate_fixed_ambiguities, 0);
     EXPECT_TRUE(std::isfinite(rejected->lambda_candidate_ratio));
+    EXPECT_GT(rejected->lambda_candidate_bsr, 0.0);
+    EXPECT_LE(rejected->lambda_candidate_bsr, 1.0);
+    EXPECT_LE(rejected->lambda_candidate_bsr_qscale2,
+              rejected->lambda_candidate_bsr);
+    EXPECT_LE(rejected->lambda_candidate_bsr_qscale4,
+              rejected->lambda_candidate_bsr_qscale2);
+    EXPECT_LE(rejected->lambda_candidate_bsr_qscale8,
+              rejected->lambda_candidate_bsr_qscale4);
+    EXPECT_LE(rejected->lambda_candidate_bsr_qscale16,
+              rejected->lambda_candidate_bsr_qscale8);
+    EXPECT_TRUE(rejected->lambda_candidate_ffrt_table_supported);
+    EXPECT_EQ(rejected->lambda_candidate_ffrt_pass,
+              rejected->lambda_candidate_ffrt_accepts_any &&
+                  rejected->lambda_candidate_ratio >
+                      rejected->lambda_candidate_ffrt_min_ratio);
 }
 
 TEST(FGOAmbiguityOutcomeTelemetryTest,


### PR DESCRIPTION
## Summary
- expose per-candidate bootstrapped success rate at nominal and 2/4/8/16x covariance scales
- expose Hou et al. fixed-failure-rate ratio threshold support, minimum ratio, and monitor-only verdict
- reuse the exact Top-K LAMBDA search already underneath `lambdaSearch`, with no CLI option and no decision-path changes

## Validation
- focused LAMBDA/FGO telemetry tests: 6/6 passed
- full native suite: 819 passed, 60 existing skips, 0 failed (879 total)
- Tokyo1 prefix (200 epochs): zero mismatches in status, ECEF, ratio, ratio threshold, nfixed, AR outcome, candidate count, attempts, and selected stage
- Tokyo1 full (11,905 epochs): zero mismatches in the same behavior fields; 8,143 candidate epochs received diagnostics
- BSR monotonicity under covariance inflation: zero violations

## Initial finding
On Tokyo1 ratio-rejected candidates, FFRT passed 135 correct and 1,435 wrong candidates. Mean nominal BSR was 0.9756 for correct candidates and 0.9844 for wrong candidates. This evidence says BSR/FFRT must not be wired directly as a rescue policy; the PR is telemetry-only and the next experiment will evaluate SRC-PAR candidate reduction separately.

Contributes evidence to #389.