### PR TITLE
apps: remove receiver sys.path fallbacks

### DIFF
--- a/apps/commands/receivers/gnss_binex_info.py
+++ b/apps/commands/receivers/gnss_binex_info.py
@@ -6,14 +6,9 @@ from __future__ import annotations
 import argparse
 import binascii
 import os
-import sys
 from dataclasses import dataclass
 
-try:
-    from support.gnss_input_source import InputSource
-except ModuleNotFoundError:
-    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    from support.gnss_input_source import InputSource
+from support.gnss_input_source import InputSource
 
 
 BINEX_SYNC_BIG_ENDIAN_REGULAR = 0xE2

--- a/apps/commands/receivers/gnss_nmea_info.py
+++ b/apps/commands/receivers/gnss_nmea_info.py
@@ -6,14 +6,8 @@ from __future__ import annotations
 import argparse
 import os
 from dataclasses import dataclass
-from pathlib import Path
-import sys
 
-try:
-    from support.gnss_input_source import InputSource, NMEA_SERIAL_BAUDS
-except ModuleNotFoundError:
-    sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-    from support.gnss_input_source import InputSource, NMEA_SERIAL_BAUDS
+from support.gnss_input_source import InputSource, NMEA_SERIAL_BAUDS
 
 
 @dataclass

--- a/apps/commands/receivers/gnss_novatel_info.py
+++ b/apps/commands/receivers/gnss_novatel_info.py
@@ -8,14 +8,9 @@ import binascii
 import os
 from dataclasses import dataclass
 import struct
-import sys
 import zlib
 
-try:
-    from support.gnss_input_source import InputSource
-except ModuleNotFoundError:
-    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    from support.gnss_input_source import InputSource
+from support.gnss_input_source import InputSource
 
 
 @dataclass

--- a/apps/commands/receivers/gnss_sbf_info.py
+++ b/apps/commands/receivers/gnss_sbf_info.py
@@ -8,14 +8,9 @@ import binascii
 import math
 import os
 import struct
-import sys
 from dataclasses import dataclass
 
-try:
-    from support.gnss_input_source import InputSource
-except ModuleNotFoundError:
-    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    from support.gnss_input_source import InputSource
+from support.gnss_input_source import InputSource
 
 
 SBF_SYNC = b"$@"

--- a/apps/commands/receivers/gnss_sbp_info.py
+++ b/apps/commands/receivers/gnss_sbp_info.py
@@ -7,14 +7,9 @@ import argparse
 import binascii
 import os
 import struct
-import sys
 from dataclasses import dataclass
 
-try:
-    from support.gnss_input_source import InputSource
-except ModuleNotFoundError:
-    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    from support.gnss_input_source import InputSource
+from support.gnss_input_source import InputSource
 
 
 SBP_PREAMBLE = 0x55

--- a/apps/commands/receivers/gnss_skytraq_info.py
+++ b/apps/commands/receivers/gnss_skytraq_info.py
@@ -5,14 +5,9 @@ from __future__ import annotations
 
 import argparse
 import os
-import sys
 from dataclasses import dataclass
 
-try:
-    from support.gnss_input_source import InputSource
-except ModuleNotFoundError:
-    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    from support.gnss_input_source import InputSource
+from support.gnss_input_source import InputSource
 
 
 STQ_SYNC1 = 0xA0

--- a/apps/commands/receivers/gnss_trimble_info.py
+++ b/apps/commands/receivers/gnss_trimble_info.py
@@ -7,14 +7,9 @@ import argparse
 import math
 import os
 import struct
-import sys
 from dataclasses import dataclass
 
-try:
-    from support.gnss_input_source import InputSource
-except ModuleNotFoundError:
-    sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-    from support.gnss_input_source import InputSource
+from support.gnss_input_source import InputSource
 
 
 GSOF_STX = 0x02

--- a/tests/cli_cases/README.md
+++ b/tests/cli_cases/README.md
@@ -11,7 +11,7 @@ does not load the mixin modules as independent suites.
 - `analysis_visuals.py`: SPP/visibility/statistics/plot/track/report rendering (11)
 - `cli_surface.py`: help, benchmark, SmartLoc, and built ROS2 node checks (13)
 - `ppp_processing.py`: synthetic and sampled PPP/SSR/CLAS processing checks (24)
-- `stream_protocols.py`: stream relay, file protocol decoders, serial decoders, and conversion (32)
+- `stream_protocols.py`: stream relay, file protocol decoders, serial decoders, and conversion (34)
 - `qzss_l6_decode.py`: QZSS L6 frame and compact correction decoding (21)
 - `qzss_l6_policy.py`: QZSS L6 bias, atmosphere, phase, and row-policy checks (25)
 - `signoffs.py`: RTK, PPP, product, and PPC signoff workflows (29)

--- a/tests/cli_cases/stream_protocols.py
+++ b/tests/cli_cases/stream_protocols.py
@@ -1,8 +1,81 @@
 """CLI regression cases for the StreamProtocolCases domain."""
 
+import ast
+
 from ._support import *  # noqa: F401,F403
 
+
+def _sys_path_access_lines(source: str, *, filename: str = "<string>") -> list[int]:
+    tree = ast.parse(source, filename=filename)
+    nodes = tuple(ast.walk(tree))
+    sys_names = {
+        imported.asname or imported.name
+        for node in nodes
+        if isinstance(node, ast.Import)
+        for imported in node.names
+        if imported.name == "sys"
+    }
+    return sorted(
+        {
+            node.lineno
+            for node in nodes
+            if (
+                isinstance(node, ast.Attribute)
+                and node.attr == "path"
+                and isinstance(node.value, ast.Name)
+                and node.value.id in sys_names
+            )
+            or (
+                isinstance(node, ast.ImportFrom)
+                and node.module == "sys"
+                and any(imported.name == "path" for imported in node.names)
+            )
+        }
+    )
+
+
 class StreamProtocolCases:
+    def test_sys_path_access_detector_covers_aliases_and_targets(self) -> None:
+        cases = (
+            ("module alias", "import sys as s\ns.path.insert(0, 'support')\n", [2]),
+            ("from-import alias", "from sys import path as p\np.append('support')\n", [1]),
+            ("assigned path alias", "import sys\np = sys.path\np.append('support')\n", [2]),
+            ("recursive targets", "import sys\nx, sys.path = values\ndel (y, sys.path)\n", [2, 3]),
+            (
+                "non-path sys attributes",
+                (
+                    "import sys as s\n"
+                    "data = s.stdin.read()\n"
+                    "s.stderr.write(data)\n"
+                    "command = [s.executable]\n"
+                ),
+                [],
+            ),
+        )
+
+        for name, source, expected_lines in cases:
+            with self.subTest(name=name):
+                self.assertEqual(_sys_path_access_lines(source), expected_lines)
+
+    def test_receiver_commands_do_not_access_sys_path(self) -> None:
+        receiver_dir = ROOT_DIR / "apps" / "commands" / "receivers"
+        accesses: list[str] = []
+
+        for source_path in sorted(receiver_dir.glob("*.py")):
+            lines = _sys_path_access_lines(
+                source_path.read_text(encoding="utf-8"),
+                filename=str(source_path),
+            )
+            accesses.extend(
+                f"{source_path.relative_to(ROOT_DIR)}:{line}" for line in lines
+            )
+
+        self.assertEqual(
+            accesses,
+            [],
+            "Receiver command sources must not access sys.path: " + ", ".join(accesses),
+        )
+
     def test_stream_relays_rtcm_frames(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_stream_test_") as temp_dir:
             temp_root = Path(temp_dir)


### PR DESCRIPTION
## Summary

- remove the runtime `sys.path` fallback from seven receiver protocol commands
- rely on the documented source dispatcher and the installed flat-`bin` support package
- add an AST contract that prevents receiver commands from accessing `sys.path`, including common aliases
- keep the CLI-domain test inventory synchronized

## Why

The receiver commands already have two explicit import-resolution contracts:

- source tree: `python3 apps/gnss.py <command>`
- install tree: command scripts and `support/` are colocated under `bin/`

The per-script fallback duplicated path setup, mutated interpreter-global state, and preserved a grouped-file invocation mode that the command README does not expose as supported. Removing it makes the import boundary explicit without changing public commands.

## Impact

No public CLI names, help text, output formats, exit behavior, decoder behavior, or install paths change. All seven dispatcher help outputs are byte-for-byte identical to `develop`. Flat installed scripts also start successfully with `PYTHONPATH` unset.

## Validation

- clean Release configure and full build
- `bash scripts/ci/run_hygiene.sh`
- focused import-contract and eight receiver file-decoder tests
- all seven source-dispatcher help hashes matched `develop`
- all seven flat installed receiver scripts passed direct `--help` with `PYTHONPATH` unset
- core CTest lane: 37/37
- extended CTest lane, including packaging: 4/4
- optional CTest lane: 19/19
- independent Luna Max implementation review and follow-up review: no unresolved findings
