### PR TITLE
Add causal DDPR bias-state telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,16 @@ Thresholds must be selected on the development run and then held fixed for
 validation/holdout runs; see
 [`docs/fgo_fix_rate_observation_quality_plan.md`](docs/fgo_fix_rate_observation_quality_plan.md).
 
+`--predicted-ddpr-bias-state-shadow` separately tests whether those causal
+predicted-geometry residuals contain a persistent pair-specific bias.  A
+bounded scalar random walk uses only earlier rows to predict the current row;
+the current residual is assimilated after its diagnostic is emitted.  The
+option remains solver-independent and can be enabled without retaining the
+quality CSV.  With `--dump-csv <path>`, it writes
+`<path>.predicted_ddpr_bias_state.csv`.  Its causal burn-in, reset rules,
+research rationale, and staged activation gates are documented in
+[`docs/fgo_ddpr_bias_state_shadow_plan.md`](docs/fgo_ddpr_bias_state_shadow_plan.md).
+
 The normalized trace's `disposition` values are:
 
 | Value | Meaning |

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -65,6 +65,7 @@ struct Args {
     bool sd_doppler = false;     // add single-difference Doppler velocity factors
     bool clock_resilient_temporal_shadow = false;  // diagnostic-only receiver-clock-free TDCP
     bool predicted_ddpr_quality_shadow = false;  // diagnostic-only causal DDPR quality
+    bool predicted_ddpr_bias_state_shadow = false;  // causal persistent DDPR bias monitor
     std::string temporal_shadow_replay_csv;  // classify against frozen ECEF positions; skip solve
     bool temporal_shadow_truth_replay = false;  // classify against reference.csv; skip solve
     bool postfit_gate = false;
@@ -263,6 +264,10 @@ Args parseArgs(int argc, char** argv) {
         }
         if (a == "--predicted-ddpr-quality-shadow") {
             args.predicted_ddpr_quality_shadow = true;
+            continue;
+        }
+        if (a == "--predicted-ddpr-bias-state-shadow") {
+            args.predicted_ddpr_bias_state_shadow = true;
             continue;
         }
         if (a == "--gici-par") {
@@ -750,6 +755,8 @@ libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
         args.clock_resilient_temporal_shadow;
     config.monitor_predicted_ddpr_quality =
         args.predicted_ddpr_quality_shadow;
+    config.monitor_predicted_ddpr_bias_state =
+        args.predicted_ddpr_bias_state_shadow;
     config.use_geometry_free_cycle_slip_reset = args.gf_slip_reset;
     config.report_held_ambiguities_as_fixed = !args.no_held_fix_label;
     if (args.max_iters > 0) {
@@ -2013,6 +2020,47 @@ void dumpPredictedDdprQualityCsv(
     }
 }
 
+void dumpPredictedDdprBiasStateCsv(
+    const libgnss::FGOProcessor::FGOResult& result,
+    const std::string& epoch_csv_path) {
+    const std::string path =
+        epoch_csv_path + ".predicted_ddpr_bias_state.csv";
+    std::ofstream out(path);
+    if (!out) {
+        std::cerr << "Error: cannot open predicted DDPR bias-state output file "
+                  << path << "\n";
+        return;
+    }
+    out << std::fixed << std::setprecision(6);
+    out << "tow,previous_epoch,current_epoch,target,reference,signal,dt_s,"
+           "pair_age_epochs,prior_updates,continuity_reset,prediction_usable,"
+           "update_applied,update_clipped,raw_residual_m,prior_bias_m,"
+           "prior_sigma_m,corrected_residual_m,measurement_sigma_m,"
+           "innovation_sigma_m,normalized_innovation,applied_innovation_m,"
+           "posterior_bias_m,posterior_sigma_m\n";
+    for (const auto& row : result.predicted_ddpr_bias_state_factors) {
+        double tow = 0.0;
+        if (row.current_epoch_index < result.solution.solutions.size()) {
+            tow = result.solution.solutions[row.current_epoch_index].time.tow;
+        }
+        out << tow << ',' << row.previous_epoch_index << ','
+            << row.current_epoch_index << ',' << row.satellite.toString()
+            << ',' << row.reference_satellite.toString() << ','
+            << static_cast<int>(row.signal) << ',' << row.dt_s << ','
+            << row.pair_age_epochs << ',' << row.prior_updates << ','
+            << (row.continuity_reset ? 1 : 0) << ','
+            << (row.prediction_usable ? 1 : 0) << ','
+            << (row.update_applied ? 1 : 0) << ','
+            << (row.update_clipped ? 1 : 0) << ','
+            << row.raw_residual_m << ',' << row.prior_bias_m << ','
+            << row.prior_sigma_m << ',' << row.corrected_residual_m << ','
+            << row.measurement_sigma_m << ',' << row.innovation_sigma_m << ','
+            << row.normalized_innovation << ',' << row.applied_innovation_m
+            << ',' << row.posterior_bias_m << ',' << row.posterior_sigma_m
+            << '\n';
+    }
+}
+
 struct TemporalShadowReplayInput {
     std::vector<libgnss::Vector3d> positions_ecef;
     std::vector<bool> carrier_hold_active;
@@ -2837,12 +2885,28 @@ int main(int argc, char** argv) {
                 classifyClockResilientTemporalCarrierShadow(
                     problem, shadow, replay.positions_ecef,
                     epoch_diagnostics, &geometry_free);
-        if (args.predicted_ddpr_quality_shadow) {
-            replay_result.predicted_ddpr_quality_factors =
+        if (args.predicted_ddpr_quality_shadow ||
+            args.predicted_ddpr_bias_state_shadow) {
+            auto quality_rows =
                 libgnss::FGOProcessor::analyzePredictedDdprQualityShadow(
                     problem, replay.positions_ecef, replay.positions_ecef,
                     config.single_difference_doppler_sigma_mps, 5.0,
                     config.max_tdcp_gap_s);
+            if (args.predicted_ddpr_bias_state_shadow) {
+                replay_result.predicted_ddpr_bias_state_factors =
+                    libgnss::FGOProcessor::
+                        analyzePredictedDdprBiasStateShadow(
+                            quality_rows,
+                            config.predicted_ddpr_bias_process_noise_m_sqrt_s,
+                            config.predicted_ddpr_bias_initial_sigma_m,
+                            config.predicted_ddpr_bias_min_measurement_sigma_m,
+                            config.predicted_ddpr_bias_robust_update_sigma,
+                            config.predicted_ddpr_bias_min_prior_updates);
+            }
+            if (args.predicted_ddpr_quality_shadow) {
+                replay_result.predicted_ddpr_quality_factors =
+                    std::move(quality_rows);
+            }
         }
         replay_result.epoch_diagnostics = std::move(epoch_diagnostics);
         for (std::size_t i = 0; i < problem.epochs.size(); ++i) {
@@ -2854,6 +2918,10 @@ int main(int argc, char** argv) {
         dumpTemporalCarrierFactorCsv(replay_result, args.dump_csv_path);
         if (args.predicted_ddpr_quality_shadow) {
             dumpPredictedDdprQualityCsv(replay_result, args.dump_csv_path);
+        }
+        if (args.predicted_ddpr_bias_state_shadow) {
+            dumpPredictedDdprBiasStateCsv(replay_result,
+                                          args.dump_csv_path);
         }
 
         std::size_t clean = 0;
@@ -3031,6 +3099,9 @@ int main(int argc, char** argv) {
             if (args.predicted_ddpr_quality_shadow) {
                 dumpPredictedDdprQualityCsv(fl, args.dump_csv_path);
             }
+            if (args.predicted_ddpr_bias_state_shadow) {
+                dumpPredictedDdprBiasStateCsv(fl, args.dump_csv_path);
+            }
         }
 
         std::cout << "\n=== (a4) MILESTONE 2c: IncrementalFixedLagSmoother (full-scale) ===\n"
@@ -3062,6 +3133,8 @@ int main(int argc, char** argv) {
                    << (config.monitor_clock_resilient_temporal_carrier ? "on" : "off")
                    << ", predicted_ddpr_quality_shadow="
                    << (config.monitor_predicted_ddpr_quality ? "on" : "off")
+                   << ", predicted_ddpr_bias_state_shadow="
+                   << (config.monitor_predicted_ddpr_bias_state ? "on" : "off")
                    << ")\n"
                   << "  IMU ratio aperture: " << (args.imu_ratio_aperture ? "on" : "off")
                   << " (accepted=" << fl.diagnostics.imu_aided_ratio_accepts

--- a/docs/fgo_ddpr_bias_state_shadow_plan.md
+++ b/docs/fgo_ddpr_bias_state_shadow_plan.md
@@ -1,0 +1,181 @@
+# DD pseudorange bias-state shadow plan
+
+## Goal
+
+Improve the float state presented to ambiguity resolution without buying FIX
+rate by accepting more wrong integers.  This experiment asks a narrower
+question first: does a target/reference/signal DD pseudorange pair contain a
+causally predictable, persistent bias that is not already explained by the
+one-step IMU geometry prediction?
+
+TDCP is not the default answer.  Carrier, ambiguity acceptance, and the active
+graph remain unchanged while this question is measured.
+
+## Research decision
+
+The candidate families considered were:
+
+- switchable constraints, which add a latent switch, a prior favouring active
+  measurements, and optionally a temporal switch transition;
+- graduated non-convexity and robust losses, which reduce the influence of
+  large residuals during optimization;
+- explicit per-satellite pseudorange multipath/error states; and
+- a causal random-walk bias predictor evaluated outside the optimizer.
+
+Switchable constraints and GNC are credible robust-estimation techniques, but
+their first-order effect is still to weaken suspect observations.  The prior
+run1 DDPR downweight experiment increased wrong-FIX distance, so they are not
+the first activation candidate here.  A free additive bias state inside the
+graph is also unsafe as a first experiment: the current observation can help
+estimate the variable that explains itself, and pair bias remains entangled
+with position error unless persistence is demonstrated independently.
+
+The selected first step is therefore a monitor-only scalar random walk for
+each `(target satellite, reference satellite, signal)` key.  It consumes the
+existing causal predicted-DDPR residual rows.  At epoch `k`, only the posterior
+through `k-1` may predict the bias at `k`; the current residual updates the
+state only after the diagnostic row has been emitted.
+
+Research references:
+
+- Suenderhauf et al., GNSS multipath mitigation with switchable constraints:
+  <https://nikosuenderhauf.github.io/assets/papers/IV12-multipathMitigation.pdf>
+- Suenderhauf and Protzel, Switchable Constraints for Robust Pose Graph SLAM:
+  <https://nikosuenderhauf.github.io/assets/papers/IROS12-switchableConstraints.pdf>
+- Wen et al., FGO-GNC for GNSS outlier mitigation:
+  <https://arxiv.org/abs/2109.00667>
+- GTSAM GNC optimizer documentation:
+  <https://borglab.github.io/gtsam/gncoptimizer/>
+- GraphGNSSLib, an open DD GNSS factor-graph implementation:
+  <https://github.com/weisongwen/GraphGNSSLib>
+- GICI, an open GNSS/INS estimator with robust pseudorange handling:
+  <https://github.com/chichengcn/gici-open>
+
+## Shadow model
+
+For every continuous pair, propagate
+
+`P(k|k-1) = P(k-1|k-1) + q^2 dt`
+
+and emit the causal prediction `b(k|k-1)` before reading the current residual
+into the state.  The exported corrected residual is
+
+`r_corrected(k) = r_predicted_ddpr(k) - b(k|k-1)`.
+
+The update is a scalar Kalman step.  Its innovation is clipped to a configured
+multiple of the innovation sigma so that a one-epoch impulse cannot become a
+long-lived bias.  The DD row sigma is conservatively approximated from the
+existing two-epoch IMU-innovation sigma.  A minimum sigma prevents numerical
+overconfidence.
+
+The prediction is unavailable during burn-in.  Missing/non-finite IMU
+geometry, discontinuous epochs, a gap, or a reference/key change starts a new
+state.  No diagnostic field is consumed by the graph, covariance, LAMBDA,
+hold logic, or exported solution.
+
+Initial development defaults are `q=0.25 m/sqrt(s)`, initial sigma `5 m`,
+minimum measurement sigma `0.5 m`, robust update limit `3 sigma`, and two
+prior updates before a prediction is declared usable.  These are shadow
+parameters, not solver tuning.
+
+## Precommitted gates
+
+### Gate 0: exact non-interference
+
+- monitor off versus on has identical status, ECEF position, ratio, fixed
+  ambiguity count, and AR outcome at every epoch;
+- fixed-lag and batch paths remain deterministic; and
+- no shadow result can reach the active graph.
+
+### Gate 1: run1 causal predictiveness
+
+- every usable prediction is formed before the current residual update;
+- among gross truth-labelled rows, the median absolute residual must improve
+  by at least 25%;
+- clean-row absolute-residual P95 may regress by at most 5%;
+- at least 100 gross rows and 100 clean rows must be usable; and
+- report support, burn-in, resets, signed/absolute error distributions, and
+  results by pair age rather than only the best aggregate threshold.
+
+Truth is offline scoring only.  It cannot be read by the runtime monitor.
+
+### Gate 2: identifiability and short activation
+
+Before adding any graph state, show that improvement is pair-specific rather
+than a cross-pair coherent position error.  Compare the pair prediction with
+the same-epoch median across other pairs and require the pair-specific model
+to retain a material advantage.
+
+Only then may a separate default-off graph experiment be designed.  On a
+representative 500-epoch run1 slice it must have zero additional wrong FIX,
+no lost correct FIX, no new failure/non-finite epoch, and at most 10% runtime
+overhead.
+
+### Gate 3: frozen validation
+
+Run full run1 before freezing the activation.  Run2 is then a one-shot
+validation and run3 remains sealed until run2 passes.  Each holdout must have:
+
+- no increase in wrong-FIX distance;
+- no decrease in correct-FIX distance;
+- no regression in matched distance or solver failures; and
+- fixed RMS and P95 regression no greater than 5%.
+
+Failure retains useful telemetry but rejects activation.  It does not trigger
+post-hoc TDCP, ratio-threshold, or holdout tuning.
+
+## Execution sequence
+
+1. Add the independent, default-off shadow and normalized CSV.
+2. Unit-test persistence, impulse bounding, continuity reset, and causal
+   burn-in.
+3. Prove exact solver non-interference in both backend modes.
+4. Run and score run1 against the gates above.
+5. Continue to activation/run2/run3 only if every preceding gate passes.
+
+After producing a runtime bias sidecar and a truth-replay quality sidecar,
+score the frozen gates with:
+
+```bash
+python scripts/analyze_ddpr_bias_state_shadow.py \
+  --bias-csv <runtime.csv.predicted_ddpr_bias_state.csv> \
+  --truth-quality-csv <truth.csv.predicted_ddpr_quality.csv> \
+  --json <gate1-summary.json>
+```
+
+## Development result
+
+The default-off shadow passed exact non-interference in unit tests and in a
+50-epoch Tokyo run1 A/B.  The complete epoch CSV SHA-256 was identical with
+the monitor off and on.  The monitor produced 1,960 rows, of which 1,880 were
+usable after burn-in.
+
+Full run1 then passed the causal usefulness gate:
+
+| Metric | Raw | Bias-corrected shadow |
+|---|---:|---:|
+| Gross truth-labelled rows | 11,522 | 11,522 |
+| Gross absolute residual median | 10.266 m | 1.716 m |
+| Clean truth-labelled rows | 149,789 | 149,789 |
+| Clean absolute residual P95 | 1.150 m | 0.524 m |
+
+The gross median improvement was 83.29%.  A same-epoch common-bias control
+left a 9.967 m gross median, versus 1.716 m for the pair-specific prediction
+(ratio 0.172), so the gain is not primarily a coherent pose/common-mode term.
+The run contained 189,036 usable/joined rows out of 197,868 bias rows.
+
+A separate causal activation was then tested with the same frozen state
+parameters on the first 500 run1 epochs.  It subtracted the prior pair bias
+from DD code only after two earlier updates, clipped updates at 3 sigma, and
+capped the applied correction at 20 m.  It failed the precommitted short-run
+gate:
+
+- baseline: 476 correct FIX, 0 wrong FIX, fixed RMS 0.03684 m;
+- activation: 472 correct FIX, 0 wrong FIX, fixed RMS 0.04502 m;
+- transitions: 13 lost correct FIX and 9 added correct FIX; and
+- both runs had zero NONE/non-finite epochs.
+
+The activation therefore loses correct fixes and regresses fixed RMS by about
+22.2%.  Its switch and graph changes were removed.  Only the non-interfering
+shadow telemetry and scorer are retained.  Full activation, run2, and sealed
+run3 were not executed.

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -410,6 +410,16 @@ public:
         // compares measured DDPR changes with DD Doppler and the causal
         // pre-solve IMU pose prediction; no result is consumed by the graph.
         bool monitor_predicted_ddpr_quality = false;
+        // Diagnostic-only causal random-walk model of persistent DD
+        // pseudorange bias. It consumes the monitor above internally but is
+        // independent of its output switch. No result is consumed by the
+        // graph, ambiguity resolver, or exported solution.
+        bool monitor_predicted_ddpr_bias_state = false;
+        double predicted_ddpr_bias_process_noise_m_sqrt_s = 0.25;
+        double predicted_ddpr_bias_initial_sigma_m = 5.0;
+        double predicted_ddpr_bias_min_measurement_sigma_m = 0.5;
+        double predicted_ddpr_bias_robust_update_sigma = 3.0;
+        int predicted_ddpr_bias_min_prior_updates = 2;
         // When a rover/base single-difference geometry-free combination jumps
         // while the underlying rover arcs remain continuous, break both bands'
         // DD arcs after the confirmation interval below. Resetting both bands
@@ -1842,6 +1852,34 @@ public:
             PredictedDdprQualityAction::Unavailable;
     };
 
+    /// Causal, diagnostic-only scalar bias prediction for one DD pseudorange
+    /// pair. `prior_bias_m` is formed solely from earlier rows. The current
+    /// residual is assimilated only after this diagnostic has been formed.
+    struct PredictedDdprBiasStateDiagnostics {
+        std::size_t previous_epoch_index = 0;
+        std::size_t current_epoch_index = 0;
+        SatelliteId satellite;
+        SatelliteId reference_satellite;
+        SignalType signal = SignalType::GPS_L1CA;
+        double dt_s = 0.0;
+        int pair_age_epochs = 0;
+        int prior_updates = 0;
+        bool continuity_reset = false;
+        bool prediction_usable = false;
+        bool update_applied = false;
+        bool update_clipped = false;
+        double raw_residual_m = 0.0;
+        double prior_bias_m = 0.0;
+        double prior_sigma_m = 0.0;
+        double corrected_residual_m = 0.0;
+        double measurement_sigma_m = 0.0;
+        double innovation_sigma_m = 0.0;
+        double normalized_innovation = 0.0;
+        double applied_innovation_m = 0.0;
+        double posterior_bias_m = 0.0;
+        double posterior_sigma_m = 0.0;
+    };
+
     struct FGODiagnostics {
         int iterations = 0;
         bool converged = false;
@@ -2329,6 +2367,8 @@ public:
             temporal_carrier_shadow_factors;
         std::vector<PredictedDdprQualityFactorDiagnostics>
             predicted_ddpr_quality_factors;
+        std::vector<PredictedDdprBiasStateDiagnostics>
+            predicted_ddpr_bias_state_factors;
         // Milestone 2b (populated only by the GTSAM IMU-coupled path):
         // per-epoch estimated attitude as [roll, pitch, heading] in degrees
         // (body FLU -> nav ENU; heading is clockwise from North) and estimated
@@ -2379,6 +2419,17 @@ public:
         double doppler_sigma_mps = 0.2,
         double normalized_outlier_threshold = 5.0,
         double max_gap_s = 1.5);
+
+    /// Predict persistent pair-specific DD pseudorange bias from prior causal
+    /// predicted-DDPR residual rows. The current row never predicts itself.
+    static std::vector<PredictedDdprBiasStateDiagnostics>
+    analyzePredictedDdprBiasStateShadow(
+        const std::vector<PredictedDdprQualityFactorDiagnostics>& quality_rows,
+        double process_noise_m_sqrt_s = 0.25,
+        double initial_sigma_m = 5.0,
+        double min_measurement_sigma_m = 0.5,
+        double robust_update_sigma = 3.0,
+        int min_prior_updates = 2);
 
     FGOProblem buildPseudorangeProblem(const std::vector<ObservationData>& epochs,
                                        const NavigationData& nav) const;

--- a/scripts/analyze_ddpr_bias_state_shadow.py
+++ b/scripts/analyze_ddpr_bias_state_shadow.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Score causal DDPR bias-state shadow rows against offline truth labels."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+import statistics
+from collections import defaultdict
+from pathlib import Path
+
+
+KEY_FIELDS = ("current_epoch", "target", "reference", "signal")
+
+
+def key(row: dict[str, str]) -> tuple[str, ...]:
+    return tuple(row[name] for name in KEY_FIELDS)
+
+
+def percentile(values: list[float], fraction: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    position = fraction * (len(ordered) - 1)
+    lower = math.floor(position)
+    upper = math.ceil(position)
+    if lower == upper:
+        return ordered[lower]
+    weight = position - lower
+    return ordered[lower] * (1.0 - weight) + ordered[upper] * weight
+
+
+def ratio(numerator: float | None, denominator: float | None) -> float | None:
+    if numerator is None or denominator is None or denominator == 0.0:
+        return None
+    return numerator / denominator
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--bias-csv", required=True, type=Path)
+    parser.add_argument("--truth-quality-csv", required=True, type=Path)
+    parser.add_argument("--json", type=Path)
+    parser.add_argument("--gross-threshold-m", type=float, default=4.0)
+    parser.add_argument("--clean-threshold-m", type=float, default=1.0)
+    args = parser.parse_args()
+
+    with args.truth_quality_csv.open(newline="", encoding="utf-8") as stream:
+        truth = {
+            key(row): abs(float(row["current_predicted_ddpr_residual_m"]))
+            for row in csv.DictReader(stream)
+            if row["imu_geometry_evaluated"] == "1"
+        }
+
+    joined: list[dict[str, float | str]] = []
+    epoch_biases: dict[str, list[float]] = defaultdict(list)
+    total_rows = 0
+    usable_rows = 0
+    with args.bias_csv.open(newline="", encoding="utf-8") as stream:
+        for row in csv.DictReader(stream):
+            total_rows += 1
+            if row["prediction_usable"] != "1":
+                continue
+            usable_rows += 1
+            truth_abs = truth.get(key(row))
+            if truth_abs is None:
+                continue
+            raw = float(row["raw_residual_m"])
+            corrected = float(row["corrected_residual_m"])
+            prior_bias = float(row["prior_bias_m"])
+            if not all(math.isfinite(value) for value in
+                       (truth_abs, raw, corrected, prior_bias)):
+                continue
+            epoch_biases[row["current_epoch"]].append(prior_bias)
+            joined.append({
+                "epoch": row["current_epoch"],
+                "truth_abs": truth_abs,
+                "raw_abs": abs(raw),
+                "corrected_abs": abs(corrected),
+                "raw": raw,
+                "prior_bias": prior_bias,
+            })
+
+    epoch_median = {
+        epoch: statistics.median(values)
+        for epoch, values in epoch_biases.items()
+    }
+    gross = [
+        row for row in joined
+        if row["truth_abs"] > args.gross_threshold_m
+    ]
+    clean = [
+        row for row in joined
+        if row["truth_abs"] < args.clean_threshold_m
+    ]
+
+    gross_raw = [float(row["raw_abs"]) for row in gross]
+    gross_corrected = [float(row["corrected_abs"]) for row in gross]
+    clean_raw = [float(row["raw_abs"]) for row in clean]
+    clean_corrected = [float(row["corrected_abs"]) for row in clean]
+    common_corrected = [
+        abs(float(row["raw"]) - epoch_median[str(row["epoch"])])
+        for row in gross
+    ]
+
+    gross_raw_median = percentile(gross_raw, 0.5)
+    gross_corrected_median = percentile(gross_corrected, 0.5)
+    clean_raw_p95 = percentile(clean_raw, 0.95)
+    clean_corrected_p95 = percentile(clean_corrected, 0.95)
+    common_corrected_median = percentile(common_corrected, 0.5)
+    improvement = None
+    if gross_raw_median:
+        improvement = 1.0 - float(gross_corrected_median) / gross_raw_median
+
+    summary = {
+        "inputs": {
+            "bias_csv": str(args.bias_csv),
+            "truth_quality_csv": str(args.truth_quality_csv),
+            "gross_threshold_m": args.gross_threshold_m,
+            "clean_threshold_m": args.clean_threshold_m,
+        },
+        "support": {
+            "total_bias_rows": total_rows,
+            "usable_bias_rows": usable_rows,
+            "truth_joined_rows": len(joined),
+            "gross_rows": len(gross),
+            "clean_rows": len(clean),
+        },
+        "gross": {
+            "raw_abs_median_m": gross_raw_median,
+            "corrected_abs_median_m": gross_corrected_median,
+            "median_improvement_fraction": improvement,
+            "same_epoch_common_bias_corrected_abs_median_m":
+                common_corrected_median,
+            "pair_specific_vs_common_ratio":
+                ratio(gross_corrected_median, common_corrected_median),
+        },
+        "clean": {
+            "raw_abs_p95_m": clean_raw_p95,
+            "corrected_abs_p95_m": clean_corrected_p95,
+            "p95_ratio": ratio(clean_corrected_p95, clean_raw_p95),
+        },
+    }
+    summary["gate1"] = {
+        "support_pass": len(gross) >= 100 and len(clean) >= 100,
+        "gross_improvement_pass":
+            improvement is not None and improvement >= 0.25,
+        "clean_p95_pass":
+            summary["clean"]["p95_ratio"] is not None and
+            float(summary["clean"]["p95_ratio"]) <= 1.05,
+    }
+    summary["gate1"]["pass"] = all(summary["gate1"].values())
+
+    rendered = json.dumps(summary, indent=2, sort_keys=True)
+    print(rendered)
+    if args.json:
+        args.json.write_text(rendered + "\n", encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -3388,6 +3388,136 @@ FGOProcessor::analyzePredictedDdprQualityShadow(
     return result;
 }
 
+std::vector<FGOProcessor::PredictedDdprBiasStateDiagnostics>
+FGOProcessor::analyzePredictedDdprBiasStateShadow(
+    const std::vector<PredictedDdprQualityFactorDiagnostics>& quality_rows,
+    double process_noise_m_sqrt_s,
+    double initial_sigma_m,
+    double min_measurement_sigma_m,
+    double robust_update_sigma,
+    int min_prior_updates) {
+    using Key = std::tuple<SatelliteId, SatelliteId, SignalType>;
+    struct State {
+        double mean_m = 0.0;
+        double variance_m2 = 0.0;
+        int updates = 0;
+        std::size_t last_epoch_index = 0;
+        bool initialized = false;
+    };
+
+    const double q = std::max(0.0, process_noise_m_sqrt_s);
+    const double initial_sigma = std::max(1e-6, initial_sigma_m);
+    const double min_measurement_sigma =
+        std::max(1e-6, min_measurement_sigma_m);
+    const double clip_sigma = std::max(0.0, robust_update_sigma);
+    const int burn_in = std::max(0, min_prior_updates);
+    std::map<Key, State> states;
+    std::vector<PredictedDdprBiasStateDiagnostics> result;
+    result.reserve(quality_rows.size());
+
+    for (const auto& row : quality_rows) {
+        PredictedDdprBiasStateDiagnostics diagnostic;
+        diagnostic.previous_epoch_index = row.previous_epoch_index;
+        diagnostic.current_epoch_index = row.current_epoch_index;
+        diagnostic.satellite = row.satellite;
+        diagnostic.reference_satellite = row.reference_satellite;
+        diagnostic.signal = row.signal;
+        diagnostic.dt_s = row.dt_s;
+        diagnostic.pair_age_epochs = row.pair_age_epochs;
+        diagnostic.raw_residual_m =
+            row.current_predicted_ddpr_residual_m;
+
+        const Key key{row.satellite, row.reference_satellite, row.signal};
+        auto& state = states[key];
+        const bool continuous = state.initialized &&
+                                state.last_epoch_index ==
+                                    row.previous_epoch_index &&
+                                row.current_epoch_index ==
+                                    row.previous_epoch_index + 1 &&
+                                std::isfinite(row.dt_s) && row.dt_s > 0.0;
+        if (!continuous) {
+            state = State{};
+            state.variance_m2 = initial_sigma * initial_sigma;
+            diagnostic.continuity_reset = true;
+        } else {
+            state.variance_m2 += q * q * row.dt_s;
+        }
+
+        diagnostic.prior_updates = state.updates;
+        diagnostic.prior_bias_m = state.mean_m;
+        diagnostic.prior_sigma_m =
+            std::sqrt(std::max(0.0, state.variance_m2));
+        diagnostic.corrected_residual_m =
+            diagnostic.raw_residual_m - diagnostic.prior_bias_m;
+        diagnostic.prediction_usable =
+            continuous && state.updates >= burn_in &&
+            row.imu_geometry_evaluated &&
+            std::isfinite(diagnostic.raw_residual_m);
+
+        // The quality monitor propagates the two adjacent DDPR sigmas with
+        // hypot(). Divide by sqrt(2) to obtain an equal-row approximation;
+        // the floor deliberately prevents an overconfident shadow state.
+        const double approximated_row_sigma =
+            row.imu_innovation_sigma_m / std::sqrt(2.0);
+        diagnostic.measurement_sigma_m = std::max(
+            min_measurement_sigma,
+            std::isfinite(approximated_row_sigma)
+                ? approximated_row_sigma
+                : min_measurement_sigma);
+
+        const bool update_valid =
+            row.imu_geometry_evaluated &&
+            std::isfinite(diagnostic.raw_residual_m) &&
+            std::isfinite(state.mean_m) &&
+            std::isfinite(state.variance_m2);
+        if (update_valid) {
+            const double measurement_variance =
+                diagnostic.measurement_sigma_m *
+                diagnostic.measurement_sigma_m;
+            const double innovation_m =
+                diagnostic.raw_residual_m - state.mean_m;
+            diagnostic.innovation_sigma_m = std::sqrt(std::max(
+                1e-12, state.variance_m2 + measurement_variance));
+            diagnostic.normalized_innovation =
+                std::abs(innovation_m) / diagnostic.innovation_sigma_m;
+            diagnostic.applied_innovation_m = innovation_m;
+            if (clip_sigma > 0.0) {
+                const double limit =
+                    clip_sigma * diagnostic.innovation_sigma_m;
+                if (std::abs(diagnostic.applied_innovation_m) > limit) {
+                    diagnostic.applied_innovation_m =
+                        std::copysign(limit,
+                                      diagnostic.applied_innovation_m);
+                    diagnostic.update_clipped = true;
+                }
+            }
+            const double kalman_gain =
+                state.variance_m2 /
+                (state.variance_m2 + measurement_variance);
+            state.mean_m +=
+                kalman_gain * diagnostic.applied_innovation_m;
+            state.variance_m2 =
+                std::max(0.0, (1.0 - kalman_gain) * state.variance_m2);
+            ++state.updates;
+            state.last_epoch_index = row.current_epoch_index;
+            state.initialized = true;
+            diagnostic.update_applied = true;
+        } else {
+            // Invalid geometry breaks the causal chain. A later valid row
+            // starts from the configured prior instead of stale state.
+            states.erase(key);
+        }
+
+        if (diagnostic.update_applied) {
+            diagnostic.posterior_bias_m = state.mean_m;
+            diagnostic.posterior_sigma_m =
+                std::sqrt(std::max(0.0, state.variance_m2));
+        }
+        result.push_back(diagnostic);
+    }
+    return result;
+}
+
 FGOProcessor::FGOResult FGOProcessor::optimize(
     const std::vector<ObservationData>& rover_epochs,
     const std::vector<ObservationData>& base_epochs,

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -5869,12 +5869,25 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 epoch_diagnostics, &gf_slip_shadow,
                 &fde_rejected_ambiguities_by_epoch);
     }
-    if (config.monitor_predicted_ddpr_quality) {
-        result.predicted_ddpr_quality_factors = FGOProcessor::
-            analyzePredictedDdprQualityShadow(
-                problem, epoch_float_position, epoch_predicted_position,
-                config.single_difference_doppler_sigma_mps, 5.0,
-                config.max_tdcp_gap_s);
+    if (config.monitor_predicted_ddpr_quality ||
+        config.monitor_predicted_ddpr_bias_state) {
+        auto quality_rows = FGOProcessor::analyzePredictedDdprQualityShadow(
+            problem, epoch_float_position, epoch_predicted_position,
+            config.single_difference_doppler_sigma_mps, 5.0,
+            config.max_tdcp_gap_s);
+        if (config.monitor_predicted_ddpr_bias_state) {
+            result.predicted_ddpr_bias_state_factors =
+                FGOProcessor::analyzePredictedDdprBiasStateShadow(
+                    quality_rows,
+                    config.predicted_ddpr_bias_process_noise_m_sqrt_s,
+                    config.predicted_ddpr_bias_initial_sigma_m,
+                    config.predicted_ddpr_bias_min_measurement_sigma_m,
+                    config.predicted_ddpr_bias_robust_update_sigma,
+                    config.predicted_ddpr_bias_min_prior_updates);
+        }
+        if (config.monitor_predicted_ddpr_quality) {
+            result.predicted_ddpr_quality_factors = std::move(quality_rows);
+        }
     }
     const bool have_amb = !problem.ambiguity_states.empty();
     result.epoch_diagnostics = std::move(epoch_diagnostics);

--- a/tests/test_fgo.cpp
+++ b/tests/test_fgo.cpp
@@ -996,6 +996,76 @@ TEST(FGOTest, PredictedDdprQualityShadowIsClockSafeAndFailClosed) {
     EXPECT_TRUE(switched.empty());
 }
 
+TEST(FGOTest, PredictedDdprBiasStateShadowPredictsPersistentBiasCausally) {
+    const auto make_row = [](std::size_t previous_epoch,
+                             double residual_m) {
+        FGOProcessor::PredictedDdprQualityFactorDiagnostics row;
+        row.previous_epoch_index = previous_epoch;
+        row.current_epoch_index = previous_epoch + 1;
+        row.satellite = SatelliteId(GNSSSystem::GPS, 5);
+        row.reference_satellite = SatelliteId(GNSSSystem::GPS, 11);
+        row.signal = SignalType::GPS_L1CA;
+        row.dt_s = 1.0;
+        row.pair_age_epochs = static_cast<int>(previous_epoch + 2);
+        row.imu_geometry_evaluated = true;
+        row.current_predicted_ddpr_residual_m = residual_m;
+        row.imu_innovation_sigma_m = std::sqrt(0.5);
+        return row;
+    };
+    const std::vector<FGOProcessor::PredictedDdprQualityFactorDiagnostics>
+        rows = {make_row(0, 10.0), make_row(1, 10.0),
+                make_row(2, 10.0), make_row(3, 10.0)};
+
+    const auto diagnostics =
+        FGOProcessor::analyzePredictedDdprBiasStateShadow(rows);
+    ASSERT_EQ(diagnostics.size(), rows.size());
+    EXPECT_TRUE(diagnostics[0].continuity_reset);
+    EXPECT_FALSE(diagnostics[0].prediction_usable);
+    EXPECT_FALSE(diagnostics[1].prediction_usable);
+    ASSERT_TRUE(diagnostics[2].prediction_usable);
+    EXPECT_EQ(diagnostics[2].prior_updates, 2);
+    EXPECT_NEAR(diagnostics[2].prior_bias_m, 10.0, 0.2);
+    EXPECT_LT(std::abs(diagnostics[2].corrected_residual_m), 0.2);
+    EXPECT_GT(std::abs(diagnostics[2].raw_residual_m), 9.0);
+}
+
+TEST(FGOTest, PredictedDdprBiasStateShadowBoundsImpulseAndResetsOnGap) {
+    const auto make_row = [](std::size_t previous_epoch,
+                             double residual_m) {
+        FGOProcessor::PredictedDdprQualityFactorDiagnostics row;
+        row.previous_epoch_index = previous_epoch;
+        row.current_epoch_index = previous_epoch + 1;
+        row.satellite = SatelliteId(GNSSSystem::GPS, 5);
+        row.reference_satellite = SatelliteId(GNSSSystem::GPS, 11);
+        row.signal = SignalType::GPS_L1CA;
+        row.dt_s = 1.0;
+        row.pair_age_epochs = 2;
+        row.imu_geometry_evaluated = true;
+        row.current_predicted_ddpr_residual_m = residual_m;
+        row.imu_innovation_sigma_m = std::sqrt(0.5);
+        return row;
+    };
+    const std::vector<FGOProcessor::PredictedDdprQualityFactorDiagnostics>
+        rows = {make_row(0, 10.0), make_row(1, 10.0),
+                make_row(2, 40.0), make_row(3, 10.0),
+                make_row(5, -8.0)};
+
+    const auto diagnostics =
+        FGOProcessor::analyzePredictedDdprBiasStateShadow(rows);
+    ASSERT_EQ(diagnostics.size(), rows.size());
+    ASSERT_TRUE(diagnostics[2].prediction_usable);
+    EXPECT_NEAR(diagnostics[2].prior_bias_m, 10.0, 0.2)
+        << "the current impulse must not leak into its own prediction";
+    EXPECT_TRUE(diagnostics[2].update_clipped);
+    ASSERT_TRUE(diagnostics[3].prediction_usable);
+    EXPECT_LT(std::abs(diagnostics[3].prior_bias_m - 10.0), 1.0)
+        << "one impulse must not become a persistent 40 m bias";
+    EXPECT_TRUE(diagnostics[4].continuity_reset);
+    EXPECT_FALSE(diagnostics[4].prediction_usable);
+    EXPECT_EQ(diagnostics[4].prior_updates, 0);
+    EXPECT_NEAR(diagnostics[4].prior_bias_m, 0.0, 1e-12);
+}
+
 TEST(FGOTest, RobustLossDownweightsPseudorangeOutlier) {
     FGOProcessor::FGOProblem problem = makeSyntheticProblem();
     for (auto& factor : problem.pseudorange_factors) {

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -729,6 +729,7 @@ TEST(FGOPredictedDdprQualityShadowTest,
 
     FGOProcessor::FGOConfig on_config = off_config;
     on_config.monitor_predicted_ddpr_quality = true;
+    on_config.monitor_predicted_ddpr_bias_state = true;
     const auto on_result = FGOProcessor(on_config).optimizeProblem(problem);
 
     ASSERT_EQ(off_result.solution.solutions.size(),
@@ -738,6 +739,10 @@ TEST(FGOPredictedDdprQualityShadowTest,
             on_result.solution.solutions[i].position_ecef, 0.0));
         EXPECT_EQ(off_result.solution.solutions[i].status,
                   on_result.solution.solutions[i].status);
+        EXPECT_EQ(off_result.solution.solutions[i].ratio,
+                  on_result.solution.solutions[i].ratio);
+        EXPECT_EQ(off_result.solution.solutions[i].num_fixed_ambiguities,
+                  on_result.solution.solutions[i].num_fixed_ambiguities);
     }
     ASSERT_FALSE(on_result.predicted_ddpr_quality_factors.empty());
     bool saw_imu_geometry = false;
@@ -752,6 +757,16 @@ TEST(FGOPredictedDdprQualityShadowTest,
         }
     }
     EXPECT_TRUE(saw_imu_geometry);
+    ASSERT_FALSE(on_result.predicted_ddpr_bias_state_factors.empty());
+    EXPECT_EQ(on_result.predicted_ddpr_bias_state_factors.size(),
+              on_result.predicted_ddpr_quality_factors.size());
+    for (const auto& row :
+         on_result.predicted_ddpr_bias_state_factors) {
+        EXPECT_TRUE(row.update_applied);
+        EXPECT_TRUE(std::isfinite(row.prior_bias_m));
+        EXPECT_TRUE(std::isfinite(row.posterior_bias_m));
+        EXPECT_GT(row.measurement_sigma_m, 0.0);
+    }
 }
 
 TEST(FGOAmbiguityCandidateTelemetryTest,


### PR DESCRIPTION
## Summary

- add a default-off causal DD pseudorange bias-state shadow keyed by target/reference/signal
- emit a dedicated normalized CSV and add an offline Gate 1 scorer
- document the research basis, causal/reset rules, staged safety gates, and measured Tokyo run1 results
- keep graph factors, ambiguity resolution, FIX/FLOAT status, and reported positions unchanged

## Why

The existing predicted-DDPR monitor showed strong temporal structure in pair-specific code residuals, but direct DDPR downweighting had previously increased wrong-FIX distance. This change measures persistent bias causally before granting it estimator authority.

Full Tokyo run1 shadow scoring improved the gross-row median absolute residual from 10.266 m to 1.716 m (83.29%) and clean-row P95 from 1.150 m to 0.524 m. A same-epoch common-bias control retained 9.967 m, supporting pair-specific predictiveness.

A separate 500-epoch activation experiment failed the precommitted gate: correct FIX changed 476 to 472 and fixed RMS regressed from 0.03684 m to 0.04502 m. The activation path was removed; this PR retains telemetry only. Run2 and sealed run3 were not activated.

## Validation

- MSVC/GTSAM `gnss_lib_noopt` build
- focused GoogleTests: 4/4 passed
  - clock safety and fail-closed behavior
  - persistent-bias causal prediction
  - impulse bounding and gap reset
  - fixed-lag exact non-interference
- 50-epoch baseline/shadow epoch CSV SHA-256 exact match
- full 11,905-epoch Tokyo run1 shadow evaluation
- `git diff --check`
