### PR TITLE
Audit external Doppler DR ambiguity witness

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,13 @@ with `gnss_fgo_parity` (requires a GTSAM build) and the evaluated preset:
 --imu-ratio-relaxed 1.5 --gf-slip-reset
 ```
 
+A separate default-off Doppler-only dead-reckoning witness was evaluated as a
+possible FLOAT-to-FIX promotion guard.  It failed the pre-registered Tokyo
+run1 zero-wrong gate: 112 correct and 112 wrong FLOAT candidates were
+accepted.  It therefore remains monitor-only; run2/run3 were not used for
+threshold selection and no runtime activation or FIX-rate gain is claimed.
+See the [external Doppler-DR witness audit](docs/fgo_external_doppler_dr_witness_audit.md).
+
 With `--dump-csv <path>`, the epoch table includes the ambiguity-candidate
 funnel (`amb_after_hold`, `amb_final`, and `amb_excl_*`) and the last
 successfully searched LAMBDA position candidate (`lambda_candidate_*`), even

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -70,6 +70,7 @@ struct Args {
     bool temporal_shadow_truth_replay = false;  // classify against reference.csv; skip solve
     bool postfit_gate = false;
     bool adaptive_ratio = false;
+    bool external_dr_shadow = false;
     int postfit_min_n = -1;
     double postfit_rms = -1.0;
     double postfit_max_norm = -1.0;
@@ -420,6 +421,10 @@ Args parseArgs(int argc, char** argv) {
         }
         if (a == "--external-dr") {
             args.external_dr = true;
+            continue;
+        }
+        if (a == "--external-dr-shadow") {
+            args.external_dr_shadow = true;
             continue;
         }
         if (a == "--external-dr-max-age" && i + 1 < argc) {
@@ -807,6 +812,12 @@ libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
     }
     if (args.external_dr) {
         config.use_external_doppler_dr_validation = true;
+    }
+    if (args.external_dr_shadow) {
+        config.monitor_external_doppler_dr = true;
+        if (args.external_dr_reset_ratio < 0.0) {
+            config.external_doppler_dr_reset_min_ratio = 20.0;
+        }
     }
     if (args.external_dr_max_age > 0) {
         config.external_doppler_dr_max_age_epochs = args.external_dr_max_age;
@@ -2735,6 +2746,7 @@ Fingerprint computeFingerprint(const Args& args, const libgnss::FGOProcessor::FG
     COPY_BUILD_FIELD(use_double_difference_factors);
     COPY_BUILD_FIELD(use_double_difference_secondary_code_alignment);
     COPY_BUILD_FIELD(use_elevation_dependent_sigma);
+    COPY_BUILD_FIELD(monitor_external_doppler_dr);
     COPY_BUILD_FIELD(use_external_doppler_dr_validation);
     COPY_BUILD_FIELD(use_geometry_free_cycle_slip_reset);
     COPY_BUILD_FIELD(use_ionosphere_model);
@@ -3293,6 +3305,8 @@ int main(int argc, char** argv) {
                   << ", low:" << config.adaptive_ratio_nsat_low << ")\n"
                   << "  external Doppler-DR SSE: "
                   << (config.use_external_doppler_dr_validation ? "on" : "off")
+                  << ", shadow="
+                  << (config.monitor_external_doppler_dr ? "on" : "off")
                   << " (accepted=" << fl.diagnostics.external_doppler_dr_accepts
                   << ", rejected=" << fl.diagnostics.external_doppler_dr_rejects
                   << ", unavailable=" << fl.diagnostics.external_doppler_dr_unavailable

--- a/docs/fgo_arc_lifecycle_wrong_fix_audit.md
+++ b/docs/fgo_arc_lifecycle_wrong_fix_audit.md
@@ -148,7 +148,7 @@ Only one signed common clock jump occurred in the complete run: a positive
 negative event exceeded 100 km, and the single positive event preceded no
 wrong-FIX onset.  Reference changes and young arcs have high coverage because
 they are also routine during correct operation.  Ambiguity churn is the most
-discriminative category, but its 8.441% correct-FIX exposure exceeds the
+discriminative category, but its 8.330% correct-FIX exposure exceeds the
 precommitted 5% maximum.  Generation bumps and FDE exclusions meet the
 correct-exposure limit but miss both the 20% onset-coverage and four-times
 risk requirements.

--- a/docs/fgo_external_doppler_dr_witness_audit.md
+++ b/docs/fgo_external_doppler_dr_witness_audit.md
@@ -1,0 +1,104 @@
+# FGO external Doppler dead-reckoning witness audit
+
+## Purpose
+
+Determine whether a Doppler-only dead-reckoning (DR) track can safely promote
+otherwise-FLOAT LAMBDA position candidates.  This is an offline, monitor-only
+audit.  It does not add single-difference Doppler factors to the FGO graph,
+change an ambiguity decision, seed a hold, or alter a reported position.
+
+The originally proposed current-epoch SPP/LAMBDA agreement audit was not
+repeated.  The completed multi-epoch audit already included a fresh SPP
+witness within 5 m in its best zero-wrong development rule.  That combination
+recovered only six correct epochs over all 36,346 Tokyo epochs (0.0165
+percentage points) and was rejected.
+
+## Research and implementation basis
+
+- Bahrami and Ziebart use Doppler-smoothed code to improve instantaneous RTK
+  ambiguity resolution: <https://doi.org/10.1109/PLANS.2010.5507202>.
+- Jiang, Ding, and Gao use an external INS prediction and solution-separation
+  statistic to improve partial ambiguity reliability:
+  <https://doi.org/10.1016/j.asr.2024.09.048>.
+- Wang et al. formulate ambiguity-resolution integrity monitoring with
+  multiple-hypothesis solution separation:
+  <https://doi.org/10.33012/2023.18607>.
+- Teunissen et al. show why ambiguity-resolved model testing must account for
+  both ambiguity residuals and observation-model inconsistency rather than
+  relying on a conventional ratio alone:
+  <https://doi.org/10.3390/app15073531>.
+
+The repository already contains a dormant external Doppler-DR validator.  It
+solves receiver-clock-drift-free single-difference Doppler velocity by
+weighted least squares, removes rows beyond four sigma once, propagates a 3-D
+position and covariance, and compares an integer candidate through a 3-D
+Mahalanobis statistic.  Previously this was evaluated only on relaxed-ratio
+activation paths.  `--external-dr-shadow` extends the telemetry to every
+provisional LAMBDA candidate while leaving every decision path disabled.
+
+The DR track resets only from a normally accepted candidate with ratio at
+least 20 in shadow mode.  The reset epoch itself is not evaluated; candidate
+testing begins after at least one Doppler propagation epoch.  The frozen
+availability limit is 30 epochs and the frozen acceptance threshold is
+chi-square 11.345 (99% for three degrees of freedom).
+
+## Frozen development gate
+
+Tokyo run1 is the only development run.  A runtime rescue experiment and
+run2/run3 inspection are permitted only if the fixed shadow rule produces:
+
+- at least 100 evaluated FLOAT candidates;
+- at least 60 accepted correct FLOAT candidates (about +0.5 percentage points
+  over 11,905 run1 epochs); and
+- zero accepted wrong FLOAT candidates.
+
+A candidate is correct only when its own ECEF position, transformed into the
+CSV local ENU frame, is within 0.5 m in 3-D.  The reported FLOAT position is
+not substituted for the candidate.  Reference truth is read only by the
+offline scorer after the solve.
+
+If run1 fails any requirement, the experiment stops: do not inspect run2 or
+run3, do not enable the existing runtime validator, and retain the shadow only
+as diagnostic evidence.  If it passes, freeze every threshold and require
+zero accepted wrong candidates independently on run2 and run3 before any
+default-off runtime A/B.
+
+## Reproduction
+
+Append `--external-dr-shadow` to the documented shipping FGO preset and dump
+the epoch CSV.  The monitor deliberately does not require `--sd-doppler`:
+single-difference Doppler rows are materialized for the private DR estimator
+but are not inserted into the graph.
+
+```powershell
+python scripts/analyze_fgo_external_dr_witness.py `
+  --epoch-csv build-ffrt-msvc/validation/tokyo1_external_dr_shadow.csv `
+  --json build-ffrt-msvc/validation/tokyo1_external_dr_shadow.json `
+  --markdown build-ffrt-msvc/validation/tokyo1_external_dr_shadow.md
+```
+
+The scorer exits successfully only when the frozen development gate passes.
+
+## Tokyo run1 result
+
+The 50-epoch authority-neutrality replay matched all status, ECEF position,
+ratio, fixed-count, and AR-outcome fields exactly.  Only the nine intended
+external-DR diagnostic columns differed.
+
+The full 11,905-epoch run produced 8,216 candidate epochs.  The independent
+track evaluated 252 otherwise-FLOAT candidates:
+
+| Population | Count |
+|---|---:|
+| Correct / wrong evaluated FLOAT candidates | 115 / 137 |
+| Accepted correct FLOAT candidates | 112 |
+| Rejected correct FLOAT candidates | 3 |
+| Accepted wrong FLOAT candidates | **112** |
+| Rejected wrong FLOAT candidates | 25 |
+
+**Verdict: FAIL.** The support and correct-yield requirements passed, but the
+zero-wrong requirement failed by 112 candidates.  Doppler-only DR followed
+the same wrong position basin too often to be an independent ambiguity
+witness on this run.  Per the frozen protocol, run2/run3 were not inspected,
+the runtime validator was not enabled, and no FIX-rate gain is claimed.  The
+default-off shadow remains useful negative evidence and diagnostic telemetry.

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -357,6 +357,9 @@ public:
         // Independent solution-separation track: propagate the last
         // high-confidence FIX using an SD-Doppler-only velocity LS solution,
         // then test the next integer candidate with a 3-D Mahalanobis chi2.
+        // monitor_external_doppler_dr evaluates every provisional LAMBDA
+        // candidate but cannot relax a ratio gate or add Doppler graph factors.
+        bool monitor_external_doppler_dr = false;
         bool use_external_doppler_dr_validation = false;
         bool external_doppler_dr_require_for_relaxed_fix = true;
         // A statistically validated relaxed-ratio solution may label the

--- a/scripts/analyze_fgo_external_dr_witness.py
+++ b/scripts/analyze_fgo_external_dr_witness.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""Score the Doppler-only dead-reckoning witness for FGO LAMBDA candidates."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+from typing import Any
+
+
+WGS84_A = 6378137.0
+WGS84_E2 = 6.69437999014e-3
+CORRECT_ERROR_M = 0.5
+MINIMUM_EVALUATED_FLOAT_CANDIDATES = 100
+MINIMUM_ACCEPTED_CORRECT_FLOAT_CANDIDATES = 60
+MAXIMUM_ACCEPTED_WRONG_FLOAT_CANDIDATES = 0
+
+
+def as_float(row: dict[str, str], name: str) -> float:
+    value = row.get(name, "")
+    return float(value) if value else 0.0
+
+
+def as_int(row: dict[str, str], name: str) -> int:
+    return int(as_float(row, name))
+
+
+def ecef_lat_lon(x_m: float, y_m: float, z_m: float) -> tuple[float, float]:
+    longitude = math.atan2(y_m, x_m)
+    p = math.hypot(x_m, y_m)
+    latitude = math.atan2(z_m, p * (1.0 - WGS84_E2))
+    for _ in range(8):
+        sin_latitude = math.sin(latitude)
+        normal = WGS84_A / math.sqrt(1.0 - WGS84_E2 * sin_latitude**2)
+        height = p / max(math.cos(latitude), 1e-12) - normal
+        latitude = math.atan2(
+            z_m, p * (1.0 - WGS84_E2 * normal / (normal + height))
+        )
+    return latitude, longitude
+
+
+def ecef_delta_to_enu(
+    delta: tuple[float, float, float], latitude: float, longitude: float
+) -> tuple[float, float, float]:
+    dx, dy, dz = delta
+    sin_lat, cos_lat = math.sin(latitude), math.cos(latitude)
+    sin_lon, cos_lon = math.sin(longitude), math.cos(longitude)
+    return (
+        -sin_lon * dx + cos_lon * dy,
+        -sin_lat * cos_lon * dx - sin_lat * sin_lon * dy + cos_lat * dz,
+        cos_lat * cos_lon * dx + cos_lat * sin_lon * dy + sin_lat * dz,
+    )
+
+
+def candidate_error(row: dict[str, str]) -> tuple[float, float]:
+    solution = tuple(as_float(row, name) for name in ("x_ecef_m", "y_ecef_m", "z_ecef_m"))
+    candidate = tuple(
+        as_float(row, name)
+        for name in (
+            "lambda_candidate_x_ecef_m",
+            "lambda_candidate_y_ecef_m",
+            "lambda_candidate_z_ecef_m",
+        )
+    )
+    latitude, longitude = ecef_lat_lon(*solution)
+    delta_enu = ecef_delta_to_enu(
+        tuple(candidate[i] - solution[i] for i in range(3)), latitude, longitude
+    )
+    candidate_enu = tuple(
+        as_float(row, name) + delta_enu[i]
+        for i, name in enumerate(("e_pos_m", "n_pos_m", "u_pos_m"))
+    )
+    reference_enu = tuple(
+        as_float(row, name) for name in ("ref_e_pos_m", "ref_n_pos_m", "ref_u_pos_m")
+    )
+    error = tuple(candidate_enu[i] - reference_enu[i] for i in range(3))
+    return math.hypot(error[0], error[1]), math.sqrt(sum(value**2 for value in error))
+
+
+def analyze_rows(rows: list[dict[str, str]]) -> dict[str, Any]:
+    population = {
+        "candidate_epochs": 0,
+        "evaluated_candidates": 0,
+        "evaluated_float_candidates": 0,
+        "evaluated_fixed_candidates": 0,
+        "float_candidate_correct": 0,
+        "float_candidate_wrong": 0,
+        "accepted_correct_float_candidates": 0,
+        "accepted_wrong_float_candidates": 0,
+        "rejected_correct_float_candidates": 0,
+        "rejected_wrong_float_candidates": 0,
+    }
+    accepted_correct_tows: list[float] = []
+    accepted_wrong_tows: list[float] = []
+    for row in rows:
+        if as_int(row, "lambda_candidate_valid") == 0:
+            continue
+        population["candidate_epochs"] += 1
+        if as_int(row, "external_dr_eval") == 0:
+            continue
+        population["evaluated_candidates"] += 1
+        is_float = row.get("status", "").upper() != "FIXED"
+        population[
+            "evaluated_float_candidates" if is_float else "evaluated_fixed_candidates"
+        ] += 1
+        if not is_float:
+            continue
+        _, error_3d_m = candidate_error(row)
+        correct = error_3d_m <= CORRECT_ERROR_M
+        accepted = as_int(row, "external_dr_accept") > 0
+        population["float_candidate_correct" if correct else "float_candidate_wrong"] += 1
+        population[
+            ("accepted_" if accepted else "rejected_")
+            + ("correct_" if correct else "wrong_")
+            + "float_candidates"
+        ] += 1
+        if accepted:
+            (accepted_correct_tows if correct else accepted_wrong_tows).append(
+                as_float(row, "tow")
+            )
+
+    gate_passed = (
+        population["evaluated_float_candidates"]
+        >= MINIMUM_EVALUATED_FLOAT_CANDIDATES
+        and population["accepted_correct_float_candidates"]
+        >= MINIMUM_ACCEPTED_CORRECT_FLOAT_CANDIDATES
+        and population["accepted_wrong_float_candidates"]
+        <= MAXIMUM_ACCEPTED_WRONG_FLOAT_CANDIDATES
+    )
+    return {
+        "rows": len(rows),
+        "requirements": {
+            "correct_candidate_3d_error_max_m": CORRECT_ERROR_M,
+            "minimum_evaluated_float_candidates": MINIMUM_EVALUATED_FLOAT_CANDIDATES,
+            "minimum_accepted_correct_float_candidates": (
+                MINIMUM_ACCEPTED_CORRECT_FLOAT_CANDIDATES
+            ),
+            "maximum_accepted_wrong_float_candidates": (
+                MAXIMUM_ACCEPTED_WRONG_FLOAT_CANDIDATES
+            ),
+        },
+        "population": population,
+        "accepted_correct_float_tows": accepted_correct_tows,
+        "accepted_wrong_float_tows": accepted_wrong_tows,
+        "gate_passed": gate_passed,
+    }
+
+
+def render_markdown(summary: dict[str, Any]) -> str:
+    p = summary["population"]
+    return "\n".join(
+        [
+            "# FGO external Doppler-DR witness audit",
+            "",
+            f"Verdict: **{'PASS' if summary['gate_passed'] else 'FAIL'}**",
+            "",
+            "| Population | Count |",
+            "|---|---:|",
+            f"| Candidate epochs | {p['candidate_epochs']} |",
+            f"| Evaluated FLOAT candidates | {p['evaluated_float_candidates']} |",
+            f"| Correct / wrong FLOAT candidates | {p['float_candidate_correct']} / {p['float_candidate_wrong']} |",
+            f"| Accepted correct FLOAT candidates | {p['accepted_correct_float_candidates']} |",
+            f"| Accepted wrong FLOAT candidates | {p['accepted_wrong_float_candidates']} |",
+            "",
+            "The frozen promotion gate requires at least 100 evaluated FLOAT candidates, "
+            "at least 60 accepted correct candidates, and zero accepted wrong candidates.",
+            "",
+        ]
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--epoch-csv", type=Path, required=True)
+    parser.add_argument("--json", type=Path)
+    parser.add_argument("--markdown", type=Path)
+    args = parser.parse_args()
+    with args.epoch_csv.open(newline="", encoding="utf-8-sig") as stream:
+        summary = analyze_rows(list(csv.DictReader(stream)))
+    rendered = json.dumps(summary, indent=2, sort_keys=True, allow_nan=False)
+    print(rendered)
+    if args.json:
+        args.json.write_text(rendered + "\n", encoding="utf-8")
+    if args.markdown:
+        args.markdown.write_text(render_markdown(summary), encoding="utf-8")
+    return 0 if summary["gate_passed"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -2485,6 +2485,7 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
     }
 
     if (config_.use_single_difference_doppler_factors ||
+        config_.monitor_external_doppler_dr ||
         config_.use_external_doppler_dr_validation ||
         config_.use_single_difference_tdcp_factors) {
         std::map<CarrierKey, SingleDifferenceCarrierResidual>
@@ -2545,6 +2546,7 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
                 const Vector3d sd_los = rover->los - reference->los;
 
                 if ((config_.use_single_difference_doppler_factors ||
+                     config_.monitor_external_doppler_dr ||
                      config_.use_external_doppler_dr_validation) &&
                     rover->has_doppler_residual &&
                     reference->has_doppler_residual) {

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -2755,7 +2755,8 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
         // Independent SD-Doppler velocity LS and DR propagation.  No FGO
         // state enters this estimator.  A single robust re-fit removes rows
         // beyond 4 sigma so one Doppler outlier cannot dominate the track.
-        if (config.use_external_doppler_dr_validation) {
+        if (config.monitor_external_doppler_dr ||
+            config.use_external_doppler_dr_validation) {
             std::vector<const FGOProcessor::SingleDifferenceDopplerFactor*> active_doppler =
                 doppler_by_epoch[i];
             Vector3d doppler_velocity = Vector3d::Zero();
@@ -4157,6 +4158,70 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                                 ++result.diagnostics.surplus_validation_separation_rejects;
                             }
                         }
+                        // Monitor every provisional candidate against the
+                        // Doppler-only dead-reckoning track before any ratio
+                        // decision. The track contains no FGO state between
+                        // its high-confidence reset epochs, and monitor mode
+                        // never contributes to an acceptance decision.
+                        epoch_diagnostics[i].external_dr_evaluated = false;
+                        epoch_diagnostics[i].external_dr_accepted = false;
+                        epoch_diagnostics[i].external_dr_rejected = false;
+                        bool external_dr_available = false;
+                        bool external_dr_candidate_pass = false;
+                        double external_dr_separation_m = 0.0;
+                        double external_dr_mahalanobis2 = 0.0;
+                        if ((config.monitor_external_doppler_dr ||
+                             config.use_external_doppler_dr_validation) &&
+                            external_dr_position_valid &&
+                            has_provisional_fixed_ant &&
+                            has_provisional_fixed_cov &&
+                            (!config.monitor_external_doppler_dr ||
+                             external_dr_age_epochs > 0) &&
+                            external_dr_age_epochs <=
+                                config.external_doppler_dr_max_age_epochs) {
+                            Eigen::Matrix3d combined_cov =
+                                external_dr_position_cov + provisional_fixed_cov;
+                            combined_cov =
+                                0.5 * (combined_cov + combined_cov.transpose());
+                            const Eigen::LDLT<Eigen::Matrix3d> cov_ldlt(combined_cov);
+                            if (cov_ldlt.info() == Eigen::Success &&
+                                cov_ldlt.vectorD().allFinite() &&
+                                (cov_ldlt.vectorD().array() > 0.0).all()) {
+                                const Eigen::Vector3d delta =
+                                    provisional_fixed_ant - external_dr_position_ecef;
+                                const double mahalanobis2 =
+                                    delta.dot(cov_ldlt.solve(delta));
+                                external_dr_available = std::isfinite(mahalanobis2);
+                                external_dr_candidate_pass =
+                                    external_dr_available &&
+                                    mahalanobis2 <=
+                                        config.external_doppler_dr_chi2_threshold;
+                                external_dr_separation_m = delta.norm();
+                                external_dr_mahalanobis2 = mahalanobis2;
+                                if (config.monitor_external_doppler_dr) {
+                                    epoch_diagnostics[i].external_dr_evaluated =
+                                        external_dr_available;
+                                    epoch_diagnostics[i].external_dr_separation_m =
+                                        external_dr_separation_m;
+                                    epoch_diagnostics[i].external_dr_mahalanobis2 =
+                                        external_dr_mahalanobis2;
+                                    epoch_diagnostics[i].external_dr_accepted =
+                                        external_dr_candidate_pass;
+                                    epoch_diagnostics[i].external_dr_rejected =
+                                        external_dr_available &&
+                                        !external_dr_candidate_pass;
+                                }
+                                if (external_dr_available &&
+                                    config.monitor_external_doppler_dr) {
+                                    if (external_dr_candidate_pass) {
+                                        ++result.diagnostics.external_doppler_dr_accepts;
+                                    } else {
+                                        ++result.diagnostics.external_doppler_dr_rejects;
+                                    }
+                                }
+                            }
+                        }
+
                         // Integrity-aided aperture: the conventional
                         // fixed-vs-float separation is correlated because
                         // both hypotheses come from this graph.  A candidate
@@ -4338,40 +4403,23 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                             adaptive_only_pass || integrity_candidate;
                         if (relaxed_fix_path &&
                             config.use_external_doppler_dr_validation) {
-                            const bool available =
-                                external_dr_position_valid && has_provisional_fixed_ant &&
-                                has_provisional_fixed_cov &&
-                                external_dr_age_epochs <=
-                                    config.external_doppler_dr_max_age_epochs;
-                            if (available) {
-                                Eigen::Matrix3d combined_cov =
-                                    external_dr_position_cov + provisional_fixed_cov;
-                                combined_cov = 0.5 * (combined_cov + combined_cov.transpose());
-                                const Eigen::LDLT<Eigen::Matrix3d> cov_ldlt(combined_cov);
-                                if (cov_ldlt.info() == Eigen::Success &&
-                                    cov_ldlt.vectorD().allFinite() &&
-                                    (cov_ldlt.vectorD().array() > 0.0).all()) {
-                                    const Eigen::Vector3d delta =
-                                        provisional_fixed_ant - external_dr_position_ecef;
-                                    const double mahalanobis2 =
-                                        delta.dot(cov_ldlt.solve(delta));
+                            if (external_dr_available) {
+                                external_dr_pass = external_dr_candidate_pass;
+                                if (!config.monitor_external_doppler_dr) {
                                     epoch_diagnostics[i].external_dr_evaluated = true;
-                                    epoch_diagnostics[i].external_dr_separation_m = delta.norm();
-                                    epoch_diagnostics[i].external_dr_mahalanobis2 = mahalanobis2;
-                                    external_dr_pass = std::isfinite(mahalanobis2) &&
-                                        mahalanobis2 <=
-                                            config.external_doppler_dr_chi2_threshold;
-                                    if (external_dr_pass) {
+                                    epoch_diagnostics[i].external_dr_separation_m =
+                                        external_dr_separation_m;
+                                    epoch_diagnostics[i].external_dr_mahalanobis2 =
+                                        external_dr_mahalanobis2;
+                                    epoch_diagnostics[i].external_dr_accepted =
+                                        external_dr_candidate_pass;
+                                    epoch_diagnostics[i].external_dr_rejected =
+                                        !external_dr_candidate_pass;
+                                    if (external_dr_candidate_pass) {
                                         ++result.diagnostics.external_doppler_dr_accepts;
-                                        epoch_diagnostics[i].external_dr_accepted = true;
                                     } else {
                                         ++result.diagnostics.external_doppler_dr_rejects;
-                                        epoch_diagnostics[i].external_dr_rejected = true;
                                     }
-                                } else if ((adaptive_only_pass || integrity_candidate) &&
-                                           config.external_doppler_dr_require_for_relaxed_fix) {
-                                    external_dr_pass = false;
-                                    ++result.diagnostics.external_doppler_dr_unavailable;
                                 }
                             } else if ((adaptive_only_pass || integrity_candidate) &&
                                        config.external_doppler_dr_require_for_relaxed_fix) {
@@ -4577,7 +4625,8 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                             epoch_fixed_position[i] = Point3(provisional_fixed_ant);
                             epoch_has_fixed[i] = true;
                         }
-                        if (config.use_external_doppler_dr_validation &&
+                        if ((config.monitor_external_doppler_dr ||
+                             config.use_external_doppler_dr_validation) &&
                             has_provisional_fixed_ant && has_provisional_fixed_cov &&
                             external_dr_velocity_valid &&
                             ratio >= config.external_doppler_dr_reset_min_ratio) {

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -200,6 +200,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_fgo_arc_lifecycle_audit.py
     )
     add_test(
+        NAME python_fgo_external_dr_witness_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_fgo_external_dr_witness.py
+    )
+    add_test(
         NAME python_ppc_integrity_policy_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_ppc_integrity_policy_ci.py
     )
@@ -458,6 +462,7 @@ if(GTest_FOUND)
         run_tests
         clas_outage_legacy_kill_switch
         python_fgo_arc_lifecycle_audit_tests
+        python_fgo_external_dr_witness_tests
         python_ppc_integrity_policy_tests
         python_ppc_goal_completion_audit_tests
         python_artifact_manifest_contract_validator_tests

--- a/tests/test_fgo.cpp
+++ b/tests/test_fgo.cpp
@@ -766,6 +766,49 @@ TEST(FGOTest, BuiltSingleDifferenceTdcpFactorsUseCurrentEpochLos) {
     EXPECT_GT(max_previous_current_los_delta, 1e-8);
 }
 
+TEST(FGOTest, ExternalDopplerDrMonitorMaterializesShadowFactorsOnly) {
+    const NavigationData nav = makeSyntheticGpsNavigation(4);
+    const std::array<Vector3d, 2> rover_positions = {
+        Vector3d(1113194.0, -4841695.0, 3985350.0),
+        Vector3d(1113194.0, -4841695.0, 3985350.0),
+    };
+    const std::array<Vector3d, 2> base_positions = {
+        rover_positions[0] + Vector3d(-320.0, 180.0, 45.0),
+        rover_positions[1] + Vector3d(-320.0, 180.0, 45.0),
+    };
+    auto rover_epochs =
+        makeSyntheticDoubleDifferenceObservationEpochs(nav, rover_positions, 0.0);
+    auto base_epochs =
+        makeSyntheticDoubleDifferenceObservationEpochs(nav, base_positions, 0.0);
+    for (auto* epochs : {&rover_epochs, &base_epochs}) {
+        for (auto& epoch : *epochs) {
+            for (auto& observation : epoch.observations) {
+                observation.has_doppler = true;
+                observation.doppler = 0.0;
+            }
+        }
+    }
+
+    FGOProcessor::FGOConfig config;
+    config.use_spp_seed = false;
+    config.use_pseudorange_factors = false;
+    config.use_motion_factors = false;
+    config.use_tdcp_factors = false;
+    config.use_double_difference_factors = true;
+    config.use_single_difference_doppler_factors = false;
+    config.monitor_external_doppler_dr = true;
+    config.use_ionosphere_model = false;
+    config.use_troposphere_model = false;
+    config.min_elevation_deg = -90.0;
+    config.min_satellites_per_epoch = 2;
+
+    const auto problem = FGOProcessor(config).buildDoubleDifferenceProblem(
+        rover_epochs, base_epochs, nav, base_positions[0]);
+
+    EXPECT_FALSE(problem.single_difference_doppler_factors.empty());
+    EXPECT_FALSE(config.use_single_difference_doppler_factors);
+}
+
 TEST(FGOTest, ClockResilientTemporalCarrierShadowCancelsCommonClockJump) {
     const NavigationData nav = makeSyntheticGpsNavigation(4);
     const std::array<Vector3d, 2> rover_positions = {

--- a/tests/test_fgo_external_dr_witness.py
+++ b/tests/test_fgo_external_dr_witness.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+
+import importlib.util
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "analyze_fgo_external_dr_witness.py"
+SPEC = importlib.util.spec_from_file_location("external_dr_witness", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+AUDIT = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(AUDIT)
+
+
+def row(*, candidate_east_m: float, status: str = "FLOAT", accepted: bool = True) -> dict[str, str]:
+    return {
+        "tow": "1000.0",
+        "status": status,
+        "e_pos_m": "0",
+        "n_pos_m": "0",
+        "u_pos_m": "0",
+        "ref_e_pos_m": "0",
+        "ref_n_pos_m": "0",
+        "ref_u_pos_m": "0",
+        "x_ecef_m": "6378137",
+        "y_ecef_m": "0",
+        "z_ecef_m": "0",
+        "lambda_candidate_valid": "1",
+        "lambda_candidate_x_ecef_m": "6378137",
+        "lambda_candidate_y_ecef_m": str(candidate_east_m),
+        "lambda_candidate_z_ecef_m": "0",
+        "external_dr_eval": "1",
+        "external_dr_accept": "1" if accepted else "0",
+    }
+
+
+class FgoExternalDrWitnessTest(unittest.TestCase):
+    def test_candidate_error_uses_candidate_not_reported_solution(self) -> None:
+        horizontal, error_3d = AUDIT.candidate_error(row(candidate_east_m=2.0))
+        self.assertAlmostEqual(horizontal, 2.0, places=6)
+        self.assertAlmostEqual(error_3d, 2.0, places=6)
+
+    def test_fixed_epochs_are_controls_not_rescue_opportunities(self) -> None:
+        summary = AUDIT.analyze_rows([row(candidate_east_m=0.1, status="FIXED")])
+        self.assertEqual(summary["population"]["evaluated_fixed_candidates"], 1)
+        self.assertEqual(summary["population"]["evaluated_float_candidates"], 0)
+
+    def test_gate_requires_correct_yield_and_zero_wrong(self) -> None:
+        rows = [row(candidate_east_m=0.1) for _ in range(100)]
+        self.assertTrue(AUDIT.analyze_rows(rows)["gate_passed"])
+        rows[-1] = row(candidate_east_m=2.0)
+        self.assertFalse(AUDIT.analyze_rows(rows)["gate_passed"])
+
+    def test_insufficient_support_fails(self) -> None:
+        summary = AUDIT.analyze_rows([row(candidate_east_m=0.1) for _ in range(59)])
+        self.assertFalse(summary["gate_passed"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -2921,6 +2921,58 @@ TEST(FGOFixDemoteTest, DefaultOffIsNoOp) {
     EXPECT_EQ(result.solution.solutions.size(), problem.epochs.size());
 }
 
+TEST(FGOExternalDopplerDrShadowTest, MonitorDoesNotChangeSolutionAuthority) {
+    CpHoldTestOptions opt;
+    opt.satellites = lambdaCapableSatelliteGeometry();
+    opt.num_epochs = 12;
+    auto problem = makeCpHoldFixedLagProblem(opt);
+
+    const std::array<Vector3d, 4> line_of_sight = {
+        Vector3d::UnitX(), Vector3d::UnitY(), Vector3d::UnitZ(),
+        Vector3d(1.0, 1.0, 1.0).normalized(),
+    };
+    for (std::size_t epoch = 0; epoch < problem.epochs.size(); ++epoch) {
+        for (std::size_t row = 0; row < line_of_sight.size(); ++row) {
+            FGOProcessor::SingleDifferenceDopplerFactor factor;
+            factor.epoch_index = epoch;
+            factor.satellite = SatelliteId(
+                GNSSSystem::GPS, static_cast<uint8_t>(row + 2));
+            factor.reference_satellite = SatelliteId(GNSSSystem::GPS, 1);
+            factor.signal = SignalType::GPS_L1CA;
+            factor.los = line_of_sight[row];
+            factor.residual_mps = 0.0;
+            factor.sigma_mps = 0.1;
+            factor.elevation_rad = 0.7;
+            problem.single_difference_doppler_factors.push_back(factor);
+        }
+    }
+
+    FGOProcessor::FGOConfig off_config = makeFixDemoteBaseConfig();
+    const auto off_result = FGOProcessor(off_config).optimizeProblem(problem);
+
+    FGOProcessor::FGOConfig shadow_config = off_config;
+    shadow_config.monitor_external_doppler_dr = true;
+    shadow_config.external_doppler_dr_reset_min_ratio = 1.5;
+    const auto shadow_result =
+        FGOProcessor(shadow_config).optimizeProblem(problem);
+
+    ASSERT_EQ(off_result.solution.solutions.size(),
+              shadow_result.solution.solutions.size());
+    for (std::size_t i = 0; i < off_result.solution.solutions.size(); ++i) {
+        EXPECT_TRUE(off_result.solution.solutions[i].position_ecef.isApprox(
+            shadow_result.solution.solutions[i].position_ecef, 0.0));
+        EXPECT_EQ(off_result.solution.solutions[i].status,
+                  shadow_result.solution.solutions[i].status);
+    }
+    EXPECT_GT(shadow_result.diagnostics.external_doppler_dr_accepts +
+                  shadow_result.diagnostics.external_doppler_dr_rejects,
+              0u);
+    EXPECT_TRUE(std::any_of(
+        shadow_result.epoch_diagnostics.begin(),
+        shadow_result.epoch_diagnostics.end(),
+        [](const auto& epoch) { return epoch.external_dr_evaluated; }));
+}
+
 TEST(FGOFixDemoteTest, DemotesImplausibleFixedEpochToFloat) {
     const Vector3d true_position(1113194.0, -4841695.0, 3985350.0);
     constexpr std::size_t kBadEpoch = 15;


### PR DESCRIPTION
## What changed

- add a default-off `--external-dr-shadow` monitor that evaluates provisional LAMBDA candidates against an independent SD-Doppler dead-reckoning track without adding graph factors or changing FIX/FLOAT authority
- add an offline scorer with pre-registered support, yield, and zero-wrong gates
- add C++ and Python regression coverage plus a primary-literature-backed audit report
- correct one stale FIX-rate percentage in the prior arc-lifecycle audit

## Why

The existing SPP witness had already been shown to have negligible safe yield. This tests a genuinely separate Doppler-only motion witness without committing to runtime activation.

## Result / impact

The 50-epoch ON/OFF replay was authority-identical. Tokyo run1 evaluated 252 otherwise-FLOAT candidates and accepted 112 correct candidates, but also 112 wrong candidates. The frozen zero-wrong gate therefore failed. Per protocol, run2/run3 were not inspected and the runtime validator remains disabled; this PR records negative evidence and exposes monitor-only diagnostics, with no FIX-rate claim.

## Validation

- MSVC Release build of `gnss_lib_noopt`, `gnss_run_tests`, and `gnss_fgo_parity`
- 36 filtered FGO C++ tests passed
- 4 external-DR scorer Python tests passed
- 50-epoch PPC Tokyo run1 authority fields matched exactly with shadow OFF/ON
- full 11,905-epoch Tokyo run1 shadow replay completed; baseline FIX rate and position metrics were unchanged
- `git diff --check`
