### PR TITLE
Trace temporal LAMBDA integer consensus

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,18 @@ the Doppler result is not used alone because RTKLIB disables its analogous
 detector over receiver clock-jump sensitivity; requiring the clock-free GF
 event first lets the trace evaluate Doppler only as a band-isolation witness.
 
+Each provisional LAMBDA candidate also reports temporal integer-consensus
+fields.  They compare only ambiguity indices shared with the immediately
+preceding epoch, so an LLI/CMC/FDE arc change cannot count as continuity.
+`lambda_candidate_integer_overlap` and `_agreements` expose the raw counts;
+`_agreement_fraction` and `_consensus_streak` summarize consecutive epochs
+with at least four exactly matching integers.  This is a diagnostic analogue
+of the consecutive-fix evidence used before ambiguity holding in
+[RTKLIB](https://github.com/tomojitakasu/RTKLIB/blob/master/src/rtkpos.c), not
+an acceptance rule.  Tokyo run1 confirmed why: long-lived wrong integer basins
+also produce exact temporal agreement, so the fields never change FIX/FLOAT,
+hold, or graph state.
+
 `--ratio-impact-monitor` adds a counterfactual partial-AR audit for epochs
 that remain ratio-rejected. It removes each target satellite in turn, reruns
 LAMBDA, and writes the best ratio, subset size, candidate ECEF position, and

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -1497,7 +1497,10 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
            "lambda_candidate_bsr_qscale4,lambda_candidate_bsr_qscale8,"
            "lambda_candidate_bsr_qscale16,lambda_candidate_ffrt_supported,"
            "lambda_candidate_ffrt_accepts_any,lambda_candidate_ffrt_min_ratio,"
-           "lambda_candidate_ffrt_pass,"
+           "lambda_candidate_ffrt_pass,lambda_candidate_integer_overlap,"
+           "lambda_candidate_integer_agreements,"
+           "lambda_candidate_integer_agreement_fraction,"
+           "lambda_candidate_integer_consensus_streak,"
            "gf_slip_events,gf_slip_max_jump_m,gf_slip_tainted_ambiguities,"
            "doppler_slip_signals,doppler_slip_max_innovation_m,"
            "gf_doppler_isolated_pairs,"
@@ -1601,6 +1604,10 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                 << ',' << (d.lambda_candidate_ffrt_accepts_any ? 1 : 0)
                 << ',' << d.lambda_candidate_ffrt_min_ratio
                 << ',' << (d.lambda_candidate_ffrt_pass ? 1 : 0)
+                << ',' << d.lambda_candidate_integer_overlap
+                << ',' << d.lambda_candidate_integer_agreements
+                << ',' << d.lambda_candidate_integer_agreement_fraction
+                << ',' << d.lambda_candidate_integer_consensus_streak
                 << ',' << d.gf_slip_shadow_event_pairs
                 << ',' << d.gf_slip_shadow_max_jump_m
                 << ',' << d.gf_slip_shadow_tainted_ambiguities

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -2042,6 +2042,14 @@ public:
         bool lambda_candidate_ffrt_accepts_any = false;
         double lambda_candidate_ffrt_min_ratio = 0.0;
         bool lambda_candidate_ffrt_pass = false;
+        // Temporal-consensus shadow for the last LAMBDA candidate in this
+        // epoch. Ambiguity indices are stable only within an unchanged arc,
+        // so overlap automatically excludes restarted/referenced arcs. The
+        // shadow never changes acceptance, hold, or graph state.
+        int lambda_candidate_integer_overlap = 0;
+        int lambda_candidate_integer_agreements = 0;
+        double lambda_candidate_integer_agreement_fraction = 0.0;
+        int lambda_candidate_integer_consensus_streak = 0;
         // Diagnostic-only geometry-free cycle-slip shadow. It analyzes the
         // rover/base single-difference carrier phases already present in the
         // DD factors, but never changes ambiguity arcs or graph factors.

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -1316,6 +1316,10 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
     int ddpr_bootstrap_epochs_remaining =
         config.use_ddpr_anchor ? config.ddpr_anchor_bootstrap_epochs : 0;
     int continuous_unfix_streak = 0;
+    std::map<std::size_t, int> previous_lambda_candidate_cycles;
+    std::size_t previous_lambda_candidate_epoch =
+        std::numeric_limits<std::size_t>::max();
+    int lambda_candidate_integer_consensus_streak = 0;
 
     // Reference state.effective_cp_hold_epochs(): the configured CP-hold
     // length, suppressed to 0 while the DDPR-anchor bootstrap countdown is
@@ -3517,6 +3521,7 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                         order.begin(), order.begin() + attempt_n);
 
                     bool float_cycles_recorded = false;
+                    std::map<std::size_t, int> lambda_candidate_cycles_this_epoch;
                     for (std::size_t lambda_order_idx = 0;
                          lambda_order_idx < lambda_orders.size(); ++lambda_order_idx) {
                         order = lambda_orders[lambda_order_idx];
@@ -3688,6 +3693,8 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                                 fixed_cycles_by_index[epoch_amb_indices[order[r]]] =
                                     static_cast<int>(std::lround(fixed_amb(r)));
                             }
+                            lambda_candidate_cycles_this_epoch =
+                                fixed_cycles_by_index;
                             const auto ambiguityMeters = [&](std::size_t idx,
                                                              double* value_m) -> bool {
                                 if (!value_m || idx >= problem.ambiguity_states.size()) {
@@ -4478,6 +4485,55 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                             }
                         }
                         break;  // validated subset found
+                    }
+
+                    // Read-only temporal integer-consensus shadow. Compare
+                    // the final candidate attempted at adjacent epochs over
+                    // ambiguity indices shared by both candidates. Because
+                    // the index identifies a concrete DD arc, LLI/CMC/FDE
+                    // generation changes cannot masquerade as continuity.
+                    if (!lambda_candidate_cycles_this_epoch.empty()) {
+                        int overlap = 0;
+                        int agreements = 0;
+                        if (previous_lambda_candidate_epoch !=
+                                std::numeric_limits<std::size_t>::max() &&
+                            previous_lambda_candidate_epoch + 1 == i) {
+                            for (const auto& [ambiguity_index, fixed_integer] :
+                                 lambda_candidate_cycles_this_epoch) {
+                                const auto previous =
+                                    previous_lambda_candidate_cycles.find(
+                                        ambiguity_index);
+                                if (previous ==
+                                    previous_lambda_candidate_cycles.end()) {
+                                    continue;
+                                }
+                                ++overlap;
+                                if (previous->second == fixed_integer) {
+                                    ++agreements;
+                                }
+                            }
+                        }
+                        const bool consensus = overlap >= 4 && agreements == overlap;
+                        lambda_candidate_integer_consensus_streak =
+                            consensus
+                                ? lambda_candidate_integer_consensus_streak + 1
+                                : 1;
+                        epoch_diagnostics[i].lambda_candidate_integer_overlap =
+                            overlap;
+                        epoch_diagnostics[i].lambda_candidate_integer_agreements =
+                            agreements;
+                        epoch_diagnostics[i]
+                            .lambda_candidate_integer_agreement_fraction =
+                            overlap > 0
+                                ? static_cast<double>(agreements) /
+                                      static_cast<double>(overlap)
+                                : 0.0;
+                        epoch_diagnostics[i]
+                            .lambda_candidate_integer_consensus_streak =
+                            lambda_candidate_integer_consensus_streak;
+                        previous_lambda_candidate_cycles =
+                            std::move(lambda_candidate_cycles_this_epoch);
+                        previous_lambda_candidate_epoch = i;
                     }
 
                     // Monitor-only satellite-impact audit, modeled after

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -2214,6 +2214,17 @@ TEST(FGOAmbiguityOutcomeTelemetryTest, HoldFallbackPreservesRatioRejection) {
               rejected->lambda_candidate_ffrt_accepts_any &&
                   rejected->lambda_candidate_ratio >
                       rejected->lambda_candidate_ffrt_min_ratio);
+    const auto consensus = std::find_if(
+        result.epoch_diagnostics.begin(), result.epoch_diagnostics.end(),
+        [](const FGOProcessor::FGOEpochDiagnostics& diagnostics) {
+            return diagnostics.lambda_candidate_integer_consensus_streak >= 2;
+        });
+    ASSERT_NE(consensus, result.epoch_diagnostics.end());
+    EXPECT_GE(consensus->lambda_candidate_integer_overlap, 4);
+    EXPECT_EQ(consensus->lambda_candidate_integer_agreements,
+              consensus->lambda_candidate_integer_overlap);
+    EXPECT_DOUBLE_EQ(consensus->lambda_candidate_integer_agreement_fraction,
+                     1.0);
 }
 
 TEST(FGOAmbiguityOutcomeTelemetryTest,


### PR DESCRIPTION
## What changed

- compare each epoch's final provisional LAMBDA integers with the immediately preceding candidate over unchanged DD ambiguity arcs
- export overlap, exact-agreement fraction, and consecutive consensus streak in the parity CSV
- document that temporal consensus is diagnostic-only and add a focused regression test

## Why

RTKLIB requires consecutive fixed solutions before ambiguity holding, so temporal repeatability was investigated as possible evidence for safer AR. Tokyo run1 shows that coherent wrong integer basins also persist, so this PR deliberately records the evidence without changing FIX/FLOAT, hold, ambiguity generations, or factor-graph state.

## Validation

- focused telemetry test: passed
- native suite: 881 total, 821 passed, 60 existing skips, 0 failed
- Tokyo run1 full accepted-profile replay: 11,905/11,905 rows identical for tow/status/ECEF/ratio/nfixed/AR outcome/candidate counts/LAMBDA attempts/final ambiguity count/CP hold
- ratio-rejected audit: overlap >= 6 and streak >= 10 still selected 26 correct vs 104 wrong candidates; no promotion policy is enabled

Tracks #389.