### PR TITLE
Add held-out carrier witness telemetry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM ubuntu:24.04 AS builder
 
+ARG CMAKE_BUILD_PARALLEL_LEVEL=2
+
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -19,7 +21,7 @@ WORKDIR /src
 COPY . .
 
 RUN cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF \
- && cmake --build build --parallel \
+ && cmake --build build --parallel "${CMAKE_BUILD_PARALLEL_LEVEL}" \
  && cmake --install build --prefix /opt/libgnsspp \
  && py_site="$(find /opt/libgnsspp/lib -type d -path '*/site-packages' | head -n 1)" \
  && test -n "${py_site}" \

--- a/README.md
+++ b/README.md
@@ -309,8 +309,14 @@ Only integer candidates that remain identical for at least three consecutive
 epochs on the same uninterrupted DD ambiguity arc enter a reduced LAMBDA
 search (minimum four ambiguities). The CSV reports the persistent subset size,
 history depth, ratio, bootstrapped success rate, history agreement, candidate
-position, and float/IMU separations as `multiepoch_ar_*`. It never changes the
-graph, hold state, solution, ratio, or FIX/FLOAT label. See the
+position, and float/IMU separations as `multiepoch_ar_*`. It also tests each
+candidate against carrier rows whose ambiguities were not used by the reduced
+search. `multiepoch_ar_surplus_eval`, `_pass`, `_level`, and `_used` expose
+that held-out alternate-reference witness; lack of a sufficiently independent
+pool produces no verdict. It never changes the graph, hold state, solution,
+ratio, or FIX/FLOAT label. A Tokyo run1 gate selected from this witness failed
+on run2 (3 correct and 15 wrong candidate epochs), so it remains monitor-only.
+See the
 [multi-epoch AR audit](docs/fgo_multiepoch_ar_fix_rate_audit.md).
 
 Across the three courses, distance-weighted correct FIX improved from

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -1528,7 +1528,9 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
            "multiepoch_ar_ratio_pass,multiepoch_ar_candidate_valid,"
            "multiepoch_ar_x_ecef_m,multiepoch_ar_y_ecef_m,"
            "multiepoch_ar_z_ecef_m,multiepoch_ar_float_sep_m,"
-           "multiepoch_ar_imu_sep_m,"
+           "multiepoch_ar_imu_sep_m,multiepoch_ar_surplus_eval,"
+           "multiepoch_ar_surplus_pass,multiepoch_ar_surplus_level,"
+           "multiepoch_ar_surplus_used,"
            "gf_slip_events,gf_slip_max_jump_m,gf_slip_tainted_ambiguities,"
            "doppler_slip_signals,doppler_slip_max_innovation_m,"
            "gf_doppler_isolated_pairs,"
@@ -1658,6 +1660,10 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                 << ',' << multiepoch.candidate_position_ecef.z()
                 << ',' << multiepoch.float_separation_m
                 << ',' << multiepoch.imu_separation_m
+                << ',' << (multiepoch.surplus_validation_evaluated ? 1 : 0)
+                << ',' << (multiepoch.surplus_validation_pass ? 1 : 0)
+                << ',' << multiepoch.surplus_validation_fallback_level
+                << ',' << multiepoch.surplus_validation_surplus_used
                 << ',' << d.gf_slip_shadow_event_pairs
                 << ',' << d.gf_slip_shadow_max_jump_m
                 << ',' << d.gf_slip_shadow_tainted_ambiguities

--- a/docs/fgo_multiepoch_ar_fix_rate_audit.md
+++ b/docs/fgo_multiepoch_ar_fix_rate_audit.md
@@ -108,3 +108,53 @@ should add an independent observation-domain witness, such as the constrained
 graph range-cost check used by GICI-LIB or a held-out carrier residual that was
 not part of the LAMBDA marginal. Any future gate must again be selected without
 run3 truth and then validated on a held-out course.
+
+## Held-out carrier witness follow-up
+
+The follow-up implements the second experiment without changing estimator
+output. For each multi-epoch candidate, it passes only the ambiguities in the
+persistent subset to the existing surplus-satellite validator. Carrier rows
+outside that subset are therefore re-differenced against an alternate
+reference and evaluated at the candidate position without contributing an
+integer or covariance entry to the reduced LAMBDA search. The CSV fields are:
+
+- `multiepoch_ar_surplus_eval`: an independent pool was large enough to decide;
+- `multiepoch_ar_surplus_pass`: every required held-out check passed;
+- `multiepoch_ar_surplus_level`: constellation fallback, 0 for the strongest
+  GQEBR pool through 5 for GQ;
+- `multiepoch_ar_surplus_used`: number of held-out satellites in the deciding
+  pool.
+
+This follows the fixed-hypothesis validation direction used by
+[GICI-LIB](https://github.com/chichengcn/gici-open/blob/master/src/gnss/ambiguity_resolution.cpp),
+which rejects a constrained update when range cost increases, and
+[RTKLIB](https://github.com/tomojitakasu/RTKLIB/blob/master/src/rtkpos.c),
+which recomputes and validates fixed-solution post-fit residuals. The important
+difference is explicit sample splitting: the new verdict uses carrier rows
+whose ambiguity was not fixed by the multi-epoch search.
+
+The shipping preset was replayed over all of Tokyo runs 1 and 2. Correct and
+wrong below classify counterfactual FLOAT candidates by 3D error at or below,
+or above, 0.5 m. The shadow continued to leave status, ECEF position, ratio,
+fixed ambiguity count, and AR outcome unchanged.
+
+| FLOAT candidate filter | Run1 correct / wrong | Run2 correct / wrong |
+|---|---:|---:|
+| All multi-epoch candidates | 293 / 1,024 | 114 / 164 |
+| Held-out verdict available | 264 / 856 | 102 / 144 |
+| Held-out verdict passed | 118 / 230 | 34 / 33 |
+| Strongest GQEBR pool passed | 100 / 184 | 25 / 27 |
+| Run1-selected gate | **45 / 0** | **3 / 15** |
+
+The run1-selected gate required the strongest GQEBR pool, ratio above 50, and
+candidate/IMU-prediction separation at most 0.1 m. It looked safe in development
+but failed immediately on run2, where 15 of 18 accepted candidates were wrong
+and the maximum candidate error was 1.755 m. An exploratory run1+2 grid adding
+fresh-SPP separation found no non-empty zero-wrong rule. Run3 remains an
+unconsumed holdout for this follow-up because the candidate already failed its
+validation course.
+
+Decision: retain the held-out verdict as diagnostic evidence, but do not add a
+multi-epoch rescue switch or change the shipping FIX rate. Independent carrier
+rows can share the same urban multipath basin and are not, by themselves, a
+safe integer-aperture witness.

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -2060,6 +2060,13 @@ public:
         Vector3d candidate_position_ecef = Vector3d::Zero();
         double float_separation_m = 0.0;
         double imu_separation_m = 0.0;
+        // Held-out carrier witness: rows whose ambiguity is not part of the
+        // persistent LAMBDA subset are checked at the candidate position.
+        // A missing independent pool leaves evaluated=false (fail closed).
+        bool surplus_validation_evaluated = false;
+        bool surplus_validation_pass = false;
+        int surplus_validation_fallback_level = -1;
+        int surplus_validation_surplus_used = 0;
     };
 
     /// Per-epoch fixed-lag integrity state.  These values expose why an epoch

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -4793,6 +4793,50 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                                             (shadow.candidate_position_ecef -
                                              Eigen::Vector3d(antennaOf(pose_seed)))
                                                 .norm();
+
+                                        // Validate the persistent integer
+                                        // hypothesis with carrier rows that
+                                        // did not participate in this reduced
+                                        // LAMBDA search. This reuses the
+                                        // established alternate-reference
+                                        // surplus test, but supplies exactly
+                                        // the multi-epoch subset so every
+                                        // deciding row is held out from the
+                                        // candidate covariance and integers.
+                                        std::map<std::size_t, int>
+                                            persistent_cycles_by_index;
+                                        for (int r = 0; r < np; ++r) {
+                                            const std::size_t ambiguity_index =
+                                                epoch_amb_indices[
+                                                    persistent_order[r]];
+                                            persistent_cycles_by_index[
+                                                ambiguity_index] =
+                                                static_cast<int>(std::lround(
+                                                    persistent_diagnostics
+                                                        .candidates(r, 0)));
+                                        }
+                                        std::vector<const FGOProcessor::
+                                            DoubleDifferenceCarrierFactor*>
+                                            surplus_pool = cp_by_epoch[i];
+                                        surplus_pool.insert(
+                                            surplus_pool.end(),
+                                            cp_excluded_by_epoch[i].begin(),
+                                            cp_excluded_by_epoch[i].end());
+                                        const SurplusValidationOutcome
+                                            surplus_diag =
+                                                evaluateSurplusSatelliteValidation(
+                                                    surplus_pool,
+                                                    persistent_cycles_by_index,
+                                                    shadow.candidate_position_ecef,
+                                                    config);
+                                        shadow.surplus_validation_evaluated =
+                                            surplus_diag.evaluated;
+                                        shadow.surplus_validation_pass =
+                                            surplus_diag.pass;
+                                        shadow.surplus_validation_fallback_level =
+                                            surplus_diag.fallback_level;
+                                        shadow.surplus_validation_surplus_used =
+                                            surplus_diag.surplus_used;
                                     }
                                 }
                             }

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -2286,7 +2286,24 @@ TEST(FGOAmbiguityOutcomeTelemetryTest,
     CpHoldTestOptions opt;
     opt.satellites = lambdaCapableSatelliteGeometry();
     opt.num_epochs = 12;
-    const auto problem = makeCpHoldFixedLagProblem(opt);
+    auto problem = makeCpHoldFixedLagProblem(opt);
+    // Move one complete satellite arc outside the searchable ambiguity set.
+    // It remains observable only through the build-time-excluded carrier
+    // collection, which exercises the held-out verdict without duplicating a
+    // satellite in both the fixed and surplus pools.
+    const std::size_t heldout_index = problem.ambiguity_states.size() - 1;
+    for (auto it = problem.double_difference_carrier_factors.begin();
+         it != problem.double_difference_carrier_factors.end();) {
+        if (it->ambiguity_index != heldout_index) {
+            ++it;
+            continue;
+        }
+        auto excluded = *it;
+        excluded.ambiguity_index = std::numeric_limits<std::size_t>::max();
+        problem.excluded_double_difference_carrier_factors.push_back(excluded);
+        it = problem.double_difference_carrier_factors.erase(it);
+    }
+    problem.ambiguity_states.pop_back();
 
     FGOProcessor::FGOConfig config = makeStalePinBaseConfig();
     config.lambda_ratio_threshold = 1.0e200;
@@ -2299,6 +2316,7 @@ TEST(FGOAmbiguityOutcomeTelemetryTest,
     config.monitor_multiepoch_ar = true;
     config.multiepoch_ar_min_consensus_epochs = 3;
     config.multiepoch_ar_min_ambiguities = 4;
+    config.surplus_validation_min_surplus_satellites = 1;
     FGOProcessor shadow_processor(config);
     const auto shadow = shadow_processor.optimizeProblem(problem);
 
@@ -2327,6 +2345,11 @@ TEST(FGOAmbiguityOutcomeTelemetryTest,
     EXPECT_LE(multi.bootstrapped_success_rate, 1.0);
     EXPECT_TRUE(multi.history_integers_agree);
     EXPECT_GT(multi.candidate_position_ecef.norm(), 1.0e6);
+    EXPECT_TRUE(multi.surplus_validation_evaluated);
+    EXPECT_TRUE(multi.surplus_validation_pass);
+    EXPECT_GE(multi.surplus_validation_fallback_level, 0);
+    EXPECT_LE(multi.surplus_validation_fallback_level, 5);
+    EXPECT_GT(multi.surplus_validation_surplus_used, 0);
 }
 
 TEST(FGOAmbiguityOutcomeTelemetryTest,


### PR DESCRIPTION
## What changed

- evaluate each multi-epoch AR candidate with the existing alternate-reference surplus-carrier validator
- expose evaluation/pass/fallback-level/held-out-count fields in the parity CSV
- add a synthetic integration test that proves the held-out path runs without changing status, ratio, or position
- document the Tokyo run1/run2 audit and the no-activation decision
- bound Docker CMake builds to two parallel jobs by default, with a build-argument override

## Why

The previous multi-epoch audit found long-lived wrong integer basins, so temporal agreement, ratio, and BSR cannot safely promote FLOAT epochs. This follow-up tests the candidate against carrier rows whose ambiguities were excluded from the reduced LAMBDA search.

The original inline Docker smoke lost its hosted runner twice. After Docker smoke was isolated in PR #427, this branch exposed a second peak-load failure during the unrestricted C++ build. Bounding Docker build parallelism prevents runner starvation without changing the built artifacts.

## Result and impact

The monitor remains diagnostic-only. A gate selected on Tokyo run1 (GQEBR surplus pass, ratio > 50, IMU separation <= 0.1 m) produced 45 correct and 0 wrong candidate epochs, but failed on run2 with 3 correct and 15 wrong candidates (maximum error 1.755 m). No rescue switch was added and the shipping FIX rate is unchanged. Run3 remains unconsumed for this follow-up.

Production behavior is unchanged by the Docker adjustment. The successful CI run built the image with two parallel jobs and completed Docker smoke in 6m33s.

## Validation

- MSVC Release build of `gnss_fgo_parity`
- 886 tests: 826 passed, 60 data-dependent skipped, 0 failed
- Tokyo run1 full replay: 11,905 epochs
- Tokyo run2 full replay: 9,147 epochs
- Tokyo run1 500-epoch baseline/shadow A/B: 500 rows, 0 differences in status, ECEF, ratio, fixed count, or AR outcome
- GitHub CI: Linux GCC/Clang, macOS Clang, static analysis, MADOCA parity, extended tests, Docker smoke, and optional sign-offs all passed
