### PR TITLE
Stabilize macOS CI cold builds

### DIFF
--- a/.github/actions/prepare-build/action.yml
+++ b/.github/actions/prepare-build/action.yml
@@ -50,6 +50,8 @@ runs:
       with:
         path: ${{ runner.os == 'Linux' && '~/.cache/ccache' || '~/Library/Caches/ccache' }}
         key: ${{ runner.os }}-ccache-${{ hashFiles('CMakeLists.txt', 'src/**', 'include/**') }}
+        restore-keys: |
+          ${{ runner.os }}-ccache-
 
     - name: Install dependencies (Ubuntu)
       if: ${{ startsWith(inputs.os-name, 'ubuntu') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
     needs: [changes, hygiene]
     if: needs.changes.outputs.run_heavy == 'true'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 120
+    timeout-minutes: ${{ matrix.os == 'macos-latest' && 180 || 120 }}
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## What changed

- Restore the latest OS-specific ccache entry when the source-hash key has no exact match.
- Allow the macOS build-and-test matrix entry up to 180 minutes while retaining the 120-minute Linux limit.

## Root cause

PR #430 and its post-merge develop run had no exact macOS ccache entry because the key changes for every source edit. The resulting cold build exceeded the 120-minute job limit and was cancelled while compiling; Linux, hygiene, static analysis, and MADoCA checks passed, and no compiler error was reported.

## Impact

Source-changing pull requests can reuse the latest compatible ccache instead of rebuilding the entire project from scratch. A truly cold macOS build also has enough time to finish.

## Validation

- YAML parsed successfully with PyYAML.
- CI scope classifier confirms these workflow changes run heavy CI.
- CIScopeDetectionTest: 4 tests passed.
- git diff --check passed.
- Local actionlint was unavailable because Docker is not installed; the PR hygiene job will provide the authoritative actionlint result.