### PR TITLE
apps: load shared scripts without sys.path

### DIFF
--- a/apps/commands/benchmarks/gnss_odaiba_benchmark.py
+++ b/apps/commands/benchmarks/gnss_odaiba_benchmark.py
@@ -13,17 +13,17 @@ import subprocess
 import sys
 import tempfile
 
-from support.gnss_runtime import resolve_gnss_command
+from support.gnss_runtime import load_python_module, resolve_gnss_command
 
 
 from support.gnss_runtime import application_root
 
 ROOT_DIR = application_root(__file__)
 DEFAULT_RTKLIB = "/tmp/RTKLIB/app/rnx2rtkp/gcc/rnx2rtkp"
-
-sys.path.insert(0, str(ROOT_DIR / "scripts"))
-
-import generate_driving_comparison as driving_comparison  # noqa: E402
+driving_comparison = load_python_module(
+    "gnssplusplus_generate_driving_comparison",
+    ROOT_DIR / "scripts" / "generate_driving_comparison.py",
+)
 
 
 def parse_args() -> argparse.Namespace:

--- a/apps/commands/benchmarks/gnss_odaiba_scan.py
+++ b/apps/commands/benchmarks/gnss_odaiba_scan.py
@@ -8,21 +8,21 @@ import csv
 import os
 from pathlib import Path
 import subprocess
-import sys
 import tempfile
 import time
 
-from support.gnss_runtime import resolve_gnss_command
-
-
-from support.gnss_runtime import application_root
+from support.gnss_runtime import application_root, load_python_module, resolve_gnss_command
 
 ROOT_DIR = application_root(__file__)
-SCRIPTS_DIR = ROOT_DIR / "scripts"
-if str(SCRIPTS_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPTS_DIR))
-
-from generate_driving_comparison import match_to_reference, read_libgnss_pos, read_reference_csv, read_rtklib_pos, summarize
+driving_comparison = load_python_module(
+    "gnssplusplus_generate_driving_comparison",
+    ROOT_DIR / "scripts" / "generate_driving_comparison.py",
+)
+match_to_reference = driving_comparison.match_to_reference
+read_libgnss_pos = driving_comparison.read_libgnss_pos
+read_reference_csv = driving_comparison.read_reference_csv
+read_rtklib_pos = driving_comparison.read_rtklib_pos
+summarize = driving_comparison.summarize
 
 
 def parse_args() -> argparse.Namespace:

--- a/apps/commands/support/gnss_runtime.py
+++ b/apps/commands/support/gnss_runtime.py
@@ -3,12 +3,20 @@
 
 from __future__ import annotations
 
+import importlib.util
 import json
+from datetime import date
 from pathlib import Path
 import shutil
 import subprocess
 import sys
-from datetime import date
+import threading
+from types import ModuleType
+
+
+_MODULE_MISSING = object()
+_MODULE_LOAD_LOCK = threading.RLock()
+_MODULES_LOADING: set[str] = set()
 
 
 def application_root(script_file: str) -> Path:
@@ -17,6 +25,65 @@ def application_root(script_file: str) -> Path:
     if script_path.parent.parent.name == "commands":
         return script_path.parents[3]
     return script_path.parent.parent
+
+
+def _module_origin(module: ModuleType) -> Path | None:
+    origin = getattr(module, "__file__", None)
+    if origin is None:
+        origin = getattr(getattr(module, "__spec__", None), "origin", None)
+    if not isinstance(origin, (str, Path)):
+        return None
+    try:
+        return Path(origin).resolve()
+    except (OSError, RuntimeError, ValueError):
+        return None
+
+
+def load_python_module(module_name: str, module_path: Path) -> ModuleType:
+    """Load a Python file by path without changing the process import path."""
+    if not isinstance(module_name, str) or not module_name:
+        raise ValueError("module_name must be a non-empty string")
+
+    try:
+        resolved_path = Path(module_path).expanduser().resolve()
+    except (OSError, RuntimeError) as exc:
+        raise ImportError(f"Cannot resolve Python module path: {module_path}") from exc
+
+    with _MODULE_LOAD_LOCK:
+        existing = sys.modules.get(module_name, _MODULE_MISSING)
+        if existing is not _MODULE_MISSING:
+            existing_path = _module_origin(existing) if isinstance(existing, ModuleType) else None
+            if isinstance(existing, ModuleType) and existing_path == resolved_path:
+                if module_name in _MODULES_LOADING:
+                    raise ImportError(f"Python module {module_name!r} is still initializing")
+                return existing
+            origin = str(existing_path) if existing_path is not None else "<unknown file>"
+            raise ImportError(
+                f"Module name collision: {module_name!r} is already loaded from {origin}; "
+                f"cannot load {resolved_path}"
+            )
+
+        if not resolved_path.exists():
+            raise FileNotFoundError(f"Python module file does not exist: {resolved_path}")
+        if not resolved_path.is_file():
+            raise ImportError(f"Python module path is not a file: {resolved_path}")
+
+        spec = importlib.util.spec_from_file_location(module_name, resolved_path)
+        if spec is None or spec.loader is None or not hasattr(spec.loader, "exec_module"):
+            raise ImportError(f"No usable Python loader for {resolved_path}")
+
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        _MODULES_LOADING.add(module_name)
+        try:
+            spec.loader.exec_module(module)
+        except BaseException:
+            if sys.modules.get(module_name) is module:
+                del sys.modules[module_name]
+            raise
+        finally:
+            _MODULES_LOADING.discard(module_name)
+        return module
 
 
 def resolve_gnss_command(root_dir: Path) -> list[str]:

--- a/apps/commands/visualization/gnss_web.py
+++ b/apps/commands/visualization/gnss_web.py
@@ -11,22 +11,19 @@ from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 import signal
-import sys
 import threading
 from typing import Any
 from urllib.parse import parse_qs, urlparse
 
 from support.gnss_toml_config import parse_args_with_toml
 
-from support.gnss_runtime import application_root
+from support.gnss_runtime import application_root, load_python_module
 
 ROOT_DIR = application_root(__file__)
-SCRIPTS_DIR = ROOT_DIR / "scripts"
-
-if str(SCRIPTS_DIR) not in sys.path:
-    sys.path.insert(0, str(SCRIPTS_DIR))
-
-import generate_driving_comparison as driving_comparison  # noqa: E402
+driving_comparison = load_python_module(
+    "gnssplusplus_generate_driving_comparison",
+    ROOT_DIR / "scripts" / "generate_driving_comparison.py",
+)
 
 
 STATUS_COLORS = {

--- a/tests/test_web_http_ux.py
+++ b/tests/test_web_http_ux.py
@@ -4,26 +4,40 @@
 from __future__ import annotations
 
 import argparse
+import importlib
 import json
+import os
+import shutil
+import subprocess
 import sys
 import tempfile
 import threading
 import unittest
 from http.server import ThreadingHTTPServer
 from pathlib import Path
+from types import ModuleType
 from urllib import error, request
 
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 COMMANDS_DIR = ROOT_DIR / "apps" / "commands"
 APPS_DIR = COMMANDS_DIR / "visualization"
+BENCHMARKS_DIR = COMMANDS_DIR / "benchmarks"
 
 if str(COMMANDS_DIR) not in sys.path:
     sys.path.insert(0, str(COMMANDS_DIR))
 if str(APPS_DIR) not in sys.path:
     sys.path.insert(0, str(APPS_DIR))
+if str(BENCHMARKS_DIR) not in sys.path:
+    sys.path.insert(0, str(BENCHMARKS_DIR))
+
+from support import gnss_runtime
 
 import gnss_web  # noqa: E402
+import gnss_odaiba_benchmark  # noqa: E402
+import gnss_odaiba_scan  # noqa: E402
+
+load_python_module = gnss_runtime.load_python_module
 
 
 def make_args(root: Path, manifest_path: Path) -> argparse.Namespace:
@@ -67,7 +81,241 @@ def fetch_json(url: str) -> tuple[int, str, dict[str, object]]:
     return status, content_type, json.loads(body)
 
 
+class _ObservedRLock:
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._attempt_lock = threading.Lock()
+        self._attempts = 0
+        self.second_attempt = threading.Event()
+
+    def __enter__(self) -> _ObservedRLock:
+        with self._attempt_lock:
+            self._attempts += 1
+            if self._attempts == 2:
+                self.second_attempt.set()
+        self._lock.acquire()
+        return self
+
+    def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
+        self._lock.release()
+
+
 class WebHttpUxTest(unittest.TestCase):
+    def test_load_python_module_registers_dataclass_and_caches(self) -> None:
+        module_name = "_web_http_ux_dataclass_module"
+        with tempfile.TemporaryDirectory(prefix="gnss_runtime_dataclass_") as temp_dir:
+            module_path = Path(temp_dir) / "dataclass_module.py"
+            module_path.write_text(
+                "from dataclasses import dataclass\n"
+                "@dataclass\n"
+                "class Sample:\n"
+                "    value: int\n",
+                encoding="utf-8",
+            )
+            original_sys_path = list(sys.path)
+            try:
+                module = load_python_module(module_name, module_path)
+                cached = load_python_module(module_name, module_path)
+                self.assertIs(module, cached)
+                self.assertEqual(module.Sample(7).value, 7)
+                self.assertIs(sys.modules[module_name], module)
+                module_path.unlink()
+                self.assertIs(load_python_module(module_name, module_path), module)
+                self.assertEqual(sys.path, original_sys_path)
+            finally:
+                sys.modules.pop(module_name, None)
+
+    def test_load_python_module_is_atomic_for_concurrent_callers(self) -> None:
+        module_name = "_web_http_ux_concurrent_module"
+        control_name = "_web_http_ux_concurrent_control"
+        started = threading.Event()
+        allow_finish = threading.Event()
+        control = ModuleType(control_name)
+        control.started = started
+        control.allow_finish = allow_finish
+        observed_lock = _ObservedRLock()
+        original_lock = gnss_runtime._MODULE_LOAD_LOCK
+        results: list[ModuleType | None] = [None, None]
+        ready_values: list[object | None] = [None, None]
+        errors: list[BaseException | None] = [None, None]
+        threads: list[threading.Thread] = []
+
+        with tempfile.TemporaryDirectory(prefix="gnss_runtime_concurrent_") as temp_dir:
+            module_path = Path(temp_dir) / "concurrent_module.py"
+            module_path.write_text(
+                f"from {control_name} import allow_finish, started\n"
+                "started.set()\n"
+                "if not allow_finish.wait(5.0):\n"
+                "    raise RuntimeError('concurrent loader test timed out')\n"
+                "READY = object()\n",
+                encoding="utf-8",
+            )
+
+            def load_in_thread(index: int) -> None:
+                try:
+                    module = load_python_module(module_name, module_path)
+                    ready_values[index] = module.READY
+                    results[index] = module
+                except BaseException as exc:
+                    errors[index] = exc
+
+            sys.modules[control_name] = control
+            gnss_runtime._MODULE_LOAD_LOCK = observed_lock
+            try:
+                threads.append(threading.Thread(target=load_in_thread, args=(0,)))
+                threads[0].start()
+                self.assertTrue(started.wait(5.0), "first module load did not start")
+
+                threads.append(threading.Thread(target=load_in_thread, args=(1,)))
+                threads[1].start()
+                self.assertTrue(
+                    observed_lock.second_attempt.wait(5.0),
+                    "second module load did not contend on the loader lock",
+                )
+                allow_finish.set()
+                for thread in threads:
+                    thread.join(timeout=5.0)
+
+                self.assertTrue(all(not thread.is_alive() for thread in threads))
+                self.assertEqual(errors, [None, None])
+                self.assertIs(results[0], results[1])
+                self.assertIsNotNone(results[0])
+                self.assertIs(ready_values[0], ready_values[1])
+            finally:
+                allow_finish.set()
+                for thread in threads:
+                    thread.join(timeout=5.0)
+                gnss_runtime._MODULE_LOAD_LOCK = original_lock
+                gnss_runtime._MODULES_LOADING.discard(module_name)
+                sys.modules.pop(module_name, None)
+                sys.modules.pop(control_name, None)
+
+    def test_load_python_module_rejects_collisions_and_rolls_back_failures(self) -> None:
+        module_name = "_web_http_ux_collision_module"
+        failure_name = "_web_http_ux_failure_module"
+        replacement_name = "_web_http_ux_replacement_module"
+        with tempfile.TemporaryDirectory(prefix="gnss_runtime_boundary_") as temp_dir:
+            temp_root = Path(temp_dir)
+            first_path = temp_root / "first.py"
+            second_path = temp_root / "second.py"
+            failure_path = temp_root / "failure.py"
+            replacement_path = temp_root / "replacement.py"
+            first_path.write_text("VALUE = 'first'\n", encoding="utf-8")
+            second_path.write_text("VALUE = 'second'\n", encoding="utf-8")
+            failure_path.write_text("raise SystemExit('expected loader exit')\n", encoding="utf-8")
+            replacement_path.write_text(
+                "import sys\n"
+                "from types import ModuleType\n"
+                "replacement = ModuleType(__name__)\n"
+                "replacement.preserved = True\n"
+                "sys.modules[__name__] = replacement\n"
+                "raise SystemExit('expected replacement exit')\n",
+                encoding="utf-8",
+            )
+            try:
+                module = load_python_module(module_name, first_path)
+                with self.assertRaisesRegex(ImportError, "Module name collision"):
+                    load_python_module(module_name, second_path)
+                self.assertIs(sys.modules[module_name], module)
+
+                with self.assertRaisesRegex(SystemExit, "expected loader exit"):
+                    load_python_module(failure_name, failure_path)
+                self.assertNotIn(failure_name, sys.modules)
+
+                with self.assertRaisesRegex(SystemExit, "expected replacement exit"):
+                    load_python_module(replacement_name, replacement_path)
+                replacement = sys.modules.get(replacement_name)
+                self.assertIsInstance(replacement, ModuleType)
+                self.assertIs(getattr(replacement, "preserved", None), True)
+            finally:
+                sys.modules.pop(module_name, None)
+                sys.modules.pop(failure_name, None)
+                sys.modules.pop(replacement_name, None)
+
+    def test_source_tree_odaiba_commands_preserve_comparison_aliases(self) -> None:
+        comparison = gnss_web.driving_comparison
+        self.assertIs(gnss_odaiba_benchmark.driving_comparison, comparison)
+        self.assertIs(gnss_odaiba_scan.driving_comparison, comparison)
+        for function_name in (
+            "match_to_reference",
+            "read_libgnss_pos",
+            "read_reference_csv",
+            "read_rtklib_pos",
+            "summarize",
+        ):
+            self.assertIs(getattr(gnss_odaiba_scan, function_name), getattr(comparison, function_name))
+
+    def test_importing_gnss_web_does_not_add_scripts_directory_to_sys_path(self) -> None:
+        scripts_entry = str((ROOT_DIR / "scripts").resolve())
+        original_sys_path = list(sys.path)
+        try:
+            sys.path[:] = [entry for entry in sys.path if entry != scripts_entry]
+            before_import = list(sys.path)
+            importlib.reload(gnss_web)
+            self.assertEqual(sys.path, before_import)
+            self.assertNotIn(scripts_entry, sys.path)
+        finally:
+            sys.path[:] = original_sys_path
+
+    def test_odaiba_command_sources_do_not_access_sys_path(self) -> None:
+        command_sources = (
+            ROOT_DIR / "apps/commands/visualization/gnss_web.py",
+            ROOT_DIR / "apps/commands/benchmarks/gnss_odaiba_benchmark.py",
+            ROOT_DIR / "apps/commands/benchmarks/gnss_odaiba_scan.py",
+        )
+        for source_path in command_sources:
+            self.assertNotIn("sys.path", source_path.read_text(encoding="utf-8"), source_path)
+
+    def test_flat_installed_commands_load_shared_script_without_pythonpath(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_flat_install_") as temp_dir:
+            prefix = Path(temp_dir)
+            bin_dir = prefix / "bin"
+            support_dir = bin_dir / "support"
+            scripts_dir = prefix / "scripts"
+            support_dir.mkdir(parents=True)
+            scripts_dir.mkdir()
+
+            support_source = COMMANDS_DIR / "support"
+            for filename in ("__init__.py", "gnss_runtime.py", "gnss_toml_config.py"):
+                shutil.copy2(support_source / filename, support_dir / filename)
+
+            command_cases = (
+                ("web", APPS_DIR / "gnss_web.py", "--port-file"),
+                (
+                    "odaiba-benchmark",
+                    BENCHMARKS_DIR / "gnss_odaiba_benchmark.py",
+                    "--summary-json",
+                ),
+                ("odaiba-scan", BENCHMARKS_DIR / "gnss_odaiba_scan.py", "--window-size"),
+            )
+            for _, source_path, _ in command_cases:
+                shutil.copy2(source_path, bin_dir / source_path.name)
+            shutil.copy2(
+                ROOT_DIR / "scripts" / "generate_driving_comparison.py",
+                scripts_dir / "generate_driving_comparison.py",
+            )
+
+            base_env = dict(os.environ)
+            base_env.pop("PYTHONPATH", None)
+            base_env["PYTHONDONTWRITEBYTECODE"] = "1"
+            self.assertNotIn("PYTHONPATH", base_env)
+
+            for command_name, source_path, expected_option in command_cases:
+                env = dict(base_env)
+                env["GNSS_CLI_NAME"] = f"gnss {command_name}"
+                completed = subprocess.run(
+                    [sys.executable, str(bin_dir / source_path.name), "--help"],
+                    cwd=prefix,
+                    env=env,
+                    capture_output=True,
+                    text=True,
+                    check=False,
+                    timeout=10.0,
+                )
+                self.assertEqual(completed.returncode, 0, msg=completed.stderr)
+                self.assertIn(expected_option, completed.stdout)
+                self.assertNotIn("Traceback (most recent call last)", completed.stderr)
+
     def test_web_http_entrypoints_are_stable_without_browser(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss_web_http_") as temp_dir:
             root = Path(temp_dir)


### PR DESCRIPTION
## Summary

- add a shared path-based Python module loader with deterministic caching, collision checks, atomic initialization, and identity-safe rollback
- remove `sys.path` mutation from `gnss web`, `gnss odaiba-benchmark`, and `gnss odaiba-scan`
- preserve the Odaiba scan function aliases while sharing one loaded comparison module
- add source-tree, concurrency, failure, and flat installed-prefix import contracts

## Why

These commands need the installed `scripts/generate_driving_comparison.py`, but adding the scripts directory to process-global `sys.path` made import resolution implicit and exposed the commands to unrelated module shadowing.

The shared loader makes the exact file boundary explicit in both supported layouts:

- source tree: repository-root `scripts/`
- install tree: `<prefix>/scripts/`

## Impact

No public command names, help text, output formats, exit behavior, Web HTML, install paths, or benchmark schemas change. All three help outputs and the rendered Web HTML are byte-for-byte identical to `develop`. The shared comparison script itself is unchanged.

## Validation

- clean Release configure and full build
- `bash scripts/ci/run_hygiene.sh`
- loader/Web contract tests: 8/8
- loader/Web contract test repeated 20 times without failure
- benchmark regression suite: 179/179
- CLI UX suite: 18/18
- source Odaiba help checks: 2/2
- all three source and installed dispatcher help hashes matched `develop`
- all three flat installed scripts passed direct `--help` with `PYTHONPATH` unset
- installed Web render hash matched `develop`
- core CTest lane: 37/37
- extended CTest lane, including packaging: 4/4
- optional CTest lane: 19/19
- two-stage independent Luna Max review: no unresolved findings
