### PR TITLE
Audit FGO NHC/ZUPT motion constraints

### DIFF
--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -55,6 +55,7 @@ struct Args {
     bool fixed_lag_qr = false;   // rank-tolerant iSAM2 elimination
     bool use_nhc = false;        // milestone 2d
     bool use_zupt = false;       // milestone 2d
+    bool motion_constraint_shadow = false;
     bool use_hold = false;       // milestone 2e: fix-and-hold
     bool no_held_fix_label = false;  // keep hold priors; require fresh AR for FIX output
     double elev_mask_deg = -1.0; // milestone 2e: >0 overrides preset elevation mask
@@ -244,6 +245,10 @@ Args parseArgs(int argc, char** argv) {
         }
         if (a == "--fixed-lag-qr") {
             args.fixed_lag_qr = true;
+            continue;
+        }
+        if (a == "--motion-constraint-shadow") {
+            args.motion_constraint_shadow = true;
             continue;
         }
         if (a == "--no-held-fix-label") {
@@ -767,6 +772,7 @@ libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
         args.predicted_ddpr_quality_shadow;
     config.monitor_predicted_ddpr_bias_state =
         args.predicted_ddpr_bias_state_shadow;
+    config.monitor_motion_constraints = args.motion_constraint_shadow;
     config.use_geometry_free_cycle_slip_reset = args.gf_slip_reset;
     config.report_held_ambiguities_as_fixed = !args.no_held_fix_label;
     if (args.max_iters > 0) {
@@ -1615,7 +1621,7 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
            "ddpr_anchor_eval,ddpr_anchor_n,ddpr_anchor_res_m,"
            "ddpr_anchor_x_ecef_m,ddpr_anchor_y_ecef_m,ddpr_anchor_z_ecef_m,"
            "ddpr_anchor_h_err_m,ddpr_anchor_u_err_m,ddpr_anchor_prior,"
-           "fixed_float_sep_m,fixed_imu_pred_sep_m,fixed_postfit_ddcp_rms_m,fixed_postfit_ddcp_max_norm,fixed_postfit_ddcp_chi2_dof,fixed_postfit_ddcp_n,external_dr_sep_m,external_dr_mahal2,external_dr_age,external_doppler_valid,external_doppler_vel_e_mps,external_doppler_vel_n_mps,external_doppler_vel_u_mps,external_dr_eval,external_dr_accept,external_dr_reject,cp_hold,"
+           "fixed_float_sep_m,fixed_imu_pred_sep_m,fixed_postfit_ddcp_rms_m,fixed_postfit_ddcp_max_norm,fixed_postfit_ddcp_chi2_dof,fixed_postfit_ddcp_n,external_dr_sep_m,external_dr_mahal2,external_dr_age,external_doppler_valid,external_doppler_vel_e_mps,external_doppler_vel_n_mps,external_doppler_vel_u_mps,external_dr_eval,external_dr_accept,external_dr_reject,motion_imu_n,motion_accel_std_mps2,motion_gyro_std_radps,motion_gyro_median_radps,motion_yaw_rate_radps,motion_seed_speed_mps,zupt_candidate,zupt_applied,nhc_candidate,nhc_applied,cp_hold,"
            "imu_aperture_accept,imu_aperture_reject,cp_available,cp_added,"
            "cp_suppressed_hold,amb_after_hold,amb_final,amb_excl_build,"
            "amb_excl_hold,amb_excl_one_band,amb_excl_constellation,"
@@ -1837,6 +1843,16 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                 << ',' << (d.external_dr_evaluated ? 1 : 0)
                 << ',' << (d.external_dr_accepted ? 1 : 0)
                 << ',' << (d.external_dr_rejected ? 1 : 0)
+                << ',' << d.motion_constraint_imu_samples
+                << ',' << d.motion_constraint_accel_std_mps2
+                << ',' << d.motion_constraint_gyro_std_radps
+                << ',' << d.motion_constraint_gyro_median_radps
+                << ',' << d.motion_constraint_yaw_rate_radps
+                << ',' << d.motion_constraint_seed_speed_mps
+                << ',' << (d.zupt_candidate ? 1 : 0)
+                << ',' << (d.zupt_applied ? 1 : 0)
+                << ',' << (d.nhc_candidate ? 1 : 0)
+                << ',' << (d.nhc_applied ? 1 : 0)
                 << ',' << (d.carrier_hold_active ? 1 : 0)
                 << ',' << (d.imu_aperture_accepted ? 1 : 0)
                 << ',' << (d.imu_aperture_rejected ? 1 : 0)
@@ -3316,7 +3332,8 @@ int main(int argc, char** argv) {
                   << "  NHC/ZUPT: nhc=" << (args.use_nhc ? "on" : "off")
                   << " (applied " << fl.diagnostics.nhc_epochs << " epochs), zupt="
                   << (args.use_zupt ? "on" : "off") << " (applied " << fl.diagnostics.zupt_epochs
-                  << " epochs)\n"
+                  << " epochs), shadow="
+                  << (args.motion_constraint_shadow ? "on" : "off") << "\n"
                   << "  quality-gates: " << (args.gates ? "on" : "off")
                   << " (fixing suppressed on " << fl.diagnostics.quality_gated_epochs
                   << " epochs)\n"

--- a/docs/fgo_nhc_zupt_fix_rate_audit.md
+++ b/docs/fgo_nhc_zupt_fix_rate_audit.md
@@ -1,0 +1,130 @@
+# FGO NHC/ZUPT FIX-rate audit
+
+## Objective
+
+Determine whether vehicle-motion constraints improve the float state presented
+to ambiguity resolution without relaxing LAMBDA, adding a TDCP promotion rule,
+or increasing wrong FIX.  NHC and ZUPT remain default-off until every staged
+gate passes.
+
+Tokyo run1 is the only development run.  Run2 stays sealed until a full-run1
+activation passes, and run3 stays sealed until the unchanged run2 activation
+passes.
+
+## Research and code audit
+
+- Kilic et al. add zero-velocity information to a GNSS/INS factor graph for
+  wheeled robots: <https://arxiv.org/abs/2112.07176>.
+- Liu et al. formulate NHC as a factor in ground-vehicle FGO and emphasize the
+  no-side-slip/no-vertical-motion assumption:
+  <https://doi.org/10.3390/mi13091400>.
+- The local `tightly-coupled-gnss-imu-fgo` reference applies body-frame
+  lateral/vertical velocity constraints and gates ZUPT with causal IMU-window
+  statistics plus an optional previous-velocity check.
+
+The current C++ NHC residual and GTSAM Jacobians use the correct body-to-ENU
+rotation convention.  The ZUPT statistics do not exactly match their stated
+reference, however: the reference computes the RMS vector deviation from the
+window mean, while C++ computes the standard deviation of per-sample vector
+norms.  The latter can hide directional vibration at nearly constant norm.
+This discrepancy must be corrected and covered by a deterministic test before
+any activation result is accepted.
+
+The other central risk is observability.  Quiet constant-speed travel can look
+stationary to accelerometer/gyro dispersion, while a true stop whose velocity
+estimate already drifted above the 0.5 m/s gate cannot receive ZUPT.  Therefore
+removing the velocity gate or tuning only IMU thresholds is out of scope.
+
+## Frozen development protocol
+
+### Gate 0: correctness and non-interference
+
+- correct the IMU-window statistic to the documented vector-deviation RMS;
+- unit-test directional vibration, true stationary data, ZUPT speed rejection,
+  NHC speed/turn rejection, and NHC residual/Jacobians;
+- with both switches off, the shipping solution remains unchanged.
+
+### Gate 1: fixed 500-epoch development slice
+
+Use a 500-epoch Tokyo run1 replay beginning at source epoch 5000.  It was
+selected before any NHC/ZUPT replay because the corresponding preserved
+full-run window contains 60 correct FLOAT opportunities and zero wrong FIX
+epochs, unlike the nearly saturated opening 500 epochs.  `--start-epoch`
+starts a fresh solve at epoch 5000 rather than retaining the full run's solver
+history, so its baseline is frozen independently before any active constraint
+replay: 333 FIX, 167 FLOAT, zero NONE/non-finite, and 0.024057 m fixed
+horizontal RMS (21.1719 s solver wall time).
+
+Compare exactly four configurations using the shipping preset:
+
+1. baseline;
+2. NHC only;
+3. ZUPT only; and
+4. NHC + ZUPT.
+
+A configuration advances only with:
+
+- zero additional wrong FIX epochs;
+- zero lost correct FIX epochs;
+- at least three additional correct FIX epochs;
+- no additional NONE/non-finite epoch;
+- fixed horizontal RMS and P95 regression no greater than 5%; and
+- solver wall-time overhead no greater than 10%.
+
+No sigma or detector threshold is tuned after this four-way replay.  If none
+passes, stop activation and retain only corrected tests/telemetry.
+
+### Gate 2: full run1
+
+Run only Gate-1 survivors over all 11,905 epochs.  Require zero increase in
+wrong-FIX distance, no decrease in correct-FIX distance, no solver/matched-
+distance regression, at least +0.2 percentage points correct-FIX distance,
+and no more than 5% fixed RMS/P95 regression.
+
+### Gate 3: sealed holdouts
+
+Freeze the configuration after run1.  Run2 and then run3 once each.  Each must
+independently have zero wrong-FIX-distance increase, no correct-FIX-distance
+decrease, no solver/matched-distance regression, and at most 5% fixed RMS/P95
+regression.  Any failure ends activation without tuning against that run.
+
+## Result
+
+Gate 0 passed.  The focused deterministic tests cover directional vibration,
+ZUPT application, NHC application, and turn rejection.  A 500-epoch
+monitor-off/monitor-on replay had zero differences in every pre-existing CSV
+field; only the ten new motion-diagnostic fields changed.
+
+The frozen Gate-1 replay produced:
+
+| configuration | correct FIX | wrong FIX | added correct | added wrong | fixed horizontal RMS | P95 | wall time | result |
+|---|---:|---:|---:|---:|---:|---:|---:|---|
+| baseline | 333 | 0 | -- | -- | 0.024085 m | 0.0340 m | 21.1719 s | reference |
+| NHC | 333 | 0 | 0 | 0 | 0.023850 m | 0.0334 m | 18.4081 s | fail: no FIX gain |
+| ZUPT | 333 | 0 | 0 | 0 | 0.023802 m | 0.0330 m | 20.8266 s | fail: no FIX gain |
+| NHC + ZUPT | 333 | 2 | 0 | 2 | 0.961176 m | 0.0330 m | 24.6932 s | fail: wrong FIX, RMS, runtime, and no correct-FIX gain |
+
+The combined configuration changed two baseline FLOAT epochs into wrong FIX
+at TOW 188564.0 and 188564.2; their 3-D errors were 22.399 m and 22.361 m.
+The shadow observed 87 ZUPT and 316 NHC candidates in the baseline.  NHC-only
+applied 316 factors; ZUPT-only applied 108 as its velocity feedback changed
+later candidate decisions.  Neither changed the FIX classification.
+
+No configuration passes Gate 1, so the audit stops without a full run1 or any
+inspection of sealed run2/run3.  NHC and ZUPT remain default-off.  The accepted
+deliverable is limited to the corrected vector-deviation statistic,
+authority-neutral telemetry, deterministic tests, and the reproducible
+offline A/B scorer.  The machine-readable result is generated with:
+
+```powershell
+python scripts/analyze_fgo_motion_constraint_ab.py `
+  --baseline build-ffrt-msvc/validation/tokyo1_motion_e5000_n500_baseline.csv `
+  --baseline-runtime-s 21.1719 `
+  --variant nhc=build-ffrt-msvc/validation/tokyo1_motion_e5000_n500_nhc.csv `
+  --runtime-s nhc=18.4081 `
+  --variant zupt=build-ffrt-msvc/validation/tokyo1_motion_e5000_n500_zupt.csv `
+  --runtime-s zupt=20.8266 `
+  --variant both=build-ffrt-msvc/validation/tokyo1_motion_e5000_n500_both.csv `
+  --runtime-s both=24.6932 `
+  --json build-ffrt-msvc/validation/tokyo1_motion_e5000_n500_ab.json
+```

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -688,6 +688,7 @@ public:
         // [v_body.y, v_body.z] = [ (R^T v_nav).y, (R^T v_nav).z ]. Gated to
         // moving, non-turning epochs so it never fights legitimate lateral
         // motion.
+        bool monitor_motion_constraints = false;
         bool use_nhc = false;
         double nhc_min_speed_mps = 2.0;          ///< only apply NHC above this speed
         double nhc_max_yaw_rate_radps = 0.20;    ///< skip NHC when |yaw rate| exceeds this (turn)
@@ -2358,6 +2359,18 @@ public:
         bool external_dr_evaluated = false;
         bool external_dr_accepted = false;
         bool external_dr_rejected = false;
+        // Monitor-only NHC/ZUPT gate inputs and decisions. These values are
+        // computed before the current epoch is optimized and never feed AR.
+        int motion_constraint_imu_samples = 0;
+        double motion_constraint_accel_std_mps2 = 0.0;
+        double motion_constraint_gyro_std_radps = 0.0;
+        double motion_constraint_gyro_median_radps = 0.0;
+        double motion_constraint_yaw_rate_radps = 0.0;
+        double motion_constraint_seed_speed_mps = 0.0;
+        bool zupt_candidate = false;
+        bool zupt_applied = false;
+        bool nhc_candidate = false;
+        bool nhc_applied = false;
         bool carrier_hold_active = false;
         bool imu_aperture_accepted = false;
         bool imu_aperture_rejected = false;

--- a/scripts/analyze_fgo_motion_constraint_ab.py
+++ b/scripts/analyze_fgo_motion_constraint_ab.py
@@ -1,0 +1,132 @@
+#!/usr/bin/env python3
+"""Score frozen NHC/ZUPT A/B replays without feeding truth into the solver."""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from pathlib import Path
+
+
+def load(path: Path) -> dict[float, dict[str, str]]:
+    with path.open(newline="", encoding="utf-8") as stream:
+        rows = list(csv.DictReader(stream))
+    return {float(row["tow"]): row for row in rows}
+
+
+def error3d(row: dict[str, str]) -> float:
+    return math.sqrt(sum(float(row[key]) ** 2 for key in ("e_err_m", "n_err_m", "u_err_m")))
+
+
+def percentile(values: list[float], pct: float) -> float:
+    ordered = sorted(values)
+    if not ordered:
+        return math.nan
+    rank = (len(ordered) - 1) * pct / 100.0
+    lo = math.floor(rank)
+    hi = math.ceil(rank)
+    return ordered[lo] + (ordered[hi] - ordered[lo]) * (rank - lo)
+
+
+def metrics(rows: dict[float, dict[str, str]]) -> dict[str, float | int]:
+    fixed = [row for row in rows.values() if row["status"] == "FIXED"]
+    correct = [row for row in fixed if error3d(row) <= 0.5]
+    horizontal = [float(row["horiz_err_m"]) for row in fixed]
+    return {
+        "rows": len(rows),
+        "fixed": len(fixed),
+        "correct_fixed": len(correct),
+        "wrong_fixed": len(fixed) - len(correct),
+        "fixed_horizontal_rms_m": math.sqrt(sum(value * value for value in horizontal) / len(horizontal)),
+        "fixed_horizontal_p95_m": percentile(horizontal, 95.0),
+        "zupt_candidates": sum(int(row["zupt_candidate"]) for row in rows.values()),
+        "zupt_applied": sum(int(row["zupt_applied"]) for row in rows.values()),
+        "nhc_candidates": sum(int(row["nhc_candidate"]) for row in rows.values()),
+        "nhc_applied": sum(int(row["nhc_applied"]) for row in rows.values()),
+    }
+
+
+def compare(
+    baseline: dict[float, dict[str, str]],
+    variant: dict[float, dict[str, str]],
+    baseline_runtime_s: float,
+    variant_runtime_s: float,
+) -> dict[str, object]:
+    if baseline.keys() != variant.keys():
+        raise ValueError("baseline and variant TOW sets differ")
+    base_metrics = metrics(baseline)
+    variant_metrics = metrics(variant)
+    added_correct = lost_correct = added_wrong = 0
+    for tow, base in baseline.items():
+        candidate = variant[tow]
+        base_correct = base["status"] == "FIXED" and error3d(base) <= 0.5
+        candidate_correct = candidate["status"] == "FIXED" and error3d(candidate) <= 0.5
+        base_wrong = base["status"] == "FIXED" and not base_correct
+        candidate_wrong = candidate["status"] == "FIXED" and not candidate_correct
+        added_correct += candidate_correct and not base_correct
+        lost_correct += base_correct and not candidate_correct
+        added_wrong += candidate_wrong and not base_wrong
+    rms_ratio = float(variant_metrics["fixed_horizontal_rms_m"]) / float(base_metrics["fixed_horizontal_rms_m"])
+    p95_ratio = float(variant_metrics["fixed_horizontal_p95_m"]) / float(base_metrics["fixed_horizontal_p95_m"])
+    runtime_ratio = variant_runtime_s / baseline_runtime_s
+    gate_checks = {
+        "zero_added_wrong_fix": added_wrong == 0,
+        "zero_lost_correct_fix": lost_correct == 0,
+        "at_least_three_added_correct_fix": added_correct >= 3,
+        "same_row_count": variant_metrics["rows"] == base_metrics["rows"],
+        "fixed_rms_within_5pct": rms_ratio <= 1.05,
+        "fixed_p95_within_5pct": p95_ratio <= 1.05,
+        "runtime_within_10pct": runtime_ratio <= 1.10,
+    }
+    return {
+        "metrics": variant_metrics,
+        "added_correct_fix": added_correct,
+        "lost_correct_fix": lost_correct,
+        "added_wrong_fix": added_wrong,
+        "fixed_rms_ratio": rms_ratio,
+        "fixed_p95_ratio": p95_ratio,
+        "runtime_ratio": runtime_ratio,
+        "gate_checks": gate_checks,
+        "passes": all(gate_checks.values()),
+    }
+
+
+def parse_assignment(value: str) -> tuple[str, str]:
+    name, separator, item = value.partition("=")
+    if not separator or not name or not item:
+        raise argparse.ArgumentTypeError("expected NAME=VALUE")
+    return name, item
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--baseline", type=Path, required=True)
+    parser.add_argument("--baseline-runtime-s", type=float, required=True)
+    parser.add_argument("--variant", action="append", type=parse_assignment, required=True)
+    parser.add_argument("--runtime-s", action="append", type=parse_assignment, required=True)
+    parser.add_argument("--json", type=Path, required=True)
+    args = parser.parse_args()
+    runtimes = {name: float(value) for name, value in args.runtime_s}
+    baseline = load(args.baseline)
+    payload: dict[str, object] = {
+        "correct_fix_threshold_3d_m": 0.5,
+        "baseline": metrics(baseline),
+        "baseline_runtime_s": args.baseline_runtime_s,
+        "variants": {},
+    }
+    variants = payload["variants"]
+    assert isinstance(variants, dict)
+    for name, value in args.variant:
+        if name not in runtimes:
+            parser.error(f"missing --runtime-s {name}=SECONDS")
+        variants[name] = compare(baseline, load(Path(value)), args.baseline_runtime_s, runtimes[name])
+    args.json.parent.mkdir(parents=True, exist_ok=True)
+    args.json.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -758,10 +758,9 @@ class SingleDifferenceDopplerVelocityFactor
 };
 
 // Stationarity stats over an IMU sample sub-range [begin, end), mirroring the
-// Stage-1 ESKF LooseCouplingProcessor::detectStationary(): std of the norm of
-// (accel - accel_bias) and (gyro - gyro_bias), plus the median of the gyro
-// deviation norm. Bias-referenced against the Stage-1 init bias (not a running
-// estimate), exactly as inuex35's compute_zupt_stats recommends.
+// Vector-deviation RMS plus the median bias-referenced gyro norm, matching
+// inuex35's compute_zupt_stats. The older std-of-norms formulation could hide
+// directional vibration whose magnitude stayed nearly constant.
 struct ImuWindowStats {
     int n = 0;
     double accel_std = 0.0;
@@ -779,34 +778,31 @@ inline ImuWindowStats imuWindowStats(const std::vector<ImuSample>& samples, std:
     if (n == 0) {
         return s;
     }
-    std::vector<double> accel_devs, gyro_devs;
-    accel_devs.reserve(n);
-    gyro_devs.reserve(n);
+    Vector3d accel_mean = Vector3d::Zero();
+    Vector3d gyro_mean = Vector3d::Zero();
+    std::vector<double> gyro_residual_norms;
+    gyro_residual_norms.reserve(n);
     double gyro_z_sum = 0.0;
     for (std::size_t k = begin; k < end; ++k) {
-        accel_devs.push_back((samples[k].accel_raw - accel_bias).norm());
-        gyro_devs.push_back((samples[k].gyro_raw_radps - gyro_bias).norm());
+        accel_mean += samples[k].accel_raw;
+        gyro_mean += samples[k].gyro_raw_radps;
+        gyro_residual_norms.push_back(
+            (samples[k].gyro_raw_radps - gyro_bias).norm());
         gyro_z_sum += samples[k].gyro_raw_radps.z() - gyro_bias.z();
     }
-    auto mean = [](const std::vector<double>& v) {
-        double m = 0.0;
-        for (double x : v) m += x;
-        return m / static_cast<double>(v.size());
-    };
-    auto stddev = [&](const std::vector<double>& v) {
-        const double m = mean(v);
-        double s2 = 0.0;
-        for (double x : v) {
-            const double d = x - m;
-            s2 += d * d;
-        }
-        return std::sqrt(s2 / static_cast<double>(v.size()));
-    };
-    std::vector<double> g = gyro_devs;
-    std::sort(g.begin(), g.end());
-    s.accel_std = stddev(accel_devs);
-    s.gyro_std = stddev(gyro_devs);
-    s.gyro_median = g[g.size() / 2];
+    accel_mean /= static_cast<double>(n);
+    gyro_mean /= static_cast<double>(n);
+    double accel_variance = 0.0;
+    double gyro_variance = 0.0;
+    for (std::size_t k = begin; k < end; ++k) {
+        accel_variance += (samples[k].accel_raw - accel_mean).squaredNorm();
+        gyro_variance +=
+            (samples[k].gyro_raw_radps - gyro_mean).squaredNorm();
+    }
+    std::sort(gyro_residual_norms.begin(), gyro_residual_norms.end());
+    s.accel_std = std::sqrt(accel_variance / static_cast<double>(n));
+    s.gyro_std = std::sqrt(gyro_variance / static_cast<double>(n));
+    s.gyro_median = gyro_residual_norms[gyro_residual_norms.size() / 2];
     s.yaw_rate_abs = std::abs(gyro_z_sum / static_cast<double>(n));
     return s;
 }
@@ -2592,19 +2588,29 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
 
         // --- Milestone 2d: NHC + ZUPT pseudo-measurements (gated per epoch) ---
         const ImuWindowStats wstats =
-            (config.use_nhc || config.use_zupt)
+            (config.monitor_motion_constraints || config.use_nhc ||
+             config.use_zupt)
                 ? imuWindowStats(imu_samples, win_begin, win_end, problem.imu.init_accel_bias,
                                  problem.imu.init_gyro_bias)
                 : ImuWindowStats{};
         const double seed_speed = vel_seed.norm();
-        const bool stationary =
-            config.use_zupt && wstats.n >= config.zupt_min_samples &&
+        const bool zupt_candidate =
+            wstats.n >= config.zupt_min_samples &&
             wstats.accel_std <= config.zupt_max_accel_std &&
             wstats.gyro_std <= config.zupt_max_gyro_std &&
             wstats.gyro_median <= config.zupt_max_gyro_median &&
             // Velocity gate: reject false ZUPT during constant-velocity motion
             // (quiet accelerometer but non-zero speed).
             (config.zupt_max_speed_mps <= 0.0 || seed_speed <= config.zupt_max_speed_mps);
+        const bool stationary = config.use_zupt && zupt_candidate;
+        auto& motion_diag = epoch_diagnostics[i];
+        motion_diag.motion_constraint_imu_samples = wstats.n;
+        motion_diag.motion_constraint_accel_std_mps2 = wstats.accel_std;
+        motion_diag.motion_constraint_gyro_std_radps = wstats.gyro_std;
+        motion_diag.motion_constraint_gyro_median_radps = wstats.gyro_median;
+        motion_diag.motion_constraint_yaw_rate_radps = wstats.yaw_rate_abs;
+        motion_diag.motion_constraint_seed_speed_mps = seed_speed;
+        motion_diag.zupt_candidate = zupt_candidate;
         if (stationary && config.zupt_sigma_mps > 0.0) {
             // ZUPT: pin Vel(i) ~ 0 (mirrors inuex35 _add_zero_velocity_prior).
             const gtsam::Vector3 zero_velocity = gtsam::Vector3::Zero();
@@ -2612,20 +2618,26 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 velocityKey(i), zero_velocity,
                 gtsam::noiseModel::Isotropic::Sigma(3, config.zupt_sigma_mps));
             ++result.diagnostics.zupt_epochs;
+            motion_diag.zupt_applied = true;
         }
+        const double horizontal_seed_speed = std::hypot(vel_seed.x(), vel_seed.y());
+        const bool nhc_candidate =
+            (!config.use_zupt || !zupt_candidate) &&
+            horizontal_seed_speed >= config.nhc_min_speed_mps &&
+            wstats.yaw_rate_abs <= config.nhc_max_yaw_rate_radps;
+        motion_diag.nhc_candidate = nhc_candidate;
         if (config.use_nhc && !stationary) {
             // NHC: apply only to moving, non-turning epochs so it never fights
             // legitimate lateral motion (mirrors nhc.py's speed gate + a
             // yaw-rate gate for turns). Speed comes from the seed velocity.
-            const double speed = std::hypot(vel_seed.x(), vel_seed.y());
-            if (speed >= config.nhc_min_speed_mps &&
-                wstats.yaw_rate_abs <= config.nhc_max_yaw_rate_radps) {
+            if (nhc_candidate) {
                 gtsam::Vector2 nhc_sigmas(config.nhc_sigma_lateral_mps,
                                           config.nhc_sigma_vertical_mps);
                 new_factors.emplace_shared<NonHolonomicFactor>(
                     positionKey(i), velocityKey(i),
                     gtsam::noiseModel::Diagonal::Sigmas(nhc_sigmas));
                 ++result.diagnostics.nhc_epochs;
+                motion_diag.nhc_applied = true;
             }
         }
 

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -2973,6 +2973,82 @@ TEST(FGOExternalDopplerDrShadowTest, MonitorDoesNotChangeSolutionAuthority) {
         [](const auto& epoch) { return epoch.external_dr_evaluated; }));
 }
 
+TEST(FGOMotionConstraintShadowTest,
+     DirectionalVibrationIsVisibleAndMonitorDoesNotChangeSolution) {
+    CpHoldTestOptions opt;
+    opt.num_epochs = 3;
+    auto problem = makeCpHoldFixedLagProblem(opt);
+    const double g = problem.imu.noise.gravity_mps2;
+    for (std::size_t i = 0; i < problem.imu.samples_body_flu.size(); ++i) {
+        problem.imu.samples_body_flu[i].accel_raw =
+            i % 2 == 0 ? Vector3d(g, 0.0, 0.0) : Vector3d(0.0, 0.0, g);
+        problem.imu.samples_body_flu[i].gyro_raw_radps =
+            i % 2 == 0 ? Vector3d(0.1, 0.0, 0.0)
+                       : Vector3d(0.0, 0.1, 0.0);
+    }
+
+    FGOProcessor::FGOConfig off_config = makeCpHoldBaseConfig();
+    const auto off_result = FGOProcessor(off_config).optimizeProblem(problem);
+
+    FGOProcessor::FGOConfig shadow_config = off_config;
+    shadow_config.monitor_motion_constraints = true;
+    const auto shadow_result =
+        FGOProcessor(shadow_config).optimizeProblem(problem);
+
+    ASSERT_EQ(off_result.solution.solutions.size(),
+              shadow_result.solution.solutions.size());
+    ASSERT_EQ(shadow_result.epoch_diagnostics.size(), problem.epochs.size());
+    for (std::size_t i = 0; i < off_result.solution.solutions.size(); ++i) {
+        EXPECT_TRUE(off_result.solution.solutions[i].position_ecef.isApprox(
+            shadow_result.solution.solutions[i].position_ecef, 0.0));
+        EXPECT_EQ(off_result.solution.solutions[i].status,
+                  shadow_result.solution.solutions[i].status);
+    }
+    EXPECT_GT(shadow_result.epoch_diagnostics.front()
+                  .motion_constraint_accel_std_mps2,
+              5.0);
+    EXPECT_GT(shadow_result.epoch_diagnostics.front()
+                  .motion_constraint_gyro_std_radps,
+              0.05);
+    EXPECT_FALSE(shadow_result.epoch_diagnostics.front().zupt_candidate);
+}
+
+TEST(FGOMotionConstraintGateTest, AppliesStationaryZuptAndRejectsTurningNhc) {
+    CpHoldTestOptions opt;
+    opt.num_epochs = 3;
+    const auto stationary_problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig zupt_config = makeCpHoldBaseConfig();
+    zupt_config.use_zupt = true;
+    const auto zupt_result =
+        FGOProcessor(zupt_config).optimizeProblem(stationary_problem);
+    EXPECT_GT(zupt_result.diagnostics.zupt_epochs, 0u);
+    EXPECT_TRUE(std::any_of(
+        zupt_result.epoch_diagnostics.begin(),
+        zupt_result.epoch_diagnostics.end(),
+        [](const auto& epoch) { return epoch.zupt_applied; }));
+
+    auto straight_problem = stationary_problem;
+    straight_problem.imu.init_velocity_nav = Vector3d(3.0, 0.0, 0.0);
+    FGOProcessor::FGOConfig nhc_config = makeCpHoldBaseConfig();
+    nhc_config.use_nhc = true;
+    const auto straight_result =
+        FGOProcessor(nhc_config).optimizeProblem(straight_problem);
+    EXPECT_GT(straight_result.diagnostics.nhc_epochs, 0u);
+
+    auto turning_problem = straight_problem;
+    for (auto& sample : turning_problem.imu.samples_body_flu) {
+        sample.gyro_raw_radps.z() += 0.5;
+    }
+    const auto turning_result =
+        FGOProcessor(nhc_config).optimizeProblem(turning_problem);
+    EXPECT_EQ(turning_result.diagnostics.nhc_epochs, 0u);
+    EXPECT_TRUE(std::none_of(
+        turning_result.epoch_diagnostics.begin(),
+        turning_result.epoch_diagnostics.end(),
+        [](const auto& epoch) { return epoch.nhc_applied; }));
+}
+
 TEST(FGOFixDemoteTest, DemotesImplausibleFixedEpochToFloat) {
     const Vector3d true_position(1113194.0, -4841695.0, 3985350.0);
     constexpr std::size_t kBadEpoch = 15;

--- a/tests/test_fgo_motion_constraint_ab.py
+++ b/tests/test_fgo_motion_constraint_ab.py
@@ -1,0 +1,68 @@
+import csv
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "scripts" / "analyze_fgo_motion_constraint_ab.py"
+SPEC = importlib.util.spec_from_file_location("motion_ab", SCRIPT)
+assert SPEC and SPEC.loader
+MODULE = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(MODULE)
+
+
+class MotionConstraintAbTest(unittest.TestCase):
+    def write_rows(self, path: Path, rows: list[dict[str, object]]) -> None:
+        with path.open("w", newline="", encoding="utf-8") as stream:
+            writer = csv.DictWriter(stream, fieldnames=rows[0].keys())
+            writer.writeheader()
+            writer.writerows(rows)
+
+    def test_compare_rejects_added_wrong_fix(self) -> None:
+        fields = {
+            "n_err_m": 0.0, "u_err_m": 0.0, "zupt_candidate": 0,
+            "zupt_applied": 0, "nhc_candidate": 0, "nhc_applied": 0,
+        }
+        baseline_rows = [
+            {"tow": 1, "status": "FIXED", "e_err_m": 0.1, "horiz_err_m": 0.1, **fields},
+            {"tow": 2, "status": "FLOAT", "e_err_m": 2.0, "horiz_err_m": 2.0, **fields},
+        ]
+        variant_rows = [
+            baseline_rows[0],
+            {"tow": 2, "status": "FIXED", "e_err_m": 2.0, "horiz_err_m": 2.0, **fields},
+        ]
+        with tempfile.TemporaryDirectory() as directory:
+            base_path = Path(directory) / "base.csv"
+            variant_path = Path(directory) / "variant.csv"
+            self.write_rows(base_path, baseline_rows)
+            self.write_rows(variant_path, variant_rows)
+            result = MODULE.compare(MODULE.load(base_path), MODULE.load(variant_path), 10.0, 10.0)
+        self.assertEqual(result["added_wrong_fix"], 1)
+        self.assertFalse(result["passes"])
+
+    def test_compare_accepts_three_safe_added_fixes(self) -> None:
+        fields = {
+            "n_err_m": 0.0, "u_err_m": 0.0, "zupt_candidate": 0,
+            "zupt_applied": 0, "nhc_candidate": 0, "nhc_applied": 0,
+        }
+        baseline_rows = [
+            {"tow": 1, "status": "FIXED", "e_err_m": 0.1, "horiz_err_m": 0.1, **fields},
+            *[
+                {"tow": tow, "status": "FLOAT", "e_err_m": 0.1, "horiz_err_m": 0.1, **fields}
+                for tow in (2, 3, 4)
+            ],
+        ]
+        variant_rows = [dict(row, status="FIXED") for row in baseline_rows]
+        with tempfile.TemporaryDirectory() as directory:
+            base_path = Path(directory) / "base.csv"
+            variant_path = Path(directory) / "variant.csv"
+            self.write_rows(base_path, baseline_rows)
+            self.write_rows(variant_path, variant_rows)
+            result = MODULE.compare(MODULE.load(base_path), MODULE.load(variant_path), 10.0, 10.5)
+        self.assertEqual(result["added_correct_fix"], 3)
+        self.assertTrue(result["passes"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What changed

- correct the ZUPT IMU-window statistic to RMS vector deviation, preventing constant-magnitude directional vibration from appearing stationary
- add authority-neutral NHC/ZUPT gate telemetry to the parity CSV
- add deterministic GTSAM tests and a reproducible offline A/B scorer
- document the primary-source rationale, frozen gates, and Tokyo run1 development result

## Why

The old standard deviation of sample norms could hide directional vibration. NHC and ZUPT also needed a truth-isolated, pre-registered evaluation before any activation decision.

## Result

Both constraints remain default-off. On the frozen 500-epoch Tokyo run1 replay, NHC-only and ZUPT-only added no correct FIX epochs. Their combination added two wrong FIX epochs (about 22.4 m 3-D error) and regressed fixed horizontal RMS, so the protocol stopped before full run1 and sealed run2/run3.

## Validation

- `run_tests.exe --gtest_filter=FGO*` — 107/107 passed
- `python -m unittest tests.test_fgo_motion_constraint_ab` — 2/2 passed
- 500-epoch monitor OFF/ON authority comparison — zero differences in every pre-existing CSV field
- four-way frozen replay — baseline/NHC/ZUPT/both completed; no activation survivor
- full local CTest was attempted, but the monolithic existing `run_tests` target remained silent past 5 minutes and was stopped; targeted changed-area suites above completed successfully
