### PR TITLE
Add clock-resilient temporal carrier shadow

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,15 @@ funnel (`amb_after_hold`, `amb_final`, and `amb_excl_*`) and the last
 successfully searched LAMBDA position candidate (`lambda_candidate_*`), even
 when the ratio or a later integrity decision leaves the epoch FLOAT. A
 normalized satellite/signal trace is written beside it as
-`<path>.ar_candidates.csv`. Its `disposition` values are:
+`<path>.ar_candidates.csv`.
+
+`--clock-resilient-temporal-shadow` additionally audits receiver-clock-free
+satellite-single-difference temporal carrier residuals. It is monitor-only and
+does not add graph factors or change FIX/FLOAT decisions. The formulation,
+research basis, and three-run Tokyo validation are documented in
+[`docs/fgo_clock_resilient_temporal_shadow.md`](docs/fgo_clock_resilient_temporal_shadow.md).
+
+The normalized trace's `disposition` values are:
 
 | Value | Meaning |
 |---:|---|

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -63,6 +63,7 @@ struct Args {
     bool single_freq = false;    // multi-freq control: force L1/E1/B1-only DD (single-frequency baseline)
     bool multi_freq = false;     // force multi-frequency DD on (library default is now OFF)
     bool sd_doppler = false;     // add single-difference Doppler velocity factors
+    bool clock_resilient_temporal_shadow = false;  // diagnostic-only receiver-clock-free TDCP
     bool postfit_gate = false;
     bool adaptive_ratio = false;
     int postfit_min_n = -1;
@@ -241,6 +242,10 @@ Args parseArgs(int argc, char** argv) {
         }
         if (a == "--no-held-fix-label") {
             args.no_held_fix_label = true;
+            continue;
+        }
+        if (a == "--clock-resilient-temporal-shadow") {
+            args.clock_resilient_temporal_shadow = true;
             continue;
         }
         if (a == "--gici-par") {
@@ -724,6 +729,8 @@ libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
     libgnss::FGOProcessor::FGOConfig config = makeRealDataDdConfig();
     // Reuse the existing diagnostic surface; do not add another CLI option.
     config.monitor_geometry_free_cycle_slip = !args.dump_csv_path.empty();
+    config.monitor_clock_resilient_temporal_carrier =
+        args.clock_resilient_temporal_shadow;
     config.use_geometry_free_cycle_slip_reset = args.gf_slip_reset;
     config.report_held_ambiguities_as_fixed = !args.no_held_fix_label;
     if (args.max_iters > 0) {
@@ -1508,7 +1515,7 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
            "x_ecef_m,y_ecef_m,z_ecef_m,position_covariance_trace_m2,"
            "ref_e_pos_m,ref_n_pos_m,ref_u_pos_m,"
            "vel_e_mps,vel_n_mps,vel_u_mps,"
-           "ratio,ratio_threshold,nfixed,ar_outcome,ddpr_rms_m,sd_doppler_rms_mps,gdop,nsat,sd_doppler_n,"
+           "ratio,ratio_threshold,nfixed,ar_outcome,ddpr_rms_m,sd_doppler_rms_mps,clock_resilient_tdcp_n,clock_resilient_tdcp_rms_m,clock_resilient_tdcp_max_abs_m,gdop,nsat,sd_doppler_n,"
            "amb_candidates,lambda_attempts,lambda_stage,amb_var_median,amb_var_max,"
            "imu_pose_correction_m,spp_seed_fresh,spp_seed_x_ecef_m,"
            "spp_seed_y_ecef_m,spp_seed_z_ecef_m,"
@@ -1620,6 +1627,9 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                 << ',' << s.num_fixed_ambiguities
                 << ',' << static_cast<int>(d.ar_outcome)
                 << ',' << d.ddpr_rms_m << ',' << d.sd_doppler_rms_mps
+                << ',' << d.clock_resilient_tdcp_factors
+                << ',' << d.clock_resilient_tdcp_rms_m
+                << ',' << d.clock_resilient_tdcp_max_abs_m
                 << ',' << d.gdop << ',' << d.num_satellites
                 << ',' << d.sd_doppler_factors
                 << ',' << d.ambiguity_candidates << ',' << d.lambda_attempts
@@ -2676,6 +2686,8 @@ int main(int argc, char** argv) {
                    << (config.monitor_conditional_multiband_ar ? "on" : "off")
                    << ", multiepoch_ar_shadow="
                    << (config.monitor_multiepoch_ar ? "on" : "off")
+                   << ", clock_resilient_temporal_shadow="
+                   << (config.monitor_clock_resilient_temporal_carrier ? "on" : "off")
                    << ")\n"
                   << "  IMU ratio aperture: " << (args.imu_ratio_aperture ? "on" : "off")
                   << " (accepted=" << fl.diagnostics.imu_aided_ratio_accepts

--- a/docs/fgo_clock_resilient_temporal_shadow.md
+++ b/docs/fgo_clock_resilient_temporal_shadow.md
@@ -1,0 +1,105 @@
+# Clock-resilient temporal carrier shadow
+
+## Purpose
+
+Receiver clock jumps make undifferenced Doppler and TDCP continuity checks
+unsafe when the jump is not modelled consistently. This diagnostic forms a
+satellite single difference before taking the time difference:
+
+```
+((carrier_target - range_target) - (carrier_ref - range_ref))_k
+  - ((carrier_target - range_target) - (carrier_ref - range_ref))_{k-1}
+```
+
+A carrier-domain term common to every satellite at epoch `k`, including a
+receiver clock jump, cancels in the first satellite difference. This is a
+diagnostic shadow only: it is never inserted into the Eigen or GTSAM graph and
+cannot change the exported position, ambiguity decision, or FIX/FLOAT status.
+
+## Continuity rules
+
+- Observations are grouped by constellation and signal.
+- The highest-elevation usable satellite starts as the causal reference.
+- The reference remains fixed while it is usable. A reference change starts a
+  new temporal arc; no factor bridges the change.
+- Both target and reference must have carrier phase and no loss-of-lock flag.
+- Only adjacent epochs within `max_tdcp_gap_s` are compared.
+- `previous_los` comes from the previous epoch and `los` from the current
+  epoch. The legacy Taroz-parity SD-TDCP builder remains unchanged.
+
+Enable the audit in `gnss_fgo_parity` with
+`--clock-resilient-temporal-shadow`. With `--dump-csv`, the following columns
+are emitted:
+
+- `clock_resilient_tdcp_n`
+- `clock_resilient_tdcp_rms_m`
+- `clock_resilient_tdcp_max_abs_m`
+
+## Tokyo validation
+
+The evaluated production profile was first replayed for the first 500 run1
+epochs with the shadow disabled and enabled. All 500 rows had identical ECEF
+position, solution status, ambiguity ratio, fixed count, and AR outcome.
+
+| Metric | Result |
+|---|---:|
+| Epochs with a temporal carrier diagnostic | 499 / 500 |
+| Evaluated satellite-difference factors | 22,482 |
+| Factor-weighted RMS | 0.0122 m |
+| Per-epoch RMS median / P95 | 0.006 / 0.028 m |
+| Maximum absolute residual | 0.511 m |
+| Epochs with maximum residual above 0.1 m | 41 |
+| Epochs with maximum residual above 1 m | 0 |
+| FIX epochs, disabled / enabled | 499 / 499 |
+
+The centimetre-scale bulk distribution is promising, but the 0.511 m tail is
+too large for direct graph insertion at millimetre carrier sigma. The next
+step is to classify the tail using loss-of-lock, geometry-free, and Doppler
+consistency witnesses, then test robust gating on held-out runs before this
+measurement is allowed to influence the estimator.
+
+The same frozen profile and thresholds were then run over all three Tokyo
+sequences. Run1 was the design sequence, run2 the fixed evaluation sequence,
+and run3 the holdout. Each run was compared with its pre-existing baseline;
+ECEF position, status, ratio, fixed count, and AR outcome matched on every
+row.
+
+| Run | Rows | Active epochs | Factors | Epoch RMS P50 / P95 | Max abs. | Epochs max >0.1 m | Covered by existing witness |
+|---|---:|---:|---:|---:|---:|---:|---:|
+| Tokyo run1 | 11,905 | 11,860 | 277,226 | 0.011 / 0.301 m | 480.248 m | 2,896 | 2,059 |
+| Tokyo run2 | 9,147 | 9,069 | 292,607 | 0.008 / 0.061 m | 16.115 m | 952 | 469 |
+| Tokyo run3 holdout | 15,294 | 15,095 | 513,824 | 0.007 / 0.190 m | 147.929 m | 2,743 | 1,972 |
+| Total | 36,346 | 36,024 | 1,083,657 | - | 480.248 m | 6,591 | 4,500 |
+
+An existing witness means at least one geometry-free event, Doppler event,
+carrier-FDE exclusion, or active carrier hold occurred in the same epoch.
+That coarse coverage still leaves 2,091 epochs above 0.1 m unexplained. The
+factor-weighted RMS is 1.20 m because a small number of gross carrier-arc
+errors dominate it, even though all three medians are 7--11 mm.
+
+Decision: keep this path monitor-only. Receiver-clock cancellation works and
+the bulk signal is useful, but epoch-level guards are not selective enough for
+safe graph insertion. The next phase must emit per-factor innovations and
+classify each target/reference arc using loss-of-lock, geometry-free,
+Doppler, reference-change, and robust residual evidence. Only a frozen gate
+that survives run2 and run3 should be promoted to a graph factor.
+
+## References and implementation precedents
+
+- Momoh, Bhattarai, and Ziebart (2019), receiver clock jump and cycle-slip
+  correction using adaptive time differences and WLS:
+  https://doi.org/10.1007/s10291-019-0832-4
+- Guo and Zhang (2014), real-time receiver clock-jump classification and
+  observable reconstruction for PPP:
+  https://doi.org/10.1007/s10291-012-0307-3
+- Freda et al. (2015), TDCP velocity estimation and quality control:
+  https://doi.org/10.1007/s10291-014-0425-1
+- Wang et al. (2020), TDCP constraints in tightly coupled INS/GNSS:
+  https://doi.org/10.1109/TIM.2019.2957848
+- Angrisano et al. (2022), smartphone TDCP velocity and reliability testing:
+  https://doi.org/10.3390/s22218514
+- RTKLIB disables a Doppler slip detector because of clock-jump sensitivity:
+  https://github.com/tomojitakasu/RTKLIB/blob/master/src/rtkpos.c
+- GICI-LIB records receiver clock-jump handling as an open issue in its
+  relative-position cycle-slip path:
+  https://github.com/chichengcn/gici-open/blob/master/src/gnss/ambiguity_common.cpp

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -398,6 +398,14 @@ public:
         int multiepoch_ar_min_ambiguities = 4;
         // Diagnostic-only geometry-free slip/arc-continuity shadow.
         bool monitor_geometry_free_cycle_slip = false;
+        // Diagnostic-only, receiver-clock-free temporal carrier shadow.
+        // It forms satellite single differences against a causal reference,
+        // resets continuity whenever that reference changes, and time-
+        // differences only consecutive observations.  Unlike the legacy
+        // Taroz-parity SD-TDCP path, it uses the actual previous/current LOS
+        // vectors.  The shadow is never inserted into either optimizer and
+        // cannot change the exported solution or FIX/FLOAT decision.
+        bool monitor_clock_resilient_temporal_carrier = false;
         // When a rover/base single-difference geometry-free combination jumps
         // while the underlying rover arcs remain continuous, break both bands'
         // DD arcs after the confirmation interval below. Resetting both bands
@@ -2086,6 +2094,9 @@ public:
             AmbiguityResolutionOutcome::NotAttempted;
         double ddpr_rms_m = 0.0;
         double sd_doppler_rms_mps = 0.0;
+        int clock_resilient_tdcp_factors = 0;
+        double clock_resilient_tdcp_rms_m = 0.0;
+        double clock_resilient_tdcp_max_abs_m = 0.0;
         double gdop = 0.0;
         int num_satellites = 0;
         int sd_doppler_factors = 0;
@@ -2245,6 +2256,11 @@ public:
     analyzeGeometryFreeSlipShadow(const FGOProblem& problem,
                                   double threshold_m = 0.05,
                                   double max_gap_s = 1.5);
+
+    static std::vector<SingleDifferenceTdcpFactor>
+    buildClockResilientTemporalCarrierShadow(const FGOProblem& problem,
+                                             double sigma_m = 0.003,
+                                             double max_gap_s = 1.5);
 
     FGOProblem buildPseudorangeProblem(const std::vector<ObservationData>& epochs,
                                        const NavigationData& nav) const;

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -2810,6 +2810,136 @@ FGOProcessor::analyzeGeometryFreeSlipShadow(const FGOProblem& problem,
     return shadow;
 }
 
+std::vector<FGOProcessor::SingleDifferenceTdcpFactor>
+FGOProcessor::buildClockResilientTemporalCarrierShadow(
+    const FGOProblem& problem, double sigma_m, double max_gap_s) {
+    using GroupKey = std::pair<GNSSSystem, SignalType>;
+    using ObservationKey = std::pair<SatelliteId, SignalType>;
+    using HistoryKey = std::tuple<SatelliteId, SatelliteId, SignalType>;
+
+    struct HistorySample {
+        std::size_t epoch_index = 0;
+        double residual_m = 0.0;
+        Vector3d los = Vector3d::Zero();
+    };
+
+    const auto& observations = problem.carrier_observations.empty()
+        ? problem.double_difference_pseudorange_observations
+        : problem.carrier_observations;
+    std::vector<std::map<ObservationKey, const CarrierPhaseFactor*>> by_epoch(
+        problem.epochs.size());
+    for (const auto& observation : observations) {
+        if (observation.epoch_index >= by_epoch.size() ||
+            !observation.has_carrier_phase || observation.loss_of_lock ||
+            !std::isfinite(observation.corrected_carrier_m) ||
+            !std::isfinite(observation.model_debug.geometric_range_m) ||
+            !observation.los.allFinite()) {
+            continue;
+        }
+        by_epoch[observation.epoch_index]
+                [{observation.satellite, observation.signal}] = &observation;
+    }
+
+    std::vector<SingleDifferenceTdcpFactor> factors;
+    std::map<GroupKey, SatelliteId> causal_references;
+    std::map<HistoryKey, HistorySample> previous;
+    const double safe_sigma = std::max(1e-4, sigma_m);
+    const double safe_max_gap = std::max(0.0, max_gap_s);
+
+    for (std::size_t epoch_index = 0; epoch_index < by_epoch.size();
+         ++epoch_index) {
+        std::map<GroupKey, std::vector<const CarrierPhaseFactor*>> groups;
+        for (const auto& [key, observation] : by_epoch[epoch_index]) {
+            (void)key;
+            groups[{observation->satellite.system, observation->signal}]
+                .push_back(observation);
+        }
+
+        std::map<HistoryKey, HistorySample> current;
+        for (const auto& [group_key, group] : groups) {
+            if (group.size() < 2) {
+                causal_references.erase(group_key);
+                continue;
+            }
+
+            const CarrierPhaseFactor* reference = nullptr;
+            const auto prior_reference = causal_references.find(group_key);
+            if (prior_reference != causal_references.end()) {
+                for (const auto* candidate : group) {
+                    if (candidate->satellite == prior_reference->second) {
+                        reference = candidate;
+                        break;
+                    }
+                }
+            }
+            if (reference == nullptr) {
+                reference = *std::max_element(
+                    group.begin(), group.end(),
+                    [](const auto* lhs, const auto* rhs) {
+                        if (lhs->elevation_rad != rhs->elevation_rad) {
+                            return lhs->elevation_rad < rhs->elevation_rad;
+                        }
+                        return rhs->satellite < lhs->satellite;
+                    });
+            }
+            causal_references[group_key] = reference->satellite;
+
+            const double reference_residual =
+                reference->corrected_carrier_m -
+                reference->model_debug.geometric_range_m;
+            for (const auto* observation : group) {
+                if (observation->satellite == reference->satellite) {
+                    continue;
+                }
+                const double residual =
+                    observation->corrected_carrier_m -
+                    observation->model_debug.geometric_range_m -
+                    reference_residual;
+                const Vector3d los = observation->los - reference->los;
+                const HistoryKey history_key{observation->satellite,
+                                             reference->satellite,
+                                             observation->signal};
+                current[history_key] = {epoch_index, residual, los};
+
+                const auto prior = previous.find(history_key);
+                if (prior == previous.end()) {
+                    continue;
+                }
+                const double dt = problem.epochs[epoch_index].time -
+                                  problem.epochs[prior->second.epoch_index].time;
+                if (prior->second.epoch_index + 1 != epoch_index || dt <= 0.0 ||
+                    (safe_max_gap > 0.0 && dt > safe_max_gap)) {
+                    continue;
+                }
+
+                const double delta = residual - prior->second.residual_m;
+                if (!std::isfinite(delta)) {
+                    continue;
+                }
+                SingleDifferenceTdcpFactor factor;
+                factor.previous_epoch_index = prior->second.epoch_index;
+                factor.current_epoch_index = epoch_index;
+                factor.satellite = observation->satellite;
+                factor.reference_satellite = reference->satellite;
+                factor.signal = observation->signal;
+                factor.previous_los = prior->second.los;
+                factor.los = los;
+                factor.delta_carrier_m = delta;
+                const double sin_el = std::max(
+                    0.1, std::sin(std::min(observation->elevation_rad,
+                                           reference->elevation_rad)));
+                factor.sigma_m = safe_sigma / std::sqrt(sin_el);
+                factor.elevation_rad =
+                    std::min(observation->elevation_rad,
+                             reference->elevation_rad);
+                factors.push_back(factor);
+            }
+        }
+        previous = std::move(current);
+    }
+    return factors;
+}
+
 FGOProcessor::FGOResult FGOProcessor::optimize(
     const std::vector<ObservationData>& rover_epochs,
     const std::vector<ObservationData>& base_epochs,

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -884,6 +884,13 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
         ? FGOProcessor::analyzeGeometryFreeSlipShadow(
               problem, 0.05, config.max_tdcp_gap_s)
         : std::vector<FGOProcessor::GeometryFreeSlipShadowEpoch>{};
+    // Materialize this diagnostic stream once; it is never added to new_factors.
+    const auto clock_resilient_tdcp_shadow =
+        config.monitor_clock_resilient_temporal_carrier
+            ? FGOProcessor::buildClockResilientTemporalCarrierShadow(
+                  problem, config.single_difference_tdcp_sigma_m,
+                  config.max_tdcp_gap_s)
+            : std::vector<FGOProcessor::SingleDifferenceTdcpFactor>{};
     const Point3 lever_arm_body(config.pose3_lever_arm_body_m.x(),
                                 config.pose3_lever_arm_body_m.y(),
                                 config.pose3_lever_arm_body_m.z());
@@ -5847,6 +5854,41 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
     // consensus gate; a correct fix would recompute (or cache) the marginal
     // for each epoch's FINAL window-exit pose, which is a larger, separately
     // scoped change.
+    if (!clock_resilient_tdcp_shadow.empty()) {
+        std::vector<double> sum_sq(num_epochs, 0.0);
+        for (const auto& factor : clock_resilient_tdcp_shadow) {
+            if (factor.previous_epoch_index >= num_epochs ||
+                factor.current_epoch_index >= num_epochs) {
+                continue;
+            }
+            const Vector3d previous_delta =
+                epoch_float_position[factor.previous_epoch_index] -
+                problem.epochs[factor.previous_epoch_index].position_ecef;
+            const Vector3d current_delta =
+                epoch_float_position[factor.current_epoch_index] -
+                problem.epochs[factor.current_epoch_index].position_ecef;
+            const double predicted = factor.los.dot(current_delta) -
+                                     factor.previous_los.dot(previous_delta);
+            const double residual = factor.delta_carrier_m - predicted;
+            if (!std::isfinite(residual)) {
+                continue;
+            }
+            auto& diagnostics = epoch_diagnostics[factor.current_epoch_index];
+            ++diagnostics.clock_resilient_tdcp_factors;
+            sum_sq[factor.current_epoch_index] += residual * residual;
+            diagnostics.clock_resilient_tdcp_max_abs_m =
+                std::max(diagnostics.clock_resilient_tdcp_max_abs_m,
+                         std::abs(residual));
+        }
+        for (std::size_t i = 0; i < num_epochs; ++i) {
+            const int count = epoch_diagnostics[i].clock_resilient_tdcp_factors;
+            if (count > 0) {
+                epoch_diagnostics[i].clock_resilient_tdcp_rms_m =
+                    std::sqrt(sum_sq[i] / static_cast<double>(count));
+            }
+        }
+    }
+
     const bool have_amb = !problem.ambiguity_states.empty();
     result.epoch_diagnostics = std::move(epoch_diagnostics);
     result.epoch_attitude_rpy_deg.resize(num_epochs);

--- a/tests/test_fgo.cpp
+++ b/tests/test_fgo.cpp
@@ -766,6 +766,111 @@ TEST(FGOTest, BuiltSingleDifferenceTdcpFactorsUseCurrentEpochLos) {
     EXPECT_GT(max_previous_current_los_delta, 1e-8);
 }
 
+TEST(FGOTest, ClockResilientTemporalCarrierShadowCancelsCommonClockJump) {
+    const NavigationData nav = makeSyntheticGpsNavigation(4);
+    const std::array<Vector3d, 2> rover_positions = {
+        Vector3d(1113194.0, -4841695.0, 3985350.0),
+        Vector3d(1113214.0, -4841680.0, 3985342.0),
+    };
+    const std::array<Vector3d, 2> base_positions = {
+        rover_positions[0] + Vector3d(-320.0, 180.0, 45.0),
+        rover_positions[1] + Vector3d(-320.0, 180.0, 45.0),
+    };
+    const auto rover_epochs =
+        makeSyntheticDoubleDifferenceObservationEpochs(nav, rover_positions, 0.04);
+    const auto base_epochs =
+        makeSyntheticDoubleDifferenceObservationEpochs(nav, base_positions, 0.02);
+
+    FGOProcessor::FGOConfig config;
+    config.use_spp_seed = false;
+    config.use_pseudorange_factors = false;
+    config.use_motion_factors = false;
+    config.use_tdcp_factors = false;
+    config.use_double_difference_factors = true;
+    config.use_ionosphere_model = false;
+    config.use_troposphere_model = false;
+    config.min_elevation_deg = -90.0;
+    config.min_satellites_per_epoch = 2;
+
+    FGOProcessor processor(config);
+    const auto problem = processor.buildDoubleDifferenceProblem(
+        rover_epochs, base_epochs, nav, base_positions[0]);
+    const auto baseline =
+        FGOProcessor::buildClockResilientTemporalCarrierShadow(problem);
+    ASSERT_FALSE(baseline.empty());
+
+    auto jumped_problem = problem;
+    constexpr double clock_jump_m = constants::SPEED_OF_LIGHT * 0.001;
+    for (auto& observation : jumped_problem.carrier_observations) {
+        if (observation.epoch_index == 1) {
+            observation.corrected_carrier_m += clock_jump_m;
+        }
+    }
+    const auto jumped =
+        FGOProcessor::buildClockResilientTemporalCarrierShadow(jumped_problem);
+    ASSERT_EQ(jumped.size(), baseline.size());
+
+    using ObservationKey = std::tuple<std::size_t, SatelliteId, SignalType>;
+    std::map<ObservationKey, const FGOProcessor::CarrierPhaseFactor*> observations;
+    for (const auto& observation :
+         problem.double_difference_pseudorange_observations) {
+        observations[{observation.epoch_index, observation.satellite,
+                      observation.signal}] = &observation;
+    }
+
+    double max_previous_current_los_delta = 0.0;
+    for (std::size_t i = 0; i < baseline.size(); ++i) {
+        const auto& factor = baseline[i];
+        const auto& jumped_factor = jumped[i];
+        EXPECT_EQ(jumped_factor.satellite, factor.satellite);
+        EXPECT_EQ(jumped_factor.reference_satellite,
+                  factor.reference_satellite);
+        EXPECT_EQ(jumped_factor.signal, factor.signal);
+        EXPECT_NEAR(jumped_factor.delta_carrier_m, factor.delta_carrier_m,
+                    1e-9);
+
+        const auto previous_satellite = observations.at(
+            {factor.previous_epoch_index, factor.satellite, factor.signal});
+        const auto previous_reference = observations.at(
+            {factor.previous_epoch_index, factor.reference_satellite,
+             factor.signal});
+        const auto current_satellite = observations.at(
+            {factor.current_epoch_index, factor.satellite, factor.signal});
+        const auto current_reference = observations.at(
+            {factor.current_epoch_index, factor.reference_satellite,
+             factor.signal});
+        const Vector3d previous_los =
+            previous_satellite->los - previous_reference->los;
+        const Vector3d current_los =
+            current_satellite->los - current_reference->los;
+        EXPECT_LT((factor.previous_los - previous_los).norm(), 1e-12);
+        EXPECT_LT((factor.los - current_los).norm(), 1e-12);
+        max_previous_current_los_delta = std::max(
+            max_previous_current_los_delta,
+            (factor.previous_los - factor.los).norm());
+    }
+    EXPECT_GT(max_previous_current_los_delta, 1e-8);
+
+    auto switched_reference_problem = problem;
+    std::set<std::pair<SatelliteId, SignalType>> initial_references;
+    for (const auto& factor : baseline) {
+        initial_references.insert(
+            {factor.reference_satellite, factor.signal});
+    }
+    for (auto& observation : switched_reference_problem.carrier_observations) {
+        if (observation.epoch_index == 1 &&
+            initial_references.count(
+                {observation.satellite, observation.signal}) != 0) {
+            observation.has_carrier_phase = false;
+        }
+    }
+    const auto after_reference_switch =
+        FGOProcessor::buildClockResilientTemporalCarrierShadow(
+            switched_reference_problem);
+    EXPECT_TRUE(after_reference_switch.empty())
+        << "a new reference must start a fresh temporal arc";
+}
+
 TEST(FGOTest, RobustLossDownweightsPseudorangeOutlier) {
     FGOProcessor::FGOProblem problem = makeSyntheticProblem();
     for (auto& factor : problem.pseudorange_factors) {

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -11,6 +11,7 @@
 #include <cmath>
 #include <cstdio>
 #include <limits>
+#include <map>
 #include <set>
 #include <vector>
 
@@ -532,6 +533,75 @@ TEST(FGOAmbiguityCandidateTelemetryTest, ReportsDisabledCandidateFunnel) {
                     AmbiguityResolutionDisabled);
         }
     }
+}
+
+TEST(FGOClockResilientTemporalCarrierShadowTest,
+     ReportsResidualsWithoutChangingFixedLagSolution) {
+    CpHoldTestOptions opt;
+    opt.num_epochs = 3;
+    auto problem = makeCpHoldFixedLagProblem(opt);
+
+    using ObservationKey = std::pair<std::size_t, SatelliteId>;
+    std::map<ObservationKey, FGOProcessor::CarrierPhaseFactor> observations;
+    for (const auto& factor : problem.double_difference_carrier_factors) {
+        const auto add_observation =
+            [&](const SatelliteId satellite, const Vector3d& satellite_position,
+                const FGOProcessor::ObservationModelDebug& model) {
+                FGOProcessor::CarrierPhaseFactor observation;
+                observation.epoch_index = factor.epoch_index;
+                observation.satellite = satellite;
+                observation.signal = factor.signal;
+                observation.satellite_position_ecef = satellite_position;
+                observation.corrected_carrier_m = model.corrected_carrier_m;
+                observation.has_carrier_phase = true;
+                observation.loss_of_lock = false;
+                const Vector3d range_vector =
+                    satellite_position -
+                    problem.epochs[factor.epoch_index].position_ecef;
+                observation.los = range_vector.normalized();
+                observation.elevation_rad = factor.elevation_rad;
+                observation.model_debug.geometric_range_m =
+                    range_vector.norm();
+                observations[{factor.epoch_index, satellite}] = observation;
+            };
+        add_observation(factor.satellite,
+                        factor.rover_satellite_position_ecef,
+                        factor.rover_satellite_model);
+        add_observation(factor.reference_satellite,
+                        factor.rover_reference_position_ecef,
+                        factor.rover_reference_model);
+    }
+    for (const auto& [key, observation] : observations) {
+        (void)key;
+        problem.carrier_observations.push_back(observation);
+    }
+
+    FGOProcessor::FGOConfig off_config = makeCpHoldBaseConfig();
+    FGOProcessor off_processor(off_config);
+    const auto off_result = off_processor.optimizeProblem(problem);
+
+    FGOProcessor::FGOConfig on_config = off_config;
+    on_config.monitor_clock_resilient_temporal_carrier = true;
+    FGOProcessor on_processor(on_config);
+    const auto on_result = on_processor.optimizeProblem(problem);
+
+    ASSERT_EQ(off_result.solution.solutions.size(),
+              on_result.solution.solutions.size());
+    ASSERT_EQ(on_result.epoch_diagnostics.size(), problem.epochs.size());
+    int total_shadow_factors = 0;
+    for (std::size_t i = 0; i < on_result.solution.solutions.size(); ++i) {
+        EXPECT_TRUE(off_result.solution.solutions[i].position_ecef.isApprox(
+            on_result.solution.solutions[i].position_ecef, 0.0));
+        EXPECT_EQ(off_result.solution.solutions[i].status,
+                  on_result.solution.solutions[i].status);
+        total_shadow_factors +=
+            on_result.epoch_diagnostics[i].clock_resilient_tdcp_factors;
+        EXPECT_TRUE(std::isfinite(
+            on_result.epoch_diagnostics[i].clock_resilient_tdcp_rms_m));
+        EXPECT_TRUE(std::isfinite(
+            on_result.epoch_diagnostics[i].clock_resilient_tdcp_max_abs_m));
+    }
+    EXPECT_GT(total_shadow_factors, 0);
 }
 
 TEST(FGOAmbiguityCandidateTelemetryTest,


### PR DESCRIPTION
## Summary

- add a diagnostic-only, receiver-clock-free temporal carrier shadow
- preserve a causal reference and break continuity when the reference changes
- use distinct previous/current LOS vectors without changing the legacy Taroz-parity SD-TDCP path
- expose per-epoch factor count, RMS, and maximum residual in `gnss_fgo_parity` CSV output
- document the paper/OSS survey and three-run Tokyo validation

## Why

Undifferenced temporal carrier checks can be corrupted by receiver clock jumps. Satellite single differences cancel the common receiver-clock term, but direct graph insertion is not yet safe because gross carrier-arc outliers remain.

This implementation is monitor-only: it never adds graph factors and cannot change estimator state or FIX/FLOAT decisions.

## Validation

- 31 focused FGO tests passed
- new unit coverage verifies common 1 ms clock-jump cancellation, correct previous/current LOS, and reference-switch arc reset
- fixed-lag integration test verifies diagnostics are emitted while solution/status remain identical
- GTSAM and non-GTSAM MSVC builds passed
- Tokyo baseline comparison matched position/status/ratio/fixed-count/AR-outcome on every row:
  - run1: 11,905 / 11,905
  - run2: 9,147 / 9,147
  - run3 holdout: 15,294 / 15,294

Across the three runs, 1,083,657 shadow factors were evaluated. Median epoch RMS was 7–11 mm, but gross tails reached 480 m and 2,091 epochs above 0.1 m were not covered by existing epoch-level witnesses. The path therefore remains monitor-only; the next phase is per-factor arc/slip/outlier classification before any graph insertion.
