### PR TITLE
Isolate Docker smoke CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,15 +207,6 @@ jobs:
           build/Testing/Temporary/LastTestsFailed.log
         if-no-files-found: ignore
 
-    - name: Docker smoke
-      run: |
-        docker build -t libgnsspp-ci .
-        docker run --rm libgnsspp-ci --help >/dev/null
-        python3 scripts/ci/validate_cli_json_contract.py --cli docker run --rm libgnsspp-ci
-        docker run --rm libgnsspp-ci help web >/dev/null
-        docker run --rm libgnsspp-ci web --help >/dev/null
-        docker compose -f compose.yaml config >/dev/null
-
     - name: Generate dashboard artifacts
       run: bash scripts/ci/generate_dashboard_artifacts.sh
 
@@ -234,8 +225,35 @@ jobs:
           output/visibility_static.png
         if-no-files-found: error
 
+  docker-smoke:
+    needs: [changes, hygiene, build-and-test]
+    if: needs.changes.outputs.run_heavy == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build Docker image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        file: ./Dockerfile
+        load: true
+        tags: libgnsspp-ci
+
+    - name: Run Docker smoke tests
+      run: |
+        docker run --rm libgnsspp-ci --help >/dev/null
+        python3 scripts/ci/validate_cli_json_contract.py --cli docker run --rm libgnsspp-ci
+        docker run --rm libgnsspp-ci help web >/dev/null
+        docker run --rm libgnsspp-ci web --help >/dev/null
+        docker compose -f compose.yaml config >/dev/null
+
   linux-optional-signoffs:
-    needs: [changes, linux-extended-tests]
+    needs: [changes, linux-extended-tests, docker-smoke]
     if: needs.changes.outputs.run_heavy == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 60


### PR DESCRIPTION
## What changed

- move Docker smoke coverage out of `linux-extended-tests` into a dedicated `docker-smoke` job
- build the smoke image with the same Buildx actions used by the proven Docker publish workflow
- require both extended tests and Docker smoke before optional sign-offs

## Why

PR #426's `linux-extended-tests` completed its extended test suite successfully, but the hosted runner lost communication during the inline Docker build twice at nearly the same point. The inline build was sharing a runner with the extended build/test setup. A dedicated runner isolates the Docker workload, while Buildx matches the repository's Docker workflow that has repeatedly completed in about 6–7 minutes.

## Impact

Production code and test behavior are unchanged. Heavy CI now reports Docker smoke separately and avoids losing the extended-test result when the Docker build destabilizes its runner.

## Validation

- parsed `.github/workflows/ci.yml` with PyYAML
- asserted the new job dependency graph
- `python -m compileall -q apps python scripts tests`
- `python scripts/ci/detect_ci_scope.py` for the workflow path
- `git diff --check`

Local Docker/actionlint execution was unavailable because Docker CLI is not installed on the Windows host; the draft PR CI is the end-to-end validation.
