### PR TITLE
Trace geometry-free cycle-slip exposure

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,16 @@ normalized satellite/signal trace is written beside it as
 These fields only report decisions already made by the solver; enabling the
 CSV dump does not alter candidate selection or FIX/FLOAT decisions.
 
+The same dump also includes `gf_slip_events`, `gf_slip_max_jump_m`, and
+`gf_slip_tainted_ambiguities`. This geometry-free shadow follows the 0.05 m
+single-difference carrier jump used by
+[GICI-LIB](https://github.com/chichengcn/gici-open/blob/master/src/gnss/ambiguity_common.cpp)
+and the multi-frequency arc checks in
+[RTKLIB](https://github.com/tomojitakasu/RTKLIB/blob/master/src/rtkpos.c).
+It ignores gaps and arcs already restarted by the existing LLI/CMC logic,
+then reports how many unchanged DD ambiguity arcs remain exposed after a
+new jump. It never restarts an arc or changes the factor graph.
+
 `--ratio-impact-monitor` adds a counterfactual partial-AR audit for epochs
 that remain ratio-rejected. It removes each target satellite in turn, reruns
 LAMBDA, and writes the best ratio, subset size, candidate ECEF position, and

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -707,6 +707,8 @@ libgnss::FGOProcessor::FGOConfig makeRealDataDdConfig() {
 // call, without duplicating this arg-to-config mapping logic.
 libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
     libgnss::FGOProcessor::FGOConfig config = makeRealDataDdConfig();
+    // Reuse the existing diagnostic surface; do not add another CLI option.
+    config.monitor_geometry_free_cycle_slip = !args.dump_csv_path.empty();
     config.report_held_ambiguities_as_fixed = !args.no_held_fix_label;
     if (args.max_iters > 0) {
         config.max_iterations = args.max_iters;
@@ -1496,6 +1498,7 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
            "lambda_candidate_bsr_qscale16,lambda_candidate_ffrt_supported,"
            "lambda_candidate_ffrt_accepts_any,lambda_candidate_ffrt_min_ratio,"
            "lambda_candidate_ffrt_pass,"
+           "gf_slip_events,gf_slip_max_jump_m,gf_slip_tainted_ambiguities,"
            "ratio_impact_eval,ratio_impact_trials,ratio_impact_best_ratio,"
            "ratio_impact_best_nfixed,ratio_impact_x_ecef_m,"
            "ratio_impact_y_ecef_m,ratio_impact_z_ecef_m,"
@@ -1596,6 +1599,9 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                 << ',' << (d.lambda_candidate_ffrt_accepts_any ? 1 : 0)
                 << ',' << d.lambda_candidate_ffrt_min_ratio
                 << ',' << (d.lambda_candidate_ffrt_pass ? 1 : 0)
+                << ',' << d.gf_slip_shadow_event_pairs
+                << ',' << d.gf_slip_shadow_max_jump_m
+                << ',' << d.gf_slip_shadow_tainted_ambiguities
                 << ',' << (d.ratio_impact_evaluated ? 1 : 0)
                 << ',' << d.ratio_impact_trials
                 << ',' << d.ratio_impact_best_ratio

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -384,6 +384,8 @@ public:
         // satellite in turn and record the best candidate. Never changes the
         // selected subset, FIX/FLOAT status, graph, or hold state.
         bool monitor_ratio_impact_partial_ar = false;
+        // Diagnostic-only geometry-free slip/arc-continuity shadow.
+        bool monitor_geometry_free_cycle_slip = false;
         // GICI-style PAR: prefer ambiguities with the smallest marginal
         // variance and do not attempt a subset whose least precise member
         // exceeds this standard deviation in cycles (<=0 disables the gate).
@@ -1712,6 +1714,12 @@ public:
         FGOProblemDiagnostics diagnostics;
     };
 
+    struct GeometryFreeSlipShadowEpoch {
+        int event_pairs = 0;
+        double max_jump_m = 0.0;
+        int tainted_ambiguities = 0;
+    };
+
     struct FGODiagnostics {
         int iterations = 0;
         bool converged = false;
@@ -2029,6 +2037,12 @@ public:
         bool lambda_candidate_ffrt_accepts_any = false;
         double lambda_candidate_ffrt_min_ratio = 0.0;
         bool lambda_candidate_ffrt_pass = false;
+        // Diagnostic-only geometry-free cycle-slip shadow. It analyzes the
+        // rover/base single-difference carrier phases already present in the
+        // DD factors, but never changes ambiguity arcs or graph factors.
+        int gf_slip_shadow_event_pairs = 0;
+        double gf_slip_shadow_max_jump_m = 0.0;
+        int gf_slip_shadow_tainted_ambiguities = 0;
         bool ratio_impact_evaluated = false;
         int ratio_impact_trials = 0;
         double ratio_impact_best_ratio = 0.0;
@@ -2131,6 +2145,11 @@ public:
 
     const FGOConfig& getConfig() const { return config_; }
     void setConfig(const FGOConfig& config) { config_ = config; }
+
+    static std::vector<GeometryFreeSlipShadowEpoch>
+    analyzeGeometryFreeSlipShadow(const FGOProblem& problem,
+                                  double threshold_m = 0.05,
+                                  double max_gap_s = 1.5);
 
     FGOProblem buildPseudorangeProblem(const std::vector<ObservationData>& epochs,
                                        const NavigationData& nav) const;

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -2470,6 +2470,116 @@ FGOProcessor::FGOResult FGOProcessor::optimize(
     return optimizeProblem(buildPseudorangeProblem(epochs, nav));
 }
 
+std::vector<FGOProcessor::GeometryFreeSlipShadowEpoch>
+FGOProcessor::analyzeGeometryFreeSlipShadow(const FGOProblem& problem,
+                                            double threshold_m,
+                                            double max_gap_s) {
+    struct PhaseSample {
+        double single_difference_phase_m = 0.0;
+        std::set<std::size_t> ambiguity_indices;
+    };
+    struct History {
+        GNSSTime time;
+        double geometry_free_m = 0.0;
+        std::set<std::size_t> first_ambiguity_indices;
+        std::set<std::size_t> second_ambiguity_indices;
+    };
+
+    using CarrierKey = std::pair<SatelliteId, SignalType>;
+    using PairKey = std::tuple<SatelliteId, SignalType, SignalType>;
+    std::vector<std::map<CarrierKey, PhaseSample>> phases_by_epoch(
+        problem.epochs.size());
+    for (const auto& factor : problem.double_difference_carrier_factors) {
+        if (factor.epoch_index >= phases_by_epoch.size()) {
+            continue;
+        }
+        auto& phases = phases_by_epoch[factor.epoch_index];
+        const auto add_phase = [&](const CarrierKey& key, double phase_m) {
+            auto& sample = phases[key];
+            sample.single_difference_phase_m = phase_m;
+            sample.ambiguity_indices.insert(factor.ambiguity_index);
+        };
+        add_phase({factor.satellite, factor.signal},
+                  factor.rover_satellite_model.raw_carrier_m -
+                      factor.base_satellite_model.raw_carrier_m);
+        // A slip on the DD reference contaminates every target ambiguity in
+        // that group, hence the same factor ambiguity is attached here too.
+        add_phase({factor.reference_satellite, factor.signal},
+                  factor.rover_reference_model.raw_carrier_m -
+                      factor.base_reference_model.raw_carrier_m);
+    }
+
+    std::vector<GeometryFreeSlipShadowEpoch> shadow(problem.epochs.size());
+    std::map<PairKey, History> history;
+    std::set<std::size_t> tainted_ambiguities;
+    const double safe_threshold = std::max(0.0, threshold_m);
+    const double safe_max_gap = std::max(0.0, max_gap_s);
+    for (std::size_t epoch_index = 0; epoch_index < phases_by_epoch.size();
+         ++epoch_index) {
+        std::map<SatelliteId, std::vector<std::pair<SignalType, PhaseSample>>>
+            by_satellite;
+        for (const auto& [key, sample] : phases_by_epoch[epoch_index]) {
+            by_satellite[key.first].push_back({key.second, sample});
+        }
+        const GNSSTime time = problem.epochs[epoch_index].time;
+        for (const auto& [satellite, samples] : by_satellite) {
+            for (std::size_t first = 0; first < samples.size(); ++first) {
+                for (std::size_t second = first + 1; second < samples.size();
+                     ++second) {
+                    const auto& first_sample = samples[first].second;
+                    const auto& second_sample = samples[second].second;
+                    const double geometry_free =
+                        first_sample.single_difference_phase_m -
+                        second_sample.single_difference_phase_m;
+                    const PairKey key{satellite, samples[first].first,
+                                      samples[second].first};
+                    const auto previous = history.find(key);
+                    if (previous != history.end()) {
+                        const double dt = time - previous->second.time;
+                        const bool same_arcs =
+                            previous->second.first_ambiguity_indices ==
+                                first_sample.ambiguity_indices &&
+                            previous->second.second_ambiguity_indices ==
+                                second_sample.ambiguity_indices;
+                        if (same_arcs && dt > 0.0 &&
+                            (safe_max_gap <= 0.0 || dt <= safe_max_gap)) {
+                            const double jump = std::abs(
+                                geometry_free - previous->second.geometry_free_m);
+                            if (jump > safe_threshold) {
+                                ++shadow[epoch_index].event_pairs;
+                                shadow[epoch_index].max_jump_m = std::max(
+                                    shadow[epoch_index].max_jump_m, jump);
+                                tainted_ambiguities.insert(
+                                    first_sample.ambiguity_indices.begin(),
+                                    first_sample.ambiguity_indices.end());
+                                tainted_ambiguities.insert(
+                                    second_sample.ambiguity_indices.begin(),
+                                    second_sample.ambiguity_indices.end());
+                            }
+                        }
+                    }
+                    history[key] = {time, geometry_free,
+                                    first_sample.ambiguity_indices,
+                                    second_sample.ambiguity_indices};
+                }
+            }
+        }
+
+        std::set<std::size_t> tainted_present;
+        for (const auto& [key, sample] : phases_by_epoch[epoch_index]) {
+            (void)key;
+            for (const std::size_t ambiguity_index : sample.ambiguity_indices) {
+                if (tainted_ambiguities.count(ambiguity_index) != 0) {
+                    tainted_present.insert(ambiguity_index);
+                }
+            }
+        }
+        shadow[epoch_index].tainted_ambiguities =
+            static_cast<int>(tainted_present.size());
+    }
+    return shadow;
+}
+
 FGOProcessor::FGOResult FGOProcessor::optimize(
     const std::vector<ObservationData>& rover_epochs,
     const std::vector<ObservationData>& base_epochs,

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -823,6 +823,10 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
     const auto start_time = std::chrono::high_resolution_clock::now();
 
     const std::size_t num_epochs = problem.epochs.size();
+    const auto gf_slip_shadow = config.monitor_geometry_free_cycle_slip
+        ? FGOProcessor::analyzeGeometryFreeSlipShadow(
+              problem, 0.05, config.max_tdcp_gap_s)
+        : std::vector<FGOProcessor::GeometryFreeSlipShadowEpoch>{};
     const Point3 lever_arm_body(config.pose3_lever_arm_body_m.x(),
                                 config.pose3_lever_arm_body_m.y(),
                                 config.pose3_lever_arm_body_m.z());
@@ -1972,6 +1976,14 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             problem.epochs[i].fresh_spp_solution;
         epoch_diagnostics[i].spp_seed_position_ecef =
             problem.epochs[i].position_ecef;
+        if (i < gf_slip_shadow.size()) {
+            epoch_diagnostics[i].gf_slip_shadow_event_pairs =
+                gf_slip_shadow[i].event_pairs;
+            epoch_diagnostics[i].gf_slip_shadow_max_jump_m =
+                gf_slip_shadow[i].max_jump_m;
+            epoch_diagnostics[i].gf_slip_shadow_tainted_ambiguities =
+                gf_slip_shadow[i].tainted_ambiguities;
+        }
         epoch_diagnostics[i].ar_outcome = config.use_lambda_ambiguity_fix
             ? FGOProcessor::AmbiguityResolutionOutcome::SmootherFailure
             : FGOProcessor::AmbiguityResolutionOutcome::Disabled;

--- a/tests/test_fgo.cpp
+++ b/tests/test_fgo.cpp
@@ -1142,6 +1142,47 @@ TEST(FGOTest, PropagatesTdcpQualityDiagnostics) {
     EXPECT_EQ(result.diagnostics.tdcp_rejected_code_phase_jump, 5u);
 }
 
+TEST(FGOTest, GeometryFreeSlipShadowTaintsExistingDdAmbiguityArc) {
+    FGOProcessor::FGOProblem problem;
+    for (int epoch = 0; epoch < 3; ++epoch) {
+        FGOProcessor::EpochSeed seed;
+        seed.time = GNSSTime(2300, 100000.0 + 0.2 * epoch);
+        problem.epochs.push_back(seed);
+
+        const auto add_factor = [&](SignalType signal,
+                                    std::size_t ambiguity_index,
+                                    double target_sd_phase_m,
+                                    double reference_sd_phase_m) {
+            FGOProcessor::DoubleDifferenceCarrierFactor factor;
+            factor.epoch_index = static_cast<std::size_t>(epoch);
+            factor.ambiguity_index = ambiguity_index;
+            factor.satellite = SatelliteId(GNSSSystem::GPS, 1);
+            factor.reference_satellite = SatelliteId(GNSSSystem::GPS, 2);
+            factor.signal = signal;
+            factor.rover_satellite_model.raw_carrier_m = target_sd_phase_m;
+            factor.base_satellite_model.raw_carrier_m = 0.0;
+            factor.rover_reference_model.raw_carrier_m = reference_sd_phase_m;
+            factor.base_reference_model.raw_carrier_m = 0.0;
+            problem.double_difference_carrier_factors.push_back(factor);
+        };
+
+        const double slip_m = epoch == 0 ? 0.0 : 0.10;
+        add_factor(SignalType::GPS_L1CA, 0, 10.0 + slip_m, 1.0);
+        add_factor(SignalType::GPS_L2C, 1, 8.0, 2.0);
+    }
+
+    const auto shadow =
+        FGOProcessor::analyzeGeometryFreeSlipShadow(problem, 0.05, 1.5);
+    ASSERT_EQ(shadow.size(), 3u);
+    EXPECT_EQ(shadow[0].event_pairs, 0);
+    EXPECT_EQ(shadow[0].tainted_ambiguities, 0);
+    EXPECT_EQ(shadow[1].event_pairs, 1);
+    EXPECT_NEAR(shadow[1].max_jump_m, 0.10, 1e-12);
+    EXPECT_EQ(shadow[1].tainted_ambiguities, 2);
+    EXPECT_EQ(shadow[2].event_pairs, 0);
+    EXPECT_EQ(shadow[2].tainted_ambiguities, 2);
+}
+
 TEST(FGOTest, CmcJumpForcesAmbiguityArcBreak) {
     const NavigationData nav = makeSyntheticGpsNavigation(2);
     const Vector3d rover_position(1113194.0, -4841695.0, 3985350.0);


### PR DESCRIPTION
## Summary\n- add a diagnostic-only geometry-free cycle-slip shadow over rover/base single-difference carrier phases already present in DD factors\n- report per-epoch GF event count, maximum jump, and ambiguity arcs still exposed after a missed jump\n- attach monitoring automatically to the existing --dump-csv surface; no new CLI option and normal library operation remains off\n- document the RTKLIB/GICI basis and add a synthetic arc-continuity test\n\n## Validation\n- focused native tests: 5/5 passed\n- full native suite: 820 passed, 60 existing skips, 0 failed (880 total)\n- Tokyo1 first 200: 0 behavior-field mismatches vs PR #416 baseline; 3 GF events, 29 tainted epochs\n- Tokyo1 full 11905: 0 behavior-field mismatches; 300 GF event pairs over 278 epochs, 5069 tainted epochs\n- wrong FIX exposure: 559/649 (86.1%) on tainted arcs\n- correct FIX exposure: 3165/5682 (55.7%) on tainted arcs\n\nThe shadow is intentionally not used as a demotion gate: its precision is insufficient. The next experiment will evaluate arc reinitialization at a confirmed GF event instead.\n\nRelates to #389.