### PR TITLE
Add disjoint constellation AR shadow audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,18 @@ written beside the epoch CSV as `<dump>.ratio_impact.csv`; it includes the
 excluded satellite, its ambiguity variance/fractional-cycle/DDPR-residual
 proxies, and the resulting counterfactual candidate.
 
+`--disjoint-ar-shadow` balances whole constellation groups into two
+satellite-disjoint ambiguity partitions, runs a reduced top-two LAMBDA search
+for each partition, and records their candidate-position solution separation.
+It is monitor-only and writes `<dump>.disjoint_ar_shadow.csv`; neither
+partition can change the graph, ambiguity hold, or FIX/FLOAT output. The
+research basis, shared-float-state limitation, and staged promotion gates are
+documented in
+[`docs/fgo_disjoint_ar_shadow_plan.md`](docs/fgo_disjoint_ar_shadow_plan.md).
+The full run1 audit retained 44.28% of wrong-candidate detection at the frozen
+5% correct-candidate harm limit, below the precommitted 50% continuation gate;
+activation and run2/run3 evaluation were therefore not attempted.
+
 The epoch CSV also records whether its builder position came from a fresh
 current-epoch SPP solution (`spp_seed_fresh`) and that seed's ECEF position.
 These diagnostic-only fields allow integer candidates to be audited against

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -101,6 +101,7 @@ struct Args {
     bool constellation_par = false;
     bool residual_par = false;
     bool ratio_impact_monitor = false;
+    bool disjoint_ar_shadow = false;
     bool gf_slip_reset = false;
     bool conditional_mf_shadow = false;
     bool multiepoch_ar_shadow = false;
@@ -280,6 +281,10 @@ Args parseArgs(int argc, char** argv) {
         }
         if (a == "--ratio-impact-monitor") {
             args.ratio_impact_monitor = true;
+            continue;
+        }
+        if (a == "--disjoint-ar-shadow") {
+            args.disjoint_ar_shadow = true;
             continue;
         }
         if (a == "--gf-slip-reset") {
@@ -842,6 +847,9 @@ libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
     }
     if (args.conditional_mf_shadow) {
         config.monitor_conditional_multiband_ar = true;
+    }
+    if (args.disjoint_ar_shadow) {
+        config.monitor_disjoint_constellation_ar = true;
     }
     if (args.multiepoch_ar_shadow) {
         config.monitor_multiepoch_ar = true;
@@ -1581,6 +1589,17 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
            "ratio_impact_best_nfixed,ratio_impact_x_ecef_m,"
            "ratio_impact_y_ecef_m,ratio_impact_z_ecef_m,"
            "ratio_impact_float_sep_m,ratio_impact_imu_sep_m,"
+           "disjoint_ar_eval,disjoint_ar_a_system_mask,"
+           "disjoint_ar_b_system_mask,disjoint_ar_a_n,disjoint_ar_b_n,"
+           "disjoint_ar_a_ratio,disjoint_ar_b_ratio,"
+           "disjoint_ar_a_bsr,disjoint_ar_b_bsr,"
+           "disjoint_ar_a_ratio_pass,disjoint_ar_b_ratio_pass,"
+           "disjoint_ar_a_candidate_valid,disjoint_ar_b_candidate_valid,"
+           "disjoint_ar_a_x_ecef_m,disjoint_ar_a_y_ecef_m,"
+           "disjoint_ar_a_z_ecef_m,disjoint_ar_b_x_ecef_m,"
+           "disjoint_ar_b_y_ecef_m,disjoint_ar_b_z_ecef_m,"
+           "disjoint_ar_ab_sep_m,disjoint_ar_a_primary_sep_m,"
+           "disjoint_ar_b_primary_sep_m,"
            "ddpr_anchor_eval,ddpr_anchor_n,ddpr_anchor_res_m,"
            "ddpr_anchor_x_ecef_m,ddpr_anchor_y_ecef_m,ddpr_anchor_z_ecef_m,"
            "ddpr_anchor_h_err_m,ddpr_anchor_u_err_m,ddpr_anchor_prior,"
@@ -1649,6 +1668,7 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
             const auto& d = r.epoch_diagnostics[si];
             const auto& conditional = d.conditional_multiband_ar_shadow;
             const auto& multiepoch = d.multiepoch_ar_shadow;
+            const auto& disjoint = d.disjoint_constellation_ar_shadow;
             out << ',' << d.effective_ratio_threshold
                 << ',' << s.num_fixed_ambiguities
                 << ',' << static_cast<int>(d.ar_outcome)
@@ -1742,7 +1762,29 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                 << ',' << d.ratio_impact_best_position_ecef.y()
                 << ',' << d.ratio_impact_best_position_ecef.z()
                 << ',' << d.ratio_impact_best_float_separation_m
-                << ',' << d.ratio_impact_best_imu_separation_m;
+                << ',' << d.ratio_impact_best_imu_separation_m
+                << ',' << (disjoint.evaluated ? 1 : 0)
+                << ',' << disjoint.partition_a_system_mask
+                << ',' << disjoint.partition_b_system_mask
+                << ',' << disjoint.partition_a_ambiguities
+                << ',' << disjoint.partition_b_ambiguities
+                << ',' << disjoint.partition_a_ratio
+                << ',' << disjoint.partition_b_ratio
+                << ',' << disjoint.partition_a_bootstrapped_success_rate
+                << ',' << disjoint.partition_b_bootstrapped_success_rate
+                << ',' << (disjoint.partition_a_ratio_passed ? 1 : 0)
+                << ',' << (disjoint.partition_b_ratio_passed ? 1 : 0)
+                << ',' << (disjoint.partition_a_candidate_available ? 1 : 0)
+                << ',' << (disjoint.partition_b_candidate_available ? 1 : 0)
+                << ',' << disjoint.partition_a_position_ecef.x()
+                << ',' << disjoint.partition_a_position_ecef.y()
+                << ',' << disjoint.partition_a_position_ecef.z()
+                << ',' << disjoint.partition_b_position_ecef.x()
+                << ',' << disjoint.partition_b_position_ecef.y()
+                << ',' << disjoint.partition_b_position_ecef.z()
+                << ',' << disjoint.partition_separation_m
+                << ',' << disjoint.partition_a_primary_separation_m
+                << ',' << disjoint.partition_b_primary_separation_m;
             double anchor_horiz = -1.0;
             double anchor_up = -1.0;
             if (d.ddpr_anchor_evaluated && d.ddpr_anchor_position_ecef.norm() > 1e6) {
@@ -1962,6 +2004,61 @@ void dumpTemporalCarrierFactorCsv(
             << (row.carrier_hold_witness ? 1 : 0) << ','
             << (row.carrier_fde_witness ? 1 : 0) << ',' << classification
             << '\n';
+    }
+}
+
+void dumpDisjointArShadowCsv(
+    const libgnss::FGOProcessor::FGOResult& result,
+    const std::string& epoch_csv_path) {
+    const std::string path = epoch_csv_path + ".disjoint_ar_shadow.csv";
+    std::ofstream out(path);
+    if (!out) {
+        std::cerr << "Error: cannot open disjoint AR shadow output file "
+                  << path << "\n";
+        return;
+    }
+    out << std::fixed << std::setprecision(6);
+    out << "tow,evaluated,primary_candidate_available,primary_ratio,"
+           "primary_x_ecef_m,primary_y_ecef_m,primary_z_ecef_m,"
+           "partition_a_system_mask,partition_b_system_mask,"
+           "partition_a_ambiguities,partition_b_ambiguities,"
+           "partition_a_ratio,partition_b_ratio,partition_a_bsr,partition_b_bsr,"
+           "partition_a_ratio_passed,partition_b_ratio_passed,"
+           "partition_a_candidate_available,partition_b_candidate_available,"
+           "partition_a_x_ecef_m,partition_a_y_ecef_m,partition_a_z_ecef_m,"
+           "partition_b_x_ecef_m,partition_b_y_ecef_m,partition_b_z_ecef_m,"
+           "partition_separation_m,partition_a_primary_separation_m,"
+           "partition_b_primary_separation_m\n";
+    for (const auto& epoch : result.epoch_diagnostics) {
+        const auto& shadow = epoch.disjoint_constellation_ar_shadow;
+        out << epoch.time.tow << ','
+            << (shadow.evaluated ? 1 : 0) << ','
+            << (epoch.lambda_candidate_available ? 1 : 0) << ','
+            << epoch.lambda_candidate_ratio << ','
+            << epoch.lambda_candidate_position_ecef.x() << ','
+            << epoch.lambda_candidate_position_ecef.y() << ','
+            << epoch.lambda_candidate_position_ecef.z() << ','
+            << shadow.partition_a_system_mask << ','
+            << shadow.partition_b_system_mask << ','
+            << shadow.partition_a_ambiguities << ','
+            << shadow.partition_b_ambiguities << ','
+            << shadow.partition_a_ratio << ','
+            << shadow.partition_b_ratio << ','
+            << shadow.partition_a_bootstrapped_success_rate << ','
+            << shadow.partition_b_bootstrapped_success_rate << ','
+            << (shadow.partition_a_ratio_passed ? 1 : 0) << ','
+            << (shadow.partition_b_ratio_passed ? 1 : 0) << ','
+            << (shadow.partition_a_candidate_available ? 1 : 0) << ','
+            << (shadow.partition_b_candidate_available ? 1 : 0) << ','
+            << shadow.partition_a_position_ecef.x() << ','
+            << shadow.partition_a_position_ecef.y() << ','
+            << shadow.partition_a_position_ecef.z() << ','
+            << shadow.partition_b_position_ecef.x() << ','
+            << shadow.partition_b_position_ecef.y() << ','
+            << shadow.partition_b_position_ecef.z() << ','
+            << shadow.partition_separation_m << ','
+            << shadow.partition_a_primary_separation_m << ','
+            << shadow.partition_b_primary_separation_m << '\n';
     }
 }
 
@@ -3093,6 +3190,9 @@ int main(int argc, char** argv) {
         const HorizError he = horizontalErrorVsRef(fl, ref_rows);
         if (!args.dump_csv_path.empty()) {
             dumpEpochCsv(fl, ref_rows, args.dump_csv_path);
+            if (args.disjoint_ar_shadow) {
+                dumpDisjointArShadowCsv(fl, args.dump_csv_path);
+            }
             if (args.clock_resilient_temporal_shadow) {
                 dumpTemporalCarrierFactorCsv(fl, args.dump_csv_path);
             }
@@ -3125,6 +3225,8 @@ int main(int argc, char** argv) {
                    << ", max_std_cycles=" << config.partial_ar_max_std_cycles
                    << ", ratio_impact_monitor="
                    << (config.monitor_ratio_impact_partial_ar ? "on" : "off")
+                   << ", disjoint_ar_shadow="
+                   << (config.monitor_disjoint_constellation_ar ? "on" : "off")
                    << ", conditional_mf_shadow="
                    << (config.monitor_conditional_multiband_ar ? "on" : "off")
                    << ", multiepoch_ar_shadow="

--- a/docs/fgo_disjoint_ar_shadow_plan.md
+++ b/docs/fgo_disjoint_ar_shadow_plan.md
@@ -1,0 +1,170 @@
+# FGO disjoint-constellation AR shadow plan
+
+## Objective
+
+Improve correct-FIX distance without increasing wrong-FIX distance.  The next
+experiment does not relax the shipped ratio threshold and does not make TDCP
+an acceptance authority.  It asks whether an ambiguity candidate is reproduced
+by two satellite-disjoint constellation partitions before any lower-ratio
+candidate is considered for promotion.
+
+The first implementation is monitor-only.  It cannot change the active graph,
+integer priors, ambiguity hold state, reported position, or FIX/FLOAT status.
+
+## Why this experiment is next
+
+The completed Tokyo audits reject the following as sufficient acceptance
+evidence:
+
+- temporal integer agreement, bootstrapped success rate, and ratio alone;
+- conditional multi-band ambiguity resolution;
+- held-out carrier rows from the same urban measurement basin;
+- constrained graph cost evaluated on the same active factors;
+- direct DD pseudorange downweighting or causal bias subtraction; and
+- a TDCP-specific gate while raw receiver-clock jumps remain unresolved.
+
+All of those checks can agree inside one biased urban measurement basin.  A
+satellite-disjoint split changes the carrier observations used to form each
+integer candidate and exposes whether the resulting fixed positions separate.
+
+## Research and OSS basis
+
+- Wang et al. apply modified multiple-hypothesis solution separation to
+  ambiguity-resolved GNSS and compare subset solutions with the all-in-view
+  solution while accounting for incorrect-fix events:
+  <https://doi.org/10.33012/2023.18607>.
+- Teunissen's ambiguity-validation framework treats acceptance as a separate
+  decision from integer estimation.  Extra availability is not evidence of a
+  controlled failure rate:
+  <https://www.ion.org/publications/abstract.cfm?articleID=11030>.
+- Verhagen describes success-rate bounds and the pitfalls of common
+  discrimination tests, supporting a fail-closed shadow before activation:
+  <https://doi.org/10.1002/j.2161-4296.2005.tb01736.x>.
+- RTKLIB performs LAMBDA validation and preserves explicit satellite/arc
+  lifecycle and residual checks rather than treating a ratio result as a
+  complete integrity proof:
+  <https://github.com/tomojitakasu/RTKLIB/blob/master/src/rtkpos.c>.
+- GICI-LIB retries partial ambiguity subsets and rejects a constrained graph
+  update when range cost worsens.  Those mechanisms are useful comparisons,
+  but the existing Tokyo audit shows that same-graph cost is not independent
+  enough on its own:
+  <https://github.com/chichengcn/gici-open/blob/master/src/gnss/ambiguity_resolution.cpp>.
+
+The repository already contains a stricter disjoint-satellite evidence
+contract for the standalone RTK path.  The FGO shadow deliberately does not
+claim that same level of independence: both partition marginals originate
+from the same float graph and share IMU/code information.  The carrier
+ambiguity rows and DD reference satellites are disjoint, but common-state
+correlation remains.  This limitation is why the first stage is telemetry,
+not an activation switch.
+
+## Shadow construction
+
+For each epoch with at least two represented GNSS constellations:
+
+1. group eligible ambiguity rows by constellation, keeping every target and
+   its same-constellation DD reference in one group;
+2. assign whole constellation groups greedily to two balanced partitions,
+   with deterministic constellation-ID tie breaking;
+3. require at least four ambiguities in each partition;
+4. extract each partition's float ambiguity subvector, covariance submatrix,
+   and position/ambiguity cross-covariance;
+5. run the existing top-two LAMBDA implementation independently on A and B;
+6. form each partition's covariance-conditioned candidate position; and
+7. export partition ratios, bootstrapped success rates, system masks,
+   candidate positions, A/B separation, and separation from the primary
+   all-in-view candidate.
+
+No thresholded consensus verdict is needed in the runtime monitor.  Offline
+scoring must report complete trade-off curves and freeze a rule using run1
+only.
+
+## Precommitted gates
+
+### Gate 0: exact non-interference
+
+- monitor off/on epoch CSVs are identical in status, ECEF position, ratio,
+  fixed ambiguity count, and AR outcome;
+- missing partitions, singular covariance, a failed LAMBDA search, or a
+  non-finite candidate reports unavailable and never bad; and
+- neither partition candidate can reach graph mutation or ambiguity hold.
+
+### Gate 1: development usefulness on Tokyo run1
+
+Using reference truth only after replay:
+
+- report coverage separately for correct FIX, wrong FIX, correct FLOAT, and
+  wrong FLOAT primary candidates;
+- identify a truth-free separation rule that catches at least 50% of wrong
+  primary candidates while rejecting at most 5% of correct primary
+  candidates;
+- require at least 100 scored correct and 100 scored wrong primary candidates;
+  and
+- report results by partition composition so one favourable constellation
+  split cannot hide a failing split.
+
+If support is insufficient or the operating point fails, retain telemetry and
+stop.  Do not tune on run2.
+
+### Gate 2: frozen validation on Tokyo run2
+
+Apply the run1-frozen rule once.  It must meet the same 50% wrong-candidate
+capture and 5% correct-candidate harm limits.  Any failure ends activation;
+run3 remains sealed.
+
+### Gate 3: bounded activation experiment
+
+Only after Gates 0-2 pass may a separate default-off switch use consensus to
+permit a narrowly relaxed-ratio candidate.  Start with a representative
+500-epoch run1 slice and require:
+
+- zero additional wrong FIX epochs;
+- no lost correct FIX epochs;
+- no new NONE/non-finite epoch;
+- fixed RMS and P95 regression no greater than 5%; and
+- runtime overhead no greater than 15%.
+
+Then freeze every threshold on full run1, validate run2, and inspect sealed
+run3 only after run2 passes.  Wrong-FIX distance may not increase and
+correct-FIX distance may not decrease on either holdout individually.
+
+## Execution sequence
+
+1. Add the default-off shadow, CLI flag, normalized CSV, and deterministic
+   partition helper.
+2. Unit-test balanced whole-constellation assignment, fail-closed behavior,
+   and candidate separation.
+3. Prove exact baseline non-interference on a short replay.
+4. Run and score full Tokyo run1.
+5. Continue to run2, activation, and sealed run3 only when every preceding
+   gate passes.
+
+## Development result
+
+The default-off implementation passed a 50-epoch Tokyo run1 non-interference
+A/B.  Baseline and shadow matched in all 50 rows for time, status, ECEF
+position, ratio, fixed ambiguity count, and AR outcome.  Both partition
+candidates were available in every epoch; their position separation had a
+5.388 mm median and 21.439 mm maximum in this clean opening segment.
+
+Full Tokyo run1 produced 7,049 truth-scorable primary candidates from 11,905
+epochs.  The population contained 4,244 correct candidates (3D error at most
+0.5 m) and 2,805 wrong candidates, so the precommitted support requirement was
+comfortably met.  The run1-selected rule rejects a primary candidate when the
+maximum of A/B, A/primary, and B/primary position separation exceeds
+0.421369 m.  It gives:
+
+| Metric | Result | Gate |
+|---|---:|---:|
+| Correct candidates rejected | 212 / 4,244 = 4.995% | at most 5% |
+| Wrong candidates caught | 1,242 / 2,805 = 44.278% | at least 50% |
+
+Gate 1 therefore fails on development data.  The failure is not caused by
+insufficient labels: satellite-disjoint ambiguity subsets can still agree
+inside a shared biased float-state basin.  The full shadow solver time was
+848.646 s; the extra two LAMBDA searches per eligible epoch also make this
+substantially more expensive than the existing same-preset baseline reports.
+
+Decision: retain the raw monitor and scorer as diagnostic evidence, but do not
+add a consensus veto, relaxed-ratio rescue, graph prior, or FIX label.  Tokyo
+run2 and sealed run3 were not inspected for this experiment.

--- a/include/libgnss++/algorithms/disjoint_constellation_partition.hpp
+++ b/include/libgnss++/algorithms/disjoint_constellation_partition.hpp
@@ -1,0 +1,66 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <map>
+#include <utility>
+#include <vector>
+
+namespace libgnss::disjoint_constellation_partition {
+
+struct Candidate {
+    int system = -1;
+    int index = -1;
+};
+
+struct Result {
+    std::vector<int> partition_a;
+    std::vector<int> partition_b;
+    std::uint64_t partition_a_system_mask = 0;
+    std::uint64_t partition_b_system_mask = 0;
+
+    bool available(int minimum_per_partition) const {
+        return minimum_per_partition > 0 &&
+            static_cast<int>(partition_a.size()) >= minimum_per_partition &&
+            static_cast<int>(partition_b.size()) >= minimum_per_partition;
+    }
+};
+
+// Keep complete constellation groups together so a target and its
+// same-constellation DD reference can never be shared across partitions.
+// Largest groups are assigned first to the currently smaller partition;
+// constellation ID breaks ties deterministically.
+inline Result partition(const std::vector<Candidate>& candidates) {
+    std::map<int, std::vector<int>> by_system;
+    for (const auto& candidate : candidates) {
+        if (candidate.system < 0 || candidate.index < 0) continue;
+        by_system[candidate.system].push_back(candidate.index);
+    }
+
+    std::vector<std::pair<int, std::vector<int>>> groups;
+    groups.reserve(by_system.size());
+    for (auto& [system, indexes] : by_system) {
+        groups.emplace_back(system, std::move(indexes));
+    }
+    std::sort(groups.begin(), groups.end(), [](const auto& lhs, const auto& rhs) {
+        if (lhs.second.size() != rhs.second.size()) {
+            return lhs.second.size() > rhs.second.size();
+        }
+        return lhs.first < rhs.first;
+    });
+
+    Result result;
+    for (const auto& [system, indexes] : groups) {
+        auto* destination = &result.partition_a;
+        auto* mask = &result.partition_a_system_mask;
+        if (result.partition_b.size() < result.partition_a.size()) {
+            destination = &result.partition_b;
+            mask = &result.partition_b_system_mask;
+        }
+        destination->insert(destination->end(), indexes.begin(), indexes.end());
+        if (system < 64) *mask |= std::uint64_t{1} << system;
+    }
+    return result;
+}
+
+}  // namespace libgnss::disjoint_constellation_partition

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -7,6 +7,7 @@
 #include <libgnss++/io/imu.hpp>
 
 #include <cstddef>
+#include <cstdint>
 #include <limits>
 #include <map>
 #include <set>
@@ -384,6 +385,14 @@ public:
         // satellite in turn and record the best candidate. Never changes the
         // selected subset, FIX/FLOAT status, graph, or hold state.
         bool monitor_ratio_impact_partial_ar = false;
+        // Diagnostic-only ambiguity solution-separation audit. Eligible DD
+        // ambiguities are grouped by constellation, whole constellation
+        // groups are balanced into two satellite-disjoint partitions, and
+        // each partition runs an independent reduced LAMBDA search. The
+        // shared float graph still correlates both partitions, so this is
+        // evidence telemetry rather than an acceptance authority.
+        bool monitor_disjoint_constellation_ar = false;
+        int disjoint_constellation_ar_min_ambiguities = 4;
         // Diagnostic-only two-stage multi-frequency ambiguity resolution.
         // Resolve one primary band per satellite, then condition the remaining
         // ambiguity distribution on those integers. Never changes estimator
@@ -2158,6 +2167,30 @@ public:
         double imu_separation_m = 0.0;
     };
 
+    /// Two constellation-disjoint reduced LAMBDA candidates. Populated only
+    /// by monitor_disjoint_constellation_ar and never consumed by the
+    /// estimator.
+    struct DisjointConstellationArShadow {
+        bool evaluated = false;
+        std::uint64_t partition_a_system_mask = 0;
+        std::uint64_t partition_b_system_mask = 0;
+        int partition_a_ambiguities = 0;
+        int partition_b_ambiguities = 0;
+        double partition_a_ratio = 0.0;
+        double partition_b_ratio = 0.0;
+        double partition_a_bootstrapped_success_rate = 0.0;
+        double partition_b_bootstrapped_success_rate = 0.0;
+        bool partition_a_ratio_passed = false;
+        bool partition_b_ratio_passed = false;
+        bool partition_a_candidate_available = false;
+        bool partition_b_candidate_available = false;
+        Vector3d partition_a_position_ecef = Vector3d::Zero();
+        Vector3d partition_b_position_ecef = Vector3d::Zero();
+        double partition_separation_m = 0.0;
+        double partition_a_primary_separation_m = 0.0;
+        double partition_b_primary_separation_m = 0.0;
+    };
+
     /// Counterfactual two-stage multi-frequency AR result. Populated only by
     /// monitor_conditional_multiband_ar and never consumed by the estimator.
     struct ConditionalMultibandArShadow {
@@ -2282,6 +2315,7 @@ public:
         double ratio_impact_best_float_separation_m = 0.0;
         double ratio_impact_best_imu_separation_m = 0.0;
         std::vector<RatioImpactTrialTrace> ratio_impact_trial_trace;
+        DisjointConstellationArShadow disjoint_constellation_ar_shadow;
         bool ddpr_anchor_evaluated = false;
         bool ddpr_anchor_bootstrap_prior_applied = false;
         int ddpr_anchor_active_factors = 0;

--- a/scripts/analyze_disjoint_ar_shadow.py
+++ b/scripts/analyze_disjoint_ar_shadow.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Score disjoint-constellation AR solution separation against offline truth."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from bisect import bisect_left
+from pathlib import Path
+from typing import Any
+
+
+def tow_key(value: str) -> int:
+    return round(float(value) * 1000.0)
+
+
+def ecef(row: dict[str, str], prefix: str) -> tuple[float, float, float]:
+    return tuple(float(row[f"{prefix}_{axis}_ecef_m"]) for axis in "xyz")  # type: ignore[return-value]
+
+
+def distance(a: tuple[float, float, float], b: tuple[float, float, float]) -> float:
+    return math.sqrt(sum((x - y) ** 2 for x, y in zip(a, b)))
+
+
+def percentile(values: list[float], fraction: float) -> float | None:
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = max(0, min(len(ordered) - 1, math.ceil(fraction * len(ordered)) - 1))
+    return ordered[index]
+
+
+def load_reference(path: Path) -> tuple[list[int], dict[int, tuple[float, float, float]]]:
+    rows: dict[int, tuple[float, float, float]] = {}
+    with path.open(newline="", encoding="utf-8-sig") as stream:
+        for raw in csv.DictReader(stream):
+            row = {key.strip(): value.strip() for key, value in raw.items()}
+            key = tow_key(row["GPS TOW (s)"])
+            rows[key] = (
+                float(row["ECEF X (m)"]),
+                float(row["ECEF Y (m)"]),
+                float(row["ECEF Z (m)"]),
+            )
+    return sorted(rows), rows
+
+
+def nearest_reference(
+    key: int,
+    ordered: list[int],
+    rows: dict[int, tuple[float, float, float]],
+) -> tuple[float, float, float] | None:
+    index = bisect_left(ordered, key)
+    choices = ordered[max(0, index - 1) : min(len(ordered), index + 1)]
+    if not choices:
+        return None
+    nearest = min(choices, key=lambda candidate: abs(candidate - key))
+    return rows[nearest] if abs(nearest - key) <= 110 else None
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--epoch-csv", type=Path, required=True)
+    parser.add_argument("--shadow-csv", type=Path, required=True)
+    parser.add_argument("--reference-csv", type=Path, required=True)
+    parser.add_argument("--json", type=Path)
+    parser.add_argument("--correct-threshold-m", type=float, default=0.5)
+    parser.add_argument("--maximum-correct-harm", type=float, default=0.05)
+    parser.add_argument("--minimum-wrong-capture", type=float, default=0.50)
+    parser.add_argument("--minimum-support", type=int, default=100)
+    args = parser.parse_args()
+
+    epoch_rows: dict[int, dict[str, str]] = {}
+    with args.epoch_csv.open(newline="", encoding="utf-8-sig") as stream:
+        for row in csv.DictReader(stream):
+            epoch_rows[tow_key(row["tow"])] = row
+
+    reference_order, reference_rows = load_reference(args.reference_csv)
+    scored: list[dict[str, Any]] = []
+    unavailable = 0
+    with args.shadow_csv.open(newline="", encoding="utf-8-sig") as stream:
+        for row in csv.DictReader(stream):
+            key = tow_key(row["tow"])
+            epoch = epoch_rows.get(key)
+            truth = nearest_reference(key, reference_order, reference_rows)
+            if (
+                epoch is None
+                or truth is None
+                or row["evaluated"] != "1"
+                or row["primary_candidate_available"] != "1"
+                or row["partition_a_candidate_available"] != "1"
+                or row["partition_b_candidate_available"] != "1"
+            ):
+                unavailable += 1
+                continue
+            primary_error = distance(ecef(row, "primary"), truth)
+            separations = [
+                float(row["partition_separation_m"]),
+                float(row["partition_a_primary_separation_m"]),
+                float(row["partition_b_primary_separation_m"]),
+            ]
+            if not math.isfinite(primary_error) or not all(map(math.isfinite, separations)):
+                unavailable += 1
+                continue
+            scored.append(
+                {
+                    "correct": primary_error <= args.correct_threshold_m,
+                    "status": epoch["status"],
+                    "score": max(separations),
+                    "composition": (
+                        f"{row['partition_a_system_mask']}/"
+                        f"{row['partition_b_system_mask']}"
+                    ),
+                }
+            )
+
+    correct_scores = [row["score"] for row in scored if row["correct"]]
+    wrong_scores = [row["score"] for row in scored if not row["correct"]]
+    threshold = percentile(correct_scores, 1.0 - args.maximum_correct_harm)
+    correct_rejected = (
+        sum(score > threshold for score in correct_scores)
+        if threshold is not None
+        else 0
+    )
+    wrong_rejected = (
+        sum(score > threshold for score in wrong_scores)
+        if threshold is not None
+        else 0
+    )
+    correct_harm = correct_rejected / len(correct_scores) if correct_scores else None
+    wrong_capture = wrong_rejected / len(wrong_scores) if wrong_scores else None
+
+    population = {
+        f"{'correct' if row['correct'] else 'wrong'}_{row['status'].lower()}": 0
+        for row in scored
+    }
+    composition: dict[str, dict[str, int]] = {}
+    for row in scored:
+        population[f"{'correct' if row['correct'] else 'wrong'}_{row['status'].lower()}"] += 1
+        bucket = composition.setdefault(row["composition"], {"correct": 0, "wrong": 0})
+        bucket["correct" if row["correct"] else "wrong"] += 1
+
+    grid = []
+    for candidate in (0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1.0, 2.0, 5.0, 10.0):
+        grid.append(
+            {
+                "threshold_m": candidate,
+                "correct_harm": (
+                    sum(score > candidate for score in correct_scores) / len(correct_scores)
+                    if correct_scores
+                    else None
+                ),
+                "wrong_capture": (
+                    sum(score > candidate for score in wrong_scores) / len(wrong_scores)
+                    if wrong_scores
+                    else None
+                ),
+            }
+        )
+
+    gate_passed = (
+        len(correct_scores) >= args.minimum_support
+        and len(wrong_scores) >= args.minimum_support
+        and correct_harm is not None
+        and correct_harm <= args.maximum_correct_harm
+        and wrong_capture is not None
+        and wrong_capture >= args.minimum_wrong_capture
+    )
+    summary = {
+        "gate_passed": gate_passed,
+        "rows": {
+            "epoch": len(epoch_rows),
+            "scored": len(scored),
+            "unavailable": unavailable,
+            "correct": len(correct_scores),
+            "wrong": len(wrong_scores),
+        },
+        "population": population,
+        "selected_rule": {
+            "reject_when_max_separation_exceeds_m": threshold,
+            "correct_rejected": correct_rejected,
+            "correct_harm": correct_harm,
+            "wrong_rejected": wrong_rejected,
+            "wrong_capture": wrong_capture,
+        },
+        "requirements": {
+            "minimum_support_each": args.minimum_support,
+            "maximum_correct_harm": args.maximum_correct_harm,
+            "minimum_wrong_capture": args.minimum_wrong_capture,
+        },
+        "partition_composition": composition,
+        "threshold_grid": grid,
+    }
+    rendered = json.dumps(summary, indent=2, sort_keys=True, allow_nan=False)
+    print(rendered)
+    if args.json:
+        args.json.write_text(rendered + "\n", encoding="utf-8")
+    return 0 if gate_passed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -24,6 +24,7 @@
 // node (seeded with libgnss's lumped value, in cycles) and ambTarget <- a
 // single shared dummy node pinned to 0 with a tight prior.
 
+#include <libgnss++/algorithms/disjoint_constellation_partition.hpp>
 #include <libgnss++/algorithms/fgo.hpp>
 #include <libgnss++/algorithms/lambda.hpp>
 #include <libgnss++/core/constants.hpp>
@@ -4726,6 +4727,136 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                             }
                         }
                         break;  // validated subset found
+                    }
+
+                    // Constellation-disjoint ambiguity solution-separation
+                    // shadow. Whole constellation groups stay together so
+                    // no target/reference satellite can occur in both
+                    // reduced LAMBDA searches. Both subproblems still come
+                    // from the shared float graph, so their agreement is
+                    // telemetry only and never authorizes a FIX.
+                    if (config.monitor_disjoint_constellation_ar) {
+                        std::vector<disjoint_constellation_partition::Candidate>
+                            partition_candidates;
+                        partition_candidates.reserve(static_cast<std::size_t>(n));
+                        for (int candidate = 0; candidate < n; ++candidate) {
+                            const std::size_t ambiguity_index =
+                                epoch_amb_indices[candidate];
+                            if (ambiguity_index >= problem.ambiguity_states.size()) {
+                                continue;
+                            }
+                            partition_candidates.push_back({
+                                static_cast<int>(problem.ambiguity_states[ambiguity_index]
+                                                     .satellite.system),
+                                candidate});
+                        }
+                        const auto partitioned =
+                            disjoint_constellation_partition::partition(
+                                partition_candidates);
+                        auto& shadow = epoch_diagnostics[i]
+                                           .disjoint_constellation_ar_shadow;
+                        shadow.partition_a_system_mask =
+                            partitioned.partition_a_system_mask;
+                        shadow.partition_b_system_mask =
+                            partitioned.partition_b_system_mask;
+                        shadow.partition_a_ambiguities =
+                            static_cast<int>(partitioned.partition_a.size());
+                        shadow.partition_b_ambiguities =
+                            static_cast<int>(partitioned.partition_b.size());
+                        const int minimum_partition = std::max(
+                            1, config.disjoint_constellation_ar_min_ambiguities);
+                        if (partitioned.available(minimum_partition)) {
+                            shadow.evaluated = true;
+                            const Eigen::Vector3d float_antenna = Eigen::Vector3d(
+                                antennaOf(lambda_linearization_point.at<Pose3>(
+                                    positionKey(i))));
+                            const auto solvePartition =
+                                [&](const std::vector<int>& indexes,
+                                    double& ratio,
+                                    double& bootstrapped_success_rate,
+                                    bool& ratio_passed,
+                                    bool& candidate_available,
+                                    Vector3d& candidate_position) {
+                                    const int count =
+                                        static_cast<int>(indexes.size());
+                                    Eigen::VectorXd partition_float(count);
+                                    Eigen::MatrixXd partition_q(count, count);
+                                    Eigen::MatrixXd partition_pos(3, count);
+                                    for (int row = 0; row < count; ++row) {
+                                        partition_float(row) = float_amb(indexes[row]);
+                                        partition_pos.col(row) = pos_amb.col(indexes[row]);
+                                        for (int column = 0; column < count; ++column) {
+                                            partition_q(row, column) =
+                                                q_amb(indexes[row], indexes[column]);
+                                        }
+                                    }
+                                    LambdaCandidateDiagnostics diagnostics;
+                                    if (!lambdaSearchTopK(partition_float, partition_q,
+                                                          2, diagnostics)) {
+                                        return;
+                                    }
+                                    const double best =
+                                        diagnostics.squared_residuals(0);
+                                    ratio = best > 0.0
+                                        ? diagnostics.squared_residuals(1) / best
+                                        : 0.0;
+                                    bootstrapped_success_rate =
+                                        diagnostics.bootstrapped_success_rate;
+                                    ratio_passed = std::isfinite(ratio) &&
+                                        (config.lambda_ratio_threshold <= 0.0 ||
+                                         ratio > config.lambda_ratio_threshold);
+                                    const Eigen::LDLT<Eigen::MatrixXd> ldlt(
+                                        partition_q);
+                                    if (ldlt.info() != Eigen::Success) return;
+                                    const Eigen::VectorXd correction = ldlt.solve(
+                                        partition_float -
+                                        diagnostics.candidates.col(0));
+                                    const Eigen::Vector3d position_delta =
+                                        partition_pos * correction;
+                                    if (!correction.allFinite() ||
+                                        !position_delta.allFinite()) {
+                                        return;
+                                    }
+                                    candidate_position =
+                                        float_antenna - position_delta;
+                                    candidate_available =
+                                        candidate_position.allFinite();
+                                };
+                            solvePartition(
+                                partitioned.partition_a,
+                                shadow.partition_a_ratio,
+                                shadow.partition_a_bootstrapped_success_rate,
+                                shadow.partition_a_ratio_passed,
+                                shadow.partition_a_candidate_available,
+                                shadow.partition_a_position_ecef);
+                            solvePartition(
+                                partitioned.partition_b,
+                                shadow.partition_b_ratio,
+                                shadow.partition_b_bootstrapped_success_rate,
+                                shadow.partition_b_ratio_passed,
+                                shadow.partition_b_candidate_available,
+                                shadow.partition_b_position_ecef);
+                            if (shadow.partition_a_candidate_available &&
+                                shadow.partition_b_candidate_available) {
+                                shadow.partition_separation_m =
+                                    (shadow.partition_a_position_ecef -
+                                     shadow.partition_b_position_ecef)
+                                        .norm();
+                                if (epoch_diagnostics[i]
+                                        .lambda_candidate_available) {
+                                    shadow.partition_a_primary_separation_m =
+                                        (shadow.partition_a_position_ecef -
+                                         epoch_diagnostics[i]
+                                             .lambda_candidate_position_ecef)
+                                            .norm();
+                                    shadow.partition_b_primary_separation_m =
+                                        (shadow.partition_b_position_ecef -
+                                         epoch_diagnostics[i]
+                                             .lambda_candidate_position_ecef)
+                                            .norm();
+                                }
+                            }
+                        }
                     }
 
                     // Multi-epoch AR shadow. Select only uninterrupted DD

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -37,6 +37,7 @@ if(GTest_FOUND)
           test_fix_failure_budget.cpp
     test_inertial_fix_evidence.cpp
     test_disjoint_satellite_fix_evidence.cpp
+        test_disjoint_constellation_partition.cpp
         test_causal_ambiguity_arc.cpp
         test_nlos_weights.cpp
         test_float_trust_policy.cpp

--- a/tests/test_disjoint_constellation_partition.cpp
+++ b/tests/test_disjoint_constellation_partition.cpp
@@ -1,0 +1,59 @@
+#include <gtest/gtest.h>
+
+#include <libgnss++/algorithms/disjoint_constellation_partition.hpp>
+
+#include <algorithm>
+#include <vector>
+
+namespace {
+
+using libgnss::disjoint_constellation_partition::Candidate;
+using libgnss::disjoint_constellation_partition::partition;
+
+TEST(DisjointConstellationPartition, KeepsWholeSystemsDisjoint) {
+    const auto result = partition({
+        {1, 0}, {1, 1}, {1, 2}, {1, 3},
+        {2, 4}, {2, 5}, {2, 6},
+        {3, 7}, {3, 8},
+    });
+
+    EXPECT_EQ(result.partition_a_system_mask & result.partition_b_system_mask, 0u);
+    EXPECT_EQ(result.partition_a.size() + result.partition_b.size(), 9u);
+    EXPECT_TRUE(result.available(4));
+
+    for (int index : {0, 1, 2, 3}) {
+        const bool in_a = std::find(result.partition_a.begin(),
+                                    result.partition_a.end(), index) !=
+            result.partition_a.end();
+        const bool in_b = std::find(result.partition_b.begin(),
+                                    result.partition_b.end(), index) !=
+            result.partition_b.end();
+        EXPECT_NE(in_a, in_b);
+    }
+}
+
+TEST(DisjointConstellationPartition, IsDeterministicOnEqualSizedGroups) {
+    const std::vector<Candidate> input = {
+        {4, 4}, {4, 5}, {2, 0}, {2, 1}, {3, 2}, {3, 3},
+    };
+    const auto first = partition(input);
+    const auto second = partition(input);
+    EXPECT_EQ(first.partition_a, second.partition_a);
+    EXPECT_EQ(first.partition_b, second.partition_b);
+    EXPECT_EQ(first.partition_a_system_mask, second.partition_a_system_mask);
+    EXPECT_EQ(first.partition_b_system_mask, second.partition_b_system_mask);
+}
+
+TEST(DisjointConstellationPartition, FailsClosedWithoutTwoSupportedPools) {
+    const auto one_system = partition({
+        {1, 0}, {1, 1}, {1, 2}, {1, 3}, {1, 4}, {1, 5},
+    });
+    EXPECT_FALSE(one_system.available(1));
+
+    const auto undersized = partition({
+        {1, 0}, {1, 1}, {1, 2}, {2, 3}, {2, 4}, {2, 5},
+    });
+    EXPECT_FALSE(undersized.available(4));
+}
+
+}  // namespace

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -535,6 +535,65 @@ TEST(FGOAmbiguityCandidateTelemetryTest, ReportsDisabledCandidateFunnel) {
     }
 }
 
+TEST(FGODisjointConstellationArShadowTest,
+     ProducesTwoCandidatesWithoutChangingFixedLagSolution) {
+    CpHoldTestOptions opt;
+    opt.num_epochs = 3;
+    opt.satellites = gtsamParitySatelliteGeometry();
+    opt.satellites.push_back(Vector3d(-21500000.0, 9000000.0, 11000000.0));
+    opt.satellites.push_back(Vector3d(9000000.0, 22000000.0, -12000000.0));
+    opt.satellites.push_back(Vector3d(-8000000.0, -21000000.0, -14000000.0));
+    auto problem = makeCpHoldFixedLagProblem(opt);
+
+    for (std::size_t index = 4; index < problem.ambiguity_states.size(); ++index) {
+        auto& ambiguity = problem.ambiguity_states[index];
+        ambiguity.satellite = SatelliteId(
+            GNSSSystem::Galileo, ambiguity.satellite.prn);
+        ambiguity.reference_satellite = SatelliteId(GNSSSystem::Galileo, 1);
+    }
+    for (auto& factor : problem.double_difference_carrier_factors) {
+        if (factor.ambiguity_index < 4) continue;
+        factor.satellite = SatelliteId(GNSSSystem::Galileo, factor.satellite.prn);
+        factor.reference_satellite = SatelliteId(GNSSSystem::Galileo, 1);
+    }
+
+    FGOProcessor::FGOConfig base_config = makeCpHoldBaseConfig();
+    base_config.use_carrier_phase_factors = true;
+    base_config.use_lambda_ambiguity_fix = true;
+    base_config.min_fixed_ambiguities = 4;
+    const auto baseline = FGOProcessor(base_config).optimizeProblem(problem);
+
+    auto shadow_config = base_config;
+    shadow_config.monitor_disjoint_constellation_ar = true;
+    shadow_config.disjoint_constellation_ar_min_ambiguities = 4;
+    const auto shadow = FGOProcessor(shadow_config).optimizeProblem(problem);
+
+    ASSERT_EQ(baseline.solution.solutions.size(), shadow.solution.solutions.size());
+    ASSERT_EQ(shadow.epoch_diagnostics.size(), problem.epochs.size());
+    for (std::size_t epoch = 0; epoch < shadow.solution.solutions.size(); ++epoch) {
+        EXPECT_EQ(baseline.solution.solutions[epoch].status,
+                  shadow.solution.solutions[epoch].status);
+        EXPECT_DOUBLE_EQ(baseline.solution.solutions[epoch].ratio,
+                         shadow.solution.solutions[epoch].ratio);
+        EXPECT_EQ(baseline.solution.solutions[epoch].num_fixed_ambiguities,
+                  shadow.solution.solutions[epoch].num_fixed_ambiguities);
+        EXPECT_TRUE(baseline.solution.solutions[epoch].position_ecef.isApprox(
+            shadow.solution.solutions[epoch].position_ecef, 0.0));
+
+        const auto& diagnostic =
+            shadow.epoch_diagnostics[epoch].disjoint_constellation_ar_shadow;
+        EXPECT_TRUE(diagnostic.evaluated);
+        EXPECT_EQ(diagnostic.partition_a_ambiguities, 4);
+        EXPECT_EQ(diagnostic.partition_b_ambiguities, 4);
+        EXPECT_EQ(diagnostic.partition_a_system_mask &
+                      diagnostic.partition_b_system_mask,
+                  0u);
+        EXPECT_TRUE(diagnostic.partition_a_candidate_available);
+        EXPECT_TRUE(diagnostic.partition_b_candidate_available);
+        EXPECT_TRUE(std::isfinite(diagnostic.partition_separation_m));
+    }
+}
+
 TEST(FGOClockResilientTemporalCarrierShadowTest,
      ReportsResidualsWithoutChangingFixedLagSolution) {
     CpHoldTestOptions opt;


### PR DESCRIPTION
## Summary

- add a default-off, monitor-only disjoint-constellation ambiguity-resolution shadow
- export normalized epoch and sidecar telemetry for the two reduced LAMBDA candidates
- add deterministic partition tests, GTSAM non-interference coverage, and an offline truth scorer
- document the research basis, precommitted promotion gates, and Tokyo run1 result

## Why

Previous acceptance signals can agree inside the same biased urban measurement basin. This experiment tests whether whole-constellation, carrier-ambiguity-disjoint subsets produce separated integer candidate positions without changing estimator authority.

Tokyo run1 did not meet the precommitted usefulness gate: the frozen 5% correct-candidate harm operating point caught 44.28% of wrong candidates, below the required 50%. The monitor remains diagnostic-only; run2/run3 and activation were not attempted.

## Impact

The feature is disabled by default. Even when enabled with `--disjoint-ar-shadow`, it cannot change the graph, ambiguity hold, position, or FIX/FLOAT result. It writes additional telemetry and incurs two reduced LAMBDA searches per eligible epoch.

## Validation

- full test executable: 836 passed, 60 skipped for unavailable datasets, 0 failed
- 4 focused partition/GTSAM tests passed
- 50-epoch Tokyo baseline/shadow A/B: exact match for status, ECEF, ratio, fixed count, and AR outcome
- full Tokyo run1: 11,905 epochs; 7,049 truth-scorable candidates
- `python -m py_compile scripts/analyze_disjoint_ar_shadow.py`
- `git diff --check`