### PR TITLE
Add fail-closed GNSS and IMU research paths

### DIFF
--- a/apps/native/gnss_fuse.cpp
+++ b/apps/native/gnss_fuse.cpp
@@ -2999,6 +2999,7 @@ int runRtkFusion(const FuseOptions& options, libgnss::ImuSeries& imu_series,
     int skipped_rover_epochs = 0;
     int derived_velocity_updates = 0;
     int tight_dd_epochs = 0;
+    int tight_dd_heading_deferred = 0;
     int tight_dd_accepted = 0;
     int tight_dd_rejected = 0;
     int tight_dd_carrier_fallbacks = 0;
@@ -3592,6 +3593,9 @@ int runRtkFusion(const FuseOptions& options, libgnss::ImuSeries& imu_series,
                     const auto dd_result = fusion_processor.processTightlyCoupledDD(
                         dd_rows, &pos_solution);
                     ++tight_dd_epochs;
+                    if (dd_result.deferred_until_heading_converged) {
+                        ++tight_dd_heading_deferred;
+                    }
                     tight_dd_rows += static_cast<int>(dd_rows.size());
                     if (std::isfinite(dd_result.update.nis_per_observation)) {
                         ++tight_dd_nis_samples;
@@ -3964,7 +3968,9 @@ int runRtkFusion(const FuseOptions& options, libgnss::ImuSeries& imu_series,
         if (options.tightly_coupled_dd_imu) {
             std::cout << "Tight DD/IMU epochs: " << tight_dd_epochs
                       << " (accepted=" << tight_dd_accepted
-                      << ", innovation_rejected=" << tight_dd_rejected << ")\n";
+                      << ", innovation_rejected=" << tight_dd_rejected
+                      << ", heading_deferred=" << tight_dd_heading_deferred
+                      << ")\n";
             std::cout << "Tight DD rows: " << tight_dd_rows << "\n";
             std::cout << "Carrier-to-code fallbacks: "
                       << tight_dd_carrier_fallbacks << "\n";

--- a/apps/native/gnss_solve.cpp
+++ b/apps/native/gnss_solve.cpp
@@ -130,6 +130,16 @@ struct SolveConfig {
     double multisd_fgo_shadow_min_bootstrapped_success_rate = 0.0;
     double multisd_fgo_shadow_max_adop_cycles = 0.0;
     double multisd_fgo_shadow_fallback_min_bootstrapped_success_rate = 0.0;
+    bool multisd_fgo_shadow_tdcp_slip_repair = false;
+    int multisd_fgo_shadow_tdcp_slip_repair_max_cycles = 32;
+    double multisd_fgo_shadow_tdcp_slip_repair_tolerance_cycles = 0.20;
+    bool multisd_fgo_shadow_wcmc = false;
+    int multisd_fgo_shadow_wcmc_warmup_epochs = 5;
+    double multisd_fgo_shadow_wcmc_baseline_alpha = 0.05;
+    double multisd_fgo_shadow_wcmc_min_correction_m = 0.5;
+    double multisd_fgo_shadow_wcmc_max_correction_m = 10.0;
+    bool multisd_fgo_shadow_fallback_integer_aperture = false;
+    double multisd_fgo_shadow_fallback_ia_covariance_scale = 16.0;
     double rtk_update_outlier_threshold = 0.0;
     bool student_t_rtk_front_end = false;
     double ratio_threshold = 3.0;
@@ -1995,6 +2005,26 @@ void printAdvancedUsage(const char* program_name) {
         << "                             Maximum ambiguity dilution of precision (default: 0/off)\n"
         << "  --multisd-fgo-shadow-fallback-min-bsr <0..1>\n"
         << "                             Minimum BSR for later validator groups only (default: 0)\n"
+        << "  --multisd-fgo-shadow-tdcp-slip-repair\n"
+        << "                             Repair bounded integer SD-TDCP slips using Doppler (default: off)\n"
+        << "  --multisd-fgo-shadow-tdcp-slip-repair-max-cycles <n>\n"
+        << "                             Maximum absolute repaired slip, 1..10000 (default: 32)\n"
+        << "  --multisd-fgo-shadow-tdcp-slip-repair-tolerance <cycles>\n"
+        << "                             Integer residual aperture in (0,0.5] (default: 0.20)\n"
+        << "  --multisd-fgo-shadow-wcmc\n"
+        << "                             Carrier-condition time-varying DD code bias (default: off)\n"
+        << "  --multisd-fgo-shadow-wcmc-warmup <epochs>\n"
+        << "                             Causal CMC baseline warm-up (default: 5)\n"
+        << "  --multisd-fgo-shadow-wcmc-alpha <0..1>\n"
+        << "                             CMC baseline EWMA update (default: 0.05)\n"
+        << "  --multisd-fgo-shadow-wcmc-min-correction <m>\n"
+        << "                             Minimum detected time-varying code bias (default: 0.5)\n"
+        << "  --multisd-fgo-shadow-wcmc-max-correction <m>\n"
+        << "                             Fail-closed absolute correction aperture (default: 10)\n"
+        << "  --multisd-fgo-shadow-fallback-integer-aperture\n"
+        << "                             Hou FFRT gate for fallback PAR groups (default: off)\n"
+        << "  --multisd-fgo-shadow-fallback-ia-covariance-scale <x>\n"
+        << "                             Conservative FFRT covariance scale (default: 16)\n"
         << "  --realtime-fix-integrity   Gate FIX output with bounded-latency residual checks\n"
         << "                             (default: off; maximum latency: 7 epochs)\n"
         << "  --integrity-base-gate      Also enable the frozen offline low-satellite/ratio\n"
@@ -2348,6 +2378,56 @@ SolveConfig parseArguments(int argc, char* argv[]) {
         }
         if (arg == "--multisd-fgo-shadow-fallback-min-bsr" && i + 1 < argc) {
             config.multisd_fgo_shadow_fallback_min_bootstrapped_success_rate =
+                std::stod(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-tdcp-slip-repair") {
+            config.multisd_fgo_shadow_tdcp_slip_repair = true;
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-tdcp-slip-repair-max-cycles" &&
+            i + 1 < argc) {
+            config.multisd_fgo_shadow_tdcp_slip_repair_max_cycles =
+                std::stoi(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-tdcp-slip-repair-tolerance" &&
+            i + 1 < argc) {
+            config.multisd_fgo_shadow_tdcp_slip_repair_tolerance_cycles =
+                std::stod(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-wcmc") {
+            config.multisd_fgo_shadow_wcmc = true;
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-wcmc-warmup" && i + 1 < argc) {
+            config.multisd_fgo_shadow_wcmc_warmup_epochs = std::stoi(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-wcmc-alpha" && i + 1 < argc) {
+            config.multisd_fgo_shadow_wcmc_baseline_alpha = std::stod(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-wcmc-min-correction" &&
+            i + 1 < argc) {
+            config.multisd_fgo_shadow_wcmc_min_correction_m =
+                std::stod(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-wcmc-max-correction" &&
+            i + 1 < argc) {
+            config.multisd_fgo_shadow_wcmc_max_correction_m =
+                std::stod(argv[++i]);
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-fallback-integer-aperture") {
+            config.multisd_fgo_shadow_fallback_integer_aperture = true;
+            continue;
+        }
+        if (arg == "--multisd-fgo-shadow-fallback-ia-covariance-scale" &&
+            i + 1 < argc) {
+            config.multisd_fgo_shadow_fallback_ia_covariance_scale =
                 std::stod(argv[++i]);
             continue;
         }
@@ -3624,6 +3704,49 @@ SolveConfig parseArguments(int argc, char* argv[]) {
             "--multisd-fgo-shadow-fallback-min-bsr must be in [0, 1]",
             argv[0]);
     }
+    if (config.multisd_fgo_shadow_tdcp_slip_repair_max_cycles < 1 ||
+        config.multisd_fgo_shadow_tdcp_slip_repair_max_cycles > 10000) {
+        argumentError(
+            "--multisd-fgo-shadow-tdcp-slip-repair-max-cycles must be in [1, 10000]",
+            argv[0]);
+    }
+    if (!std::isfinite(
+            config.multisd_fgo_shadow_tdcp_slip_repair_tolerance_cycles) ||
+        config.multisd_fgo_shadow_tdcp_slip_repair_tolerance_cycles <= 0.0 ||
+        config.multisd_fgo_shadow_tdcp_slip_repair_tolerance_cycles > 0.5) {
+        argumentError(
+            "--multisd-fgo-shadow-tdcp-slip-repair-tolerance must be in (0, 0.5]",
+            argv[0]);
+    }
+    if (config.multisd_fgo_shadow_wcmc_warmup_epochs < 1) {
+        argumentError("--multisd-fgo-shadow-wcmc-warmup must be >= 1", argv[0]);
+    }
+    if (!std::isfinite(config.multisd_fgo_shadow_wcmc_baseline_alpha) ||
+        config.multisd_fgo_shadow_wcmc_baseline_alpha < 0.0 ||
+        config.multisd_fgo_shadow_wcmc_baseline_alpha > 1.0) {
+        argumentError("--multisd-fgo-shadow-wcmc-alpha must be in [0, 1]",
+                      argv[0]);
+    }
+    if (!std::isfinite(config.multisd_fgo_shadow_wcmc_max_correction_m) ||
+        config.multisd_fgo_shadow_wcmc_max_correction_m <= 0.0) {
+        argumentError(
+            "--multisd-fgo-shadow-wcmc-max-correction must be > 0", argv[0]);
+    }
+    if (!std::isfinite(config.multisd_fgo_shadow_wcmc_min_correction_m) ||
+        config.multisd_fgo_shadow_wcmc_min_correction_m < 0.0 ||
+        config.multisd_fgo_shadow_wcmc_min_correction_m >
+            config.multisd_fgo_shadow_wcmc_max_correction_m) {
+        argumentError(
+            "--multisd-fgo-shadow-wcmc-min-correction must be in [0, max]",
+            argv[0]);
+    }
+    if (!std::isfinite(
+            config.multisd_fgo_shadow_fallback_ia_covariance_scale) ||
+        config.multisd_fgo_shadow_fallback_ia_covariance_scale <= 0.0) {
+        argumentError(
+            "--multisd-fgo-shadow-fallback-ia-covariance-scale must be > 0",
+            argv[0]);
+    }
 
     return config;
 }
@@ -3748,6 +3871,26 @@ libgnss::FGOProcessor::FGOConfig makeGnssOnlyMultiSdShadowConfig(
     config.use_double_difference_factors = true;
     config.use_single_difference_doppler_factors = true;
     config.use_single_difference_tdcp_factors = true;
+    config.use_single_difference_tdcp_integer_slip_repair =
+        solve_config.multisd_fgo_shadow_tdcp_slip_repair;
+    config.single_difference_tdcp_slip_repair_max_cycles =
+        solve_config.multisd_fgo_shadow_tdcp_slip_repair_max_cycles;
+    config.single_difference_tdcp_slip_repair_tolerance_cycles =
+        solve_config.multisd_fgo_shadow_tdcp_slip_repair_tolerance_cycles;
+    config.use_wcmc_pseudorange_conditioning =
+        solve_config.multisd_fgo_shadow_wcmc;
+    config.code_minus_carrier_warmup_epochs =
+        solve_config.multisd_fgo_shadow_wcmc_warmup_epochs;
+    config.code_minus_carrier_baseline_alpha =
+        solve_config.multisd_fgo_shadow_wcmc_baseline_alpha;
+    config.wcmc_max_correction_m =
+        solve_config.multisd_fgo_shadow_wcmc_max_correction_m;
+    config.wcmc_min_correction_m =
+        solve_config.multisd_fgo_shadow_wcmc_min_correction_m;
+    config.use_multisd_fallback_integer_aperture =
+        solve_config.multisd_fgo_shadow_fallback_integer_aperture;
+    config.multisd_fallback_integer_aperture_covariance_scale =
+        solve_config.multisd_fgo_shadow_fallback_ia_covariance_scale;
     config.use_velocity_states = true;
     config.use_velocity_motion_factors = true;
     config.fix_ambiguities = true;
@@ -4144,7 +4287,12 @@ int main(int argc, char* argv[]) {
                    "cuda_hypothesis_batch_attempts,"
                    "cuda_hypothesis_batch_successes,"
                    "cuda_hypothesis_batch_rhs_columns,"
-                   "fixed_float_separation_m,seed_separation_m\n";
+                   "fixed_float_separation_m,seed_separation_m,"
+                   "sd_tdcp_repair_candidates,sd_tdcp_repairs,"
+                   "sd_tdcp_repair_rejects,sd_tdcp_reference_change_rejects,"
+                   "wcmc_corrections,wcmc_correction_rms_m,"
+                   "integer_aperture_attempts,integer_aperture_passes,"
+                   "integer_aperture_rejects\n";
         }
 
         std::unique_ptr<IntegrityShadowTimeline> integrity_shadow;
@@ -4603,6 +4751,19 @@ int main(int argc, char* argv[]) {
                         multisd_shadow_csv,
                         diagnostics.multisd_validation_seed_separation_m);
                     multisd_shadow_csv
+                        << ','
+                        << diagnostics.single_difference_tdcp_slip_repair_candidates
+                        << ','
+                        << diagnostics.single_difference_tdcp_slip_repairs
+                        << ','
+                        << diagnostics.single_difference_tdcp_slip_repair_rejects
+                        << ','
+                        << diagnostics.single_difference_tdcp_rejected_reference_change
+                        << ',' << diagnostics.wcmc_pseudorange_corrections
+                        << ',' << diagnostics.wcmc_pseudorange_correction_rms_m
+                        << ',' << diagnostics.multisd_integer_aperture_attempts
+                        << ',' << diagnostics.multisd_integer_aperture_passes
+                        << ',' << diagnostics.multisd_integer_aperture_rejects
                         << '\n';
                 }
             }

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -218,6 +218,12 @@ public:
         // Optional bootstrap-success aperture for validator fallback groups.
         // The first group retains the regular LAMBDA gate.
         double multisd_fallback_min_bootstrapped_success_rate = 0.0;
+        // Dimension/covariance-aware Integer Aperture gate for fallback PAR
+        // groups. Uses the published Hou et al. Pf_tol=0.001 FFRT table and
+        // a conservative covariance scale. It replaces the scalar fallback
+        // BSR floor when enabled; disjoint validation remains final authority.
+        bool use_multisd_fallback_integer_aperture = false;
+        double multisd_fallback_integer_aperture_covariance_scale = 16.0;
         bool use_epoch_lambda_fixed_output = false;
         bool use_partial_lambda_ambiguity_fix = true;
         // Independently re-optimize the active fixed-lag graph with the
@@ -559,6 +565,16 @@ public:
         bool reject_rover_carrier_loss_of_lock = false;
         bool reject_tdcp_code_phase_jump = true;
         double tdcp_code_phase_jump_threshold_m = 10.0;
+        // Opt-in GNSS-only cycle-slip repair for satellite-single-difference
+        // TDCP.  The builder compares the carrier residual delta with the
+        // trapezoidal integral of the matching SD Doppler residual, rounds
+        // only a bounded near-integer wavelength offset, and subtracts that
+        // offset before inserting the TDCP row.  Reference changes and
+        // ambiguous/non-integer offsets fail closed.  Default OFF keeps the
+        // established MultiSD route byte-identical.
+        bool use_single_difference_tdcp_integer_slip_repair = false;
+        int single_difference_tdcp_slip_repair_max_cycles = 32;
+        double single_difference_tdcp_slip_repair_tolerance_cycles = 0.20;
 
         bool use_ionosphere_model = true;
         bool use_troposphere_model = true;
@@ -826,6 +842,18 @@ public:
         // choice so the group is never dropped. Default OFF: bit-identical
         // to the pre-change baseline when false.
         bool cmc_aware_reference_selection = false;
+
+        // Windowed Code-Minus-Carrier (WCMC) DD-pseudorange conditioner.
+        // After the per-(satellite,signal) CMC warm-up, use the carrier-
+        // referenced change from its causal baseline as an estimate of the
+        // time-varying single-difference code bias.  The target-minus-
+        // reference estimate is removed from the DD code row only; carrier
+        // rows and ambiguity states are untouched.  Corrections outside the
+        // bounded aperture fail closed.  Default OFF preserves the existing
+        // graph exactly.
+        bool use_wcmc_pseudorange_conditioning = false;
+        double wcmc_min_correction_m = 0.5;
+        double wcmc_max_correction_m = 10.0;
 
         // --- Per-epoch quality gates (port of the inuex35 reference's
         // preprocess/gate.py + validation/postfit.py policy) ---
@@ -1567,6 +1595,8 @@ public:
         double delta_carrier_m = 0.0;
         double sigma_m = 0.003;
         double elevation_rad = 0.0;
+        int repaired_slip_cycles = 0;
+        bool repaired_cycle_slip = false;
     };
 
     struct AmbiguityState {
@@ -1665,9 +1695,18 @@ public:
         std::size_t tdcp_rejected_missing_previous = 0;
         std::size_t tdcp_rejected_loss_of_lock = 0;
         std::size_t tdcp_rejected_code_phase_jump = 0;
+        std::size_t single_difference_tdcp_rejected_reference_change = 0;
+        std::size_t single_difference_tdcp_slip_repair_candidates = 0;
+        std::size_t single_difference_tdcp_slip_repairs = 0;
+        std::size_t single_difference_tdcp_slip_repair_rejects = 0;
+        std::size_t multisd_integer_aperture_attempts = 0;
+        std::size_t multisd_integer_aperture_passes = 0;
+        std::size_t multisd_integer_aperture_rejects = 0;
         std::size_t code_minus_carrier_jump_resets = 0;       ///< CMC screening: arc breaks forced
         std::size_t code_minus_carrier_level_exclusions = 0;  ///< CMC screening: (sat,signal) epochs excluded
         std::size_t cmc_ref_avoided_count = 0;  ///< cmc_aware_reference_selection: references changed away from a CMC-excluded candidate
+        std::size_t wcmc_pseudorange_corrections = 0;
+        double wcmc_pseudorange_correction_square_sum_m2 = 0.0;
     };
 
     // --- Phase 2 milestone 2b: IMU preintegration inputs ---
@@ -1819,6 +1858,13 @@ public:
         std::size_t tdcp_rejected_missing_previous = 0;
         std::size_t tdcp_rejected_loss_of_lock = 0;
         std::size_t tdcp_rejected_code_phase_jump = 0;
+        std::size_t single_difference_tdcp_rejected_reference_change = 0;
+        std::size_t single_difference_tdcp_slip_repair_candidates = 0;
+        std::size_t single_difference_tdcp_slip_repairs = 0;
+        std::size_t single_difference_tdcp_slip_repair_rejects = 0;
+        std::size_t multisd_integer_aperture_attempts = 0;
+        std::size_t multisd_integer_aperture_passes = 0;
+        std::size_t multisd_integer_aperture_rejects = 0;
         std::size_t double_difference_matched_base_epochs = 0;
         std::size_t double_difference_interpolated_base_epochs = 0;
         std::size_t double_difference_candidate_pairs = 0;
@@ -1845,6 +1891,8 @@ public:
         std::size_t code_minus_carrier_jump_resets = 0;       ///< CMC screening: arc breaks forced
         std::size_t code_minus_carrier_level_exclusions = 0;  ///< CMC screening: (sat,signal) epochs excluded
         std::size_t cmc_ref_avoided_count = 0;  ///< cmc_aware_reference_selection: references changed away from a CMC-excluded candidate
+        std::size_t wcmc_pseudorange_corrections = 0;
+        double wcmc_pseudorange_correction_rms_m = 0.0;
         // --- CP-hold / sanity FSM diagnostics (use_cp_hold_recovery) ---
         std::size_t cp_hold_triggers = 0;         ///< times CP-hold was (re)engaged/extended
         std::size_t cp_hold_epochs_held = 0;      ///< cumulative epochs with carrier suppressed

--- a/include/libgnss++/fusion/fusion_processor.hpp
+++ b/include/libgnss++/fusion/fusion_processor.hpp
@@ -167,6 +167,12 @@ public:
     void processGnssSolution(const PositionSolution& solution);
 
     struct TightlyCoupledDDResult {
+        // DD geometry is expressed in the live local navigation frame and
+        // shares the INS error state.  Defer it until the GNSS-velocity
+        // heading latch is both present and healthy; otherwise an accepted
+        // low-NIS update can still corrupt an unobservable yaw/position
+        // prefix.
+        bool deferred_until_heading_converged = false;
         dd_imu_bridge::UpdateResult update;
         dd_imu_bridge::PartialARResult partial_ar;
         dd_imu_bridge::SSEPartialARResult sse_partial_ar;
@@ -175,6 +181,7 @@ public:
     };
 
     /** Apply real DD code/carrier rows to the live INS state and ambiguities.
+     * Updates are fail-closed until isHeadingConverged() is true.
      * The optional position solution is used only for innovation-gated soft
      * recovery; a valid propagated nominal state is never hard-overwritten.
      */

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -647,8 +647,12 @@ struct SingleDifferenceDefaultReferenceKey {
 
 struct SingleDifferenceCarrierResidual {
     std::size_t epoch_index = 0;
+    SatelliteId reference_satellite;
     double residual_m = 0.0;
     Vector3d los = Vector3d::Zero();
+    bool has_doppler_residual = false;
+    double doppler_residual_mps = 0.0;
+    double wavelength_m = 0.0;
 };
 
 std::map<CarrierKey, PreparedCarrierObservation> prepareCarrierObservationsForReceiver(
@@ -1671,6 +1675,8 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
     // FGOConfig::cmc_aware_reference_selection: count of DD reference
     // picks steered away from a CMC-level-excluded candidate this run.
     std::size_t cmc_ref_avoided_total = 0;
+    std::size_t wcmc_correction_total = 0;
+    double wcmc_correction_square_sum_m2 = 0.0;
 
     for (std::size_t epoch_index = 0; epoch_index < problem.epochs.size(); ++epoch_index) {
         // Reference: tc._update_epoch_dt(obs) runs unconditionally at the top
@@ -1784,7 +1790,10 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
         // CP loop's ambiguity-arc bookkeeping (jump forces a new arc).
         std::set<CarrierKey> cmc_level_exclude_this_epoch;
         std::set<CarrierKey> cmc_jump_reset_this_epoch;
-        if (config_.use_code_minus_carrier_screening &&
+        std::map<CarrierKey, double> wcmc_correction_this_epoch;
+        std::set<CarrierKey> wcmc_ready_this_epoch;
+        if ((config_.use_code_minus_carrier_screening ||
+             config_.use_wcmc_pseudorange_conditioning) &&
             rover_it != rover_carriers_by_epoch.end()) {
             for (const auto* rover_factor : rover_it->second) {
                 const CarrierKey key{rover_factor->satellite, rover_factor->signal};
@@ -1819,7 +1828,8 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
                 CmcState& state = cmc_states[key];
                 if (rover_arc_restarted) {
                     state = CmcState{};
-                } else if (state.has_prev &&
+                } else if (config_.use_code_minus_carrier_screening &&
+                           state.has_prev &&
                            std::abs(cmc - state.prev_cmc_m) >
                                config_.code_minus_carrier_jump_threshold_m) {
                     cmc_jump_reset_this_epoch.insert(key);
@@ -1834,7 +1844,8 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
 
                 const double level_threshold =
                     config_.code_minus_carrier_level_threshold_m;
-                if (level_threshold > 0.0) {
+                if (level_threshold > 0.0 ||
+                    config_.use_wcmc_pseudorange_conditioning) {
                     if (!state.has_baseline) {
                         state.baseline_m = cmc;
                         state.warmup_count = 1;
@@ -1845,10 +1856,25 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
                             (state.baseline_m * state.warmup_count + cmc) /
                             (state.warmup_count + 1);
                         ++state.warmup_count;
-                    } else if (std::abs(cmc - state.baseline_m) > level_threshold) {
+                    } else if (level_threshold > 0.0 &&
+                               std::abs(cmc - state.baseline_m) >
+                                   level_threshold) {
                         cmc_level_exclude_this_epoch.insert(key);
                         ++cmc_level_exclusion_total;
                     } else {
+                        const double correction_m = cmc - state.baseline_m;
+                        if (config_.use_wcmc_pseudorange_conditioning &&
+                            std::isfinite(correction_m) &&
+                            std::abs(correction_m) <=
+                                std::max(0.0,
+                                         config_.wcmc_max_correction_m)) {
+                            wcmc_ready_this_epoch.insert(key);
+                            if (std::abs(correction_m) >=
+                                std::max(0.0,
+                                         config_.wcmc_min_correction_m)) {
+                                wcmc_correction_this_epoch[key] = correction_m;
+                            }
+                        }
                         const double alpha = config_.code_minus_carrier_baseline_alpha;
                         state.baseline_m =
                             (1.0 - alpha) * state.baseline_m + alpha * cmc;
@@ -2052,6 +2078,36 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
                      base_satellite.corrected_pseudorange_m) -
                     (reference->corrected_pseudorange_m -
                      base_reference.corrected_pseudorange_m);
+                if (config_.use_wcmc_pseudorange_conditioning) {
+                    const CarrierKey reference_key{reference->satellite,
+                                                   reference->signal};
+                    if (wcmc_ready_this_epoch.count(satellite_key) > 0 &&
+                        wcmc_ready_this_epoch.count(reference_key) > 0) {
+                        const auto satellite_correction_it =
+                            wcmc_correction_this_epoch.find(satellite_key);
+                        const auto reference_correction_it =
+                            wcmc_correction_this_epoch.find(reference_key);
+                        const double satellite_correction_m =
+                            satellite_correction_it ==
+                                    wcmc_correction_this_epoch.end()
+                                ? 0.0
+                                : satellite_correction_it->second;
+                        const double reference_correction_m =
+                            reference_correction_it ==
+                                    wcmc_correction_this_epoch.end()
+                                ? 0.0
+                                : reference_correction_it->second;
+                        const double dd_correction_m =
+                            satellite_correction_m - reference_correction_m;
+                        pseudorange_factor.observed_dd_pseudorange_m -=
+                            dd_correction_m;
+                        if (dd_correction_m != 0.0) {
+                            ++wcmc_correction_total;
+                            wcmc_correction_square_sum_m2 +=
+                                dd_correction_m * dd_correction_m;
+                        }
+                    }
+                }
                 const double pseudorange_band_scale =
                     signal_policy::isSecondarySignal(satellite->satellite.system,
                                                      satellite->signal)
@@ -2536,10 +2592,12 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
                     }
                 }
 
+                const bool current_loss_of_lock =
+                    rover->loss_of_lock || reference->loss_of_lock;
                 if (rover->has_carrier_phase &&
                     reference->has_carrier_phase &&
-                    !rover->loss_of_lock &&
-                    !reference->loss_of_lock) {
+                    (!current_loss_of_lock ||
+                     config_.use_single_difference_tdcp_integer_slip_repair)) {
                     const double rover_carrier_residual =
                         rover->corrected_carrier_m -
                         rover->model_debug.geometric_range_m;
@@ -2551,16 +2609,105 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
                     current_sd_carrier_residuals[carrier_key] =
                         SingleDifferenceCarrierResidual{
                             epoch_index,
+                            reference_satellite,
                             sd_carrier_residual,
                             sd_los,
+                            rover->has_doppler_residual &&
+                                reference->has_doppler_residual,
+                            rover->doppler_residual_mps -
+                                reference->doppler_residual_mps,
+                            rover->wavelength_m,
                         };
 
                     const auto previous_it =
                         previous_sd_carrier_residuals.find(carrier_key);
                     if (config_.use_single_difference_tdcp_factors &&
                         previous_it != previous_sd_carrier_residuals.end()) {
-                        const double tdcp =
+                        double tdcp =
                             sd_carrier_residual - previous_it->second.residual_m;
+                        int repaired_slip_cycles = 0;
+                        bool repaired_cycle_slip = false;
+
+                        if (config_
+                                .use_single_difference_tdcp_integer_slip_repair) {
+                            if (!(previous_it->second.reference_satellite ==
+                                  reference_satellite)) {
+                                ++problem.diagnostics
+                                      .single_difference_tdcp_rejected_reference_change;
+                                continue;
+                            }
+
+                            const double dt =
+                                problem.epochs[epoch_index].time -
+                                problem.epochs[previous_it->second.epoch_index].time;
+                            const double wavelength = rover->wavelength_m;
+                            const bool repair_observable =
+                                dt > 0.0 &&
+                                (config_.max_tdcp_gap_s <= 0.0 ||
+                                 dt <= config_.max_tdcp_gap_s) &&
+                                previous_it->second.has_doppler_residual &&
+                                rover->has_doppler_residual &&
+                                reference->has_doppler_residual &&
+                                std::isfinite(wavelength) && wavelength > 0.0;
+                            bool repair_accepted = false;
+                            if (repair_observable) {
+                                const double current_sd_doppler_mps =
+                                    rover->doppler_residual_mps -
+                                    reference->doppler_residual_mps;
+                                const double predicted_tdcp_m =
+                                    0.5 *
+                                    (previous_it->second.doppler_residual_mps +
+                                     current_sd_doppler_mps) *
+                                    dt;
+                                const double float_slip_cycles =
+                                    (tdcp - predicted_tdcp_m) / wavelength;
+                                const long long rounded_slip_cycles =
+                                    std::llround(float_slip_cycles);
+                                const double integer_residual_cycles =
+                                    std::abs(float_slip_cycles -
+                                             static_cast<double>(
+                                                 rounded_slip_cycles));
+                                const bool nonzero_candidate =
+                                    rounded_slip_cycles != 0;
+                                if (current_loss_of_lock) {
+                                    ++problem.diagnostics
+                                          .single_difference_tdcp_slip_repair_candidates;
+                                }
+                                // Doppler on its own is not a sufficiently
+                                // independent slip detector on a moving
+                                // low-cost receiver: range-rate/model errors
+                                // can sit close to an integer wavelength.
+                                // Use it only to estimate the integer amount
+                                // after the receiver LLI has declared an arc
+                                // break.
+                                if (current_loss_of_lock && nonzero_candidate &&
+                                    std::abs(rounded_slip_cycles) <=
+                                        std::max(
+                                            0,
+                                            config_
+                                                .single_difference_tdcp_slip_repair_max_cycles) &&
+                                    integer_residual_cycles <=
+                                        std::max(
+                                            0.0,
+                                            config_
+                                                .single_difference_tdcp_slip_repair_tolerance_cycles)) {
+                                    repaired_slip_cycles =
+                                        static_cast<int>(rounded_slip_cycles);
+                                    tdcp -= static_cast<double>(
+                                                repaired_slip_cycles) *
+                                            wavelength;
+                                    repaired_cycle_slip = true;
+                                    repair_accepted = true;
+                                    ++problem.diagnostics
+                                          .single_difference_tdcp_slip_repairs;
+                                }
+                            }
+                            if (current_loss_of_lock && !repair_accepted) {
+                                ++problem.diagnostics
+                                      .single_difference_tdcp_slip_repair_rejects;
+                                continue;
+                            }
+                        }
                         if (std::isfinite(tdcp) && tdcp != 0.0) {
                             SingleDifferenceTdcpFactor factor;
                             factor.previous_epoch_index =
@@ -2579,6 +2726,8 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
                                          config_.single_difference_tdcp_sigma_m /
                                              std::sqrt(sin_el));
                             factor.elevation_rad = rover->elevation_rad;
+                            factor.repaired_slip_cycles = repaired_slip_cycles;
+                            factor.repaired_cycle_slip = repaired_cycle_slip;
                             problem.single_difference_tdcp_factors.push_back(factor);
                         }
                     }
@@ -2593,6 +2742,9 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
     problem.diagnostics.code_minus_carrier_level_exclusions =
         cmc_level_exclusion_total;
     problem.diagnostics.cmc_ref_avoided_count = cmc_ref_avoided_total;
+    problem.diagnostics.wcmc_pseudorange_corrections = wcmc_correction_total;
+    problem.diagnostics.wcmc_pseudorange_correction_square_sum_m2 =
+        wcmc_correction_square_sum_m2;
 
     return problem;
 }
@@ -2742,6 +2894,14 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
         problem.diagnostics.tdcp_rejected_loss_of_lock;
     result.diagnostics.tdcp_rejected_code_phase_jump =
         problem.diagnostics.tdcp_rejected_code_phase_jump;
+    result.diagnostics.single_difference_tdcp_rejected_reference_change =
+        problem.diagnostics.single_difference_tdcp_rejected_reference_change;
+    result.diagnostics.single_difference_tdcp_slip_repair_candidates =
+        problem.diagnostics.single_difference_tdcp_slip_repair_candidates;
+    result.diagnostics.single_difference_tdcp_slip_repairs =
+        problem.diagnostics.single_difference_tdcp_slip_repairs;
+    result.diagnostics.single_difference_tdcp_slip_repair_rejects =
+        problem.diagnostics.single_difference_tdcp_slip_repair_rejects;
     result.diagnostics.double_difference_matched_base_epochs =
         problem.diagnostics.double_difference_matched_base_epochs;
     result.diagnostics.double_difference_interpolated_base_epochs =
@@ -2758,6 +2918,14 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
         problem.diagnostics.code_minus_carrier_level_exclusions;
     result.diagnostics.cmc_ref_avoided_count =
         problem.diagnostics.cmc_ref_avoided_count;
+    result.diagnostics.wcmc_pseudorange_corrections =
+        problem.diagnostics.wcmc_pseudorange_corrections;
+    if (problem.diagnostics.wcmc_pseudorange_corrections > 0) {
+        result.diagnostics.wcmc_pseudorange_correction_rms_m = std::sqrt(
+            problem.diagnostics.wcmc_pseudorange_correction_square_sum_m2 /
+            static_cast<double>(
+                problem.diagnostics.wcmc_pseudorange_corrections));
+    }
 
     if (problem.epochs.empty() ||
         (problem.pseudorange_factors.empty() &&
@@ -4316,8 +4484,33 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                               config_.lambda_ratio_threshold,
                               config_.multisd_lambda_candidate_ratio_threshold)
                         : config_.lambda_ratio_threshold;
+                const bool is_fallback_group =
+                    !lambda_hypothesis_group_ends.empty();
+                bool integer_aperture_passed = true;
+                if (is_fallback_group &&
+                    config_.use_multisd_fallback_integer_aperture) {
+                    ++result.diagnostics.multisd_integer_aperture_attempts;
+                    const double scaled_bsr = bootstrappedSuccessRate(
+                        lambda_diagnostics.conditional_variances,
+                        config_
+                            .multisd_fallback_integer_aperture_covariance_scale);
+                    FixedFailureRateRatioThreshold aperture;
+                    integer_aperture_passed =
+                        fixedFailureRateRatioThreshold(
+                            n, scaled_bsr, 0.001, aperture) &&
+                        aperture.accepts_any_candidate &&
+                        std::isfinite(lambda_ratio) &&
+                        lambda_ratio >=
+                            aperture.minimum_second_to_best_ratio;
+                    if (integer_aperture_passed) {
+                        ++result.diagnostics.multisd_integer_aperture_passes;
+                    } else {
+                        ++result.diagnostics.multisd_integer_aperture_rejects;
+                    }
+                }
                 const double minimum_bootstrapped_success_rate =
-                    !lambda_hypothesis_group_ends.empty() &&
+                    is_fallback_group &&
+                            !config_.use_multisd_fallback_integer_aperture &&
                             config_
                                     .multisd_fallback_min_bootstrapped_success_rate >
                                 0.0
@@ -4330,6 +4523,7 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(
                     !std::isfinite(lambda_ratio) ||
                     (candidate_ratio_threshold > 0.0 &&
                      lambda_ratio < candidate_ratio_threshold) ||
+                    !integer_aperture_passed ||
                     (minimum_bootstrapped_success_rate > 0.0 &&
                      lambda_diagnostics.bootstrapped_success_rate <
                          minimum_bootstrapped_success_rate) ||

--- a/src/fusion/fusion_processor.cpp
+++ b/src/fusion/fusion_processor.cpp
@@ -452,6 +452,10 @@ LooseCouplingProcessor::processTightlyCoupledDD(
     if (!initialized_ || !origin_set_ || observations.empty()) {
         return result;
     }
+    if (!isHeadingConverged()) {
+        result.deferred_until_heading_converged = true;
+        return result;
+    }
     if (!dd_imu_bridge_) {
         dd_imu_bridge::BridgeConfig bridge_config;
         bridge_config.commit_carrier_updates =

--- a/tests/test_fgo.cpp
+++ b/tests/test_fgo.cpp
@@ -310,7 +310,9 @@ bool makeSyntheticGpsL1Observation(const NavigationData& nav,
                                    const GNSSTime& time,
                                    const Vector3d& receiver_position,
                                    double carrier_bias_m,
-                                   Observation& observation) {
+                                   Observation& observation,
+                                   double doppler_residual_mps =
+                                       std::numeric_limits<double>::quiet_NaN()) {
     double pseudorange = 22'000'000.0;
     Vector3d satellite_position = Vector3d::Zero();
     Vector3d satellite_velocity = Vector3d::Zero();
@@ -339,6 +341,23 @@ bool makeSyntheticGpsL1Observation(const NavigationData& nav,
     observation.snr = 45.0;
     observation.has_pseudorange = true;
     observation.has_carrier_phase = true;
+    if (std::isfinite(doppler_residual_mps)) {
+        const Vector3d delta = satellite_position - receiver_position;
+        const Vector3d ex = delta.normalized();
+        const double sagnac_rate =
+            constants::OMEGA_E / constants::SPEED_OF_LIGHT *
+            (satellite_velocity(1) * receiver_position(0) -
+             satellite_velocity(0) * receiver_position(1));
+        const double modeled_range_rate =
+            satellite_velocity.dot(ex) + sagnac_rate;
+        const double satellite_clock_drift_mps =
+            satellite_clock_drift * constants::SPEED_OF_LIGHT;
+        observation.doppler =
+            -(modeled_range_rate - satellite_clock_drift_mps +
+              doppler_residual_mps) /
+            constants::GPS_L1_WAVELENGTH;
+        observation.has_doppler = true;
+    }
     observation.valid = true;
     return true;
 }
@@ -364,7 +383,8 @@ std::vector<ObservationData> makeSyntheticDoubleDifferenceObservationEpochs(
                     epoch.time,
                     receiver_positions[epoch_index],
                     carrier_bias_m,
-                    observation)) {
+                    observation,
+                    carrier_epoch_slope_m * static_cast<double>(prn))) {
                 epoch.addObservation(observation);
             }
         }
@@ -731,6 +751,80 @@ TEST(FGOTest, BuiltSingleDifferenceTdcpFactorsUseCurrentEpochLos) {
     }
 
     EXPECT_GT(max_previous_current_los_delta, 1e-8);
+}
+
+TEST(FGOTest, SingleDifferenceTdcpIntegerSlipRepairUsesDopplerAndFailsClosed) {
+    const NavigationData nav = makeSyntheticGpsNavigation(4);
+    const std::array<Vector3d, 2> rover_positions = {
+        Vector3d(1113194.0, -4841695.0, 3985350.0),
+        Vector3d(1113214.0, -4841680.0, 3985342.0),
+    };
+    const std::array<Vector3d, 2> base_positions = {
+        rover_positions[0] + Vector3d(-320.0, 180.0, 45.0),
+        rover_positions[1] + Vector3d(-320.0, 180.0, 45.0),
+    };
+    auto rover_epochs =
+        makeSyntheticDoubleDifferenceObservationEpochs(nav, rover_positions, 0.04);
+    const auto base_epochs =
+        makeSyntheticDoubleDifferenceObservationEpochs(nav, base_positions, 0.02);
+
+    FGOProcessor::FGOConfig config;
+    config.use_spp_seed = false;
+    config.use_pseudorange_factors = false;
+    config.use_motion_factors = false;
+    config.use_tdcp_factors = false;
+    config.use_double_difference_factors = true;
+    config.use_single_difference_tdcp_factors = true;
+    config.use_single_difference_tdcp_integer_slip_repair = true;
+    config.use_ionosphere_model = false;
+    config.use_troposphere_model = false;
+    config.reject_tdcp_code_phase_jump = false;
+    config.min_elevation_deg = -90.0;
+    config.min_satellites_per_epoch = 2;
+
+    FGOProcessor processor(config);
+    const auto clean_problem = processor.buildDoubleDifferenceProblem(
+        rover_epochs, base_epochs, nav, base_positions[0]);
+    ASSERT_FALSE(clean_problem.single_difference_tdcp_factors.empty());
+    EXPECT_EQ(clean_problem.diagnostics.single_difference_tdcp_slip_repairs, 0u);
+    EXPECT_EQ(
+        clean_problem.diagnostics.single_difference_tdcp_slip_repair_candidates,
+        0u);
+
+    for (auto& observation : rover_epochs[1].observations) {
+        observation.carrier_phase +=
+            2.0 * static_cast<double>(observation.satellite.prn);
+        observation.lli |= 0x01U;
+    }
+    const auto repaired_problem = processor.buildDoubleDifferenceProblem(
+        rover_epochs, base_epochs, nav, base_positions[0]);
+
+    ASSERT_EQ(repaired_problem.single_difference_tdcp_factors.size(),
+              clean_problem.single_difference_tdcp_factors.size());
+    EXPECT_EQ(repaired_problem.diagnostics.single_difference_tdcp_slip_repairs,
+              repaired_problem.single_difference_tdcp_factors.size());
+    EXPECT_EQ(
+        repaired_problem.diagnostics.single_difference_tdcp_slip_repair_rejects,
+        0u);
+    for (std::size_t i = 0;
+         i < repaired_problem.single_difference_tdcp_factors.size(); ++i) {
+        const auto& repaired = repaired_problem.single_difference_tdcp_factors[i];
+        const auto& clean = clean_problem.single_difference_tdcp_factors[i];
+        EXPECT_TRUE(repaired.repaired_cycle_slip);
+        EXPECT_NE(repaired.repaired_slip_cycles, 0);
+        EXPECT_NEAR(repaired.delta_carrier_m, clean.delta_carrier_m, 1e-6);
+    }
+
+    auto missing_doppler_epochs = rover_epochs;
+    for (auto& observation : missing_doppler_epochs[1].observations) {
+        observation.has_doppler = false;
+    }
+    const auto rejected_problem = processor.buildDoubleDifferenceProblem(
+        missing_doppler_epochs, base_epochs, nav, base_positions[0]);
+    EXPECT_TRUE(rejected_problem.single_difference_tdcp_factors.empty());
+    EXPECT_GT(
+        rejected_problem.diagnostics.single_difference_tdcp_slip_repair_rejects,
+        0u);
 }
 
 TEST(FGOTest, RobustLossDownweightsPseudorangeOutlier) {
@@ -1275,6 +1369,66 @@ TEST(FGOTest, CmcScreeningDefaultOffIsNoOp) {
 
     EXPECT_EQ(problem.diagnostics.code_minus_carrier_jump_resets, 0u);
     EXPECT_EQ(problem.diagnostics.code_minus_carrier_level_exclusions, 0u);
+}
+
+TEST(FGOTest, WcmcConditionsTimeVaryingDdCodeBiasWithoutChangingCarrierArc) {
+    const NavigationData nav = makeSyntheticGpsNavigation(2);
+    const Vector3d rover_position(1113194.0, -4841695.0, 3985350.0);
+    const Vector3d base_position =
+        rover_position + Vector3d(-320.0, 180.0, 45.0);
+    const std::vector<std::array<double, 2>> zero_bias = {
+        {0.0, 0.0}, {0.0, 0.0},
+    };
+    const auto clean_rover =
+        makeCmcObservationEpochs(nav, rover_position, zero_bias, 1.0);
+    auto biased_rover = clean_rover;
+    const auto base_epochs =
+        makeCmcObservationEpochs(nav, base_position, zero_bias, 1.0);
+    // Epoch 0 establishes the causal CMC baseline. At epoch 1 add distinct
+    // satellite code biases while leaving carrier phase unchanged.
+    ASSERT_EQ(biased_rover[1].observations.size(), 2u);
+    biased_rover[1].observations[0].pseudorange += 2.0;
+    biased_rover[1].observations[1].pseudorange += 5.0;
+
+    FGOProcessor::FGOConfig clean_config = makeCmcTestConfig();
+    clean_config.use_code_minus_carrier_screening = false;
+    FGOProcessor clean_processor(clean_config);
+    const auto clean_problem = clean_processor.buildDoubleDifferenceProblem(
+        clean_rover, base_epochs, nav, base_position);
+    const auto unconditioned_problem = clean_processor.buildDoubleDifferenceProblem(
+        biased_rover, base_epochs, nav, base_position);
+
+    FGOProcessor::FGOConfig wcmc_config = clean_config;
+    wcmc_config.use_wcmc_pseudorange_conditioning = true;
+    wcmc_config.code_minus_carrier_warmup_epochs = 1;
+    wcmc_config.code_minus_carrier_baseline_alpha = 0.0;
+    wcmc_config.wcmc_max_correction_m = 10.0;
+    FGOProcessor wcmc_processor(wcmc_config);
+    const auto conditioned_problem = wcmc_processor.buildDoubleDifferenceProblem(
+        biased_rover, base_epochs, nav, base_position);
+
+    ASSERT_EQ(clean_problem.double_difference_pseudorange_factors.size(), 2u);
+    ASSERT_EQ(unconditioned_problem.double_difference_pseudorange_factors.size(),
+              2u);
+    ASSERT_EQ(conditioned_problem.double_difference_pseudorange_factors.size(),
+              2u);
+    const double clean_epoch1 =
+        clean_problem.double_difference_pseudorange_factors[1]
+            .observed_dd_pseudorange_m;
+    const double biased_epoch1 =
+        unconditioned_problem.double_difference_pseudorange_factors[1]
+            .observed_dd_pseudorange_m;
+    const double conditioned_epoch1 =
+        conditioned_problem.double_difference_pseudorange_factors[1]
+            .observed_dd_pseudorange_m;
+    EXPECT_GT(std::abs(biased_epoch1 - clean_epoch1), 2.9);
+    EXPECT_NEAR(conditioned_epoch1, clean_epoch1, 1e-3);
+    EXPECT_EQ(conditioned_problem.diagnostics.wcmc_pseudorange_corrections, 1u);
+    ASSERT_EQ(conditioned_problem.double_difference_carrier_factors.size(), 2u);
+    EXPECT_EQ(conditioned_problem.double_difference_carrier_factors[0]
+                  .ambiguity_index,
+              conditioned_problem.double_difference_carrier_factors[1]
+                  .ambiguity_index);
 }
 
 TEST(FGOTest, CmcLevelExclusionSkipsBothFactorsWithoutUpdatingBaseline) {

--- a/tests/test_fusion_processor_synthetic.cpp
+++ b/tests/test_fusion_processor_synthetic.cpp
@@ -131,8 +131,28 @@ TEST(FusionProcessorSyntheticTest, AppliesTightlyCoupledDDRowsToLiveINSState) {
     row.elevation_rad = 0.8;
     row.lock_count = 100;
 
+    const double unaligned_x = processor.state().nominal.position_enu.x();
+    const auto deferred = processor.processTightlyCoupledDD({row}, &anchor);
+    EXPECT_TRUE(deferred.deferred_until_heading_converged);
+    EXPECT_FALSE(deferred.update.ok);
+    EXPECT_DOUBLE_EQ(processor.state().nominal.position_enu.x(), unaligned_x);
+
+    // Three mutually consistent moving GNSS epochs satisfy the production
+    // heading-health gate before the DD row can touch the live INS state.
+    const Eigen::Vector3d east_velocity_enu(5.0, 0.0, 0.0);
+    anchor.has_velocity = true;
+    anchor.velocity_ecef =
+        processor.ecefToLocalEnuRotation().transpose() * east_velocity_enu;
+    anchor.velocity_covariance = 0.01 * Eigen::Matrix3d::Identity();
+    for (int i = 0; i < 3; ++i) {
+        anchor.time = time + (0.5 * i);
+        processor.processGnssSolution(anchor);
+    }
+    ASSERT_TRUE(processor.isHeadingConverged());
+
     const double before_x = processor.state().nominal.position_enu.x();
     const auto result = processor.processTightlyCoupledDD({row}, &anchor);
+    EXPECT_FALSE(result.deferred_until_heading_converged);
     EXPECT_TRUE(result.update.ok);
     EXPECT_EQ(result.update.observation_count, 2);
     EXPECT_GT(processor.state().nominal.position_enu.x(), before_x);


### PR DESCRIPTION
## What changed

- add opt-in Doppler-conditioned SD-TDCP integer cycle-slip repair
- add opt-in causal WCMC pseudorange conditioning and fallback Integer Aperture diagnostics
- expose all research controls and telemetry through `gnss_solve`
- fail closed for tight-DD/IMU updates until heading is converged
- add synthetic coverage for slip repair, WCMC carrier-arc invariance, and the IMU heading gate

## Why

PPC experiments needed paper-derived GNSS candidates without weakening the existing false-FIX authority, followed by a safe native IMU fusion path. A Nagoya smoke test found that tight-DD updates could be accepted at low NIS before heading observability and corrupt the fused prefix. The new library-level gate prevents any caller from applying those updates before heading convergence.

All new GNSS research candidates are default-off because the six-route evaluations did not establish a cross-route availability improvement. The existing safe GNSS policy remains unchanged.

## Validation

- monolithic C++ suite: 826 tests, 766 passed, 60 dataset-dependent skipped, 0 failed
- focused FGO suite: 29/29 passed
- IMU preintegration and DD bridge: 26/26 passed
- fusion synthetic suite: 10/10 passed
- Python GNSS fuse/solve CLI tests: 4/4 and 5/5 passed
- PPC unaligned smoke: honest score restored from 0% to 100%; 90/90 DD epochs deferred
- six blocked spans: 3,204 accepted, 57 innovation-rejected, 1,524 heading-deferred; mixed per-route accuracy keeps tight-DD opt-in
