### PR TITLE
refactor: share receiver input handling

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -189,6 +189,7 @@ install(FILES
 
 install(FILES
     ${CMAKE_CURRENT_SOURCE_DIR}/commands/support/__init__.py
+    ${CMAKE_CURRENT_SOURCE_DIR}/commands/support/gnss_input_source.py
     ${CMAKE_CURRENT_SOURCE_DIR}/commands/support/gnss_runtime.py
     ${CMAKE_CURRENT_SOURCE_DIR}/commands/support/gnss_toml_config.py
     DESTINATION ${CMAKE_INSTALL_BINDIR}/support

--- a/apps/commands/receivers/gnss_binex_info.py
+++ b/apps/commands/receivers/gnss_binex_info.py
@@ -5,19 +5,21 @@ from __future__ import annotations
 
 import argparse
 import binascii
-import errno
 import os
+import sys
 from dataclasses import dataclass
 
-if os.name != "nt":
-    import termios
+try:
+    from support.gnss_input_source import InputSource
+except ModuleNotFoundError:
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from support.gnss_input_source import InputSource
 
 
 BINEX_SYNC_BIG_ENDIAN_REGULAR = 0xE2
 BINEX_RECORD_METADATA = 0x00
 BINEX_RECORD_NAV = 0x01
 BINEX_RECORD_PROTO = 0x7F
-DEFAULT_SERIAL_BAUD = 115200
 
 
 @dataclass
@@ -70,76 +72,6 @@ def parse_args() -> argparse.Namespace:
         help="Suppress per-record printing and show only the summary.",
     )
     return parser.parse_args()
-
-
-def parse_serial_path(path: str) -> tuple[str, int]:
-    raw = path[len("serial://") :] if path.startswith("serial://") else path
-    if "?baud=" in raw:
-        device, baud_text = raw.split("?baud=", 1)
-        return device, int(baud_text)
-    return raw, DEFAULT_SERIAL_BAUD
-
-
-def configure_serial(fd: int, baud: int) -> None:
-    if os.name == "nt":
-        raise RuntimeError("serial input is not supported on this platform")
-    baud_map = {
-        9600: termios.B9600,
-        19200: termios.B19200,
-        38400: termios.B38400,
-        57600: termios.B57600,
-        115200: termios.B115200,
-        230400: termios.B230400,
-    }
-    if baud not in baud_map:
-        raise ValueError(f"unsupported serial baud rate: {baud}")
-    attrs = termios.tcgetattr(fd)
-    attrs[0] = 0
-    attrs[1] = 0
-    attrs[2] = termios.CLOCAL | termios.CREAD | termios.CS8
-    attrs[3] = 0
-    attrs[4] = baud_map[baud]
-    attrs[5] = baud_map[baud]
-    attrs[6][termios.VMIN] = 1
-    attrs[6][termios.VTIME] = 0
-    termios.tcsetattr(fd, termios.TCSANOW, attrs)
-
-
-class InputSource:
-    def __init__(self, path: str) -> None:
-        self.path = path
-        self.handle = None
-        self.fd: int | None = None
-
-    def open(self) -> bool:
-        if self.path.startswith("serial://") or self.path.startswith("/dev/tty"):
-            device, baud = parse_serial_path(self.path)
-            fd = os.open(device, os.O_RDONLY | os.O_NOCTTY)
-            configure_serial(fd, baud)
-            self.fd = fd
-            return True
-        self.handle = open(self.path, "rb")
-        return True
-
-    def close(self) -> None:
-        if self.handle is not None:
-            self.handle.close()
-            self.handle = None
-        if self.fd is not None:
-            os.close(self.fd)
-            self.fd = None
-
-    def read(self, size: int = 4096) -> bytes:
-        if self.handle is not None:
-            return self.handle.read(size)
-        if self.fd is not None:
-            try:
-                return os.read(self.fd, size)
-            except OSError as exc:
-                if exc.errno == errno.EIO:
-                    return b""
-                raise
-        return b""
 
 
 def decode_ubnxi(buffer: bytes, offset: int) -> tuple[int, int] | None:

--- a/apps/commands/receivers/gnss_nmea_info.py
+++ b/apps/commands/receivers/gnss_nmea_info.py
@@ -9,8 +9,11 @@ from dataclasses import dataclass
 from pathlib import Path
 import sys
 
-if os.name != "nt":
-    import termios
+try:
+    from support.gnss_input_source import InputSource, NMEA_SERIAL_BAUDS
+except ModuleNotFoundError:
+    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+    from support.gnss_input_source import InputSource, NMEA_SERIAL_BAUDS
 
 
 @dataclass
@@ -74,75 +77,6 @@ def parse_args() -> argparse.Namespace:
         help="Suppress per-sentence printing and show only the summary.",
     )
     return parser.parse_args()
-
-
-def parse_serial_path(path: str) -> tuple[str, int]:
-    default_baud = 9600
-    if path.startswith("serial://"):
-        raw = path[len("serial://"):]
-    else:
-        raw = path
-    if "?baud=" in raw:
-        device, baud_text = raw.split("?baud=", 1)
-        return device, int(baud_text)
-    return raw, default_baud
-
-
-def configure_serial(fd: int, baud: int) -> None:
-    if os.name == "nt":
-        raise RuntimeError("serial input is not supported on this platform")
-    baud_map = {
-        4800: termios.B4800,
-        9600: termios.B9600,
-        19200: termios.B19200,
-        38400: termios.B38400,
-        57600: termios.B57600,
-        115200: termios.B115200,
-    }
-    if baud not in baud_map:
-        raise ValueError(f"unsupported serial baud rate: {baud}")
-    attrs = termios.tcgetattr(fd)
-    attrs[0] = 0
-    attrs[1] = 0
-    attrs[2] = termios.CLOCAL | termios.CREAD | termios.CS8
-    attrs[3] = 0
-    attrs[4] = baud_map[baud]
-    attrs[5] = baud_map[baud]
-    attrs[6][termios.VMIN] = 1
-    attrs[6][termios.VTIME] = 0
-    termios.tcsetattr(fd, termios.TCSANOW, attrs)
-
-
-class InputSource:
-    def __init__(self, path: str) -> None:
-        self.path = path
-        self.handle = None
-        self.fd: int | None = None
-
-    def open(self) -> bool:
-        if self.path.startswith("serial://") or self.path.startswith("/dev/tty"):
-            device, baud = parse_serial_path(self.path)
-            fd = os.open(device, os.O_RDONLY | os.O_NOCTTY)
-            configure_serial(fd, baud)
-            self.fd = fd
-            return True
-        self.handle = open(self.path, "rb")
-        return True
-
-    def close(self) -> None:
-        if self.handle is not None:
-            self.handle.close()
-            self.handle = None
-        if self.fd is not None:
-            os.close(self.fd)
-            self.fd = None
-
-    def read(self, size: int = 4096) -> bytes:
-        if self.handle is not None:
-            return self.handle.read(size)
-        if self.fd is not None:
-            return os.read(self.fd, size)
-        return b""
 
 
 def nmea_checksum(payload: str) -> int:
@@ -237,7 +171,12 @@ def main() -> int:
     if args.limit == 0:
         raise SystemExit("--limit must be positive or -1")
 
-    source = InputSource(args.input)
+    source = InputSource(
+        args.input,
+        default_baud=9600,
+        allowed_bauds=NMEA_SERIAL_BAUDS,
+        eio_as_eof=False,
+    )
     if not source.open():
         raise SystemExit(f"failed to open input: {args.input}")
 

--- a/apps/commands/receivers/gnss_novatel_info.py
+++ b/apps/commands/receivers/gnss_novatel_info.py
@@ -8,10 +8,14 @@ import binascii
 import os
 from dataclasses import dataclass
 import struct
+import sys
 import zlib
 
-if os.name != "nt":
-    import termios
+try:
+    from support.gnss_input_source import InputSource
+except ModuleNotFoundError:
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from support.gnss_input_source import InputSource
 
 
 @dataclass
@@ -75,80 +79,6 @@ def parse_args() -> argparse.Namespace:
         help="Suppress per-record printing and show only the summary.",
     )
     return parser.parse_args()
-
-
-def parse_serial_path(path: str) -> tuple[str, int]:
-    default_baud = 115200
-    if path.startswith("serial://"):
-        raw = path[len("serial://"):]
-    else:
-        raw = path
-    if "?baud=" in raw:
-        device, baud_text = raw.split("?baud=", 1)
-        return device, int(baud_text)
-    return raw, default_baud
-
-
-def configure_serial(fd: int, baud: int) -> None:
-    if os.name == "nt":
-        raise RuntimeError("serial input is not supported on this platform")
-    baud_map = {
-        9600: termios.B9600,
-        19200: termios.B19200,
-        38400: termios.B38400,
-        57600: termios.B57600,
-        115200: termios.B115200,
-        230400: termios.B230400,
-    }
-    if baud not in baud_map:
-        raise ValueError(f"unsupported serial baud rate: {baud}")
-    attrs = termios.tcgetattr(fd)
-    attrs[0] = 0
-    attrs[1] = 0
-    attrs[2] = termios.CLOCAL | termios.CREAD | termios.CS8
-    attrs[3] = 0
-    attrs[4] = baud_map[baud]
-    attrs[5] = baud_map[baud]
-    attrs[6][termios.VMIN] = 1
-    attrs[6][termios.VTIME] = 0
-    termios.tcsetattr(fd, termios.TCSANOW, attrs)
-
-
-class InputSource:
-    def __init__(self, path: str) -> None:
-        self.path = path
-        self.handle = None
-        self.fd: int | None = None
-
-    def open(self) -> bool:
-        if self.path.startswith("serial://") or self.path.startswith("/dev/tty"):
-            device, baud = parse_serial_path(self.path)
-            fd = os.open(device, os.O_RDONLY | os.O_NOCTTY)
-            configure_serial(fd, baud)
-            self.fd = fd
-            return True
-        self.handle = open(self.path, "rb")
-        return True
-
-    def close(self) -> None:
-        if self.handle is not None:
-            self.handle.close()
-            self.handle = None
-        if self.fd is not None:
-            os.close(self.fd)
-            self.fd = None
-
-    def read(self, size: int = 4096) -> bytes:
-        if self.handle is not None:
-            return self.handle.read(size)
-        if self.fd is not None:
-            try:
-                return os.read(self.fd, size)
-            except OSError as exc:
-                if getattr(exc, "errno", None) == 5:
-                    return b""
-                raise
-        return b""
 
 
 def valid_crc32(content: str, checksum_text: str) -> bool:

--- a/apps/commands/receivers/gnss_sbf_info.py
+++ b/apps/commands/receivers/gnss_sbf_info.py
@@ -5,14 +5,17 @@ from __future__ import annotations
 
 import argparse
 import binascii
-import errno
 import math
 import os
 import struct
+import sys
 from dataclasses import dataclass
 
-if os.name != "nt":
-    import termios
+try:
+    from support.gnss_input_source import InputSource
+except ModuleNotFoundError:
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from support.gnss_input_source import InputSource
 
 
 SBF_SYNC = b"$@"
@@ -166,80 +169,6 @@ def parse_args() -> argparse.Namespace:
         help="Suppress per-record printing and show only the summary.",
     )
     return parser.parse_args()
-
-
-def parse_serial_path(path: str) -> tuple[str, int]:
-    default_baud = 115200
-    if path.startswith("serial://"):
-        raw = path[len("serial://") :]
-    else:
-        raw = path
-    if "?baud=" in raw:
-        device, baud_text = raw.split("?baud=", 1)
-        return device, int(baud_text)
-    return raw, default_baud
-
-
-def configure_serial(fd: int, baud: int) -> None:
-    if os.name == "nt":
-        raise RuntimeError("serial input is not supported on this platform")
-    baud_map = {
-        9600: termios.B9600,
-        19200: termios.B19200,
-        38400: termios.B38400,
-        57600: termios.B57600,
-        115200: termios.B115200,
-        230400: termios.B230400,
-    }
-    if baud not in baud_map:
-        raise ValueError(f"unsupported serial baud rate: {baud}")
-    attrs = termios.tcgetattr(fd)
-    attrs[0] = 0
-    attrs[1] = 0
-    attrs[2] = termios.CLOCAL | termios.CREAD | termios.CS8
-    attrs[3] = 0
-    attrs[4] = baud_map[baud]
-    attrs[5] = baud_map[baud]
-    attrs[6][termios.VMIN] = 1
-    attrs[6][termios.VTIME] = 0
-    termios.tcsetattr(fd, termios.TCSANOW, attrs)
-
-
-class InputSource:
-    def __init__(self, path: str) -> None:
-        self.path = path
-        self.handle = None
-        self.fd: int | None = None
-
-    def open(self) -> bool:
-        if self.path.startswith("serial://") or self.path.startswith("/dev/tty"):
-            device, baud = parse_serial_path(self.path)
-            fd = os.open(device, os.O_RDONLY | os.O_NOCTTY)
-            configure_serial(fd, baud)
-            self.fd = fd
-            return True
-        self.handle = open(self.path, "rb")
-        return True
-
-    def close(self) -> None:
-        if self.handle is not None:
-            self.handle.close()
-            self.handle = None
-        if self.fd is not None:
-            os.close(self.fd)
-            self.fd = None
-
-    def read(self, size: int = 4096) -> bytes:
-        if self.handle is not None:
-            return self.handle.read(size)
-        if self.fd is not None:
-            try:
-                return os.read(self.fd, size)
-            except OSError as exc:
-                if exc.errno == errno.EIO:
-                    return b""
-                raise
-        return b""
 
 
 def compute_crc(data: bytes) -> int:

--- a/apps/commands/receivers/gnss_sbp_info.py
+++ b/apps/commands/receivers/gnss_sbp_info.py
@@ -5,13 +5,16 @@ from __future__ import annotations
 
 import argparse
 import binascii
-import errno
 import os
 import struct
+import sys
 from dataclasses import dataclass
 
-if os.name != "nt":
-    import termios
+try:
+    from support.gnss_input_source import InputSource
+except ModuleNotFoundError:
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from support.gnss_input_source import InputSource
 
 
 SBP_PREAMBLE = 0x55
@@ -107,80 +110,6 @@ def parse_args() -> argparse.Namespace:
         help="Suppress per-record printing and show only the summary.",
     )
     return parser.parse_args()
-
-
-def parse_serial_path(path: str) -> tuple[str, int]:
-    default_baud = 115200
-    if path.startswith("serial://"):
-        raw = path[len("serial://") :]
-    else:
-        raw = path
-    if "?baud=" in raw:
-        device, baud_text = raw.split("?baud=", 1)
-        return device, int(baud_text)
-    return raw, default_baud
-
-
-def configure_serial(fd: int, baud: int) -> None:
-    if os.name == "nt":
-        raise RuntimeError("serial input is not supported on this platform")
-    baud_map = {
-        9600: termios.B9600,
-        19200: termios.B19200,
-        38400: termios.B38400,
-        57600: termios.B57600,
-        115200: termios.B115200,
-        230400: termios.B230400,
-    }
-    if baud not in baud_map:
-        raise ValueError(f"unsupported serial baud rate: {baud}")
-    attrs = termios.tcgetattr(fd)
-    attrs[0] = 0
-    attrs[1] = 0
-    attrs[2] = termios.CLOCAL | termios.CREAD | termios.CS8
-    attrs[3] = 0
-    attrs[4] = baud_map[baud]
-    attrs[5] = baud_map[baud]
-    attrs[6][termios.VMIN] = 1
-    attrs[6][termios.VTIME] = 0
-    termios.tcsetattr(fd, termios.TCSANOW, attrs)
-
-
-class InputSource:
-    def __init__(self, path: str) -> None:
-        self.path = path
-        self.handle = None
-        self.fd: int | None = None
-
-    def open(self) -> bool:
-        if self.path.startswith("serial://") or self.path.startswith("/dev/tty"):
-            device, baud = parse_serial_path(self.path)
-            fd = os.open(device, os.O_RDONLY | os.O_NOCTTY)
-            configure_serial(fd, baud)
-            self.fd = fd
-            return True
-        self.handle = open(self.path, "rb")
-        return True
-
-    def close(self) -> None:
-        if self.handle is not None:
-            self.handle.close()
-            self.handle = None
-        if self.fd is not None:
-            os.close(self.fd)
-            self.fd = None
-
-    def read(self, size: int = 4096) -> bytes:
-        if self.handle is not None:
-            return self.handle.read(size)
-        if self.fd is not None:
-            try:
-                return os.read(self.fd, size)
-            except OSError as exc:
-                if exc.errno == errno.EIO:
-                    return b""
-                raise
-        return b""
 
 
 def compute_crc(frame_without_preamble: bytes) -> int:

--- a/apps/commands/receivers/gnss_skytraq_info.py
+++ b/apps/commands/receivers/gnss_skytraq_info.py
@@ -4,12 +4,15 @@
 from __future__ import annotations
 
 import argparse
-import errno
 import os
+import sys
 from dataclasses import dataclass
 
-if os.name != "nt":
-    import termios
+try:
+    from support.gnss_input_source import InputSource
+except ModuleNotFoundError:
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from support.gnss_input_source import InputSource
 
 
 STQ_SYNC1 = 0xA0
@@ -19,7 +22,6 @@ STQ_MSG_RAW = 0xDD
 STQ_MSG_RAWX = 0xE5
 STQ_MSG_ACK = 0x83
 STQ_MSG_NACK = 0x84
-DEFAULT_SERIAL_BAUD = 115200
 
 
 @dataclass
@@ -96,76 +98,6 @@ def parse_args() -> argparse.Namespace:
         help="Suppress per-record printing and show only the summary.",
     )
     return parser.parse_args()
-
-
-def parse_serial_path(path: str) -> tuple[str, int]:
-    raw = path[len("serial://") :] if path.startswith("serial://") else path
-    if "?baud=" in raw:
-        device, baud_text = raw.split("?baud=", 1)
-        return device, int(baud_text)
-    return raw, DEFAULT_SERIAL_BAUD
-
-
-def configure_serial(fd: int, baud: int) -> None:
-    if os.name == "nt":
-        raise RuntimeError("serial input is not supported on this platform")
-    baud_map = {
-        9600: termios.B9600,
-        19200: termios.B19200,
-        38400: termios.B38400,
-        57600: termios.B57600,
-        115200: termios.B115200,
-        230400: termios.B230400,
-    }
-    if baud not in baud_map:
-        raise ValueError(f"unsupported serial baud rate: {baud}")
-    attrs = termios.tcgetattr(fd)
-    attrs[0] = 0
-    attrs[1] = 0
-    attrs[2] = termios.CLOCAL | termios.CREAD | termios.CS8
-    attrs[3] = 0
-    attrs[4] = baud_map[baud]
-    attrs[5] = baud_map[baud]
-    attrs[6][termios.VMIN] = 1
-    attrs[6][termios.VTIME] = 0
-    termios.tcsetattr(fd, termios.TCSANOW, attrs)
-
-
-class InputSource:
-    def __init__(self, path: str) -> None:
-        self.path = path
-        self.handle = None
-        self.fd: int | None = None
-
-    def open(self) -> bool:
-        if self.path.startswith("serial://") or self.path.startswith("/dev/tty"):
-            device, baud = parse_serial_path(self.path)
-            fd = os.open(device, os.O_RDONLY | os.O_NOCTTY)
-            configure_serial(fd, baud)
-            self.fd = fd
-            return True
-        self.handle = open(self.path, "rb")
-        return True
-
-    def close(self) -> None:
-        if self.handle is not None:
-            self.handle.close()
-            self.handle = None
-        if self.fd is not None:
-            os.close(self.fd)
-            self.fd = None
-
-    def read(self, size: int = 4096) -> bytes:
-        if self.handle is not None:
-            return self.handle.read(size)
-        if self.fd is not None:
-            try:
-                return os.read(self.fd, size)
-            except OSError as exc:
-                if exc.errno == errno.EIO:
-                    return b""
-                raise
-        return b""
 
 
 @dataclass

--- a/apps/commands/receivers/gnss_trimble_info.py
+++ b/apps/commands/receivers/gnss_trimble_info.py
@@ -7,10 +7,14 @@ import argparse
 import math
 import os
 import struct
+import sys
 from dataclasses import dataclass
 
-if os.name != "nt":
-    import termios
+try:
+    from support.gnss_input_source import InputSource
+except ModuleNotFoundError:
+    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    from support.gnss_input_source import InputSource
 
 
 GSOF_STX = 0x02
@@ -19,7 +23,6 @@ GSOF_PACKET_TYPE_GENOUT = 0x40
 GSOF_RECORD_TIME = 1
 GSOF_RECORD_LLH = 2
 GSOF_RECORD_VELOCITY = 8
-DEFAULT_SERIAL_BAUD = 115200
 
 
 @dataclass
@@ -93,76 +96,6 @@ def parse_args() -> argparse.Namespace:
         help="Suppress per-record printing and show only the summary.",
     )
     return parser.parse_args()
-
-
-def parse_serial_path(path: str) -> tuple[str, int]:
-    raw = path[len("serial://"):] if path.startswith("serial://") else path
-    if "?baud=" in raw:
-        device, baud_text = raw.split("?baud=", 1)
-        return device, int(baud_text)
-    return raw, DEFAULT_SERIAL_BAUD
-
-
-def configure_serial(fd: int, baud: int) -> None:
-    if os.name == "nt":
-        raise RuntimeError("serial input is not supported on this platform")
-    baud_map = {
-        9600: termios.B9600,
-        19200: termios.B19200,
-        38400: termios.B38400,
-        57600: termios.B57600,
-        115200: termios.B115200,
-        230400: termios.B230400,
-    }
-    if baud not in baud_map:
-        raise ValueError(f"unsupported serial baud rate: {baud}")
-    attrs = termios.tcgetattr(fd)
-    attrs[0] = 0
-    attrs[1] = 0
-    attrs[2] = termios.CLOCAL | termios.CREAD | termios.CS8
-    attrs[3] = 0
-    attrs[4] = baud_map[baud]
-    attrs[5] = baud_map[baud]
-    attrs[6][termios.VMIN] = 1
-    attrs[6][termios.VTIME] = 0
-    termios.tcsetattr(fd, termios.TCSANOW, attrs)
-
-
-class InputSource:
-    def __init__(self, path: str) -> None:
-        self.path = path
-        self.handle = None
-        self.fd: int | None = None
-
-    def open(self) -> bool:
-        if self.path.startswith("serial://") or self.path.startswith("/dev/tty"):
-            device, baud = parse_serial_path(self.path)
-            fd = os.open(device, os.O_RDONLY | os.O_NOCTTY)
-            configure_serial(fd, baud)
-            self.fd = fd
-            return True
-        self.handle = open(self.path, "rb")
-        return True
-
-    def close(self) -> None:
-        if self.handle is not None:
-            self.handle.close()
-            self.handle = None
-        if self.fd is not None:
-            os.close(self.fd)
-            self.fd = None
-
-    def read(self, size: int = 4096) -> bytes:
-        if self.handle is not None:
-            return self.handle.read(size)
-        if self.fd is not None:
-            try:
-                return os.read(self.fd, size)
-            except OSError as exc:
-                if getattr(exc, "errno", None) == 5:
-                    return b""
-                raise
-        return b""
 
 
 def checksum_matches(frame: bytes) -> bool:

--- a/apps/commands/support/gnss_input_source.py
+++ b/apps/commands/support/gnss_input_source.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Binary file and POSIX serial input shared by receiver CLI tools."""
+
+from __future__ import annotations
+
+import errno
+import os
+from typing import BinaryIO
+
+if os.name != "nt":
+    import termios
+
+
+DEFAULT_SERIAL_BAUD = 115200
+DEFAULT_SERIAL_BAUDS = (9600, 19200, 38400, 57600, 115200, 230400)
+NMEA_SERIAL_BAUDS = (4800, 9600, 19200, 38400, 57600, 115200)
+
+
+def is_serial_path(path: str) -> bool:
+    return path.startswith("serial://") or path.startswith("/dev/tty")
+
+
+def parse_serial_path(path: str, default_baud: int = DEFAULT_SERIAL_BAUD) -> tuple[str, int]:
+    raw = path[len("serial://") :] if path.startswith("serial://") else path
+    if "?baud=" in raw:
+        device, baud_text = raw.split("?baud=", 1)
+        return device, int(baud_text)
+    return raw, default_baud
+
+
+def configure_serial(
+    fd: int,
+    baud: int,
+    allowed_bauds: tuple[int, ...] = DEFAULT_SERIAL_BAUDS,
+) -> None:
+    if os.name == "nt":
+        raise RuntimeError("serial input is not supported on this platform")
+    baud_map = {
+        allowed_baud: getattr(termios, f"B{allowed_baud}")
+        for allowed_baud in allowed_bauds
+    }
+    if baud not in baud_map:
+        raise ValueError(f"unsupported serial baud rate: {baud}")
+    attrs = termios.tcgetattr(fd)
+    attrs[0] = 0
+    attrs[1] = 0
+    attrs[2] = termios.CLOCAL | termios.CREAD | termios.CS8
+    attrs[3] = 0
+    attrs[4] = baud_map[baud]
+    attrs[5] = baud_map[baud]
+    attrs[6][termios.VMIN] = 1
+    attrs[6][termios.VTIME] = 0
+    termios.tcsetattr(fd, termios.TCSANOW, attrs)
+
+
+class InputSource:
+    def __init__(
+        self,
+        path: str,
+        *,
+        default_baud: int = DEFAULT_SERIAL_BAUD,
+        allowed_bauds: tuple[int, ...] = DEFAULT_SERIAL_BAUDS,
+        eio_as_eof: bool = True,
+    ) -> None:
+        self.path = path
+        self.default_baud = default_baud
+        self.allowed_bauds = allowed_bauds
+        self.eio_as_eof = eio_as_eof
+        self.handle: BinaryIO | None = None
+        self.fd: int | None = None
+
+    def open(self) -> bool:
+        if is_serial_path(self.path):
+            device, baud = parse_serial_path(self.path, self.default_baud)
+            fd = os.open(device, os.O_RDONLY | os.O_NOCTTY)
+            configure_serial(fd, baud, self.allowed_bauds)
+            self.fd = fd
+            return True
+        self.handle = open(self.path, "rb")
+        return True
+
+    def close(self) -> None:
+        if self.handle is not None:
+            self.handle.close()
+            self.handle = None
+        if self.fd is not None:
+            os.close(self.fd)
+            self.fd = None
+
+    def read(self, size: int = 4096) -> bytes:
+        if self.handle is not None:
+            return self.handle.read(size)
+        if self.fd is not None:
+            try:
+                return os.read(self.fd, size)
+            except OSError as exc:
+                if self.eio_as_eof and getattr(exc, "errno", None) == errno.EIO:
+                    return b""
+                raise
+        return b""

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -100,6 +100,7 @@ class PackagingSmokeTest(unittest.TestCase):
                 prefix / "bin" / "gnss_web.py",
                 prefix / "bin" / "gnss_web.html",
                 prefix / "bin" / "support" / "__init__.py",
+                prefix / "bin" / "support" / "gnss_input_source.py",
                 prefix / "bin" / "support" / "gnss_runtime.py",
                 prefix / "bin" / "support" / "gnss_toml_config.py",
                 prefix / "bin" / "gnss_live_signoff.py",
@@ -114,6 +115,8 @@ class PackagingSmokeTest(unittest.TestCase):
                 prefix / "bin" / "gnss_ppc_demo.py",
                 prefix / "bin" / "gnss_ppc_rtk_signoff.py",
                 prefix / "bin" / "gnss_clas_ppp.py",
+                prefix / "bin" / "gnss_nmea_info.py",
+                prefix / "bin" / "gnss_novatel_info.py",
                 prefix / "bin" / "gnss_sbp_info.py",
                 prefix / "bin" / "gnss_sbf_info.py",
                 prefix / "bin" / "gnss_trimble_info.py",
@@ -198,6 +201,25 @@ class PackagingSmokeTest(unittest.TestCase):
                 installed_web_hash.stdout.strip(),
                 hashlib.sha256((prefix / "bin" / "gnss_web.html").read_bytes()).hexdigest(),
             )
+
+            for command in (
+                "nmea-info",
+                "novatel-info",
+                "sbp-info",
+                "sbf-info",
+                "trimble-info",
+                "skytraq-info",
+                "binex-info",
+            ):
+                receiver_help = subprocess.run(
+                    [str(prefix / "bin" / "gnss"), command, "--help"],
+                    check=True,
+                    cwd=ROOT_DIR,
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertIn("--input", receiver_help.stdout)
 
             if repo_data_exists(
                 "data/short_baseline/TSK200JPN_R_20240010000_01D_30S_MO.rnx",


### PR DESCRIPTION
## Summary

- Add `support/gnss_input_source.py` as the shared binary file/POSIX serial input implementation for seven receiver inspection CLIs.
- Replace their duplicated serial parsing, baud setup, file/serial lifecycle, and read handling while preserving each command's existing defaults and EIO behavior.
- Install the shared module and extend packaging smoke coverage to exercise all seven installed receiver commands.
- Reduce the seven CLI files from 2,655 to 2,179 lines; after adding the 100-line shared module, production Python is net -376 lines.

## Scope

- [x] Single feature / single operational improvement / single user-visible value
- [x] Adds or tightens one regression, sign-off, dogfood, or artifact-schema check
- [x] No unrelated refactor mixed in
- [x] No docs-only noise mixed into solver/protocol work
- [x] Protocol ingest, parser work, runtime knobs, solver behavior, and docs are split unless this PR explicitly needs the boundary crossing

## External Reference

- Source repo used for comparison, if any: None
- What was adopted here: Existing per-command behavior, centralized locally
- What was intentionally not adopted: No parser or protocol behavior changes

## Behavior Boundary

- Runtime default changed? no
- Env-gated or config-gated? no
- Artifact/schema changed? no
- Dataset or credentials required? no

NMEA retains its 9600 default, 4800 support, and EIO propagation. The other six commands retain their 115200 default, 230400 support, and EIO-as-EOF behavior. Dispatcher `--help` output is byte-for-byte unchanged for all seven commands (matching SHA-256 hashes).

## Validation

- [x] `python3 tests/test_cli_tools.py -q` — 212 passed, 50 skipped
- [ ] `python3 tests/test_benchmark_scripts.py` — not affected
- [x] `python3 tests/test_packaging.py -q` — 2 passed
- [ ] `python3 tests/test_python_bindings.py -v` — not affected
- [ ] `python3 tests/test_ros2_node.py` — not affected
- [x] `ctest --test-dir build -R '^python_cli_tests$|^python_packaging_tests$' --output-on-failure` — 2/2 passed
- [x] `bash scripts/ci/run_hygiene.sh`
- [x] `python3 -m compileall -q ...`
- [x] Direct-source `--help` smoke for all seven receiver CLIs

Focused checks run:

```bash
python3 tests/test_cli_tools.py -q \
  CLIToolsTest.test_nmea_info_decodes_gga_and_rmc_from_file \
  CLIToolsTest.test_novatel_info_decodes_bestpos_and_bestvel_from_file \
  CLIToolsTest.test_novatel_info_decodes_binary_bestpos_and_bestvel_from_file \
  CLIToolsTest.test_sbp_info_decodes_gps_time_pos_llh_and_vel_ned_from_file \
  CLIToolsTest.test_sbf_info_decodes_pvt_lband_and_p2pp_from_file \
  CLIToolsTest.test_trimble_info_decodes_time_llh_and_velocity_from_file \
  CLIToolsTest.test_skytraq_info_decodes_epoch_rawx_and_ack_from_file \
  CLIToolsTest.test_binex_info_decodes_metadata_nav_and_proto_from_file \
  CLIToolsTest.test_nmea_info_reads_sentences_from_serial_device \
  CLIToolsTest.test_novatel_info_reads_records_from_serial_device \
  CLIToolsTest.test_novatel_info_reads_binary_records_from_serial_device \
  CLIToolsTest.test_sbp_info_reads_records_from_serial_device \
  CLIToolsTest.test_sbf_info_reads_records_from_serial_device \
  CLIToolsTest.test_trimble_info_reads_records_from_serial_device \
  CLIToolsTest.test_skytraq_info_reads_epoch_and_nack_from_serial_device \
  CLIToolsTest.test_binex_info_reads_records_from_serial_device
# Ran 16 tests — OK
```

## Sign-off / Benchmark Impact

- Added or updated regression/sign-off: Installed-package receiver help smoke coverage
- Affected dataset(s): None
- Expected metric impact: None
- Regression budget or threshold: Existing CLI behavior must remain unchanged
- Artifact(s) produced: None

## Notes

- Risk: Low; centralized POSIX serial behavior is covered by file and pseudo-terminal tests for every migrated command.
- Follow-up PRs: Consider centralizing command import/bootstrap setup separately.
- Explicit non-goals: QZSS L6 and CLAS receiver/solver paths, protocol parsing changes, and unrelated handoff/experiment files.
