### PR TITLE
Add multi-epoch AR shadow telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,6 +304,15 @@ Historical full-run candidate auditing found that ratio/BSR passage alone was
 not a safe promotion rule, so activation remains deliberately unavailable.
 See the [multi-band AR audit](docs/fgo_multiband_ar_fix_rate_audit.md).
 
+`--multiepoch-ar-shadow` adds an independent temporal partial-AR experiment.
+Only integer candidates that remain identical for at least three consecutive
+epochs on the same uninterrupted DD ambiguity arc enter a reduced LAMBDA
+search (minimum four ambiguities). The CSV reports the persistent subset size,
+history depth, ratio, bootstrapped success rate, history agreement, candidate
+position, and float/IMU separations as `multiepoch_ar_*`. It never changes the
+graph, hold state, solution, ratio, or FIX/FLOAT label. See the
+[multi-epoch AR audit](docs/fgo_multiepoch_ar_fix_rate_audit.md).
+
 Across the three courses, distance-weighted correct FIX improved from
 57.0731% at the pre-reprieve baseline to approximately **58.2153%**, while
 distance-weighted wrong FIX fell from 7.7043% to **7.0089%**. The policy is

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -98,6 +98,7 @@ struct Args {
     bool ratio_impact_monitor = false;
     bool gf_slip_reset = false;
     bool conditional_mf_shadow = false;
+    bool multiepoch_ar_shadow = false;
     bool variance_par = false;
     bool gici_par = false;          // GICI-style strict PAR + continuous-unfix reacquisition profile
     bool anchor_gated_unfix_reset = false;
@@ -260,6 +261,10 @@ Args parseArgs(int argc, char** argv) {
         }
         if (a == "--conditional-mf-shadow") {
             args.conditional_mf_shadow = true;
+            continue;
+        }
+        if (a == "--multiepoch-ar-shadow") {
+            args.multiepoch_ar_shadow = true;
             continue;
         }
         if (a == "--integer-constrained-reoptimization") {
@@ -804,6 +809,9 @@ libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
     }
     if (args.conditional_mf_shadow) {
         config.monitor_conditional_multiband_ar = true;
+    }
+    if (args.multiepoch_ar_shadow) {
+        config.monitor_multiepoch_ar = true;
     }
     if (args.integer_constrained_reoptimization) {
         config.use_integer_constrained_reoptimization = true;
@@ -1515,6 +1523,12 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
            "lambda_candidate_integer_agreements,"
            "lambda_candidate_integer_agreement_fraction,"
            "lambda_candidate_integer_consensus_streak,"
+           "multiepoch_ar_eval,multiepoch_ar_n,multiepoch_ar_support_epochs,"
+           "multiepoch_ar_ratio,multiepoch_ar_bsr,multiepoch_ar_history_agree,"
+           "multiepoch_ar_ratio_pass,multiepoch_ar_candidate_valid,"
+           "multiepoch_ar_x_ecef_m,multiepoch_ar_y_ecef_m,"
+           "multiepoch_ar_z_ecef_m,multiepoch_ar_float_sep_m,"
+           "multiepoch_ar_imu_sep_m,"
            "gf_slip_events,gf_slip_max_jump_m,gf_slip_tainted_ambiguities,"
            "doppler_slip_signals,doppler_slip_max_innovation_m,"
            "gf_doppler_isolated_pairs,"
@@ -1596,6 +1610,7 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
         if (si < r.epoch_diagnostics.size()) {
             const auto& d = r.epoch_diagnostics[si];
             const auto& conditional = d.conditional_multiband_ar_shadow;
+            const auto& multiepoch = d.multiepoch_ar_shadow;
             out << ',' << d.effective_ratio_threshold
                 << ',' << s.num_fixed_ambiguities
                 << ',' << static_cast<int>(d.ar_outcome)
@@ -1630,6 +1645,19 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                 << ',' << d.lambda_candidate_integer_agreements
                 << ',' << d.lambda_candidate_integer_agreement_fraction
                 << ',' << d.lambda_candidate_integer_consensus_streak
+                << ',' << (multiepoch.evaluated ? 1 : 0)
+                << ',' << multiepoch.persistent_ambiguities
+                << ',' << multiepoch.minimum_support_epochs
+                << ',' << multiepoch.ratio
+                << ',' << multiepoch.bootstrapped_success_rate
+                << ',' << (multiepoch.history_integers_agree ? 1 : 0)
+                << ',' << (multiepoch.ratio_passed ? 1 : 0)
+                << ',' << (multiepoch.candidate_available ? 1 : 0)
+                << ',' << multiepoch.candidate_position_ecef.x()
+                << ',' << multiepoch.candidate_position_ecef.y()
+                << ',' << multiepoch.candidate_position_ecef.z()
+                << ',' << multiepoch.float_separation_m
+                << ',' << multiepoch.imu_separation_m
                 << ',' << d.gf_slip_shadow_event_pairs
                 << ',' << d.gf_slip_shadow_max_jump_m
                 << ',' << d.gf_slip_shadow_tainted_ambiguities
@@ -2630,6 +2658,8 @@ int main(int argc, char** argv) {
                    << (config.monitor_ratio_impact_partial_ar ? "on" : "off")
                    << ", conditional_mf_shadow="
                    << (config.monitor_conditional_multiband_ar ? "on" : "off")
+                   << ", multiepoch_ar_shadow="
+                   << (config.monitor_multiepoch_ar ? "on" : "off")
                    << ")\n"
                   << "  IMU ratio aperture: " << (args.imu_ratio_aperture ? "on" : "off")
                   << " (accepted=" << fl.diagnostics.imu_aided_ratio_accepts

--- a/docs/fgo_multiepoch_ar_fix_rate_audit.md
+++ b/docs/fgo_multiepoch_ar_fix_rate_audit.md
@@ -1,0 +1,110 @@
+# Multi-epoch ambiguity-resolution shadow audit
+
+## Scope
+
+This experiment asks whether repeated integer candidates on an uninterrupted
+double-difference ambiguity arc provide a safe, truth-free way to recover
+FLOAT epochs. It is deliberately independent of the shipped estimator: the
+shadow cannot add graph factors, pin ambiguities, change the selected partial
+AR subset, or alter the reported position and FIX/FLOAT status.
+
+The implementation is not a TDCP-specific change. It uses the fixed-lag
+ambiguity marginal already produced by tightly coupled carrier-phase/IMU FGO.
+An ambiguity enters the counterfactual subset only after its integer candidate
+is identical for three consecutive epochs on the same internal arc index.
+At least four such ambiguities are required. The current joint covariance is
+then reduced to that subset and a fresh two-candidate LAMBDA search reports:
+
+- persistent ambiguity count and minimum history support;
+- ratio and bootstrapped success-rate lower bound;
+- whether the fresh search agrees with the historical integers;
+- counterfactual ECEF position and its float/IMU-prediction separation.
+
+Enable it in the parity harness with `--multiepoch-ar-shadow`. The default is
+off.
+
+## Research and OSS audit
+
+- The ION GNSS+ 2024 multi-epoch FGO-RTK study compares single-epoch AR,
+  ambiguity merging, and multi-epoch AR with single-differenced ambiguity
+  constraints. It motivates keeping arc identity and window history explicit,
+  rather than treating repeated solution labels as independent votes:
+  [Li et al., 2024](https://www.ion.org/publications/abstract.cfm?articleID=19805).
+- Integer-aperture theory requires controlling the probability of an incorrect
+  integer output, not merely maximizing availability. A repeated candidate is
+  therefore telemetry, not sufficient evidence for promotion:
+  [Teunissen, 2003](https://doi.org/10.1007/s00190-002-0299-9).
+- RTKLIB delays ambiguity holding until a configurable number of consecutive
+  validated fixes and resets that evidence when FIX is lost. This supports
+  tracking persistence separately from the per-epoch ratio test:
+  [RTKLIB `rtkpos.c`](https://github.com/tomojitakasu/RTKLIB/blob/master/src/rtkpos.c).
+- GICI-LIB uses partial ambiguity resolution and validates the constrained
+  graph by rejecting an integer update when the range cost worsens. This
+  supports requiring an independent post-fix witness before activation:
+  [GICI-LIB ambiguity resolution](https://github.com/chichengcn/gici-open/blob/master/src/gnss/ambiguity_resolution.cpp).
+- GraphGNSSLib demonstrates windowed DD pseudorange/carrier/Doppler FGO with
+  LAMBDA, but does not supply a production-grade integer-aperture activation
+  rule that can replace dataset validation here:
+  [GraphGNSSLib](https://github.com/weisongwen/GraphGNSSLib).
+
+The audited stash was not applied wholesale. Its public LAMBDA diagnostics,
+stale-key filtering, bootstrapped success rate, and solution-separation ideas
+are already present on `develop` in a more complete form. Adaptive covariance
+scaling and held-only anchor mutation were excluded from this isolated
+multi-epoch experiment.
+
+## Validation protocol
+
+The shipped Tokyo preset is replayed on PPC Tokyo runs 1, 2, and 3. The
+baseline and shadow must have identical status, ECEF position, ratio, fixed
+ambiguity count, and AR outcome at every epoch. Candidate correctness is used
+only offline: a counterfactual candidate is classed correct when its 3D error
+is below 0.5 m. Activation may be considered only if a truth-free rule adds no
+wrong fixes on any run; otherwise the feature remains monitor-only.
+
+## Results
+
+The full shadow replays produced the following counterfactual candidates.
+“FLOAT correct/wrong” counts only epochs where the shipped solution remained
+FLOAT, so these are the potential additions to fix rate.
+
+| Run | Epochs | All candidates correct/wrong | FLOAT correct/wrong | FLOAT ratio > 3 correct/wrong |
+|---|---:|---:|---:|---:|
+| Tokyo run1 | 11,905 | 4,608 / 2,859 | 293 / 1,024 | 87 / 170 |
+| Tokyo run2 | 9,147 | 7,139 / 255 | 114 / 164 | 57 / 45 |
+| Tokyo run3 | 15,294 | 10,785 / 384 | 413 / 233 | 17 / 29 |
+
+The baseline and shadow CSVs have the same row count on every run. Status,
+ECEF position, reported ratio, fixed ambiguity count, and AR outcome are
+identical in every one of the 36,346 rows. A separate 500-epoch current-build
+A/B replay also had zero differing rows. This confirms that the implementation
+is diagnostic-only.
+
+Bootstrapped success rate does not rescue the rule: at a threshold of 0.999 it
+accepted 1,314/1,317, 273/278, and 645/646 FLOAT candidates on runs 1, 2, and
+3 respectively, including the wrong integer basins. Exact integers can remain
+stable for many epochs when the underlying urban measurement model is biased.
+
+A threshold grid was selected using runs 1 and 2 only, then checked on run 3.
+The best zero-wrong training family required ratio above 20, float separation
+at most 0.05 m, IMU-prediction separation at most 0.1 m, and a fresh SPP
+witness within 5 m (the default three-epoch/four-ambiguity requirements still
+apply). It recovered only three correct epochs in the training runs and three
+correct epochs on held-out run 3. Six epochs over 36,346 is about **0.0165
+percentage points**, far below a meaningful fix-rate improvement, and the
+threshold was selected after a grid search. It is not promoted to a shipping
+gate.
+
+The diagnostic also has measurable cost when enabled. Solver wall time was
+463.520→566.505 s, 584.568→543.092 s, and 844.915→930.754 s for runs 1–3;
+summed wall time increased by about 7.8% (individual runs include normal timing
+noise). Since the default is off, shipped runtime is unchanged.
+
+## Decision
+
+Keep `--multiepoch-ar-shadow` monitor-only. Do not increase fix rate from
+temporal integer agreement, ratio, or BSR alone. The next activation experiment
+should add an independent observation-domain witness, such as the constrained
+graph range-cost check used by GICI-LIB or a held-out carrier residual that was
+not part of the LAMBDA marginal. Any future gate must again be selected without
+run3 truth and then validated on a held-out course.

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -389,6 +389,13 @@ public:
         // ambiguity distribution on those integers. Never changes estimator
         // state or the exported FIX/FLOAT decision.
         bool monitor_conditional_multiband_ar = false;
+        // Diagnostic-only multi-epoch AR shadow. Ambiguity integers must be
+        // identical on the same uninterrupted DD arc for the configured
+        // number of consecutive epochs before they enter a fresh, reduced
+        // LAMBDA search. Never changes graph state or FIX/FLOAT output.
+        bool monitor_multiepoch_ar = false;
+        int multiepoch_ar_min_consensus_epochs = 3;
+        int multiepoch_ar_min_ambiguities = 4;
         // Diagnostic-only geometry-free slip/arc-continuity shadow.
         bool monitor_geometry_free_cycle_slip = false;
         // When a rover/base single-difference geometry-free combination jumps
@@ -2039,6 +2046,22 @@ public:
         double imu_separation_m = 0.0;
     };
 
+    /// Counterfactual LAMBDA result using only ambiguity arcs whose integer
+    /// candidate has persisted across multiple consecutive epochs.
+    struct MultiEpochArShadow {
+        bool evaluated = false;
+        int persistent_ambiguities = 0;
+        int minimum_support_epochs = 0;
+        double ratio = 0.0;
+        double bootstrapped_success_rate = 0.0;
+        bool history_integers_agree = false;
+        bool ratio_passed = false;
+        bool candidate_available = false;
+        Vector3d candidate_position_ecef = Vector3d::Zero();
+        double float_separation_m = 0.0;
+        double imu_separation_m = 0.0;
+    };
+
     /// Per-epoch fixed-lag integrity state.  These values expose why an epoch
     /// did or did not fix, rather than only reporting the final FIX/FLOAT label.
     struct FGOEpochDiagnostics {
@@ -2098,6 +2121,7 @@ public:
         double doppler_slip_shadow_max_innovation_m = 0.0;
         int gf_doppler_shadow_isolated_pairs = 0;
         ConditionalMultibandArShadow conditional_multiband_ar_shadow;
+        MultiEpochArShadow multiepoch_ar_shadow;
         bool ratio_impact_evaluated = false;
         int ratio_impact_trials = 0;
         double ratio_impact_best_ratio = 0.0;

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -1325,6 +1325,12 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
     std::size_t previous_lambda_candidate_epoch =
         std::numeric_limits<std::size_t>::max();
     int lambda_candidate_integer_consensus_streak = 0;
+    struct MultiEpochIntegerHistory {
+        int integer = 0;
+        int consecutive_epochs = 0;
+        std::size_t last_epoch = std::numeric_limits<std::size_t>::max();
+    };
+    std::map<std::size_t, MultiEpochIntegerHistory> multiepoch_integer_history;
 
     // Reference state.effective_cp_hold_epochs(): the configured CP-hold
     // length, suppressed to 0 while the DDPR-anchor bootstrap countdown is
@@ -4679,6 +4685,140 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                             }
                         }
                         break;  // validated subset found
+                    }
+
+                    // Multi-epoch AR shadow. Select only uninterrupted DD
+                    // arcs whose integer candidate has persisted for the
+                    // configured number of epochs, then run LAMBDA again on
+                    // their current joint marginal. This is deliberately
+                    // read-only: it cannot add factors, hold ambiguities, or
+                    // alter epoch_fixed/epoch_ratio.
+                    if (config.monitor_multiepoch_ar &&
+                        !lambda_candidate_cycles_this_epoch.empty()) {
+                        std::vector<int> persistent_order;
+                        int minimum_support = std::numeric_limits<int>::max();
+                        for (int candidate = 0; candidate < n; ++candidate) {
+                            const std::size_t ambiguity_index =
+                                epoch_amb_indices[candidate];
+                            const auto current =
+                                lambda_candidate_cycles_this_epoch.find(
+                                    ambiguity_index);
+                            if (current ==
+                                lambda_candidate_cycles_this_epoch.end()) {
+                                continue;
+                            }
+                            const auto history = multiepoch_integer_history.find(
+                                ambiguity_index);
+                            if (history == multiepoch_integer_history.end() ||
+                                history->second.last_epoch + 1 != i ||
+                                history->second.integer != current->second) {
+                                continue;
+                            }
+                            const int support =
+                                history->second.consecutive_epochs + 1;
+                            if (support >=
+                                std::max(2,
+                                    config.multiepoch_ar_min_consensus_epochs)) {
+                                persistent_order.push_back(candidate);
+                                minimum_support = std::min(minimum_support, support);
+                            }
+                        }
+
+                        auto& shadow = epoch_diagnostics[i].multiepoch_ar_shadow;
+                        shadow.persistent_ambiguities =
+                            static_cast<int>(persistent_order.size());
+                        shadow.minimum_support_epochs =
+                            minimum_support == std::numeric_limits<int>::max()
+                                ? 0
+                                : minimum_support;
+                        if (shadow.persistent_ambiguities >=
+                            std::max(1, config.multiepoch_ar_min_ambiguities)) {
+                            shadow.evaluated = true;
+                            const int np = shadow.persistent_ambiguities;
+                            Eigen::VectorXd persistent_float(np);
+                            Eigen::MatrixXd persistent_q(np, np);
+                            Eigen::MatrixXd persistent_pos(3, np);
+                            for (int r = 0; r < np; ++r) {
+                                persistent_float(r) = float_amb(persistent_order[r]);
+                                persistent_pos.col(r) = pos_amb.col(persistent_order[r]);
+                                for (int c = 0; c < np; ++c) {
+                                    persistent_q(r, c) =
+                                        q_amb(persistent_order[r],
+                                              persistent_order[c]);
+                                }
+                            }
+                            LambdaCandidateDiagnostics persistent_diagnostics;
+                            if (lambdaSearchTopK(persistent_float, persistent_q, 2,
+                                                 persistent_diagnostics)) {
+                                const double best =
+                                    persistent_diagnostics.squared_residuals(0);
+                                shadow.ratio = best > 0.0
+                                    ? persistent_diagnostics.squared_residuals(1) /
+                                          best
+                                    : 0.0;
+                                shadow.bootstrapped_success_rate =
+                                    persistent_diagnostics.bootstrapped_success_rate;
+                                shadow.ratio_passed = std::isfinite(shadow.ratio) &&
+                                    (config.lambda_ratio_threshold <= 0.0 ||
+                                     shadow.ratio > config.lambda_ratio_threshold);
+                                shadow.history_integers_agree = true;
+                                for (int r = 0; r < np; ++r) {
+                                    const std::size_t ambiguity_index =
+                                        epoch_amb_indices[persistent_order[r]];
+                                    const int resolved = static_cast<int>(std::lround(
+                                        persistent_diagnostics.candidates(r, 0)));
+                                    if (resolved !=
+                                        lambda_candidate_cycles_this_epoch.at(
+                                            ambiguity_index)) {
+                                        shadow.history_integers_agree = false;
+                                        break;
+                                    }
+                                }
+                                const Eigen::LDLT<Eigen::MatrixXd> ldlt(persistent_q);
+                                if (ldlt.info() == Eigen::Success) {
+                                    const Eigen::VectorXd correction = ldlt.solve(
+                                        persistent_float -
+                                        persistent_diagnostics.candidates.col(0));
+                                    const Eigen::Vector3d position_delta =
+                                        persistent_pos * correction;
+                                    if (correction.allFinite() &&
+                                        position_delta.allFinite()) {
+                                        shadow.candidate_position_ecef =
+                                            Eigen::Vector3d(antennaOf(pose_i)) -
+                                            position_delta;
+                                        shadow.candidate_available = true;
+                                        shadow.float_separation_m =
+                                            position_delta.norm();
+                                        shadow.imu_separation_m =
+                                            (shadow.candidate_position_ecef -
+                                             Eigen::Vector3d(antennaOf(pose_seed)))
+                                                .norm();
+                                    }
+                                }
+                            }
+                        }
+
+                        for (const auto& [ambiguity_index, fixed_integer] :
+                             lambda_candidate_cycles_this_epoch) {
+                            auto& history =
+                                multiepoch_integer_history[ambiguity_index];
+                            if (history.last_epoch + 1 == i &&
+                                history.integer == fixed_integer) {
+                                ++history.consecutive_epochs;
+                            } else {
+                                history.consecutive_epochs = 1;
+                            }
+                            history.integer = fixed_integer;
+                            history.last_epoch = i;
+                        }
+                        for (auto it = multiepoch_integer_history.begin();
+                             it != multiepoch_integer_history.end();) {
+                            if (it->second.last_epoch + 1 < i) {
+                                it = multiepoch_integer_history.erase(it);
+                            } else {
+                                ++it;
+                            }
+                        }
                     }
 
                     // Read-only temporal integer-consensus shadow. Compare

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -2282,6 +2282,54 @@ TEST(FGOAmbiguityOutcomeTelemetryTest,
 }
 
 TEST(FGOAmbiguityOutcomeTelemetryTest,
+     MultiEpochArMonitorIsDiagnosticOnlyAndBuildsPersistentSubset) {
+    CpHoldTestOptions opt;
+    opt.satellites = lambdaCapableSatelliteGeometry();
+    opt.num_epochs = 12;
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig config = makeStalePinBaseConfig();
+    config.lambda_ratio_threshold = 1.0e200;
+    config.ambiguity_hold_ratio_threshold = 1.0e200;
+    config.use_cp_hold_recovery = false;
+
+    FGOProcessor baseline_processor(config);
+    const auto baseline = baseline_processor.optimizeProblem(problem);
+
+    config.monitor_multiepoch_ar = true;
+    config.multiepoch_ar_min_consensus_epochs = 3;
+    config.multiepoch_ar_min_ambiguities = 4;
+    FGOProcessor shadow_processor(config);
+    const auto shadow = shadow_processor.optimizeProblem(problem);
+
+    ASSERT_EQ(shadow.solution.solutions.size(), baseline.solution.solutions.size());
+    for (std::size_t i = 0; i < shadow.solution.solutions.size(); ++i) {
+        EXPECT_EQ(shadow.solution.solutions[i].status,
+                  baseline.solution.solutions[i].status);
+        EXPECT_DOUBLE_EQ(shadow.solution.solutions[i].ratio,
+                         baseline.solution.solutions[i].ratio);
+        EXPECT_TRUE(shadow.solution.solutions[i].position_ecef.isApprox(
+            baseline.solution.solutions[i].position_ecef, 0.0));
+    }
+
+    const auto monitored = std::find_if(
+        shadow.epoch_diagnostics.begin(), shadow.epoch_diagnostics.end(),
+        [](const FGOProcessor::FGOEpochDiagnostics& diagnostics) {
+            return diagnostics.multiepoch_ar_shadow.evaluated &&
+                   diagnostics.multiepoch_ar_shadow.candidate_available;
+        });
+    ASSERT_NE(monitored, shadow.epoch_diagnostics.end());
+    const auto& multi = monitored->multiepoch_ar_shadow;
+    EXPECT_GE(multi.persistent_ambiguities, 4);
+    EXPECT_GE(multi.minimum_support_epochs, 3);
+    EXPECT_GT(multi.ratio, 0.0);
+    EXPECT_GT(multi.bootstrapped_success_rate, 0.0);
+    EXPECT_LE(multi.bootstrapped_success_rate, 1.0);
+    EXPECT_TRUE(multi.history_integers_agree);
+    EXPECT_GT(multi.candidate_position_ecef.norm(), 1.0e6);
+}
+
+TEST(FGOAmbiguityOutcomeTelemetryTest,
      ConditionalMultibandMonitorIsDiagnosticOnlyAndBuildsTwoStageCandidate) {
     CpHoldTestOptions opt;
     opt.satellites = lambdaCapableSatelliteGeometry();


### PR DESCRIPTION
## What changed

- add an opt-in `--multiepoch-ar-shadow` monitor for ambiguity integers that persist on the same uninterrupted DD arc
- rerun LAMBDA on the persistent subset and export ratio, BSR, history agreement, candidate position, and separation telemetry
- add an A/B regression test proving the shadow does not change status, position, ratio, or hold behavior
- document the paper/OSS audit and full Tokyo run1-3 evaluation

## Why

Temporal integer agreement looked like a possible truth-free FIX-rate signal, but it needed to be isolated and measured before any estimator activation. The implementation stays monitor-only so false integer basins cannot alter the graph or solution.

## Impact

Default behavior and runtime are unchanged. The shadow is enabled only with `--multiepoch-ar-shadow`. Full-run evidence shows that temporal agreement, ratio, and BSR are not safe promotion rules, so this PR intentionally does not add a FIX gate.

## Validation

- MSVC Release build: `gnss_lib_noopt`, `gnss_run_tests`, `gnss_fgo_parity`
- full local suite: 886 tests, 826 passed, 60 data-dependent skipped, 0 failed
- Tokyo run1-3: 36,346 baseline/shadow rows; status, ECEF position, ratio, fixed ambiguity count, and AR outcome identical on every row
- held-out gate audit: best zero-wrong rule recovered only 6 total epochs (~0.0165 pp), therefore rejected
- post-merge CI for the base branch was green before publication