### PR TITLE
Trace Doppler-confirmed cycle-slip bands

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,15 @@ It ignores gaps and arcs already restarted by the existing LLI/CMC logic,
 then reports how many unchanged DD ambiguity arcs remain exposed after a
 new jump. It never restarts an arc or changes the factor graph.
 
+The same shadow also compares each rover/base single-difference phase change
+with trapezoid-integrated Doppler at the existing RTK detector's 0.20 m
+threshold. `doppler_slip_signals` reports per-signal innovations and
+`gf_doppler_isolated_pairs` counts GF events for which Doppler identifies
+exactly one of the two bands. This remains diagnostic-only. In particular,
+the Doppler result is not used alone because RTKLIB disables its analogous
+detector over receiver clock-jump sensitivity; requiring the clock-free GF
+event first lets the trace evaluate Doppler only as a band-isolation witness.
+
 `--ratio-impact-monitor` adds a counterfactual partial-AR audit for epochs
 that remain ratio-rejected. It removes each target satellite in turn, reruns
 LAMBDA, and writes the best ratio, subset size, candidate ECEF position, and

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -1499,6 +1499,8 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
            "lambda_candidate_ffrt_accepts_any,lambda_candidate_ffrt_min_ratio,"
            "lambda_candidate_ffrt_pass,"
            "gf_slip_events,gf_slip_max_jump_m,gf_slip_tainted_ambiguities,"
+           "doppler_slip_signals,doppler_slip_max_innovation_m,"
+           "gf_doppler_isolated_pairs,"
            "ratio_impact_eval,ratio_impact_trials,ratio_impact_best_ratio,"
            "ratio_impact_best_nfixed,ratio_impact_x_ecef_m,"
            "ratio_impact_y_ecef_m,ratio_impact_z_ecef_m,"
@@ -1602,6 +1604,9 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                 << ',' << d.gf_slip_shadow_event_pairs
                 << ',' << d.gf_slip_shadow_max_jump_m
                 << ',' << d.gf_slip_shadow_tainted_ambiguities
+                << ',' << d.doppler_slip_shadow_event_signals
+                << ',' << d.doppler_slip_shadow_max_innovation_m
+                << ',' << d.gf_doppler_shadow_isolated_pairs
                 << ',' << (d.ratio_impact_evaluated ? 1 : 0)
                 << ',' << d.ratio_impact_trials
                 << ',' << d.ratio_impact_best_ratio
@@ -2114,7 +2119,7 @@ FileId statFile(const std::string& path) {
 // vector, new factor field, ...) -- an old cache then fails the magic/version
 // check in load() below and is rebuilt instead of misread.
 constexpr uint32_t kMagic = 0x50434647u;  // "PCFG" (problem-cache fgo)
-constexpr uint32_t kVersion = 7u;
+constexpr uint32_t kVersion = 8u;
 constexpr std::size_t kBuilderFingerprintBytes = 512u;
 
 struct Fingerprint {

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -1478,6 +1478,8 @@ public:
         double geometric_range_m = 0.0;
         double elevation_rad = 0.0;
         double azimuth_rad = 0.0;
+        bool has_doppler_residual = false;
+        double doppler_residual_mps = 0.0;
         // Raw rover-receiver SNR/CN0 [dB-Hz] for this observation (Observation::snr
         // at the point this model_debug was built). Added for the sat-badness
         // EWMA down-weighting port's elevation/SNR penalty terms (see
@@ -1718,6 +1720,9 @@ public:
         int event_pairs = 0;
         double max_jump_m = 0.0;
         int tainted_ambiguities = 0;
+        int doppler_event_signals = 0;
+        double doppler_max_innovation_m = 0.0;
+        int doppler_isolated_event_pairs = 0;
     };
 
     struct FGODiagnostics {
@@ -2043,6 +2048,9 @@ public:
         int gf_slip_shadow_event_pairs = 0;
         double gf_slip_shadow_max_jump_m = 0.0;
         int gf_slip_shadow_tainted_ambiguities = 0;
+        int doppler_slip_shadow_event_signals = 0;
+        double doppler_slip_shadow_max_innovation_m = 0.0;
+        int gf_doppler_shadow_isolated_pairs = 0;
         bool ratio_impact_evaluated = false;
         int ratio_impact_trials = 0;
         double ratio_impact_best_ratio = 0.0;

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -762,6 +762,10 @@ std::map<CarrierKey, PreparedCarrierObservation> prepareCarrierObservationsForRe
                     (modeled_range_rate - satellite_clock_drift_mps);
                 carrier.has_doppler_residual =
                     std::isfinite(carrier.doppler_residual_mps);
+                model_debug.has_doppler_residual =
+                    carrier.has_doppler_residual;
+                model_debug.doppler_residual_mps =
+                    carrier.doppler_residual_mps;
             }
         }
         carrier.model_debug = model_debug;
@@ -1228,6 +1232,10 @@ FGOProcessor::FGOProblem FGOProcessor::buildPseudorangeProblem(
                         (modeled_range_rate - satellite_clock_drift_mps);
                     carrier.has_doppler_residual =
                         std::isfinite(carrier.doppler_residual_mps);
+                    model_debug.has_doppler_residual =
+                        carrier.has_doppler_residual;
+                    model_debug.doppler_residual_mps =
+                        carrier.doppler_residual_mps;
                 }
             }
             carrier.model_debug = model_debug;
@@ -2476,6 +2484,8 @@ FGOProcessor::analyzeGeometryFreeSlipShadow(const FGOProblem& problem,
                                             double max_gap_s) {
     struct PhaseSample {
         double single_difference_phase_m = 0.0;
+        bool has_single_difference_doppler = false;
+        double single_difference_doppler_mps = 0.0;
         std::set<std::size_t> ambiguity_indices;
     };
     struct History {
@@ -2483,6 +2493,12 @@ FGOProcessor::analyzeGeometryFreeSlipShadow(const FGOProblem& problem,
         double geometry_free_m = 0.0;
         std::set<std::size_t> first_ambiguity_indices;
         std::set<std::size_t> second_ambiguity_indices;
+    };
+    struct DopplerHistory {
+        GNSSTime time;
+        double single_difference_phase_m = 0.0;
+        double single_difference_doppler_mps = 0.0;
+        std::set<std::size_t> ambiguity_indices;
     };
 
     using CarrierKey = std::pair<SatelliteId, SignalType>;
@@ -2494,23 +2510,37 @@ FGOProcessor::analyzeGeometryFreeSlipShadow(const FGOProblem& problem,
             continue;
         }
         auto& phases = phases_by_epoch[factor.epoch_index];
-        const auto add_phase = [&](const CarrierKey& key, double phase_m) {
+        const auto add_phase = [&](const CarrierKey& key, double phase_m,
+                                   const ObservationModelDebug& rover_model,
+                                   const ObservationModelDebug& base_model) {
             auto& sample = phases[key];
             sample.single_difference_phase_m = phase_m;
+            if (rover_model.has_doppler_residual &&
+                base_model.has_doppler_residual) {
+                sample.has_single_difference_doppler = true;
+                sample.single_difference_doppler_mps =
+                    rover_model.doppler_residual_mps -
+                    base_model.doppler_residual_mps;
+            }
             sample.ambiguity_indices.insert(factor.ambiguity_index);
         };
         add_phase({factor.satellite, factor.signal},
                   factor.rover_satellite_model.raw_carrier_m -
-                      factor.base_satellite_model.raw_carrier_m);
+                      factor.base_satellite_model.raw_carrier_m,
+                  factor.rover_satellite_model,
+                  factor.base_satellite_model);
         // A slip on the DD reference contaminates every target ambiguity in
         // that group, hence the same factor ambiguity is attached here too.
         add_phase({factor.reference_satellite, factor.signal},
                   factor.rover_reference_model.raw_carrier_m -
-                      factor.base_reference_model.raw_carrier_m);
+                      factor.base_reference_model.raw_carrier_m,
+                  factor.rover_reference_model,
+                  factor.base_reference_model);
     }
 
     std::vector<GeometryFreeSlipShadowEpoch> shadow(problem.epochs.size());
     std::map<PairKey, History> history;
+    std::map<CarrierKey, DopplerHistory> doppler_history;
     std::set<std::size_t> tainted_ambiguities;
     const double safe_threshold = std::max(0.0, threshold_m);
     const double safe_max_gap = std::max(0.0, max_gap_s);
@@ -2522,6 +2552,44 @@ FGOProcessor::analyzeGeometryFreeSlipShadow(const FGOProblem& problem,
             by_satellite[key.first].push_back({key.second, sample});
         }
         const GNSSTime time = problem.epochs[epoch_index].time;
+        std::set<CarrierKey> doppler_events;
+        for (const auto& [key, sample] : phases_by_epoch[epoch_index]) {
+            const auto previous = doppler_history.find(key);
+            if (sample.has_single_difference_doppler &&
+                previous != doppler_history.end()) {
+                const double dt = time - previous->second.time;
+                const bool same_arcs =
+                    previous->second.ambiguity_indices ==
+                    sample.ambiguity_indices;
+                if (same_arcs && dt > 0.0 &&
+                    (safe_max_gap <= 0.0 || dt <= safe_max_gap)) {
+                    const double predicted_delta_m =
+                        0.5 * (previous->second.single_difference_doppler_mps +
+                               sample.single_difference_doppler_mps) * dt;
+                    const double innovation_m = std::abs(
+                        sample.single_difference_phase_m -
+                        previous->second.single_difference_phase_m -
+                        predicted_delta_m);
+                    if (innovation_m > 0.20) {
+                        doppler_events.insert(key);
+                        shadow[epoch_index].doppler_max_innovation_m =
+                            std::max(
+                                shadow[epoch_index].doppler_max_innovation_m,
+                                innovation_m);
+                    }
+                }
+            }
+            if (sample.has_single_difference_doppler) {
+                doppler_history[key] = {
+                    time, sample.single_difference_phase_m,
+                    sample.single_difference_doppler_mps,
+                    sample.ambiguity_indices};
+            } else {
+                doppler_history.erase(key);
+            }
+        }
+        shadow[epoch_index].doppler_event_signals =
+            static_cast<int>(doppler_events.size());
         for (const auto& [satellite, samples] : by_satellite) {
             for (std::size_t first = 0; first < samples.size(); ++first) {
                 for (std::size_t second = first + 1; second < samples.size();
@@ -2555,6 +2623,15 @@ FGOProcessor::analyzeGeometryFreeSlipShadow(const FGOProblem& problem,
                                 tainted_ambiguities.insert(
                                     second_sample.ambiguity_indices.begin(),
                                     second_sample.ambiguity_indices.end());
+                                const int doppler_matches =
+                                    static_cast<int>(doppler_events.count(
+                                        {satellite, samples[first].first})) +
+                                    static_cast<int>(doppler_events.count(
+                                        {satellite, samples[second].first}));
+                                if (doppler_matches == 1) {
+                                    ++shadow[epoch_index]
+                                          .doppler_isolated_event_pairs;
+                                }
                             }
                         }
                     }

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -1983,6 +1983,12 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 gf_slip_shadow[i].max_jump_m;
             epoch_diagnostics[i].gf_slip_shadow_tainted_ambiguities =
                 gf_slip_shadow[i].tainted_ambiguities;
+            epoch_diagnostics[i].doppler_slip_shadow_event_signals =
+                gf_slip_shadow[i].doppler_event_signals;
+            epoch_diagnostics[i].doppler_slip_shadow_max_innovation_m =
+                gf_slip_shadow[i].doppler_max_innovation_m;
+            epoch_diagnostics[i].gf_doppler_shadow_isolated_pairs =
+                gf_slip_shadow[i].doppler_isolated_event_pairs;
         }
         epoch_diagnostics[i].ar_outcome = config.use_lambda_ambiguity_fix
             ? FGOProcessor::AmbiguityResolutionOutcome::SmootherFailure

--- a/tests/test_fgo.cpp
+++ b/tests/test_fgo.cpp
@@ -1183,6 +1183,51 @@ TEST(FGOTest, GeometryFreeSlipShadowTaintsExistingDdAmbiguityArc) {
     EXPECT_EQ(shadow[2].tainted_ambiguities, 2);
 }
 
+TEST(FGOTest, GeometryFreeSlipShadowUsesDopplerToIsolateSignal) {
+    FGOProcessor::FGOProblem problem;
+    for (int epoch = 0; epoch < 3; ++epoch) {
+        FGOProcessor::EpochSeed seed;
+        seed.time = GNSSTime(2300, 100000.0 + 0.2 * epoch);
+        problem.epochs.push_back(seed);
+
+        const auto add_factor = [&](SignalType signal,
+                                    std::size_t ambiguity_index,
+                                    double target_sd_phase_m,
+                                    double reference_sd_phase_m) {
+            FGOProcessor::DoubleDifferenceCarrierFactor factor;
+            factor.epoch_index = static_cast<std::size_t>(epoch);
+            factor.ambiguity_index = ambiguity_index;
+            factor.satellite = SatelliteId(GNSSSystem::GPS, 1);
+            factor.reference_satellite = SatelliteId(GNSSSystem::GPS, 2);
+            factor.signal = signal;
+            factor.rover_satellite_model.raw_carrier_m = target_sd_phase_m;
+            factor.base_satellite_model.raw_carrier_m = 0.0;
+            factor.rover_reference_model.raw_carrier_m = reference_sd_phase_m;
+            factor.base_reference_model.raw_carrier_m = 0.0;
+            factor.rover_satellite_model.has_doppler_residual = true;
+            factor.base_satellite_model.has_doppler_residual = true;
+            factor.rover_reference_model.has_doppler_residual = true;
+            factor.base_reference_model.has_doppler_residual = true;
+            problem.double_difference_carrier_factors.push_back(factor);
+        };
+
+        const double slip_m = epoch == 0 ? 0.0 : 0.40;
+        add_factor(SignalType::GPS_L1CA, 0, 10.0 + slip_m, 1.0);
+        add_factor(SignalType::GPS_L2C, 1, 8.0, 2.0);
+    }
+
+    const auto shadow =
+        FGOProcessor::analyzeGeometryFreeSlipShadow(problem, 0.05, 1.5);
+    ASSERT_EQ(shadow.size(), 3u);
+    EXPECT_EQ(shadow[0].doppler_event_signals, 0);
+    EXPECT_EQ(shadow[1].event_pairs, 1);
+    EXPECT_EQ(shadow[1].doppler_event_signals, 1);
+    EXPECT_NEAR(shadow[1].doppler_max_innovation_m, 0.40, 1e-12);
+    EXPECT_EQ(shadow[1].doppler_isolated_event_pairs, 1);
+    EXPECT_EQ(shadow[2].doppler_event_signals, 0);
+    EXPECT_EQ(shadow[2].doppler_isolated_event_pairs, 0);
+}
+
 TEST(FGOTest, CmcJumpForcesAmbiguityArcBreak) {
     const NavigationData nav = makeSyntheticGpsNavigation(2);
     const Vector3d rover_position(1113194.0, -4841695.0, 3985350.0);


### PR DESCRIPTION
## Summary
- extend the existing geometry-free cycle-slip shadow with per-signal rover/base SD phase-vs-Doppler innovations
- count GF event pairs where Doppler identifies exactly one affected band, without changing arcs, factors, or FIX/FLOAT decisions
- expose the three monitor fields in `--dump-csv` and bump the raw problem-cache version

## Rationale
GICI-LIB and RTKLIB mark both bands on a geometry-free jump, so GF alone cannot identify which signal slipped. RTKLIB contains a phase-vs-Doppler detector but disables it because receiver clock jumps can create false alarms. This PR therefore never acts on Doppler alone: it records Doppler only as a band-isolation witness for an already clock-free GF event.

Primary implementations:
- https://github.com/chichengcn/gici-open/blob/master/src/gnss/ambiguity_common.cpp
- https://github.com/tomojitakasu/RTKLIB/blob/master/src/rtkpos.c

## Validation
- focused geometry-free/Doppler tests: 2/2 passed
- native suite: 881 total, 821 passed, 60 existing skips, 0 failed
- Tokyo1 full accepted-profile replay: 11,905/11,905 rows exactly matched the accepted baseline for tow, status, ECEF, ratio, nfixed, AR outcome, ambiguity candidate counts, LAMBDA attempts, final ambiguity count, and CP-hold state
- observed: 300 GF event pairs; 300 Doppler event signals over 215 epochs; only 16 GF pairs over 15 epochs had exactly one Doppler-confirmed band (5.3%); maximum raw Doppler innovation was 299,793 m, confirming that Doppler-alone action would be unsafe

No new command-line option is added; the fields share the existing CSV-triggered geometry-free monitor.
