### PR TITLE
apps: discover Python command installs

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -117,67 +117,54 @@ install(PROGRAMS
     RENAME gnss
 )
 
+file(GLOB GNSS_PYTHON_COMMAND_FILES CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/commands/*/*.py"
+)
+
+set(GNSS_PYTHON_COMMAND_PROGRAMS)
+set(GNSS_PYTHON_COMMAND_INSTALL_KEYS)
+list(SORT GNSS_PYTHON_COMMAND_FILES)
+foreach(GNSS_PYTHON_COMMAND_FILE IN LISTS GNSS_PYTHON_COMMAND_FILES)
+    get_filename_component(GNSS_PYTHON_COMMAND_CATEGORY_DIR
+        "${GNSS_PYTHON_COMMAND_FILE}" DIRECTORY)
+    get_filename_component(GNSS_PYTHON_COMMAND_CATEGORY_NAME
+        "${GNSS_PYTHON_COMMAND_CATEGORY_DIR}" NAME)
+    if(GNSS_PYTHON_COMMAND_CATEGORY_NAME STREQUAL "support")
+        continue()
+    endif()
+
+    get_filename_component(GNSS_PYTHON_COMMAND_BASENAME
+        "${GNSS_PYTHON_COMMAND_FILE}" NAME)
+    string(TOLOWER "${GNSS_PYTHON_COMMAND_BASENAME}"
+        GNSS_PYTHON_COMMAND_INSTALL_KEY)
+    list(FIND GNSS_PYTHON_COMMAND_INSTALL_KEYS
+        "${GNSS_PYTHON_COMMAND_INSTALL_KEY}"
+        GNSS_PYTHON_COMMAND_DUPLICATE_INDEX)
+    if(NOT GNSS_PYTHON_COMMAND_DUPLICATE_INDEX EQUAL -1)
+        list(GET GNSS_PYTHON_COMMAND_PROGRAMS
+            ${GNSS_PYTHON_COMMAND_DUPLICATE_INDEX}
+            GNSS_PYTHON_COMMAND_PREVIOUS)
+        get_filename_component(GNSS_PYTHON_COMMAND_PREVIOUS_BASENAME
+            "${GNSS_PYTHON_COMMAND_PREVIOUS}" NAME)
+        message(FATAL_ERROR
+            "Python command install basename collision (case-insensitive): "
+            "${GNSS_PYTHON_COMMAND_PREVIOUS_BASENAME} "
+            "(${GNSS_PYTHON_COMMAND_PREVIOUS}) and "
+            "${GNSS_PYTHON_COMMAND_BASENAME} (${GNSS_PYTHON_COMMAND_FILE})")
+    endif()
+    list(APPEND GNSS_PYTHON_COMMAND_INSTALL_KEYS
+        "${GNSS_PYTHON_COMMAND_INSTALL_KEY}")
+    list(APPEND GNSS_PYTHON_COMMAND_PROGRAMS "${GNSS_PYTHON_COMMAND_FILE}")
+endforeach()
+list(SORT GNSS_PYTHON_COMMAND_PROGRAMS)
+
+file(GLOB GNSS_PYTHON_SUPPORT_FILES CONFIGURE_DEPENDS
+    "${CMAKE_CURRENT_SOURCE_DIR}/commands/support/*.py"
+)
+list(SORT GNSS_PYTHON_SUPPORT_FILES)
+
 install(PROGRAMS
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/diagnostics/gnss_doctor.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/diagnostics/gnss_robotics_smoke.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/diagnostics/gnss_ros2_doctor.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/diagnostics/gnss_ros2_bag_doctor.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/diagnostics/gnss_field_report.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/receivers/gnss_rcv.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/visualization/gnss_web.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/diagnostics/gnss_mode_compare.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_ppc_taroz_amb_pdc_smoke.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_taroz_p_dogfood.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_taroz_pd_dogfood.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_taroz_pc_dogfood.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_taroz_observable_dogfood.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_taroz_pos_vel_amb_pdc_dogfood.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_taroz_oracle_suite.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/positioning/gnss_live_signoff.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/positioning/gnss_moving_base_signoff.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/positioning/gnss_scorpion_moving_base_signoff.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/positioning/gnss_moving_base_prepare.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/visualization/gnss_moving_base_plot.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/products/gnss_fetch_products.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/visualization/gnss_artifact_manifest.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/products/gnss_ionex_info.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/products/gnss_dcb_info.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/visualization/gnss_visibility_plot.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_odaiba_benchmark.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_odaiba_scan.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/positioning/gnss_short_baseline_signoff.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/positioning/gnss_rtk_kinematic_signoff.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/positioning/gnss_ppp_static_signoff.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/positioning/gnss_ppp_kinematic_signoff.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_ppp_iers_solid_tide_bench.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_ppp_iers_pole_tide_bench.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_ppp_iers_atm_tidal_loading_bench.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_ppp_iers_atm_tidal_loading_multisite_bench.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_ppp_iers_pole_tide_multisite_bench.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_ppp_iers_truth_bench.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_ppp_iers_truth_multisite_bench.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_ppp_iers_sub_daily_eop_bench.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_ppp_iers_sub_daily_eop_multisite_bench.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_ppp_iers_ocean_loading_bench.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/products/gnss_vmf_atl.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/positioning/gnss_ppp_products_signoff.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_ppc_demo.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_ppc_commercial.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_ppc_metrics.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_ppc_rtk_signoff.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_public_rtk_benchmarks.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_smartloc_adapter.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/benchmarks/gnss_smartloc_signoff.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/positioning/gnss_clas_ppp.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/receivers/gnss_nmea_info.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/receivers/gnss_novatel_info.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/receivers/gnss_sbp_info.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/receivers/gnss_sbf_info.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/receivers/gnss_trimble_info.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/receivers/gnss_skytraq_info.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/receivers/gnss_binex_info.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/receivers/gnss_qzss_l6_info.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/receivers/gnss_qzss_l6_bias.py
+    ${GNSS_PYTHON_COMMAND_PROGRAMS}
     ${CMAKE_CURRENT_SOURCE_DIR}/compat/gnss_pos2kml
     DESTINATION ${CMAKE_INSTALL_BINDIR}
 )
@@ -188,10 +175,7 @@ install(FILES
 )
 
 install(FILES
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/support/__init__.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/support/gnss_input_source.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/support/gnss_runtime.py
-    ${CMAKE_CURRENT_SOURCE_DIR}/commands/support/gnss_toml_config.py
+    ${GNSS_PYTHON_SUPPORT_FILES}
     DESTINATION ${CMAKE_INSTALL_BINDIR}/support
 )
 

--- a/apps/gnss.py
+++ b/apps/gnss.py
@@ -15,67 +15,51 @@ APPS_DIR = os.path.dirname(os.path.abspath(__file__))
 EXE_SUFFIX = ".exe" if os.name == "nt" else ""
 BUILD_CONFIGS = ("Release", "RelWithDebInfo", "Debug", "MinSizeRel")
 
-PYTHON_COMMAND_GROUPS = {
-    "diagnostics": {
-        "gnss_dd_residuals.py", "gnss_doctor.py", "gnss_field_report.py",
-        "gnss_mode_compare.py", "gnss_robotics_smoke.py",
-        "gnss_ros2_bag_doctor.py", "gnss_ros2_doctor.py",
-    },
-    "receivers": {
-        "gnss_binex_info.py", "gnss_nmea_info.py", "gnss_novatel_info.py",
-        "gnss_qzss_l6_info.py", "gnss_rcv.py", "gnss_sbf_info.py",
-        "gnss_sbp_info.py", "gnss_skytraq_info.py", "gnss_trimble_info.py",
-    },
-    "products": {
-        "gnss_dcb_info.py", "gnss_fetch_products.py", "gnss_ionex_info.py",
-        "gnss_vmf_atl.py",
-    },
-    "positioning": {
-        "gnss_clas_ppp.py", "gnss_live_signoff.py",
-        "gnss_moving_base_prepare.py", "gnss_moving_base_signoff.py",
-        "gnss_ppp_kinematic_signoff.py", "gnss_ppp_products_signoff.py",
-        "gnss_ppp_static_signoff.py", "gnss_rtk_kinematic_signoff.py",
-        "gnss_scorpion_moving_base_signoff.py", "gnss_short_baseline_signoff.py",
-    },
-    "visualization": {
-        "gnss_artifact_manifest.py", "gnss_moving_base_plot.py",
-        "gnss_visibility_plot.py", "gnss_web.py",
-    },
-    "benchmarks": {
-        "gnss_odaiba_benchmark.py", "gnss_odaiba_scan.py",
-        "gnss_ppc_commercial.py", "gnss_ppc_coverage_matrix.py",
-        "gnss_ppc_demo.py", "gnss_ppc_metrics.py", "gnss_ppc_rtk_signoff.py",
-        "gnss_ppc_spp_compare.py", "gnss_ppc_spp_jump_sweep.py",
-        "gnss_ppc_spp_policy_report.py", "gnss_ppc_spp_policy_suite.py",
-        "gnss_ppc_taroz_amb_pdc_smoke.py",
-        "gnss_ppp_iers_atm_tidal_loading_bench.py",
-        "gnss_ppp_iers_atm_tidal_loading_multisite_bench.py",
-        "gnss_ppp_iers_ocean_loading_bench.py",
-        "gnss_ppp_iers_pole_tide_bench.py",
-        "gnss_ppp_iers_pole_tide_multisite_bench.py",
-        "gnss_ppp_iers_solid_tide_bench.py",
-        "gnss_ppp_iers_sub_daily_eop_bench.py",
-        "gnss_ppp_iers_sub_daily_eop_multisite_bench.py",
-        "gnss_ppp_iers_truth_bench.py", "gnss_ppp_iers_truth_multisite_bench.py",
-        "gnss_public_rtk_benchmarks.py", "gnss_smartloc_adapter.py",
-        "gnss_smartloc_signoff.py", "gnss_taroz_observable_dogfood.py",
-        "gnss_taroz_oracle_suite.py", "gnss_taroz_p_dogfood.py",
-        "gnss_taroz_pc_dogfood.py", "gnss_taroz_pd_dogfood.py",
-        "gnss_taroz_pos_vel_amb_pdc_dogfood.py",
-    },
-}
-PYTHON_COMMAND_GROUP = {
-    filename: group
-    for group, filenames in PYTHON_COMMAND_GROUPS.items()
-    for filename in filenames
-}
+PYTHON_COMMANDS_DIR = os.path.join(APPS_DIR, "commands")
+
+
+def _discover_python_command_sources() -> tuple[dict[str, str], tuple[str, ...]]:
+    source_paths = sorted(glob.glob(os.path.join(PYTHON_COMMANDS_DIR, "*", "*.py")))
+    sources: dict[str, str] = {}
+    install_sources: dict[str, tuple[str, str]] = {}
+    source_dirs: list[str] = []
+    for source_path in source_paths:
+        category_dir = os.path.dirname(source_path)
+        if os.path.basename(category_dir) == "support":
+            continue
+        if category_dir not in source_dirs:
+            source_dirs.append(category_dir)
+
+        filename = os.path.basename(source_path)
+        install_key = filename.casefold()
+        previous_source = install_sources.get(install_key)
+        if previous_source is not None:
+            previous_filename, previous_path = previous_source
+            raise RuntimeError(
+                "duplicate Python command basenames would collide case-insensitively "
+                f"when installed flat: {previous_filename!r} ({previous_path}) and "
+                f"{filename!r} ({source_path})"
+            )
+        install_sources[install_key] = (filename, source_path)
+        sources[filename] = source_path
+    return sources, tuple(source_dirs)
+
+
+PYTHON_COMMAND_DISCOVERY_ERROR: str | None = None
+try:
+    PYTHON_COMMAND_SOURCES, PYTHON_COMMAND_SOURCE_DIRS = (
+        _discover_python_command_sources()
+    )
+except RuntimeError as exc:
+    PYTHON_COMMAND_SOURCES = {}
+    PYTHON_COMMAND_SOURCE_DIRS = ()
+    PYTHON_COMMAND_DISCOVERY_ERROR = str(exc)
 
 
 def python_target(filename: str) -> str:
     """Resolve a grouped source command or its flat installed counterpart."""
-    group = PYTHON_COMMAND_GROUP[filename]
-    source_target = os.path.join(APPS_DIR, "commands", group, filename)
-    if os.path.isfile(source_target):
+    source_target = PYTHON_COMMAND_SOURCES.get(filename)
+    if source_target is not None:
         return source_target
     return os.path.join(APPS_DIR, filename)
 
@@ -996,11 +980,7 @@ def find_binary(target_name: str) -> str | None:
 def run_python(target: str, command_name: str, args: list[str]) -> int:
     env = os.environ.copy()
     env["GNSS_CLI_NAME"] = f"gnss {command_name}"
-    source_import_dirs = [
-        os.path.join(APPS_DIR, "commands", group)
-        for group in PYTHON_COMMAND_GROUPS
-    ]
-    source_import_dirs.append(os.path.join(APPS_DIR, "commands"))
+    source_import_dirs = [*PYTHON_COMMAND_SOURCE_DIRS, PYTHON_COMMANDS_DIR]
     existing_pythonpath = env.get("PYTHONPATH")
     if existing_pythonpath:
         source_import_dirs.append(existing_pythonpath)
@@ -1055,6 +1035,10 @@ def dispatch_command(command_name: str, args: list[str]) -> int:
 
 
 def main() -> int:
+    if PYTHON_COMMAND_DISCOVERY_ERROR is not None:
+        print(f"Error: {PYTHON_COMMAND_DISCOVERY_ERROR}", file=sys.stderr)
+        return 1
+
     if len(sys.argv) < 2:
         print(usage())
         return 1

--- a/tests/test_cli_ux.py
+++ b/tests/test_cli_ux.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import importlib.util
+import io
 import json
 import re
 import subprocess
@@ -11,6 +12,7 @@ import sys
 import tempfile
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
@@ -436,6 +438,97 @@ class CliUxTest(unittest.TestCase):
                 failures.append(f"{command}: python target escapes repo root: {target}")
 
         self.assertEqual(failures, [])
+
+    def test_python_command_discovery_is_sorted_and_unique(self) -> None:
+        dispatcher = self.dispatcher_module()
+        commands_root = ROOT_DIR / "apps" / "commands"
+        source_paths = sorted(commands_root.glob("*/*.py"))
+        expected_sources = [
+            source.resolve()
+            for source in source_paths
+            if source.parent.name != "support"
+        ]
+        expected_basenames = [source.name for source in expected_sources]
+        expected_category_dirs = sorted(
+            {source.parent.resolve() for source in expected_sources}
+        )
+        discovered_sources = [
+            Path(source).resolve()
+            for source in dispatcher.PYTHON_COMMAND_SOURCES.values()
+        ]
+
+        self.assertEqual(discovered_sources, expected_sources)
+        self.assertEqual(list(dispatcher.PYTHON_COMMAND_SOURCES), expected_basenames)
+        self.assertEqual(
+            len(expected_basenames),
+            len({basename.casefold() for basename in expected_basenames}),
+        )
+        self.assertEqual(
+            [source.parent for source in discovered_sources],
+            [source.parent for source in expected_sources],
+        )
+        self.assertEqual(
+            [Path(path).resolve() for path in dispatcher.PYTHON_COMMAND_SOURCE_DIRS],
+            expected_category_dirs,
+        )
+
+    def test_registered_grouped_python_commands_resolve_to_discovered_sources(self) -> None:
+        dispatcher = self.dispatcher_module()
+        failures: list[str] = []
+
+        for command, metadata in dispatcher.COMMANDS.items():
+            if metadata.get("kind") != "python":
+                continue
+            target = metadata["target"]
+            filename = Path(target).name
+            source = dispatcher.PYTHON_COMMAND_SOURCES.get(filename)
+            if source is None:
+                continue
+            if Path(target).resolve() != Path(source).resolve():
+                failures.append(f"{command}: unexpected target {target}")
+
+        self.assertEqual(failures, [])
+
+    def test_python_target_uses_discovered_source_or_flat_fallback(self) -> None:
+        dispatcher = self.dispatcher_module()
+        discovered_filename = "gnss_doctor.py"
+        fallback_filename = "gnss_not_discovered.py"
+
+        self.assertEqual(
+            dispatcher.python_target(discovered_filename),
+            dispatcher.PYTHON_COMMAND_SOURCES[discovered_filename],
+        )
+        self.assertEqual(
+            dispatcher.python_target(fallback_filename),
+            str(ROOT_DIR / "apps" / fallback_filename),
+        )
+
+    def test_case_insensitive_collision_reports_concise_startup_error(self) -> None:
+        fake_sources = [
+            str(ROOT_DIR / "apps" / "commands" / "alpha" / "foo.py"),
+            str(ROOT_DIR / "apps" / "commands" / "beta" / "FOO.py"),
+        ]
+        with mock.patch("glob.glob", return_value=fake_sources):
+            dispatcher = self.dispatcher_module()
+
+        discovery_error = dispatcher.PYTHON_COMMAND_DISCOVERY_ERROR
+        self.assertIsNotNone(discovery_error)
+        self.assertIn("case-insensitively", discovery_error)
+        self.assertIn("'foo.py'", discovery_error)
+        self.assertIn("'FOO.py'", discovery_error)
+        self.assertEqual(dispatcher.PYTHON_COMMAND_SOURCES, {})
+        self.assertEqual(dispatcher.PYTHON_COMMAND_SOURCE_DIRS, ())
+
+        stdout = io.StringIO()
+        stderr = io.StringIO()
+        with mock.patch.object(dispatcher.sys, "argv", ["gnss", "--help"]), \
+                mock.patch.object(dispatcher.sys, "stdout", stdout), \
+                mock.patch.object(dispatcher.sys, "stderr", stderr):
+            returncode = dispatcher.main()
+
+        self.assertEqual(returncode, 1)
+        self.assertEqual(stdout.getvalue(), "")
+        self.assertEqual(stderr.getvalue(), f"Error: {discovery_error}\n")
 
     def test_markdown_gnss_examples_use_registered_dispatcher_commands(self) -> None:
         markdown_files = [ROOT_DIR / "README.md", *sorted((ROOT_DIR / "docs").rglob("*.md"))]

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -81,6 +81,7 @@ class PackagingSmokeTest(unittest.TestCase):
 
             expected_paths = [
                 prefix / "bin" / "gnss",
+                prefix / "bin" / "gnss_pos2kml",
                 prefix / "bin" / "gnss_doctor.py",
                 prefix / "bin" / "gnss_robotics_smoke.py",
                 prefix / "bin" / "gnss_ros2_doctor.py",
@@ -143,6 +144,26 @@ class PackagingSmokeTest(unittest.TestCase):
                 prefix / "configs" / "signoff" / "live_signoff.example.toml",
                 prefix / "configs" / "signoff" / "ppc_rtk_signoff.example.toml",
             ]
+            commands_root = ROOT_DIR / "apps" / "commands"
+            command_sources = [
+                source
+                for category_dir in sorted(commands_root.iterdir())
+                if category_dir.is_dir() and category_dir.name != "support"
+                for source in sorted(category_dir.glob("*.py"))
+            ]
+            support_sources = sorted((commands_root / "support").glob("*.py"))
+            command_basenames = [source.name for source in command_sources]
+            self.assertEqual(
+                len(command_basenames),
+                len({basename.casefold() for basename in command_basenames}),
+            )
+            expected_paths.extend(
+                prefix / "bin" / source.name for source in command_sources
+            )
+            expected_paths.extend(
+                prefix / "bin" / "support" / source.name
+                for source in support_sources
+            )
             ros2_binary = next((path for path in BUILD_DIR.rglob("gnss_solution_node") if path.is_file()), None)
             if ros2_binary is not None:
                 expected_paths.append(prefix / "bin" / "gnss_solution_node")
@@ -220,6 +241,23 @@ class PackagingSmokeTest(unittest.TestCase):
                     text=True,
                 )
                 self.assertIn("--input", receiver_help.stdout)
+
+            for command in (
+                "ppc-coverage-matrix",
+                "ppc-spp-jump-sweep",
+                "ppc-spp-compare",
+                "ppc-spp-policy-report",
+                "ppc-spp-policy-suite",
+            ):
+                ppc_help = subprocess.run(
+                    [str(prefix / "bin" / "gnss"), command, "--help"],
+                    check=True,
+                    cwd=ROOT_DIR,
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                )
+                self.assertIn("usage:", ppc_help.stdout.lower())
 
             if repo_data_exists(
                 "data/short_baseline/TSK200JPN_R_20240010000_01D_30S_MO.rnx",


### PR DESCRIPTION
## Summary

- discover grouped Python command sources and import directories from `apps/commands/*/*.py`, replacing the duplicated hardcoded group table
- discover flat command and support-module installs in CMake with deterministic ordering and case-insensitive basename collision guards
- add source/installed fallback, controlled discovery-error, and complete packaging contracts

## Why

The dispatcher grouping table and the CMake install list described the same source layout independently, so they drifted. Five already-registered PPC commands were runnable from a source checkout but absent from installed packages, and the residual-diagnostics script did not receive all of its support modules.

The source layout under `apps/commands/` is now the canonical discovery surface for both dispatch and install behavior.

## Compatibility and impact

- no `COMMANDS` names, kinds, summaries, ordering, help text, JSON schema, or exit behavior changed on normal paths
- top-level help and command-list outputs are byte-identical to `develop`
- CMake remains compatible with the existing 3.14 minimum
- native targets, `gnss_pos2kml`, `gnss_web.html`, tools, scripts, and install destinations are preserved
- installed packages now include the five previously omitted registered PPC commands plus the residual diagnostic and its support modules; no new dispatcher command was added

## Validation

- `cmake -S . -B build -DCMAKE_BUILD_TYPE=Release`
- `cmake --build build --parallel 2`
- CLI UX: 22/22 passed
- CTest core: 37/37 passed
- CTest extended: 4/4 passed
- packaging/install: passed, including all 66 discovered command programs, 10 support modules, five installed PPC help paths, and `gnss_pos2kml`
- `bash scripts/ci/run_hygiene.sh`
- `python3 -m compileall -q apps python scripts tests`
- `git diff --check`
- independent review: no actionable findings
