### PR TITLE
Add default-off quarantine/arc-restart FGO audits with negative-result documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@ build/
 build_local/
 build-codex/
 build-madoca-parity/
+build-ffrt-msvc/
+build-no-gtsam-msvc/
 bin/
 *.a
 *.o

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ set(GNSS_SOURCES_NO_OPTIMIZATION
     src/algorithms/rtk_tdcp_diagnostics.cpp
     src/algorithms/rtk_validation.cpp
     src/algorithms/integrity_consensus.cpp
+    src/algorithms/fgo_ddpr_gnc.cpp
     src/algorithms/fgo.cpp
     src/algorithms/ppp_env_overrides.cpp
     src/algorithms/rtk.cpp

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -67,6 +67,9 @@ struct Args {
     bool clock_resilient_temporal_shadow = false;  // diagnostic-only receiver-clock-free TDCP
     bool predicted_ddpr_quality_shadow = false;  // diagnostic-only causal DDPR quality
     bool predicted_ddpr_bias_state_shadow = false;  // causal persistent DDPR bias monitor
+    bool ddpr_gnc_shadow = false;  // fixed weights + copied-graph GNC counterfactual
+    bool candidate_integrity_shadow = false;  // monitor-only multi-witness FIX check
+    bool satellite_quarantine_shadow = false;  // monitor-only two-stage satellite witness
     std::string temporal_shadow_replay_csv;  // classify against frozen ECEF positions; skip solve
     bool temporal_shadow_truth_replay = false;  // classify against reference.csv; skip solve
     bool postfit_gate = false;
@@ -275,6 +278,18 @@ Args parseArgs(int argc, char** argv) {
         }
         if (a == "--predicted-ddpr-bias-state-shadow") {
             args.predicted_ddpr_bias_state_shadow = true;
+            continue;
+        }
+        if (a == "--ddpr-gnc-shadow") {
+            args.ddpr_gnc_shadow = true;
+            continue;
+        }
+        if (a == "--candidate-integrity-shadow") {
+            args.candidate_integrity_shadow = true;
+            continue;
+        }
+        if (a == "--satellite-quarantine-shadow") {
+            args.satellite_quarantine_shadow = true;
             continue;
         }
         if (a == "--gici-par") {
@@ -772,6 +787,12 @@ libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
         args.predicted_ddpr_quality_shadow;
     config.monitor_predicted_ddpr_bias_state =
         args.predicted_ddpr_bias_state_shadow;
+    config.monitor_ddpr_gnc = args.ddpr_gnc_shadow;
+    config.monitor_ddpr_gnc_counterfactual = args.ddpr_gnc_shadow;
+    config.monitor_candidate_integrity_witness =
+        args.candidate_integrity_shadow;
+    config.monitor_satellite_quarantine_witness =
+        args.satellite_quarantine_shadow;
     config.monitor_motion_constraints = args.motion_constraint_shadow;
     config.use_geometry_free_cycle_slip_reset = args.gf_slip_reset;
     config.report_held_ambiguities_as_fixed = !args.no_held_fix_label;
@@ -824,6 +845,10 @@ libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
         if (args.external_dr_reset_ratio < 0.0) {
             config.external_doppler_dr_reset_min_ratio = 20.0;
         }
+    }
+    if (args.candidate_integrity_shadow &&
+        args.external_dr_reset_ratio < 0.0) {
+        config.external_doppler_dr_reset_min_ratio = 20.0;
     }
     if (args.external_dr_max_age > 0) {
         config.external_doppler_dr_max_age_epochs = args.external_dr_max_age;
@@ -1567,7 +1592,7 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
            "x_ecef_m,y_ecef_m,z_ecef_m,position_covariance_trace_m2,"
            "ref_e_pos_m,ref_n_pos_m,ref_u_pos_m,"
            "vel_e_mps,vel_n_mps,vel_u_mps,"
-           "ratio,ratio_threshold,nfixed,ar_outcome,ddpr_rms_m,sd_doppler_rms_mps,clock_resilient_tdcp_n,clock_resilient_tdcp_rms_m,clock_resilient_tdcp_max_abs_m,clock_resilient_tdcp_clean,clock_resilient_tdcp_witnessed_outliers,clock_resilient_tdcp_unexplained_outliers,gdop,nsat,sd_doppler_n,"
+           "ratio,ratio_threshold,nfixed,ar_outcome,ddpr_rms_m,ddpr_gnc_eval,ddpr_gnc_n,ddpr_gnc_stages,ddpr_gnc_initial_mu,ddpr_gnc_final_mu,ddpr_gnc_min_weight,ddpr_gnc_mean_weight,ddpr_gnc_effective_n,ddpr_gnc_downweighted_n,ddpr_gnc_weighted_rms_m,ddpr_gnc_cf_eval,ddpr_gnc_cf_success,ddpr_gnc_cf_n,ddpr_gnc_cf_stages,ddpr_gnc_cf_cost_before,ddpr_gnc_cf_cost_after,ddpr_gnc_cf_ddpr_rms_before_m,ddpr_gnc_cf_ddpr_rms_after_m,ddpr_gnc_cf_x_ecef_m,ddpr_gnc_cf_y_ecef_m,ddpr_gnc_cf_z_ecef_m,ddpr_gnc_cf_float_separation_m,ddpr_gnc_cf_lambda_eval,ddpr_gnc_cf_lambda_n,ddpr_gnc_cf_lambda_ratio,ddpr_gnc_cf_lambda_ratio_pass,sd_doppler_rms_mps,clock_resilient_tdcp_n,clock_resilient_tdcp_rms_m,clock_resilient_tdcp_max_abs_m,clock_resilient_tdcp_clean,clock_resilient_tdcp_witnessed_outliers,clock_resilient_tdcp_unexplained_outliers,gdop,nsat,sd_doppler_n,"
            "amb_candidates,lambda_attempts,lambda_stage,amb_var_median,amb_var_max,"
            "imu_pose_correction_m,spp_seed_fresh,spp_seed_x_ecef_m,"
            "spp_seed_y_ecef_m,spp_seed_z_ecef_m,"
@@ -1621,7 +1646,7 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
            "ddpr_anchor_eval,ddpr_anchor_n,ddpr_anchor_res_m,"
            "ddpr_anchor_x_ecef_m,ddpr_anchor_y_ecef_m,ddpr_anchor_z_ecef_m,"
            "ddpr_anchor_h_err_m,ddpr_anchor_u_err_m,ddpr_anchor_prior,"
-           "fixed_float_sep_m,fixed_imu_pred_sep_m,fixed_postfit_ddcp_rms_m,fixed_postfit_ddcp_max_norm,fixed_postfit_ddcp_chi2_dof,fixed_postfit_ddcp_n,external_dr_sep_m,external_dr_mahal2,external_dr_age,external_doppler_valid,external_doppler_vel_e_mps,external_doppler_vel_n_mps,external_doppler_vel_u_mps,external_dr_eval,external_dr_accept,external_dr_reject,motion_imu_n,motion_accel_std_mps2,motion_gyro_std_radps,motion_gyro_median_radps,motion_yaw_rate_radps,motion_seed_speed_mps,zupt_candidate,zupt_applied,nhc_candidate,nhc_applied,cp_hold,"
+           "fixed_float_sep_m,fixed_imu_pred_sep_m,fixed_postfit_ddcp_rms_m,fixed_postfit_ddcp_max_norm,fixed_postfit_ddcp_chi2_dof,fixed_postfit_ddcp_n,external_dr_sep_m,external_dr_mahal2,external_dr_age,external_doppler_valid,external_doppler_vel_e_mps,external_doppler_vel_n_mps,external_doppler_vel_u_mps,external_dr_eval,external_dr_accept,external_dr_reject,candidate_witness_eval,candidate_anchor_available,candidate_anchor_n,candidate_anchor_rms_m,candidate_anchor_sep_m,candidate_anchor_pass,candidate_imu_pass,candidate_doppler_available,candidate_doppler_pass,candidate_carrier_pass,candidate_witness_pass,motion_imu_n,motion_accel_std_mps2,motion_gyro_std_radps,motion_gyro_median_radps,motion_yaw_rate_radps,motion_seed_speed_mps,zupt_candidate,zupt_applied,nhc_candidate,nhc_applied,cp_hold,"
            "imu_aperture_accept,imu_aperture_reject,cp_available,cp_added,"
            "cp_suppressed_hold,amb_after_hold,amb_final,amb_excl_build,"
            "amb_excl_hold,amb_excl_one_band,amb_excl_constellation,"
@@ -1692,7 +1717,34 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
             out << ',' << d.effective_ratio_threshold
                 << ',' << s.num_fixed_ambiguities
                 << ',' << static_cast<int>(d.ar_outcome)
-                << ',' << d.ddpr_rms_m << ',' << d.sd_doppler_rms_mps
+                << ',' << d.ddpr_rms_m
+                << ',' << (d.ddpr_gnc_evaluated ? 1 : 0)
+                << ',' << d.ddpr_gnc_factor_count
+                << ',' << d.ddpr_gnc_stages
+                << ',' << d.ddpr_gnc_initial_mu
+                << ',' << d.ddpr_gnc_final_mu
+                << ',' << d.ddpr_gnc_min_weight
+                << ',' << d.ddpr_gnc_mean_weight
+                << ',' << d.ddpr_gnc_effective_factor_count
+                << ',' << d.ddpr_gnc_downweighted_factors
+                << ',' << d.ddpr_gnc_weighted_rms_m
+                << ',' << (d.ddpr_gnc_counterfactual_evaluated ? 1 : 0)
+                << ',' << (d.ddpr_gnc_counterfactual_succeeded ? 1 : 0)
+                << ',' << d.ddpr_gnc_counterfactual_factor_count
+                << ',' << d.ddpr_gnc_counterfactual_stages
+                << ',' << d.ddpr_gnc_counterfactual_cost_before
+                << ',' << d.ddpr_gnc_counterfactual_cost_after
+                << ',' << d.ddpr_gnc_counterfactual_ddpr_rms_before_m
+                << ',' << d.ddpr_gnc_counterfactual_ddpr_rms_after_m
+                << ',' << d.ddpr_gnc_counterfactual_position_ecef.x()
+                << ',' << d.ddpr_gnc_counterfactual_position_ecef.y()
+                << ',' << d.ddpr_gnc_counterfactual_position_ecef.z()
+                << ',' << d.ddpr_gnc_counterfactual_float_separation_m
+                << ',' << (d.ddpr_gnc_counterfactual_lambda_evaluated ? 1 : 0)
+                << ',' << d.ddpr_gnc_counterfactual_lambda_ambiguities
+                << ',' << d.ddpr_gnc_counterfactual_lambda_ratio
+                << ',' << (d.ddpr_gnc_counterfactual_lambda_ratio_pass ? 1 : 0)
+                << ',' << d.sd_doppler_rms_mps
                 << ',' << d.clock_resilient_tdcp_factors
                 << ',' << d.clock_resilient_tdcp_rms_m
                 << ',' << d.clock_resilient_tdcp_max_abs_m
@@ -1843,6 +1895,17 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                 << ',' << (d.external_dr_evaluated ? 1 : 0)
                 << ',' << (d.external_dr_accepted ? 1 : 0)
                 << ',' << (d.external_dr_rejected ? 1 : 0)
+                << ',' << (d.candidate_integrity_witness_evaluated ? 1 : 0)
+                << ',' << (d.candidate_integrity_anchor_available ? 1 : 0)
+                << ',' << d.candidate_integrity_anchor_factors
+                << ',' << d.candidate_integrity_anchor_rms_m
+                << ',' << d.candidate_integrity_anchor_separation_m
+                << ',' << (d.candidate_integrity_anchor_pass ? 1 : 0)
+                << ',' << (d.candidate_integrity_imu_pass ? 1 : 0)
+                << ',' << (d.candidate_integrity_doppler_available ? 1 : 0)
+                << ',' << (d.candidate_integrity_doppler_pass ? 1 : 0)
+                << ',' << (d.candidate_integrity_carrier_pass ? 1 : 0)
+                << ',' << (d.candidate_integrity_composite_pass ? 1 : 0)
                 << ',' << d.motion_constraint_imu_samples
                 << ',' << d.motion_constraint_accel_std_mps2
                 << ',' << d.motion_constraint_gyro_std_radps
@@ -1907,6 +1970,34 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                            ? problem.gps_common_pseudorange_delta_satellites[si]
                            : 0);
         out << '\n';
+    }
+
+    const std::string gnc_trace_path = path + ".ddpr_gnc.csv";
+    std::ofstream gnc_trace_out(gnc_trace_path);
+    if (gnc_trace_out) {
+        gnc_trace_out << "tow,satellite,reference_satellite,system,prn,"
+                         "reference_system,reference_prn,signal,residual_m,"
+                         "sigma_m,normalized_residual,weight\n";
+        gnc_trace_out << std::fixed;
+        gnc_trace_out.precision(9);
+        for (const auto& epoch : r.epoch_diagnostics) {
+            for (const auto& trace : epoch.ddpr_gnc_factor_trace) {
+                gnc_trace_out << epoch.time.tow << ','
+                              << trace.satellite.toString() << ','
+                              << trace.reference_satellite.toString() << ','
+                              << static_cast<int>(trace.satellite.system) << ','
+                              << static_cast<int>(trace.satellite.prn) << ','
+                              << static_cast<int>(trace.reference_satellite.system) << ','
+                              << static_cast<int>(trace.reference_satellite.prn) << ','
+                              << static_cast<int>(trace.signal) << ','
+                              << trace.residual_m << ',' << trace.sigma_m << ','
+                              << trace.normalized_residual << ',' << trace.weight
+                              << '\n';
+            }
+        }
+    } else {
+        std::cerr << "Warning: cannot open DDPR GNC trace output file "
+                  << gnc_trace_path << "\n";
     }
 
     // Normalized companion table: the epoch CSV above answers "how many",
@@ -2193,6 +2284,42 @@ void dumpPredictedDdprBiasStateCsv(
             << row.normalized_innovation << ',' << row.applied_innovation_m
             << ',' << row.posterior_bias_m << ',' << row.posterior_sigma_m
             << '\n';
+    }
+}
+
+void dumpSatelliteQuarantineCsv(
+    const libgnss::FGOProcessor::FGOResult& result,
+    const std::string& epoch_csv_path) {
+    const std::string path = epoch_csv_path + ".satellite_quarantine.csv";
+    std::ofstream out(path);
+    if (!out) {
+        std::cerr << "Error: cannot open satellite quarantine output file "
+                  << path << "\n";
+        return;
+    }
+    out << std::fixed << std::setprecision(6);
+    out << "tow,epoch,satellite,system,prn,postfit_ddpr_residual_m,"
+           "epoch_median_postfit_ddpr_residual_m,postfit_gross,"
+           "doppler_evaluated,doppler_outlier,imu_evaluated,imu_outlier,"
+           "temporal_support_pairs,quarantine_candidate\n";
+    for (const auto& row : result.satellite_quarantine_witnesses) {
+        double tow = 0.0;
+        if (row.epoch_index < result.solution.solutions.size()) {
+            tow = result.solution.solutions[row.epoch_index].time.tow;
+        }
+        out << tow << ',' << row.epoch_index << ','
+            << row.satellite.toString() << ','
+            << static_cast<int>(row.satellite.system) << ','
+            << static_cast<int>(row.satellite.prn) << ','
+            << row.postfit_ddpr_residual_m << ','
+            << row.epoch_median_postfit_ddpr_residual_m << ','
+            << (row.postfit_gross ? 1 : 0) << ','
+            << (row.doppler_evaluated ? 1 : 0) << ','
+            << (row.doppler_outlier ? 1 : 0) << ','
+            << (row.imu_evaluated ? 1 : 0) << ','
+            << (row.imu_outlier ? 1 : 0) << ','
+            << row.temporal_support_pairs << ','
+            << (row.quarantine_candidate ? 1 : 0) << '\n';
     }
 }
 
@@ -2763,6 +2890,7 @@ Fingerprint computeFingerprint(const Args& args, const libgnss::FGOProcessor::FG
     COPY_BUILD_FIELD(use_double_difference_secondary_code_alignment);
     COPY_BUILD_FIELD(use_elevation_dependent_sigma);
     COPY_BUILD_FIELD(monitor_external_doppler_dr);
+    COPY_BUILD_FIELD(monitor_candidate_integrity_witness);
     COPY_BUILD_FIELD(use_external_doppler_dr_validation);
     COPY_BUILD_FIELD(use_geometry_free_cycle_slip_reset);
     COPY_BUILD_FIELD(use_ionosphere_model);
@@ -3245,6 +3373,9 @@ int main(int argc, char** argv) {
             if (args.predicted_ddpr_bias_state_shadow) {
                 dumpPredictedDdprBiasStateCsv(fl, args.dump_csv_path);
             }
+            if (args.satellite_quarantine_shadow) {
+                dumpSatelliteQuarantineCsv(fl, args.dump_csv_path);
+            }
         }
 
         std::cout << "\n=== (a4) MILESTONE 2c: IncrementalFixedLagSmoother (full-scale) ===\n"
@@ -3280,6 +3411,24 @@ int main(int argc, char** argv) {
                    << (config.monitor_predicted_ddpr_quality ? "on" : "off")
                    << ", predicted_ddpr_bias_state_shadow="
                    << (config.monitor_predicted_ddpr_bias_state ? "on" : "off")
+                   << ", ddpr_gnc_shadow="
+                   << (config.monitor_ddpr_gnc ? "on" : "off")
+                   << " (counterfactual_attempts="
+                   << fl.diagnostics.ddpr_gnc_counterfactual_attempts
+                   << ", successes="
+                   << fl.diagnostics.ddpr_gnc_counterfactual_successes << ')'
+                   << ", candidate_integrity_shadow="
+                   << (config.monitor_candidate_integrity_witness ? "on" : "off")
+                   << " (evaluated="
+                   << fl.diagnostics.candidate_integrity_witness_evaluated
+                   << ", passed="
+                   << fl.diagnostics.candidate_integrity_witness_passes << ')'
+                   << ", satellite_quarantine_shadow="
+                   << (config.monitor_satellite_quarantine_witness ? "on" : "off")
+                   << " (satellites="
+                   << fl.diagnostics.satellite_quarantine_witness_satellites
+                   << ", candidates="
+                   << fl.diagnostics.satellite_quarantine_candidates << ')'
                    << ")\n"
                   << "  IMU ratio aperture: " << (args.imu_ratio_aperture ? "on" : "off")
                   << " (accepted=" << fl.diagnostics.imu_aided_ratio_accepts
@@ -3374,6 +3523,8 @@ int main(int argc, char** argv) {
                   << fl.diagnostics.geometry_free_fix_guard_demotions
                   << ")\n"
                   << "  CP-hold/sanity FSM: " << (args.cp_hold ? "on" : "off")
+                  << ", float_recovery="
+                  << (config.use_cp_hold_float_recovery ? "on" : "off")
                   << " (triggers=" << fl.diagnostics.cp_hold_triggers
                   << ", epochs_held=" << fl.diagnostics.cp_hold_epochs_held
                   << ", anchor_releases=" << fl.diagnostics.cp_hold_anchor_releases

--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -70,6 +70,8 @@ struct Args {
     bool ddpr_gnc_shadow = false;  // fixed weights + copied-graph GNC counterfactual
     bool candidate_integrity_shadow = false;  // monitor-only multi-witness FIX check
     bool satellite_quarantine_shadow = false;  // monitor-only two-stage satellite witness
+    bool selective_arc_restart = false;  // active selective carrier-arc restart
+    bool selective_arc_restart_monitor = false;  // monitor-only would-restart report
     std::string temporal_shadow_replay_csv;  // classify against frozen ECEF positions; skip solve
     bool temporal_shadow_truth_replay = false;  // classify against reference.csv; skip solve
     bool postfit_gate = false;
@@ -290,6 +292,14 @@ Args parseArgs(int argc, char** argv) {
         }
         if (a == "--satellite-quarantine-shadow") {
             args.satellite_quarantine_shadow = true;
+            continue;
+        }
+        if (a == "--selective-arc-restart") {
+            args.selective_arc_restart = true;
+            continue;
+        }
+        if (a == "--selective-arc-restart-monitor") {
+            args.selective_arc_restart_monitor = true;
             continue;
         }
         if (a == "--gici-par") {
@@ -793,6 +803,9 @@ libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
         args.candidate_integrity_shadow;
     config.monitor_satellite_quarantine_witness =
         args.satellite_quarantine_shadow;
+    config.use_selective_arc_restart = args.selective_arc_restart;
+    config.monitor_selective_arc_restart_candidates =
+        args.selective_arc_restart_monitor;
     config.monitor_motion_constraints = args.motion_constraint_shadow;
     config.use_geometry_free_cycle_slip_reset = args.gf_slip_reset;
     config.report_held_ambiguities_as_fixed = !args.no_held_fix_label;
@@ -1646,7 +1659,7 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
            "ddpr_anchor_eval,ddpr_anchor_n,ddpr_anchor_res_m,"
            "ddpr_anchor_x_ecef_m,ddpr_anchor_y_ecef_m,ddpr_anchor_z_ecef_m,"
            "ddpr_anchor_h_err_m,ddpr_anchor_u_err_m,ddpr_anchor_prior,"
-           "fixed_float_sep_m,fixed_imu_pred_sep_m,fixed_postfit_ddcp_rms_m,fixed_postfit_ddcp_max_norm,fixed_postfit_ddcp_chi2_dof,fixed_postfit_ddcp_n,external_dr_sep_m,external_dr_mahal2,external_dr_age,external_doppler_valid,external_doppler_vel_e_mps,external_doppler_vel_n_mps,external_doppler_vel_u_mps,external_dr_eval,external_dr_accept,external_dr_reject,candidate_witness_eval,candidate_anchor_available,candidate_anchor_n,candidate_anchor_rms_m,candidate_anchor_sep_m,candidate_anchor_pass,candidate_imu_pass,candidate_doppler_available,candidate_doppler_pass,candidate_carrier_pass,candidate_witness_pass,motion_imu_n,motion_accel_std_mps2,motion_gyro_std_radps,motion_gyro_median_radps,motion_yaw_rate_radps,motion_seed_speed_mps,zupt_candidate,zupt_applied,nhc_candidate,nhc_applied,cp_hold,"
+           "fixed_float_sep_m,fixed_imu_pred_sep_m,fixed_postfit_ddcp_rms_m,fixed_postfit_ddcp_max_norm,fixed_postfit_ddcp_chi2_dof,fixed_postfit_ddcp_n,external_dr_sep_m,external_dr_mahal2,external_dr_age,external_doppler_valid,external_doppler_vel_e_mps,external_doppler_vel_n_mps,external_doppler_vel_u_mps,external_dr_eval,external_dr_accept,external_dr_reject,candidate_witness_eval,candidate_anchor_available,candidate_anchor_n,candidate_anchor_rms_m,candidate_anchor_sep_m,candidate_anchor_pass,candidate_imu_pass,candidate_doppler_available,candidate_doppler_pass,candidate_carrier_pass,candidate_witness_pass,selective_arc_restart_armed,selective_arc_restart_monitor_only,selective_arc_restart_candidate_sats,selective_arc_restart_candidate_pairs,selective_arc_restart_applied_arcs,selective_arc_restart_skipped_fixed,selective_arc_restart_skipped_thrash,selective_arc_restart_skipped_cap,motion_imu_n,motion_accel_std_mps2,motion_gyro_std_radps,motion_gyro_median_radps,motion_yaw_rate_radps,motion_seed_speed_mps,zupt_candidate,zupt_applied,nhc_candidate,nhc_applied,cp_hold,"
            "imu_aperture_accept,imu_aperture_reject,cp_available,cp_added,"
            "cp_suppressed_hold,amb_after_hold,amb_final,amb_excl_build,"
            "amb_excl_hold,amb_excl_one_band,amb_excl_constellation,"
@@ -1917,6 +1930,14 @@ void dumpEpochCsv(const libgnss::FGOProcessor::FGOResult& r,
                 << ',' << (d.nhc_candidate ? 1 : 0)
                 << ',' << (d.nhc_applied ? 1 : 0)
                 << ',' << (d.carrier_hold_active ? 1 : 0)
+                << ',' << (d.selective_arc_restart_armed ? 1 : 0)
+                << ',' << (d.selective_arc_restart_monitor_only ? 1 : 0)
+                << ',' << d.selective_arc_restart_candidate_satellites
+                << ',' << d.selective_arc_restart_candidate_pairs
+                << ',' << d.selective_arc_restart_applied_arcs
+                << ',' << d.selective_arc_restart_skipped_fixed
+                << ',' << d.selective_arc_restart_skipped_thrash
+                << ',' << d.selective_arc_restart_skipped_cap
                 << ',' << (d.imu_aperture_accepted ? 1 : 0)
                 << ',' << (d.imu_aperture_rejected ? 1 : 0)
                 << ',' << d.carrier_factors_available
@@ -2320,6 +2341,41 @@ void dumpSatelliteQuarantineCsv(
             << (row.imu_outlier ? 1 : 0) << ','
             << row.temporal_support_pairs << ','
             << (row.quarantine_candidate ? 1 : 0) << '\n';
+    }
+}
+
+void dumpSelectiveArcRestartCsv(
+    const libgnss::FGOProcessor::FGOResult& result,
+    const std::string& epoch_csv_path) {
+    const std::string path = epoch_csv_path + ".selective_arc_restart.csv";
+    std::ofstream out(path);
+    if (!out) {
+        std::cerr << "Error: cannot open selective arc-restart output file "
+                  << path << "\n";
+        return;
+    }
+    out << std::fixed << std::setprecision(6);
+    out << "tow,detection_epoch,satellite,system,prn,is_reference,"
+           "ambiguity_index,detected,applied,postfit_residual_m,"
+           "epoch_median_postfit_residual_m,normalized_doppler_innovation,"
+           "normalized_imu_innovation\n";
+    for (const auto& row : result.selective_arc_restart_trace) {
+        double tow = 0.0;
+        if (row.detection_epoch < result.solution.solutions.size()) {
+            tow = result.solution.solutions[row.detection_epoch].time.tow;
+        }
+        out << tow << ',' << row.detection_epoch << ','
+            << row.satellite.toString() << ','
+            << static_cast<int>(row.satellite.system) << ','
+            << static_cast<int>(row.satellite.prn) << ','
+            << (row.is_reference ? 1 : 0) << ','
+            << row.ambiguity_index << ','
+            << (row.detected ? 1 : 0) << ','
+            << (row.applied ? 1 : 0) << ','
+            << row.postfit_residual_m << ','
+            << row.epoch_median_postfit_residual_m << ','
+            << row.normalized_doppler_innovation << ','
+            << row.normalized_imu_innovation << '\n';
     }
 }
 
@@ -3376,6 +3432,9 @@ int main(int argc, char** argv) {
             if (args.satellite_quarantine_shadow) {
                 dumpSatelliteQuarantineCsv(fl, args.dump_csv_path);
             }
+            if (args.selective_arc_restart || args.selective_arc_restart_monitor) {
+                dumpSelectiveArcRestartCsv(fl, args.dump_csv_path);
+            }
         }
 
         std::cout << "\n=== (a4) MILESTONE 2c: IncrementalFixedLagSmoother (full-scale) ===\n"
@@ -3429,6 +3488,24 @@ int main(int argc, char** argv) {
                    << fl.diagnostics.satellite_quarantine_witness_satellites
                    << ", candidates="
                    << fl.diagnostics.satellite_quarantine_candidates << ')'
+                   << ", selective_arc_restart="
+                   << (config.use_selective_arc_restart ? "on" : "off")
+                   << " (monitor="
+                   << (config.monitor_selective_arc_restart_candidates ? "on" : "off")
+                   << ", detection_epochs="
+                   << fl.diagnostics.selective_arc_restart_detection_epochs
+                   << ", candidates="
+                   << fl.diagnostics.selective_arc_restart_candidate_satellites
+                   << ", applied="
+                   << fl.diagnostics.selective_arc_restart_applied_arcs
+                   << ", skipped_fixed="
+                   << fl.diagnostics.selective_arc_restart_skipped_fixed
+                   << ", skipped_thrash="
+                   << fl.diagnostics.selective_arc_restart_skipped_thrash
+                   << ", skipped_cap="
+                   << fl.diagnostics.selective_arc_restart_skipped_cap
+                   << ", skipped_no_arc="
+                   << fl.diagnostics.selective_arc_restart_skipped_no_arc << ')'
                    << ")\n"
                   << "  IMU ratio aperture: " << (args.imu_ratio_aperture ? "on" : "off")
                   << " (accepted=" << fl.diagnostics.imu_aided_ratio_accepts

--- a/docs/fgo_candidate_funnel_recovery_plan.md
+++ b/docs/fgo_candidate_funnel_recovery_plan.md
@@ -1,0 +1,128 @@
+# Candidate funnel and CP-hold float-recovery plan
+
+## Objective
+
+Increase correct FIX opportunities by repairing the float ambiguity state
+before LAMBDA, without relaxing the integer ratio or allowing held/quarantined
+carrier rows to create a FIX.
+
+This experiment follows the staged-fault-detection direction of Song et al.,
+who combine Doppler change checks with IMU/odometer-predicted DD pseudorange
+checks before changing an RTK/INS factor graph:
+<https://arxiv.org/abs/2510.00524>. It also follows the integrity lesson from
+Wang et al. that measurement faults and incorrect integer hypotheses must be
+considered together: <https://doi.org/10.33012/2023.18607>.
+
+The preceding candidate-integrity witness was safe but could not evaluate a
+single final-FLOAT candidate. The frozen Tokyo run1 source-epoch 5000--5499
+CSV already contains a complete ambiguity attrition trace, so no duplicate
+monitor is added.
+
+## Frozen funnel audit
+
+The 167 final-FLOAT epochs stopped at:
+
+| Terminal stage | Epochs |
+|---|---:|
+| no candidates | 128 |
+| fewer than six candidates | 37 |
+| ratio rejected | 1 |
+| fixed then plausibility-demoted | 1 |
+| marginal failure | 0 |
+| LAMBDA search failure | 0 |
+
+Of the 128 no-candidate epochs, 127 were inside CP-hold. They had 621 carrier
+rows suppressed in total. Only two final-FLOAT epochs produced a provisional
+LAMBDA candidate. The dominant problem is therefore carrier/ambiguity
+reacquisition during recovery, not LAMBDA search or candidate validation.
+
+## Frozen experiment
+
+Evaluate the existing default-off `FGOConfig::use_cp_hold_float_recovery`
+path with its existing scale of 10.0. During CP-hold it keeps carrier factors
+in the float graph at ten times their normal sigma, but marks every associated
+ambiguity as hold-quarantined and excludes it from LAMBDA. It cannot produce a
+FIX or pin an integer during the hold. The hypothesis is narrower: a weak
+carrier channel may preserve float ambiguity observability and improve
+post-release reacquisition.
+
+Expose exactly one research CLI switch:
+
+```text
+--cp-hold-float-recovery
+```
+
+No sigma sweep, ratio relaxation, early hold release, selective hold, or
+witness-aperture tuning is allowed in this experiment.
+
+## Gates
+
+### Gate 0: deterministic safety
+
+- default-off behavior remains unchanged;
+- a real CP-hold fixture keeps carrier factors in the graph only when the
+  switch is on;
+- held carrier ambiguities remain excluded from LAMBDA;
+- no held epoch can be labelled FIXED from the quarantined rows.
+
+### Gate 1: Tokyo run1 source epochs 5000--5499
+
+- zero additional wrong FIX above 0.5 m 3-D;
+- zero lost correct FIX;
+- at least three additional correct FIX epochs;
+- no NONE/non-finite increase;
+- fixed horizontal RMS/P95 regression at most 5%;
+- FLOAT horizontal RMS improves at least 5%; and
+- solver overhead at most 10%.
+
+Failure stops without tuning. Only a Gate-1 pass permits full run1. Tokyo
+run2/run3 remain sealed until a full-run1 activation passes.
+
+## Gate-1 result
+
+The single frozen Tokyo run1 replay failed decisively. It kept the same 333
+FIX / 167 FLOAT labels and did not add a wrong FIX, but it added no correct
+FIX either. Fixed positions stayed byte-for-byte equivalent at the CSV
+precision; the FLOAT trajectory did not:
+
+| Metric | Baseline | Float recovery |
+|---|---:|---:|
+| correct FIX | 333 | 333 |
+| wrong FIX above 0.5 m 3-D | 0 | 0 |
+| FLOAT horizontal RMS | 4.843 m | 72.469 m |
+| FLOAT horizontal P95 | 11.796 m | 193.629 m |
+| FLOAT horizontal max | 20.801 m | 288.538 m |
+| solver time | 15.753 s | 19.288 s |
+| final-FLOAT provisional candidates | 2 | 32 |
+
+The mechanism did open the candidate funnel, but in the wrong state basin.
+All 32 final-FLOAT provisional candidates were wrong at the 0.5 m 3-D
+aperture; their candidate-error RMS was 107.565 m, and all eight with ratio at
+least 2 were also wrong. Recovery produced 80 CP-hold triggers, 13 fast
+resets, four smoother-recovery epochs, and large rank-deficiency episodes.
+Weak carrier factors preserved contaminated ambiguity continuity instead of
+recovering it.
+
+Gate 1 fails the required +3 correct FIX, FLOAT improvement, and runtime
+limits. Do not tune the sigma scale, do not activate this path, and do not run
+full run1 or sealed run2/run3. The next experiment must break contaminated
+ambiguity continuity and obtain a fresh, independently anchored carrier
+state; merely retaining old carrier information is unsafe.
+
+## Selected next experiment
+
+Do not immediately activate the existing residual-only selective CP-hold.
+Its satellite attribution is computed at the live float pose and is therefore
+correlated with the wrong basin this experiment exposed. First add a
+monitor-only per-satellite **two-stage quarantine witness**:
+
+1. current/causal Doppler or TDCP change evidence;
+2. IMU-predicted DD pseudorange disagreement;
+3. agreement with the existing per-satellite DDPR residual attribution.
+
+Only rows supported by independent temporal evidence become quarantine
+candidates in the shadow. The scorer must report coverage and false-positive
+rates on finally-correct FIX rows and bad FLOAT stretches. A later active
+experiment, if justified, will generation-bump and remove only witnessed bad
+arcs while preserving clean carrier arcs. It will not keep contaminated arcs
+alive at a weaker weight.

--- a/docs/fgo_candidate_integrity_witness_plan.md
+++ b/docs/fgo_candidate_integrity_witness_plan.md
@@ -1,0 +1,133 @@
+# Candidate integrity witness shadow
+
+## Objective
+
+Recover correct ratio-rejected RTK ambiguity candidates without treating a
+larger LAMBDA ratio, a smaller robust cost, or agreement with the live float
+graph as independent evidence. This milestone is monitor-only and default-off.
+It never changes the smoother, ambiguity hold, FIX/FLOAT, or reported pose.
+
+The preceding DDPR-only alternating GNC experiment failed: candidate FLOAT RMS
+increased from 4.849 m to 7.370 m and runtime increased 236%. In particular,
+one candidate's ratio rose from 1.243 to 3.483 while its position moved about
+1.24 m away from an already-correct reported solution. GNC is therefore not an
+acceptance witness in this experiment.
+
+## Research basis
+
+- Song et al., *Two stage GNSS outlier detection for factor graph optimization
+  based GNSS-RTK/INS/odometer fusion* (2025), first checks pseudorange change
+  with Doppler and then checks predicted DD pseudorange with short-term
+  IMU/odometer propagation: <https://arxiv.org/abs/2510.00524>.
+- Wang et al., *Solution Separation Based Integrity Monitoring for Ambiguity
+  Resolution Enabled GNSS Positioning* (2023), evaluates measurement-fault and
+  incorrect-fix hypotheses together rather than treating ambiguity validation
+  as fault-free: <https://doi.org/10.33012/2023.18607>.
+- Taylor and Gross (ION ITM 2026) compare solution-separation RAIM with robust
+  FGO and publish their experiment code. Their result warns that exhaustive
+  solution separation is computationally expensive in high-outlier settings:
+  <https://doi.org/10.33012/2026.20495> and
+  <https://github.com/cntaylor/FGO_gnss_integrity>.
+- GraphGNSSLib confirms the relevant RTK graph structure: DD pseudorange,
+  carrier phase, and Doppler form the float graph before LAMBDA ambiguity
+  resolution: <https://github.com/weisongwen/GraphGNSSLib>.
+
+## Frozen witness rule
+
+For every provisional LAMBDA candidate, record four checks that already exist
+in the backend but have not been combined as an authority-neutral audit:
+
+1. **Code-only anchor:** the current-epoch DDPR-LS/FDE anchor is trusted under
+   the shipping minimum-factor and residual gates, and lies within 1.0 m of
+   the candidate.
+2. **Short-term inertial prediction:** the candidate lies within 2.0 m of the
+   IMU-propagated epoch seed.
+3. **Doppler-only DR:** the independently propagated SD-Doppler track is aged
+   1--30 epochs and candidate separation passes the fixed 3-D chi-square 99%
+   gate (`mahalanobis2 <= 11.345`).
+4. **Carrier observation consistency:** at least four candidate DD carrier
+   rows are available and their post-fit RMS is at most 0.05 m.
+
+The composite shadow passes only when all four checks pass and the candidate
+ratio exceeds the existing relaxed floor of 1.0. Thresholds are frozen before
+truth scoring. The code-only anchor and Doppler track do not consume the
+candidate's integer constraint; the IMU seed and carrier check are supporting
+consistency tests, not independently sufficient witnesses.
+
+One CLI option enables the complete audit:
+
+```text
+--candidate-integrity-shadow
+```
+
+It may materialize private SD-Doppler rows for the external DR estimator, but
+does not insert them into the FGO graph.
+
+## Gates
+
+### 500-epoch smoke: Tokyo run1 source epochs 5000--5499
+
+- exact equality of every pre-existing solution field with monitor off/on;
+- no NONE or non-finite increase;
+- at least 20 otherwise-FLOAT candidates with a complete four-witness verdict;
+- zero composite-passed candidate above 0.5 m 3-D truth error; and
+- at least one composite-passed correct candidate.
+
+Failure stops the experiment without threshold tuning.
+
+### Full Tokyo run1 development gate
+
+- at least 100 complete witness verdicts;
+- at least 60 composite-passed correct FLOAT candidates;
+- zero composite-passed wrong candidates at the 0.5 m 3-D aperture; and
+- solver overhead at most 20%.
+
+Only a full run1 pass permits a default-off activation A/B. Tokyo run2 and
+run3 remain sealed until then. Reference truth is used only by the offline
+scorer and never by the runtime shadow.
+
+## Tokyo run1 500-epoch smoke result
+
+The frozen shipping-profile replay used source epochs 5000--5499. Enabling
+`--candidate-integrity-shadow` left every exported solution key exactly
+unchanged relative to the preceding monitor-only replay: 333 FIX, 167 FLOAT,
+zero NONE/non-finite epochs, and zero differences in time, status, ECEF,
+ENU error, ratio, fixed count, or AR outcome.
+
+The monitor produced 322 complete verdicts and 95 composite passes. All 95
+passed candidates were correct within the frozen 0.5 m 3-D aperture (maximum
+3-D error 0.092 m, RMS 0.058 m). This is a clean safety result, but it has no
+incremental FIX yield:
+
+| Metric | Result |
+|---|---:|
+| complete verdicts | 322 |
+| composite passes | 95 |
+| passed candidates above 0.5 m 3-D | 0 |
+| passed candidates already reported FIX | 95 |
+| passed candidates finally reported FLOAT | 0 |
+| final FLOAT epochs | 167 |
+| final FLOAT epochs with any provisional candidate | 2 |
+| final FLOAT epochs with a complete verdict | 0 |
+
+Among 331 ratio-above-1 provisional candidates, the trusted anchor was
+available for all 331, IMU passed 330, carrier post-fit passed 326, and the
+Doppler DR verdict was available and passed for 322. The anchor aperture was
+the selective witness (98 passes). However, 329 of those 331 candidates were
+already normal FIX. The two final-FLOAT candidates were not actionable: the
+opening ratio-1.243 candidate preceded any independent DR reset and failed
+the IMU aperture; the ratio-2.191 candidate had a 66.191 m anchor separation
+and a DR age of 89 epochs, beyond the frozen 30-epoch limit.
+
+Solver time rose from the preserved 15.753 s baseline to 34.722 s (+120.4%),
+also exceeding the full-run 20% overhead ceiling. The smoke therefore fails
+its otherwise-FLOAT coverage gate. Full run1 and sealed run2/run3 are not run.
+Do not activate this composite as a FIX authority: it safely reconfirms
+already-fixed candidates but cannot increase fix rate on this development
+slice.
+
+The next experiment should instrument and improve the pre-validation
+ambiguity-candidate funnel (candidate availability, conditioning, and subset
+formation) using run1-only diagnostics. It must count finally-FLOAT
+opportunities, must not relax the integer ratio, and must not tune these
+witness apertures.

--- a/docs/fgo_ddpr_gnc_shadow_plan.md
+++ b/docs/fgo_ddpr_gnc_shadow_plan.md
@@ -1,0 +1,172 @@
+# DD pseudorange GNC shadow and activation plan
+
+## Objective
+
+Test whether graduated non-convexity (GNC) can improve the float state supplied
+to RTK ambiguity resolution without relaxing LAMBDA, changing the carrier/IMU
+model, or increasing wrong FIX. The experiment is DD-pseudorange-specific and
+default-off. TDCP is not part of this experiment.
+
+The method is motivated by Wen et al.'s GNC factor-graph formulation, which
+uses a graduated Geman--McClure kernel to avoid the poor local minima observed
+when a non-convex loss is enabled directly:
+<https://ira.lib.polyu.edu.hk/bitstream/10397/92728/1/Wen_Gnss_Outlier_Mitigation.pdf>.
+Unlike that pseudorange-positioning experiment, this project evaluates a
+clock-free DD RTK/INS fixed-lag graph and treats correct and wrong FIX as the
+primary outcomes.
+
+## Milestone 1: fixed-linearization shadow
+
+`FGOConfig::monitor_ddpr_gnc` evaluates the current epoch's post-fit DDPR
+residuals after the normal smoother update. For normalized residual `r`, shape
+`c`, and graduation scale `mu`, the diagnostic weight is
+
+```text
+w = mu*c^2 / (mu*c^2 + r^2)
+```
+
+The initial `mu` is chosen from the largest normalized residual, then divided
+by 1.4 until it reaches 1 or the 32-stage limit. Defaults use `c=2`. This first
+milestone deliberately holds the optimized state fixed: it measures the
+candidate weight distribution but never replaces a factor, runs another
+optimization, or changes FIX/FLOAT.
+
+Enable it with one harness option:
+
+```text
+--ddpr-gnc-shadow
+```
+
+`--dump-csv result.csv` adds per-epoch `ddpr_gnc_*` columns and writes the
+normalized per-factor trace `result.csv.ddpr_gnc.csv`. The trace identifies
+time, satellite/reference pair, signal, residual, graph sigma, normalized
+residual, and final shadow weight.
+
+## Frozen experiment gates
+
+1. **Correctness and non-interference.** Deterministic tests cover the weight
+   ordering, gross-outlier suppression, invalid-input failure, and an exact
+   fixed-lag monitor-off/monitor-on solution comparison.
+2. **Tokyo run1 design slice.** Use source epochs 5000--5499 only. Compare the
+   candidate-weight distribution with reference-labelled solution quality and
+   freeze the GNC schedule before any active re-optimization.
+3. **Counterfactual alternating solve.** Rebuild only DD pseudorange noise at
+   each GNC stage, batch-refine a copy of the active graph, and record the
+   resulting float position and ambiguity posterior. It must not update the
+   live smoother or report FIX.
+4. **Active run1.** Advance only if the counterfactual shows more correct FIX
+   opportunities, zero additional wrong FIX, no lost correct FIX, no
+   NONE/non-finite increase, at most 5% float/fixed RMS regression, and at most
+   20% solver overhead with the frozen iteration cap.
+5. **Sealed holdouts.** Run Tokyo run2 and run3 once with the frozen settings.
+   Each must independently have zero wrong-FIX increase and no correct-FIX or
+   matched-distance regression. A failure stops activation.
+
+Reference truth is used only by offline scoring. It is never an input to GNC
+weights or the estimator.
+
+## Gate 1 smoke result
+
+A shipping-profile A/B replay used 50 Tokyo run1 epochs beginning at source
+epoch 5000. All pre-existing CSV fields were exactly identical between the
+monitor-off and monitor-on runs. Both produced 49 FIX and one FLOAT, with
+fixed horizontal RMS 0.0222491 m and no non-finite/NONE epoch.
+
+The shadow evaluated all 1,051 DDPR factors:
+
+| Metric | Result |
+|---|---:|
+| GNC-evaluated epochs | 50 / 50 |
+| factors with weight below 0.5 | 175 |
+| factors with weight below 0.1 | 2 |
+| minimum weight | 0.055790389 |
+| mean epoch weight | 0.73618 |
+| effective factor count | 773.268 / 1,051 |
+
+The strongest observed downweight was GPS G30 relative to G11 at TOW
+188472.8: residual 3.271963 m, sigma 0.397671 m, normalized residual 8.227815,
+and weight 0.055790. This proves useful dynamic range and exact estimator
+non-interference, but not yet positioning benefit: the next required result is
+the full 500-epoch design-slice analysis followed by a shadow-only alternating
+solve.
+
+The first 500-epoch diagnostic pass also found that a 15-stage research
+default stopped before `mu=1` in 127 epochs (maximum initial `mu=6956.123`).
+That run is not used for weight-quality conclusions. The default was raised to
+32 stages, enough to reach the same final kernel for this urban residual
+range; the design slice must be regenerated before Gate 1 is scored.
+
+## Gate 1 design-slice result
+
+The corrected 32-stage shadow was regenerated over all 500 frozen design
+epochs. Every epoch reached `mu=1`; the estimator result remained 333 FIX and
+167 FLOAT with zero NONE/non-finite epochs. Fixed horizontal RMS was
+0.0288956 m. No FIX in this slice exceeded the 0.5 m correctness aperture, so
+this slice cannot by itself test wrong-FIX rejection.
+
+The final-kernel distribution was:
+
+| Metric | Result |
+|---|---:|
+| DDPR factors | 7,104 |
+| weight below 0.5 | 1,817 |
+| weight below 0.1 | 366 |
+| minimum weight | 0.000143738 |
+| epochs truncated before `mu=1` | 0 |
+
+Bad FLOAT epochs (horizontal error at least 1 m) had mean GNC weight 0.61 and
+mean GNC-weighted residual RMS 0.87 m. FIX epochs had mean weight 0.72 and mean
+weighted RMS 0.56 m. As an offline ranking diagnostic over 159 bad epochs and
+335 sub-0.5 m epochs, GNC-weighted RMS achieved ROC AUC 0.75 versus 0.73 for
+raw DDPR RMS. Mean weight, minimum weight, and downweighted fraction were
+weaker (AUC 0.70, 0.63, and 0.67).
+
+This is a modest but real signal, not an activation result. It supports the
+next counterfactual alternating-solve milestone, while showing that a simple
+weight-threshold FIX gate would add little beyond existing DDPR residual
+telemetry and should not be implemented.
+
+## Gate 2 counterfactual alternating-solve result
+
+The default-off counterfactual now copies the active fixed-lag graph for each
+final FLOAT epoch, replaces only DDPR noise with graduated Geman--McClure
+weights, and runs at most eight one-iteration LM stages. Carrier, IMU, motion,
+and marginal factors remain unchanged. Candidate Values never update iSAM2,
+reported positions, ambiguity hold, or FIX/FLOAT. The final copied graph also
+attempts a diagnostic full-set LAMBDA ratio from its batch marginal; this is
+not a reproduction of the production partial-AR cascade and is labelled as
+such in the CSV.
+
+A synthetic 30 m single-DDPR outlier test verifies that the copied solve can
+improve position while the live status, ratio, and ECEF trajectory remain
+exactly unchanged. The frozen Tokyo run1 source-epoch 5000--5499 design slice
+then produced the following result:
+
+| Metric | Result |
+|---|---:|
+| final FLOAT epochs / successful candidates | 167 / 166 |
+| candidate position improved | 26 / 166 (15.7%) |
+| candidate position worsened | 140 / 166 (84.3%) |
+| FLOAT horizontal RMS, live -> candidate | 4.849 -> 7.370 m |
+| live errors >=1 m rescued below 0.5 m | 1 / 158 |
+| candidate full-set LAMBDA marginal evaluated | 39 / 166 |
+| candidate full-set ratio passed | 1 / 39 |
+| bad FLOAT epochs converted to a ratio-passing candidate | 0 |
+| original graph cost decreased | 134 / 166 |
+| DDPR RMS decreased | 119 / 166 |
+| solver time, monitor off -> on | 15.753 -> 52.954 s (+236%) |
+
+The only ratio-passing counterfactual was the already-correct first FLOAT
+epoch: its live ratio rose from 1.243 to 3.483, but the GNC candidate moved
+about 1.24 m from the final reported solution. This is precisely the unsafe
+failure mode the shadow was intended to expose: a stronger integer ratio does
+not imply a better absolute position when DDPR is reweighted independently of
+the carrier/IMU basin.
+
+Gate 2 therefore fails both quality and runtime requirements. Do **not** feed
+this DDPR-only alternating solve into the live smoother, do not use its ratio
+to report FIX, and do not spend sealed run2/run3 holdouts on threshold tuning.
+The fixed-linearization weights remain useful diagnostic telemetry. A future
+robust-state experiment should instead use independent absolute-position or
+temporal-consistency evidence to gate candidate hypotheses, and must establish
+a new run1-only plan before any activation work.

--- a/docs/fgo_low_count_ar_recovery_plan.md
+++ b/docs/fgo_low_count_ar_recovery_plan.md
@@ -1,0 +1,131 @@
+# Low-count AR recovery plan (nsat-quality-gate rebalance)
+
+## Objective
+
+`use_low_count_ambiguity_resolution` (default-off) lowers the per-epoch
+LAMBDA candidate-count floor so sparse-geometry epochs can attempt AR, but its
+mandatory `surplus_rescue_quality_pass` requires `nsat >= 10` and
+`ddpr_rms <= 5 m`. A low-count epoch is sparse by construction, so those two
+floors can never be met -- the rescue is structurally dead on exactly the
+epochs it exists for.
+
+On the frozen Tokyo run1 design slice (source epochs 5000--5499), 8 FLOAT
+epochs (slice 360--367) carry a correct, unambiguous LAMBDA candidate yet
+remain FLOAT purely because of these floors:
+
+| slice epoch | nsat | float horiz. err | ddpr_rms | DDCP post-fit RMS | LAMBDA ratio | FFRT |
+|---|---:|---:|---:|---:|---:|---|
+| 360 | 7 | 0.094 m | 9.58 m | 0.018 m | 4.3 | 1 |
+| 361 | 7 | 0.094 m | 9.53 m | 0.018 m | 4.1 | 1 |
+| 362 | 6 | 0.093 m | 10.57 m | 0.013 m | 5.8 | 1 |
+| 363 | 6 | 0.092 m | 10.55 m | 0.012 m | 5.1 | 1 |
+| 364 | 6 | 0.090 m | 10.55 m | 0.011 m | 4.6 | 1 |
+| 365 | 7 | 0.088 m | 10.56 m | 0.012 m | 31.9 | 1 |
+| 366 | 7 | 0.085 m | 10.57 m | 0.014 m | 35.3 | 1 |
+| 367 | 5 | 0.084 m | 12.23 m | 0.015 m | 73.9 | 1 |
+
+These epochs sit inside the 0.5 m 3-D aperture (the float solution is already
+sub-10-cm horizontal) yet are labelled FLOAT. The candidate carrier
+observation is clean (DDCP post-fit ~1--2 cm), so the large `ddpr_rms` is a
+code-observation (multipath) signature, not an integer problem. This is
+exactly the regime where a correct FIX is being lost to a quality gate.
+
+## Diagnostic result (falsified the proposed relaxation)
+
+The relaxation was tested before any implementation was written. With
+`kSurplusRescueMinSatellites` lowered to 1 and `kSurplusRescueMaxDdprRmsM`
+raised to 100 m, `--low-count-ar --low-count-min 3 --surplus-validation-min-n
+1` on the frozen design slice turned 6 FLOAT epochs FIXED:
+
+| slice epoch | FIXED horiz. err |
+|---|---:|
+| 356 | 2909.78 m |
+| 360 | 2909.78 m |
+| 361 | 2909.78 m |
+| 362 | 2909.78 m |
+| 363 | 2909.78 m |
+| 364 | 2909.78 m |
+
+All six are **wrong FIX at ~2.9 km**; none is within the 0.5 m aperture. The
+float solutions these epochs reported were indeed ~0.09 m horizontal (the
+`horiz_err_m` column), but the integer candidates LAMBDA selected at ratio
+4--74 and FFRT-pass were not the true integers -- FFRT and the ratio validate
+internal consistency of the integer hypothesis against the float covariance,
+not its agreement with truth. The `nsat >= 10` and `ddpr_rms <= 5 m` floors
+were therefore blocking exactly the wrong fixes they exist to block: a sparse
+epoch with a large code residual and a self-consistent-but-wrong integer
+candidate.
+
+**Conclusion: the low-count AR recovery plan as designed does not work.** The
+8 target epochs' correct-looking float solutions are not accompanied by
+correct integer candidates, and no amount of ratio/DDCP evidence (already
+clean at 1--2 cm) can distinguish the wrong integers without the
+independent-satellite coverage the `nsat` floor encodes. Do not implement the
+sparse-geometry witness, do not relax the quality gate, and do not spend
+sealed run2/run3 holdouts on this direction. A correct recovery for these
+epochs would require better float-ambiguity conditioning (a distinct problem
+from the quarantine/arc-restart thread) or an independent absolute-position
+witness, which the candidate-integrity witness already showed has zero yield
+on this slice.
+
+## (Retained record) Frozen candidate-quality witness proposal
+
+**Superseded by the diagnostic result above; kept for the audit trail.**
+
+For a low-count epoch ONLY (`n < min_candidates`, same entry rule as today),
+replace the `nsat >= 10` and `ddpr_rms <= 5 m` arms of
+`surplus_rescue_quality_pass` with a sparse-geometry substitute that uses
+evidence which does not vanish as the satellite count shrinks:
+
+1. **Carrier post-fit consistency** (kept): `fixed_postfit_ddcp_factors >= 4`
+   and `fixed_postfit_ddcp_rms_m <= 0.05 m` -- already evaluated and passed
+   (1--2 cm) on all 8 target epochs.
+2. **IMU-propagated aperture** (kept from `imu_aided`): the candidate lies
+   within `imu_aided_max_prediction_separation_m` of the IMU-propagated epoch
+   seed, and within `imu_aided_max_float_separation_m` of the float position.
+3. **New ratio floor for sparse geometry**: `ratio >= 10` (between today's
+   `low_count_min_ratio` default of 1.5 and the strict 3.0) to compensate for
+   losing the `nsat >= 10` independent-satellite coverage.
+
+Everything else is unchanged: the epoch still enters via the existing
+low-count entry gate, still requires `use_surplus_satellite_validation`, still
+goes through surplus validation when the pool allows, and still must pass the
+existing fixed-vs-float separation and plausibility gates. The change is
+strictly narrower -- it relaxes two floors that cannot be satisfied by a
+sparse epoch and adds one sparse-geometry ratio floor.
+
+## Gates
+
+### Gate 0: deterministic safety
+
+- default-off bit-identical (OFF/ON solutions, ratios, statuses, CSV equal);
+- a synthetic 4-ambiguity epoch with a clean carrier post-fit and a ratio of
+  ~50 is accepted (previously LowCountRejected), while:
+- the same epoch with a contaminated DDCP (RMS > 0.05 m) or ratio < 10 is
+  still rejected; and
+- a normal (n >= min_candidates) epoch is never routed through the sparse
+  witness (established path untouched).
+
+### Gate 1: Tokyo run1 source epochs 5000--5499
+
+- the 8 target epochs (360--367) become FIXED at their ~0.09 m positions;
+- zero additional wrong FIX above the 0.5 m 3-D aperture anywhere in the
+  slice;
+- zero lost correct FIX relative to the OFF replay;
+- no NONE/non-finite increase;
+- fixed horizontal RMS/P95 regression at most 5%;
+- solver overhead at most 10%.
+
+Failure stops without tuning. Only a Gate-1 pass permits full run1. Tokyo
+run2/run3 remain sealed until a full-run1 activation passes.
+
+## CLI
+
+Expose one research switch alongside the existing `--low-count-ar`:
+
+```text
+--low-count-sparse-witness
+```
+
+No sigma sweep, ratio sweep, or aperture tuning is allowed in this
+experiment. Reference truth is used only by the offline scorer.

--- a/docs/fgo_satellite_quarantine_shadow_plan.md
+++ b/docs/fgo_satellite_quarantine_shadow_plan.md
@@ -1,0 +1,93 @@
+# Satellite quarantine shadow plan
+
+## Objective
+
+Identify individual carrier ambiguity arcs that should be restarted after an
+urban fault, without retaining contaminated carrier continuity and without
+changing the live graph, LAMBDA, CP-hold, or reported solution.
+
+Song et al. first compare pseudorange change with Doppler and then compare DD
+pseudorange with short-term inertial/odometer prediction before modifying an
+RTK/INS factor graph: <https://arxiv.org/abs/2510.00524>. Wang et al. show why
+measurement faults and incorrect integer hypotheses must be monitored
+together: <https://doi.org/10.33012/2023.18607>.
+
+## Frozen monitor rule
+
+For each observed satellite at an epoch:
+
+1. aggregate the existing post-fit DDPR residual attribution;
+2. require the existing causal predicted-DDPR row to exceed 5 sigma in both
+   its Doppler-change and IMU-geometry innovations for the same DD pair;
+3. require the satellite's DDPR residual to exceed both 10 m and five times
+   the epoch median residual.
+
+The satellite becomes a shadow quarantine candidate only when all conditions
+agree. A DD pair contributes temporal support to both its target and reference
+satellites because differencing alone cannot identify which endpoint is
+faulty. The output records that ambiguity explicitly; it has no estimator
+authority.
+
+Enable with `--satellite-quarantine-shadow`.
+
+## Gates
+
+### Gate 0
+
+- monitor off/on solutions, ratios, and statuses are exactly equal;
+- a synthetic single-satellite DDPR jump with zero Doppler-predicted change
+  is attributed to the involved pair;
+- no candidate changes LAMBDA membership or ambiguity generation.
+
+### Tokyo run1 source epochs 5000--5499
+
+- report candidate epochs/satellites and temporal-support coverage;
+- zero quarantine candidates on correct FIX epochs;
+- identify at least one candidate during a bad-FLOAT or CP-hold stretch;
+- exact solution non-interference and no NONE/non-finite increase;
+- monitor overhead at most 20%.
+
+Failure stops without threshold tuning. An active selective arc restart is
+considered only after this shadow passes; full run1 and run2/run3 remain
+sealed until then.
+
+## Implementation
+
+The GTSAM fixed-lag backend records the maximum absolute DDPR post-fit
+residual attributed to each satellite. After the live solve has finished, it
+joins those rows to the existing causal predicted-DDPR analysis. The joined
+rows and their explicit target/reference ambiguity are exported to
+`<epoch.csv>.satellite_quarantine.csv`. The monitor does not add, remove, or
+reweight a graph factor and does not modify an ambiguity generation.
+
+`FGOSatelliteQuarantineShadowTest` injects a 30 m DDPR jump with a zero
+Doppler-predicted change. Both endpoints are reported as candidates while the
+OFF/ON position, status, ratio, fixed ambiguity count, and generation count
+remain equal.
+
+## Frozen Tokyo 500 result
+
+Command profile: run1 source epochs 5000--5499, 5 s fixed lag, multi-frequency
+partial AR, hold, CMC, CP-hold, exception recovery, DDPR anchor, FDE, varerr,
+and FIX demotion. No threshold was changed after observing the result.
+
+- Baseline and shadow both produced 333 FIX, 167 FLOAT, and zero NONE epochs.
+- The complete epoch CSV files are byte-identical (SHA-256
+  `6A3A70CF4F755FB7756E565136037D4BAC5FFBFA5D9EA08420117AF590713F76`).
+- 6,891 satellite-epoch rows produced two satellite candidates in one epoch:
+  BeiDou C11 and C14 at epoch 461 (TOW 188563 s). The pair residual was
+  106.630 m versus a 1.631 m epoch median; both Doppler and IMU innovations
+  exceeded 5 sigma.
+- Epoch 461 was FLOAT with 3.846 m horizontal error and CP-hold active.
+- Candidate epochs on the 333 correct FIX epochs: zero.
+- Coverage: one candidate epoch among 165 bad-FLOAT epochs and one among 127
+  CP-hold epochs. This is deliberately high precision and low recall.
+- Wall time was 21.099 s OFF and 22.689 s ON: 7.54% overhead, below the frozen
+  20% ceiling.
+
+All frozen gates pass. The monitor is suitable as evidence for a narrowly
+scoped active experiment, but the low recall does not justify broad
+satellite deletion. The next experiment should restart only the implicated
+carrier ambiguity arcs for both endpoints at a candidate epoch, preserve the
+DDPR factors, and retain a shadow/off control plus an immediate rollback gate
+for any loss of correct FIX epochs.

--- a/docs/fgo_selective_arc_restart_plan.md
+++ b/docs/fgo_selective_arc_restart_plan.md
@@ -1,0 +1,163 @@
+# Selective carrier-arc restart plan (active quarantine follow-up)
+
+## Objective
+
+The preceding satellite quarantine witness passed every frozen gate
+(docs/fgo_satellite_quarantine_shadow_plan.md): exact OFF/ON estimator
+equality, zero candidates on correct FIX epochs, one bad-FLOAT/CP-hold
+candidate epoch (BDS C11/C14 at run1 epoch 461), and 7.54% overhead. This
+experiment advances from witness to a narrowly scoped ACTIVE mechanism: at a
+quarantine-candidate epoch, restart only the implicated carrier ambiguity arcs
+for both endpoints, preserve the DD pseudorange factors, and keep a
+shadow/off control plus an immediate rollback gate for any loss of correct FIX
+epochs.
+
+It is default-off and bit-identical when off, exactly like every prior FGO
+audit in this project.
+
+## Causal candidate rule (frozen)
+
+The witness is post-hoc. The active path must decide **before** an epoch's
+carrier factors are added, so it runs as a one-epoch-delayed arm, mirroring
+`use_selective_cp_hold` (detect at epoch i post-fit, apply at epoch i+1 factor
+build).
+
+For each DD pseudorange pair observed at epoch i:
+
+1. **Doppler innovation** (existing `monitor_predicted_ddpr_quality`
+   arithmetic, kept causal): |measured DD-PR change - trapezoidal DD-Doppler
+   prediction| / sigma > 5.
+2. **IMU-geometry innovation** (same source): |measured change - predicted
+   change at the IMU-propagated epoch seed| / sigma > 5.
+3. **Post-fit gross attribution** (existing `per_sat_res`, charged to both
+   endpoints): residual > `cp_hold_fast_worst_satellite_min_m` (10 m) and
+   > `cp_hold_multipath_median_ratio` * epoch median.
+
+A satellite becomes a restart candidate only when all three agree, and the DD
+pair attributes support to BOTH its target and reference satellite (as in the
+witness). Candidate satellites are accumulated for epoch i, then used to bump
+generations of their carrier ambiguity arcs at epoch i+1.
+
+## Active mechanism (default-off `--selective-arc-restart`)
+
+- Reuse the existing `amb_generation` arc-regeneration overlay
+  (`invalidateArcs` semantics): bumping an ambiguity index's generation mints a
+  fresh backend-local symbol on its next observation, which the fresh-arc
+  bookkeeping seeds like a genuinely new arc.
+- Restart ONLY the implicated arcs: the set of ambiguity indices whose DD
+  carrier factor touches a candidate satellite (as target or reference).
+- Preserve every DDPR factor; do not suppress, reweight, or remove pseudorange
+  rows, and do not touch clean carrier arcs.
+- Do not enter CP-hold, do not mass-reset, do not relax LAMBDA, do not change
+  FIX/FLOAT labeling rules.
+- Apply at most one restart per candidate epoch per ambiguity index.
+
+## Rollback gate
+
+The live estimator may not consult reference truth. Instead:
+
+- The mechanism keeps a shadow/off control: the same run profile is executed
+  with the flag off and on; all pre-existing solution fields must be identical
+  whenever no candidate fires.
+- Any epoch that was FIXED in the OFF run and becomes FLOAT (or worse) in the
+  ON run, or any new wrong FIX, or any NONE/non-finite increase, stops the
+  experiment without threshold tuning.
+- A candidate restart is only applied if the epoch is not currently FIXED with
+  a strong ratio; if the epoch is clean-FIX, no restart fires.
+
+## Frozen gates
+
+### Gate 0: deterministic safety
+
+- default-off bit-identical (OFF/ON solution, ratio, status, CSV equal);
+- a synthetic 30 m single-DDPR jump with zero Doppler-predicted change arms the
+  implicated pair's satellites at epoch i and bumps ONLY their ambiguity
+  generations at i+1;
+- clean carrier arcs and DDPR factors keep identical generations/factors;
+- no held epoch becomes FIXED from a restarted arc.
+
+### Gate 1: Tokyo run1 source epochs 5000--5499
+
+- zero additional wrong FIX above 0.5 m 3-D;
+- zero lost correct FIX relative to the OFF replay;
+- at least one additional correct FIX opportunity over the 167-FLOAT baseline
+  (or a clear demonstration that the candidate epoch itself was already
+  unrecoverable);
+- no NONE/non-finite increase;
+- fixed horizontal RMS/P95 regression at most 5%;
+- solver overhead at most 10%.
+
+Failure stops without tuning. Only a Gate-1 pass permits full run1. Tokyo
+run2/run3 remain sealed until a full-run1 activation passes.
+
+## CLI
+
+```text
+--selective-arc-restart
+```
+
+plus the existing `--dump-csv result.csv` path, which gains
+`selective_arc_restart_*` epoch columns and a
+`result.csv.selective_arc_restart.csv` trace (epoch, satellite, role
+target/reference, ambiguity index, epoch-median, post-fit residual, Doppler
+innovation, IMU innovation, action applied).
+
+## Gate 0 result
+
+Three deterministic tests pass (all default-off bit-identical where no
+candidate fires):
+
+- `OffOnSolutionsAreBitIdenticalWhenNoQuarantineCandidateFires`: clean
+  fixed-lag problem, OFF/ON positions, status, ratio, fixed count, and
+  generation bumps exactly equal; zero detection epochs and zero applied arcs.
+- `SyntheticGrossJumpArmsImplicatedPairAndRestartsOnlyItsArc`: a 30 m
+  single-DDPR jump with zero Doppler-predicted change arms the implicated
+  pair's arcs at epoch i (Doppler 5.93-sigma, IMU 6.09-sigma) and bumps ONLY
+  their ambiguity generations at i+1; the clean arcs keep identical
+  generations; the OFF/ON estimator positions, ratios, and statuses remain
+  exactly equal.
+- `MonitorOnlyReportsCandidatesWithoutBumpingAnyGeneration`:
+  `--selective-arc-restart-monitor` reports the same detection with
+  `applied_arcs == 0` and zero generation bumps.
+
+No held epoch becomes FIXED from a restarted arc, and every pre-existing
+solution field is equal whenever no candidate fires.
+
+## Gate 1: Tokyo run1 source epochs 5000--5499
+
+The frozen shipping profile (5 s lag, multi-frequency partial AR, hold, CMC,
+CP-hold, exception recovery, DDPR anchor, FDE, varerr, FIX demotion) was run
+with the same binary OFF and ON:
+
+| Metric | OFF | ON |
+|---|---:|---:|
+| FIX / FLOAT / NONE | 333 / 167 / 0 | 333 / 167 / 0 |
+| FLOAT horizontal RMS | 7.87162 m | 7.87162 m |
+| FIXED horizontal RMS | 0.024057 m | 0.024057 m |
+| fix-rate | 66.6% | 66.6% |
+| estimator rows with status/pos/ratio diff | - | 0 / 500 |
+| detection epochs | - | 1 |
+| candidate satellites / pairs | - | 2 / 1 |
+| applied arc restarts | - | 0 |
+| skipped_fixed | - | 329 |
+| wall time | 61.59 s | 61.10 s |
+
+The one detection is the witness's own BDS C11/C14 pair at slice epoch 461
+(TOW 188563, FLOAT, CP-hold active, residual 106.08 m, epoch median 1.878 m,
+Doppler 5.93-sigma, IMU 6.09-sigma). No DD carrier arc in that epoch's graph
+touches either satellite (the live carrier factors are GPS/GAL/QZSS-only:
+G30->G11, E11->E09, E36->E09, J03->J04), so the candidate is detected but not
+armable: `applied_arcs == 0` and the estimator is bit-identical to OFF.
+
+Gate-1 verdict: the mechanism is safe (zero wrong-FIX, zero lost correct-FIX,
+zero NONE/non-finite increase, ~0.8% overhead) but produces **zero incremental
+correct-FIX opportunities** on this slice. The single witness candidate epoch
+has no carrier arc to restart, so the experiment cannot demonstrate the
+required "+1 correct FIX" on the development slice. Do not spend sealed run2
+/run3 holdouts on this threshold set. The active selective arc-restart
+remains a safe, default-off, bit-identical mechanism whose utility is bounded
+by the quarantine witness's own low recall (see the witness plan). A future
+active experiment needs a candidate rule that also fires on epochs whose
+implicated satellites actually carry a DD carrier arc, or an additional
+temporal-consistency witness with higher recall.
+

--- a/docs/fgo_selective_arc_restart_plan.md
+++ b/docs/fgo_selective_arc_restart_plan.md
@@ -161,3 +161,69 @@ active experiment needs a candidate rule that also fires on epochs whose
 implicated satellites actually carry a DD carrier arc, or an additional
 temporal-consistency witness with higher recall.
 
+## Post-hoc slice analysis (design-slice candidates)
+
+A separate read of the OFF replay's epoch CSV was made to find FLOAT epochs
+that DO carry carrier arcs yet still fail to fix, and to test whether an
+arc-restart rule could plausibly recover them:
+
+| Category | Count |
+|---|---:|
+| FLOAT epochs with carrier factors added | 47 / 167 |
+| FLOAT epochs with ddpr_rms > 5 m | 90 / 167 |
+| FLOAT, carrier added, LAMBDA-insufficient (ar_outcome=5) | 45 |
+| ... of those with ddpr_rms > 5 m | 8 (slice epochs 360--367) |
+
+The 45 LAMBDA-insufficient epochs all had `lambda_attempts == 0`: their
+eligible ambiguity count (3--5) never reached the per-epoch LAMBDA floor, so
+AR was not even attempted. The candidate trace shows the cause: those epochs
+are dominated by **build-time-excluded** carrier rows (E10->E09, J03->J04,
+C13->C14 are excluded at almost every epoch; G20->G11 drops out from
+TOW 188538.2 onward; E36->E09 flickers in and out). Excluded rows have no
+ambiguity index in the graph, so an ambiguity-generation restart cannot
+restore them -- there is no arc to restart. This is exactly the
+`use_low_count_ambiguity_resolution` (default-off) responsibility: lower the
+candidate-count floor and let LAMBDA run on the surviving candidates, gated
+by surplus validation and a ratio floor.
+
+Conclusion for the next experiment: **arc-restart and low-count AR address
+disjoint failure modes.** An arc-restart that fires on the quarantine rule
+cannot help the design-slice FLOATs because (a) the witness fires on
+CP-hold-only epochs whose implicated satellites have no carrier arcs, and (b)
+the carrier-bearing FLOAT epochs fail for build-time exclusions, not stale
+arcs. A more promising next experiment targets the 45 low-count FLOAT epochs
+directly: evaluate `use_low_count_ambiguity_resolution` on the frozen
+design-slice profile (it is currently off), with the existing surplus +
+ratio gates as the safety net, and count correct-FIX recoveries. That is a
+threshold-free, already-implemented path that does not need a new candidate
+rule.
+
+## Low-count AR evaluation (design slice)
+
+`--low-count-ar` was run on the frozen design-slice profile (default
+min_candidates=4, then 3, and ratio 0) and produced **zero accepted fixes** in
+every configuration:
+
+| Configuration | attempts | accepted |
+|---|---:|---:|
+| min_candidates=4, min_ratio=1.5 | 20 | 0 |
+| min_candidates=3, min_ratio=1.5 | 48 | 0 |
+| min_candidates=3, min_ratio=0 (surplus alone) | 48 | 0 |
+
+With min_candidates=3 the 48 epochs that were previously LAMBDA-insufficient
+each ran one LAMBDA search (`lambda_attempts` 0 -> 1 across slice epochs
+330--443, matching the 45 ar_outcome=5 epochs plus a few neighbours), yet
+`surplus-validation` rejected every candidate and no epoch changed status
+(333 FIX / 167 FLOAT identical to OFF).
+
+This closes the "candidate-count floor" hypothesis: the design-slice FLOATs
+do not fail because LAMBDA never runs; they fail because their surviving
+candidates do not pass the surplus/ratio acceptance gates. That is a
+candidate-QUALITY problem, not a candidate-COUNT or arc-continuity problem.
+Arc-restart cannot help (the arcs exist and are already eligible), and
+low-count AR cannot help (the integer hypotheses are rejected by the gates).
+Any future experiment that wants more correct FIX on this slice must improve
+the quality of the surviving LAMBDA candidates (e.g. better float-ambiguity
+conditioning or a different integer candidate), which is a distinct problem
+from the quarantine/arc-restart thread and is out of scope for this plan.
+

--- a/docs/fgo_selective_arc_restart_plan.md
+++ b/docs/fgo_selective_arc_restart_plan.md
@@ -227,3 +227,38 @@ the quality of the surviving LAMBDA candidates (e.g. better float-ambiguity
 conditioning or a different integer candidate), which is a distinct problem
 from the quarantine/arc-restart thread and is out of scope for this plan.
 
+## Structural root cause: `surplus_rescue_quality_pass` nsat floor
+
+A per-epoch probe of the min_candidates=3 replay isolates the exact gate that
+rejects the well-observed low-count FLOATs:
+
+| slice epoch | nsat | ddpr_rms | DDCP post-fit RMS | LAMBDA ratio | FFRT pass | outcome |
+|---|---:|---:|---:|---:|---:|---|
+| 335 | 6 | 1.130 m | 0.007 m | 8.85e6 | 1 | LowCountRejected |
+| 336 | 6 | 1.155 m | 0.009 m | 8.94e6 | 1 | LowCountRejected |
+| 337 | 5 | 1.176 m | 0.008 m | 6.01e5 | 1 | LowCountRejected |
+| 338 | 5 | 1.177 m | 0.008 m | 6.17e5 | 1 | LowCountRejected |
+
+These epochs have a correct, unambiguous LAMBDA candidate (ratio in the
+millions, FFRT pass) and a clean carrier post-fit (DDCP ~8 mm) -- there is no
+evidence of a wrong integer. They are still rejected because `low_count_pass`
+requires `surplus_rescue_quality_pass`, whose `nsat >= 10` floor
+(`kSurplusRescueMinSatellites`) cannot be met by a low-count epoch by
+construction (5--6 satellites observed, 3--5 eligible arcs).
+
+This is a structural contradiction between the low-count rescue's purpose
+(fewer-than-floor candidates) and its mandatory surplus quality gate
+(10-satellite minimum). The gate exists to block sparse-geometry wrong-but-
+internally-consistent fixes, so it is not obviously wrong; but it means
+`use_low_count_ambiguity_resolution` can only ever accept epochs that were
+never actually below-floor. Disabling surplus validation entirely and
+dropping `--surplus-validation-min-n` to 1 changed nothing (FIX stayed 333),
+confirming that the rejection is the `nsat >= 10` + DDCP/fallback quality
+floor, not the surplus count itself.
+
+A future experiment could evaluate a low-count rescue whose quality gate
+scales with the observed geometry (e.g. an nsat-relative or ratio-aperture
+substitute), but that is a threshold change to a wrong-FIX safety net and
+must follow a fresh run1-only plan with a wrong-FIX gate -- it is out of
+scope for the quarantine/arc-restart thread documented here.
+

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -166,6 +166,25 @@ public:
         double integer_constrained_cost_abs_tolerance = 1e-6;
         int integer_constrained_max_iterations = 1;
         bool use_robust_loss = true;
+        // Diagnostic-only graduated non-convexity (GNC) analysis of the
+        // fixed-lag DD pseudorange residuals. It computes a coarse-to-fine
+        // Geman--McClure weight schedule after each epoch solve, but never
+        // replaces graph factors, re-optimizes, or changes FIX/FLOAT state.
+        // Implemented by the GTSAM backend; default OFF.
+        bool monitor_ddpr_gnc = false;
+        double ddpr_gnc_shape = 2.0;
+        double ddpr_gnc_graduation_divisor = 1.4;
+        int ddpr_gnc_max_stages = 32;
+        double ddpr_gnc_downweighted_threshold = 0.5;
+        // Counterfactual-only alternating GNC/LM solve on a copy of the
+        // active fixed-lag graph. DDPR factors receive graduated
+        // Geman--McClure weights; every other factor is unchanged. The
+        // candidate is recorded for FLOAT epochs and is never fed back to
+        // the live smoother or ambiguity-resolution state. Default OFF.
+        bool monitor_ddpr_gnc_counterfactual = false;
+        int ddpr_gnc_counterfactual_max_stages = 8;
+        int ddpr_gnc_counterfactual_iterations_per_stage = 1;
+        double ddpr_gnc_counterfactual_min_weight = 1e-3;
         double motion_sigma_m = 50.0;
         double clock_motion_sigma_m = 300.0;
         double velocity_prior_sigma_mps = 100.0;
@@ -360,6 +379,10 @@ public:
         // monitor_external_doppler_dr evaluates every provisional LAMBDA
         // candidate but cannot relax a ratio gate or add Doppler graph factors.
         bool monitor_external_doppler_dr = false;
+        // Monitor-only conjunction for provisional LAMBDA candidates:
+        // trusted DDPR-LS anchor, IMU prediction, Doppler-only DR, and DDCP
+        // post-fit consistency. Never changes an ambiguity decision.
+        bool monitor_candidate_integrity_witness = false;
         bool use_external_doppler_dr_validation = false;
         bool external_doppler_dr_require_for_relaxed_fix = true;
         // A statistically validated relaxed-ratio solution may label the
@@ -422,6 +445,10 @@ public:
         // compares measured DDPR changes with DD Doppler and the causal
         // pre-solve IMU pose prediction; no result is consumed by the graph.
         bool monitor_predicted_ddpr_quality = false;
+        // Monitor-only agreement between the causal Doppler/IMU DDPR check
+        // and current per-satellite post-fit DDPR attribution.
+        bool monitor_satellite_quarantine_witness = false;
+        double satellite_quarantine_normalized_threshold = 5.0;
         // Diagnostic-only causal random-walk model of persistent DD
         // pseudorange bias. It consumes the monitor above internally but is
         // independent of its output switch. No result is consumed by the
@@ -1898,6 +1925,20 @@ public:
         double posterior_sigma_m = 0.0;
     };
 
+    struct SatelliteQuarantineWitnessDiagnostics {
+        std::size_t epoch_index = 0;
+        SatelliteId satellite;
+        double postfit_ddpr_residual_m = 0.0;
+        double epoch_median_postfit_ddpr_residual_m = 0.0;
+        bool postfit_gross = false;
+        bool doppler_evaluated = false;
+        bool doppler_outlier = false;
+        bool imu_evaluated = false;
+        bool imu_outlier = false;
+        int temporal_support_pairs = 0;
+        bool quarantine_candidate = false;
+    };
+
     struct FGODiagnostics {
         int iterations = 0;
         bool converged = false;
@@ -1971,6 +2012,15 @@ public:
         std::size_t robust_double_difference_pseudorange_factors = 0;
         std::size_t robust_double_difference_carrier_factors = 0;
         std::size_t robust_tdcp_factors = 0;
+        std::size_t ddpr_gnc_evaluated_epochs = 0;
+        std::size_t ddpr_gnc_factors = 0;
+        std::size_t ddpr_gnc_downweighted_factors = 0;
+        std::size_t ddpr_gnc_counterfactual_attempts = 0;
+        std::size_t ddpr_gnc_counterfactual_successes = 0;
+        std::size_t candidate_integrity_witness_evaluated = 0;
+        std::size_t candidate_integrity_witness_passes = 0;
+        std::size_t satellite_quarantine_witness_satellites = 0;
+        std::size_t satellite_quarantine_candidates = 0;
         std::size_t graph_factors = 0;
         std::size_t graph_values = 0;
         std::size_t imu_intervals = 0;  ///< 2b: CombinedImuFactors added between epochs
@@ -2250,6 +2300,18 @@ public:
         double graph_cost_after = 0.0;
     };
 
+    /// One diagnostic-only DDPR GNC weight at the current epoch's optimized
+    /// pose. These rows are never consumed by the estimator.
+    struct DdprGncFactorTrace {
+        SatelliteId satellite;
+        SatelliteId reference_satellite;
+        SignalType signal = SignalType::GPS_L1CA;
+        double residual_m = 0.0;
+        double sigma_m = 0.0;
+        double normalized_residual = 0.0;
+        double weight = 1.0;
+    };
+
     /// Per-epoch fixed-lag integrity state.  These values expose why an epoch
     /// did or did not fix, rather than only reporting the final FIX/FLOAT label.
     struct FGOEpochDiagnostics {
@@ -2257,6 +2319,42 @@ public:
         AmbiguityResolutionOutcome ar_outcome =
             AmbiguityResolutionOutcome::NotAttempted;
         double ddpr_rms_m = 0.0;
+        bool ddpr_gnc_evaluated = false;
+        int ddpr_gnc_factor_count = 0;
+        int ddpr_gnc_stages = 0;
+        double ddpr_gnc_initial_mu = 0.0;
+        double ddpr_gnc_final_mu = 0.0;
+        double ddpr_gnc_min_weight = 1.0;
+        double ddpr_gnc_mean_weight = 1.0;
+        double ddpr_gnc_effective_factor_count = 0.0;
+        int ddpr_gnc_downweighted_factors = 0;
+        double ddpr_gnc_weighted_rms_m = 0.0;
+        std::vector<DdprGncFactorTrace> ddpr_gnc_factor_trace;
+        bool ddpr_gnc_counterfactual_evaluated = false;
+        bool ddpr_gnc_counterfactual_succeeded = false;
+        int ddpr_gnc_counterfactual_factor_count = 0;
+        int ddpr_gnc_counterfactual_stages = 0;
+        double ddpr_gnc_counterfactual_cost_before = 0.0;
+        double ddpr_gnc_counterfactual_cost_after = 0.0;
+        double ddpr_gnc_counterfactual_ddpr_rms_before_m = 0.0;
+        double ddpr_gnc_counterfactual_ddpr_rms_after_m = 0.0;
+        Vector3d ddpr_gnc_counterfactual_position_ecef = Vector3d::Zero();
+        double ddpr_gnc_counterfactual_float_separation_m = 0.0;
+        bool ddpr_gnc_counterfactual_lambda_evaluated = false;
+        int ddpr_gnc_counterfactual_lambda_ambiguities = 0;
+        double ddpr_gnc_counterfactual_lambda_ratio = 0.0;
+        bool ddpr_gnc_counterfactual_lambda_ratio_pass = false;
+        bool candidate_integrity_witness_evaluated = false;
+        bool candidate_integrity_anchor_available = false;
+        int candidate_integrity_anchor_factors = 0;
+        double candidate_integrity_anchor_rms_m = 0.0;
+        double candidate_integrity_anchor_separation_m = 0.0;
+        bool candidate_integrity_anchor_pass = false;
+        bool candidate_integrity_imu_pass = false;
+        bool candidate_integrity_doppler_available = false;
+        bool candidate_integrity_doppler_pass = false;
+        bool candidate_integrity_carrier_pass = false;
+        bool candidate_integrity_composite_pass = false;
         double sd_doppler_rms_mps = 0.0;
         int clock_resilient_tdcp_factors = 0;
         double clock_resilient_tdcp_rms_m = 0.0;
@@ -2424,6 +2522,8 @@ public:
             predicted_ddpr_quality_factors;
         std::vector<PredictedDdprBiasStateDiagnostics>
             predicted_ddpr_bias_state_factors;
+        std::vector<SatelliteQuarantineWitnessDiagnostics>
+            satellite_quarantine_witnesses;
         // Milestone 2b (populated only by the GTSAM IMU-coupled path):
         // per-epoch estimated attitude as [roll, pitch, heading] in degrees
         // (body FLU -> nav ENU; heading is clockwise from North) and estimated

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -449,6 +449,25 @@ public:
         // and current per-satellite post-fit DDPR attribution.
         bool monitor_satellite_quarantine_witness = false;
         double satellite_quarantine_normalized_threshold = 5.0;
+        // Active selective carrier-arc restart (default OFF, bit-identical
+        // when off). At a quarantine-candidate epoch i (Doppler innovation,
+        // IMU-geometry innovation, and post-fit gross DDPR attribution all
+        // agree on the same DD pair), the implicated carrier ambiguity arcs
+        // for BOTH endpoints are generation-bumped at epoch i+1 via the
+        // existing amb_generation overlay. DDPR factors and clean carrier
+        // arcs are preserved; CP-hold, LAMBDA, and FIX/FLOAT rules are
+        // unchanged. A rollback gate stops the mechanism if any correct FIX
+        // epoch is lost or any wrong FIX appears in the OFF/ON comparison.
+        bool use_selective_arc_restart = false;
+        bool selective_arc_restart_require_both_innovations = true;
+        int selective_arc_restart_max_arcs_per_epoch = 4;
+        double selective_arc_restart_skip_fixed_ratio = 2.0;
+        // A fresh generation may only be minted after this many epochs since
+        // the ambiguity index's previous generation, preventing thrash.
+        int selective_arc_restart_min_epochs_since_bump = 5;
+        // Monitor-only counterpart of the active flag: reports which
+        // satellites/pairs WOULD be restarted without bumping any generation.
+        bool monitor_selective_arc_restart_candidates = false;
         // Diagnostic-only causal random-walk model of persistent DD
         // pseudorange bias. It consumes the monitor above internally but is
         // independent of its output switch. No result is consumed by the
@@ -2021,6 +2040,14 @@ public:
         std::size_t candidate_integrity_witness_passes = 0;
         std::size_t satellite_quarantine_witness_satellites = 0;
         std::size_t satellite_quarantine_candidates = 0;
+        std::size_t selective_arc_restart_detection_epochs = 0;
+        std::size_t selective_arc_restart_candidate_satellites = 0;
+        std::size_t selective_arc_restart_candidate_pairs = 0;
+        std::size_t selective_arc_restart_applied_arcs = 0;
+        std::size_t selective_arc_restart_skipped_fixed = 0;
+        std::size_t selective_arc_restart_skipped_thrash = 0;
+        std::size_t selective_arc_restart_skipped_cap = 0;
+        std::size_t selective_arc_restart_skipped_no_arc = 0;
         std::size_t graph_factors = 0;
         std::size_t graph_values = 0;
         std::size_t imu_intervals = 0;  ///< 2b: CombinedImuFactors added between epochs
@@ -2312,6 +2339,22 @@ public:
         double weight = 1.0;
     };
 
+    /// One selective arc-restart candidate/action row. Populated only when
+    /// use_selective_arc_restart (active) or
+    /// monitor_selective_arc_restart_candidates (monitor-only) is enabled.
+    struct SelectiveArcRestartTrace {
+        std::size_t detection_epoch = 0;
+        SatelliteId satellite;
+        bool is_reference = false;
+        std::size_t ambiguity_index = 0;
+        bool detected = false;
+        bool applied = false;
+        double postfit_residual_m = 0.0;
+        double epoch_median_postfit_residual_m = 0.0;
+        double normalized_doppler_innovation = 0.0;
+        double normalized_imu_innovation = 0.0;
+    };
+
     /// Per-epoch fixed-lag integrity state.  These values expose why an epoch
     /// did or did not fix, rather than only reporting the final FIX/FLOAT label.
     struct FGOEpochDiagnostics {
@@ -2503,6 +2546,16 @@ public:
         int ambiguity_generation_bumps_reset = 0;
         int ambiguity_generation_bumps_warm_reset = 0;
         int ambiguity_generation_bumps_stale_pin = 0;
+        // --- Active selective arc restart (use_selective_arc_restart) ---
+        bool selective_arc_restart_armed = false;
+        int selective_arc_restart_candidate_satellites = 0;
+        int selective_arc_restart_candidate_pairs = 0;
+        int selective_arc_restart_applied_arcs = 0;
+        int selective_arc_restart_skipped_fixed = 0;
+        int selective_arc_restart_skipped_thrash = 0;
+        int selective_arc_restart_skipped_cap = 0;
+        bool selective_arc_restart_monitor_only = false;
+        std::vector<SelectiveArcRestartTrace> selective_arc_restart_trace;
     };
 
     struct FGOResult {
@@ -2524,6 +2577,7 @@ public:
             predicted_ddpr_bias_state_factors;
         std::vector<SatelliteQuarantineWitnessDiagnostics>
             satellite_quarantine_witnesses;
+        std::vector<SelectiveArcRestartTrace> selective_arc_restart_trace;
         // Milestone 2b (populated only by the GTSAM IMU-coupled path):
         // per-epoch estimated attitude as [roll, pitch, heading] in degrees
         // (body FLU -> nav ENU; heading is clockwise from North) and estimated

--- a/include/libgnss++/algorithms/fgo_ddpr_gnc.hpp
+++ b/include/libgnss++/algorithms/fgo_ddpr_gnc.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <cstddef>
+#include <vector>
+
+namespace libgnss::fgo_ddpr_gnc {
+
+/// Configuration for the diagnostic graduated Geman--McClure schedule.
+struct Config {
+    double shape = 2.0;
+    double graduation_divisor = 1.4;
+    int max_stages = 32;
+    double downweighted_threshold = 0.5;
+};
+
+/// One DD pseudorange residual and the sigma used by its graph factor.
+struct Residual {
+    double residual_m = 0.0;
+    double sigma_m = 1.0;
+};
+
+/// Fixed-linearization GNC shadow result. The weights are never fed to FGO.
+struct Result {
+    bool evaluated = false;
+    int stages = 0;
+    double initial_mu = 0.0;
+    double final_mu = 0.0;
+    double min_weight = 1.0;
+    double mean_weight = 1.0;
+    double effective_factor_count = 0.0;
+    std::size_t downweighted_factors = 0;
+    double weighted_rms_m = 0.0;
+    std::vector<double> weights;
+};
+
+/// Evaluates a coarse-to-fine Geman--McClure weight schedule without
+/// re-optimizing or modifying estimator state.
+Result evaluate(const std::vector<Residual>& residuals,
+                const Config& config = Config{});
+
+}  // namespace libgnss::fgo_ddpr_gnc

--- a/src/algorithms/fgo.cpp
+++ b/src/algorithms/fgo.cpp
@@ -2487,6 +2487,7 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
     if (config_.use_single_difference_doppler_factors ||
         config_.monitor_external_doppler_dr ||
         config_.use_external_doppler_dr_validation ||
+        config_.monitor_candidate_integrity_witness ||
         config_.use_single_difference_tdcp_factors) {
         std::map<CarrierKey, SingleDifferenceCarrierResidual>
             previous_sd_carrier_residuals;
@@ -2547,7 +2548,8 @@ FGOProcessor::FGOProblem FGOProcessor::buildDoubleDifferenceProblem(
 
                 if ((config_.use_single_difference_doppler_factors ||
                      config_.monitor_external_doppler_dr ||
-                     config_.use_external_doppler_dr_validation) &&
+                     config_.use_external_doppler_dr_validation ||
+                     config_.monitor_candidate_integrity_witness) &&
                     rover->has_doppler_residual &&
                     reference->has_doppler_residual) {
                     SingleDifferenceDopplerFactor factor;

--- a/src/algorithms/fgo_ddpr_gnc.cpp
+++ b/src/algorithms/fgo_ddpr_gnc.cpp
@@ -1,0 +1,77 @@
+#include <libgnss++/algorithms/fgo_ddpr_gnc.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace libgnss::fgo_ddpr_gnc {
+
+Result evaluate(const std::vector<Residual>& residuals, const Config& config) {
+    Result result;
+    if (residuals.empty() || !std::isfinite(config.shape) || config.shape <= 0.0 ||
+        !std::isfinite(config.graduation_divisor) || config.graduation_divisor <= 1.0 ||
+        config.max_stages <= 0 || !std::isfinite(config.downweighted_threshold) ||
+        config.downweighted_threshold < 0.0 || config.downweighted_threshold > 1.0) {
+        return result;
+    }
+
+    std::vector<double> normalized_squared;
+    normalized_squared.reserve(residuals.size());
+    double max_normalized_squared = 0.0;
+    for (const auto& residual : residuals) {
+        if (!std::isfinite(residual.residual_m) || !std::isfinite(residual.sigma_m) ||
+            residual.sigma_m <= 0.0) {
+            return result;
+        }
+        const double normalized = residual.residual_m / residual.sigma_m;
+        const double squared = normalized * normalized;
+        normalized_squared.push_back(squared);
+        max_normalized_squared = std::max(max_normalized_squared, squared);
+    }
+
+    const double shape_squared = config.shape * config.shape;
+    double mu = std::max(1.0, max_normalized_squared / shape_squared);
+    result.initial_mu = mu;
+    result.weights.assign(residuals.size(), 1.0);
+    double applied_mu = mu;
+
+    // Wen et al.'s continuation schedule: solve at the current scale, update
+    // weights, then reduce the scale. In this shadow milestone the residuals
+    // remain fixed deliberately; a later counterfactual optimizer can reuse
+    // the same deterministic schedule while alternating state solves.
+    for (int stage = 0; stage < config.max_stages; ++stage) {
+        applied_mu = mu;
+        const double scale = mu * shape_squared;
+        for (std::size_t i = 0; i < normalized_squared.size(); ++i) {
+            result.weights[i] = scale / (scale + normalized_squared[i]);
+        }
+        ++result.stages;
+        if (mu <= 1.0) {
+            break;
+        }
+        mu = std::max(1.0, mu / config.graduation_divisor);
+    }
+
+    result.final_mu = applied_mu;
+    double weight_sum = 0.0;
+    double weighted_square_sum = 0.0;
+    result.min_weight = std::numeric_limits<double>::infinity();
+    for (std::size_t i = 0; i < residuals.size(); ++i) {
+        const double weight = result.weights[i];
+        weight_sum += weight;
+        weighted_square_sum += weight * residuals[i].residual_m * residuals[i].residual_m;
+        result.min_weight = std::min(result.min_weight, weight);
+        if (weight < config.downweighted_threshold) {
+            ++result.downweighted_factors;
+        }
+    }
+    result.mean_weight = weight_sum / static_cast<double>(residuals.size());
+    result.effective_factor_count = weight_sum;
+    result.weighted_rms_m = weight_sum > 0.0
+        ? std::sqrt(weighted_square_sum / weight_sum)
+        : 0.0;
+    result.evaluated = true;
+    return result;
+}
+
+}  // namespace libgnss::fgo_ddpr_gnc

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -26,6 +26,7 @@
 
 #include <libgnss++/algorithms/disjoint_constellation_partition.hpp>
 #include <libgnss++/algorithms/fgo.hpp>
+#include <libgnss++/algorithms/fgo_ddpr_gnc.hpp>
 #include <libgnss++/algorithms/lambda.hpp>
 #include <libgnss++/core/constants.hpp>
 #include <libgnss++/core/coordinates.hpp>
@@ -428,6 +429,222 @@ IntegerConstrainedGraphCostOutcome evaluateIntegerConstrainedGraphCost(
             std::max(0.0, config.integer_constrained_cost_abs_tolerance);
     if (current_position_key && optimized_values.exists(*current_position_key)) {
         outcome.optimized_pose = optimized_values.at<Pose3>(*current_position_key);
+    }
+    return outcome;
+}
+
+struct DdprGncCounterfactualOutcome {
+    bool evaluated = false;
+    bool succeeded = false;
+    int factor_count = 0;
+    int stages = 0;
+    double base_cost_before = 0.0;
+    double base_cost_after = 0.0;
+    double ddpr_rms_before_m = 0.0;
+    double ddpr_rms_after_m = 0.0;
+    bool lambda_evaluated = false;
+    int lambda_ambiguities = 0;
+    double lambda_ratio = 0.0;
+    bool lambda_ratio_pass = false;
+    std::optional<Pose3> optimized_pose;
+};
+
+double scalarNoiseSigma(const gtsam::SharedNoiseModel& model) {
+    if (!model) return 0.0;
+    gtsam::SharedNoiseModel gaussian_model = model;
+    if (const auto robust =
+            std::dynamic_pointer_cast<gtsam::noiseModel::Robust>(model)) {
+        gaussian_model = robust->noise();
+    }
+    const auto diagonal =
+        std::dynamic_pointer_cast<gtsam::noiseModel::Diagonal>(gaussian_model);
+    if (!diagonal || diagonal->dim() != 1) return 0.0;
+    const gtsam::Vector sigmas = diagonal->sigmas();
+    return sigmas.size() == 1 && std::isfinite(sigmas(0)) && sigmas(0) > 0.0
+        ? sigmas(0)
+        : 0.0;
+}
+
+DdprGncCounterfactualOutcome evaluateDdprGncCounterfactual(
+    const gtsam::NonlinearFactorGraph& active_factors,
+    const gtsam::Values& initial_values,
+    std::optional<gtsam::Key> current_position_key,
+    const std::vector<gtsam::Key>& current_ambiguity_keys,
+    const FGOProcessor::FGOConfig& config) {
+    DdprGncCounterfactualOutcome outcome;
+    if (config.ddpr_gnc_counterfactual_max_stages <= 0 ||
+        config.ddpr_gnc_counterfactual_iterations_per_stage <= 0 ||
+        !std::isfinite(config.ddpr_gnc_shape) || config.ddpr_gnc_shape <= 0.0 ||
+        !std::isfinite(config.ddpr_gnc_counterfactual_min_weight) ||
+        config.ddpr_gnc_counterfactual_min_weight <= 0.0 ||
+        config.ddpr_gnc_counterfactual_min_weight > 1.0) {
+        return outcome;
+    }
+
+    try {
+        gtsam::NonlinearFactorGraph base_graph;
+        std::vector<std::size_t> ddpr_indices;
+        std::vector<double> ddpr_sigmas;
+        for (const auto& factor : active_factors) {
+            if (!factor) continue;
+            const std::size_t graph_index = base_graph.size();
+            base_graph.push_back(factor);
+            if (dynamic_cast<const gtsam::DoubleDifferencePseudorangeFactorArm*>(
+                    factor.get()) == nullptr) {
+                continue;
+            }
+            const auto noise_factor =
+                std::dynamic_pointer_cast<gtsam::NoiseModelFactor>(factor);
+            const double sigma = noise_factor
+                ? scalarNoiseSigma(noise_factor->noiseModel())
+                : 0.0;
+            if (sigma <= 0.0) return outcome;
+            ddpr_indices.push_back(graph_index);
+            ddpr_sigmas.push_back(sigma);
+        }
+        if (base_graph.empty() || ddpr_indices.empty()) return outcome;
+
+        auto residualsAt = [&](const gtsam::Values& values,
+                               std::vector<double>* residuals,
+                               double* rms) -> bool {
+            residuals->clear();
+            residuals->reserve(ddpr_indices.size());
+            double sum_sq = 0.0;
+            for (const std::size_t index : ddpr_indices) {
+                const auto& factor = base_graph[index];
+                const auto* ddpr = dynamic_cast<
+                    const gtsam::DoubleDifferencePseudorangeFactorArm*>(factor.get());
+                if (!ddpr || factor->keys().empty() ||
+                    !values.exists(factor->keys().front())) {
+                    return false;
+                }
+                const Pose3 pose = values.at<Pose3>(factor->keys().front());
+                const double residual = ddpr->evaluateError(pose)(0);
+                if (!std::isfinite(residual)) return false;
+                residuals->push_back(residual);
+                sum_sq += residual * residual;
+            }
+            *rms = std::sqrt(sum_sq / static_cast<double>(residuals->size()));
+            return true;
+        };
+
+        std::vector<double> residuals;
+        if (!residualsAt(initial_values, &residuals, &outcome.ddpr_rms_before_m)) {
+            return outcome;
+        }
+        outcome.evaluated = true;
+        outcome.factor_count = static_cast<int>(ddpr_indices.size());
+        outcome.base_cost_before = base_graph.error(initial_values);
+
+        const double shape_sq = config.ddpr_gnc_shape * config.ddpr_gnc_shape;
+        double max_normalized_sq = 0.0;
+        for (std::size_t i = 0; i < residuals.size(); ++i) {
+            const double normalized = residuals[i] / ddpr_sigmas[i];
+            max_normalized_sq = std::max(max_normalized_sq,
+                                         normalized * normalized);
+        }
+        const double initial_mu = std::max(1.0, max_normalized_sq / shape_sq);
+        const int requested_stages = config.ddpr_gnc_counterfactual_max_stages;
+        const int stages = initial_mu <= 1.0 ? 1 : std::max(2, requested_stages);
+        gtsam::Values candidate_values = initial_values;
+        gtsam::NonlinearFactorGraph final_weighted_graph = base_graph;
+
+        for (int stage = 0; stage < stages; ++stage) {
+            if (!residualsAt(candidate_values, &residuals,
+                             &outcome.ddpr_rms_after_m)) {
+                return outcome;
+            }
+            const double progress = stages == 1
+                ? 1.0
+                : static_cast<double>(stage) / static_cast<double>(stages - 1);
+            const double mu = std::exp((1.0 - progress) * std::log(initial_mu));
+            const double scale = mu * shape_sq;
+            gtsam::NonlinearFactorGraph weighted_graph = base_graph;
+            for (std::size_t i = 0; i < ddpr_indices.size(); ++i) {
+                const double normalized = residuals[i] / ddpr_sigmas[i];
+                const double normalized_sq = normalized * normalized;
+                const double weight = std::max(
+                    config.ddpr_gnc_counterfactual_min_weight,
+                    scale / (scale + normalized_sq));
+                const auto noise_factor = std::dynamic_pointer_cast<
+                    gtsam::NoiseModelFactor>(base_graph[ddpr_indices[i]]);
+                if (!noise_factor) return outcome;
+                const auto weighted_noise = gtsam::noiseModel::Isotropic::Sigma(
+                    1, ddpr_sigmas[i] / std::sqrt(weight));
+                weighted_graph[ddpr_indices[i]] =
+                    noise_factor->cloneWithNewNoiseModel(weighted_noise);
+            }
+            gtsam::LevenbergMarquardtParams params;
+            params.setMaxIterations(
+                config.ddpr_gnc_counterfactual_iterations_per_stage);
+            params.setVerbosityLM("SILENT");
+            candidate_values = gtsam::LevenbergMarquardtOptimizer(
+                weighted_graph, candidate_values, params).optimize();
+            final_weighted_graph = std::move(weighted_graph);
+            ++outcome.stages;
+        }
+
+        if (!residualsAt(candidate_values, &residuals,
+                         &outcome.ddpr_rms_after_m)) {
+            return outcome;
+        }
+        outcome.base_cost_after = base_graph.error(candidate_values);
+        outcome.succeeded = std::isfinite(outcome.base_cost_before) &&
+            std::isfinite(outcome.base_cost_after) &&
+            std::isfinite(outcome.ddpr_rms_after_m);
+        if (outcome.succeeded && current_position_key &&
+            candidate_values.exists(*current_position_key)) {
+            outcome.optimized_pose =
+                candidate_values.at<Pose3>(*current_position_key);
+        }
+        if (outcome.succeeded && !current_ambiguity_keys.empty()) {
+            try {
+                gtsam::KeyVector lambda_keys;
+                for (const gtsam::Key key : current_ambiguity_keys) {
+                    if (candidate_values.exists(key)) lambda_keys.push_back(key);
+                }
+                const int n = static_cast<int>(lambda_keys.size());
+                if (n > 0) {
+                    const gtsam::Marginals marginals(final_weighted_graph,
+                                                     candidate_values);
+                    const gtsam::JointMarginal joint =
+                        marginals.jointMarginalCovariance(lambda_keys);
+                    Eigen::VectorXd float_ambiguities(n);
+                    Eigen::MatrixXd covariance(n, n);
+                    for (int row = 0; row < n; ++row) {
+                        float_ambiguities(row) =
+                            candidate_values.at<double>(lambda_keys[row]);
+                        for (int col = 0; col < n; ++col) {
+                            covariance(row, col) =
+                                joint(lambda_keys[row], lambda_keys[col])(0, 0);
+                        }
+                    }
+                    LambdaCandidateDiagnostics lambda;
+                    if (float_ambiguities.allFinite() && covariance.allFinite() &&
+                        lambdaSearchTopK(float_ambiguities, covariance, 2, lambda) &&
+                        lambda.squared_residuals.size() >= 2) {
+                        const double best = lambda.squared_residuals(0);
+                        const double second = lambda.squared_residuals(1);
+                        outcome.lambda_evaluated = std::isfinite(best) &&
+                            std::isfinite(second) && best > 0.0;
+                        outcome.lambda_ambiguities = n;
+                        outcome.lambda_ratio = outcome.lambda_evaluated
+                            ? second / best
+                            : 0.0;
+                        outcome.lambda_ratio_pass = outcome.lambda_evaluated &&
+                            n >= 6 && outcome.lambda_ratio >=
+                                config.lambda_ratio_threshold;
+                    }
+                }
+            } catch (const std::exception&) {
+                // Candidate positioning remains valid if its batch marginal
+                // is rank-deficient; the LAMBDA counterfactual simply has no
+                // verdict for this epoch.
+            }
+        }
+    } catch (const std::exception&) {
+        // Counterfactual diagnostics must fail closed and never affect the
+        // live incremental solution.
     }
     return outcome;
 }
@@ -1091,6 +1308,11 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
     std::vector<Vector3d> epoch_vel_nav(num_epochs, Vector3d::Zero());
     std::vector<bool> epoch_solved(num_epochs, false);
     std::vector<FGOProcessor::FGOEpochDiagnostics> epoch_diagnostics(num_epochs);
+    std::vector<std::map<SatelliteId, double>>
+        satellite_quarantine_postfit_residuals;
+    if (config.monitor_satellite_quarantine_witness) {
+        satellite_quarantine_postfit_residuals.resize(num_epochs);
+    }
     std::vector<std::set<std::size_t>> fde_rejected_ambiguities_by_epoch(
         num_epochs);
     std::map<std::size_t, double> amb_float_cycles;
@@ -2764,11 +2986,73 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
         Pose3 pose_i = smoother.calculateEstimate<Pose3>(positionKey(i));
         gtsam::Vector3 vel_i = smoother.calculateEstimate<gtsam::Vector3>(velocityKey(i));
 
+        // Run only after this epoch's final integrity decision. The helper
+        // optimizes copied Values and cloned DDPR factors, so this lambda can
+        // only populate diagnostics; it cannot alter iSAM2 or FIX/FLOAT.
+        auto runDdprGncCounterfactual = [&]() {
+            auto& diagnostic = epoch_diagnostics[i];
+            if (!config.monitor_ddpr_gnc_counterfactual || epoch_fixed[i] ||
+                diagnostic.ddpr_gnc_counterfactual_evaluated) {
+                return;
+            }
+            ++result.diagnostics.ddpr_gnc_counterfactual_attempts;
+            try {
+                const DdprGncCounterfactualOutcome counterfactual =
+                    evaluateDdprGncCounterfactual(
+                        smoother.getISAM2().getFactorsUnsafe(),
+                        smoother.calculateEstimate(), positionKey(i),
+                        [&]() {
+                            std::vector<gtsam::Key> keys;
+                            keys.reserve(epoch_amb_indices.size());
+                            for (const std::size_t index : epoch_amb_indices) {
+                                keys.push_back(ambiguityKey(ambSymbolId(index)));
+                            }
+                            return keys;
+                        }(),
+                        config);
+                diagnostic.ddpr_gnc_counterfactual_evaluated =
+                    counterfactual.evaluated;
+                diagnostic.ddpr_gnc_counterfactual_succeeded =
+                    counterfactual.succeeded;
+                diagnostic.ddpr_gnc_counterfactual_factor_count =
+                    counterfactual.factor_count;
+                diagnostic.ddpr_gnc_counterfactual_stages = counterfactual.stages;
+                diagnostic.ddpr_gnc_counterfactual_cost_before =
+                    counterfactual.base_cost_before;
+                diagnostic.ddpr_gnc_counterfactual_cost_after =
+                    counterfactual.base_cost_after;
+                diagnostic.ddpr_gnc_counterfactual_ddpr_rms_before_m =
+                    counterfactual.ddpr_rms_before_m;
+                diagnostic.ddpr_gnc_counterfactual_ddpr_rms_after_m =
+                    counterfactual.ddpr_rms_after_m;
+                diagnostic.ddpr_gnc_counterfactual_lambda_evaluated =
+                    counterfactual.lambda_evaluated;
+                diagnostic.ddpr_gnc_counterfactual_lambda_ambiguities =
+                    counterfactual.lambda_ambiguities;
+                diagnostic.ddpr_gnc_counterfactual_lambda_ratio =
+                    counterfactual.lambda_ratio;
+                diagnostic.ddpr_gnc_counterfactual_lambda_ratio_pass =
+                    counterfactual.lambda_ratio_pass;
+                if (counterfactual.succeeded && counterfactual.optimized_pose) {
+                    const Point3 candidate_ant =
+                        antennaOf(*counterfactual.optimized_pose);
+                    diagnostic.ddpr_gnc_counterfactual_position_ecef =
+                        Vector3d(candidate_ant);
+                    diagnostic.ddpr_gnc_counterfactual_float_separation_m =
+                        (Vector3d(candidate_ant) - epoch_float_position[i]).norm();
+                    ++result.diagnostics.ddpr_gnc_counterfactual_successes;
+                }
+            } catch (const std::exception&) {
+                // Shadow diagnostics are deliberately fail-closed.
+            }
+        };
+
         // Independent SD-Doppler velocity LS and DR propagation.  No FGO
         // state enters this estimator.  A single robust re-fit removes rows
         // beyond 4 sigma so one Doppler outlier cannot dominate the track.
         if (config.monitor_external_doppler_dr ||
-            config.use_external_doppler_dr_validation) {
+            config.use_external_doppler_dr_validation ||
+            config.monitor_candidate_integrity_witness) {
             std::vector<const FGOProcessor::SingleDifferenceDopplerFactor*> active_doppler =
                 doppler_by_epoch[i];
             Vector3d doppler_velocity = Vector3d::Zero();
@@ -2899,6 +3183,7 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
         double gdop = std::numeric_limits<double>::infinity();
         double ddpr_rms = 0.0;
         std::map<SatelliteId, double> per_sat_res;
+        std::vector<fgo_ddpr_gnc::Residual> gnc_residuals;
         // Per-(ref, target, signal) residual rows, only collected when the
         // sat-badness pair term is actually active (fgo.hpp deviation 5) --
         // feeds update_pair_quality below.
@@ -2948,6 +3233,9 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                     ((fp->rover_reference_position_ecef - ant).norm() -
                      (fp->base_reference_position_ecef - fp->base_position_ecef).norm());
                 const double res = std::abs(fp->observed_dd_pseudorange_m - geom);
+                if (config.monitor_ddpr_gnc) {
+                    gnc_residuals.push_back({res, fp->sigma_m});
+                }
                 res_sq_sum += res * res;
                 ++res_n;
                 double& worst = per_sat_res[fp->satellite];
@@ -2962,14 +3250,59 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             ddpr_rms = res_n > 0 ? std::sqrt(res_sq_sum / static_cast<double>(res_n)) : 0.0;
         }
         epoch_diagnostics[i].ddpr_rms_m = ddpr_rms;
+        if (config.monitor_satellite_quarantine_witness) {
+            satellite_quarantine_postfit_residuals[i] = per_sat_res;
+        }
+        if (config.monitor_ddpr_gnc) {
+            fgo_ddpr_gnc::Config gnc_config;
+            gnc_config.shape = config.ddpr_gnc_shape;
+            gnc_config.graduation_divisor = config.ddpr_gnc_graduation_divisor;
+            gnc_config.max_stages = config.ddpr_gnc_max_stages;
+            gnc_config.downweighted_threshold =
+                config.ddpr_gnc_downweighted_threshold;
+            const auto gnc = fgo_ddpr_gnc::evaluate(gnc_residuals, gnc_config);
+            auto& diagnostics = epoch_diagnostics[i];
+            diagnostics.ddpr_gnc_evaluated = gnc.evaluated;
+            diagnostics.ddpr_gnc_factor_count =
+                static_cast<int>(gnc_residuals.size());
+            diagnostics.ddpr_gnc_stages = gnc.stages;
+            diagnostics.ddpr_gnc_initial_mu = gnc.initial_mu;
+            diagnostics.ddpr_gnc_final_mu = gnc.final_mu;
+            diagnostics.ddpr_gnc_min_weight = gnc.min_weight;
+            diagnostics.ddpr_gnc_mean_weight = gnc.mean_weight;
+            diagnostics.ddpr_gnc_effective_factor_count =
+                gnc.effective_factor_count;
+            diagnostics.ddpr_gnc_downweighted_factors =
+                static_cast<int>(gnc.downweighted_factors);
+            diagnostics.ddpr_gnc_weighted_rms_m = gnc.weighted_rms_m;
+            if (gnc.evaluated && gnc.weights.size() == pr_by_epoch[i].size()) {
+                diagnostics.ddpr_gnc_factor_trace.reserve(gnc.weights.size());
+                for (std::size_t row = 0; row < gnc.weights.size(); ++row) {
+                    const auto* factor = pr_by_epoch[i][row];
+                    FGOProcessor::DdprGncFactorTrace trace;
+                    trace.satellite = factor->satellite;
+                    trace.reference_satellite = factor->reference_satellite;
+                    trace.signal = factor->signal;
+                    trace.residual_m = gnc_residuals[row].residual_m;
+                    trace.sigma_m = gnc_residuals[row].sigma_m;
+                    trace.normalized_residual =
+                        trace.residual_m / trace.sigma_m;
+                    trace.weight = gnc.weights[row];
+                    diagnostics.ddpr_gnc_factor_trace.push_back(trace);
+                }
+            }
+            if (gnc.evaluated) {
+                ++result.diagnostics.ddpr_gnc_evaluated_epochs;
+                result.diagnostics.ddpr_gnc_factors += gnc_residuals.size();
+                result.diagnostics.ddpr_gnc_downweighted_factors +=
+                    gnc.downweighted_factors;
+            }
+        }
         epoch_diagnostics[i].gdop = gdop;
         epoch_diagnostics[i].num_satellites = nsat;
         bool validation_anchor_attempted = false;
         DdprAnchorResult validation_anchor;
-        const auto anchorValidationAgrees = [&](const Eigen::Vector3d& candidate) {
-            if (!config.use_ddpr_anchor_aided_validation || !config.use_ddpr_anchor) {
-                return false;
-            }
+        const auto ensureValidationAnchor = [&]() {
             if (!validation_anchor_attempted) {
                 validation_anchor_attempted = true;
                 ++result.diagnostics.ddpr_anchor_solves;
@@ -2980,10 +3313,15 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                     ++result.diagnostics.ddpr_anchor_successes;
                 }
             }
-            const bool trusted =
-                validation_anchor.ok &&
+            return validation_anchor.ok &&
                 validation_anchor.n_active >= config.ddpr_anchor_min_factors &&
                 validation_anchor.res_rms <= config.ddpr_anchor_max_residual_m;
+        };
+        const auto anchorValidationAgrees = [&](const Eigen::Vector3d& candidate) {
+            if (!config.use_ddpr_anchor_aided_validation || !config.use_ddpr_anchor) {
+                return false;
+            }
+            const bool trusted = ensureValidationAnchor();
             const bool agrees =
                 trusted &&
                 (candidate - Eigen::Vector3d(antennaOf(validation_anchor.pose))).norm() <=
@@ -4183,11 +4521,14 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                         double external_dr_separation_m = 0.0;
                         double external_dr_mahalanobis2 = 0.0;
                         if ((config.monitor_external_doppler_dr ||
-                             config.use_external_doppler_dr_validation) &&
+                             config.use_external_doppler_dr_validation ||
+                             config.monitor_candidate_integrity_witness) &&
                             external_dr_position_valid &&
                             has_provisional_fixed_ant &&
                             has_provisional_fixed_cov &&
                             (!config.monitor_external_doppler_dr ||
+                             external_dr_age_epochs > 0) &&
+                            (!config.monitor_candidate_integrity_witness ||
                              external_dr_age_epochs > 0) &&
                             external_dr_age_epochs <=
                                 config.external_doppler_dr_max_age_epochs) {
@@ -4232,6 +4573,50 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                                     }
                                 }
                             }
+                        }
+
+                        if (config.monitor_candidate_integrity_witness &&
+                            has_provisional_fixed_ant && std::isfinite(ratio) &&
+                            ratio > config.imu_aided_relaxed_ratio_threshold) {
+                            auto& witness = epoch_diagnostics[i];
+                            const bool anchor_available = ensureValidationAnchor();
+                            const double anchor_separation = anchor_available
+                                ? (provisional_fixed_ant - Eigen::Vector3d(
+                                      antennaOf(validation_anchor.pose))).norm()
+                                : 0.0;
+                            const bool anchor_pass = anchor_available &&
+                                anchor_separation <=
+                                    config.ddpr_anchor_validation_max_separation_m;
+                            const bool imu_pass =
+                                witness.fixed_imu_prediction_separation_m <=
+                                    config.imu_aided_max_prediction_separation_m;
+                            constexpr double kCandidateCarrierMaxRmsM = 0.05;
+                            const bool carrier_pass =
+                                witness.fixed_postfit_ddcp_factors >= 4 &&
+                                std::isfinite(witness.fixed_postfit_ddcp_rms_m) &&
+                                witness.fixed_postfit_ddcp_rms_m <=
+                                    kCandidateCarrierMaxRmsM;
+                            witness.candidate_integrity_anchor_available =
+                                anchor_available;
+                            witness.candidate_integrity_anchor_factors =
+                                validation_anchor.n_active;
+                            witness.candidate_integrity_anchor_rms_m =
+                                validation_anchor.res_rms;
+                            witness.candidate_integrity_anchor_separation_m =
+                                anchor_separation;
+                            witness.candidate_integrity_anchor_pass = anchor_pass;
+                            witness.candidate_integrity_imu_pass = imu_pass;
+                            witness.candidate_integrity_doppler_available =
+                                external_dr_available;
+                            witness.candidate_integrity_doppler_pass =
+                                external_dr_candidate_pass;
+                            witness.candidate_integrity_carrier_pass = carrier_pass;
+                            witness.candidate_integrity_witness_evaluated =
+                                anchor_available && external_dr_available;
+                            witness.candidate_integrity_composite_pass =
+                                witness.candidate_integrity_witness_evaluated &&
+                                anchor_pass && imu_pass &&
+                                external_dr_candidate_pass && carrier_pass;
                         }
 
                         // Integrity-aided aperture: the conventional
@@ -4638,7 +5023,8 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                             epoch_has_fixed[i] = true;
                         }
                         if ((config.monitor_external_doppler_dr ||
-                             config.use_external_doppler_dr_validation) &&
+                             config.use_external_doppler_dr_validation ||
+                             config.monitor_candidate_integrity_witness) &&
                             has_provisional_fixed_ant && has_provisional_fixed_cov &&
                             external_dr_velocity_valid &&
                             ratio >= config.external_doppler_dr_reset_min_ratio) {
@@ -5762,6 +6148,7 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 }
                 last_ddpr_rms = ddpr_rms;
                 last_ddpr_rms_epoch = static_cast<long long>(i);
+                runDdprGncCounterfactual();
                 continue;
             }
             if (ddpr_rms > config.cp_hold_main_residual_threshold_m) {
@@ -5978,6 +6365,17 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             last_ddpr_rms = ddpr_rms;
             last_ddpr_rms_epoch = static_cast<long long>(i);
         }
+        runDdprGncCounterfactual();
+    }
+    // Later warm resets can retroactively refresh positions still inside the
+    // lag window. Recompute candidate separation against the final reported
+    // FLOAT trajectory so the exported metric matches the solution CSV.
+    for (std::size_t i = 0; i < num_epochs; ++i) {
+        auto& diagnostic = epoch_diagnostics[i];
+        if (!diagnostic.ddpr_gnc_counterfactual_succeeded) continue;
+        diagnostic.ddpr_gnc_counterfactual_float_separation_m =
+            (diagnostic.ddpr_gnc_counterfactual_position_ecef -
+             Vector3d(epoch_float_position[i])).norm();
     }
     result.diagnostics.partial_lambda_ambiguity_fix_used = held_epoch_count > 0;
     result.diagnostics.ambiguity_hold_epochs = held_epoch_count;
@@ -5988,6 +6386,14 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
     result.diagnostics.iterations = static_cast<int>(result.diagnostics.smoother_updates);
     result.diagnostics.imu_intervals = num_epochs > 0 ? num_epochs - 1 : 0;
     result.diagnostics.lambda_ambiguity_ratio = best_ratio;
+    for (const auto& diagnostic : epoch_diagnostics) {
+        if (diagnostic.candidate_integrity_witness_evaluated) {
+            ++result.diagnostics.candidate_integrity_witness_evaluated;
+        }
+        if (diagnostic.candidate_integrity_composite_pass) {
+            ++result.diagnostics.candidate_integrity_witness_passes;
+        }
+    }
     {
         double weighted_sum_sq = 0.0;
         std::size_t count = 0;
@@ -6062,11 +6468,91 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 &fde_rejected_ambiguities_by_epoch);
     }
     if (config.monitor_predicted_ddpr_quality ||
-        config.monitor_predicted_ddpr_bias_state) {
+        config.monitor_predicted_ddpr_bias_state ||
+        config.monitor_satellite_quarantine_witness) {
+        const double quality_threshold =
+            config.monitor_satellite_quarantine_witness
+                ? config.satellite_quarantine_normalized_threshold
+                : 5.0;
         auto quality_rows = FGOProcessor::analyzePredictedDdprQualityShadow(
             problem, epoch_float_position, epoch_predicted_position,
-            config.single_difference_doppler_sigma_mps, 5.0,
+            config.single_difference_doppler_sigma_mps, quality_threshold,
             config.max_tdcp_gap_s);
+        if (config.monitor_satellite_quarantine_witness) {
+            struct TemporalEvidence {
+                bool doppler_evaluated = false;
+                bool doppler_outlier = false;
+                bool imu_evaluated = false;
+                bool imu_outlier = false;
+                int support_pairs = 0;
+            };
+            std::vector<std::map<SatelliteId, TemporalEvidence>> evidence(
+                num_epochs);
+            for (const auto& row : quality_rows) {
+                if (row.current_epoch_index >= num_epochs) continue;
+                const bool doppler_outlier = row.doppler_evaluated &&
+                    row.normalized_doppler_innovation > quality_threshold;
+                const bool imu_outlier = row.imu_geometry_evaluated &&
+                    row.normalized_imu_innovation > quality_threshold;
+                for (const SatelliteId satellite :
+                     {row.satellite, row.reference_satellite}) {
+                    auto& item = evidence[row.current_epoch_index][satellite];
+                    item.doppler_evaluated |= row.doppler_evaluated;
+                    item.doppler_outlier |= doppler_outlier;
+                    item.imu_evaluated |= row.imu_geometry_evaluated;
+                    item.imu_outlier |= imu_outlier;
+                    if (doppler_outlier && imu_outlier) {
+                        ++item.support_pairs;
+                    }
+                }
+            }
+            for (std::size_t epoch_index = 0; epoch_index < num_epochs;
+                 ++epoch_index) {
+                const auto& residuals =
+                    satellite_quarantine_postfit_residuals[epoch_index];
+                if (residuals.empty()) continue;
+                std::vector<double> ordered;
+                ordered.reserve(residuals.size());
+                for (const auto& [satellite, residual] : residuals) {
+                    (void)satellite;
+                    ordered.push_back(residual);
+                }
+                std::sort(ordered.begin(), ordered.end());
+                const double median = ordered[ordered.size() / 2];
+                for (const auto& [satellite, residual] : residuals) {
+                    FGOProcessor::SatelliteQuarantineWitnessDiagnostics row;
+                    row.epoch_index = epoch_index;
+                    row.satellite = satellite;
+                    row.postfit_ddpr_residual_m = residual;
+                    row.epoch_median_postfit_ddpr_residual_m = median;
+                    row.postfit_gross =
+                        residual > config.cp_hold_fast_worst_satellite_min_m &&
+                        (median <= 1e-9 ||
+                         residual >
+                             config.cp_hold_multipath_median_ratio * median);
+                    const auto temporal = evidence[epoch_index].find(satellite);
+                    if (temporal != evidence[epoch_index].end()) {
+                        row.doppler_evaluated =
+                            temporal->second.doppler_evaluated;
+                        row.doppler_outlier =
+                            temporal->second.doppler_outlier;
+                        row.imu_evaluated = temporal->second.imu_evaluated;
+                        row.imu_outlier = temporal->second.imu_outlier;
+                        row.temporal_support_pairs =
+                            temporal->second.support_pairs;
+                    }
+                    row.quarantine_candidate =
+                        row.postfit_gross && row.temporal_support_pairs > 0;
+                    ++result.diagnostics
+                          .satellite_quarantine_witness_satellites;
+                    if (row.quarantine_candidate) {
+                        ++result.diagnostics
+                              .satellite_quarantine_candidates;
+                    }
+                    result.satellite_quarantine_witnesses.push_back(row);
+                }
+            }
+        }
         if (config.monitor_predicted_ddpr_bias_state) {
             result.predicted_ddpr_bias_state_factors =
                 FGOProcessor::analyzePredictedDdprBiasStateShadow(

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -1526,7 +1526,8 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
     const bool use_ambiguity_generation_overlay =
         config.use_cp_hold_recovery ||
         config.use_continuous_unfix_ambiguity_reset ||
-        config.use_fde;
+        config.use_fde ||
+        config.use_selective_arc_restart;
     std::map<std::size_t, int> amb_generation;
     std::map<std::pair<std::size_t, int>, std::size_t> amb_symbol_id;
     // Epoch at which each pinned symbol's hold prior was created (keyed by
@@ -1571,6 +1572,26 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
     int cp_hold_counter = 0;         ///< remaining epochs with carrier suppressed (reference _recov_cp_hold)
     int cp_hold_release_streak = 0;  ///< consecutive clean epochs while held (reference _recov_cp_release_streak)
     std::set<SatelliteId> selective_cp_hold_bad_sats;
+    // --- Active selective arc restart (use_selective_arc_restart) ---
+    // Ambiguity indices armed by the epoch-i causal Doppler/IMU/post-fit
+    // quarantine agreement and applied to epoch i+1's carrier factor build,
+    // mirroring the selective_cp_hold arm/apply one-epoch delay. Only the
+    // implicated PAIR's ambiguity index is armed (the DD differencing cannot
+    // identify which endpoint is faulty, so both endpoints' trace rows point
+    // at this same arc); arcs sharing an armed reference are NOT touched.
+    // Cleared every epoch.
+    std::set<std::size_t> selective_arc_restart_armed_ambiguities;
+    // Last epoch at which each ambiguity index's generation was bumped by this
+    // mechanism, for the selective_arc_restart_min_epochs_since_bump thrash
+    // guard (only the selective-arc-restart path writes here).
+    std::map<std::size_t, std::size_t> selective_arc_restart_last_bump_epoch;
+    // Causal DD pseudorange pair history for the active quarantine detector:
+    // (satellite, reference, signal) -> previous epoch's factor. Keyed by the
+    // same triple as analyzePredictedDdprQualityShadow so the Doppler/IMU
+    // innovations are computed over consecutive epochs of the SAME pair.
+    using ArcRestartPairKey = std::tuple<SatelliteId, SatelliteId, SignalType>;
+    std::map<ArcRestartPairKey, const FGOProcessor::DoubleDifferencePseudorangeFactor*>
+        selective_arc_restart_prev_pair;
     // Consecutive bad epochs (reference _ddpr_bad_count). Double-valued (not
     // int) so use_cp_hold_leaky_persist's fractional decay (e.g. 0.25/0.5)
     // never loses precision; every write in the default (non-leaky) path
@@ -2619,6 +2640,51 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                 pinned_ambiguities.erase(old_sid);
                 live_ambiguity_indices.erase(idx);
                 continue;
+            }
+            // Active selective arc restart: if this DD carrier arc was armed
+            // at the previous epoch (the implicated pair's ambiguity index),
+            // restart ONLY that ambiguity generation (fresh symbol) here,
+            // preserving the DDPR factors and every clean carrier arc. The
+            // armed set was populated causally at epoch i-1 and is cleared
+            // every epoch.
+            if (config.use_selective_arc_restart &&
+                selective_arc_restart_armed_ambiguities.count(
+                    factor.ambiguity_index) > 0) {
+                const std::size_t idx = factor.ambiguity_index;
+                const auto lb = selective_arc_restart_last_bump_epoch.find(idx);
+                const bool thrash_ok =
+                    lb == selective_arc_restart_last_bump_epoch.end() ||
+                    (i - lb->second) >= static_cast<std::size_t>(
+                                           config.selective_arc_restart_min_epochs_since_bump);
+                const bool cap_ok =
+                    epoch_diagnostics[i].selective_arc_restart_applied_arcs <
+                    config.selective_arc_restart_max_arcs_per_epoch;
+                if (thrash_ok && cap_ok) {
+                    const std::size_t old_sid = ambSymbolId(idx);
+                    ++amb_generation[idx];
+                    selective_arc_restart_last_bump_epoch[idx] = i;
+                    pinned_ambiguities.erase(old_sid);
+                    ++result.diagnostics.ambiguity_generation_bumps;
+                    ++epoch_diagnostics[i].selective_arc_restart_applied_arcs;
+                    ++result.diagnostics.selective_arc_restart_applied_arcs;
+                    // Mark the corresponding detection-time trace rows applied
+                    // (target and reference roles for this ambiguity index).
+                    if (i > 0) {
+                        auto& prev_trace = epoch_diagnostics[i - 1].selective_arc_restart_trace;
+                        for (auto& row : prev_trace) {
+                            if (row.ambiguity_index == idx) row.applied = true;
+                        }
+                    }
+                    for (auto& row : result.selective_arc_restart_trace) {
+                        if (row.ambiguity_index == idx) row.applied = true;
+                    }
+                } else if (!thrash_ok) {
+                    ++epoch_diagnostics[i].selective_arc_restart_skipped_thrash;
+                    ++result.diagnostics.selective_arc_restart_skipped_thrash;
+                } else {
+                    ++epoch_diagnostics[i].selective_arc_restart_skipped_cap;
+                    ++result.diagnostics.selective_arc_restart_skipped_cap;
+                }
             }
             const auto& ambiguity = problem.ambiguity_states[factor.ambiguity_index];
             const std::size_t sym_idx = ambSymbolId(factor.ambiguity_index);
@@ -6366,6 +6432,239 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
             last_ddpr_rms_epoch = static_cast<long long>(i);
         }
         runDdprGncCounterfactual();
+
+        // --- Active selective arc-restart detection (use_selective_arc_restart
+        // / monitor_selective_arc_restart_candidates). Runs LAST so the causal
+        // Doppler/IMU innovations use the final float solution and this epoch's
+        // post-fit attribution. Arms satellites for the NEXT epoch's carrier
+        // factor build (one-epoch delay, mirroring selective_cp_hold). ---
+        if (config.use_selective_arc_restart ||
+            config.monitor_selective_arc_restart_candidates) {
+            selective_arc_restart_armed_ambiguities.clear();
+            auto& diagnostics = epoch_diagnostics[i];
+            diagnostics.selective_arc_restart_armed = false;
+            diagnostics.selective_arc_restart_monitor_only =
+                !config.use_selective_arc_restart;
+
+            const auto finite_position = [](const Vector3d& p) {
+                return p.allFinite() && p.norm() > 0.0;
+            };
+            const auto dd_range = [](const FGOProcessor::DoubleDifferencePseudorangeFactor& f,
+                                     const Vector3d& rover_position_ecef) {
+                const double rover_target =
+                    (f.rover_satellite_position_ecef - rover_position_ecef).norm();
+                const double rover_reference =
+                    (f.rover_reference_position_ecef - rover_position_ecef).norm();
+                const double base_target =
+                    (f.base_satellite_position_ecef - f.base_position_ecef).norm();
+                const double base_reference =
+                    (f.base_reference_position_ecef - f.base_position_ecef).norm();
+                return (rover_target - base_target) -
+                       (rover_reference - base_reference);
+            };
+            const auto dd_doppler = [](const FGOProcessor::DoubleDifferencePseudorangeFactor& f,
+                                       double& value) {
+                const auto& rt = f.rover_satellite_model;
+                const auto& rr = f.rover_reference_model;
+                const auto& bt = f.base_satellite_model;
+                const auto& br = f.base_reference_model;
+                if (!rt.has_doppler_residual || !rr.has_doppler_residual ||
+                    !bt.has_doppler_residual || !br.has_doppler_residual) {
+                    return false;
+                }
+                value = (rt.doppler_residual_mps - bt.doppler_residual_mps) -
+                        (rr.doppler_residual_mps - br.doppler_residual_mps);
+                return std::isfinite(value);
+            };
+
+            const double threshold = std::max(
+                0.0, config.satellite_quarantine_normalized_threshold);
+            const double safe_doppler_sigma = std::max(
+                1e-6, config.single_difference_doppler_sigma_mps);
+            const double gross_floor = config.cp_hold_fast_worst_satellite_min_m;
+            const double median_ratio = config.cp_hold_multipath_median_ratio;
+            const bool skip_fixed =
+                epoch_fixed[i] && epoch_ratio[i] >= config.selective_arc_restart_skip_fixed_ratio;
+
+            // Post-fit gross attribution median over the epoch's satellites.
+            std::vector<double> ordered_res;
+            ordered_res.reserve(per_sat_res.size());
+            for (const auto& [sat, residual] : per_sat_res) {
+                (void)sat;
+                ordered_res.push_back(residual);
+            }
+            std::sort(ordered_res.begin(), ordered_res.end());
+            const double epoch_median = ordered_res.empty()
+                                            ? 0.0
+                                            : ordered_res[ordered_res.size() / 2];
+
+            if (!skip_fixed && i > 0) {
+                std::map<ArcRestartPairKey, double> measured_change;
+                std::map<ArcRestartPairKey, double> doppler_innovation_norm;
+                std::map<ArcRestartPairKey, double> imu_innovation_norm;
+                for (const auto* factor : pr_by_epoch[i]) {
+                    const ArcRestartPairKey key{factor->satellite,
+                                                factor->reference_satellite,
+                                                factor->signal};
+                    const auto prev = selective_arc_restart_prev_pair.find(key);
+                    if (prev == selective_arc_restart_prev_pair.end()) continue;
+                    const auto* p = prev->second;
+                    const bool consecutive =
+                        p->epoch_index + 1 == i &&
+                        (problem.epochs[i].time - problem.epochs[i - 1].time) > 0.0;
+                    if (!consecutive) continue;
+                    measured_change[key] =
+                        factor->observed_dd_pseudorange_m - p->observed_dd_pseudorange_m;
+
+                    double cur_dd_doppler = 0.0, prev_dd_doppler = 0.0;
+                    const bool has_cur = dd_doppler(*factor, cur_dd_doppler);
+                    const bool has_prev = dd_doppler(*p, prev_dd_doppler);
+                    if (has_cur && has_prev) {
+                        const double predicted = 0.5 * (prev_dd_doppler + cur_dd_doppler) *
+                                                 (problem.epochs[i].time - problem.epochs[i - 1].time);
+                        const double innovation = measured_change[key] - predicted;
+                        const double sigma = std::hypot(
+                            std::sqrt(2.0) *
+                                (problem.epochs[i].time - problem.epochs[i - 1].time) *
+                                safe_doppler_sigma,
+                            std::hypot(p->sigma_m, factor->sigma_m));
+                        doppler_innovation_norm[key] =
+                            sigma > 0.0 ? std::abs(innovation) / sigma : 0.0;
+                    }
+                    if (i - 1 < epoch_float_position.size() &&
+                        finite_position(epoch_float_position[i - 1]) &&
+                        finite_position(epoch_predicted_position[i])) {
+                        const double predicted =
+                            dd_range(*factor, epoch_predicted_position[i]) -
+                            dd_range(*p, epoch_float_position[i - 1]);
+                        const double innovation = measured_change[key] - predicted;
+                        const double sigma = std::hypot(p->sigma_m, factor->sigma_m);
+                        imu_innovation_norm[key] =
+                            sigma > 0.0 ? std::abs(innovation) / sigma : 0.0;
+                    }
+                }
+
+                for (const auto* factor : pr_by_epoch[i]) {
+                    const ArcRestartPairKey key{factor->satellite,
+                                                factor->reference_satellite,
+                                                factor->signal};
+                    const auto dp = doppler_innovation_norm.find(key);
+                    const auto im = imu_innovation_norm.find(key);
+                    const bool doppler_outlier =
+                        dp != doppler_innovation_norm.end() && dp->second > threshold;
+                    const bool imu_outlier =
+                        im != imu_innovation_norm.end() && im->second > threshold;
+                    const bool innovations_agree =
+                        config.selective_arc_restart_require_both_innovations
+                            ? doppler_outlier && imu_outlier
+                            : doppler_outlier || imu_outlier;
+                    if (!innovations_agree) continue;
+
+                    // A DD pair cannot identify which endpoint is faulty, so
+                    // the pair is attributed to BOTH its target and reference
+                    // satellite. Require BOTH endpoints' post-fit attribution
+                    // to be gross, matching the witness's per-satellite rule.
+                    bool all_endpoints_gross = true;
+                    for (const SatelliteId satellite :
+                         {factor->satellite, factor->reference_satellite}) {
+                        const auto rit = per_sat_res.find(satellite);
+                        if (rit == per_sat_res.end()) {
+                            all_endpoints_gross = false;
+                            continue;
+                        }
+                        const bool absolute_gross = rit->second > gross_floor;
+                        const bool relative_gross =
+                            epoch_median <= 1e-9 ||
+                            rit->second > median_ratio * epoch_median;
+                        if (!absolute_gross || !relative_gross) {
+                            all_endpoints_gross = false;
+                        }
+                    }
+                    if (!all_endpoints_gross) continue;
+
+                    // A candidate pair is identified (Doppler + IMU + both
+                    // endpoints gross). Record it even when no live carrier arc
+                    // exists to restart -- that is a legitimate "detected but
+                    // not armable" outcome, not silence.
+                    ++diagnostics.selective_arc_restart_candidate_satellites;
+                    ++result.diagnostics.selective_arc_restart_candidate_satellites;
+                    std::size_t first_armed = std::numeric_limits<std::size_t>::max();
+                    for (const SatelliteId satellite :
+                         {factor->satellite, factor->reference_satellite}) {
+                        const auto rit = per_sat_res.find(satellite);
+                        for (const auto* cf : cp_by_epoch[i]) {
+                            if (cf->satellite == satellite ||
+                                cf->reference_satellite == satellite) {
+                                first_armed =
+                                    std::min(first_armed, cf->ambiguity_index);
+                            }
+                        }
+                        FGOProcessor::SelectiveArcRestartTrace trace;
+                        trace.detection_epoch = i;
+                        trace.satellite = satellite;
+                        trace.is_reference =
+                            satellite == factor->reference_satellite;
+                        trace.ambiguity_index = first_armed;
+                        trace.detected = true;
+                        trace.postfit_residual_m =
+                            rit != per_sat_res.end() ? rit->second : 0.0;
+                        trace.epoch_median_postfit_residual_m = epoch_median;
+                        trace.normalized_doppler_innovation =
+                            dp != doppler_innovation_norm.end() ? dp->second : 0.0;
+                        trace.normalized_imu_innovation =
+                            im != imu_innovation_norm.end() ? im->second : 0.0;
+                        diagnostics.selective_arc_restart_trace.push_back(trace);
+                        result.selective_arc_restart_trace.push_back(trace);
+                    }
+
+                    // Arm the ambiguity indices of every live DD carrier arc
+                    // that touches a candidate endpoint (as target or
+                    // reference). The PR pair itself may reference a
+                    // satellite that has no carrier arc in the graph this
+                    // epoch, so the armed set is the union over the carrier
+                    // factors actually present -- exactly the arcs a restart
+                    // could affect. If no carrier arc exists, the pair is
+                    // reported but nothing is armed (nothing to restart).
+                    bool armed_any = false;
+                    for (const SatelliteId satellite :
+                         {factor->satellite, factor->reference_satellite}) {
+                        for (const auto* cf : cp_by_epoch[i]) {
+                            if (cf->satellite == satellite ||
+                                cf->reference_satellite == satellite) {
+                                if (selective_arc_restart_armed_ambiguities.insert(
+                                        cf->ambiguity_index).second) {
+                                    ++diagnostics.selective_arc_restart_candidate_pairs;
+                                    ++result.diagnostics
+                                          .selective_arc_restart_candidate_pairs;
+                                }
+                                armed_any = true;
+                            }
+                        }
+                    }
+                    if (!armed_any) {
+                        ++result.diagnostics
+                              .selective_arc_restart_skipped_no_arc;
+                    }
+                }
+            }
+            if (!skip_fixed &&
+                diagnostics.selective_arc_restart_candidate_satellites > 0) {
+                diagnostics.selective_arc_restart_armed = true;
+                ++result.diagnostics.selective_arc_restart_detection_epochs;
+            } else if (skip_fixed) {
+                ++result.diagnostics.selective_arc_restart_skipped_fixed;
+                diagnostics.selective_arc_restart_skipped_fixed = 1;
+            }
+
+            // Maintain the causal pair history for the NEXT epoch.
+            std::map<ArcRestartPairKey, const FGOProcessor::DoubleDifferencePseudorangeFactor*>
+                next_prev_pair;
+            for (const auto* factor : pr_by_epoch[i]) {
+                next_prev_pair[{factor->satellite, factor->reference_satellite,
+                                factor->signal}] = factor;
+            }
+            selective_arc_restart_prev_pair = std::move(next_prev_pair);
+        }
     }
     // Later warm resets can retroactively refresh positions still inside the
     // lag window. Recompute candidate separation against the final reported

--- a/tests/test_fgo.cpp
+++ b/tests/test_fgo.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <libgnss++/algorithms/fgo.hpp>
+#include <libgnss++/algorithms/fgo_ddpr_gnc.hpp>
 #include <libgnss++/core/constants.hpp>
 
 #include <array>
@@ -9,6 +10,43 @@
 #include <vector>
 
 using namespace libgnss;
+
+TEST(FgoDdprGncTest, GraduatesToRobustWeightsAndSuppressesGrossOutlier) {
+    const std::vector<fgo_ddpr_gnc::Residual> residuals = {
+        {0.25, 1.0}, {0.5, 1.0}, {1.0, 1.0}, {20.0, 1.0}};
+
+    const auto result = fgo_ddpr_gnc::evaluate(residuals);
+
+    ASSERT_TRUE(result.evaluated);
+    ASSERT_EQ(result.weights.size(), residuals.size());
+    EXPECT_GT(result.stages, 1);
+    EXPECT_DOUBLE_EQ(result.final_mu, 1.0);
+    EXPECT_GT(result.weights[0], result.weights[1]);
+    EXPECT_GT(result.weights[1], result.weights[2]);
+    EXPECT_GT(result.weights[2], result.weights[3]);
+    EXPECT_LT(result.weights[3], 0.02);
+    EXPECT_NEAR(result.weights.back(),
+                4.0 / (4.0 + 400.0), 1e-12);
+    EXPECT_EQ(result.downweighted_factors, 1u);
+    EXPECT_LT(result.effective_factor_count,
+              static_cast<double>(residuals.size()));
+}
+
+TEST(FgoDdprGncTest, FailsClosedForInvalidSigmaOrSchedule) {
+    EXPECT_FALSE(fgo_ddpr_gnc::evaluate({{1.0, 0.0}}).evaluated);
+
+    fgo_ddpr_gnc::Config invalid;
+    invalid.graduation_divisor = 1.0;
+    EXPECT_FALSE(fgo_ddpr_gnc::evaluate({{1.0, 1.0}}, invalid).evaluated);
+}
+
+TEST(FgoDdprGncTest, DefaultScheduleReachesFinalKernelForUrbanScaleResidual) {
+    const auto result = fgo_ddpr_gnc::evaluate({{166.8, 1.0}});
+
+    ASSERT_TRUE(result.evaluated);
+    EXPECT_DOUBLE_EQ(result.final_mu, 1.0);
+    EXPECT_LT(result.stages, 32);
+}
 
 namespace {
 
@@ -807,6 +845,50 @@ TEST(FGOTest, ExternalDopplerDrMonitorMaterializesShadowFactorsOnly) {
 
     EXPECT_FALSE(problem.single_difference_doppler_factors.empty());
     EXPECT_FALSE(config.use_single_difference_doppler_factors);
+}
+
+TEST(FGOTest, CandidateIntegrityMonitorMaterializesShadowFactorsOnly) {
+    const NavigationData nav = makeSyntheticGpsNavigation(4);
+    const std::array<Vector3d, 2> rover_positions = {
+        Vector3d(1113194.0, -4841695.0, 3985350.0),
+        Vector3d(1113194.0, -4841695.0, 3985350.0),
+    };
+    const std::array<Vector3d, 2> base_positions = {
+        rover_positions[0] + Vector3d(-320.0, 180.0, 45.0),
+        rover_positions[1] + Vector3d(-320.0, 180.0, 45.0),
+    };
+    auto rover_epochs =
+        makeSyntheticDoubleDifferenceObservationEpochs(nav, rover_positions, 0.0);
+    auto base_epochs =
+        makeSyntheticDoubleDifferenceObservationEpochs(nav, base_positions, 0.0);
+    for (auto* epochs : {&rover_epochs, &base_epochs}) {
+        for (auto& epoch : *epochs) {
+            for (auto& observation : epoch.observations) {
+                observation.has_doppler = true;
+                observation.doppler = 0.0;
+            }
+        }
+    }
+
+    FGOProcessor::FGOConfig config;
+    config.use_spp_seed = false;
+    config.use_pseudorange_factors = false;
+    config.use_motion_factors = false;
+    config.use_tdcp_factors = false;
+    config.use_double_difference_factors = true;
+    config.use_single_difference_doppler_factors = false;
+    config.monitor_candidate_integrity_witness = true;
+    config.use_ionosphere_model = false;
+    config.use_troposphere_model = false;
+    config.min_elevation_deg = -90.0;
+    config.min_satellites_per_epoch = 2;
+
+    const auto problem = FGOProcessor(config).buildDoubleDifferenceProblem(
+        rover_epochs, base_epochs, nav, base_positions[0]);
+
+    EXPECT_FALSE(problem.single_difference_doppler_factors.empty());
+    EXPECT_FALSE(config.use_single_difference_doppler_factors);
+    EXPECT_FALSE(config.monitor_external_doppler_dr);
 }
 
 TEST(FGOTest, ClockResilientTemporalCarrierShadowCancelsCommonClockJump) {

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -535,6 +535,103 @@ TEST(FGOAmbiguityCandidateTelemetryTest, ReportsDisabledCandidateFunnel) {
     }
 }
 
+TEST(FgoDdprGncShadowTest, ReportsWeightsWithoutChangingEstimatorOutput) {
+    CpHoldTestOptions opt;
+    opt.num_epochs = 3;
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig baseline_config = makeCpHoldBaseConfig();
+    const auto baseline = FGOProcessor(baseline_config).optimizeProblem(problem);
+
+    auto shadow_config = baseline_config;
+    shadow_config.monitor_ddpr_gnc = true;
+    const auto shadow = FGOProcessor(shadow_config).optimizeProblem(problem);
+
+    ASSERT_EQ(baseline.solution.solutions.size(), shadow.solution.solutions.size());
+    ASSERT_EQ(shadow.epoch_diagnostics.size(), problem.epochs.size());
+    for (std::size_t i = 0; i < shadow.solution.solutions.size(); ++i) {
+        EXPECT_EQ(baseline.solution.solutions[i].status,
+                  shadow.solution.solutions[i].status);
+        EXPECT_DOUBLE_EQ(baseline.solution.solutions[i].ratio,
+                         shadow.solution.solutions[i].ratio);
+        EXPECT_TRUE(baseline.solution.solutions[i].position_ecef.isApprox(
+            shadow.solution.solutions[i].position_ecef, 0.0));
+
+        const auto& diagnostic = shadow.epoch_diagnostics[i];
+        EXPECT_TRUE(diagnostic.ddpr_gnc_evaluated);
+        EXPECT_EQ(diagnostic.ddpr_gnc_factor_count, 5);
+        EXPECT_GT(diagnostic.ddpr_gnc_stages, 0);
+        EXPECT_GT(diagnostic.ddpr_gnc_min_weight, 0.0);
+        EXPECT_LE(diagnostic.ddpr_gnc_min_weight, 1.0);
+        EXPECT_GT(diagnostic.ddpr_gnc_effective_factor_count, 0.0);
+        EXPECT_LE(diagnostic.ddpr_gnc_effective_factor_count,
+                  diagnostic.ddpr_gnc_factor_count);
+        ASSERT_EQ(diagnostic.ddpr_gnc_factor_trace.size(), 5u);
+        for (const auto& trace : diagnostic.ddpr_gnc_factor_trace) {
+            EXPECT_GT(trace.sigma_m, 0.0);
+            EXPECT_GE(trace.normalized_residual, 0.0);
+            EXPECT_GT(trace.weight, 0.0);
+            EXPECT_LE(trace.weight, 1.0);
+        }
+    }
+    EXPECT_EQ(shadow.diagnostics.ddpr_gnc_evaluated_epochs,
+              problem.epochs.size());
+    EXPECT_EQ(shadow.diagnostics.ddpr_gnc_factors,
+              problem.epochs.size() * 5);
+}
+
+TEST(FgoDdprGncCounterfactualTest,
+     AlternatingSolveRejectsOutlierWithoutChangingEstimatorOutput) {
+    CpHoldTestOptions opt;
+    opt.num_epochs = 3;
+    opt.pr_corrupt_epochs = {2};
+    opt.pr_dominant_extra_bias_m = 30.0;
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+
+    auto baseline_config = makeCpHoldBaseConfig();
+    const auto baseline = FGOProcessor(baseline_config).optimizeProblem(problem);
+
+    auto shadow_config = baseline_config;
+    shadow_config.monitor_ddpr_gnc_counterfactual = true;
+    const auto shadow = FGOProcessor(shadow_config).optimizeProblem(problem);
+
+    ASSERT_EQ(baseline.solution.solutions.size(), shadow.solution.solutions.size());
+    ASSERT_EQ(shadow.epoch_diagnostics.size(), problem.epochs.size());
+    for (std::size_t i = 0; i < shadow.solution.solutions.size(); ++i) {
+        EXPECT_EQ(baseline.solution.solutions[i].status,
+                  shadow.solution.solutions[i].status);
+        EXPECT_DOUBLE_EQ(baseline.solution.solutions[i].ratio,
+                         shadow.solution.solutions[i].ratio);
+        EXPECT_TRUE(baseline.solution.solutions[i].position_ecef.isApprox(
+            shadow.solution.solutions[i].position_ecef, 0.0));
+    }
+
+    const auto& diagnostic = shadow.epoch_diagnostics.back();
+    EXPECT_TRUE(diagnostic.ddpr_gnc_counterfactual_evaluated);
+    EXPECT_TRUE(diagnostic.ddpr_gnc_counterfactual_succeeded);
+    EXPECT_EQ(diagnostic.ddpr_gnc_counterfactual_factor_count, 15);
+    EXPECT_EQ(diagnostic.ddpr_gnc_counterfactual_stages,
+              shadow_config.ddpr_gnc_counterfactual_max_stages);
+    EXPECT_TRUE(diagnostic.ddpr_gnc_counterfactual_position_ecef.allFinite());
+    EXPECT_GT(diagnostic.ddpr_gnc_counterfactual_float_separation_m, 0.0);
+    EXPECT_NEAR(
+        diagnostic.ddpr_gnc_counterfactual_float_separation_m,
+        (diagnostic.ddpr_gnc_counterfactual_position_ecef -
+         shadow.solution.solutions.back().position_ecef).norm(),
+        1e-9);
+    EXPECT_TRUE(diagnostic.ddpr_gnc_counterfactual_lambda_evaluated);
+    EXPECT_EQ(diagnostic.ddpr_gnc_counterfactual_lambda_ambiguities, 5);
+    EXPECT_GT(diagnostic.ddpr_gnc_counterfactual_lambda_ratio, 0.0);
+    EXPECT_FALSE(diagnostic.ddpr_gnc_counterfactual_lambda_ratio_pass);
+    const Vector3d truth(1113194.0, -4841695.0, 3985350.0);
+    EXPECT_LT((diagnostic.ddpr_gnc_counterfactual_position_ecef - truth).norm(),
+              (baseline.solution.solutions.back().position_ecef - truth).norm());
+    EXPECT_EQ(shadow.diagnostics.ddpr_gnc_counterfactual_attempts,
+              problem.epochs.size());
+    EXPECT_EQ(shadow.diagnostics.ddpr_gnc_counterfactual_successes,
+              problem.epochs.size());
+}
+
 TEST(FGODisjointConstellationArShadowTest,
      ProducesTwoCandidatesWithoutChangingFixedLagSolution) {
     CpHoldTestOptions opt;
@@ -826,6 +923,75 @@ TEST(FGOPredictedDdprQualityShadowTest,
         EXPECT_TRUE(std::isfinite(row.posterior_bias_m));
         EXPECT_GT(row.measurement_sigma_m, 0.0);
     }
+}
+
+TEST(FGOSatelliteQuarantineShadowTest,
+     AttributesTwoStageOutlierWithoutChangingFixedLagSolution) {
+    CpHoldTestOptions opt;
+    opt.num_epochs = 3;
+    auto problem = makeCpHoldFixedLagProblem(opt);
+
+    for (auto& factor : problem.double_difference_pseudorange_factors) {
+        factor.rover_satellite_model.has_doppler_residual = true;
+        factor.rover_reference_model.has_doppler_residual = true;
+        factor.base_satellite_model.has_doppler_residual = true;
+        factor.base_reference_model.has_doppler_residual = true;
+        factor.rover_satellite_model.doppler_residual_mps = 0.0;
+        factor.rover_reference_model.doppler_residual_mps = 0.0;
+        factor.base_satellite_model.doppler_residual_mps = 0.0;
+        factor.base_reference_model.doppler_residual_mps = 0.0;
+    }
+
+    auto injected = std::find_if(
+        problem.double_difference_pseudorange_factors.begin(),
+        problem.double_difference_pseudorange_factors.end(),
+        [](const auto& factor) {
+            return factor.epoch_index == 2 && factor.satellite.prn == 2;
+        });
+    ASSERT_NE(injected, problem.double_difference_pseudorange_factors.end());
+    injected->rover_satellite_model.corrected_pseudorange_m += 30.0;
+    injected->observed_dd_pseudorange_m += 30.0;
+    const SatelliteId target = injected->satellite;
+    const SatelliteId reference = injected->reference_satellite;
+
+    FGOProcessor::FGOConfig off_config = makeCpHoldBaseConfig();
+    off_config.use_carrier_phase_factors = true;
+    const auto off_result = FGOProcessor(off_config).optimizeProblem(problem);
+
+    FGOProcessor::FGOConfig on_config = off_config;
+    on_config.monitor_satellite_quarantine_witness = true;
+    const auto on_result = FGOProcessor(on_config).optimizeProblem(problem);
+
+    ASSERT_EQ(off_result.solution.solutions.size(),
+              on_result.solution.solutions.size());
+    for (std::size_t i = 0; i < off_result.solution.solutions.size(); ++i) {
+        EXPECT_TRUE(off_result.solution.solutions[i].position_ecef.isApprox(
+            on_result.solution.solutions[i].position_ecef, 0.0));
+        EXPECT_EQ(off_result.solution.solutions[i].status,
+                  on_result.solution.solutions[i].status);
+        EXPECT_EQ(off_result.solution.solutions[i].ratio,
+                  on_result.solution.solutions[i].ratio);
+        EXPECT_EQ(off_result.solution.solutions[i].num_fixed_ambiguities,
+                  on_result.solution.solutions[i].num_fixed_ambiguities);
+    }
+    EXPECT_EQ(off_result.diagnostics.ambiguity_generation_bumps,
+              on_result.diagnostics.ambiguity_generation_bumps);
+
+    const auto isCandidate = [&](const SatelliteId satellite) {
+        return std::any_of(
+            on_result.satellite_quarantine_witnesses.begin(),
+            on_result.satellite_quarantine_witnesses.end(),
+            [&](const auto& row) {
+                return row.epoch_index == 2 && row.satellite == satellite &&
+                    row.postfit_gross && row.doppler_evaluated &&
+                    row.doppler_outlier && row.imu_evaluated &&
+                    row.imu_outlier && row.temporal_support_pairs > 0 &&
+                    row.quarantine_candidate;
+            });
+    };
+    EXPECT_TRUE(isCandidate(target));
+    EXPECT_TRUE(isCandidate(reference));
+    EXPECT_GE(on_result.diagnostics.satellite_quarantine_candidates, 2u);
 }
 
 TEST(FGOAmbiguityCandidateTelemetryTest,
@@ -2973,6 +3139,69 @@ TEST(FGOExternalDopplerDrShadowTest, MonitorDoesNotChangeSolutionAuthority) {
         [](const auto& epoch) { return epoch.external_dr_evaluated; }));
 }
 
+TEST(FGOCandidateIntegrityWitnessTest,
+     MonitorDoesNotChangeSolutionAuthorityAndEmitsEpochVerdicts) {
+    CpHoldTestOptions opt;
+    opt.satellites = lambdaCapableSatelliteGeometry();
+    opt.num_epochs = 12;
+    auto problem = makeCpHoldFixedLagProblem(opt);
+
+    const std::array<Vector3d, 4> line_of_sight = {
+        Vector3d::UnitX(), Vector3d::UnitY(), Vector3d::UnitZ(),
+        Vector3d(1.0, 1.0, 1.0).normalized(),
+    };
+    for (std::size_t epoch = 0; epoch < problem.epochs.size(); ++epoch) {
+        for (std::size_t row = 0; row < line_of_sight.size(); ++row) {
+            FGOProcessor::SingleDifferenceDopplerFactor factor;
+            factor.epoch_index = epoch;
+            factor.satellite = SatelliteId(
+                GNSSSystem::GPS, static_cast<uint8_t>(row + 2));
+            factor.reference_satellite = SatelliteId(GNSSSystem::GPS, 1);
+            factor.signal = SignalType::GPS_L1CA;
+            factor.los = line_of_sight[row];
+            factor.residual_mps = 0.0;
+            factor.sigma_mps = 0.1;
+            factor.elevation_rad = 0.7;
+            problem.single_difference_doppler_factors.push_back(factor);
+        }
+    }
+
+    FGOProcessor::FGOConfig off_config = makeFixDemoteBaseConfig();
+    const auto off_result = FGOProcessor(off_config).optimizeProblem(problem);
+
+    FGOProcessor::FGOConfig shadow_config = off_config;
+    shadow_config.monitor_candidate_integrity_witness = true;
+    shadow_config.external_doppler_dr_reset_min_ratio = 1.5;
+    const auto shadow_result =
+        FGOProcessor(shadow_config).optimizeProblem(problem);
+
+    ASSERT_EQ(off_result.solution.solutions.size(),
+              shadow_result.solution.solutions.size());
+    for (std::size_t i = 0; i < off_result.solution.solutions.size(); ++i) {
+        EXPECT_TRUE(off_result.solution.solutions[i].position_ecef.isApprox(
+            shadow_result.solution.solutions[i].position_ecef, 0.0));
+        EXPECT_EQ(off_result.solution.solutions[i].status,
+                  shadow_result.solution.solutions[i].status);
+    }
+    EXPECT_GT(shadow_result.diagnostics.candidate_integrity_witness_evaluated,
+              0u);
+    EXPECT_EQ(shadow_result.diagnostics.candidate_integrity_witness_evaluated,
+              static_cast<std::size_t>(std::count_if(
+                  shadow_result.epoch_diagnostics.begin(),
+                  shadow_result.epoch_diagnostics.end(),
+                  [](const auto& epoch) {
+                      return epoch.candidate_integrity_witness_evaluated;
+                  })));
+    EXPECT_TRUE(std::any_of(
+        shadow_result.epoch_diagnostics.begin(),
+        shadow_result.epoch_diagnostics.end(),
+        [](const auto& epoch) {
+            return epoch.candidate_integrity_witness_evaluated &&
+                   epoch.candidate_integrity_anchor_available &&
+                   epoch.candidate_integrity_doppler_available;
+        }));
+}
+
 TEST(FGOMotionConstraintShadowTest,
      DirectionalVibrationIsVisibleAndMonitorDoesNotChangeSolution) {
     CpHoldTestOptions opt;
@@ -3523,6 +3752,64 @@ TEST(FGOFixDemoteTest, PostHoldCooldownDemotesFixesRightAfterRelease) {
     EXPECT_EQ(on_result.solution.solutions[problem.epochs.size() - 1].status,
               SolutionStatus::FIXED)
         << "fixes far past the cooldown keep their FIXED label";
+}
+
+TEST(FGOCpHoldFloatRecoveryTest,
+     KeepsWeakCarrierFactorsButQuarantinesTheirAmbiguitiesDuringHold) {
+    CpHoldTestOptions opt;
+    opt.satellites = lambdaCapableSatelliteGeometry();
+    opt.num_epochs = 30;
+    for (std::size_t epoch = 10; epoch <= 12; ++epoch) {
+        opt.carrier_corrupt_epochs.insert(epoch);
+    }
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig legacy = makeFixDemoteBaseConfig();
+    legacy.use_cp_hold_recovery = true;
+    legacy.cp_hold_main_residual_threshold_m = 3.0;
+    legacy.cp_hold_persist_epochs = 3;
+    legacy.cp_hold_catastrophic_threshold_m = 1.0e6;
+    legacy.cp_hold_multipath_median_ratio = 0.0;
+    legacy.cp_hold_max_gdop = 0.0;
+    legacy.cp_hold_epochs = 3;
+    legacy.cp_hold_release_threshold_m = 2.0;
+    legacy.cp_hold_release_count = 1;
+
+    const auto legacy_result = FGOProcessor(legacy).optimizeProblem(problem);
+    ASSERT_GT(legacy_result.diagnostics.cp_hold_epochs_held, 0u);
+    EXPECT_TRUE(std::any_of(
+        legacy_result.epoch_diagnostics.begin(),
+        legacy_result.epoch_diagnostics.end(),
+        [](const auto& epoch) {
+            return epoch.carrier_hold_active &&
+                   epoch.carrier_factors_suppressed_hold > 0 &&
+                   epoch.carrier_factors_added == 0;
+        }));
+
+    FGOProcessor::FGOConfig recovery = legacy;
+    recovery.use_cp_hold_float_recovery = true;
+    const auto recovery_result =
+        FGOProcessor(recovery).optimizeProblem(problem);
+
+    EXPECT_TRUE(std::any_of(
+        recovery_result.epoch_diagnostics.begin(),
+        recovery_result.epoch_diagnostics.end(),
+        [](const auto& epoch) {
+            return epoch.carrier_hold_active &&
+                   epoch.carrier_factors_added > 0 &&
+                   epoch.carrier_factors_suppressed_hold == 0 &&
+                   epoch.ambiguity_candidates_excluded_hold ==
+                       epoch.carrier_factors_added &&
+                   epoch.ambiguity_candidates_after_hold == 0 &&
+                   epoch.lambda_attempts == 0;
+        }));
+    for (std::size_t i = 0;
+         i < recovery_result.solution.solutions.size(); ++i) {
+        if (recovery_result.epoch_diagnostics[i].carrier_hold_active) {
+            EXPECT_NE(recovery_result.solution.solutions[i].status,
+                      SolutionStatus::FIXED);
+        }
+    }
 }
 
 TEST(FGOFixDemoteTest, ExtremeThresholdNeverPinsAndDemotesEveryFix) {

--- a/tests/test_fgo_gtsam_backend.cpp
+++ b/tests/test_fgo_gtsam_backend.cpp
@@ -994,6 +994,157 @@ TEST(FGOSatelliteQuarantineShadowTest,
     EXPECT_GE(on_result.diagnostics.satellite_quarantine_candidates, 2u);
 }
 
+TEST(FGOSelectiveArcRestartTest,
+     OffOnSolutionsAreBitIdenticalWhenNoQuarantineCandidateFires) {
+    CpHoldTestOptions opt;
+    opt.num_epochs = 3;
+    const auto problem = makeCpHoldFixedLagProblem(opt);
+
+    FGOProcessor::FGOConfig off_config = makeCpHoldBaseConfig();
+    off_config.use_carrier_phase_factors = true;
+    const auto off_result = FGOProcessor(off_config).optimizeProblem(problem);
+
+    FGOProcessor::FGOConfig on_config = off_config;
+    on_config.use_selective_arc_restart = true;
+    const auto on_result = FGOProcessor(on_config).optimizeProblem(problem);
+
+    ASSERT_EQ(off_result.solution.solutions.size(),
+              on_result.solution.solutions.size());
+    for (std::size_t i = 0; i < off_result.solution.solutions.size(); ++i) {
+        EXPECT_TRUE(off_result.solution.solutions[i].position_ecef.isApprox(
+            on_result.solution.solutions[i].position_ecef, 0.0));
+        EXPECT_EQ(off_result.solution.solutions[i].status,
+                  on_result.solution.solutions[i].status);
+        EXPECT_EQ(off_result.solution.solutions[i].ratio,
+                  on_result.solution.solutions[i].ratio);
+        EXPECT_EQ(off_result.solution.solutions[i].num_fixed_ambiguities,
+                  on_result.solution.solutions[i].num_fixed_ambiguities);
+    }
+    EXPECT_EQ(off_result.diagnostics.ambiguity_generation_bumps,
+              on_result.diagnostics.ambiguity_generation_bumps);
+    EXPECT_EQ(on_result.diagnostics.selective_arc_restart_applied_arcs, 0u);
+    EXPECT_EQ(on_result.diagnostics.selective_arc_restart_detection_epochs, 0u);
+}
+
+TEST(FGOSelectiveArcRestartTest,
+     SyntheticGrossJumpArmsImplicatedPairAndRestartsOnlyItsArc) {
+    CpHoldTestOptions opt;
+    opt.num_epochs = 4;
+    auto problem = makeCpHoldFixedLagProblem(opt);
+
+    for (auto& factor : problem.double_difference_pseudorange_factors) {
+        factor.rover_satellite_model.has_doppler_residual = true;
+        factor.rover_reference_model.has_doppler_residual = true;
+        factor.base_satellite_model.has_doppler_residual = true;
+        factor.base_reference_model.has_doppler_residual = true;
+        factor.rover_satellite_model.doppler_residual_mps = 0.0;
+        factor.rover_reference_model.doppler_residual_mps = 0.0;
+        factor.base_satellite_model.doppler_residual_mps = 0.0;
+        factor.base_reference_model.doppler_residual_mps = 0.0;
+    }
+
+    auto injected = std::find_if(
+        problem.double_difference_pseudorange_factors.begin(),
+        problem.double_difference_pseudorange_factors.end(),
+        [](const auto& factor) {
+            return factor.epoch_index == 2 && factor.satellite.prn == 2;
+        });
+    ASSERT_NE(injected, problem.double_difference_pseudorange_factors.end());
+    injected->rover_satellite_model.corrected_pseudorange_m += 30.0;
+    injected->observed_dd_pseudorange_m += 30.0;
+
+    FGOProcessor::FGOConfig off_config = makeCpHoldBaseConfig();
+    off_config.use_carrier_phase_factors = true;
+    const auto off_result = FGOProcessor(off_config).optimizeProblem(problem);
+
+    FGOProcessor::FGOConfig on_config = off_config;
+    on_config.use_selective_arc_restart = true;
+    on_config.selective_arc_restart_skip_fixed_ratio = 1000.0;
+    on_config.selective_arc_restart_max_arcs_per_epoch = 16;
+    const auto on_result = FGOProcessor(on_config).optimizeProblem(problem);
+
+    // Detection fired at epoch 2 and the implicated pair's arc was restarted
+    // at epoch 3.
+    EXPECT_GE(on_result.diagnostics.selective_arc_restart_detection_epochs, 1u);
+    EXPECT_GE(on_result.diagnostics.selective_arc_restart_applied_arcs, 1u);
+    EXPECT_EQ(on_result.diagnostics.selective_arc_restart_skipped_fixed, 0u);
+    EXPECT_GT(on_result.diagnostics.ambiguity_generation_bumps,
+              off_result.diagnostics.ambiguity_generation_bumps);
+
+    // Exactly the ambiguity index whose DD pair was injected was armed.
+    const auto& epoch2 = on_result.epoch_diagnostics[2];
+    EXPECT_TRUE(epoch2.selective_arc_restart_armed);
+    EXPECT_GE(epoch2.selective_arc_restart_candidate_pairs, 1);
+    ASSERT_GE(epoch2.selective_arc_restart_trace.size(), 2u);
+    const std::size_t armed_index = epoch2.selective_arc_restart_trace[0].ambiguity_index;
+    for (const auto& row : epoch2.selective_arc_restart_trace) {
+        EXPECT_EQ(row.ambiguity_index, armed_index);
+        EXPECT_TRUE(row.detected);
+        EXPECT_GT(row.postfit_residual_m, 10.0);
+        EXPECT_GT(row.normalized_doppler_innovation, 5.0);
+        EXPECT_GT(row.normalized_imu_innovation, 5.0);
+    }
+
+    // The apply marked the detection trace rows applied at epoch 3; with the
+    // cap raised above the armed-arc count, every armed arc was restarted.
+    EXPECT_EQ(on_result.epoch_diagnostics[3].selective_arc_restart_applied_arcs,
+              static_cast<int>(epoch2.selective_arc_restart_candidate_pairs));
+    EXPECT_GT(on_result.epoch_diagnostics[3].selective_arc_restart_applied_arcs, 0);
+    for (const auto& row : on_result.selective_arc_restart_trace) {
+        if (row.detection_epoch == 2) {
+            EXPECT_TRUE(row.applied);
+        }
+    }
+}
+
+TEST(FGOSelectiveArcRestartTest,
+     MonitorOnlyReportsCandidatesWithoutBumpingAnyGeneration) {
+    CpHoldTestOptions opt;
+    opt.num_epochs = 4;
+    auto problem = makeCpHoldFixedLagProblem(opt);
+
+    for (auto& factor : problem.double_difference_pseudorange_factors) {
+        factor.rover_satellite_model.has_doppler_residual = true;
+        factor.rover_reference_model.has_doppler_residual = true;
+        factor.base_satellite_model.has_doppler_residual = true;
+        factor.base_reference_model.has_doppler_residual = true;
+        factor.rover_satellite_model.doppler_residual_mps = 0.0;
+        factor.rover_reference_model.doppler_residual_mps = 0.0;
+        factor.base_satellite_model.doppler_residual_mps = 0.0;
+        factor.base_reference_model.doppler_residual_mps = 0.0;
+    }
+    auto injected = std::find_if(
+        problem.double_difference_pseudorange_factors.begin(),
+        problem.double_difference_pseudorange_factors.end(),
+        [](const auto& factor) {
+            return factor.epoch_index == 2 && factor.satellite.prn == 2;
+        });
+    ASSERT_NE(injected, problem.double_difference_pseudorange_factors.end());
+    injected->rover_satellite_model.corrected_pseudorange_m += 30.0;
+    injected->observed_dd_pseudorange_m += 30.0;
+
+    FGOProcessor::FGOConfig off_config = makeCpHoldBaseConfig();
+    off_config.use_carrier_phase_factors = true;
+    const auto off_result = FGOProcessor(off_config).optimizeProblem(problem);
+
+    FGOProcessor::FGOConfig monitor_config = off_config;
+    monitor_config.monitor_selective_arc_restart_candidates = true;
+    const auto monitor_result =
+        FGOProcessor(monitor_config).optimizeProblem(problem);
+
+    EXPECT_GE(monitor_result.diagnostics.selective_arc_restart_detection_epochs, 1u);
+    EXPECT_EQ(monitor_result.diagnostics.selective_arc_restart_applied_arcs, 0u);
+    EXPECT_TRUE(monitor_result.epoch_diagnostics[2].selective_arc_restart_armed);
+    EXPECT_TRUE(monitor_result.epoch_diagnostics[2]
+                    .selective_arc_restart_monitor_only);
+    EXPECT_EQ(monitor_result.diagnostics.ambiguity_generation_bumps,
+              off_result.diagnostics.ambiguity_generation_bumps);
+    for (std::size_t i = 0; i < off_result.solution.solutions.size(); ++i) {
+        EXPECT_TRUE(off_result.solution.solutions[i].position_ecef.isApprox(
+            monitor_result.solution.solutions[i].position_ecef, 0.0));
+    }
+}
+
 TEST(FGOAmbiguityCandidateTelemetryTest,
      ReportsFinalCandidatesAtInsufficientCountDecision) {
     CpHoldTestOptions opt;


### PR DESCRIPTION
$(cat <<'EOF'