### PR TITLE
Add causal temporal carrier and DDPR quality telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,23 @@ recomputes the trace at the reference trajectory without rerunning the solver.
 The formulation, research basis, and Tokyo validation are documented in
 [`docs/fgo_clock_resilient_temporal_shadow.md`](docs/fgo_clock_resilient_temporal_shadow.md).
 
+`--predicted-ddpr-quality-shadow` audits each temporally continuous DD
+pseudorange pair against two causal witnesses: trapezoid-integrated
+double-difference Doppler and the one-step IMU-predicted geometry.  The two
+tests remain receiver-clock-free because rover and base clock terms cancel in
+the satellite double difference.  This option is monitor-only: it neither
+changes factor weights nor participates in ambiguity resolution.  With
+`--dump-csv <path>`, its per-factor trace is written to
+`<path>.predicted_ddpr_quality.csv`.
+
+For offline threshold development, combine it with
+`--clock-resilient-shadow-truth-replay --ref reference.csv`.  The resulting
+DDPR sidecar adds the previous and current truth-position DDPR residuals, so a
+causal runtime score can be joined to an independently labelled observation.
+Thresholds must be selected on the development run and then held fixed for
+validation/holdout runs; see
+[`docs/fgo_fix_rate_observation_quality_plan.md`](docs/fgo_fix_rate_observation_quality_plan.md).
+
 The normalized trace's `disposition` values are:
 
 | Value | Meaning |

--- a/README.md
+++ b/README.md
@@ -140,8 +140,13 @@ normalized satellite/signal trace is written beside it as
 
 `--clock-resilient-temporal-shadow` additionally audits receiver-clock-free
 satellite-single-difference temporal carrier residuals. It is monitor-only and
-does not add graph factors or change FIX/FLOAT decisions. The formulation,
-research basis, and three-run Tokyo validation are documented in
+does not add graph factors or change FIX/FLOAT decisions. With `--dump-csv`, a
+per-factor classification trace is written to
+`<path>.clock_resilient_tdcp_factors.csv` in addition to the epoch counters.
+For large holdouts,
+`--clock-resilient-shadow-truth-replay --ref reference.csv --dump-csv <path>`
+recomputes the trace at the reference trajectory without rerunning the solver.
+The formulation, research basis, and Tokyo validation are documented in
 [`docs/fgo_clock_resilient_temporal_shadow.md`](docs/fgo_clock_resilient_temporal_shadow.md).
 
 The normalized trace's `disposition` values are:

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -64,6 +64,8 @@ struct Args {
     bool multi_freq = false;     // force multi-frequency DD on (library default is now OFF)
     bool sd_doppler = false;     // add single-difference Doppler velocity factors
     bool clock_resilient_temporal_shadow = false;  // diagnostic-only receiver-clock-free TDCP
+    std::string temporal_shadow_replay_csv;  // classify against frozen ECEF positions; skip solve
+    bool temporal_shadow_truth_replay = false;  // classify against reference.csv; skip solve
     bool postfit_gate = false;
     bool adaptive_ratio = false;
     int postfit_min_n = -1;
@@ -245,6 +247,16 @@ Args parseArgs(int argc, char** argv) {
             continue;
         }
         if (a == "--clock-resilient-temporal-shadow") {
+            args.clock_resilient_temporal_shadow = true;
+            continue;
+        }
+        if (a == "--clock-resilient-shadow-replay" && i + 1 < argc) {
+            args.temporal_shadow_replay_csv = argv[++i];
+            args.clock_resilient_temporal_shadow = true;
+            continue;
+        }
+        if (a == "--clock-resilient-shadow-truth-replay") {
+            args.temporal_shadow_truth_replay = true;
             args.clock_resilient_temporal_shadow = true;
             continue;
         }
@@ -1515,7 +1527,7 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
            "x_ecef_m,y_ecef_m,z_ecef_m,position_covariance_trace_m2,"
            "ref_e_pos_m,ref_n_pos_m,ref_u_pos_m,"
            "vel_e_mps,vel_n_mps,vel_u_mps,"
-           "ratio,ratio_threshold,nfixed,ar_outcome,ddpr_rms_m,sd_doppler_rms_mps,clock_resilient_tdcp_n,clock_resilient_tdcp_rms_m,clock_resilient_tdcp_max_abs_m,gdop,nsat,sd_doppler_n,"
+           "ratio,ratio_threshold,nfixed,ar_outcome,ddpr_rms_m,sd_doppler_rms_mps,clock_resilient_tdcp_n,clock_resilient_tdcp_rms_m,clock_resilient_tdcp_max_abs_m,clock_resilient_tdcp_clean,clock_resilient_tdcp_witnessed_outliers,clock_resilient_tdcp_unexplained_outliers,gdop,nsat,sd_doppler_n,"
            "amb_candidates,lambda_attempts,lambda_stage,amb_var_median,amb_var_max,"
            "imu_pose_correction_m,spp_seed_fresh,spp_seed_x_ecef_m,"
            "spp_seed_y_ecef_m,spp_seed_z_ecef_m,"
@@ -1630,6 +1642,9 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                 << ',' << d.clock_resilient_tdcp_factors
                 << ',' << d.clock_resilient_tdcp_rms_m
                 << ',' << d.clock_resilient_tdcp_max_abs_m
+                << ',' << d.clock_resilient_tdcp_clean
+                << ',' << d.clock_resilient_tdcp_witnessed_outliers
+                << ',' << d.clock_resilient_tdcp_unexplained_outliers
                 << ',' << d.gdop << ',' << d.num_satellites
                 << ',' << d.sd_doppler_factors
                 << ',' << d.ambiguity_candidates << ',' << d.lambda_attempts
@@ -1870,6 +1885,203 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                        << trial.imu_separation_m << '\n';
         }
     }
+}
+
+void dumpTemporalCarrierFactorCsv(
+    const libgnss::FGOProcessor::FGOResult& result,
+    const std::string& epoch_csv_path) {
+    const std::string path =
+        epoch_csv_path + ".clock_resilient_tdcp_factors.csv";
+    std::ofstream out(path);
+    if (!out) {
+        std::cerr << "Error: cannot open temporal carrier factor output file "
+                  << path << "\n";
+        return;
+    }
+    out << std::fixed << std::setprecision(6);
+    out << "tow,previous_epoch,current_epoch,target,reference,signal,"
+           "arc_length_epochs,delta_carrier_m,sigma_m,elevation_rad,"
+           "residual_m,normalized_residual,residual_outlier,"
+           "doppler_evaluated,doppler_innovation_signed_m,"
+           "doppler_innovation_m,"
+           "doppler_innovation_sigma_m,normalized_doppler_innovation,"
+           "doppler_outlier,doppler_calibration_evaluated,doppler_bias_m,"
+           "doppler_calibrated_scale_m,doppler_centered_innovation_m,"
+           "doppler_calibrated_score,doppler_calibrated_outlier,"
+           "geometry_free_witness,carrier_hold_witness,carrier_fde_witness,"
+           "classification\n";
+    for (const auto& row : result.temporal_carrier_shadow_factors) {
+        const auto& factor = row.factor;
+        double tow = 0.0;
+        if (factor.current_epoch_index < result.solution.solutions.size()) {
+            tow = result.solution.solutions[factor.current_epoch_index].time.tow;
+        }
+        const char* classification = "clean";
+        if (row.classification == libgnss::FGOProcessor::
+                TemporalCarrierShadowClassification::WitnessedOutlier) {
+            classification = "witnessed_outlier";
+        } else if (row.classification == libgnss::FGOProcessor::
+                       TemporalCarrierShadowClassification::UnexplainedOutlier) {
+            classification = "unexplained_outlier";
+        }
+        out << tow << ',' << factor.previous_epoch_index << ','
+            << factor.current_epoch_index << ',' << factor.satellite.toString()
+            << ',' << factor.reference_satellite.toString() << ','
+            << static_cast<int>(factor.signal) << ','
+            << factor.arc_length_epochs << ',' << factor.delta_carrier_m << ','
+            << factor.sigma_m << ',' << factor.elevation_rad << ','
+            << row.residual_m << ',' << row.normalized_residual << ','
+            << (row.residual_outlier ? 1 : 0) << ','
+            << (row.doppler_evaluated ? 1 : 0) << ','
+            << row.doppler_innovation_signed_m << ','
+            << row.doppler_innovation_m << ','
+            << row.doppler_innovation_sigma_m << ','
+            << row.normalized_doppler_innovation << ','
+            << (row.doppler_outlier ? 1 : 0) << ','
+            << (row.doppler_calibration_evaluated ? 1 : 0) << ','
+            << row.doppler_bias_m << ','
+            << row.doppler_calibrated_scale_m << ','
+            << row.doppler_centered_innovation_m << ','
+            << row.doppler_calibrated_score << ','
+            << (row.doppler_calibrated_outlier ? 1 : 0) << ','
+            << (row.geometry_free_witness ? 1 : 0) << ','
+            << (row.carrier_hold_witness ? 1 : 0) << ','
+            << (row.carrier_fde_witness ? 1 : 0) << ',' << classification
+            << '\n';
+    }
+}
+
+struct TemporalShadowReplayInput {
+    std::vector<libgnss::Vector3d> positions_ecef;
+    std::vector<bool> carrier_hold_active;
+};
+
+bool loadTemporalShadowReplayCsv(
+    const std::string& path,
+    const libgnss::FGOProcessor::FGOProblem& problem,
+    TemporalShadowReplayInput& replay) {
+    std::ifstream input(path);
+    if (!input) {
+        std::cerr << "Error: cannot open temporal-shadow replay CSV " << path
+                  << "\n";
+        return false;
+    }
+    const auto split = [](const std::string& line) {
+        std::vector<std::string> fields;
+        std::stringstream stream(line);
+        std::string field;
+        while (std::getline(stream, field, ',')) {
+            fields.push_back(field);
+        }
+        return fields;
+    };
+
+    std::string line;
+    if (!std::getline(input, line)) {
+        std::cerr << "Error: temporal-shadow replay CSV is empty: " << path
+                  << "\n";
+        return false;
+    }
+    const auto header = split(line);
+    std::map<std::string, std::size_t> columns;
+    for (std::size_t i = 0; i < header.size(); ++i) {
+        columns[header[i]] = i;
+    }
+    for (const char* required :
+         {"tow", "x_ecef_m", "y_ecef_m", "z_ecef_m"}) {
+        if (columns.count(required) == 0) {
+            std::cerr << "Error: temporal-shadow replay CSV lacks column "
+                      << required << "\n";
+            return false;
+        }
+    }
+    const auto tow_column = columns["tow"];
+    const auto x_column = columns["x_ecef_m"];
+    const auto y_column = columns["y_ecef_m"];
+    const auto z_column = columns["z_ecef_m"];
+    const auto hold_column = columns.find("cp_hold");
+
+    replay.positions_ecef.clear();
+    replay.carrier_hold_active.clear();
+    replay.positions_ecef.reserve(problem.epochs.size());
+    replay.carrier_hold_active.reserve(problem.epochs.size());
+    std::size_t row = 0;
+    while (std::getline(input, line) && row < problem.epochs.size()) {
+        if (line.empty()) {
+            continue;
+        }
+        const auto fields = split(line);
+        const std::size_t required_max =
+            std::max({tow_column, x_column, y_column, z_column});
+        if (fields.size() <= required_max) {
+            std::cerr << "Error: malformed temporal-shadow replay row "
+                      << (row + 2) << "\n";
+            return false;
+        }
+        try {
+            const double tow = std::stod(fields[tow_column]);
+            if (std::abs(tow - problem.epochs[row].time.tow) > 1e-3) {
+                std::cerr << "Error: temporal-shadow replay TOW mismatch at row "
+                          << (row + 2) << " (csv=" << tow << ", problem="
+                          << problem.epochs[row].time.tow << ")\n";
+                return false;
+            }
+            replay.positions_ecef.emplace_back(std::stod(fields[x_column]),
+                                               std::stod(fields[y_column]),
+                                               std::stod(fields[z_column]));
+            bool hold = false;
+            if (hold_column != columns.end() &&
+                hold_column->second < fields.size()) {
+                hold = std::stoi(fields[hold_column->second]) != 0;
+            }
+            replay.carrier_hold_active.push_back(hold);
+        } catch (const std::exception& error) {
+            std::cerr << "Error: invalid temporal-shadow replay row "
+                      << (row + 2) << ": " << error.what() << "\n";
+            return false;
+        }
+        ++row;
+    }
+    if (row != problem.epochs.size()) {
+        std::cerr << "Error: temporal-shadow replay row count " << row
+                  << " does not match problem epochs " << problem.epochs.size()
+                  << "\n";
+        return false;
+    }
+    return true;
+}
+
+bool loadTemporalShadowTruthReplay(
+    const std::string& path,
+    const libgnss::FGOProcessor::FGOProblem& problem,
+    TemporalShadowReplayInput& replay) {
+    const auto reference = loadReference(path);
+    if (reference.empty()) {
+        std::cerr << "Error: cannot load temporal-shadow truth replay from "
+                  << path << "\n";
+        return false;
+    }
+    replay.positions_ecef.clear();
+    replay.carrier_hold_active.clear();
+    replay.positions_ecef.reserve(problem.epochs.size());
+    replay.carrier_hold_active.assign(problem.epochs.size(), false);
+    std::size_t reference_index = 0;
+    for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
+        const auto& time = problem.epochs[i].time;
+        while (reference_index + 1 < reference.size() &&
+               std::abs(reference[reference_index + 1].time - time) <
+                   std::abs(reference[reference_index].time - time)) {
+            ++reference_index;
+        }
+        const double age_s = std::abs(reference[reference_index].time - time);
+        if (age_s > 0.11) {
+            std::cerr << "Error: no reference position within 0.11 s at epoch "
+                      << i << " (nearest age=" << age_s << " s)\n";
+            return false;
+        }
+        replay.positions_ecef.push_back(reference[reference_index].ecef);
+    }
+    return true;
 }
 
 // Populate problem.imu from an imu.csv + the already-built FGOProblem epochs.
@@ -2523,6 +2735,88 @@ int main(int argc, char** argv) {
               << problem.diagnostics.geometry_free_cycle_slip_resets
               << ")\n";
 
+    if (!args.temporal_shadow_replay_csv.empty() ||
+        args.temporal_shadow_truth_replay) {
+        if (args.dump_csv_path.empty()) {
+            std::cerr << "Error: temporal-shadow replay requires --dump-csv "
+                         "<output-prefix>\n";
+            return 2;
+        }
+        TemporalShadowReplayInput replay;
+        const bool loaded = args.temporal_shadow_truth_replay
+            ? (!args.ref_path.empty() &&
+               loadTemporalShadowTruthReplay(args.ref_path, problem, replay))
+            : loadTemporalShadowReplayCsv(args.temporal_shadow_replay_csv,
+                                          problem, replay);
+        if (!loaded) {
+            if (args.temporal_shadow_truth_replay && args.ref_path.empty()) {
+                std::cerr << "Error: --clock-resilient-shadow-truth-replay "
+                             "requires --ref reference.csv\n";
+            }
+            return 1;
+        }
+        auto shadow =
+            libgnss::FGOProcessor::buildClockResilientTemporalCarrierShadow(
+                problem, config.single_difference_tdcp_sigma_m,
+                config.max_tdcp_gap_s);
+        auto geometry_free =
+            libgnss::FGOProcessor::analyzeGeometryFreeSlipShadow(
+                problem, 0.05, config.max_tdcp_gap_s);
+        std::vector<libgnss::FGOProcessor::FGOEpochDiagnostics>
+            epoch_diagnostics(problem.epochs.size());
+        for (std::size_t i = 0; i < epoch_diagnostics.size(); ++i) {
+            epoch_diagnostics[i].carrier_hold_active =
+                replay.carrier_hold_active[i];
+        }
+
+        libgnss::FGOProcessor::FGOResult replay_result;
+        replay_result.temporal_carrier_shadow_factors =
+            libgnss::FGOProcessor::
+                classifyClockResilientTemporalCarrierShadow(
+                    problem, shadow, replay.positions_ecef,
+                    epoch_diagnostics, &geometry_free);
+        replay_result.epoch_diagnostics = std::move(epoch_diagnostics);
+        for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
+            libgnss::PositionSolution solution;
+            solution.time = problem.epochs[i].time;
+            solution.position_ecef = replay.positions_ecef[i];
+            replay_result.solution.addSolution(solution);
+        }
+        dumpTemporalCarrierFactorCsv(replay_result, args.dump_csv_path);
+
+        std::size_t clean = 0;
+        std::size_t witnessed = 0;
+        std::size_t unexplained = 0;
+        for (const auto& row :
+             replay_result.temporal_carrier_shadow_factors) {
+            switch (row.classification) {
+                case libgnss::FGOProcessor::
+                    TemporalCarrierShadowClassification::Clean:
+                    ++clean;
+                    break;
+                case libgnss::FGOProcessor::
+                    TemporalCarrierShadowClassification::WitnessedOutlier:
+                    ++witnessed;
+                    break;
+                case libgnss::FGOProcessor::
+                    TemporalCarrierShadowClassification::UnexplainedOutlier:
+                    ++unexplained;
+                    break;
+            }
+        }
+        std::cout << "Temporal-shadow replay: factors="
+                  << replay_result.temporal_carrier_shadow_factors.size()
+                  << " clean=" << clean << " witnessed_outliers="
+                  << witnessed << " unexplained_outliers=" << unexplained
+                  << "\n  source="
+                  << (args.temporal_shadow_truth_replay
+                          ? args.ref_path
+                          : args.temporal_shadow_replay_csv)
+                  << "\n  output=" << args.dump_csv_path
+                  << ".clock_resilient_tdcp_factors.csv\n";
+        return 0;
+    }
+
     // --- MF hygiene diagnostics: per-signal DD residuals at the reference
     // trajectory (no solver). PR residual mean exposes per-band code/DCB
     // bias; per-arc carrier residual fractional-cycle offset exposes phase
@@ -2659,6 +2953,9 @@ int main(int argc, char** argv) {
         const HorizError he = horizontalErrorVsRef(fl, ref_rows);
         if (!args.dump_csv_path.empty()) {
             dumpEpochCsv(fl, ref_rows, args.dump_csv_path);
+            if (args.clock_resilient_temporal_shadow) {
+                dumpTemporalCarrierFactorCsv(fl, args.dump_csv_path);
+            }
         }
 
         std::cout << "\n=== (a4) MILESTONE 2c: IncrementalFixedLagSmoother (full-scale) ===\n"

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -64,6 +64,7 @@ struct Args {
     bool multi_freq = false;     // force multi-frequency DD on (library default is now OFF)
     bool sd_doppler = false;     // add single-difference Doppler velocity factors
     bool clock_resilient_temporal_shadow = false;  // diagnostic-only receiver-clock-free TDCP
+    bool predicted_ddpr_quality_shadow = false;  // diagnostic-only causal DDPR quality
     std::string temporal_shadow_replay_csv;  // classify against frozen ECEF positions; skip solve
     bool temporal_shadow_truth_replay = false;  // classify against reference.csv; skip solve
     bool postfit_gate = false;
@@ -258,6 +259,10 @@ Args parseArgs(int argc, char** argv) {
         if (a == "--clock-resilient-shadow-truth-replay") {
             args.temporal_shadow_truth_replay = true;
             args.clock_resilient_temporal_shadow = true;
+            continue;
+        }
+        if (a == "--predicted-ddpr-quality-shadow") {
+            args.predicted_ddpr_quality_shadow = true;
             continue;
         }
         if (a == "--gici-par") {
@@ -743,6 +748,8 @@ libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
     config.monitor_geometry_free_cycle_slip = !args.dump_csv_path.empty();
     config.monitor_clock_resilient_temporal_carrier =
         args.clock_resilient_temporal_shadow;
+    config.monitor_predicted_ddpr_quality =
+        args.predicted_ddpr_quality_shadow;
     config.use_geometry_free_cycle_slip_reset = args.gf_slip_reset;
     config.report_held_ambiguities_as_fixed = !args.no_held_fix_label;
     if (args.max_iters > 0) {
@@ -1951,6 +1958,61 @@ void dumpTemporalCarrierFactorCsv(
     }
 }
 
+void dumpPredictedDdprQualityCsv(
+    const libgnss::FGOProcessor::FGOResult& result,
+    const std::string& epoch_csv_path) {
+    const std::string path = epoch_csv_path + ".predicted_ddpr_quality.csv";
+    std::ofstream out(path);
+    if (!out) {
+        std::cerr << "Error: cannot open predicted DDPR quality output file "
+                  << path << "\n";
+        return;
+    }
+    out << std::fixed << std::setprecision(6);
+    out << "tow,previous_epoch,current_epoch,target,reference,signal,dt_s,"
+           "pair_age_epochs,measured_ddpr_change_m,doppler_evaluated,"
+           "doppler_predicted_change_m,doppler_innovation_m,"
+           "doppler_innovation_sigma_m,normalized_doppler_innovation,"
+           "imu_geometry_evaluated,imu_predicted_change_m,"
+           "previous_predicted_ddpr_residual_m,"
+           "current_predicted_ddpr_residual_m,imu_innovation_m,"
+           "imu_innovation_sigma_m,normalized_imu_innovation,elevation_rad,"
+           "target_snr_dbhz,reference_snr_dbhz,proposed_action\n";
+    for (const auto& row : result.predicted_ddpr_quality_factors) {
+        double tow = 0.0;
+        if (row.current_epoch_index < result.solution.solutions.size()) {
+            tow = result.solution.solutions[row.current_epoch_index].time.tow;
+        }
+        const char* action = "unavailable";
+        if (row.proposed_action == libgnss::FGOProcessor::
+                PredictedDdprQualityAction::Keep) {
+            action = "keep";
+        } else if (row.proposed_action == libgnss::FGOProcessor::
+                       PredictedDdprQualityAction::Downweight) {
+            action = "downweight";
+        }
+        out << tow << ',' << row.previous_epoch_index << ','
+            << row.current_epoch_index << ',' << row.satellite.toString()
+            << ',' << row.reference_satellite.toString() << ','
+            << static_cast<int>(row.signal) << ',' << row.dt_s << ','
+            << row.pair_age_epochs << ',' << row.measured_ddpr_change_m << ','
+            << (row.doppler_evaluated ? 1 : 0) << ','
+            << row.doppler_predicted_change_m << ','
+            << row.doppler_innovation_m << ','
+            << row.doppler_innovation_sigma_m << ','
+            << row.normalized_doppler_innovation << ','
+            << (row.imu_geometry_evaluated ? 1 : 0) << ','
+            << row.imu_predicted_change_m << ','
+            << row.previous_predicted_ddpr_residual_m << ','
+            << row.current_predicted_ddpr_residual_m << ','
+            << row.imu_innovation_m << ','
+            << row.imu_innovation_sigma_m << ','
+            << row.normalized_imu_innovation << ',' << row.elevation_rad << ','
+            << row.target_snr_dbhz << ',' << row.reference_snr_dbhz << ','
+            << action << '\n';
+    }
+}
+
 struct TemporalShadowReplayInput {
     std::vector<libgnss::Vector3d> positions_ecef;
     std::vector<bool> carrier_hold_active;
@@ -2775,6 +2837,13 @@ int main(int argc, char** argv) {
                 classifyClockResilientTemporalCarrierShadow(
                     problem, shadow, replay.positions_ecef,
                     epoch_diagnostics, &geometry_free);
+        if (args.predicted_ddpr_quality_shadow) {
+            replay_result.predicted_ddpr_quality_factors =
+                libgnss::FGOProcessor::analyzePredictedDdprQualityShadow(
+                    problem, replay.positions_ecef, replay.positions_ecef,
+                    config.single_difference_doppler_sigma_mps, 5.0,
+                    config.max_tdcp_gap_s);
+        }
         replay_result.epoch_diagnostics = std::move(epoch_diagnostics);
         for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
             libgnss::PositionSolution solution;
@@ -2783,6 +2852,9 @@ int main(int argc, char** argv) {
             replay_result.solution.addSolution(solution);
         }
         dumpTemporalCarrierFactorCsv(replay_result, args.dump_csv_path);
+        if (args.predicted_ddpr_quality_shadow) {
+            dumpPredictedDdprQualityCsv(replay_result, args.dump_csv_path);
+        }
 
         std::size_t clean = 0;
         std::size_t witnessed = 0;
@@ -2956,6 +3028,9 @@ int main(int argc, char** argv) {
             if (args.clock_resilient_temporal_shadow) {
                 dumpTemporalCarrierFactorCsv(fl, args.dump_csv_path);
             }
+            if (args.predicted_ddpr_quality_shadow) {
+                dumpPredictedDdprQualityCsv(fl, args.dump_csv_path);
+            }
         }
 
         std::cout << "\n=== (a4) MILESTONE 2c: IncrementalFixedLagSmoother (full-scale) ===\n"
@@ -2985,6 +3060,8 @@ int main(int argc, char** argv) {
                    << (config.monitor_multiepoch_ar ? "on" : "off")
                    << ", clock_resilient_temporal_shadow="
                    << (config.monitor_clock_resilient_temporal_carrier ? "on" : "off")
+                   << ", predicted_ddpr_quality_shadow="
+                   << (config.monitor_predicted_ddpr_quality ? "on" : "off")
                    << ")\n"
                   << "  IMU ratio aperture: " << (args.imu_ratio_aperture ? "on" : "off")
                   << " (accepted=" << fl.diagnostics.imu_aided_ratio_accepts

--- a/docs/fgo_clock_resilient_temporal_shadow.md
+++ b/docs/fgo_clock_resilient_temporal_shadow.md
@@ -34,6 +34,20 @@ are emitted:
 - `clock_resilient_tdcp_n`
 - `clock_resilient_tdcp_rms_m`
 - `clock_resilient_tdcp_max_abs_m`
+- `clock_resilient_tdcp_clean`
+- `clock_resilient_tdcp_witnessed_outliers`
+- `clock_resilient_tdcp_unexplained_outliers`
+
+A normalized per-factor trace is also written automatically beside the epoch
+table as `<path>.clock_resilient_tdcp_factors.csv`. Each row includes the
+target/reference/signal arc, residual, normalized residual, raw-observation
+Doppler innovation and uncertainty, normalized Doppler innovation,
+geometry-free/hold/FDE witnesses, and final
+`clean`/`witnessed_outlier`/`unexplained_outlier` classification. The frozen
+diagnostic thresholds are 0.10 m for the temporal-carrier residual and 5 sigma
+for the Doppler-integrated innovation. The latter combines temporal-carrier
+sigma with the trapezoid-integrated single-difference Doppler sigmas. They are
+deliberately not estimator gates.
 
 ## Tokyo validation
 
@@ -79,10 +93,88 @@ errors dominate it, even though all three medians are 7--11 mm.
 
 Decision: keep this path monitor-only. Receiver-clock cancellation works and
 the bulk signal is useful, but epoch-level guards are not selective enough for
-safe graph insertion. The next phase must emit per-factor innovations and
-classify each target/reference arc using loss-of-lock, geometry-free,
-Doppler, reference-change, and robust residual evidence. Only a frozen gate
-that survives run2 and run3 should be promoted to a graph factor.
+safe graph insertion. Per-factor innovations and target/reference arc
+classifications are therefore required before any later graph experiment.
+Only a frozen gate that survives run2 and run3 should be promoted to a graph
+factor.
+
+### Per-factor classifier checkpoint
+
+The classifier was then replayed over the same first 500 run1 epochs. Raw
+single-difference Doppler is carried with each shadow factor, so the witness is
+available even when Doppler graph factors are disabled by the production
+profile.
+
+| Metric | Result |
+|---|---:|
+| Factors / residual outliers | 22,482 / 50 |
+| Outliers with an independent witness | 10 (20%) |
+| Unexplained outliers | 40 (80%) |
+| Doppler-evaluated factors | 22,482 (100%) |
+| Factors above the 5-sigma Doppler threshold | 5,570 (24.8%) |
+| Factors with causal arc calibration | 21,188 (94.2%) |
+| Factors above the calibrated 5-sigma threshold | 233 (1.10%) |
+| Residual outliers above the calibrated threshold | 0 / 50 |
+| Residual outliers with a geometry-free witness | 10 |
+| Maximum temporal-carrier residual | 0.511 m |
+| Baseline rows changed | 0 / 500 |
+
+Replacing the original 0.20 m Doppler threshold with the propagated 5-sigma
+test reduced its background flag rate only from 27.4% to 24.8%. Per-signal
+quantiles also varied widely and would suppress genuine carrier tails if used
+as fixed thresholds. The dominant effect was instead a persistent
+target/reference arc bias.
+
+A causal arc calibration was therefore added: after ten prior samples, the
+current signed innovation is centred by the median of at most 30 prior samples
+and scaled by the larger of propagated measurement sigma and `1.4826 * MAD`.
+The current sample is appended only after classification, so the diagnostic
+does not use future data or dilute its own event. This reduced the background
+flag rate to 1.10%, but none of the 50 temporal-carrier residual tails was a
+calibrated Doppler event at any tested threshold from 3 to 10 sigma. The
+previous Doppler coverage was therefore caused by persistent bias rather than
+independent transient evidence.
+
+Decision: raw and propagated-sigma Doppler values remain in the trace, but no
+longer have classification authority. Only a causally calibrated Doppler
+event, geometry-free event, carrier hold, or carrier-FDE rejection can mark a
+residual as witnessed. On the run1 design slice this leaves the ten
+geometry-free-witnessed tails and correctly marks the other 40 as unexplained.
+No Doppler-derived gate should be inserted into the estimator unless a future
+holdout shows transient-event correlation that is absent here.
+
+### Solver-independent truth replay and holdouts
+
+`gnss_fgo_parity --clock-resilient-shadow-truth-replay --ref reference.csv
+--dump-csv <path>` evaluates the same shadow and classifier at the high-precision
+reference ECEF trajectory without running GTSAM. A cached 9,147-epoch run2
+problem replays in seconds; run3 including RINEX parsing, problem construction,
+cache creation, and 513,824-factor classification completed in under three
+minutes on the validation machine.
+
+The run1 500-epoch truth replay produced the same 50-outlier count as the full
+solver evaluation and matched 49 of the 50 factor identities. This is stronger
+than replaying the exported solution CSV: that table rounds ECEF to millimetres
+and exports the selected FIXED position, while the original shadow is evaluated
+at the internal float trajectory.
+
+The frozen 0.10 m residual and causal 5-sigma witness rules were then applied
+unchanged to run2 and run3:
+
+| Run | Factors | Residual tails | Tail rate | Witnessed | Unexplained | Unexplained share | Calibrated Doppler flags | Max abs. |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| run1 design (500 epochs) | 22,482 | 50 | 0.22% | 10 | 40 | 80.0% | 233 / 21,188 (1.10%) | 0.511 m |
+| run2 holdout | 292,607 | 1,222 | 0.42% | 209 | 1,013 | 82.9% | 7,915 / 268,009 (2.95%) | 2.219 m |
+| run3 holdout | 513,824 | 2,309 | 0.45% | 314 | 1,995 | 86.4% | 15,300 / 475,744 (3.22%) | 2.397 m |
+| Total | 828,913 | 3,581 | 0.43% | 533 | 3,048 | 85.1% | - | - |
+
+Final decision: do not insert this temporal-carrier path into the graph and do
+not use it as an ambiguity/FIX gate. Receiver-clock cancellation is correct,
+but tail frequency roughly doubles on both holdouts and 85.1% of all tails
+lack an independent witness. The monitor, normalized trace, and fast truth
+replay remain useful research/diagnostic surfaces. FIX-rate development should
+now move to independently validated ambiguity selection and integrity evidence
+rather than further TDCP threshold tuning.
 
 ## References and implementation precedents
 

--- a/docs/fgo_fix_rate_observation_quality_plan.md
+++ b/docs/fgo_fix_rate_observation_quality_plan.md
@@ -74,8 +74,8 @@ The monitor exports, per DD row:
 - measured DDPR change;
 - Doppler- and IMU-predicted change;
 - signed innovation and propagated sigma for each witness;
-- elevation, rover/reference SNR, existing sigma, CMC/GF/FDE state;
-- a causal robust center/scale estimate; and
+- the previous/current DDPR residual against the causal predicted geometry;
+- elevation and rover/reference SNR; and
 - proposed action (`keep`, `downweight`, or `unavailable`).
 
 No graph factor, covariance, ambiguity set, hold state, reported position, or
@@ -157,6 +157,64 @@ fails, retain telemetry and reject activation.
    default-off switch and run the staged A/B protocol.
 6. Promote nothing unless every full-run gate passes; otherwise record the
    negative result and move to a different observation model.
+
+## Development checkpoint
+
+The default-off monitor passed Gate 0 on both the first 500 epochs and the
+full 11,905-epoch run1: status, ECEF position, ratio, fixed ambiguity count,
+and AR outcome were byte-for-byte identical to the preserved baseline CSV.
+The focused clock-cancellation, fail-closed, and fixed-lag non-interference
+tests also pass.
+
+The original rule requiring both normalized temporal innovations to exceed a
+common threshold did not meet the full-run development target.  At 0.2 sigma
+it captured 50.973% of gross truth-labelled rows but flagged 12.531% of clean
+rows; at 0.3 sigma the rates were 40.675% and 5.634%.  This rule is rejected.
+
+The causal absolute residual against the one-step IMU-predicted geometry is a
+substantially stronger development score.  Freezing the rule
+`abs(current predicted DDPR residual) > 1.5 m` on run1 captures 85.522% of
+14,498 gross rows while flagging 2.848% of 153,347 clean rows.  The 30,023
+rows between 1 m and 4 m are an explicit ambiguity band and are excluded from
+Gate 1 scoring.  This 1.5 m threshold is now frozen for the run2 validation;
+it must not be adjusted using run2 or run3.
+
+With that rule unchanged, run2 passes Gate 1: it captures 5,705 of 5,894
+gross rows (96.793%) and flags 477 of 166,600 clean rows (0.286%).  The
+monitor remains non-interfering across all 9,147 run2 epochs, with exact
+agreement in status, ECEF position, ratio, fixed ambiguity count, and AR
+outcome.  This unlocks the bounded-downweight experiment on run1.  Run3
+remains sealed until the activation rule, inflation scale, and all other
+parameters have been frozen.
+
+The bounded activation sweep on the first 500 run1 epochs rejected 3x and 5x
+because each introduced one wrong FIX.  The 2x variant introduced no wrong
+FIX but exchanged one previously correct FIX epoch for another and therefore
+failed the strict per-epoch no-loss gate.  The 1.5x and 1.75x variants changed
+no FIX/FLOAT labels.  The 1.25x variant was the only improving safe candidate:
+one additional correct FIX, no lost correct FIX, no wrong FIX, and no NONE or
+non-finite epoch.  Consequently 1.25x is the sole candidate advanced to the
+full-run1 activation A/B; the stronger multipliers are permanently rejected.
+
+The full-run1 A/B rejects that remaining 1.25x candidate.  It increased
+correct-FIX distance by 148.467 m (+1.439 percentage points) and improved the
+official 50 cm distance by 144.574 m (+1.401 pp), but it also increased
+wrong-FIX distance by 189.135 m (+1.833 pp) and lost 619 previously correct
+FIX epochs.  This violates the zero-wrong-FIX-increase stop condition even
+though the net correct-FIX count increased.  Therefore the activation switch
+was removed, run2/run3 activation was not run, and only the non-interfering
+telemetry is retained.  The run3 observation-quality labels remain sealed;
+no activation result was inspected there.
+
+As the next independent observation-model check, the existing receiver-clock-
+drift-free single-difference Doppler velocity factors were evaluated on the
+same run1 500-epoch development slice at 0.5 m/s (the less aggressive setting
+favoured by the earlier RTK study).  They added 18,356 Doppler rows but changed
+no FIX/FLOAT decision: both baseline and candidate had 499 correct FIX and
+zero wrong FIX.  Meanwhile fixed horizontal RMS regressed from 0.0422 m to
+0.0539 m (about 28%).  With no correct-FIX gain and a clear accuracy
+regression, this model was not advanced to a full run.  The temporary harness
+sigma override was removed as well.
 
 ## Stop conditions
 

--- a/docs/fgo_fix_rate_observation_quality_plan.md
+++ b/docs/fgo_fix_rate_observation_quality_plan.md
@@ -1,0 +1,167 @@
+# FGO FIX-rate observation-quality plan
+
+## Objective
+
+Close the remaining approximately 0.7955 percentage-point gap to the current
+`+2 pp` correct-FIX-distance goal without increasing wrong-FIX distance on a
+held-out Tokyo run. Raw FIX labels are not the optimization target: a change
+that promotes more wrong integer solutions fails even when the reported FIX
+rate rises.
+
+The next experiment targets the float observation model before LAMBDA. It does
+not further tune TDCP thresholds and does not promote the existing multi-epoch
+or conditional multi-band shadow candidates.
+
+## Evidence already consumed
+
+Do not repeat the following rejected directions:
+
+- temporal integer agreement, BSR, and ratio alone;
+- held-out carrier rows from the same urban measurement basin;
+- constrained graph cost using the same active factors;
+- conditional multi-band AR;
+- direct temporal-carrier promotion or a TDCP-based FIX gate; and
+- uncapped satellite-badness feedback, which starved ambiguity resolution.
+
+The current three-run logs also separate the remaining opportunity:
+
+- run1 correct FLOAT epochs are split mainly between no/insufficient
+  candidates and ratio rejection;
+- run2 and run3 correct FLOAT epochs are dominated by ratio rejection; and
+- lowering the ratio threshold is unsafe because the rejected population also
+  contains many wrong candidates.
+
+The working hypothesis is therefore that biased DD pseudorange factors are
+degrading the float state and ambiguity covariance before integer search. The
+candidate generator should be improved before any acceptance rule is relaxed.
+
+## Research basis
+
+- Song et al. (2025) compare pseudorange change with Doppler-predicted range
+  change, then compare DD pseudorange change with IMU/odometer-predicted DD
+  geometry. Measurements that fail are downweighted before FGO:
+  <https://arxiv.org/html/2510.00524v1>.
+- Wen and Hsu's GraphGNSSLib supplies an open FGO/RTK reference using DD
+  pseudorange, carrier phase, Doppler, and LAMBDA, and points to graduated
+  non-convexity work for urban outlier mitigation:
+  <https://github.com/weisongwen/GraphGNSSLib>.
+- Gao et al. connect pseudorange, carrier, and Doppler in an urban RTK factor
+  graph and perform ambiguity resolution after the float optimization:
+  <https://doi.org/10.33012/2022.18190>.
+- Teunissen-style integer aperture remains the safety model: observation
+  cleanup may improve the float distribution, but it does not authorize
+  relaxing the existing ambiguity acceptance tests.
+
+## Proposed experiment
+
+Add an opt-in, monitor-only `predicted DDPR quality` trace. For every DD
+pseudorange row with an uninterrupted target/reference pairing, calculate two
+causal innovations:
+
+1. **DD Doppler consistency:** compare the epoch-to-epoch measured DD
+   pseudorange change with integrated DD Doppler range change.
+2. **IMU geometry consistency:** compare the same measured change with the DD
+   geometric-range change from the one-step IMU-predicted antenna pose.
+
+Both tests must use satellite double differences. This cancels common rover
+and base receiver-clock terms and avoids importing the raw clock-jump failure
+seen by the temporal-carrier investigation. The current epoch's optimized pose
+must not be used to classify its own input factor.
+
+The monitor exports, per DD row:
+
+- epoch, target, reference, signal, and arc/pair age;
+- measured DDPR change;
+- Doppler- and IMU-predicted change;
+- signed innovation and propagated sigma for each witness;
+- elevation, rover/reference SNR, existing sigma, CMC/GF/FDE state;
+- a causal robust center/scale estimate; and
+- proposed action (`keep`, `downweight`, or `unavailable`).
+
+No graph factor, covariance, ambiguity set, hold state, reported position, or
+FIX/FLOAT status reads the monitor result.
+
+Only after the monitor passes its gates may a separate experimental switch
+apply a bounded sigma inflation to DD pseudorange factors. Hard exclusion is
+out of scope for the first activation experiment. Carrier factors and LAMBDA
+thresholds remain unchanged.
+
+## Dataset and holdout protocol
+
+1. **Development:** Tokyo run1 only. Select normalization and bounded
+   downweighting parameters.
+2. **Validation:** freeze all rules, then run Tokyo run2 once. A failure ends
+   the experiment; do not tune against run2.
+3. **Final holdout:** run Tokyo run3 only after run2 passes. Do not unlock or
+   adjust any threshold after seeing run3.
+4. Preserve the existing baseline CSVs and problem caches. Every experimental
+   output uses a new prefix and records the exact command and cache
+   fingerprint.
+
+Reference truth is used only for offline scoring. Runtime classification may
+use GNSS observations, Doppler, IMU prediction, and causal state, but never
+`reference.csv`.
+
+## Gates
+
+### Gate 0: monitor non-interference
+
+- status, ECEF position, ratio, fixed ambiguity count, and AR outcome are
+  identical to baseline at every epoch;
+- common rover/base clock-jump unit tests do not create a DD innovation; and
+- missing Doppler, pair changes, gaps, or non-finite covariance fail to
+  `unavailable`, never `bad`.
+
+### Gate 1: witness usefulness
+
+Using truth-position DDPR residuals only as offline labels, the frozen monitor
+must, on run2, capture at least 50% of gross DDPR rows while flagging no more
+than 5% of clean rows. Report the complete precision/recall curve; the stated
+operating point is the minimum continuation gate, not a post-hoc optimum.
+
+### Gate 2: short solver A/B
+
+On a representative 500-epoch run1 slice:
+
+- zero additional wrong FIX epochs;
+- no loss of correct FIX epochs;
+- no additional smoother failure or non-finite epoch; and
+- wall-clock overhead at or below 10%.
+
+### Gate 3: full-run activation
+
+With parameters frozen after full run1:
+
+- wrong-FIX distance must not increase on run2 or run3 individually;
+- correct-FIX distance must not decrease on either holdout;
+- aggregate correct-FIX distance must close the remaining 0.7955 pp goal;
+- official score and all-solution `<50 cm` distance must not regress by more
+  than 0.1 pp on any run;
+- fixed horizontal RMS and P95 must not regress by more than 5%; and
+- matched positioning distance and solver-failure counts must not regress.
+
+If the improvement is positive but below the target, keep the switch
+experimental and document the measured contribution. If any safety condition
+fails, retain telemetry and reject activation.
+
+## Implementation sequence
+
+1. Checkpoint the completed temporal-carrier work, then create a dedicated
+   observation-quality branch so the two experiments remain reviewable.
+2. Add solver-independent DDPR innovation records and deterministic unit
+   tests for geometry, clock cancellation, gaps, pair changes, and missing
+   witnesses.
+3. Wire a default-off CLI monitor and normalized per-factor CSV.
+4. Run baseline/monitor A/B and Gate 1 without changing the graph.
+5. If Gate 1 passes, add bounded DDPR sigma inflation behind a second
+   default-off switch and run the staged A/B protocol.
+6. Promote nothing unless every full-run gate passes; otherwise record the
+   negative result and move to a different observation model.
+
+## Stop conditions
+
+Stop before activation if the score is mainly explained by the optimized
+current pose, if DD formation does not cancel injected receiver-clock jumps,
+if run2 misses Gate 1, or if the first bounded-downweight run adds any wrong
+FIX. These conditions prevent another expensive threshold search over a
+non-independent witness.

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -406,6 +406,10 @@ public:
         // vectors.  The shadow is never inserted into either optimizer and
         // cannot change the exported solution or FIX/FLOAT decision.
         bool monitor_clock_resilient_temporal_carrier = false;
+        // Diagnostic-only temporal DD pseudorange quality monitor. It
+        // compares measured DDPR changes with DD Doppler and the causal
+        // pre-solve IMU pose prediction; no result is consumed by the graph.
+        bool monitor_predicted_ddpr_quality = false;
         // When a rover/base single-difference geometry-free combination jumps
         // while the underlying rover arcs remain continuous, break both bands'
         // DD arcs after the confirmation interval below. Resetting both bands
@@ -1800,6 +1804,44 @@ public:
             TemporalCarrierShadowClassification::Clean;
     };
 
+    enum class PredictedDdprQualityAction {
+        Unavailable = 0,
+        Keep = 1,
+        Downweight = 2,
+    };
+
+    /// Causal, diagnostic-only temporal quality check for one DD pseudorange
+    /// row. The previous position is the already-solved prior epoch and the
+    /// current position is the pre-solve IMU prediction. No field has
+    /// estimator authority.
+    struct PredictedDdprQualityFactorDiagnostics {
+        std::size_t previous_epoch_index = 0;
+        std::size_t current_epoch_index = 0;
+        SatelliteId satellite;
+        SatelliteId reference_satellite;
+        SignalType signal = SignalType::GPS_L1CA;
+        double dt_s = 0.0;
+        int pair_age_epochs = 0;
+        double measured_ddpr_change_m = 0.0;
+        bool doppler_evaluated = false;
+        double doppler_predicted_change_m = 0.0;
+        double doppler_innovation_m = 0.0;
+        double doppler_innovation_sigma_m = 0.0;
+        double normalized_doppler_innovation = 0.0;
+        bool imu_geometry_evaluated = false;
+        double imu_predicted_change_m = 0.0;
+        double previous_predicted_ddpr_residual_m = 0.0;
+        double current_predicted_ddpr_residual_m = 0.0;
+        double imu_innovation_m = 0.0;
+        double imu_innovation_sigma_m = 0.0;
+        double normalized_imu_innovation = 0.0;
+        double elevation_rad = 0.0;
+        double target_snr_dbhz = 0.0;
+        double reference_snr_dbhz = 0.0;
+        PredictedDdprQualityAction proposed_action =
+            PredictedDdprQualityAction::Unavailable;
+    };
+
     struct FGODiagnostics {
         int iterations = 0;
         bool converged = false;
@@ -2285,6 +2327,8 @@ public:
         std::vector<FGOEpochDiagnostics> epoch_diagnostics;
         std::vector<TemporalCarrierShadowFactorDiagnostics>
             temporal_carrier_shadow_factors;
+        std::vector<PredictedDdprQualityFactorDiagnostics>
+            predicted_ddpr_quality_factors;
         // Milestone 2b (populated only by the GTSAM IMU-coupled path):
         // per-epoch estimated attitude as [roll, pitch, heading] in degrees
         // (body FLU -> nav ENU; heading is clockwise from North) and estimated
@@ -2322,6 +2366,19 @@ public:
             nullptr,
         const std::vector<std::set<std::size_t>>*
             fde_rejected_ambiguities_by_epoch = nullptr);
+
+    /// Compare temporal DD pseudorange changes with receiver-clock-free DD
+    /// Doppler and a one-step predicted antenna trajectory. `previous_*`
+    /// supplies the causal solved pose at k-1; `predicted_*` supplies the
+    /// pre-solve pose prediction at k. The result is monitor-only.
+    static std::vector<PredictedDdprQualityFactorDiagnostics>
+    analyzePredictedDdprQualityShadow(
+        const FGOProblem& problem,
+        const std::vector<Vector3d>& previous_solution_positions_ecef,
+        const std::vector<Vector3d>& predicted_positions_ecef,
+        double doppler_sigma_mps = 0.2,
+        double normalized_outlier_threshold = 5.0,
+        double max_gap_s = 1.5);
 
     FGOProblem buildPseudorangeProblem(const std::vector<ObservationData>& epochs,
                                        const NavigationData& nav) const;

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -1564,6 +1564,15 @@ public:
         double delta_carrier_m = 0.0;
         double sigma_m = 0.003;
         double elevation_rad = 0.0;
+        std::size_t target_ambiguity_index = 0;
+        std::size_t reference_ambiguity_index = 0;
+        int arc_length_epochs = 0;
+        double dt_s = 0.0;
+        bool has_doppler_witness = false;
+        double previous_sd_doppler_mps = 0.0;
+        double current_sd_doppler_mps = 0.0;
+        double previous_sd_doppler_sigma_mps = 0.0;
+        double current_sd_doppler_sigma_mps = 0.0;
     };
 
     struct AmbiguityState {
@@ -1756,6 +1765,39 @@ public:
         int doppler_event_signals = 0;
         double doppler_max_innovation_m = 0.0;
         int doppler_isolated_event_pairs = 0;
+        std::set<std::pair<SatelliteId, SignalType>> event_satellite_signals;
+    };
+
+    enum class TemporalCarrierShadowClassification {
+        Clean = 0,
+        WitnessedOutlier = 1,
+        UnexplainedOutlier = 2,
+    };
+
+    /// Diagnostic-only classification of one receiver-clock-free temporal
+    /// carrier difference.  None of these fields has estimator authority.
+    struct TemporalCarrierShadowFactorDiagnostics {
+        SingleDifferenceTdcpFactor factor;
+        double residual_m = 0.0;
+        double normalized_residual = 0.0;
+        bool residual_outlier = false;
+        bool doppler_evaluated = false;
+        double doppler_innovation_signed_m = 0.0;
+        double doppler_innovation_m = 0.0;
+        double doppler_innovation_sigma_m = 0.0;
+        double normalized_doppler_innovation = 0.0;
+        bool doppler_outlier = false;
+        bool doppler_calibration_evaluated = false;
+        double doppler_bias_m = 0.0;
+        double doppler_calibrated_scale_m = 0.0;
+        double doppler_centered_innovation_m = 0.0;
+        double doppler_calibrated_score = 0.0;
+        bool doppler_calibrated_outlier = false;
+        bool geometry_free_witness = false;
+        bool carrier_hold_witness = false;
+        bool carrier_fde_witness = false;
+        TemporalCarrierShadowClassification classification =
+            TemporalCarrierShadowClassification::Clean;
     };
 
     struct FGODiagnostics {
@@ -2097,6 +2139,9 @@ public:
         int clock_resilient_tdcp_factors = 0;
         double clock_resilient_tdcp_rms_m = 0.0;
         double clock_resilient_tdcp_max_abs_m = 0.0;
+        int clock_resilient_tdcp_clean = 0;
+        int clock_resilient_tdcp_witnessed_outliers = 0;
+        int clock_resilient_tdcp_unexplained_outliers = 0;
         double gdop = 0.0;
         int num_satellites = 0;
         int sd_doppler_factors = 0;
@@ -2238,6 +2283,8 @@ public:
         std::vector<LambdaDebugEntry> lambda_debug_entries;
         std::vector<CostTraceEntry> cost_trace_entries;
         std::vector<FGOEpochDiagnostics> epoch_diagnostics;
+        std::vector<TemporalCarrierShadowFactorDiagnostics>
+            temporal_carrier_shadow_factors;
         // Milestone 2b (populated only by the GTSAM IMU-coupled path):
         // per-epoch estimated attitude as [roll, pitch, heading] in degrees
         // (body FLU -> nav ENU; heading is clockwise from North) and estimated
@@ -2261,6 +2308,20 @@ public:
     buildClockResilientTemporalCarrierShadow(const FGOProblem& problem,
                                              double sigma_m = 0.003,
                                              double max_gap_s = 1.5);
+
+    /// Evaluate and classify a pre-built temporal-carrier shadow against a
+    /// supplied per-epoch ECEF trajectory. This routine is solver-independent
+    /// so a frozen solution CSV can replay diagnostics without rerunning GTSAM.
+    static std::vector<TemporalCarrierShadowFactorDiagnostics>
+    classifyClockResilientTemporalCarrierShadow(
+        const FGOProblem& problem,
+        const std::vector<SingleDifferenceTdcpFactor>& factors,
+        const std::vector<Vector3d>& epoch_positions_ecef,
+        std::vector<FGOEpochDiagnostics>& epoch_diagnostics,
+        const std::vector<GeometryFreeSlipShadowEpoch>* geometry_free_shadow =
+            nullptr,
+        const std::vector<std::set<std::size_t>>*
+            fde_rejected_ambiguities_by_epoch = nullptr);
 
     FGOProblem buildPseudorangeProblem(const std::vector<ObservationData>& epochs,
                                        const NavigationData& nav) const;

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -3202,6 +3202,192 @@ FGOProcessor::classifyClockResilientTemporalCarrierShadow(
     return classified_factors;
 }
 
+std::vector<FGOProcessor::PredictedDdprQualityFactorDiagnostics>
+FGOProcessor::analyzePredictedDdprQualityShadow(
+    const FGOProblem& problem,
+    const std::vector<Vector3d>& previous_solution_positions_ecef,
+    const std::vector<Vector3d>& predicted_positions_ecef,
+    double doppler_sigma_mps,
+    double normalized_outlier_threshold,
+    double max_gap_s) {
+    using Key = std::tuple<SatelliteId, SatelliteId, SignalType>;
+    struct History {
+        const DoubleDifferencePseudorangeFactor* factor = nullptr;
+        std::size_t epoch_index = 0;
+        double dd_doppler_mps = 0.0;
+        bool has_dd_doppler = false;
+        int pair_age_epochs = 0;
+    };
+
+    const auto finite_position = [](const Vector3d& position) {
+        return position.allFinite() && position.norm() > 0.0;
+    };
+    const auto dd_range = [](const DoubleDifferencePseudorangeFactor& factor,
+                             const Vector3d& rover_position_ecef) {
+        const double rover_target =
+            (factor.rover_satellite_position_ecef - rover_position_ecef).norm();
+        const double rover_reference =
+            (factor.rover_reference_position_ecef - rover_position_ecef).norm();
+        const double base_target =
+            (factor.base_satellite_position_ecef - factor.base_position_ecef)
+                .norm();
+        const double base_reference =
+            (factor.base_reference_position_ecef - factor.base_position_ecef)
+                .norm();
+        return (rover_target - base_target) -
+               (rover_reference - base_reference);
+    };
+    const auto dd_doppler = [](const DoubleDifferencePseudorangeFactor& factor,
+                               double& value) {
+        const auto& rt = factor.rover_satellite_model;
+        const auto& rr = factor.rover_reference_model;
+        const auto& bt = factor.base_satellite_model;
+        const auto& br = factor.base_reference_model;
+        if (!rt.has_doppler_residual || !rr.has_doppler_residual ||
+            !bt.has_doppler_residual || !br.has_doppler_residual) {
+            return false;
+        }
+        value = (rt.doppler_residual_mps - bt.doppler_residual_mps) -
+                (rr.doppler_residual_mps - br.doppler_residual_mps);
+        return std::isfinite(value);
+    };
+
+    const std::size_t num_epochs = problem.epochs.size();
+    std::vector<std::vector<const DoubleDifferencePseudorangeFactor*>>
+        factors_by_epoch(num_epochs);
+    for (const auto& factor : problem.double_difference_pseudorange_factors) {
+        if (factor.epoch_index < num_epochs) {
+            factors_by_epoch[factor.epoch_index].push_back(&factor);
+        }
+    }
+
+    const double safe_doppler_sigma = std::max(1e-6, doppler_sigma_mps);
+    const double safe_threshold = std::max(0.0, normalized_outlier_threshold);
+    const double safe_max_gap = std::max(0.0, max_gap_s);
+    std::map<Key, History> history;
+    std::vector<PredictedDdprQualityFactorDiagnostics> result;
+    result.reserve(problem.double_difference_pseudorange_factors.size());
+    for (std::size_t epoch_index = 0; epoch_index < num_epochs; ++epoch_index) {
+        std::map<Key, History> current;
+        for (const auto* factor : factors_by_epoch[epoch_index]) {
+            const Key key{factor->satellite, factor->reference_satellite,
+                          factor->signal};
+            double current_dd_doppler = 0.0;
+            const bool current_has_doppler =
+                dd_doppler(*factor, current_dd_doppler);
+            History current_history{factor, epoch_index, current_dd_doppler,
+                                    current_has_doppler, 1};
+            const auto prior = history.find(key);
+            if (prior == history.end()) {
+                current[key] = current_history;
+                continue;
+            }
+
+            const std::size_t previous_epoch_index = prior->second.epoch_index;
+            const double dt = problem.epochs[epoch_index].time -
+                              problem.epochs[previous_epoch_index].time;
+            if (previous_epoch_index + 1 != epoch_index || dt <= 0.0 ||
+                (safe_max_gap > 0.0 && dt > safe_max_gap)) {
+                current[key] = current_history;
+                continue;
+            }
+
+            current_history.pair_age_epochs = prior->second.pair_age_epochs + 1;
+            current[key] = current_history;
+            PredictedDdprQualityFactorDiagnostics diagnostic;
+            diagnostic.previous_epoch_index = previous_epoch_index;
+            diagnostic.current_epoch_index = epoch_index;
+            diagnostic.satellite = factor->satellite;
+            diagnostic.reference_satellite = factor->reference_satellite;
+            diagnostic.signal = factor->signal;
+            diagnostic.dt_s = dt;
+            diagnostic.pair_age_epochs = current_history.pair_age_epochs;
+            diagnostic.measured_ddpr_change_m =
+                factor->observed_dd_pseudorange_m -
+                prior->second.factor->observed_dd_pseudorange_m;
+            diagnostic.elevation_rad = std::min(
+                factor->rover_satellite_model.elevation_rad,
+                factor->rover_reference_model.elevation_rad);
+            diagnostic.target_snr_dbhz =
+                factor->rover_satellite_model.snr_dbhz;
+            diagnostic.reference_snr_dbhz =
+                factor->rover_reference_model.snr_dbhz;
+
+            if (current_has_doppler && prior->second.has_dd_doppler) {
+                diagnostic.doppler_evaluated = true;
+                diagnostic.doppler_predicted_change_m =
+                    0.5 * (prior->second.dd_doppler_mps +
+                           current_dd_doppler) *
+                    dt;
+                diagnostic.doppler_innovation_m =
+                    diagnostic.measured_ddpr_change_m -
+                    diagnostic.doppler_predicted_change_m;
+                const double measured_sigma = std::hypot(
+                    prior->second.factor->sigma_m, factor->sigma_m);
+                // Four receiver/satellite Doppler terms form each DD. The
+                // trapezoidal difference uses two epochs, yielding
+                // sqrt(2)*dt*sigma for equal independent link sigmas.
+                const double integrated_doppler_sigma =
+                    std::sqrt(2.0) * dt * safe_doppler_sigma;
+                diagnostic.doppler_innovation_sigma_m =
+                    std::hypot(measured_sigma, integrated_doppler_sigma);
+                diagnostic.normalized_doppler_innovation =
+                    std::abs(diagnostic.doppler_innovation_m) /
+                    diagnostic.doppler_innovation_sigma_m;
+            }
+
+            if (previous_epoch_index <
+                    previous_solution_positions_ecef.size() &&
+                epoch_index < predicted_positions_ecef.size() &&
+                finite_position(previous_solution_positions_ecef[
+                    previous_epoch_index]) &&
+                finite_position(predicted_positions_ecef[epoch_index])) {
+                diagnostic.imu_geometry_evaluated = true;
+                diagnostic.imu_predicted_change_m =
+                    dd_range(*factor, predicted_positions_ecef[epoch_index]) -
+                    dd_range(*prior->second.factor,
+                             previous_solution_positions_ecef[
+                                 previous_epoch_index]);
+                diagnostic.previous_predicted_ddpr_residual_m =
+                    prior->second.factor->observed_dd_pseudorange_m -
+                    dd_range(*prior->second.factor,
+                             previous_solution_positions_ecef[
+                                 previous_epoch_index]);
+                diagnostic.current_predicted_ddpr_residual_m =
+                    factor->observed_dd_pseudorange_m -
+                    dd_range(*factor,
+                             predicted_positions_ecef[epoch_index]);
+                diagnostic.imu_innovation_m =
+                    diagnostic.measured_ddpr_change_m -
+                    diagnostic.imu_predicted_change_m;
+                diagnostic.imu_innovation_sigma_m = std::hypot(
+                    prior->second.factor->sigma_m, factor->sigma_m);
+                diagnostic.normalized_imu_innovation =
+                    std::abs(diagnostic.imu_innovation_m) /
+                    std::max(1e-6, diagnostic.imu_innovation_sigma_m);
+            }
+
+            if (!diagnostic.doppler_evaluated &&
+                !diagnostic.imu_geometry_evaluated) {
+                diagnostic.proposed_action =
+                    PredictedDdprQualityAction::Unavailable;
+            } else {
+                diagnostic.proposed_action = PredictedDdprQualityAction::Keep;
+                if (diagnostic.doppler_evaluated &&
+                    diagnostic.imu_geometry_evaluated &&
+                    diagnostic.normalized_doppler_innovation > safe_threshold &&
+                    diagnostic.normalized_imu_innovation > safe_threshold) {
+                    diagnostic.proposed_action =
+                        PredictedDdprQualityAction::Downweight;
+                }
+            }
+            result.push_back(diagnostic);
+        }
+        history = std::move(current);
+    }
+    return result;
+}
+
 FGOProcessor::FGOResult FGOProcessor::optimize(
     const std::vector<ObservationData>& rover_epochs,
     const std::vector<ObservationData>& base_epochs,

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -2770,6 +2770,10 @@ FGOProcessor::analyzeGeometryFreeSlipShadow(const FGOProblem& problem,
                                 ++shadow[epoch_index].event_pairs;
                                 shadow[epoch_index].max_jump_m = std::max(
                                     shadow[epoch_index].max_jump_m, jump);
+                                shadow[epoch_index].event_satellite_signals.insert(
+                                    {satellite, samples[first].first});
+                                shadow[epoch_index].event_satellite_signals.insert(
+                                    {satellite, samples[second].first});
                                 tainted_ambiguities.insert(
                                     first_sample.ambiguity_indices.begin(),
                                     first_sample.ambiguity_indices.end());
@@ -2821,6 +2825,10 @@ FGOProcessor::buildClockResilientTemporalCarrierShadow(
         std::size_t epoch_index = 0;
         double residual_m = 0.0;
         Vector3d los = Vector3d::Zero();
+        int arc_length_epochs = 1;
+        bool has_sd_doppler = false;
+        double sd_doppler_mps = 0.0;
+        double sd_doppler_sigma_mps = 0.0;
     };
 
     const auto& observations = problem.carrier_observations.empty()
@@ -2899,7 +2907,20 @@ FGOProcessor::buildClockResilientTemporalCarrierShadow(
                 const HistoryKey history_key{observation->satellite,
                                              reference->satellite,
                                              observation->signal};
-                current[history_key] = {epoch_index, residual, los};
+                const bool has_sd_doppler =
+                    observation->has_doppler_residual &&
+                    reference->has_doppler_residual;
+                const double sd_doppler_mps = has_sd_doppler
+                    ? observation->doppler_residual_mps -
+                          reference->doppler_residual_mps
+                    : 0.0;
+                const double sd_doppler_sigma_mps = has_sd_doppler
+                    ? std::hypot(observation->doppler_sigma_mps,
+                                 reference->doppler_sigma_mps)
+                    : 0.0;
+                current[history_key] = {epoch_index, residual, los, 1,
+                                        has_sd_doppler, sd_doppler_mps,
+                                        sd_doppler_sigma_mps};
 
                 const auto prior = previous.find(history_key);
                 if (prior == previous.end()) {
@@ -2925,6 +2946,20 @@ FGOProcessor::buildClockResilientTemporalCarrierShadow(
                 factor.previous_los = prior->second.los;
                 factor.los = los;
                 factor.delta_carrier_m = delta;
+                factor.target_ambiguity_index = observation->ambiguity_index;
+                factor.reference_ambiguity_index = reference->ambiguity_index;
+                factor.arc_length_epochs = prior->second.arc_length_epochs + 1;
+                factor.dt_s = dt;
+                factor.has_doppler_witness =
+                    prior->second.has_sd_doppler && has_sd_doppler;
+                factor.previous_sd_doppler_mps =
+                    prior->second.sd_doppler_mps;
+                factor.current_sd_doppler_mps = sd_doppler_mps;
+                factor.previous_sd_doppler_sigma_mps =
+                    prior->second.sd_doppler_sigma_mps;
+                factor.current_sd_doppler_sigma_mps =
+                    sd_doppler_sigma_mps;
+                current[history_key].arc_length_epochs = factor.arc_length_epochs;
                 const double sin_el = std::max(
                     0.1, std::sin(std::min(observation->elevation_rad,
                                            reference->elevation_rad)));
@@ -2938,6 +2973,233 @@ FGOProcessor::buildClockResilientTemporalCarrierShadow(
         previous = std::move(current);
     }
     return factors;
+}
+
+std::vector<FGOProcessor::TemporalCarrierShadowFactorDiagnostics>
+FGOProcessor::classifyClockResilientTemporalCarrierShadow(
+    const FGOProblem& problem,
+    const std::vector<SingleDifferenceTdcpFactor>& factors,
+    const std::vector<Vector3d>& epoch_positions_ecef,
+    std::vector<FGOEpochDiagnostics>& epoch_diagnostics,
+    const std::vector<GeometryFreeSlipShadowEpoch>* geometry_free_shadow,
+    const std::vector<std::set<std::size_t>>*
+        fde_rejected_ambiguities_by_epoch) {
+    const std::size_t num_epochs = problem.epochs.size();
+    if (epoch_diagnostics.size() < num_epochs) {
+        epoch_diagnostics.resize(num_epochs);
+    }
+    if (epoch_positions_ecef.size() < num_epochs) {
+        return {};
+    }
+
+    using DopplerKey =
+        std::tuple<std::size_t, SatelliteId, SatelliteId, SignalType>;
+    std::map<DopplerKey, SingleDifferenceDopplerFactor> sd_doppler_by_factor;
+    for (const auto& doppler : problem.single_difference_doppler_factors) {
+        sd_doppler_by_factor[{doppler.epoch_index, doppler.satellite,
+                              doppler.reference_satellite, doppler.signal}] =
+            doppler;
+    }
+
+    constexpr double kResidualOutlierThresholdM = 0.10;
+    constexpr double kDopplerNormalizedInnovationThreshold = 5.0;
+    constexpr std::size_t kDopplerCalibrationWarmup = 10;
+    constexpr std::size_t kDopplerCalibrationWindow = 30;
+    constexpr double kDopplerCalibratedScoreThreshold = 5.0;
+    using DopplerCalibrationKey =
+        std::tuple<std::size_t, SatelliteId, SatelliteId, SignalType>;
+    std::map<DopplerCalibrationKey, std::vector<double>>
+        doppler_innovation_history;
+    const auto median = [](std::vector<double> values) {
+        const std::size_t middle = values.size() / 2;
+        std::nth_element(values.begin(), values.begin() + middle, values.end());
+        double value = values[middle];
+        if (values.size() % 2 == 0) {
+            const auto lower =
+                std::max_element(values.begin(), values.begin() + middle);
+            value = 0.5 * (value + *lower);
+        }
+        return value;
+    };
+
+    std::vector<double> sum_sq(num_epochs, 0.0);
+    std::vector<TemporalCarrierShadowFactorDiagnostics> classified_factors;
+    classified_factors.reserve(factors.size());
+    for (const auto& factor : factors) {
+        if (factor.previous_epoch_index >= num_epochs ||
+            factor.current_epoch_index >= num_epochs) {
+            continue;
+        }
+        const Vector3d previous_delta =
+            epoch_positions_ecef[factor.previous_epoch_index] -
+            problem.epochs[factor.previous_epoch_index].position_ecef;
+        const Vector3d current_delta =
+            epoch_positions_ecef[factor.current_epoch_index] -
+            problem.epochs[factor.current_epoch_index].position_ecef;
+        const double predicted = factor.los.dot(current_delta) -
+                                 factor.previous_los.dot(previous_delta);
+        const double residual = factor.delta_carrier_m - predicted;
+        if (!std::isfinite(residual)) {
+            continue;
+        }
+        auto& diagnostics = epoch_diagnostics[factor.current_epoch_index];
+        ++diagnostics.clock_resilient_tdcp_factors;
+        sum_sq[factor.current_epoch_index] += residual * residual;
+        diagnostics.clock_resilient_tdcp_max_abs_m =
+            std::max(diagnostics.clock_resilient_tdcp_max_abs_m,
+                     std::abs(residual));
+
+        TemporalCarrierShadowFactorDiagnostics classified;
+        classified.factor = factor;
+        classified.residual_m = residual;
+        classified.normalized_residual =
+            residual / std::max(1e-4, factor.sigma_m);
+        classified.residual_outlier =
+            std::abs(residual) > kResidualOutlierThresholdM;
+
+        const auto evaluate_doppler = [&](double previous_mps,
+                                          double current_mps,
+                                          double previous_sigma_mps,
+                                          double current_sigma_mps,
+                                          double dt) {
+            if (dt <= 0.0 || !std::isfinite(dt) ||
+                previous_sigma_mps <= 0.0 || current_sigma_mps <= 0.0) {
+                return;
+            }
+            const double predicted_delta =
+                0.5 * (previous_mps + current_mps) * dt;
+            classified.doppler_innovation_signed_m =
+                factor.delta_carrier_m - predicted_delta;
+            classified.doppler_innovation_m =
+                std::abs(classified.doppler_innovation_signed_m);
+            const double integrated_doppler_sigma_m =
+                0.5 * dt *
+                std::hypot(previous_sigma_mps, current_sigma_mps);
+            classified.doppler_innovation_sigma_m =
+                std::hypot(factor.sigma_m, integrated_doppler_sigma_m);
+            classified.normalized_doppler_innovation =
+                classified.doppler_innovation_m /
+                std::max(1e-4, classified.doppler_innovation_sigma_m);
+            classified.doppler_evaluated =
+                std::isfinite(classified.doppler_innovation_m) &&
+                std::isfinite(classified.normalized_doppler_innovation);
+            classified.doppler_outlier =
+                classified.doppler_evaluated &&
+                classified.normalized_doppler_innovation >
+                    kDopplerNormalizedInnovationThreshold;
+        };
+        if (factor.has_doppler_witness) {
+            evaluate_doppler(factor.previous_sd_doppler_mps,
+                             factor.current_sd_doppler_mps,
+                             factor.previous_sd_doppler_sigma_mps,
+                             factor.current_sd_doppler_sigma_mps, factor.dt_s);
+        } else {
+            const DopplerKey previous_key{
+                factor.previous_epoch_index, factor.satellite,
+                factor.reference_satellite, factor.signal};
+            const DopplerKey current_key{
+                factor.current_epoch_index, factor.satellite,
+                factor.reference_satellite, factor.signal};
+            const auto previous_doppler = sd_doppler_by_factor.find(previous_key);
+            const auto current_doppler = sd_doppler_by_factor.find(current_key);
+            if (previous_doppler != sd_doppler_by_factor.end() &&
+                current_doppler != sd_doppler_by_factor.end()) {
+                const double dt =
+                    problem.epochs[factor.current_epoch_index].time -
+                    problem.epochs[factor.previous_epoch_index].time;
+                evaluate_doppler(previous_doppler->second.residual_mps,
+                                 current_doppler->second.residual_mps,
+                                 previous_doppler->second.sigma_mps,
+                                 current_doppler->second.sigma_mps, dt);
+            }
+        }
+
+        if (classified.doppler_evaluated && factor.arc_length_epochs >= 2) {
+            const std::size_t arc_start_epoch =
+                factor.current_epoch_index + 1 -
+                static_cast<std::size_t>(factor.arc_length_epochs);
+            const DopplerCalibrationKey key{
+                arc_start_epoch, factor.satellite,
+                factor.reference_satellite, factor.signal};
+            auto& history = doppler_innovation_history[key];
+            if (history.size() >= kDopplerCalibrationWarmup) {
+                classified.doppler_bias_m = median(history);
+                std::vector<double> deviations;
+                deviations.reserve(history.size());
+                for (const double sample : history) {
+                    deviations.push_back(
+                        std::abs(sample - classified.doppler_bias_m));
+                }
+                const double robust_sigma_m = 1.4826 * median(deviations);
+                classified.doppler_calibrated_scale_m = std::max(
+                    {1e-4, classified.doppler_innovation_sigma_m,
+                     robust_sigma_m});
+                classified.doppler_centered_innovation_m =
+                    classified.doppler_innovation_signed_m -
+                    classified.doppler_bias_m;
+                classified.doppler_calibrated_score =
+                    std::abs(classified.doppler_centered_innovation_m) /
+                    classified.doppler_calibrated_scale_m;
+                classified.doppler_calibration_evaluated =
+                    std::isfinite(classified.doppler_calibrated_score);
+                classified.doppler_calibrated_outlier =
+                    classified.doppler_calibration_evaluated &&
+                    classified.doppler_calibrated_score >
+                        kDopplerCalibratedScoreThreshold;
+            }
+            history.push_back(classified.doppler_innovation_signed_m);
+            if (history.size() > kDopplerCalibrationWindow) {
+                history.erase(history.begin());
+            }
+        }
+
+        if (geometry_free_shadow != nullptr &&
+            factor.current_epoch_index < geometry_free_shadow->size()) {
+            const auto& events =
+                (*geometry_free_shadow)[factor.current_epoch_index]
+                    .event_satellite_signals;
+            classified.geometry_free_witness =
+                events.count({factor.satellite, factor.signal}) != 0 ||
+                events.count({factor.reference_satellite, factor.signal}) != 0;
+        }
+        classified.carrier_hold_witness = diagnostics.carrier_hold_active;
+        if (fde_rejected_ambiguities_by_epoch != nullptr &&
+            factor.current_epoch_index <
+                fde_rejected_ambiguities_by_epoch->size()) {
+            const auto& rejected = (*fde_rejected_ambiguities_by_epoch)
+                [factor.current_epoch_index];
+            classified.carrier_fde_witness =
+                rejected.count(factor.target_ambiguity_index) != 0 ||
+                rejected.count(factor.reference_ambiguity_index) != 0;
+        }
+
+        const bool witnessed = classified.doppler_calibrated_outlier ||
+            classified.geometry_free_witness ||
+            classified.carrier_hold_witness ||
+            classified.carrier_fde_witness;
+        if (!classified.residual_outlier) {
+            classified.classification =
+                TemporalCarrierShadowClassification::Clean;
+            ++diagnostics.clock_resilient_tdcp_clean;
+        } else if (witnessed) {
+            classified.classification =
+                TemporalCarrierShadowClassification::WitnessedOutlier;
+            ++diagnostics.clock_resilient_tdcp_witnessed_outliers;
+        } else {
+            classified.classification =
+                TemporalCarrierShadowClassification::UnexplainedOutlier;
+            ++diagnostics.clock_resilient_tdcp_unexplained_outliers;
+        }
+        classified_factors.push_back(std::move(classified));
+    }
+    for (std::size_t i = 0; i < num_epochs; ++i) {
+        const int count = epoch_diagnostics[i].clock_resilient_tdcp_factors;
+        if (count > 0) {
+            epoch_diagnostics[i].clock_resilient_tdcp_rms_m =
+                std::sqrt(sum_sq[i] / static_cast<double>(count));
+        }
+    }
+    return classified_factors;
 }
 
 FGOProcessor::FGOResult FGOProcessor::optimize(

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -1079,6 +1079,8 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
 
     // Per-epoch outputs.
     std::vector<Point3> epoch_float_position(num_epochs, Point3(0, 0, 0));
+    std::vector<Vector3d> epoch_predicted_position(
+        num_epochs, Vector3d::Zero());
     std::vector<Point3> epoch_fixed_position(num_epochs, Point3(0, 0, 0));
     std::vector<bool> epoch_has_fixed(num_epochs, false);
     std::vector<bool> epoch_fixed(num_epochs, false);
@@ -2213,6 +2215,7 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                     gtsam::noiseModel::Isotropic::Sigma(6, 1.0));
             }
         }
+        epoch_predicted_position[i] = antennaOf(pose_seed);
         new_values.insert(positionKey(i), pose_seed);
         new_values.insert(velocityKey(i), vel_seed);
         new_values.insert(biasKey(i), prev_bias);
@@ -5865,6 +5868,13 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 problem, clock_resilient_tdcp_shadow, epoch_float_position,
                 epoch_diagnostics, &gf_slip_shadow,
                 &fde_rejected_ambiguities_by_epoch);
+    }
+    if (config.monitor_predicted_ddpr_quality) {
+        result.predicted_ddpr_quality_factors = FGOProcessor::
+            analyzePredictedDdprQualityShadow(
+                problem, epoch_float_position, epoch_predicted_position,
+                config.single_difference_doppler_sigma_mps, 5.0,
+                config.max_tdcp_gap_s);
     }
     const bool have_amb = !problem.ambiguity_states.empty();
     result.epoch_diagnostics = std::move(epoch_diagnostics);

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -880,7 +880,9 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
     const auto start_time = std::chrono::high_resolution_clock::now();
 
     const std::size_t num_epochs = problem.epochs.size();
-    const auto gf_slip_shadow = config.monitor_geometry_free_cycle_slip
+    const auto gf_slip_shadow =
+        (config.monitor_geometry_free_cycle_slip ||
+         config.monitor_clock_resilient_temporal_carrier)
         ? FGOProcessor::analyzeGeometryFreeSlipShadow(
               problem, 0.05, config.max_tdcp_gap_s)
         : std::vector<FGOProcessor::GeometryFreeSlipShadowEpoch>{};
@@ -1090,6 +1092,8 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
     std::vector<Vector3d> epoch_vel_nav(num_epochs, Vector3d::Zero());
     std::vector<bool> epoch_solved(num_epochs, false);
     std::vector<FGOProcessor::FGOEpochDiagnostics> epoch_diagnostics(num_epochs);
+    std::vector<std::set<std::size_t>> fde_rejected_ambiguities_by_epoch(
+        num_epochs);
     std::map<std::size_t, double> amb_float_cycles;
     std::map<std::size_t, int> amb_fixed_cycles;
     std::map<std::size_t, double> amb_fixed_residual;
@@ -3213,6 +3217,7 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             std::set<std::size_t> fde_rejected_amb;
             const std::size_t fde_removed =
                 runFde(i, fde_local_indices, fde_new_indices, &fde_rejected_amb);
+            fde_rejected_ambiguities_by_epoch[i] = fde_rejected_amb;
             const std::size_t pr_rejected =
                 result.diagnostics.fde_pseudorange_rejections -
                 pr_rejections_before;
@@ -5855,40 +5860,12 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
     // for each epoch's FINAL window-exit pose, which is a larger, separately
     // scoped change.
     if (!clock_resilient_tdcp_shadow.empty()) {
-        std::vector<double> sum_sq(num_epochs, 0.0);
-        for (const auto& factor : clock_resilient_tdcp_shadow) {
-            if (factor.previous_epoch_index >= num_epochs ||
-                factor.current_epoch_index >= num_epochs) {
-                continue;
-            }
-            const Vector3d previous_delta =
-                epoch_float_position[factor.previous_epoch_index] -
-                problem.epochs[factor.previous_epoch_index].position_ecef;
-            const Vector3d current_delta =
-                epoch_float_position[factor.current_epoch_index] -
-                problem.epochs[factor.current_epoch_index].position_ecef;
-            const double predicted = factor.los.dot(current_delta) -
-                                     factor.previous_los.dot(previous_delta);
-            const double residual = factor.delta_carrier_m - predicted;
-            if (!std::isfinite(residual)) {
-                continue;
-            }
-            auto& diagnostics = epoch_diagnostics[factor.current_epoch_index];
-            ++diagnostics.clock_resilient_tdcp_factors;
-            sum_sq[factor.current_epoch_index] += residual * residual;
-            diagnostics.clock_resilient_tdcp_max_abs_m =
-                std::max(diagnostics.clock_resilient_tdcp_max_abs_m,
-                         std::abs(residual));
-        }
-        for (std::size_t i = 0; i < num_epochs; ++i) {
-            const int count = epoch_diagnostics[i].clock_resilient_tdcp_factors;
-            if (count > 0) {
-                epoch_diagnostics[i].clock_resilient_tdcp_rms_m =
-                    std::sqrt(sum_sq[i] / static_cast<double>(count));
-            }
-        }
+        result.temporal_carrier_shadow_factors = FGOProcessor::
+            classifyClockResilientTemporalCarrierShadow(
+                problem, clock_resilient_tdcp_shadow, epoch_float_position,
+                epoch_diagnostics, &gf_slip_shadow,
+                &fde_rejected_ambiguities_by_epoch);
     }
-
     const bool have_amb = !problem.ambiguity_states.empty();
     result.epoch_diagnostics = std::move(epoch_diagnostics);
     result.epoch_attitude_rpy_deg.resize(num_epochs);

--- a/tests/test_fgo.cpp
+++ b/tests/test_fgo.cpp
@@ -845,6 +845,11 @@ TEST(FGOTest, ClockResilientTemporalCarrierShadowCancelsCommonClockJump) {
             current_satellite->los - current_reference->los;
         EXPECT_LT((factor.previous_los - previous_los).norm(), 1e-12);
         EXPECT_LT((factor.los - current_los).norm(), 1e-12);
+        EXPECT_EQ(factor.target_ambiguity_index,
+                  current_satellite->ambiguity_index);
+        EXPECT_EQ(factor.reference_ambiguity_index,
+                  current_reference->ambiguity_index);
+        EXPECT_EQ(factor.arc_length_epochs, 2);
         max_previous_current_los_delta = std::max(
             max_previous_current_los_delta,
             (factor.previous_los - factor.los).norm());

--- a/tests/test_fgo.cpp
+++ b/tests/test_fgo.cpp
@@ -876,6 +876,126 @@ TEST(FGOTest, ClockResilientTemporalCarrierShadowCancelsCommonClockJump) {
         << "a new reference must start a fresh temporal arc";
 }
 
+TEST(FGOTest, PredictedDdprQualityShadowIsClockSafeAndFailClosed) {
+    FGOProcessor::FGOProblem problem;
+    problem.epochs.resize(2);
+    problem.epochs[0].time = GNSSTime(2300, 100000.0);
+    problem.epochs[1].time = GNSSTime(2300, 100001.0);
+
+    const Vector3d rover0(1113194.0, -4841695.0, 3985350.0);
+    const Vector3d rover1 = rover0 + Vector3d(12.0, 4.0, -1.0);
+    const Vector3d base = rover0 + Vector3d(-320.0, 180.0, 45.0);
+    const Vector3d target_satellite(15600000.0, 7540000.0, 20140000.0);
+    const Vector3d reference_satellite(-18760000.0, 2750000.0,
+                                        18610000.0);
+    const auto dd_range = [&](const Vector3d& rover) {
+        return ((target_satellite - rover).norm() -
+                (target_satellite - base).norm()) -
+               ((reference_satellite - rover).norm() -
+                (reference_satellite - base).norm());
+    };
+    const double geometry0 = dd_range(rover0);
+    const double geometry1 = dd_range(rover1);
+    const double dd_rate = geometry1 - geometry0;
+
+    const auto make_factor = [&](std::size_t epoch, double geometry,
+                                 double rover_clock_m,
+                                 double base_clock_m) {
+        FGOProcessor::DoubleDifferencePseudorangeFactor factor;
+        factor.epoch_index = epoch;
+        factor.satellite = SatelliteId(GNSSSystem::GPS, 5);
+        factor.reference_satellite = SatelliteId(GNSSSystem::GPS, 11);
+        factor.signal = SignalType::GPS_L1CA;
+        factor.rover_satellite_position_ecef = target_satellite;
+        factor.rover_reference_position_ecef = reference_satellite;
+        factor.base_satellite_position_ecef = target_satellite;
+        factor.base_reference_position_ecef = reference_satellite;
+        factor.base_position_ecef = base;
+        const double rover_target = (target_satellite -
+            (epoch == 0 ? rover0 : rover1)).norm();
+        const double rover_reference = (reference_satellite -
+            (epoch == 0 ? rover0 : rover1)).norm();
+        const double base_target = (target_satellite - base).norm();
+        const double base_reference = (reference_satellite - base).norm();
+        factor.observed_dd_pseudorange_m =
+            ((rover_target + rover_clock_m) -
+             (base_target + base_clock_m)) -
+            ((rover_reference + rover_clock_m) -
+             (base_reference + base_clock_m));
+        EXPECT_NEAR(factor.observed_dd_pseudorange_m, geometry, 1e-8);
+        factor.sigma_m = 0.5;
+        factor.rover_satellite_model.has_doppler_residual = true;
+        factor.rover_reference_model.has_doppler_residual = true;
+        factor.base_satellite_model.has_doppler_residual = true;
+        factor.base_reference_model.has_doppler_residual = true;
+        factor.rover_satellite_model.doppler_residual_mps = dd_rate;
+        factor.rover_satellite_model.elevation_rad = 0.8;
+        factor.rover_reference_model.elevation_rad = 0.9;
+        factor.rover_satellite_model.snr_dbhz = 42.0;
+        factor.rover_reference_model.snr_dbhz = 44.0;
+        return factor;
+    };
+    problem.double_difference_pseudorange_factors.push_back(
+        make_factor(0, geometry0, 25.0, -10.0));
+    // A roughly one-millisecond common rover clock jump cancels in the DD.
+    problem.double_difference_pseudorange_factors.push_back(
+        make_factor(1, geometry1, 299817.458, -10.0));
+
+    const std::vector<Vector3d> solved = {rover0, rover1};
+    const std::vector<Vector3d> predicted = {rover0, rover1};
+    const auto clean = FGOProcessor::analyzePredictedDdprQualityShadow(
+        problem, solved, predicted, 0.2, 5.0, 1.5);
+    ASSERT_EQ(clean.size(), 1u);
+    EXPECT_TRUE(clean[0].doppler_evaluated);
+    EXPECT_TRUE(clean[0].imu_geometry_evaluated);
+    EXPECT_NEAR(clean[0].doppler_innovation_m, 0.0, 1e-8);
+    EXPECT_NEAR(clean[0].imu_innovation_m, 0.0, 1e-8);
+    EXPECT_NEAR(clean[0].previous_predicted_ddpr_residual_m, 0.0, 1e-8);
+    EXPECT_NEAR(clean[0].current_predicted_ddpr_residual_m, 0.0, 1e-8);
+    EXPECT_EQ(clean[0].pair_age_epochs, 2);
+    EXPECT_EQ(clean[0].proposed_action,
+              FGOProcessor::PredictedDdprQualityAction::Keep);
+
+    auto outlier_problem = problem;
+    outlier_problem.double_difference_pseudorange_factors[1]
+        .observed_dd_pseudorange_m += 20.0;
+    const auto outlier = FGOProcessor::analyzePredictedDdprQualityShadow(
+        outlier_problem, solved, predicted, 0.2, 5.0, 1.5);
+    ASSERT_EQ(outlier.size(), 1u);
+    EXPECT_GT(outlier[0].normalized_doppler_innovation, 5.0);
+    EXPECT_GT(outlier[0].normalized_imu_innovation, 5.0);
+    EXPECT_NEAR(outlier[0].current_predicted_ddpr_residual_m, 20.0, 1e-8);
+    EXPECT_EQ(outlier[0].proposed_action,
+              FGOProcessor::PredictedDdprQualityAction::Downweight);
+
+    auto unavailable_problem = problem;
+    for (auto& factor :
+         unavailable_problem.double_difference_pseudorange_factors) {
+        factor.rover_satellite_model.has_doppler_residual = false;
+        factor.rover_reference_model.has_doppler_residual = false;
+        factor.base_satellite_model.has_doppler_residual = false;
+        factor.base_reference_model.has_doppler_residual = false;
+    }
+    const std::vector<Vector3d> unavailable_positions(2, Vector3d::Zero());
+    const auto unavailable =
+        FGOProcessor::analyzePredictedDdprQualityShadow(
+            unavailable_problem, unavailable_positions,
+            unavailable_positions);
+    ASSERT_EQ(unavailable.size(), 1u);
+    EXPECT_FALSE(unavailable[0].doppler_evaluated);
+    EXPECT_FALSE(unavailable[0].imu_geometry_evaluated);
+    EXPECT_EQ(unavailable[0].proposed_action,
+              FGOProcessor::PredictedDdprQualityAction::Unavailable);
+
+    auto switched_reference_problem = problem;
+    switched_reference_problem.double_difference_pseudorange_factors[1]
+        .reference_satellite = SatelliteId(GNSSSystem::GPS, 12);
+    const auto switched =
+        FGOProcessor::analyzePredictedDdprQualityShadow(
+            switched_reference_problem, solved, predicted);
+    EXPECT_TRUE(switched.empty());
+}
+
 TEST(FGOTest, RobustLossDownweightsPseudorangeOutlier) {
     FGOProcessor::FGOProblem problem = makeSyntheticProblem();
     for (auto& factor : problem.pseudorange_factors) {

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -718,6 +718,42 @@ TEST(FGOClockResilientTemporalCarrierShadowTest,
         }));
 }
 
+TEST(FGOPredictedDdprQualityShadowTest,
+     ReportsCausalRowsWithoutChangingFixedLagSolution) {
+    CpHoldTestOptions opt;
+    opt.num_epochs = 3;
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig off_config = makeCpHoldBaseConfig();
+    const auto off_result = FGOProcessor(off_config).optimizeProblem(problem);
+
+    FGOProcessor::FGOConfig on_config = off_config;
+    on_config.monitor_predicted_ddpr_quality = true;
+    const auto on_result = FGOProcessor(on_config).optimizeProblem(problem);
+
+    ASSERT_EQ(off_result.solution.solutions.size(),
+              on_result.solution.solutions.size());
+    for (std::size_t i = 0; i < off_result.solution.solutions.size(); ++i) {
+        EXPECT_TRUE(off_result.solution.solutions[i].position_ecef.isApprox(
+            on_result.solution.solutions[i].position_ecef, 0.0));
+        EXPECT_EQ(off_result.solution.solutions[i].status,
+                  on_result.solution.solutions[i].status);
+    }
+    ASSERT_FALSE(on_result.predicted_ddpr_quality_factors.empty());
+    bool saw_imu_geometry = false;
+    for (const auto& row : on_result.predicted_ddpr_quality_factors) {
+        EXPECT_GE(row.pair_age_epochs, 2);
+        EXPECT_GT(row.dt_s, 0.0);
+        EXPECT_TRUE(std::isfinite(row.measured_ddpr_change_m));
+        if (row.imu_geometry_evaluated) {
+            saw_imu_geometry = true;
+            EXPECT_GT(row.imu_innovation_sigma_m, 0.0);
+            EXPECT_TRUE(std::isfinite(row.normalized_imu_innovation));
+        }
+    }
+    EXPECT_TRUE(saw_imu_geometry);
+}
+
 TEST(FGOAmbiguityCandidateTelemetryTest,
      ReportsFinalCandidatesAtInsufficientCountDecision) {
     CpHoldTestOptions opt;

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -602,6 +602,120 @@ TEST(FGOClockResilientTemporalCarrierShadowTest,
             on_result.epoch_diagnostics[i].clock_resilient_tdcp_max_abs_m));
     }
     EXPECT_GT(total_shadow_factors, 0);
+    ASSERT_EQ(on_result.temporal_carrier_shadow_factors.size(),
+              static_cast<std::size_t>(total_shadow_factors));
+    std::vector<Vector3d> replay_positions;
+    replay_positions.reserve(on_result.solution.solutions.size());
+    for (const auto& solution : on_result.solution.solutions) {
+        replay_positions.push_back(solution.position_ecef);
+    }
+    auto replay_epoch_diagnostics = on_result.epoch_diagnostics;
+    for (auto& diagnostics : replay_epoch_diagnostics) {
+        diagnostics.clock_resilient_tdcp_factors = 0;
+        diagnostics.clock_resilient_tdcp_rms_m = 0.0;
+        diagnostics.clock_resilient_tdcp_max_abs_m = 0.0;
+        diagnostics.clock_resilient_tdcp_clean = 0;
+        diagnostics.clock_resilient_tdcp_witnessed_outliers = 0;
+        diagnostics.clock_resilient_tdcp_unexplained_outliers = 0;
+    }
+    const auto replay_shadow =
+        FGOProcessor::buildClockResilientTemporalCarrierShadow(problem);
+    const auto replay_geometry_free =
+        FGOProcessor::analyzeGeometryFreeSlipShadow(problem);
+    const auto replay_rows =
+        FGOProcessor::classifyClockResilientTemporalCarrierShadow(
+            problem, replay_shadow, replay_positions,
+            replay_epoch_diagnostics, &replay_geometry_free);
+    ASSERT_EQ(replay_rows.size(),
+              on_result.temporal_carrier_shadow_factors.size());
+    for (std::size_t i = 0; i < replay_rows.size(); ++i) {
+        EXPECT_DOUBLE_EQ(replay_rows[i].residual_m,
+                         on_result.temporal_carrier_shadow_factors[i].residual_m);
+        EXPECT_DOUBLE_EQ(
+            replay_rows[i].normalized_doppler_innovation,
+            on_result.temporal_carrier_shadow_factors[i]
+                .normalized_doppler_innovation);
+        EXPECT_EQ(replay_rows[i].classification,
+                  on_result.temporal_carrier_shadow_factors[i].classification);
+    }
+    int classified_total = 0;
+    for (const auto& epoch : on_result.epoch_diagnostics) {
+        classified_total += epoch.clock_resilient_tdcp_clean;
+        classified_total += epoch.clock_resilient_tdcp_witnessed_outliers;
+        classified_total += epoch.clock_resilient_tdcp_unexplained_outliers;
+    }
+    EXPECT_EQ(classified_total, total_shadow_factors);
+    for (const auto& row : on_result.temporal_carrier_shadow_factors) {
+        EXPECT_TRUE(std::isfinite(row.residual_m));
+        EXPECT_TRUE(std::isfinite(row.normalized_residual));
+        EXPECT_GE(row.factor.arc_length_epochs, 2);
+        if (row.doppler_evaluated) {
+            EXPECT_GT(row.doppler_innovation_sigma_m, 0.0);
+            EXPECT_TRUE(std::isfinite(row.normalized_doppler_innovation));
+        }
+        if (row.doppler_calibration_evaluated) {
+            EXPECT_GT(row.doppler_calibrated_scale_m, 0.0);
+            EXPECT_TRUE(std::isfinite(row.doppler_bias_m));
+            EXPECT_TRUE(std::isfinite(row.doppler_centered_innovation_m));
+            EXPECT_TRUE(std::isfinite(row.doppler_calibrated_score));
+        }
+    }
+
+    auto outlier_problem = problem;
+    const auto shadow =
+        FGOProcessor::buildClockResilientTemporalCarrierShadow(outlier_problem);
+    ASSERT_FALSE(shadow.empty());
+    const auto& injected = shadow.back();
+    bool injected_outlier = false;
+    for (auto& observation : outlier_problem.carrier_observations) {
+        if (observation.epoch_index == injected.current_epoch_index &&
+            observation.satellite == injected.satellite &&
+            observation.signal == injected.signal) {
+            observation.corrected_carrier_m += 1.0;
+            injected_outlier = true;
+            break;
+        }
+    }
+    ASSERT_TRUE(injected_outlier);
+    const auto outlier_result = on_processor.optimizeProblem(outlier_problem);
+    EXPECT_TRUE(std::any_of(
+        outlier_result.temporal_carrier_shadow_factors.begin(),
+        outlier_result.temporal_carrier_shadow_factors.end(),
+        [](const auto& row) {
+            return row.classification == FGOProcessor::
+                TemporalCarrierShadowClassification::UnexplainedOutlier;
+        }));
+
+    auto witnessed_problem = outlier_problem;
+    for (const std::size_t epoch_index :
+         {injected.previous_epoch_index, injected.current_epoch_index}) {
+        FGOProcessor::SingleDifferenceDopplerFactor doppler;
+        doppler.epoch_index = epoch_index;
+        doppler.satellite = injected.satellite;
+        doppler.reference_satellite = injected.reference_satellite;
+        doppler.signal = injected.signal;
+        doppler.residual_mps = 0.0;
+        doppler.sigma_mps = 0.2;
+        witnessed_problem.single_difference_doppler_factors.push_back(doppler);
+    }
+    const auto modeled_doppler_result =
+        on_processor.optimizeProblem(witnessed_problem);
+    EXPECT_TRUE(std::any_of(
+        modeled_doppler_result.temporal_carrier_shadow_factors.begin(),
+        modeled_doppler_result.temporal_carrier_shadow_factors.end(),
+        [&](const auto& row) {
+            return row.factor.current_epoch_index ==
+                       injected.current_epoch_index &&
+                row.factor.satellite == injected.satellite &&
+                row.factor.reference_satellite == injected.reference_satellite &&
+                row.factor.signal == injected.signal && row.doppler_evaluated &&
+                row.doppler_outlier &&
+                row.normalized_doppler_innovation > 5.0 &&
+                !row.doppler_calibration_evaluated &&
+                !row.doppler_calibrated_outlier &&
+                row.classification == FGOProcessor::
+                    TemporalCarrierShadowClassification::UnexplainedOutlier;
+        }));
 }
 
 TEST(FGOAmbiguityCandidateTelemetryTest,


### PR DESCRIPTION
## What changed

- add receiver-clock-resilient temporal carrier shadow replay and per-factor CSV telemetry
- add causal predicted-DDPR quality telemetry using DD Doppler and the pre-solve IMU geometry
- support reference-only truth replay for offline labels without rerunning the solver
- document the literature/OSS basis, run1/run2 validation, and activation stop conditions
- add deterministic clock-cancellation, fail-closed, and fixed-lag non-interference tests

## Why

The remaining correct-FIX gap needs observation-quality evidence that is causal and independent of the optimized current pose. The new diagnostics expose clock-free temporal carrier and DDPR witnesses without changing graph factors or FIX/FLOAT decisions.

## Safety and evaluation

- monitor A/B was byte-identical to baseline for status, ECEF, ratio, fixed ambiguity count, and AR outcome on full Tokyo run1 and run2
- the frozen 1.5 m predicted-DDPR score captured 96.793% of gross run2 rows while flagging 0.286% of clean rows
- bounded DDPR down-weighting was rejected because full run1 wrong-FIX distance increased by 189.135 m; no activation code is included
- SD Doppler 0.5 m/s was rejected after a neutral FIX result and about 28% fixed-horizontal-RMS regression on run1-500

## Validation

- MSVC GTSAM and non-GTSAM library builds
- run_tests.exe: 890 tests, 830 passed, 60 skipped, 0 failed
- focused causal DDPR, clock cancellation, temporal carrier, and fixed-lag non-interference tests
- git diff --check
