### PR TITLE
Add multi-epoch graph-cost shadow telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,9 +313,14 @@ position, and float/IMU separations as `multiepoch_ar_*`. It also tests each
 candidate against carrier rows whose ambiguities were not used by the reduced
 search. `multiepoch_ar_surplus_eval`, `_pass`, `_level`, and `_used` expose
 that held-out alternate-reference witness; lack of a sufficiently independent
-pool produces no verdict. It never changes the graph, hold state, solution,
-ratio, or FIX/FLOAT label. A Tokyo run1 gate selected from this witness failed
-on run2 (3 correct and 15 wrong candidate epochs), so it remains monitor-only.
+pool produces no verdict. The `multiepoch_ar_graph_cost_*` columns independently
+impose the persistent integers as tight priors, batch-refine a copy of the
+active fixed-lag graph, and score the result against the original prior-free
+graph. They report evaluation/pass state, active factor count, before/after
+cost, and delta. Neither witness changes the graph, hold state, solution,
+ratio, or FIX/FLOAT label. A held-out-carrier gate failed on Tokyo run2; a
+later combined carrier/IMU/graph-cost gate survived run2 but failed on the
+previously unused run3. Both therefore remain monitor-only.
 See the
 [multi-epoch AR audit](docs/fgo_multiepoch_ar_fix_rate_audit.md).
 

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -1530,7 +1530,10 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
            "multiepoch_ar_z_ecef_m,multiepoch_ar_float_sep_m,"
            "multiepoch_ar_imu_sep_m,multiepoch_ar_surplus_eval,"
            "multiepoch_ar_surplus_pass,multiepoch_ar_surplus_level,"
-           "multiepoch_ar_surplus_used,"
+           "multiepoch_ar_surplus_used,multiepoch_ar_graph_cost_eval,"
+           "multiepoch_ar_graph_cost_pass,multiepoch_ar_graph_cost_factors,"
+           "multiepoch_ar_graph_cost_before,multiepoch_ar_graph_cost_after,"
+           "multiepoch_ar_graph_cost_delta,"
            "gf_slip_events,gf_slip_max_jump_m,gf_slip_tainted_ambiguities,"
            "doppler_slip_signals,doppler_slip_max_innovation_m,"
            "gf_doppler_isolated_pairs,"
@@ -1664,6 +1667,13 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                 << ',' << (multiepoch.surplus_validation_pass ? 1 : 0)
                 << ',' << multiepoch.surplus_validation_fallback_level
                 << ',' << multiepoch.surplus_validation_surplus_used
+                << ',' << (multiepoch.graph_cost_evaluated ? 1 : 0)
+                << ',' << (multiepoch.graph_cost_pass ? 1 : 0)
+                << ',' << multiepoch.graph_cost_factor_count
+                << ',' << multiepoch.graph_cost_before
+                << ',' << multiepoch.graph_cost_after
+                << ',' << (multiepoch.graph_cost_after -
+                             multiepoch.graph_cost_before)
                 << ',' << d.gf_slip_shadow_event_pairs
                 << ',' << d.gf_slip_shadow_max_jump_m
                 << ',' << d.gf_slip_shadow_tainted_ambiguities

--- a/docs/fgo_multiepoch_ar_fix_rate_audit.md
+++ b/docs/fgo_multiepoch_ar_fix_rate_audit.md
@@ -158,3 +158,60 @@ Decision: retain the held-out verdict as diagnostic evidence, but do not add a
 multi-epoch rescue switch or change the shipping FIX rate. Independent carrier
 rows can share the same urban multipath basin and are not, by themselves, a
 safe integer-aperture witness.
+
+## Constrained graph-cost follow-up
+
+The next follow-up reuses the estimator's existing GICI-style
+integer-constrained reoptimization as a read-only witness for multi-epoch
+FLOAT candidates. A shared helper copies the active fixed-lag factors and
+current values, adds tight ambiguity priors for the persistent integer
+hypothesis, performs the configured LM refinement (one iteration in this
+audit), and then
+evaluates both solutions on the original graph with the integer priors removed.
+The optimized values are discarded. The CSV adds:
+
+- `multiepoch_ar_graph_cost_eval` and `_pass`;
+- `multiepoch_ar_graph_cost_factors`;
+- `multiepoch_ar_graph_cost_before`, `_after`, and `_delta`.
+
+The strict pass condition is the existing absolute rule, `after <= before +
+1e-6`. For cross-epoch thresholding, the audit also divides delta by active
+factor count so changes in fixed-lag graph size do not directly become the
+gate. Candidate correctness remains truth-only offline evidence and is never
+an estimator input.
+
+A current-build Tokyo run1 development grid used only deployable telemetry.
+Graph cost alone was not safe: among FLOAT candidates its strict pass retained
+71 correct and 34 wrong candidates. The best non-empty zero-wrong development
+rule required:
+
+- held-out carrier validation pass;
+- candidate/IMU-prediction separation at most 0.05 m; and
+- graph-cost delta per active factor at most zero.
+
+The rule was frozen after run1. It passed run2 without adjustment, which
+unlocked the previously unused run3 holdout. Run3 then produced one accepted
+wrong candidate at TOW 179614.8 with 1.97 m 3D error, so activation failed.
+
+| FLOAT graph-cost population | Run1 correct / wrong | Run2 correct / wrong | Run3 correct / wrong |
+|---|---:|---:|---:|
+| All evaluated candidates | 205 / 644 | 79 / 226 | 27 / 174 |
+| Strict graph-cost pass | 71 / 34 | 42 / 23 | 3 / 41 |
+| Frozen combined gate | **36 / 0** | **1 / 0** | **0 / 1** |
+
+The shadow remained non-interfering in a current-build 500-epoch A/B replay:
+all 500 rows matched exactly in status, ECEF position, ratio, fixed ambiguity
+count, and AR outcome. The shadow evaluated 497 graph hypotheses (493 strict
+passes and four failures). Runtime increased from 114.634 s to 128.623 s in
+that short replay. Full diagnostic replays are substantially more expensive:
+run2 took 1338.44 s and run3 took 3563.02 s because each candidate launches a
+batch refinement. The feature remains default-off.
+
+Decision: retain constrained graph cost as diagnostic telemetry, but do not
+promote multi-epoch FLOAT candidates or change the shipping fix rate. The
+held-out run3 failure demonstrates that temporal agreement, alternate carrier
+rows, IMU proximity, and a non-worsening prior-free graph cost can still share
+the same biased urban measurement basin. Any next activation attempt needs a
+genuinely different observation model; TDCP is still blocked until receiver
+clock-jump/slip handling removes the observed approximately 299,793 m raw
+jumps.

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -2067,6 +2067,15 @@ public:
         bool surplus_validation_pass = false;
         int surplus_validation_fallback_level = -1;
         int surplus_validation_surplus_used = 0;
+        // GICI-style constrained graph-cost witness. The active fixed-lag
+        // graph is independently batch-refined with this candidate imposed
+        // as tight ambiguity priors, then scored using the original graph
+        // without those priors. Diagnostic-only; never updates the smoother.
+        bool graph_cost_evaluated = false;
+        bool graph_cost_pass = false;
+        int graph_cost_factor_count = 0;
+        double graph_cost_before = 0.0;
+        double graph_cost_after = 0.0;
     };
 
     /// Per-epoch fixed-lag integrity state.  These values expose why an epoch

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -379,6 +379,58 @@ inline gtsam::Key dummyAmbiguityKey() { return Symbol('z', 0); }
 inline gtsam::Key velocityKey(std::size_t epoch) { return Symbol('v', epoch); }
 inline gtsam::Key biasKey(std::size_t epoch) { return Symbol('b', epoch); }
 
+struct IntegerConstrainedGraphCostOutcome {
+    bool evaluated = false;
+    bool pass = false;
+    int base_factor_count = 0;
+    double base_cost_before = 0.0;
+    double base_cost_after = 0.0;
+    std::optional<Pose3> optimized_pose;
+};
+
+IntegerConstrainedGraphCostOutcome evaluateIntegerConstrainedGraphCost(
+    const gtsam::NonlinearFactorGraph& active_factors,
+    const gtsam::Values& initial_values,
+    const std::vector<std::pair<gtsam::Key, double>>& integer_constraints,
+    std::optional<gtsam::Key> current_position_key,
+    const FGOProcessor::FGOConfig& config) {
+    IntegerConstrainedGraphCostOutcome outcome;
+    gtsam::NonlinearFactorGraph base_graph;
+    for (const auto& factor : active_factors) {
+        if (factor) base_graph.push_back(factor);
+    }
+    outcome.base_factor_count = static_cast<int>(base_graph.size());
+    if (base_graph.empty()) return outcome;
+
+    gtsam::NonlinearFactorGraph constrained_graph = base_graph;
+    const auto integer_noise = gtsam::noiseModel::Isotropic::Sigma(
+        1, std::max(1e-9, config.integer_constrained_prior_sigma_cycles));
+    int constraints_added = 0;
+    for (const auto& [key, integer_cycles] : integer_constraints) {
+        if (!initial_values.exists(key)) continue;
+        constrained_graph.addPrior(key, integer_cycles, integer_noise);
+        ++constraints_added;
+    }
+    if (constraints_added == 0) return outcome;
+
+    outcome.evaluated = true;
+    outcome.base_cost_before = base_graph.error(initial_values);
+    gtsam::LevenbergMarquardtParams params;
+    params.setMaxIterations(std::max(1, config.integer_constrained_max_iterations));
+    params.setVerbosityLM("SILENT");
+    const gtsam::Values optimized_values = gtsam::LevenbergMarquardtOptimizer(
+        constrained_graph, initial_values, params).optimize();
+    outcome.base_cost_after = base_graph.error(optimized_values);
+    outcome.pass = std::isfinite(outcome.base_cost_before) &&
+        std::isfinite(outcome.base_cost_after) &&
+        outcome.base_cost_after <= outcome.base_cost_before +
+            std::max(0.0, config.integer_constrained_cost_abs_tolerance);
+    if (current_position_key && optimized_values.exists(*current_position_key)) {
+        outcome.optimized_pose = optimized_values.at<Pose3>(*current_position_key);
+    }
+    return outcome;
+}
+
 // ENU-from-ECEF rotation whose columns are the East/North/Up basis vectors
 // expressed in ECEF, i.e. ecef_vec = R_ecef_enu * enu_vec. Matches
 // core/coordinates.hpp enu2ecef(). Used to build the ecef_T_nav Pose3 that
@@ -4386,59 +4438,33 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                             epoch_diagnostics[i]
                                 .integer_constrained_reoptimization_evaluated = true;
                             try {
-                                gtsam::NonlinearFactorGraph base_graph;
                                 const auto& active_factors =
                                     smoother.getISAM2().getFactorsUnsafe();
-                                for (const auto& factor : active_factors) {
-                                    if (factor) base_graph.push_back(factor);
-                                }
-                                gtsam::Values initial_values = smoother.calculateEstimate();
-                                const double base_cost_before =
-                                    base_graph.error(initial_values);
-
-                                gtsam::NonlinearFactorGraph constrained_graph = base_graph;
-                                const auto integer_noise =
-                                    gtsam::noiseModel::Isotropic::Sigma(
-                                        1,
-                                        std::max(1e-9,
-                                            config.integer_constrained_prior_sigma_cycles));
+                                const gtsam::Values initial_values =
+                                    smoother.calculateEstimate();
+                                std::vector<std::pair<gtsam::Key, double>>
+                                    integer_constraints;
+                                integer_constraints.reserve(subset);
                                 for (int r = 0; r < subset; ++r) {
                                     const std::size_t idx = epoch_amb_indices[order[r]];
-                                    const gtsam::Key key =
-                                        ambiguityKey(ambSymbolId(idx));
-                                    if (!initial_values.exists(key)) continue;
-                                    constrained_graph.addPrior(
-                                        key,
-                                        static_cast<double>(std::lround(fixed_amb(r))),
-                                        integer_noise);
+                                    integer_constraints.emplace_back(
+                                        ambiguityKey(ambSymbolId(idx)),
+                                        static_cast<double>(std::lround(fixed_amb(r))));
                                 }
-                                gtsam::LevenbergMarquardtParams params;
-                                params.setMaxIterations(std::max(
-                                    1, config.integer_constrained_max_iterations));
-                                params.setVerbosityLM("SILENT");
-                                const gtsam::Values optimized_values =
-                                    gtsam::LevenbergMarquardtOptimizer(
-                                        constrained_graph, initial_values, params).optimize();
-                                const double base_cost_after =
-                                    base_graph.error(optimized_values);
+                                const IntegerConstrainedGraphCostOutcome cost =
+                                    evaluateIntegerConstrainedGraphCost(
+                                        active_factors, initial_values,
+                                        integer_constraints, positionKey(i), config);
                                 epoch_diagnostics[i]
                                     .integer_constrained_base_cost_before =
-                                        base_cost_before;
+                                        cost.base_cost_before;
                                 epoch_diagnostics[i]
                                     .integer_constrained_base_cost_after =
-                                        base_cost_after;
-                                integer_constrained_pass =
-                                    std::isfinite(base_cost_before) &&
-                                    std::isfinite(base_cost_after) &&
-                                    base_cost_after <= base_cost_before +
-                                        std::max(0.0,
-                                            config.integer_constrained_cost_abs_tolerance);
-                                if (integer_constrained_pass &&
-                                    optimized_values.exists(positionKey(i))) {
-                                    const Pose3 optimized_pose =
-                                        optimized_values.at<Pose3>(positionKey(i));
+                                        cost.base_cost_after;
+                                integer_constrained_pass = cost.evaluated && cost.pass;
+                                if (integer_constrained_pass && cost.optimized_pose) {
                                     provisional_fixed_ant =
-                                        Eigen::Vector3d(antennaOf(optimized_pose));
+                                        Eigen::Vector3d(antennaOf(*cost.optimized_pose));
                                     has_provisional_fixed_ant =
                                         provisional_fixed_ant.allFinite();
                                 }
@@ -4814,6 +4840,49 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                                                 static_cast<int>(std::lround(
                                                     persistent_diagnostics
                                                         .candidates(r, 0)));
+                                        }
+                                        // Score the persistent hypothesis
+                                        // against the complete active graph,
+                                        // including historical factors in the
+                                        // fixed-lag window. This is deliberately
+                                        // read-only: unlike the normal accepted
+                                        // FIX path, its optimized Values are not
+                                        // consumed by the estimator.
+                                        try {
+                                            std::vector<std::pair<gtsam::Key, double>>
+                                                integer_constraints;
+                                            integer_constraints.reserve(
+                                                persistent_cycles_by_index.size());
+                                            for (const auto& [ambiguity_index,
+                                                              integer_cycles] :
+                                                 persistent_cycles_by_index) {
+                                                integer_constraints.emplace_back(
+                                                    ambiguityKey(ambSymbolId(
+                                                        ambiguity_index)),
+                                                    static_cast<double>(integer_cycles));
+                                            }
+                                            const auto& active_factors =
+                                                smoother.getISAM2().getFactorsUnsafe();
+                                            const gtsam::Values initial_values =
+                                                smoother.calculateEstimate();
+                                            const IntegerConstrainedGraphCostOutcome
+                                                graph_cost =
+                                                    evaluateIntegerConstrainedGraphCost(
+                                                        active_factors, initial_values,
+                                                        integer_constraints,
+                                                        std::nullopt, config);
+                                            shadow.graph_cost_evaluated =
+                                                graph_cost.evaluated;
+                                            shadow.graph_cost_pass = graph_cost.pass;
+                                            shadow.graph_cost_factor_count =
+                                                graph_cost.base_factor_count;
+                                            shadow.graph_cost_before =
+                                                graph_cost.base_cost_before;
+                                            shadow.graph_cost_after =
+                                                graph_cost.base_cost_after;
+                                        } catch (const std::exception&) {
+                                            // A failed diagnostic must never
+                                            // alter the estimator or candidate.
                                         }
                                         std::vector<const FGOProcessor::
                                             DoubleDifferenceCarrierFactor*>

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -2350,6 +2350,10 @@ TEST(FGOAmbiguityOutcomeTelemetryTest,
     EXPECT_GE(multi.surplus_validation_fallback_level, 0);
     EXPECT_LE(multi.surplus_validation_fallback_level, 5);
     EXPECT_GT(multi.surplus_validation_surplus_used, 0);
+    EXPECT_TRUE(multi.graph_cost_evaluated);
+    EXPECT_GT(multi.graph_cost_factor_count, 0);
+    EXPECT_TRUE(std::isfinite(multi.graph_cost_before));
+    EXPECT_TRUE(std::isfinite(multi.graph_cost_after));
 }
 
 TEST(FGOAmbiguityOutcomeTelemetryTest,


### PR DESCRIPTION
## What changed

- refactor the existing integer-constrained reoptimization into a reusable graph-cost evaluator
- evaluate persistent multi-epoch FLOAT candidates without mutating the smoother
- export graph evaluation/pass, factor count, before/after cost, and delta telemetry
- extend the diagnostic-only integration test and document the Tokyo audit

## Why

Temporal integer agreement and held-out carrier rows were not independently safe in urban multipath. This adds the GICI-style prior-free graph-cost witness needed to test whether a persistent integer hypothesis remains consistent with the complete active fixed-lag graph.

The follow-up remains monitor-only. A run1-selected combined gate passed run2 but failed on the previously unused run3 with one 1.97 m wrong candidate, so this PR does not promote FLOAT candidates or change the shipping fix rate.

## Validation

- MSVC Release build: `gnss_lib_noopt`, `gnss_fgo_parity`, and `gnss_run_tests`
- focused multi-epoch telemetry test passed
- full unit suite: 886 tests, 826 passed, 60 skipped
- current-build 500-epoch A/B: 500/500 solution rows identical; 497 graph evaluations
- Tokyo FLOAT graph candidates, correct/wrong: run1 205/644, run2 79/226, run3 27/174
- frozen combined gate: run1 36/0, run2 1/0, held-out run3 0/1 (activation rejected)

The aggregate all-target MSVC build still encounters the pre-existing C1061 nesting-limit errors in `gnss_fuse.cpp` and `gnss_solve.cpp`; the changed targets build successfully.
