### PR TITLE
feat(fgo): safely reset geometry-free slip arcs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,29 +85,50 @@ versus [inuex35/tightly-coupled-gnss-imu-fgo](https://github.com/inuex35/tightly
 
 | Run | libgnss++ <50cm | Reference <50cm | libgnss++ fix | Reference fix | libgnss++ fixed RMS | Reference fixed RMS |
 |---|---:|---:|---:|---:|---:|---:|
-| Tokyo run1 | **57.0%** | 56.7% | **49.8%** | 49.5% | **0.662 m** | 0.815 m |
-| Tokyo run2 | **81.2%** | 69.9% | **72.7%** | 60.8% | **0.217 m** | 0.277 m |
-| Tokyo run3 | **73.0%** | 67.9% | **71.7%** | 59.4% | 0.257 m | **0.211 m** |
+| Tokyo run1 | 54.9% | **56.7%** | **53.8%** | 49.5% | 1.180 m | **0.815 m** |
+| Tokyo run2 | **85.7%** | 69.9% | **78.6%** | 60.8% | **0.109 m** | 0.277 m |
+| Tokyo run3 | **77.5%** | 67.9% | **69.3%** | 59.4% | **0.125 m** | 0.211 m |
 
 ![Tokyo run1 GNSS/IMU FGO](docs/gnss_imu_fgo_tokyo_run1.png)
 ![Tokyo run2 GNSS/IMU FGO](docs/gnss_imu_fgo_tokyo_run2.png)
 ![Tokyo run3 GNSS/IMU FGO](docs/gnss_imu_fgo_tokyo_run3.png)
 
-libgnss++ beats the reference on <50 cm fraction and fix-rate on all three
-runs, and on fixed-only RMS on two of three runs (run3's fixed RMS remains
-behind the reference, over the largest fixed population of the three: 10965
-epochs). Every feature is opt-in and the library is unchanged when built
-without GTSAM. Reproduce with `gnss_fgo_parity` (requires a GTSAM build) and
-the shipping preset:
+With the geometry-free reset below, libgnss++ exceeds the reference's raw FIX
+rate on all three runs, and its <50 cm fraction and fixed-only horizontal RMS
+on two of three. Raw FIX rate alone can hide wrong integer solutions, so the
+same clean full-length replays were also scored with the PPC official segment
+metric (0.11 s matching tolerance, 0.5 m correctness threshold):
+
+| Run | Correct FIX distance, baseline -> GF reset | Wrong FIX distance, baseline -> GF reset | Official score, baseline -> GF reset | GF guard demotions |
+|---|---:|---:|---:|---:|
+| Tokyo run1 | 25.656% -> **33.322%** | 23.765% -> **21.221%** | 30.823% -> **39.375%** | 14 |
+| Tokyo run2 | 60.304% -> **74.599%** | 12.573% -> **1.386%** | 65.264% -> **81.615%** | 0 |
+| Tokyo run3 | 59.175% -> **65.099%** | 7.918% -> **1.818%** | 64.081% -> **71.207%** | 17 |
+| Distance-weighted aggregate | 49.181% -> **57.409%** | 13.741% -> **7.650%** | 54.178% -> **63.692%** | 31 |
+
+Wrong FIX/FIX falls from 21.839% to 11.759% in the aggregate, while matched
+positioning distance is unchanged at 99.682%. Fixed-only horizontal
+RMS/P95 improves from 1.267/0.892 m to 1.180/0.877 m on run1, from
+0.225/0.600 m to 0.109/0.155 m on run2, and from 0.257/0.539 m to
+0.125/0.079 m on run3. Vertical absolute P95 also improves on every run
+(1.478 -> 1.463 m, 0.878 -> 0.141 m, and 1.152 -> 0.253 m). Cached-input
+solver wall times on the validation host were 463.5, 584.6, and 844.9 s;
+these are workload reports, not controlled microbenchmarks.
+
+Every new behavior is opt-in and non-GTSAM builds are unchanged. Reproduce
+with `gnss_fgo_parity` (requires a GTSAM build) and the evaluated preset:
 
 ```
 --imu <run>/imu.csv --fixed-lag 5 --multi-freq --partial-ar --hold \
---elev-mask 25 --snr-mask 30 --imu-preset-tactical --cmc --cmc-level 0.75 \
---cp-hold --cp-hold-res 2.0 --exc-recovery --ddpr-anchor --fde --varerr \
---fix-demote --fix-demote-dist 5 --fix-demote-res 25 --fix-demote-posthold 5 \
---imu-ratio-relaxed 1.5 --surplus-validation --surplus-validation-min-n 3 \
+--elev-mask 25 --snr-mask 30 --cmc --cmc-level 0.75 --cp-hold \
+--exc-recovery --ddpr-anchor --fde --varerr --fix-demote \
+--fix-demote-res 25 --fix-demote-posthold 5 \
+--fix-demote-surplus-crosscheck --fix-demote-surplus-anchor-reprieve \
+--fix-demote-spp-model-reprieve --surplus-validation \
+--surplus-validation-min-n 3 \
 --surplus-validation-aperture-lt1 0.15 --surplus-validation-aperture-1to2 0.3 \
---surplus-validation-aperture-gt2 0.45
+--surplus-validation-aperture-gt2 0.45 --anchor-gated-unfix-reset \
+--imu-ratio-relaxed 1.5 --gf-slip-reset
 ```
 
 With `--dump-csv <path>`, the epoch table includes the ambiguity-candidate
@@ -142,7 +163,19 @@ and the multi-frequency arc checks in
 [RTKLIB](https://github.com/tomojitakasu/RTKLIB/blob/master/src/rtkpos.c).
 It ignores gaps and arcs already restarted by the existing LLI/CMC logic,
 then reports how many unchanged DD ambiguity arcs remain exposed after a
-new jump. It never restarts an arc or changes the factor graph.
+new jump. Without `--gf-slip-reset` it never restarts an arc or changes the
+factor graph.
+
+`--gf-slip-reset` turns the shadow into a conservative arc-integrity action.
+A detected jump is held for 1.0 s and cancelled if a receiver-side LLI, gap,
+or dropout naturally replaces the arc first. If the same arc survives,
+both bands' DD ambiguities are restarted: the geometry-free combination proves
+that one integer changed but cannot safely identify which one. During the
+resulting low-redundancy reacquisition, a FIX is neither held nor reported when
+all independent code checks agree it is grossly implausible (at most six fixed
+ambiguities, ratio at most 10, DDPR RMS at least 10 m, and a fresh SPP position
+more than 25 m away). This guard is intrinsic to the GF reset even when the
+broader `--fix-demote` feature is disabled.
 
 The same shadow also compares each rover/base single-difference phase change
 with trapezoid-integrated Doppler at the existing RTK detector's 0.20 m

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -96,6 +96,7 @@ struct Args {
     bool constellation_par = false;
     bool residual_par = false;
     bool ratio_impact_monitor = false;
+    bool gf_slip_reset = false;
     bool variance_par = false;
     bool gici_par = false;          // GICI-style strict PAR + continuous-unfix reacquisition profile
     bool anchor_gated_unfix_reset = false;
@@ -250,6 +251,10 @@ Args parseArgs(int argc, char** argv) {
         }
         if (a == "--ratio-impact-monitor") {
             args.ratio_impact_monitor = true;
+            continue;
+        }
+        if (a == "--gf-slip-reset") {
+            args.gf_slip_reset = true;
             continue;
         }
         if (a == "--integer-constrained-reoptimization") {
@@ -709,6 +714,7 @@ libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
     libgnss::FGOProcessor::FGOConfig config = makeRealDataDdConfig();
     // Reuse the existing diagnostic surface; do not add another CLI option.
     config.monitor_geometry_free_cycle_slip = !args.dump_csv_path.empty();
+    config.use_geometry_free_cycle_slip_reset = args.gf_slip_reset;
     config.report_held_ambiguities_as_fixed = !args.no_held_fix_label;
     if (args.max_iters > 0) {
         config.max_iterations = args.max_iters;
@@ -2126,7 +2132,7 @@ FileId statFile(const std::string& path) {
 // vector, new factor field, ...) -- an old cache then fails the magic/version
 // check in load() below and is rebuilt instead of misread.
 constexpr uint32_t kMagic = 0x50434647u;  // "PCFG" (problem-cache fgo)
-constexpr uint32_t kVersion = 8u;
+constexpr uint32_t kVersion = 9u;
 constexpr std::size_t kBuilderFingerprintBytes = 512u;
 
 struct Fingerprint {
@@ -2188,6 +2194,8 @@ Fingerprint computeFingerprint(const Args& args, const libgnss::FGOProcessor::FG
     COPY_BUILD_FIELD(elevation_sigma_err_a_m);
     COPY_BUILD_FIELD(elevation_sigma_err_b_m);
     COPY_BUILD_FIELD(elevation_sigma_pseudorange_ratio);
+    COPY_BUILD_FIELD(geometry_free_cycle_slip_threshold_m);
+    COPY_BUILD_FIELD(geometry_free_cycle_slip_confirmation_s);
     COPY_BUILD_FIELD(max_tdcp_gap_s);
     COPY_BUILD_FIELD(min_elevation_deg);
     COPY_BUILD_FIELD(min_satellites_per_epoch);
@@ -2209,6 +2217,7 @@ Fingerprint computeFingerprint(const Args& args, const libgnss::FGOProcessor::FG
     COPY_BUILD_FIELD(use_double_difference_secondary_code_alignment);
     COPY_BUILD_FIELD(use_elevation_dependent_sigma);
     COPY_BUILD_FIELD(use_external_doppler_dr_validation);
+    COPY_BUILD_FIELD(use_geometry_free_cycle_slip_reset);
     COPY_BUILD_FIELD(use_ionosphere_model);
     COPY_BUILD_FIELD(use_multi_constellation);
     COPY_BUILD_FIELD(use_multi_frequency_double_difference);
@@ -2419,6 +2428,15 @@ int main(int argc, char** argv) {
               << ", cmc_ref=" << (args.cmc_ref ? "on" : "off")
               << ", ref_avoided=" << problem.diagnostics.cmc_ref_avoided_count
               << "\n";
+    std::cout << "  Geometry-free slip reset: "
+              << (args.gf_slip_reset ? "on" : "off")
+              << " (threshold="
+              << config.geometry_free_cycle_slip_threshold_m
+              << " m, confirmation="
+              << config.geometry_free_cycle_slip_confirmation_s
+              << " s, confirmed_resets="
+              << problem.diagnostics.geometry_free_cycle_slip_resets
+              << ")\n";
 
     // --- MF hygiene diagnostics: per-signal DD residuals at the reference
     // trajectory (no solver). PR residual mean exposes per-band code/DCB
@@ -2660,6 +2678,13 @@ int main(int argc, char** argv) {
                   << ", level_exclusions=" << fl.diagnostics.code_minus_carrier_level_exclusions
                   << ", cmc_ref=" << (args.cmc_ref ? "on" : "off")
                   << ", ref_avoided=" << fl.diagnostics.cmc_ref_avoided_count
+                  << ")\n"
+                  << "  Geometry-free slip reset: "
+                  << (args.gf_slip_reset ? "on" : "off")
+                  << " (confirmed_resets="
+                  << fl.diagnostics.geometry_free_cycle_slip_resets
+                  << ", gross_spp_demotions="
+                  << fl.diagnostics.geometry_free_fix_guard_demotions
                   << ")\n"
                   << "  CP-hold/sanity FSM: " << (args.cp_hold ? "on" : "off")
                   << " (triggers=" << fl.diagnostics.cp_hold_triggers

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -386,6 +386,18 @@ public:
         bool monitor_ratio_impact_partial_ar = false;
         // Diagnostic-only geometry-free slip/arc-continuity shadow.
         bool monitor_geometry_free_cycle_slip = false;
+        // When a rover/base single-difference geometry-free combination jumps
+        // while the underlying rover arcs remain continuous, break both bands'
+        // DD arcs after the confirmation interval below. Resetting both bands
+        // is conservative because the geometry-free combination cannot identify
+        // which integer changed. This is opt-in because it changes the graph;
+        // the monitor above remains diagnostic-only.
+        bool use_geometry_free_cycle_slip_reset = false;
+        double geometry_free_cycle_slip_threshold_m = 0.05;
+        // Debounce the inferred slip so an imminent receiver-side LLI, gap, or
+        // dropout arc break can supersede it. The reset fires only if the same
+        // receiver arc is still alive after this interval.
+        double geometry_free_cycle_slip_confirmation_s = 1.0;
         // GICI-style PAR: prefer ambiguities with the smallest marginal
         // variance and do not attempt a subset whose least precise member
         // exceeds this standard deviation in cycles (<=0 disables the gate).
@@ -1631,6 +1643,7 @@ public:
         std::size_t tdcp_rejected_loss_of_lock = 0;
         std::size_t tdcp_rejected_code_phase_jump = 0;
         std::size_t code_minus_carrier_jump_resets = 0;       ///< CMC screening: arc breaks forced
+        std::size_t geometry_free_cycle_slip_resets = 0;      ///< confirmed geometry-free band resets
         std::size_t code_minus_carrier_level_exclusions = 0;  ///< CMC screening: (sat,signal) epochs excluded
         std::size_t cmc_ref_avoided_count = 0;  ///< cmc_aware_reference_selection: references changed away from a CMC-excluded candidate
     };
@@ -1810,6 +1823,7 @@ public:
         std::size_t ambiguity_hold_arcs = 0;    ///< 2e: distinct arcs pinned at their integer
         std::size_t quality_gated_epochs = 0;   ///< epochs where the quality gates suppressed fixing
         std::size_t code_minus_carrier_jump_resets = 0;       ///< CMC screening: arc breaks forced
+        std::size_t geometry_free_cycle_slip_resets = 0;      ///< confirmed geometry-free band resets
         std::size_t code_minus_carrier_level_exclusions = 0;  ///< CMC screening: (sat,signal) epochs excluded
         std::size_t cmc_ref_avoided_count = 0;  ///< cmc_aware_reference_selection: references changed away from a CMC-excluded candidate
         // --- CP-hold / sanity FSM diagnostics (use_cp_hold_recovery) ---
@@ -1833,8 +1847,9 @@ public:
         std::size_t ambiguity_generation_bumps_stale_pin = 0;
         // --- Stale-pin invalidation diagnostics (use_stale_pin_invalidation) ---
         std::size_t stale_pin_invalidations = 0;  ///< pinned arcs released per-arc at a trigger epoch
-        // --- Fix plausibility demotion diagnostics (use_fix_plausibility_demotion) ---
-        std::size_t fix_plausibility_demotions = 0;  ///< FIXED epochs demoted to FLOAT (IMU gap or anchor gap)
+        // --- Fix plausibility demotion diagnostics ---
+        std::size_t fix_plausibility_demotions = 0;  ///< FIXED epochs demoted to FLOAT by general or intrinsic GF integrity guards
+        std::size_t geometry_free_fix_guard_demotions = 0;  ///< low-redundancy GF-reset fixes rejected by gross SPP disagreement
         std::size_t fix_plausibility_anchor_demotions = 0;  ///< of which via the DDPR-LS anchor gap
         std::size_t fix_plausibility_anchor_gross_gated = 0;  ///< anchor-gap evaluations skipped by the gross-offender gate (fix_demote_anchor_gross)
         std::size_t fix_plausibility_hold_skips = 0;  ///< fix-and-hold pinnings skipped on implausible epochs

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -577,6 +577,18 @@ struct SingleDifferenceCarrierResidual {
     Vector3d los = Vector3d::Zero();
 };
 
+struct GeometryFreeSlipState {
+    GNSSTime time;
+    double geometry_free_m = 0.0;
+    std::size_t first_rover_ambiguity_index = 0;
+    std::size_t second_rover_ambiguity_index = 0;
+};
+
+struct GeometryFreePendingReset {
+    GNSSTime time;
+    std::size_t rover_ambiguity_index = 0;
+};
+
 std::map<CarrierKey, PreparedCarrierObservation> prepareCarrierObservationsForReceiver(
     const ObservationData& epoch,
     const NavigationData& nav,
@@ -1598,6 +1610,13 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
     // reference documented on the config knob).
     std::map<CarrierKey, std::size_t> cmc_last_rover_ambiguity_index;
     std::size_t cmc_jump_reset_total = 0;
+    using GeometryFreePairKey =
+        std::tuple<SatelliteId, SignalType, SignalType>;
+    std::map<GeometryFreePairKey, GeometryFreeSlipState>
+        geometry_free_slip_states;
+    std::map<CarrierKey, GeometryFreePendingReset>
+        geometry_free_pending_resets;
+    std::size_t geometry_free_slip_reset_total = 0;
     std::size_t cmc_level_exclusion_total = 0;
     // FGOConfig::cmc_aware_reference_selection: count of DD reference
     // picks steered away from a CMC-level-excluded candidate this run.
@@ -1715,6 +1734,7 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
         // CP loop's ambiguity-arc bookkeeping (jump forces a new arc).
         std::set<CarrierKey> cmc_level_exclude_this_epoch;
         std::set<CarrierKey> cmc_jump_reset_this_epoch;
+        std::set<CarrierKey> geometry_free_reset_this_epoch;
         if (config_.use_code_minus_carrier_screening &&
             rover_it != rover_carriers_by_epoch.end()) {
             for (const auto* rover_factor : rover_it->second) {
@@ -1785,6 +1805,131 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
                             (1.0 - alpha) * state.baseline_m + alpha * cmc;
                     }
                 }
+            }
+        }
+
+        if (config_.use_geometry_free_cycle_slip_reset &&
+            rover_it != rover_carriers_by_epoch.end()) {
+            using GeometryFreeSample =
+                std::pair<const CarrierPhaseFactor*,
+                          const PreparedCarrierObservation*>;
+            std::map<SatelliteId, std::map<SignalType, GeometryFreeSample>>
+                samples_by_satellite;
+            std::map<CarrierKey, GeometryFreeSample> samples_by_key;
+            for (const auto* rover_factor : rover_it->second) {
+                const CarrierKey key{rover_factor->satellite,
+                                     rover_factor->signal};
+                const auto base_it = base_carriers.find(key);
+                if (base_it != base_carriers.end()) {
+                    const GeometryFreeSample sample{rover_factor,
+                                                    &base_it->second};
+                    samples_by_satellite[rover_factor->satellite]
+                                        [rover_factor->signal] = sample;
+                    samples_by_key[key] = sample;
+                }
+            }
+            const double confirmation_s = std::max(
+                0.0, config_.geometry_free_cycle_slip_confirmation_s);
+            for (auto pending = geometry_free_pending_resets.begin();
+                 pending != geometry_free_pending_resets.end();) {
+                const auto sample = samples_by_key.find(pending->first);
+                if (sample == samples_by_key.end() ||
+                    sample->second.first->ambiguity_index !=
+                        pending->second.rover_ambiguity_index) {
+                    pending = geometry_free_pending_resets.erase(pending);
+                    continue;
+                }
+                const double age_s = problem.epochs[epoch_index].time -
+                                     pending->second.time;
+                if (age_s >= confirmation_s) {
+                    geometry_free_reset_this_epoch.insert(pending->first);
+                    ++geometry_free_slip_reset_total;
+                    pending = geometry_free_pending_resets.erase(pending);
+                    continue;
+                }
+                ++pending;
+            }
+            std::set<CarrierKey> slip_bands_this_epoch;
+            for (const auto& [satellite, samples_by_signal] :
+                 samples_by_satellite) {
+                std::vector<GeometryFreeSample> samples;
+                samples.reserve(samples_by_signal.size());
+                for (const auto& [signal, sample] : samples_by_signal) {
+                    (void)signal;
+                    samples.push_back(sample);
+                }
+                for (std::size_t first = 0; first < samples.size(); ++first) {
+                    for (std::size_t second = first + 1;
+                         second < samples.size(); ++second) {
+                        const auto* first_rover = samples[first].first;
+                        const auto* second_rover = samples[second].first;
+                        const auto* first_base = samples[first].second;
+                        const auto* second_base = samples[second].second;
+                        const double first_sd_phase_m =
+                            first_rover->model_debug.raw_carrier_m -
+                            first_base->model_debug.raw_carrier_m;
+                        const double second_sd_phase_m =
+                            second_rover->model_debug.raw_carrier_m -
+                            second_base->model_debug.raw_carrier_m;
+                        const double geometry_free_m =
+                            first_sd_phase_m - second_sd_phase_m;
+                        const GeometryFreePairKey pair_key{
+                            satellite, first_rover->signal,
+                            second_rover->signal};
+                        const auto previous =
+                            geometry_free_slip_states.find(pair_key);
+                        if (previous != geometry_free_slip_states.end()) {
+                            const double dt = problem.epochs[epoch_index].time -
+                                              previous->second.time;
+                            const bool same_rover_arcs =
+                                previous->second.first_rover_ambiguity_index ==
+                                    first_rover->ambiguity_index &&
+                                previous->second.second_rover_ambiguity_index ==
+                                    second_rover->ambiguity_index;
+                            if (same_rover_arcs && dt > 0.0 &&
+                                (max_segment_gap <= 0.0 ||
+                                 dt <= max_segment_gap) &&
+                                std::abs(geometry_free_m -
+                                         previous->second.geometry_free_m) >
+                                    std::max(
+                                        0.0,
+                                        config_.geometry_free_cycle_slip_threshold_m)) {
+                                const CarrierKey first_key{
+                                    satellite, first_rover->signal};
+                                const CarrierKey second_key{
+                                    satellite, second_rover->signal};
+                                slip_bands_this_epoch.insert(first_key);
+                                slip_bands_this_epoch.insert(second_key);
+                            }
+                        }
+                        geometry_free_slip_states[pair_key] = {
+                            problem.epochs[epoch_index].time,
+                            geometry_free_m,
+                            first_rover->ambiguity_index,
+                            second_rover->ambiguity_index};
+                    }
+                }
+            }
+            for (const auto& key : slip_bands_this_epoch) {
+                if (geometry_free_reset_this_epoch.count(key) != 0) {
+                    continue;
+                }
+                const auto sample = samples_by_key.find(key);
+                if (sample == samples_by_key.end()) {
+                    continue;
+                }
+                const auto pending = geometry_free_pending_resets.find(key);
+                if (pending != geometry_free_pending_resets.end()) {
+                    // A second discontinuity before confirmation is
+                    // ambiguous (often an isolated outlier returning to its
+                    // former level), so fail closed instead of restarting the
+                    // timer.
+                    geometry_free_pending_resets.erase(pending);
+                    continue;
+                }
+                geometry_free_pending_resets[key] = {
+                    problem.epochs[epoch_index].time,
+                    sample->second.first->ambiguity_index};
             }
         }
 
@@ -2205,6 +2350,12 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
                     // breaks the integer ambiguity).
                     start_new_segment = true;
                 }
+                if (geometry_free_reset_this_epoch.count(
+                        CarrierKey{satellite->satellite, satellite->signal}) > 0 ||
+                    geometry_free_reset_this_epoch.count(
+                        CarrierKey{reference->satellite, reference->signal}) > 0) {
+                    start_new_segment = true;
+                }
 
                 if (start_new_segment) {
                     AmbiguityState ambiguity;
@@ -2465,6 +2616,8 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
     }
 
     problem.diagnostics.code_minus_carrier_jump_resets = cmc_jump_reset_total;
+    problem.diagnostics.geometry_free_cycle_slip_resets =
+        geometry_free_slip_reset_total;
     problem.diagnostics.code_minus_carrier_level_exclusions =
         cmc_level_exclusion_total;
     problem.diagnostics.cmc_ref_avoided_count = cmc_ref_avoided_total;
@@ -2705,6 +2858,8 @@ FGOProcessor::FGOResult FGOProcessor::optimizeProblem(const FGOProblem& problem)
         problem.diagnostics.double_difference_rejected_no_reference;
     result.diagnostics.code_minus_carrier_jump_resets =
         problem.diagnostics.code_minus_carrier_jump_resets;
+    result.diagnostics.geometry_free_cycle_slip_resets =
+        problem.diagnostics.geometry_free_cycle_slip_resets;
     result.diagnostics.code_minus_carrier_level_exclusions =
         problem.diagnostics.code_minus_carrier_level_exclusions;
     result.diagnostics.cmc_ref_avoided_count =

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -78,6 +78,11 @@ namespace {
 
 using gtsam::Point3;
 using gtsam::Pose3;
+
+constexpr int kGfGuardMaxFixedAmbiguities = 6;
+constexpr double kGfGuardMaxRatio = 10.0;
+constexpr double kGfGuardMinDdprRmsM = 10.0;
+constexpr double kGfGuardMaxSppSeparationM = 25.0;
 using gtsam::Rot3;
 using gtsam::Symbol;
 using SharedNoise = gtsam::SharedNoiseModel;
@@ -4433,6 +4438,36 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                             ++result.diagnostics.fix_plausibility_hold_skips;
                             return true;
                         };
+                        // A geometry-free arc reset deliberately discards
+                        // carrier history. During the resulting low-redundancy
+                        // reacquisition, do not pin an integer candidate when
+                        // all independent code evidence is grossly inconsistent:
+                        // poor DD-code fit plus a fresh standalone SPP solution
+                        // over 25 m away. The ratio ceiling keeps this guard on
+                        // the ambiguous near-threshold fringe; well-observed
+                        // high-ratio fixes are unaffected.
+                        const auto holdBlockedByGfGrossSpp = [&]() -> bool {
+                            if (!config.use_geometry_free_cycle_slip_reset ||
+                                subset > kGfGuardMaxFixedAmbiguities ||
+                                !std::isfinite(ratio) || ratio > kGfGuardMaxRatio ||
+                                !std::isfinite(ddpr_rms) ||
+                                ddpr_rms < kGfGuardMinDdprRmsM ||
+                                !epoch_diagnostics[i].fresh_spp_solution ||
+                                !epoch_diagnostics[i]
+                                     .spp_seed_position_ecef.allFinite()) {
+                                return false;
+                            }
+                            const Point3 fix_ant = epoch_has_fixed[i]
+                                                       ? Point3(epoch_fixed_position[i])
+                                                       : provisional_fixed_ant;
+                            if ((Eigen::Vector3d(fix_ant) -
+                                 epoch_diagnostics[i].spp_seed_position_ecef)
+                                    .norm() <= kGfGuardMaxSppSeparationM) {
+                                return false;
+                            }
+                            ++result.diagnostics.fix_plausibility_hold_skips;
+                            return true;
+                        };
                         const bool temporally_validated_partial_hold =
                             config.use_fixed_history_dr_validation &&
                             fixed_history_dr_evaluated && fixed_history_dr_pass;
@@ -4451,7 +4486,8 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                             ratio > config.ambiguity_hold_ratio_threshold &&
                             subset >= config.ambiguity_hold_min_fixed &&
                             !holdBlockedByPlausibility() &&
-                            !holdBlockedByImuAperture()) {
+                            !holdBlockedByImuAperture() &&
+                            !holdBlockedByGfGrossSpp()) {
                             gtsam::NonlinearFactorGraph hold_factors;
                             const auto hold_noise = gtsam::noiseModel::Isotropic::Sigma(
                                 1, config.ambiguity_hold_sigma_cycles);
@@ -4915,11 +4951,61 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 demote = false;
                 ++result.diagnostics.fix_plausibility_spp_model_reprieves;
             }
+            // Fail closed on the same gross code inconsistency used above to
+            // block new holds after a geometry-free arc reset. Apply this
+            // after all reprieves so correlated graph/IMU or surplus evidence
+            // cannot overrule a fresh independent SPP disagreement exceeding
+            // 25 m in the low-redundancy, poor-DDPR regime.
+            const bool gf_gross_spp_demote =
+                config.use_geometry_free_cycle_slip_reset &&
+                epoch_fixed_count[i] <= kGfGuardMaxFixedAmbiguities &&
+                std::isfinite(epoch_ratio[i]) &&
+                epoch_ratio[i] <= kGfGuardMaxRatio &&
+                std::isfinite(ddpr_rms) &&
+                ddpr_rms >= kGfGuardMinDdprRmsM &&
+                epoch_diagnostics[i].fresh_spp_solution &&
+                epoch_diagnostics[i].spp_seed_position_ecef.allFinite() &&
+                (Eigen::Vector3d(fix_ant) -
+                 epoch_diagnostics[i].spp_seed_position_ecef).norm() >
+                    kGfGuardMaxSppSeparationM;
+            if (gf_gross_spp_demote) {
+                demote = true;
+                ++result.diagnostics.geometry_free_fix_guard_demotions;
+            }
             if (demote) {
                 epoch_fixed[i] = false;
                 epoch_fixed_history_eligible[i] = false;
                 epoch_fixed_count[i] = 0;
                 epoch_has_fixed[i] = false;
+                ++result.diagnostics.fix_plausibility_demotions;
+            }
+        }
+
+        // The GF reset's integrity guard is intrinsic to that opt-in graph
+        // change. Keep it active even when the broader, independently
+        // configurable fix-plausibility demotion feature is disabled.
+        if (!config.use_fix_plausibility_demotion &&
+            config.use_geometry_free_cycle_slip_reset && epoch_fixed[i]) {
+            const Point3 fix_ant = epoch_has_fixed[i]
+                                       ? Point3(epoch_fixed_position[i])
+                                       : antennaOf(pose_i);
+            const bool gf_gross_spp_demote =
+                epoch_fixed_count[i] <= kGfGuardMaxFixedAmbiguities &&
+                std::isfinite(epoch_ratio[i]) &&
+                epoch_ratio[i] <= kGfGuardMaxRatio &&
+                std::isfinite(ddpr_rms) &&
+                ddpr_rms >= kGfGuardMinDdprRmsM &&
+                epoch_diagnostics[i].fresh_spp_solution &&
+                epoch_diagnostics[i].spp_seed_position_ecef.allFinite() &&
+                (Eigen::Vector3d(fix_ant) -
+                 epoch_diagnostics[i].spp_seed_position_ecef).norm() >
+                    kGfGuardMaxSppSeparationM;
+            if (gf_gross_spp_demote) {
+                epoch_fixed[i] = false;
+                epoch_fixed_history_eligible[i] = false;
+                epoch_fixed_count[i] = 0;
+                epoch_has_fixed[i] = false;
+                ++result.diagnostics.geometry_free_fix_guard_demotions;
                 ++result.diagnostics.fix_plausibility_demotions;
             }
         }

--- a/tests/test_fgo.cpp
+++ b/tests/test_fgo.cpp
@@ -466,6 +466,39 @@ std::vector<ObservationData> makeCmcObservationEpochs(
     return epochs;
 }
 
+std::vector<ObservationData> makeGeometryFreeObservationEpochs(
+    const NavigationData& nav,
+    const Vector3d& receiver_position,
+    const std::vector<double>& l1_bias_m,
+    const std::vector<double>& l2_bias_m) {
+    std::vector<ObservationData> epochs;
+    for (std::size_t epoch_index = 0; epoch_index < l1_bias_m.size();
+         ++epoch_index) {
+        ObservationData epoch(
+            GNSSTime(2300, 100100.0 + static_cast<double>(epoch_index)));
+        epoch.receiver_position = receiver_position;
+        for (uint8_t prn = 1; prn <= 2; ++prn) {
+            Observation l1;
+            if (!makeSyntheticGpsL1Observation(
+                    nav, SatelliteId(GNSSSystem::GPS, prn), epoch.time,
+                    receiver_position, l1_bias_m[epoch_index], l1)) {
+                continue;
+            }
+            l1.has_doppler = true;
+            l1.doppler = 0.0;
+            epoch.addObservation(l1);
+            Observation l2 = l1;
+            l2.signal = SignalType::GPS_L2C;
+            l2.carrier_phase =
+                (l2.pseudorange + l2_bias_m[epoch_index]) /
+                constants::GPS_L2_WAVELENGTH;
+            epoch.addObservation(l2);
+        }
+        epochs.push_back(epoch);
+    }
+    return epochs;
+}
+
 // Common config for CMC integration tests: minimal DD-only problem, all
 // satellites pass (no elevation/SNR gating gets in the way of a controlled
 // synthetic scenario), matching the style of
@@ -1226,6 +1259,96 @@ TEST(FGOTest, GeometryFreeSlipShadowUsesDopplerToIsolateSignal) {
     EXPECT_EQ(shadow[1].doppler_isolated_event_pairs, 1);
     EXPECT_EQ(shadow[2].doppler_event_signals, 0);
     EXPECT_EQ(shadow[2].doppler_isolated_event_pairs, 0);
+}
+
+TEST(FGOTest, GeometryFreeSlipResetBreaksBothBandsAfterConfirmation) {
+    const NavigationData nav = makeSyntheticGpsNavigation(2);
+    const Vector3d rover_position(1113194.0, -4841695.0, 3985350.0);
+    const Vector3d base_position =
+        rover_position + Vector3d(-320.0, 180.0, 45.0);
+    const std::vector<double> rover_l1 = {0.0, 0.0, 0.40, 0.40};
+    const std::vector<double> rover_l2 = {0.0, 0.0, 0.00, 0.00};
+    const std::vector<double> base_bias(4, 0.0);
+    const auto rover_epochs = makeGeometryFreeObservationEpochs(
+        nav, rover_position, rover_l1, rover_l2);
+    const auto base_epochs = makeGeometryFreeObservationEpochs(
+        nav, base_position, base_bias, base_bias);
+
+    FGOProcessor::FGOConfig config = makeCmcTestConfig();
+    config.use_code_minus_carrier_screening = false;
+    config.use_multi_frequency_double_difference = true;
+    config.use_geometry_free_cycle_slip_reset = true;
+    config.geometry_free_cycle_slip_threshold_m = 0.05;
+    const auto problem = FGOProcessor(config).buildDoubleDifferenceProblem(
+        rover_epochs, base_epochs, nav, base_position);
+
+    std::map<SignalType, std::map<std::size_t, std::size_t>> arcs;
+    for (const auto& factor : problem.double_difference_carrier_factors) {
+        arcs[factor.signal][factor.epoch_index] = factor.ambiguity_index;
+    }
+    ASSERT_EQ(arcs[SignalType::GPS_L1CA].size(), 4u);
+    ASSERT_EQ(arcs[SignalType::GPS_L2C].size(), 4u);
+    EXPECT_EQ(arcs[SignalType::GPS_L1CA].at(0),
+              arcs[SignalType::GPS_L1CA].at(1));
+    EXPECT_EQ(arcs[SignalType::GPS_L1CA].at(1),
+              arcs[SignalType::GPS_L1CA].at(2));
+    EXPECT_NE(arcs[SignalType::GPS_L1CA].at(2),
+              arcs[SignalType::GPS_L1CA].at(3));
+    EXPECT_EQ(arcs[SignalType::GPS_L2C].at(0),
+              arcs[SignalType::GPS_L2C].at(1));
+    EXPECT_EQ(arcs[SignalType::GPS_L2C].at(1),
+              arcs[SignalType::GPS_L2C].at(2));
+    EXPECT_NE(arcs[SignalType::GPS_L2C].at(2),
+              arcs[SignalType::GPS_L2C].at(3));
+    // The same controlled L1 jump is present on both satellites; one is the
+    // DD target and one the reference. Geometry-free detection cannot identify
+    // the changed band, so both bands for both satellites are conservatively
+    // reset one epoch after detection.
+    EXPECT_EQ(problem.diagnostics.geometry_free_cycle_slip_resets, 4u);
+
+    config.use_geometry_free_cycle_slip_reset = false;
+    const auto control = FGOProcessor(config).buildDoubleDifferenceProblem(
+        rover_epochs, base_epochs, nav, base_position);
+    std::map<SignalType, std::map<std::size_t, std::size_t>> control_arcs;
+    for (const auto& factor : control.double_difference_carrier_factors) {
+        control_arcs[factor.signal][factor.epoch_index] =
+            factor.ambiguity_index;
+    }
+    EXPECT_EQ(control_arcs[SignalType::GPS_L1CA].at(1),
+              control_arcs[SignalType::GPS_L1CA].at(2));
+    EXPECT_EQ(control_arcs[SignalType::GPS_L2C].at(1),
+              control_arcs[SignalType::GPS_L2C].at(2));
+    EXPECT_EQ(control.diagnostics.geometry_free_cycle_slip_resets, 0u);
+}
+
+TEST(FGOTest, GeometryFreeSlipResetDefersToReceiverArcBreak) {
+    const NavigationData nav = makeSyntheticGpsNavigation(2);
+    const Vector3d rover_position(1113194.0, -4841695.0, 3985350.0);
+    const Vector3d base_position =
+        rover_position + Vector3d(-320.0, 180.0, 45.0);
+    const std::vector<double> rover_l1 = {0.0, 0.0, 0.40, 0.40};
+    const std::vector<double> rover_l2 = {0.0, 0.0, 0.00, 0.00};
+    const std::vector<double> base_bias(4, 0.0);
+    auto rover_epochs = makeGeometryFreeObservationEpochs(
+        nav, rover_position, rover_l1, rover_l2);
+    const auto base_epochs = makeGeometryFreeObservationEpochs(
+        nav, base_position, base_bias, base_bias);
+    for (auto& observation : rover_epochs[3].observations) {
+        observation.lli = 1;
+        observation.loss_of_lock = true;
+    }
+
+    FGOProcessor::FGOConfig config = makeCmcTestConfig();
+    config.use_code_minus_carrier_screening = false;
+    config.use_multi_frequency_double_difference = true;
+    config.use_geometry_free_cycle_slip_reset = true;
+    const auto problem = FGOProcessor(config).buildDoubleDifferenceProblem(
+        rover_epochs, base_epochs, nav, base_position);
+
+    // The epoch-2 GF event was pending, but the epoch-3 receiver LLI already
+    // created new arcs. The debounce must cancel rather than count a second,
+    // redundant GF-driven reset.
+    EXPECT_EQ(problem.diagnostics.geometry_free_cycle_slip_resets, 0u);
 }
 
 TEST(FGOTest, CmcJumpForcesAmbiguityArcBreak) {

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -2782,6 +2782,66 @@ TEST(FGOFixDemoteTest, FreshSppAndStrongModelReprieveResidualOnlyDemotion) {
         0u);
 }
 
+TEST(FGOFixDemoteTest, GeometryFreeLowRedundancyGrossSppGuardDemotesAndSkipsHold) {
+    constexpr std::size_t kBadEpoch = 1;
+    CpHoldTestOptions opt;
+    opt.satellites = lambdaCapableSatelliteGeometry();
+    opt.num_epochs = 25;
+    for (std::size_t e = 0; e <= 3; ++e) {
+        opt.pr_corrupt_epochs.insert(e);
+    }
+    opt.pr_baseline_bias_m = 0.0;
+    opt.pr_dominant_extra_bias_m = 80.0;
+    auto problem = makeCpHoldFixedLagProblem(opt);
+    // Keep the synthetic LAMBDA candidate accepted but non-trivial: a
+    // quarter-cycle offset on one arc avoids the noise-free fixture's
+    // unrealistically enormous ratio while retaining a clear integer winner.
+    for (auto& factor : problem.double_difference_carrier_factors) {
+        if (factor.ambiguity_index == 0) {
+            factor.observed_dd_carrier_m += 0.05;
+            factor.rover_satellite_model.corrected_carrier_m += 0.05;
+        }
+    }
+    for (std::size_t e = 0; e <= 3; ++e) {
+        problem.epochs[e].fresh_spp_solution = true;
+        problem.epochs[e].position_ecef += Vector3d(100.0, 0.0, 0.0);
+    }
+
+    FGOProcessor::FGOConfig off_config = makeFixDemoteBaseConfig();
+    off_config.use_fixed_lag_partial_lambda = true;
+    off_config.max_lambda_ambiguities = 6;
+    off_config.use_epoch_quality_gates = true;
+    off_config.gate_gdop_max = 1e9;
+    off_config.gate_min_satellites = 0;
+    off_config.gate_ddpr_res_max_m = 1e9;
+    off_config.gate_per_sat_res_max_m = 1e9;
+    off_config.use_fix_plausibility_demotion = true;
+    off_config.fix_demote_distance_m = 1e9;
+    off_config.fix_demote_res_m = 0.0;
+
+    const auto off_result = FGOProcessor(off_config).optimizeProblem(problem);
+    ASSERT_EQ(off_result.solution.solutions[kBadEpoch].status,
+              SolutionStatus::FIXED)
+        << "fixture sanity: without the GF guard the grossly SPP-disagreed "
+           "low-redundancy candidate must remain FIXED";
+    ASSERT_LE(off_result.epoch_diagnostics[kBadEpoch]
+                  .lambda_candidate_fixed_ambiguities,
+              6);
+    ASSERT_LE(off_result.epoch_diagnostics[kBadEpoch].lambda_candidate_ratio,
+              10.0);
+
+    FGOProcessor::FGOConfig on_config = off_config;
+    on_config.use_fix_plausibility_demotion = false;
+    on_config.use_geometry_free_cycle_slip_reset = true;
+    const auto on_result = FGOProcessor(on_config).optimizeProblem(problem);
+
+    EXPECT_NE(on_result.solution.solutions[kBadEpoch].status,
+              SolutionStatus::FIXED);
+    EXPECT_GT(on_result.diagnostics.fix_plausibility_demotions, 0u);
+    EXPECT_GT(on_result.diagnostics.geometry_free_fix_guard_demotions, 0u);
+    EXPECT_GT(on_result.diagnostics.fix_plausibility_hold_skips, 0u);
+}
+
 TEST(FGOFixDemoteTest, RelativeResidualDemotesExcursionButToleratesChronicNoise) {
     // fix_demote_res_rel semantics: (1) a residual EXCURSION over a quiet
     // ambient demotes; (2) the SAME absolute residual level, when it is the


### PR DESCRIPTION
## Summary

- Add an opt-in, 1.0 s debounced geometry-free cycle-slip reset for unchanged rover/base carrier arcs.
- Conservatively restart both bands because the geometry-free combination detects an integer discontinuity but cannot identify the affected band.
- Add an intrinsic low-redundancy integrity guard that blocks hold and demotes a gross SPP-disagreed FIX, including when the broader `fix-demote` feature is off.
- Add CLI/cache/diagnostic plumbing, focused regressions, and update the GNSS/IMU comparison with official correct/wrong-FIX metrics.

Closes #389

## Scope

- [x] Single feature / single operational improvement / single user-visible value
- [x] Adds or tightens one regression, sign-off, dogfood, or artifact-schema check
- [x] No unrelated refactor mixed in
- [x] No docs-only noise mixed into solver/protocol work
- [x] Protocol ingest, parser work, runtime knobs, solver behavior, and docs are split unless this PR explicitly needs the boundary crossing

The CLI and README changes are the minimal boundary crossing needed to expose and reproduce the opt-in solver feature.

## External Reference

- Source repos used for comparison: GICI-LIB geometry-free ambiguity handling and RTKLIB multi-frequency slip/arc logic (linked from the README).
- Adopted: clock-free rover/base single-difference geometry-free jump detection, explicit ambiguity-arc replacement, and conservative multi-band invalidation.
- Intentionally not adopted: TDCP as the primary lever, immediate reset, or Doppler-only/band-isolated reset. Controlled Tokyo replays showed smaller gains or wrong-FIX/P95 regressions; Doppler remains diagnostic-only.

## Behavior Boundary

- Runtime default changed? no
- Env-gated or config-gated? yes, `FGOConfig::use_geometry_free_cycle_slip_reset` / `--gf-slip-reset` (default off)
- Artifact/schema changed? yes, problem-cache version 8 -> 9 and new GF reset/guard diagnostics
- Dataset or credentials required? public PPC Tokyo data for full replay; unit tests are synthetic
- Non-GTSAM behavior changed? no; a fresh GTSAM-disabled Release `gnss_lib` build passed

## Validation

- [ ] `python3 tests/test_cli_tools.py` (not affected)
- [ ] `python3 tests/test_benchmark_scripts.py` (not affected)
- [ ] `python3 tests/test_packaging.py` (not affected)
- [ ] `python3 tests/test_python_bindings.py -v` (not affected)
- [ ] `python3 tests/test_ros2_node.py` (not affected)
- [x] full native GoogleTest executable: 884 tests, 824 passed, 60 data-dependent skips, 0 failed

Focused checks run:

```text
run_tests.exe --gtest_filter=*GeometryFree*:FGOFixDemoteTest.*
# 19/19 passed

run_tests.exe --gtest_brief=1
# 824 passed, 60 skipped, 0 failed

cmake -S . -B build-no-gtsam-msvc ... -DCMAKE_DISABLE_FIND_PACKAGE_GTSAM=TRUE
cmake --build build-no-gtsam-msvc --config Release --target gnss_lib -- /m:1
# passed

git diff --check
# passed
```

## Sign-off / Benchmark Impact

Clean full-length PPC official segment scoring (0.11 s match tolerance, 0.5 m threshold):

| Run | Correct FIX distance | Wrong FIX distance | Wrong FIX/FIX | Official score | Positioning distance |
|---|---:|---:|---:|---:|---:|
| Tokyo 1 baseline -> candidate | 25.656% -> 33.322% | 23.765% -> 21.221% | 48.087% -> 38.907% | 30.823% -> 39.375% | 99.152% -> 99.152% |
| Tokyo 2 baseline -> candidate | 60.304% -> 74.599% | 12.573% -> 1.386% | 17.252% -> 1.824% | 65.264% -> 81.615% | 99.900% -> 99.900% |
| Tokyo 3 baseline -> candidate | 59.175% -> 65.099% | 7.918% -> 1.818% | 11.801% -> 2.717% | 64.081% -> 71.207% | 99.921% -> 99.921% |
| Distance-weighted aggregate | 49.181% -> 57.409% | 13.741% -> 7.650% | 21.839% -> 11.759% | 54.178% -> 63.692% | 99.682% -> 99.682% |

Fixed-only integrity:

| Run | H RMS baseline -> candidate | H P95 baseline -> candidate | abs(V) P95 baseline -> candidate |
|---|---:|---:|---:|
| Tokyo 1 | 1.267 -> 1.180 m | 0.892 -> 0.877 m | 1.478 -> 1.463 m |
| Tokyo 2 | 0.225 -> 0.109 m | 0.600 -> 0.155 m | 0.878 -> 0.141 m |
| Tokyo 3 | 0.257 -> 0.125 m | 0.539 -> 0.079 m | 1.152 -> 0.253 m |

The guard removed all 17 Tokyo 3 catastrophic FIX epochs from the earlier candidate (about 145 m error); final fixed maximum horizontal/vertical errors are 5.31/4.01 m. GF confirmed band resets were 207/262/399 and guard demotions 14/0/17 for Tokyo 1/2/3.

- Added or updated regression/sign-off: debounce reset, both-band reset, natural receiver-arc-break cancellation, default-off control, standalone gross-SPP guard and hold suppression
- Affected datasets: PPC Tokyo runs 1, 2, and frozen run 3 holdout
- Expected metric impact: +8.228 pp distance-weighted correct FIX, -6.091 pp wrong FIX distance, unchanged positioning distance
- Regression threshold: issue #389 merge gates; every run improves correct FIX, wrong FIX, fixed RMS, horizontal P95, and vertical P95
- Runtime: cached-input solver wall 463.5 / 584.6 / 844.9 s on the validation host (reported as workload measurements, not a controlled microbenchmark)
- Artifacts produced: local full replay CSV, normalized AR trace, cache and logs; not committed due size

## Notes

- Risk: a false GF jump can shorten two ambiguity arcs. The 1.0 s debounce lets a receiver LLI/gap/dropout supersede it, and the intrinsic SPP/DDPR guard prevents the measured low-redundancy wrong-basin FIX from being held or reported.
- Follow-up PRs: only broader held-out datasets or adaptive thresholds; neither is required for this issue's measured gate.
- Explicit non-goals: enabling GF reset by default, making TDCP a prerequisite, or treating Doppler as an independent slip decision.
