### PR TITLE
Audit FGO ambiguity lifecycle events

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,6 +260,18 @@ The full run1 audit retained 44.28% of wrong-candidate detection at the frozen
 5% correct-candidate harm limit, below the precommitted 50% continuation gate;
 activation and run2/run3 evaluation were therefore not attempted.
 
+The epoch CSV also appends the builder's existing `clock_jump` flag, signed
+common GPS pseudorange change, and matched-satellite support. Together with
+the normalized ambiguity-candidate sidecar, these fields support the offline
+wrong-FIX onset audit in
+[`scripts/analyze_fgo_arc_lifecycle.py`](scripts/analyze_fgo_arc_lifecycle.py).
+The audit derives causal reference changes, ambiguity-index churn/age, slip
+events, generation bumps, and FDE exclusions without changing the estimator;
+its frozen gates and research basis are documented in
+[`docs/fgo_arc_lifecycle_wrong_fix_audit.md`](docs/fgo_arc_lifecycle_wrong_fix_audit.md).
+Tokyo run1 contained only one clock jump and no lifecycle category met the
+frozen selectivity gate; no lifecycle-based FIX veto or reset was added.
+
 The epoch CSV also records whether its builder position came from a fresh
 current-epoch SPP solution (`spp_seed_fresh`) and that seed's ECEF position.
 These diagnostic-only fields allow integer candidates to be audited against

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -1528,6 +1528,7 @@ HorizError horizontalErrorVsRef(const libgnss::FGOProcessor::FGOResult& r,
 // demotions -- i.e. exactly the label horizontalErrorVsRef() buckets on.
 void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                   const std::vector<RefRow>& ref,
+                  const libgnss::FGOProcessor::FGOProblem& problem,
                   const std::string& path) {
     if (ref.empty()) {
         std::cerr << "Warning: --dump-csv requires --ref reference.csv; skipping dump.\n";
@@ -1614,7 +1615,9 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
            "low_count_attempted,low_count_used,"
            "integer_reopt_eval,integer_reopt_pass,integer_reopt_base_cost_before,"
            "integer_reopt_base_cost_after,integer_reopt_base_cost_delta,"
-           "dr_bypass_eval,dr_bypass_horiz_err_m,dr_bypass_applied\n";
+           "dr_bypass_eval,dr_bypass_horiz_err_m,dr_bypass_applied,"
+           "clock_jump,clock_common_delta_m,"
+           "clock_common_delta_satellites\n";
     std::size_t ri = 0;
     for (std::size_t si = 0; si < r.solution.solutions.size(); ++si) {
         const auto& s = r.solution.solutions[si];
@@ -1868,6 +1871,14 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                 << ',' << dr_bypass_horiz
                 << ',' << (d.dr_bypass_applied ? 1 : 0);
         }
+        out << ',' << (si < problem.clock_jumps.size() &&
+                       problem.clock_jumps[si] ? 1 : 0)
+            << ',' << (si < problem.gps_common_pseudorange_delta_m.size()
+                           ? problem.gps_common_pseudorange_delta_m[si]
+                           : 0.0)
+            << ',' << (si < problem.gps_common_pseudorange_delta_satellites.size()
+                           ? problem.gps_common_pseudorange_delta_satellites[si]
+                           : 0);
         out << '\n';
     }
 
@@ -2577,6 +2588,8 @@ bool readBoolVec(std::istream& is, std::vector<bool>& v) {
 void writeProblem(std::ostream& os, const libgnss::FGOProcessor::FGOProblem& p) {
     writeVec(os, p.epochs);
     writeBoolVec(os, p.clock_jumps);
+    writeVec(os, p.gps_common_pseudorange_delta_m);
+    writeVec(os, p.gps_common_pseudorange_delta_satellites);
     writeVec(os, p.pseudorange_factors);
     writeVec(os, p.tdcp_factors);
     writeVec(os, p.single_difference_doppler_factors);
@@ -2596,6 +2609,8 @@ void writeProblem(std::ostream& os, const libgnss::FGOProcessor::FGOProblem& p) 
 bool readProblem(std::istream& is, libgnss::FGOProcessor::FGOProblem& p) {
     return readVec(is, p.epochs) &&
            readBoolVec(is, p.clock_jumps) &&
+           readVec(is, p.gps_common_pseudorange_delta_m) &&
+           readVec(is, p.gps_common_pseudorange_delta_satellites) &&
            readVec(is, p.pseudorange_factors) &&
            readVec(is, p.tdcp_factors) &&
            readVec(is, p.single_difference_doppler_factors) &&
@@ -2636,7 +2651,7 @@ FileId statFile(const std::string& path) {
 // vector, new factor field, ...) -- an old cache then fails the magic/version
 // check in load() below and is rebuilt instead of misread.
 constexpr uint32_t kMagic = 0x50434647u;  // "PCFG" (problem-cache fgo)
-constexpr uint32_t kVersion = 9u;
+constexpr uint32_t kVersion = 10u;
 constexpr std::size_t kBuilderFingerprintBytes = 512u;
 
 struct Fingerprint {
@@ -3189,7 +3204,7 @@ int main(int argc, char** argv) {
         const std::size_t ne = fl.solution.solutions.size();
         const HorizError he = horizontalErrorVsRef(fl, ref_rows);
         if (!args.dump_csv_path.empty()) {
-            dumpEpochCsv(fl, ref_rows, args.dump_csv_path);
+            dumpEpochCsv(fl, ref_rows, problem, args.dump_csv_path);
             if (args.disjoint_ar_shadow) {
                 dumpDisjointArShadowCsv(fl, args.dump_csv_path);
             }

--- a/docs/fgo_arc_lifecycle_wrong_fix_audit.md
+++ b/docs/fgo_arc_lifecycle_wrong_fix_audit.md
@@ -1,0 +1,162 @@
+# FGO ambiguity lifecycle wrong-FIX audit
+
+## Objective
+
+Determine whether wrong FGO FIX events begin soon after a causal carrier-arc
+discontinuity.  The audit does not add another ambiguity acceptance gate and
+does not tune TDCP.  It joins telemetry that the estimator already produces:
+receiver clock-jump detection, reference-satellite changes, ambiguity-index
+churn, short arc age, geometry-free and Doppler slip shadows, generation
+bumps, and carrier FDE exclusions.
+
+Reference truth is used only offline to label a reported FIX as correct or
+wrong.  No truth label, score, or lifecycle verdict is available to the
+runtime estimator.
+
+## Why the scope changed
+
+The repository already contains completed clock-resilient temporal-carrier,
+geometry-free slip, Doppler slip, predicted-DDPR, causal DDPR-bias, and
+multi-epoch ambiguity audits.  Their documented holdout results reject direct
+TDCP insertion, direct DDPR downweighting, and same-state ambiguity consensus
+as safe FIX-rate improvements.  Reimplementing any of those monitors would
+repeat a closed experiment.
+
+The missing artifact is an event-level attribution report.  Existing epoch
+CSV output contains most reset and slip counters, while its normalized
+`.ar_candidates.csv` sidecar identifies the eligible ambiguity index and DD
+reference for each satellite/signal row.  The builder clock data was not
+exported; the epoch CSV now appends the existing positive-only boolean, the
+signed common GPS pseudorange change, and its matched-satellite support
+without changing any estimator state.  The signed value prevents a negative
+receiver-clock jump from disappearing from the offline audit.
+
+## Research and OSS basis
+
+- Momoh, Bhattarai, and Ziebart separate common receiver clock jumps from
+  individual cycle slips before reconstructing observations:
+  <https://doi.org/10.1007/s10291-019-0832-4>.
+- Guo and Zhang classify clock jumps and reconstruct the affected observable
+  rather than interpreting every temporal phase discontinuity as a slip:
+  <https://doi.org/10.1007/s10291-012-0307-3>.
+- RTKLIB uses LLI and geometry-free phase jumps to reset carrier bias states;
+  its Doppler slip detector is disabled explicitly because of clock-jump
+  sensitivity:
+  <https://github.com/tomojitakasu/RTKLIB/blob/master/src/rtkpos.c>.
+- EPIC's position-domain integrity work treats satellite geometry changes,
+  cycle slips, and safely re-fixing reacquired satellites as explicit
+  implementation concerns:
+  <https://www.ion.org/publications/abstract.cfm?articleID=102542>.
+
+These sources support lifecycle separation and fail-closed reacquisition.
+They do not establish that a clock jump or reference change alone proves an
+incorrect integer solution, so this stage remains an offline association
+audit.
+
+## Causal features
+
+For each truth-matched epoch, `scripts/analyze_fgo_arc_lifecycle.py` derives:
+
+- `clock_jump`: absolute signed common GPS pseudorange change above 100 km
+  with at least one matched satellite (falling back to the legacy boolean for
+  older CSVs);
+- `reference_change`: a changed `(constellation, signal) -> reference` map
+  among LAMBDA-eligible rows;
+- `high_ambiguity_churn`: Jaccard churn of eligible ambiguity indices at or
+  above 25%;
+- `young_arc`: at least one eligible ambiguity index is at most two epochs
+  old;
+- `geometry_free_slip` and `doppler_slip`: existing shadow events;
+- `generation_bump`: any hold, FDE, reset, warm-reset, or stale-pin generation
+  bump;
+- `fde_exclusion`: at least one ambiguity removed by carrier FDE; and
+- `any_lifecycle_discontinuity`: the union of the preceding events.
+
+Ambiguity age is based on the first prior appearance of an ambiguity index.
+Reference maps and active indices use only disposition `LambdaEligible` from
+the candidate sidecar.  An event can explain an onset only when it occurs in
+the onset epoch or one of the preceding five epochs; future epochs are never
+examined.
+
+## Frozen development gate
+
+Tokyo run1 is the only development sequence for this audit.  A lifecycle
+category may justify a later runtime experiment only if, at the fixed
+five-epoch causal lookback, it meets all of the following:
+
+The lookback is bounded by time as well as row count: an observation gap over
+0.25 s starts a new causal segment.  Wrong-FIX onset detection and all
+reference, ambiguity-churn, arc-age, and event-exposure history are reset at
+that boundary, so missing epochs cannot create a false temporal association.
+
+- at least 20 wrong-FIX event onsets and 100 correct-FIX control epochs exist;
+- at least 20% of wrong-FIX onsets are exposed;
+- no more than 5% of correct-FIX epochs are exposed; and
+- onset coverage is at least four times correct-FIX exposure.
+
+The scorer also reports zero-, one-, and three-epoch windows, but those are
+diagnostic and cannot replace the frozen five-epoch verdict.  If no individual
+category passes, do not add a lifecycle veto/reset and do not inspect run2 or
+run3 for threshold selection.
+
+If a category passes, the next change must still be default-off and bounded.
+It must first demonstrate exact non-interference in monitor mode, then zero
+additional wrong FIX and zero lost correct FIX on a representative run1
+slice.  Only a frozen implementation may advance to run2 and sealed run3.
+
+## Usage
+
+Run a normal parity replay with `--ref` and `--dump-csv`, then score it:
+
+```text
+python scripts/analyze_fgo_arc_lifecycle.py \
+  --epoch-csv <run.csv> \
+  --json <audit.json> \
+  --markdown <audit.md>
+```
+
+The candidate path defaults to `<run.csv>.ar_candidates.csv`.  The process
+returns success only when at least one event meets the frozen gate.  JSON uses
+strict finite values; an unbounded relative risk caused by zero correct-FIX
+exposure is represented as `null` while still satisfying the risk component
+of the gate.
+
+## Tokyo run1 result
+
+The shipping preset produced 11,905 truth-matched epochs: 4,490 correct FIX
+epochs, 1,919 wrong FIX epochs, and 133 causal wrong-FIX event onsets.  A
+50-epoch before/after CSV comparison matched exactly in every pre-existing
+column.  The full run also matched the prior output in time, status, ECEF,
+ratio, fixed ambiguity count, and AR outcome for all 11,905 rows.
+
+At the frozen five-epoch lookback:
+
+| Event | Wrong onset coverage | Correct FIX exposure | Relative risk | Gate |
+|---|---:|---:|---:|---:|
+| Clock jump | 0 / 133 = 0.000% | 6 / 4,490 = 0.134% | 0.000 | fail |
+| Reference change | 73 / 133 = 54.887% | 883 / 4,490 = 19.666% | 2.791 | fail |
+| Ambiguity churn >=25% | 47 / 133 = 35.338% | 374 / 4,490 = 8.330% | 4.242 | fail |
+| Young arc | 108 / 133 = 81.203% | 2,604 / 4,490 = 57.996% | 1.400 | fail |
+| Geometry-free slip | 25 / 133 = 18.797% | 341 / 4,490 = 7.595% | 2.475 | fail |
+| Doppler slip | 28 / 133 = 21.053% | 386 / 4,490 = 8.597% | 2.449 | fail |
+| Generation bump | 22 / 133 = 16.541% | 207 / 4,490 = 4.610% | 3.588 | fail |
+| FDE exclusion | 18 / 133 = 13.534% | 196 / 4,490 = 4.365% | 3.100 | fail |
+| Any lifecycle event | 124 / 133 = 93.233% | 2,964 / 4,490 = 66.013% | 1.412 | fail |
+
+Only one signed common clock jump occurred in the complete run: a positive
+299,715.527 m event supported by four satellites at TOW 188500.200.  No
+negative event exceeded 100 km, and the single positive event preceded no
+wrong-FIX onset.  Reference changes and young arcs have high coverage because
+they are also routine during correct operation.  Ambiguity churn is the most
+discriminative category, but its 8.441% correct-FIX exposure exceeds the
+precommitted 5% maximum.  Generation bumps and FDE exclusions meet the
+correct-exposure limit but miss both the 20% onset-coverage and four-times
+risk requirements.
+
+Decision: retain the exported clock flag and offline event ledger, but do not
+add a clock-jump, reference-change, young-arc, churn, slip, generation-bump,
+or FDE-based FIX veto/reset.  Run2 and run3 are not inspected for this audit.
+The remaining wrong-FIX population is not primarily initiated by a rare
+ambiguity lifecycle discontinuity; the next improvement should target a
+persistent observation-model error with a genuinely external witness rather
+than another temporal acceptance rule.

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -1752,6 +1752,11 @@ public:
         std::vector<EpochSeed> epochs;
         ImuInput imu;  ///< Milestone 2b IMU inputs (valid only when populated).
         std::vector<bool> clock_jumps;
+        // Diagnostic copy of the signed common GPS pseudorange change used by
+        // the legacy positive-only clock_jumps detector, plus its support.
+        // Neither field is consumed by an optimizer.
+        std::vector<double> gps_common_pseudorange_delta_m;
+        std::vector<int> gps_common_pseudorange_delta_satellites;
         std::vector<PseudorangeFactor> pseudorange_factors;
         std::vector<TimeDifferencedCarrierFactor> tdcp_factors;
         std::vector<SingleDifferenceDopplerFactor> single_difference_doppler_factors;

--- a/scripts/analyze_fgo_arc_lifecycle.py
+++ b/scripts/analyze_fgo_arc_lifecycle.py
@@ -1,0 +1,364 @@
+#!/usr/bin/env python3
+"""Audit causal ambiguity-lifecycle events around wrong FGO FIX onsets."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from collections import defaultdict
+from pathlib import Path
+from statistics import median
+from typing import Any
+
+
+FROZEN_LOOKBACK_EPOCHS = 5
+MINIMUM_WRONG_ONSETS = 20
+MINIMUM_CORRECT_FIX_EPOCHS = 100
+MINIMUM_ONSET_COVERAGE = 0.20
+MAXIMUM_CORRECT_EXPOSURE = 0.05
+MINIMUM_RELATIVE_RISK = 4.0
+MAXIMUM_CAUSAL_GAP_MS = 250
+
+
+def tow_key(value: str) -> int:
+    return round(float(value) * 1000.0)
+
+
+def as_int(row: dict[str, str], name: str) -> int:
+    value = row.get(name, "")
+    return int(float(value)) if value else 0
+
+
+def as_float(row: dict[str, str], name: str) -> float:
+    value = row.get(name, "")
+    return float(value) if value else 0.0
+
+
+def load_candidates(path: Path) -> dict[int, list[dict[str, str]]]:
+    candidates: dict[int, list[dict[str, str]]] = defaultdict(list)
+    with path.open(newline="", encoding="utf-8-sig") as stream:
+        for row in csv.DictReader(stream):
+            if row.get("disposition") == "0":
+                candidates[tow_key(row["tow"])].append(row)
+    return candidates
+
+
+def candidate_lifecycle(
+    epoch_keys: list[int], candidates: dict[int, list[dict[str, str]]]
+) -> list[dict[str, Any]]:
+    first_seen: dict[int, int] = {}
+    previous_ids: set[int] = set()
+    previous_references: dict[tuple[str, str], str] = {}
+    result: list[dict[str, Any]] = []
+    for epoch_index, key in enumerate(epoch_keys):
+        delta_ms = key - epoch_keys[epoch_index - 1] if epoch_index > 0 else 0
+        continuous = (
+            epoch_index > 0
+            and 0 < delta_ms <= MAXIMUM_CAUSAL_GAP_MS
+        )
+        if epoch_index > 0 and not continuous:
+            first_seen.clear()
+        rows = candidates.get(key, [])
+        ambiguity_ids = {int(row["ambiguity_index"]) for row in rows}
+        references = {
+            (row["system"], row["signal"]): row["reference_satellite"]
+            for row in rows
+        }
+        for ambiguity_id in ambiguity_ids:
+            first_seen.setdefault(ambiguity_id, epoch_index)
+        ages = [epoch_index - first_seen[value] + 1 for value in ambiguity_ids]
+        new_ids = ambiguity_ids - previous_ids if continuous else ambiguity_ids
+        union = ambiguity_ids | previous_ids
+        churn = (
+            1.0 - len(ambiguity_ids & previous_ids) / len(union)
+            if continuous and union
+            else 0.0
+        )
+        reference_changes = 0
+        if continuous:
+            groups = set(references) | set(previous_references)
+            reference_changes = sum(
+                references.get(group) != previous_references.get(group)
+                for group in groups
+            )
+        result.append(
+            {
+                "eligible_ambiguities": len(ambiguity_ids),
+                "new_ambiguities": len(new_ids),
+                "new_ambiguity_fraction": (
+                    len(new_ids) / len(ambiguity_ids) if ambiguity_ids else 0.0
+                ),
+                "ambiguity_churn_fraction": churn,
+                "minimum_arc_age_epochs": min(ages) if ages else 0,
+                "median_arc_age_epochs": median(ages) if ages else 0.0,
+                "reference_groups": len(references),
+                "reference_changes": reference_changes,
+            }
+        )
+        previous_ids = ambiguity_ids
+        previous_references = references
+    return result
+
+
+def label_and_events(
+    epoch_rows: list[dict[str, str]], lifecycle: list[dict[str, Any]]
+) -> tuple[list[str], list[set[str]], list[bool], list[bool]]:
+    event_names = [
+        "clock_jump",
+        "reference_change",
+        "high_ambiguity_churn",
+        "young_arc",
+        "geometry_free_slip",
+        "doppler_slip",
+        "generation_bump",
+        "fde_exclusion",
+        "any_lifecycle_discontinuity",
+    ]
+    events: list[set[str]] = []
+    wrong_fix: list[bool] = []
+    correct_fix: list[bool] = []
+    for row, arc in zip(epoch_rows, lifecycle):
+        error = math.sqrt(
+            sum(float(row[name]) ** 2 for name in ("e_err_m", "n_err_m", "u_err_m"))
+        )
+        fixed = row["status"].upper() == "FIXED"
+        wrong_fix.append(fixed and error > 0.5)
+        correct_fix.append(fixed and error <= 0.5)
+
+        current: set[str] = set()
+        has_signed_clock_delta = as_int(row, "clock_common_delta_satellites") > 0
+        if (
+            has_signed_clock_delta
+            and abs(as_float(row, "clock_common_delta_m")) > 1e5
+        ) or (not has_signed_clock_delta and as_int(row, "clock_jump") > 0):
+            current.add("clock_jump")
+        if arc["reference_changes"] > 0:
+            current.add("reference_change")
+        if arc["ambiguity_churn_fraction"] >= 0.25:
+            current.add("high_ambiguity_churn")
+        if arc["eligible_ambiguities"] > 0 and arc["minimum_arc_age_epochs"] <= 2:
+            current.add("young_arc")
+        if as_int(row, "gf_slip_events") > 0:
+            current.add("geometry_free_slip")
+        if as_int(row, "doppler_slip_signals") > 0:
+            current.add("doppler_slip")
+        if sum(
+            as_int(row, name)
+            for name in (
+                "gen_bump_hold",
+                "gen_bump_fde",
+                "gen_bump_reset",
+                "gen_bump_warm_reset",
+                "gen_bump_stale_pin",
+            )
+        ) > 0:
+            current.add("generation_bump")
+        if as_int(row, "amb_excl_fde") > 0:
+            current.add("fde_exclusion")
+        if current:
+            current.add("any_lifecycle_discontinuity")
+        events.append(current)
+    return event_names, events, wrong_fix, correct_fix
+
+
+def exposure(
+    events: list[set[str]],
+    index: int,
+    name: str,
+    lookback: int,
+    epoch_keys: list[int] | None = None,
+) -> bool:
+    begin = max(0, index - lookback)
+    for position in range(index, begin - 1, -1):
+        if (
+            epoch_keys is not None
+            and position < index
+            and not (
+                0
+                < epoch_keys[position + 1] - epoch_keys[position]
+                <= MAXIMUM_CAUSAL_GAP_MS
+            )
+        ):
+            break
+        if name in events[position]:
+            return True
+    return False
+
+
+def score(
+    event_names: list[str],
+    events: list[set[str]],
+    wrong_fix: list[bool],
+    correct_fix: list[bool],
+    epoch_keys: list[int] | None = None,
+    lookbacks: tuple[int, ...] = (0, 1, 3, FROZEN_LOOKBACK_EPOCHS),
+) -> dict[str, Any]:
+    wrong_onsets = [
+        index
+        for index, value in enumerate(wrong_fix)
+        if value
+        and (
+            index == 0
+            or not wrong_fix[index - 1]
+            or (
+                epoch_keys is not None
+                and not (
+                    0
+                    < epoch_keys[index] - epoch_keys[index - 1]
+                    <= MAXIMUM_CAUSAL_GAP_MS
+                )
+            )
+        )
+    ]
+    correct_indexes = [index for index, value in enumerate(correct_fix) if value]
+    table: dict[str, dict[str, Any]] = {}
+    for name in event_names:
+        rows: dict[str, Any] = {}
+        for lookback in lookbacks:
+            onset_count = sum(
+                exposure(events, i, name, lookback, epoch_keys) for i in wrong_onsets
+            )
+            correct_count = sum(
+                exposure(events, i, name, lookback, epoch_keys) for i in correct_indexes
+            )
+            onset_coverage = onset_count / len(wrong_onsets) if wrong_onsets else None
+            correct_exposure = (
+                correct_count / len(correct_indexes) if correct_indexes else None
+            )
+            relative_risk = (
+                onset_coverage / correct_exposure
+                if onset_coverage is not None and correct_exposure not in (None, 0.0)
+                else None
+            )
+            rows[str(lookback)] = {
+                "wrong_onsets_exposed": onset_count,
+                "wrong_onset_coverage": onset_coverage,
+                "correct_fix_exposed": correct_count,
+                "correct_fix_exposure": correct_exposure,
+                "relative_risk": relative_risk,
+            }
+        frozen = rows[str(FROZEN_LOOKBACK_EPOCHS)]
+        rows["gate_passed"] = (
+            len(wrong_onsets) >= MINIMUM_WRONG_ONSETS
+            and len(correct_indexes) >= MINIMUM_CORRECT_FIX_EPOCHS
+            and frozen["wrong_onset_coverage"] is not None
+            and frozen["wrong_onset_coverage"] >= MINIMUM_ONSET_COVERAGE
+            and frozen["correct_fix_exposure"] is not None
+            and frozen["correct_fix_exposure"] <= MAXIMUM_CORRECT_EXPOSURE
+            and (
+                (frozen["correct_fix_exposure"] == 0.0 and frozen["wrong_onset_coverage"] > 0.0)
+                or (
+                    frozen["relative_risk"] is not None
+                    and frozen["relative_risk"] >= MINIMUM_RELATIVE_RISK
+                )
+            )
+        )
+        table[name] = rows
+    return {
+        "support": {
+            "wrong_fix_epochs": sum(wrong_fix),
+            "wrong_fix_onsets": len(wrong_onsets),
+            "correct_fix_epochs": len(correct_indexes),
+        },
+        "requirements": {
+            "frozen_lookback_epochs": FROZEN_LOOKBACK_EPOCHS,
+            "maximum_causal_gap_ms": MAXIMUM_CAUSAL_GAP_MS,
+            "minimum_wrong_onsets": MINIMUM_WRONG_ONSETS,
+            "minimum_correct_fix_epochs": MINIMUM_CORRECT_FIX_EPOCHS,
+            "minimum_wrong_onset_coverage": MINIMUM_ONSET_COVERAGE,
+            "maximum_correct_fix_exposure": MAXIMUM_CORRECT_EXPOSURE,
+            "minimum_relative_risk": MINIMUM_RELATIVE_RISK,
+        },
+        "events": table,
+        "qualifying_events": [name for name, rows in table.items() if rows["gate_passed"]],
+    }
+
+
+def render_markdown(summary: dict[str, Any]) -> str:
+    support = summary["support"]
+    lines = [
+        "# FGO ambiguity lifecycle wrong-FIX audit",
+        "",
+        f"Wrong FIX: **{support['wrong_fix_epochs']} epochs / "
+        f"{support['wrong_fix_onsets']} causal onsets**; correct FIX controls: "
+        f"**{support['correct_fix_epochs']} epochs**.",
+        "",
+        "The frozen verdict uses only each onset epoch and the preceding five epochs. "
+        "Future events are never visible to the classifier, and observation gaps over "
+        f"{MAXIMUM_CAUSAL_GAP_MS} ms terminate the lookback.",
+        "",
+        "| Event | Wrong onsets exposed | Coverage | Correct FIX exposure | Relative risk | Gate |",
+        "|---|---:|---:|---:|---:|---:|",
+    ]
+    for name, event in summary["events"].items():
+        frozen = event[str(FROZEN_LOOKBACK_EPOCHS)]
+        risk = frozen["relative_risk"]
+        risk_text = f"{risk:.3f}" if risk is not None else "n/a"
+        onset_coverage = frozen["wrong_onset_coverage"]
+        correct_exposure = frozen["correct_fix_exposure"]
+        onset_text = (
+            f"{100.0 * onset_coverage:.3f}%" if onset_coverage is not None else "n/a"
+        )
+        correct_text = (
+            f"{100.0 * correct_exposure:.3f}%" if correct_exposure is not None else "n/a"
+        )
+        lines.append(
+            f"| `{name}` | {frozen['wrong_onsets_exposed']} | "
+            f"{onset_text} | {correct_text} | "
+            f"{risk_text} | "
+            f"{'PASS' if event['gate_passed'] else 'FAIL'} |"
+        )
+    lines.extend(
+        [
+            "",
+            "Qualifying events: "
+            + (", ".join(f"`{name}`" for name in summary["qualifying_events"]) or "none"),
+            "",
+        ]
+    )
+    return "\n".join(lines)
+
+
+def analyze(epoch_csv: Path, candidate_csv: Path) -> dict[str, Any]:
+    with epoch_csv.open(newline="", encoding="utf-8-sig") as stream:
+        rows = list(csv.DictReader(stream))
+    keys = [tow_key(row["tow"]) for row in rows]
+    lifecycle = candidate_lifecycle(keys, load_candidates(candidate_csv))
+    event_names, events, wrong_fix, correct_fix = label_and_events(rows, lifecycle)
+    summary = score(event_names, events, wrong_fix, correct_fix, keys)
+    summary["rows"] = len(rows)
+    summary["clock_jump_available"] = (
+        bool(rows)
+        and (
+            "clock_jump" in rows[0]
+            or {
+                "clock_common_delta_m",
+                "clock_common_delta_satellites",
+            }.issubset(rows[0])
+        )
+    )
+    return summary
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--epoch-csv", type=Path, required=True)
+    parser.add_argument("--candidate-csv", type=Path)
+    parser.add_argument("--json", type=Path)
+    parser.add_argument("--markdown", type=Path)
+    args = parser.parse_args()
+    candidate_csv = args.candidate_csv or Path(str(args.epoch_csv) + ".ar_candidates.csv")
+    summary = analyze(args.epoch_csv, candidate_csv)
+    rendered = json.dumps(summary, indent=2, sort_keys=True, allow_nan=False)
+    print(rendered)
+    if args.json:
+        args.json.write_text(rendered + "\n", encoding="utf-8")
+    if args.markdown:
+        args.markdown.write_text(render_markdown(summary), encoding="utf-8")
+    return 0 if summary["qualifying_events"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -1295,7 +1295,12 @@ FGOProcessor::FGOProblem FGOProcessor::buildPseudorangeProblem(
                 gps_pseudorange_delta_sum /
                 static_cast<double>(gps_pseudorange_delta_count);
             clock_jump = mean_delta > 1e5;
+            problem.gps_common_pseudorange_delta_m.push_back(mean_delta);
+        } else {
+            problem.gps_common_pseudorange_delta_m.push_back(0.0);
         }
+        problem.gps_common_pseudorange_delta_satellites.push_back(
+            static_cast<int>(gps_pseudorange_delta_count));
         problem.clock_jumps.push_back(clock_jump);
         previous_gps_pseudorange_by_satellite =
             std::move(gps_pseudorange_by_satellite);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -196,6 +196,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_benchmark_scripts.py
     )
     add_test(
+        NAME python_fgo_arc_lifecycle_audit_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_fgo_arc_lifecycle_audit.py
+    )
+    add_test(
         NAME python_ppc_integrity_policy_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_ppc_integrity_policy_ci.py
     )
@@ -453,6 +457,7 @@ if(GTest_FOUND)
     set(GNSSPP_CORE_TESTS
         run_tests
         clas_outage_legacy_kill_switch
+        python_fgo_arc_lifecycle_audit_tests
         python_ppc_integrity_policy_tests
         python_ppc_goal_completion_audit_tests
         python_artifact_manifest_contract_validator_tests

--- a/tests/test_fgo.cpp
+++ b/tests/test_fgo.cpp
@@ -876,6 +876,52 @@ TEST(FGOTest, ClockResilientTemporalCarrierShadowCancelsCommonClockJump) {
         << "a new reference must start a fresh temporal arc";
 }
 
+TEST(FGOTest, ReportsSignedCommonGpsPseudorangeDeltaForClockAudit) {
+    const NavigationData nav = makeSyntheticGpsNavigation(4);
+    const std::array<Vector3d, 2> rover_positions = {
+        Vector3d(1113194.0, -4841695.0, 3985350.0),
+        Vector3d(1113194.0, -4841695.0, 3985350.0),
+    };
+    const std::array<Vector3d, 2> base_positions = {
+        rover_positions[0] + Vector3d(-320.0, 180.0, 45.0),
+        rover_positions[1] + Vector3d(-320.0, 180.0, 45.0),
+    };
+    const auto rover_epochs =
+        makeSyntheticDoubleDifferenceObservationEpochs(nav, rover_positions, 0.04);
+    const auto base_epochs =
+        makeSyntheticDoubleDifferenceObservationEpochs(nav, base_positions, 0.02);
+
+    FGOProcessor::FGOConfig config;
+    config.use_spp_seed = false;
+    config.use_pseudorange_factors = true;
+    config.use_double_difference_factors = true;
+    config.use_ionosphere_model = false;
+    config.use_troposphere_model = false;
+    config.min_elevation_deg = -90.0;
+    config.min_satellites_per_epoch = 2;
+
+    constexpr double jump_m = constants::SPEED_OF_LIGHT * 0.001;
+    const auto build_with_jump = [&](double jump) {
+        auto jumped = rover_epochs;
+        for (auto& observation : jumped[1].observations) {
+            observation.pseudorange += jump;
+        }
+        return FGOProcessor(config).buildDoubleDifferenceProblem(
+            jumped, base_epochs, nav, base_positions[0]);
+    };
+
+    const auto positive = build_with_jump(jump_m);
+    ASSERT_EQ(positive.gps_common_pseudorange_delta_m.size(), 2u);
+    ASSERT_EQ(positive.gps_common_pseudorange_delta_satellites.size(), 2u);
+    EXPECT_GT(positive.gps_common_pseudorange_delta_m[1], 1e5);
+    EXPECT_GE(positive.gps_common_pseudorange_delta_satellites[1], 2);
+
+    const auto negative = build_with_jump(-jump_m);
+    ASSERT_EQ(negative.gps_common_pseudorange_delta_m.size(), 2u);
+    EXPECT_LT(negative.gps_common_pseudorange_delta_m[1], -1e5);
+    EXPECT_GE(negative.gps_common_pseudorange_delta_satellites[1], 2);
+}
+
 TEST(FGOTest, PredictedDdprQualityShadowIsClockSafeAndFailClosed) {
     FGOProcessor::FGOProblem problem;
     problem.epochs.resize(2);

--- a/tests/test_fgo_arc_lifecycle_audit.py
+++ b/tests/test_fgo_arc_lifecycle_audit.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "analyze_fgo_arc_lifecycle.py"
+SPEC = importlib.util.spec_from_file_location("arc_lifecycle", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+AUDIT = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(AUDIT)
+
+
+class FgoArcLifecycleAuditTest(unittest.TestCase):
+    def test_reference_change_and_arc_churn_are_deterministic(self) -> None:
+        candidates = {
+            1000: [
+                {"ambiguity_index": "10", "system": "1", "signal": "0", "reference_satellite": "G01"},
+                {"ambiguity_index": "11", "system": "1", "signal": "0", "reference_satellite": "G01"},
+            ],
+            1200: [
+                {"ambiguity_index": "12", "system": "1", "signal": "0", "reference_satellite": "G02"},
+                {"ambiguity_index": "13", "system": "1", "signal": "0", "reference_satellite": "G02"},
+            ],
+        }
+        lifecycle = AUDIT.candidate_lifecycle([1000, 1200], candidates)
+        self.assertEqual(lifecycle[1]["reference_changes"], 1)
+        self.assertEqual(lifecycle[1]["new_ambiguity_fraction"], 1.0)
+        self.assertEqual(lifecycle[1]["ambiguity_churn_fraction"], 1.0)
+        self.assertEqual(lifecycle[1]["minimum_arc_age_epochs"], 1)
+
+    def test_exposure_never_uses_future_events(self) -> None:
+        events = [set(), set(), {"clock_jump"}]
+        self.assertFalse(AUDIT.exposure(events, 1, "clock_jump", 5))
+        self.assertTrue(AUDIT.exposure(events, 2, "clock_jump", 0))
+
+    def test_exposure_does_not_cross_epoch_gap(self) -> None:
+        events = [{"clock_jump"}, set()]
+        self.assertFalse(
+            AUDIT.exposure(events, 1, "clock_jump", 5, [1000, 1400])
+        )
+
+    def test_epoch_gap_starts_fresh_arc_age(self) -> None:
+        candidate = {
+            "ambiguity_index": "10",
+            "system": "1",
+            "signal": "0",
+            "reference_satellite": "G01",
+        }
+        lifecycle = AUDIT.candidate_lifecycle(
+            [1000, 1200, 1600],
+            {1000: [candidate], 1200: [candidate], 1600: [candidate]},
+        )
+        self.assertEqual(lifecycle[1]["minimum_arc_age_epochs"], 2)
+        self.assertEqual(lifecycle[2]["minimum_arc_age_epochs"], 1)
+        self.assertEqual(lifecycle[2]["reference_changes"], 0)
+        self.assertEqual(lifecycle[2]["ambiguity_churn_fraction"], 0.0)
+
+    def test_signed_common_clock_delta_detects_negative_jump(self) -> None:
+        row = {
+            "status": "FIXED",
+            "e_err_m": "0",
+            "n_err_m": "0",
+            "u_err_m": "0",
+            "clock_jump": "0",
+            "clock_common_delta_m": "-299792.458",
+            "clock_common_delta_satellites": "6",
+        }
+        lifecycle = [{
+            "reference_changes": 0,
+            "ambiguity_churn_fraction": 0.0,
+            "eligible_ambiguities": 4,
+            "minimum_arc_age_epochs": 3,
+        }]
+        _, events, _, _ = AUDIT.label_and_events([row], lifecycle)
+        self.assertIn("clock_jump", events[0])
+
+    def test_frozen_gate_requires_selectivity_and_support(self) -> None:
+        size = 240
+        wrong_fix = [False] * size
+        correct_fix = [False] * size
+        events = [set() for _ in range(size)]
+        for index in range(20, 120, 5):
+            wrong_fix[index] = True
+            events[index].add("reference_change")
+        for index in range(120, 240):
+            correct_fix[index] = True
+        summary = AUDIT.score(
+            ["reference_change"], events, wrong_fix, correct_fix
+        )
+        self.assertEqual(summary["support"]["wrong_fix_onsets"], 20)
+        self.assertTrue(summary["events"]["reference_change"]["gate_passed"])
+
+    def test_markdown_handles_missing_wrong_onset_support(self) -> None:
+        summary = AUDIT.score(["clock_jump"], [set()], [False], [True])
+        rendered = AUDIT.render_markdown(summary)
+        self.assertIn("n/a", rendered)
+        self.assertIn("FAIL", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- export the signed common GPS pseudorange delta and satellite support used by the existing clock-jump detector without changing optimizer behavior
- add an offline wrong-FIX onset audit covering clock jumps, reference changes, ambiguity churn/age, GF and Doppler slips, generation bumps, and carrier FDE exclusions
- freeze causal lookback, time-gap, support, selectivity, and relative-risk gates
- document the primary literature/RTKLIB basis and the Tokyo run1 decision

## Why

Earlier TDCP, DDPR, bias-state, multi-epoch, and held-out-carrier experiments did not meet their promotion gates. This change tests a broader causal ambiguity-lifecycle hypothesis without adding another runtime veto or tuning TDCP.

The legacy clock-jump flag only identifies positive common pseudorange changes. The new diagnostic fields preserve the signed delta so negative jumps cannot disappear from the offline audit.

## Result and impact

Tokyo run1 produced 11,905 truth-matched epochs, including 1,919 wrong-FIX epochs across 133 causal onsets and 4,490 correct-FIX controls. Only one signed clock jump occurred and it did not precede a wrong-FIX onset. No lifecycle category met all frozen promotion requirements, so this PR intentionally leaves FIX/FLOAT decisions and optimizer state unchanged.

A 50-epoch before/after comparison matched every pre-existing CSV column, and the complete run matched the prior time, status, ECEF, ratio, fixed-count, and AR-outcome output for all 11,905 rows.

## Validation

- MSVC Release builds: `gnss_lib_noopt`, `gnss_fgo_parity`, and test executable
- C++ suite: 897 tests, 837 passed, 60 skipped for unavailable datasets, 0 failed
- Python lifecycle audit: 7/7 passed
- registered CTest: `python_fgo_arc_lifecycle_audit_tests` passed
- `python -m py_compile`
- `git diff --check`
