### PR TITLE
Add low-count AR separation witness + correct wrong-FIX root cause

### DIFF
--- a/apps/native/gnss_fgo_parity.cpp
+++ b/apps/native/gnss_fgo_parity.cpp
@@ -231,6 +231,9 @@ struct Args {
     int low_count_ar_min = -1;        // >0: override low_count_min_candidates (default 4)
     double low_count_ar_ratio = -1.0; // >=0: override low_count_min_ratio (default 1.5); use --low-count-ratio 0 for "surplus alone"
     bool low_count_relax_surplus_quality = false;  // exempt low-count from nsat>=10/ddcp>=4 arms
+    bool low_count_require_separation_witness = false;  // require float/IMU separation for low-count fix
+    double low_count_max_float_sep_m = 0.1;
+    double low_count_max_imu_pred_sep_m = 0.1;
     std::string dump_csv_path;  // debug: per-epoch CSV dump (tow/status/E-N-U err/position) for plotting
     // Opt-in FGOProblem cache (skips repeated RINEX parse + problem build
     // across validation runs on the SAME inputs/config). Default-off; when
@@ -448,6 +451,18 @@ Args parseArgs(int argc, char** argv) {
         }
         if (a == "--low-count-relax-surplus-quality") {
             args.low_count_relax_surplus_quality = true;
+            continue;
+        }
+        if (a == "--low-count-require-separation-witness") {
+            args.low_count_require_separation_witness = true;
+            continue;
+        }
+        if (a == "--low-count-max-float-sep" && i + 1 < argc) {
+            args.low_count_max_float_sep_m = std::stod(argv[++i]);
+            continue;
+        }
+        if (a == "--low-count-max-imu-pred-sep" && i + 1 < argc) {
+            args.low_count_max_imu_pred_sep_m = std::stod(argv[++i]);
             continue;
         }
         if (a == "--adaptive-ratio") {
@@ -1038,6 +1053,11 @@ libgnss::FGOProcessor::FGOConfig buildFgoConfig(const Args& args) {
     }
     if (args.low_count_relax_surplus_quality) {
         config.low_count_relax_surplus_quality = true;
+    }
+    if (args.low_count_require_separation_witness) {
+        config.low_count_require_separation_witness = true;
+        config.low_count_max_float_separation_m = args.low_count_max_float_sep_m;
+        config.low_count_max_imu_prediction_separation_m = args.low_count_max_imu_pred_sep_m;
     }
     if (args.no_gal_ar) {
         config.exclude_galileo_ambiguity_fixing = true;

--- a/docs/development_backlog.md
+++ b/docs/development_backlog.md
@@ -26,15 +26,23 @@ per-system alpha" listed as not pursued).
 - Open (future): full 3-city A/B and the usual bars if activation is ever
   desired; no preset promotion without a fresh run1-only plan.
 
-## 2. Low-count AR surplus-quality relaxation — DESIGN-SLICE PASSED
+## 2. Low-count AR surplus-quality relaxation — NOT ACTIVATED (root cause corrected)
 
 - Implemented in PR #438: `--low-count-relax-surplus-quality` (default OFF).
   Corrects the prior falsification that scored against `ref_e_pos_m`.
 - Design slice (Tokyo run1 5000--5499): FIX 333->335 (+2 at 0.021/0.032 m),
-  zero wrong FIX, FIXED RMS unchanged. The +12.1% wall comes from the
-  low-count attempts.
-- **In progress**: full run1 A/B to establish the activation bar and the
-  run2/run3 pathway.
+  zero wrong FIX, FIXED RMS unchanged.
+- Full run1 (2026-08-08): FIX 6409->6423 but wrong FIX>0.5m 971->976.
+  Corrective control (relax OFF) shows `--low-count-ar` alone gives the same
+  976 -- the +5 wrong FIX is from the low-count path itself, NOT the
+  relaxation. A separation witness
+  (`--low-count-require-separation-witness`, default OFF; float/IMU
+  separation <= 0.1 m) rejects the one low-count wrong fix (e3006) and drops
+  the delta to +4, but the remaining +4 are `low_count_used=0` graph-side
+  effects it cannot gate.
+- Conclusion: neither the relaxation nor the witness is activated; the
+  low-count AR path itself needs an independent gate before any activation.
+  Sealed run2/run3 untouched.
 
 ## 3. PPC submission pipeline (user-decision item)
 

--- a/docs/fgo_low_count_relax_surplus_quality_plan.md
+++ b/docs/fgo_low_count_relax_surplus_quality_plan.md
@@ -56,7 +56,7 @@ attempts (48 in the slice), not the relaxation itself. The formal
 activation bar for the combined low-count path (wall <= +10%) is not met on
 this slice, so the pair is reported but not made a default preset.
 
-## Full run1 result: falsified
+## Full run1 result: falsified (corrected)
 
 The frozen full Tokyo run1 (11905 epochs) A/B with the same profile OFF vs
 `--low-count-ar --low-count-min 3 --low-count-relax-surplus-quality`:
@@ -85,6 +85,41 @@ sealed run2/run3 holdout is spent. A future safe version would need the
 relaxation to also require an independent witness (e.g. the DDPR-LS anchor or
 a Doppler-DR pass) that the design-slice epochs happened to have but the
 full-run wrong fixes do not.
+
+## Corrective A/B: the +5 wrong FIX is from low-count AR itself, not the relaxation
+
+A full-run1 control with `--low-count-ar --low-count-min 3` **without**
+`--low-count-relax-surplus-quality` gives the same wrong-FIX count:
+
+| Configuration | FIX | wrong FIX > 0.5 m | accepted |
+|---|---:|---:|---:|
+| OFF | 6409 | 971 | - |
+| `--low-count-ar` (no relax) | 6415 | **976** | 3 |
+| `--low-count-ar` + relax | 6423 | 976 | 34 |
+| `--low-count-ar` + relax + separation witness | 6422 | **975** | 33 |
+
+The wrong FIX delta over OFF is +5 in the **no-relax** control too, so
+`low_count_relax_surplus_quality` does not add wrong FIX by itself; the
+`use_low_count_ambiguity_resolution` path is the wrong-FIX source. The four
+non-low-count wrong fixes (8336, 8710, 8753, 8754, all `low_count_used=0`,
+already FLOAT > 0.5 m in OFF) appear identically in the no-relax control, so
+they are a low-count-AR graph-side effect, not the relaxation.
+
+A separation witness was implemented and evaluated: a low-count fix must
+additionally satisfy `fixed_float_separation_m <= 0.1` and
+`fixed_imu_prediction_separation_m <= 0.1`
+(`--low-count-require-separation-witness`, default OFF). Every correct
+low-count fix in full run1 has both separations <= 0.059 m; the one
+low-count wrong fix (e3006) has 0.549 / 0.488 m, so the witness rejects it,
+dropping the low-count wrong FIX to +4 over OFF (975). The remaining +4 are
+`low_count_used=0` epochs the witness cannot gate.
+
+Conclusion (corrected): the surplus-quality relaxation is not the wrong-FIX
+culprit; `--low-count-ar` itself needs the separation witness (or another
+independent gate) before any activation, and even then the +4
+`low_count_used=0` wrong FIX from the graph-side effect must be understood.
+Neither the relaxation nor the witness is activated as a default; sealed
+run2/run3 remain untouched.
 
 ## Gate 0
 

--- a/include/libgnss++/algorithms/fgo.hpp
+++ b/include/libgnss++/algorithms/fgo.hpp
@@ -606,6 +606,18 @@ public:
         // OFF; when off the established floors are unchanged and the behavior
         // is byte-identical.
         bool low_count_relax_surplus_quality = false;
+        // Independent-separation witness for low-count fixes. A full-run1 A/B
+        // showed that relaxing the surplus-quality floors admits one wrong
+        // fix (float/IMU separation 0.49-0.55 m) while every correct
+        // low-count fix has float and IMU prediction separation <= 0.059 m.
+        // When this knob is on, a low-count fix additionally requires
+        // fixed_float_separation_m <= low_count_max_float_separation_m AND
+        // fixed_imu_prediction_separation_m <=
+        // low_count_max_imu_prediction_separation_m. Default OFF (bit-identical
+        // when off); recommended to combine with low_count_relax_surplus_quality.
+        bool low_count_require_separation_witness = false;
+        double low_count_max_float_separation_m = 0.1;
+        double low_count_max_imu_prediction_separation_m = 0.1;
         double max_tdcp_gap_s = 2.0;
         double base_epoch_match_tolerance_s = 0.02;
         double base_interpolation_max_gap_s = 1.2;

--- a/src/algorithms/fgo_gtsam_backend.cpp
+++ b/src/algorithms/fgo_gtsam_backend.cpp
@@ -4966,7 +4966,16 @@ static FGOProcessor::FGOResult optimizeProblemFixedLag(
                             (config.low_count_min_ratio <= 0.0 ||
                              ratio > config.low_count_min_ratio) &&
                             surplus_evaluated && surplus_pass &&
-                            surplus_rescue_quality_pass;
+                            surplus_rescue_quality_pass &&
+                            (!config.low_count_require_separation_witness ||
+                             (std::isfinite(
+                                  epoch_diagnostics[i].fixed_float_separation_m) &&
+                              epoch_diagnostics[i].fixed_float_separation_m <=
+                                  config.low_count_max_float_separation_m &&
+                              std::isfinite(
+                                  epoch_diagnostics[i].fixed_imu_prediction_separation_m) &&
+                              epoch_diagnostics[i].fixed_imu_prediction_separation_m <=
+                                  config.low_count_max_imu_prediction_separation_m));
                         const bool fixed_decision_pass = std::isfinite(ratio) &&
                             (is_low_count_attempt
                                  ? low_count_pass

--- a/tests/test_fgo.cpp
+++ b/tests/test_fgo.cpp
@@ -2339,8 +2339,13 @@ TEST(FGOTest, LowCountRelaxSurplusQualityIsDefaultOffAndIndependent) {
     const FGOProcessor::FGOConfig config;
     EXPECT_FALSE(config.use_low_count_ambiguity_resolution);
     EXPECT_FALSE(config.low_count_relax_surplus_quality);
+    EXPECT_FALSE(config.low_count_require_separation_witness);
     EXPECT_EQ(config.low_count_min_candidates, 4);
-    // The relaxation is inert unless the low-count path is also enabled.
+    EXPECT_DOUBLE_EQ(config.low_count_max_float_separation_m, 0.1);
+    EXPECT_DOUBLE_EQ(config.low_count_max_imu_prediction_separation_m, 0.1);
+    // The relaxation and witness are inert unless the low-count path is on.
     EXPECT_FALSE(config.low_count_relax_surplus_quality &&
+                 !config.use_low_count_ambiguity_resolution);
+    EXPECT_FALSE(config.low_count_require_separation_witness &&
                  !config.use_low_count_ambiguity_resolution);
 }


### PR DESCRIPTION
$(cat <<'EOF'