### PR TITLE
Add conditional multi-band AR shadow

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,6 +291,19 @@ and do not change candidate selection or FIX/FLOAT decisions. The FFRT
 coefficient table follows [Hou, Verhagen, and Wu (2016)](https://doi.org/10.3390/s16070945)
 and unsupported ambiguity dimensions fail closed in telemetry.
 
+`--conditional-mf-shadow` adds a separate, diagnostic-only multi-frequency AR
+experiment. It resolves one primary band per satellite, conditions the
+remaining float ambiguities and covariance on those primary integers, then
+runs a second LAMBDA search. The CSV records both stage ratios, bootstrapped
+success rates, ambiguity counts, and the counterfactual position. The shadow
+does not promote FLOAT epochs, add integer priors, alter holding, or change the
+reported position. A current-preset Tokyo run1 500-epoch A/B replay produced
+499 correct FIX and zero wrong FIX in both arms, with identical status,
+position, ratio, and AR-outcome rows; the shadow produced 197 candidates.
+Historical full-run candidate auditing found that ratio/BSR passage alone was
+not a safe promotion rule, so activation remains deliberately unavailable.
+See the [multi-band AR audit](docs/fgo_multiband_ar_fix_rate_audit.md).
+
 Across the three courses, distance-weighted correct FIX improved from
 57.0731% at the pre-reprieve baseline to approximately **58.2153%**, while
 distance-weighted wrong FIX fell from 7.7043% to **7.0089%**. The policy is

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -97,6 +97,7 @@ struct Args {
     bool residual_par = false;
     bool ratio_impact_monitor = false;
     bool gf_slip_reset = false;
+    bool conditional_mf_shadow = false;
     bool variance_par = false;
     bool gici_par = false;          // GICI-style strict PAR + continuous-unfix reacquisition profile
     bool anchor_gated_unfix_reset = false;
@@ -255,6 +256,10 @@ Args parseArgs(int argc, char** argv) {
         }
         if (a == "--gf-slip-reset") {
             args.gf_slip_reset = true;
+            continue;
+        }
+        if (a == "--conditional-mf-shadow") {
+            args.conditional_mf_shadow = true;
             continue;
         }
         if (a == "--integer-constrained-reoptimization") {
@@ -796,6 +801,9 @@ libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
     }
     if (args.partial_ar) {
         config.use_fixed_lag_partial_lambda = true;
+    }
+    if (args.conditional_mf_shadow) {
+        config.monitor_conditional_multiband_ar = true;
     }
     if (args.integer_constrained_reoptimization) {
         config.use_integer_constrained_reoptimization = true;
@@ -1510,6 +1518,13 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
            "gf_slip_events,gf_slip_max_jump_m,gf_slip_tainted_ambiguities,"
            "doppler_slip_signals,doppler_slip_max_innovation_m,"
            "gf_doppler_isolated_pairs,"
+           "conditional_mf_eval,conditional_mf_primary_n,conditional_mf_secondary_n,"
+           "conditional_mf_primary_ratio,conditional_mf_secondary_ratio,"
+           "conditional_mf_primary_bsr,conditional_mf_secondary_bsr,"
+           "conditional_mf_primary_pass,conditional_mf_secondary_pass,"
+           "conditional_mf_candidate_valid,conditional_mf_x_ecef_m,"
+           "conditional_mf_y_ecef_m,conditional_mf_z_ecef_m,"
+           "conditional_mf_float_sep_m,conditional_mf_imu_sep_m,"
            "ratio_impact_eval,ratio_impact_trials,ratio_impact_best_ratio,"
            "ratio_impact_best_nfixed,ratio_impact_x_ecef_m,"
            "ratio_impact_y_ecef_m,ratio_impact_z_ecef_m,"
@@ -1580,6 +1595,7 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
             << s.ratio;
         if (si < r.epoch_diagnostics.size()) {
             const auto& d = r.epoch_diagnostics[si];
+            const auto& conditional = d.conditional_multiband_ar_shadow;
             out << ',' << d.effective_ratio_threshold
                 << ',' << s.num_fixed_ambiguities
                 << ',' << static_cast<int>(d.ar_outcome)
@@ -1620,6 +1636,21 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                 << ',' << d.doppler_slip_shadow_event_signals
                 << ',' << d.doppler_slip_shadow_max_innovation_m
                 << ',' << d.gf_doppler_shadow_isolated_pairs
+                << ',' << (conditional.evaluated ? 1 : 0)
+                << ',' << conditional.primary_ambiguities
+                << ',' << conditional.secondary_ambiguities
+                << ',' << conditional.primary_ratio
+                << ',' << conditional.secondary_ratio
+                << ',' << conditional.primary_bootstrapped_success_rate
+                << ',' << conditional.secondary_bootstrapped_success_rate
+                << ',' << (conditional.primary_ratio_passed ? 1 : 0)
+                << ',' << (conditional.secondary_ratio_passed ? 1 : 0)
+                << ',' << (conditional.candidate_available ? 1 : 0)
+                << ',' << conditional.candidate_position_ecef.x()
+                << ',' << conditional.candidate_position_ecef.y()
+                << ',' << conditional.candidate_position_ecef.z()
+                << ',' << conditional.float_separation_m
+                << ',' << conditional.imu_separation_m
                 << ',' << (d.ratio_impact_evaluated ? 1 : 0)
                 << ',' << d.ratio_impact_trials
                 << ',' << d.ratio_impact_best_ratio
@@ -2594,9 +2625,12 @@ int main(int argc, char** argv) {
                   << "  partial AR: " << (config.use_fixed_lag_partial_lambda ? "on" : "off")
                   << " (min_fraction=" << config.fixed_lag_partial_lambda_min_fraction
                   << ", min_fixed=" << config.min_fixed_ambiguities
-                  << ", max_std_cycles=" << config.partial_ar_max_std_cycles
-                  << ", ratio_impact_monitor="
-                  << (config.monitor_ratio_impact_partial_ar ? "on" : "off") << ")\n"
+                   << ", max_std_cycles=" << config.partial_ar_max_std_cycles
+                   << ", ratio_impact_monitor="
+                   << (config.monitor_ratio_impact_partial_ar ? "on" : "off")
+                   << ", conditional_mf_shadow="
+                   << (config.monitor_conditional_multiband_ar ? "on" : "off")
+                   << ")\n"
                   << "  IMU ratio aperture: " << (args.imu_ratio_aperture ? "on" : "off")
                   << " (accepted=" << fl.diagnostics.imu_aided_ratio_accepts
                   << ", rejected=" << fl.diagnostics.imu_aided_ratio_rejects

--- a/docs/fgo_multiband_ar_fix_rate_audit.md
+++ b/docs/fgo_multiband_ar_fix_rate_audit.md
@@ -1,0 +1,100 @@
+# FGO multi-band AR FIX-rate audit
+
+## Decision
+
+Keep conditional multi-band ambiguity resolution shadow-only. The two-stage
+candidate generator is useful telemetry, but the available Tokyo run1 evidence
+does not support turning its candidates into FIX labels or graph priors.
+
+This work intentionally does not make TDCP the main FIX mechanism. TDCP and
+Doppler remain complementary arc-integrity evidence; ambiguity acceptance is
+controlled by integer-estimation evidence and independent integrity checks.
+
+## Research basis
+
+- Teunissen and Verhagen explain why ambiguity acceptance must control failure
+  probability, and why a conventional ratio threshold is not by itself a
+  guaranteed failure-rate test: <https://doi.org/10.1007/978-3-540-74584-6_22>.
+- Odijk, Arora, and Teunissen describe partial ambiguity resolution by choosing
+  a subset whose bootstrapped success-rate lower bound exceeds a required
+  probability: <https://doi.org/10.1017/S037346331400006X>.
+- Hou, Verhagen, and Wu evaluate a two-step success-rate criterion for PAR:
+  <https://doi.org/10.1016/j.asr.2016.07.029>.
+- RTKLIB supplies the operational comparison for multi-frequency arc handling,
+  ambiguity validation, and consecutive-fix holding:
+  <https://github.com/tomojitakasu/RTKLIB/blob/master/src/rtkpos.c>.
+- GICI-LIB supplies the tightly-coupled comparison for ambiguity lifecycle and
+  geometry-free cycle-slip handling:
+  <https://github.com/chichengcn/gici-open/blob/master/src/gnss/ambiguity_common.cpp>.
+- Suzuki's GNSS Odometry work shows the value of TDCP in a factor graph when
+  cycle slips are explicitly detected and estimated, supporting its use as
+  continuity evidence rather than an unconditional FIX authority:
+  <https://arxiv.org/abs/2312.02424>.
+
+The resulting design follows three constraints: select a primary subset,
+condition the remaining Gaussian ambiguity distribution correctly, and never
+activate a candidate until an offline truth audit demonstrates a low empirical
+failure rate under deployable gates.
+
+## Implementation
+
+`FGOConfig::monitor_conditional_multiband_ar` is opt-in and independent of the
+existing satellite-exclusion ratio-impact monitor. For every eligible epoch:
+
+1. choose one primary band per satellite using the established deterministic
+   selector;
+2. run top-2 LAMBDA on the primary float vector and covariance;
+3. if its configured ratio gate passes, compute the secondary conditional mean
+   and Schur-complement covariance given the primary integer candidate;
+4. run top-2 LAMBDA on the conditional secondary problem;
+5. reconstruct a complete counterfactual integer vector and position; and
+6. export dedicated ratios, bootstrapped success rates, counts, position, and
+   float/IMU separation telemetry.
+
+No estimator state, ambiguity generation, hold state, FIX/FLOAT status, or
+reported position reads the shadow result.
+
+## Reproducible 500-epoch A/B baseline
+
+Dataset: PPC Tokyo run1. Both arms use the README fixed-lag-5 multi-frequency
+preset including geometry-free slip reset. The shadow arm adds only
+`--conditional-mf-shadow`; both use the same cached input problem.
+
+| Metric | Baseline | Conditional shadow |
+|---|---:|---:|
+| Epochs | 500 | 500 |
+| FIX epochs | 499 | 499 |
+| Correct FIX, 3D error <= 0.5 m | 499 | 499 |
+| Wrong FIX | 0 | 0 |
+| Positioning epochs within 0.5 m | 500 | 500 |
+| Conditional candidates | 0 | 197 |
+| Changed status/position/ratio/AR-outcome rows | - | 0 |
+
+Artifacts are
+`build-ffrt-msvc/validation/multiband_fixrate_baseline_e500.csv` and
+`build-ffrt-msvc/validation/multiband_fixrate_shadow_e500.csv`. Their SHA-256
+digests are respectively
+`BE3AFB5280E00767AE23856BE5351FE2C568A5C0F35DD908E766E15A27B31E6E` and
+`F4766B1BDC442FA3EAF276A954C4B1D36EC1A6711CC6DEF5F1AED9836CD646CE`.
+
+## Promotion audit
+
+A historical full-length Tokyo run1 shadow replay generated 1,376 complete
+two-stage candidates. Only 77 occurred on epochs not already labelled FIXED;
+41 of those candidates were within 0.5 m and 36 were wrong. Tight IMU-position
+agreement did not isolate a safe region: at 0.05 m separation, 9 candidates
+were correct and 28 were wrong. These figures use reference truth only after
+the solver run and are therefore evaluation results, not runtime inputs.
+
+Consequently, ratio passage, high bootstrapped success rate, and proximity to
+the IMU prediction are insufficient for activation on this data. Promoting the
+shadow now would raise raw FIX rate while materially worsening wrong FIX/FIX.
+
+## Next gate before activation
+
+Activation requires a fresh full three-run Tokyo replay and a truth-free gate
+that adds genuinely independent evidence, such as surplus satellites excluded
+from the candidate construction or a clock-safe GF-triggered Doppler/TDCP arc
+check. It must improve correct-FIX distance without increasing wrong-FIX
+distance on any held-out run. Until that gate exists, the shipping preset is
+unchanged.

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -384,6 +384,11 @@ public:
         // satellite in turn and record the best candidate. Never changes the
         // selected subset, FIX/FLOAT status, graph, or hold state.
         bool monitor_ratio_impact_partial_ar = false;
+        // Diagnostic-only two-stage multi-frequency ambiguity resolution.
+        // Resolve one primary band per satellite, then condition the remaining
+        // ambiguity distribution on those integers. Never changes estimator
+        // state or the exported FIX/FLOAT decision.
+        bool monitor_conditional_multiband_ar = false;
         // Diagnostic-only geometry-free slip/arc-continuity shadow.
         bool monitor_geometry_free_cycle_slip = false;
         // When a rover/base single-difference geometry-free combination jumps
@@ -2016,6 +2021,24 @@ public:
         double imu_separation_m = 0.0;
     };
 
+    /// Counterfactual two-stage multi-frequency AR result. Populated only by
+    /// monitor_conditional_multiband_ar and never consumed by the estimator.
+    struct ConditionalMultibandArShadow {
+        bool evaluated = false;
+        int primary_ambiguities = 0;
+        int secondary_ambiguities = 0;
+        double primary_ratio = 0.0;
+        double secondary_ratio = 0.0;
+        double primary_bootstrapped_success_rate = 0.0;
+        double secondary_bootstrapped_success_rate = 0.0;
+        bool primary_ratio_passed = false;
+        bool secondary_ratio_passed = false;
+        bool candidate_available = false;
+        Vector3d candidate_position_ecef = Vector3d::Zero();
+        double float_separation_m = 0.0;
+        double imu_separation_m = 0.0;
+    };
+
     /// Per-epoch fixed-lag integrity state.  These values expose why an epoch
     /// did or did not fix, rather than only reporting the final FIX/FLOAT label.
     struct FGOEpochDiagnostics {
@@ -2074,6 +2097,7 @@ public:
         int doppler_slip_shadow_event_signals = 0;
         double doppler_slip_shadow_max_innovation_m = 0.0;
         int gf_doppler_shadow_isolated_pairs = 0;
+        ConditionalMultibandArShadow conditional_multiband_ar_shadow;
         bool ratio_impact_evaluated = false;
         int ratio_impact_trials = 0;
         double ratio_impact_best_ratio = 0.0;

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -3370,6 +3370,164 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                         epoch_diagnostics[i].ambiguity_variance_max_cycles2 = vmax;
                     }
 
+                    // Diagnostic-only conditional multi-band AR shadow. Unlike the
+                    // historical one-band mode, this retains every band in
+                    // the eventual counterfactual integer vector.  The
+                    // primary stage must first pass the configured ratio;
+                    // the remaining bands are then resolved using the exact
+                    // Gaussian conditional mean/covariance given those
+                    // primary integers.  Nothing below mutates the graph,
+                    // ambiguity map, FIX label, ratio, or hold state.
+                    if (config.monitor_conditional_multiband_ar &&
+                        config.use_multi_frequency_double_difference && n > 1) {
+                        const std::vector<std::size_t> primary_indices =
+                            selectOneBandPerSatellite(epoch_amb_indices, problem);
+                        const std::set<std::size_t> primary_set(
+                            primary_indices.begin(), primary_indices.end());
+                        std::vector<int> primary_order;
+                        std::vector<int> secondary_order;
+                        for (int candidate = 0; candidate < n; ++candidate) {
+                            if (primary_set.count(epoch_amb_indices[candidate]) != 0) {
+                                primary_order.push_back(candidate);
+                            } else {
+                                secondary_order.push_back(candidate);
+                            }
+                        }
+                        auto& shadow = epoch_diagnostics[i];
+                        if (primary_order.size() >=
+                                static_cast<std::size_t>(min_candidates) &&
+                            !secondary_order.empty()) {
+                            const int np = static_cast<int>(primary_order.size());
+                            const int ns = static_cast<int>(secondary_order.size());
+                            auto& conditional =
+                                shadow.conditional_multiband_ar_shadow;
+                            conditional.evaluated = true;
+                            conditional.primary_ambiguities = np;
+                            conditional.secondary_ambiguities = ns;
+                            Eigen::VectorXd a_primary(np);
+                            Eigen::MatrixXd q_primary(np, np);
+                            for (int r = 0; r < np; ++r) {
+                                a_primary(r) = float_amb(primary_order[r]);
+                                for (int c = 0; c < np; ++c) {
+                                    q_primary(r, c) =
+                                        q_amb(primary_order[r], primary_order[c]);
+                                }
+                            }
+                            LambdaCandidateDiagnostics primary_diag;
+                            if (lambdaSearchTopK(
+                                    a_primary, q_primary, 2, primary_diag)) {
+                                const double primary_best =
+                                    primary_diag.squared_residuals(0);
+                                conditional.primary_ratio =
+                                    primary_best > 0.0
+                                        ? primary_diag.squared_residuals(1) /
+                                              primary_best
+                                        : 0.0;
+                                conditional.primary_bootstrapped_success_rate =
+                                    primary_diag.bootstrapped_success_rate;
+                                conditional.primary_ratio_passed =
+                                    std::isfinite(conditional.primary_ratio) &&
+                                    (config.lambda_ratio_threshold <= 0.0 ||
+                                     conditional.primary_ratio >
+                                         config.lambda_ratio_threshold);
+                                if (conditional.primary_ratio_passed) {
+                                    Eigen::VectorXd a_secondary(ns);
+                                    Eigen::MatrixXd q_secondary(ns, ns);
+                                    Eigen::MatrixXd q_secondary_primary(ns, np);
+                                    for (int r = 0; r < ns; ++r) {
+                                        a_secondary(r) = float_amb(secondary_order[r]);
+                                        for (int c = 0; c < ns; ++c) {
+                                            q_secondary(r, c) =
+                                                q_amb(secondary_order[r],
+                                                      secondary_order[c]);
+                                        }
+                                        for (int c = 0; c < np; ++c) {
+                                            q_secondary_primary(r, c) =
+                                                q_amb(secondary_order[r],
+                                                      primary_order[c]);
+                                        }
+                                    }
+                                    const Eigen::LDLT<Eigen::MatrixXd> primary_ldlt(
+                                        q_primary);
+                                    if (primary_ldlt.info() == Eigen::Success) {
+                                        const Eigen::VectorXd primary_fixed =
+                                            primary_diag.candidates.col(0);
+                                        const Eigen::VectorXd conditional_float =
+                                            a_secondary + q_secondary_primary *
+                                                primary_ldlt.solve(
+                                                    primary_fixed - a_primary);
+                                        Eigen::MatrixXd conditional_q =
+                                            q_secondary - q_secondary_primary *
+                                                primary_ldlt.solve(
+                                                    q_secondary_primary.transpose());
+                                        conditional_q = 0.5 *
+                                            (conditional_q + conditional_q.transpose());
+                                        for (int k = 0; k < ns; ++k) {
+                                            conditional_q(k, k) += std::max(
+                                                1e-12,
+                                                std::abs(conditional_q(k, k)) * 1e-9);
+                                        }
+                                        LambdaCandidateDiagnostics secondary_diag;
+                                        if (conditional_float.allFinite() &&
+                                            conditional_q.allFinite() &&
+                                            lambdaSearchTopK(conditional_float,
+                                                             conditional_q, 2,
+                                                             secondary_diag)) {
+                                            const double secondary_best =
+                                                secondary_diag.squared_residuals(0);
+                                            conditional.secondary_ratio =
+                                                secondary_best > 0.0
+                                                    ? secondary_diag.squared_residuals(1) /
+                                                          secondary_best
+                                                    : 0.0;
+                                            conditional.secondary_bootstrapped_success_rate =
+                                                secondary_diag.bootstrapped_success_rate;
+                                            conditional.secondary_ratio_passed =
+                                                std::isfinite(conditional.secondary_ratio) &&
+                                                (config.lambda_ratio_threshold <= 0.0 ||
+                                                 conditional.secondary_ratio >
+                                                     config.lambda_ratio_threshold);
+                                            if (conditional.secondary_ratio_passed) {
+                                                Eigen::VectorXd all_fixed = float_amb;
+                                                for (int r = 0; r < np; ++r) {
+                                                    all_fixed(primary_order[r]) =
+                                                        primary_diag.candidates(r, 0);
+                                                }
+                                                for (int r = 0; r < ns; ++r) {
+                                                    all_fixed(secondary_order[r]) =
+                                                        secondary_diag.candidates(r, 0);
+                                                }
+                                                const Eigen::LDLT<Eigen::MatrixXd> all_ldlt(
+                                                    q_amb);
+                                                if (all_ldlt.info() == Eigen::Success) {
+                                                    const Eigen::VectorXd correction =
+                                                        all_ldlt.solve(float_amb - all_fixed);
+                                                    const Eigen::Vector3d candidate =
+                                                        Eigen::Vector3d(antennaOf(pose_i)) -
+                                                        pos_amb * correction;
+                                                    if (correction.allFinite() &&
+                                                        candidate.allFinite()) {
+                                                        conditional.candidate_available = true;
+                                                        conditional.candidate_position_ecef =
+                                                            candidate;
+                                                        conditional.float_separation_m =
+                                                            (candidate - Eigen::Vector3d(
+                                                                         antennaOf(pose_i)))
+                                                                .norm();
+                                                        conditional.imu_separation_m =
+                                                            (candidate - Eigen::Vector3d(
+                                                                         antennaOf(pose_seed)))
+                                                                .norm();
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+
                     // --- MF-AR step 2: partial AR (port of the Eigen path's
                     // use_partial_lambda_ambiguity_fix). Candidate order:
                     // identity (= the deterministic sat/ref/signal sort above)

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -2281,6 +2281,85 @@ TEST(FGOAmbiguityOutcomeTelemetryTest,
     EXPECT_GT(available_trial->candidate_position_ecef.norm(), 1.0e6);
 }
 
+TEST(FGOAmbiguityOutcomeTelemetryTest,
+     ConditionalMultibandMonitorIsDiagnosticOnlyAndBuildsTwoStageCandidate) {
+    CpHoldTestOptions opt;
+    opt.satellites = lambdaCapableSatelliteGeometry();
+    opt.num_epochs = 12;
+    auto problem = makeCpHoldFixedLagProblem(opt);
+
+    // Add a clean L2 ambiguity/factor for every existing L1 satellite.  The
+    // two bands share geometry but carry distinct integer cycles, matching
+    // the raw multi-frequency DD state representation used by production.
+    const std::size_t primary_count = problem.ambiguity_states.size();
+    for (std::size_t idx = 0; idx < primary_count; ++idx) {
+        auto secondary = problem.ambiguity_states[idx];
+        secondary.signal = SignalType::GPS_L2C;
+        secondary.wavelength_m = constants::GPS_L2_WAVELENGTH;
+        const int sat_offset = static_cast<int>(secondary.satellite.prn) - 1;
+        secondary.initial_ambiguity_m =
+            static_cast<double>(200 + sat_offset) * secondary.wavelength_m;
+        problem.ambiguity_states.push_back(secondary);
+    }
+    const auto primary_factors = problem.double_difference_carrier_factors;
+    for (const auto& primary : primary_factors) {
+        auto secondary = primary;
+        const int sat_offset = static_cast<int>(secondary.satellite.prn) - 1;
+        const double primary_ambiguity_m =
+            static_cast<double>(100 + sat_offset) * constants::GPS_L1_WAVELENGTH;
+        const double secondary_ambiguity_m =
+            static_cast<double>(200 + sat_offset) * constants::GPS_L2_WAVELENGTH;
+        const double ambiguity_delta_m =
+            secondary_ambiguity_m - primary_ambiguity_m;
+        secondary.ambiguity_index += primary_count;
+        secondary.signal = SignalType::GPS_L2C;
+        secondary.rover_satellite_model.corrected_carrier_m +=
+            ambiguity_delta_m;
+        secondary.observed_dd_carrier_m += ambiguity_delta_m;
+        problem.double_difference_carrier_factors.push_back(secondary);
+    }
+
+    FGOProcessor::FGOConfig config = makeStalePinBaseConfig();
+    config.lambda_ratio_threshold = 1.0;
+    config.ambiguity_hold_ratio_threshold = 1.0e200;
+    config.use_cp_hold_recovery = false;
+    config.use_multi_frequency_double_difference = true;
+
+    FGOProcessor baseline_processor(config);
+    const auto baseline = baseline_processor.optimizeProblem(problem);
+
+    config.monitor_conditional_multiband_ar = true;
+    FGOProcessor processor(config);
+    const auto result = processor.optimizeProblem(problem);
+
+    ASSERT_EQ(result.solution.solutions.size(), baseline.solution.solutions.size());
+    for (std::size_t i = 0; i < result.solution.solutions.size(); ++i) {
+        EXPECT_EQ(result.solution.solutions[i].status,
+                  baseline.solution.solutions[i].status);
+        EXPECT_TRUE(result.solution.solutions[i].position_ecef.isApprox(
+            baseline.solution.solutions[i].position_ecef, 0.0));
+    }
+    const auto monitored = std::find_if(
+        result.epoch_diagnostics.begin(), result.epoch_diagnostics.end(),
+        [](const FGOProcessor::FGOEpochDiagnostics& diagnostics) {
+            return diagnostics.conditional_multiband_ar_shadow
+                       .candidate_position_ecef.norm() > 1.0e6;
+        });
+    ASSERT_NE(monitored, result.epoch_diagnostics.end());
+    const auto& conditional = monitored->conditional_multiband_ar_shadow;
+    EXPECT_TRUE(conditional.evaluated);
+    EXPECT_EQ(conditional.primary_ambiguities,
+              static_cast<int>(primary_count));
+    EXPECT_EQ(conditional.secondary_ambiguities,
+              static_cast<int>(primary_count));
+    EXPECT_TRUE(conditional.primary_ratio_passed);
+    EXPECT_TRUE(conditional.secondary_ratio_passed);
+    EXPECT_TRUE(conditional.candidate_available);
+    EXPECT_GT(conditional.primary_bootstrapped_success_rate, 0.0);
+    EXPECT_GT(conditional.secondary_bootstrapped_success_rate, 0.0);
+    EXPECT_GT(conditional.candidate_position_ecef.norm(), 1.0e6);
+}
+
 TEST(FGOAmbiguityOutcomeTelemetryTest, NoCarrierCandidatesRemainNoCandidates) {
     CpHoldTestOptions opt;
     opt.satellites = lambdaCapableSatelliteGeometry();


### PR DESCRIPTION
## Summary

- add an opt-in, diagnostic-only two-stage conditional multi-band ambiguity-resolution shadow
- expose dedicated primary/secondary ratio, bootstrapped success-rate, candidate-position, and separation telemetry
- keep the existing ratio-impact monitor independent and preserve estimator/FIX/FLOAT behavior
- document the literature/OSS basis, reproducible Tokyo run1 baseline, and promotion safety audit

## Why

The existing WIP reused ratio-impact telemetry and its configuration switch for a different multi-frequency experiment. More importantly, the full-run offline audit shows that ratio/BSR passage and IMU proximity do not form a safe FLOAT-to-FIX promotion rule: among 77 non-FIX conditional candidates, 41 were correct and 36 were wrong at the 0.5 m threshold.

This PR therefore isolates the experiment behind `--conditional-mf-shadow` and keeps it strictly read-only. It improves observability for future FIX-rate work without increasing wrong FIX or changing the shipping preset.

## Validation

- 885 tests executed: 825 passed, 60 data-dependent tests skipped, 0 failed
- focused conditional multi-band and ratio-impact tests passed
- non-GTSAM MSVC `gnss_lib` build passed
- PPC Tokyo run1, current fixed-lag-5/GF-reset preset, 500-epoch A/B:
  - baseline and shadow: 499 correct FIX, 0 wrong FIX, 0.2 s TTFF, 100% within 0.5 m
  - all 500 status/position/ratio/AR-outcome rows unchanged
  - shadow produced 197 counterfactual candidates

## Safety

No conditional candidate is consumed by ambiguity holding, graph priors, estimator state, reported position, or FIX/FLOAT status. Promotion remains unavailable until a truth-free independent integrity gate passes full held-out replay validation.
