### PR TITLE
Add safe RINEX 4 reader dispatch

### DIFF
--- a/docs/rinex4_plan.md
+++ b/docs/rinex4_plan.md
@@ -171,10 +171,12 @@ Phase 2, observation support:
 - Add CRINEX policy tests that verify `.crx`/`.crx.gz` is rejected with a clear
   message or preprocessed through an external converter.
 
-Phase 3, `EPH` navigation support:
+Phase 3, `EPH` navigation support (PARTIAL after Phase 1 safe dispatch):
 
-- Parse RINEX 4 `EPH` data record headers.
+- Parse RINEX 4 `EPH` data record headers. **DONE in the Phase 1 slice.**
 - Reuse current GPS/Galileo/BeiDou/QZSS/GLONASS FDMA bodies where compatible.
+  **PARTIAL in the Phase 1 slice; message metadata and new-message models
+  remain future work.**
 - Add explicit skip/error handling for unsupported `L1NV`, `L1OC`, and `L3OC`
   before implementing them.
 - Preserve message type metadata for Galileo `FNAV` vs `INAV`.
@@ -199,7 +201,10 @@ Phase 6, writer support:
 - Emit RINEX 4 navigation data record headers.
 - Add writer round-trip tests only after reader behavior is stable.
 
-## Acceptance Gates
+## End-State Acceptance Gates
+
+These gates cover the complete roadmap, not just the current safe-dispatch
+slice. The RINEX 4 observation-row gate is intentionally deferred to Phase 2.
 
 - Existing RINEX 2/3 tests continue to pass.
 - RINEX 4 observation fixture parses header, epoch time, satellite count, and
@@ -209,9 +214,29 @@ Phase 6, writer support:
 - Unsupported RINEX 4 records fail or skip deterministically with diagnostics.
 - CRINEX input policy is explicit and tested.
 
-## Non-Goals For Iter1
+## Safe-Dispatch Slice Non-Goals
 
-- No RINEX 4 parser behavior changes.
+- No full RINEX 4 observation parser behavior changes beyond the Phase 1
+  detection/rejection boundary.
 - No native CRINEX decompressor.
 - No NavIC or GLONASS CDMA message implementation.
 - No writer behavior changes.
+
+## Phase 1 Implementation Status: DONE
+
+The safe-dispatch slice is implemented in the reader while the Phase 2
+observation parser remains intentionally out of scope:
+
+- `RINEXReader::isRinex4()` identifies versions 4.00 through 4.99 explicitly;
+  RINEX 2 and 3 continue through their existing paths.
+- RINEX 4 observation epochs are detected and rejected with a diagnostic
+  rather than being passed to the fixed-column RINEX 3 parser.
+- RINEX 4 navigation data-record headers are parsed in `rinex4.hpp/cpp`.
+  Compatible GPS/QZSS LNAV, GLONASS FDMA, Galileo FNAV/INAV, and BeiDou D1/D2
+  EPH bodies reuse the existing ephemeris parser.
+- STO/EOP/ION records and unsupported EPH message types are skipped at the
+  next `>` record boundary with diagnostics, preventing silent body misparse.
+
+Token-based RINEX 4 observation epochs, receiver-clock offsets, expanded
+second precision, and new navigation message models remain Phase 2 and later
+work as specified above.

--- a/include/libgnss++/io/rinex.hpp
+++ b/include/libgnss++/io/rinex.hpp
@@ -140,6 +140,17 @@ public:
      * @brief Get RINEX version
      */
     double getVersion() const { return header_.version; }
+
+    /**
+     * @brief Check whether the current file uses the RINEX 4 data-record
+     * syntax.
+     *
+     * RINEX 4 observation records are not interchangeable with the fixed
+     * column RINEX 3 epoch parser, and RINEX 4 navigation records have an
+     * explicit data-record header.  Keep this boundary visible to callers
+     * instead of treating every version at or above 3 as RINEX 3.
+     */
+    bool isRinex4() const { return header_.version >= 4.0 && header_.version < 5.0; }
     
     /**
      * @brief Check if file is open
@@ -155,6 +166,7 @@ private:
     std::ifstream file_;
     RINEXHeader header_;
     int current_line_ = 0;
+    bool header_read_ = false;
     bool qzss_prefer_l1l_ = false;
     bool qzss_prefer_l5_secondary_ = false;
     bool preserve_additional_frequency_bands_ = false;
@@ -185,6 +197,11 @@ private:
      * @brief Parse navigation message
      */
     bool parseNavigationMessage(const std::vector<std::string>& lines, Ephemeris& eph);
+
+    /**
+     * @brief Read RINEX 4 navigation data records after the file header.
+     */
+    bool readRinex4NavigationData(NavigationData& nav_data);
     
     /**
      * @brief Parse time string

--- a/include/libgnss++/io/rinex4.hpp
+++ b/include/libgnss++/io/rinex4.hpp
@@ -1,7 +1,41 @@
 #pragma once
 
+#include <string>
+
 namespace libgnss::io::rinex4 {
 
 inline constexpr double kVersion = 4.02;
+
+/**
+ * @brief Metadata carried by a RINEX 4 navigation data-record header.
+ *
+ * The source field is a satellite identifier for EPH records (for example
+ * G01) and may be constellation-only for STO/EOP/ION records (for example
+ * R).  The body parser is intentionally kept in RINEXReader; this type only
+ * describes the format boundary.
+ */
+struct NavigationRecordHeader {
+    std::string record_type;
+    std::string source;
+    std::string message_type;
+    std::string subtype;
+    char system = '\0';
+    int prn = 0;
+};
+
+/**
+ * @brief Parse a RINEX 4 navigation data-record header line.
+ *
+ * Returns false for malformed syntax.  Known-but-not-yet-supported GNSS
+ * constellations remain syntactically valid so callers can report them as an
+ * unsupported EPH message rather than treating them as malformed input.
+ */
+bool parseNavigationRecordHeader(const std::string& line,
+                                 NavigationRecordHeader& record);
+
+/**
+ * @brief Check whether an EPH message can reuse the existing body parser.
+ */
+bool supportsEphemerisMessage(char system, const std::string& message_type);
 
 }  // namespace libgnss::io::rinex4

--- a/src/io/rinex.cpp
+++ b/src/io/rinex.cpp
@@ -1,4 +1,5 @@
 #include <libgnss++/io/rinex.hpp>
+#include <libgnss++/io/rinex4.hpp>
 #include <libgnss++/algorithms/ppp_env_overrides.hpp>
 #include <libgnss++/core/signal_policy.hpp>
 #include <algorithm>
@@ -7,6 +8,7 @@
 #include <iomanip>
 #include <iostream>
 #include <cmath>
+#include <cctype>
 #include <set>
 
 namespace libgnss {
@@ -405,6 +407,7 @@ RINEXReader::RINEXReader()
 bool RINEXReader::open(const std::string& filename) {
     file_.open(filename);
     current_line_ = 0;
+    header_read_ = false;
     return file_.is_open();
 }
 
@@ -431,6 +434,7 @@ bool RINEXReader::readHeader(RINEXHeader& header) {
     }
     
     header_ = header;
+    header_read_ = true;
     return true;
 }
 
@@ -485,11 +489,28 @@ bool RINEXReader::readObservationEpoch(ObservationData& obs_data) {
                     continue;
                 }
             }
-        } else if (header_.version >= 3.0) {
+        } else if (isRinex4()) {
+            // RINEX 4 epoch records allow more precise seconds and an
+            // optional receiver-clock field.  The fixed-column RINEX 3
+            // parser below is intentionally not used here: accepting a
+            // shifted flag/count field would silently misread every
+            // satellite row.  Token-based RINEX 4 observation parsing is a
+            // separate follow-up slice.
+            if (!line.empty() && line[0] == '>') {
+                std::cerr << "RINEX 4 observation epochs are not supported yet; "
+                             "use a RINEX 3-compatible input or preprocess the file"
+                          << std::endl;
+                return false;
+            }
+        } else if (header_.version >= 3.0 && header_.version < 4.0) {
             // RINEX 3.x format starts with '>'
-            if (line[0] == '>') {
+            if (!line.empty() && line[0] == '>') {
                 return parseObservationEpochV3(line, obs_data);
             }
+        } else {
+            std::cerr << "Unsupported RINEX version for observation data: "
+                      << header_.version << std::endl;
+            return false;
         }
     }
 
@@ -516,82 +537,95 @@ bool RINEXReader::readNavigationData(NavigationData& nav_data) {
 
     // Skip header if not already done, but parse version info and iono params
     std::string line;
-    bool header_found = false;
-    while (readLine(line)) {
-        if (line.find("END OF HEADER") != std::string::npos) {
-            header_found = true;
-            break;
-        }
-        // Parse header lines to get version info
-        if (line.length() >= 60) {
-            std::string label = line.substr(60);
-            if (label.find("RINEX VERSION") != std::string::npos) {
-                header_.version = std::stod(line.substr(0, 9));
+    bool header_found = header_read_;
+    if (!header_read_) {
+        while (readLine(line)) {
+            if (line.find("END OF HEADER") != std::string::npos) {
+                header_found = true;
+                break;
             }
-            // Parse Klobuchar ionosphere parameters (RINEX 2: ION ALPHA / ION BETA)
-            else if (label.find("ION ALPHA") != std::string::npos) {
-                // Format: 4 values in D-format, 12 chars each starting at col 2
-                auto parseDval = [](const std::string& s) -> double {
-                    std::string v = s;
-                    v.erase(0, v.find_first_not_of(' '));
-                    v.erase(v.find_last_not_of(' ') + 1);
-                    if (v.empty()) return 0.0;
-                    auto dp = v.find('D'); if (dp != std::string::npos) v[dp] = 'E';
-                    dp = v.find('d'); if (dp != std::string::npos) v[dp] = 'E';
-                    try { return std::stod(v); } catch (...) { return 0.0; }
-                };
-                nav_data.ionosphere_model.alpha[0] = parseDval(line.substr(2, 12));
-                nav_data.ionosphere_model.alpha[1] = parseDval(line.substr(14, 12));
-                nav_data.ionosphere_model.alpha[2] = parseDval(line.substr(26, 12));
-                nav_data.ionosphere_model.alpha[3] = parseDval(line.substr(38, 12));
-                nav_data.ionosphere_model.valid = true;
-            }
-            else if (label.find("ION BETA") != std::string::npos) {
-                auto parseDval = [](const std::string& s) -> double {
-                    std::string v = s;
-                    v.erase(0, v.find_first_not_of(' '));
-                    v.erase(v.find_last_not_of(' ') + 1);
-                    if (v.empty()) return 0.0;
-                    auto dp = v.find('D'); if (dp != std::string::npos) v[dp] = 'E';
-                    dp = v.find('d'); if (dp != std::string::npos) v[dp] = 'E';
-                    try { return std::stod(v); } catch (...) { return 0.0; }
-                };
-                nav_data.ionosphere_model.beta[0] = parseDval(line.substr(2, 12));
-                nav_data.ionosphere_model.beta[1] = parseDval(line.substr(14, 12));
-                nav_data.ionosphere_model.beta[2] = parseDval(line.substr(26, 12));
-                nav_data.ionosphere_model.beta[3] = parseDval(line.substr(38, 12));
-            }
-            // Parse IONOSPHERIC CORR (RINEX 3: GPSA / GPSB)
-            else if (label.find("IONOSPHERIC CORR") != std::string::npos) {
-                auto parseDval = [](const std::string& s) -> double {
-                    std::string v = s;
-                    v.erase(0, v.find_first_not_of(' '));
-                    v.erase(v.find_last_not_of(' ') + 1);
-                    if (v.empty()) return 0.0;
-                    auto dp = v.find('D'); if (dp != std::string::npos) v[dp] = 'E';
-                    dp = v.find('d'); if (dp != std::string::npos) v[dp] = 'E';
-                    try { return std::stod(v); } catch (...) { return 0.0; }
-                };
-                std::string corr_type = line.substr(0, 4);
-                corr_type.erase(corr_type.find_last_not_of(' ') + 1);
-                if (corr_type == "GPSA") {
-                    nav_data.ionosphere_model.alpha[0] = parseDval(line.substr(5, 12));
-                    nav_data.ionosphere_model.alpha[1] = parseDval(line.substr(17, 12));
-                    nav_data.ionosphere_model.alpha[2] = parseDval(line.substr(29, 12));
-                    nav_data.ionosphere_model.alpha[3] = parseDval(line.substr(41, 12));
+            // Parse header lines to get version info
+            if (line.length() >= 60) {
+                std::string label = line.substr(60);
+                if (label.find("RINEX VERSION") != std::string::npos) {
+                    header_.version = std::stod(line.substr(0, 9));
+                }
+                // Parse Klobuchar ionosphere parameters (RINEX 2: ION ALPHA / ION BETA)
+                else if (label.find("ION ALPHA") != std::string::npos) {
+                    // Format: 4 values in D-format, 12 chars each starting at col 2
+                    auto parseDval = [](const std::string& s) -> double {
+                        std::string v = s;
+                        v.erase(0, v.find_first_not_of(' '));
+                        v.erase(v.find_last_not_of(' ') + 1);
+                        if (v.empty()) return 0.0;
+                        auto dp = v.find('D'); if (dp != std::string::npos) v[dp] = 'E';
+                        dp = v.find('d'); if (dp != std::string::npos) v[dp] = 'E';
+                        try { return std::stod(v); } catch (...) { return 0.0; }
+                    };
+                    nav_data.ionosphere_model.alpha[0] = parseDval(line.substr(2, 12));
+                    nav_data.ionosphere_model.alpha[1] = parseDval(line.substr(14, 12));
+                    nav_data.ionosphere_model.alpha[2] = parseDval(line.substr(26, 12));
+                    nav_data.ionosphere_model.alpha[3] = parseDval(line.substr(38, 12));
                     nav_data.ionosphere_model.valid = true;
-                } else if (corr_type == "GPSB") {
-                    nav_data.ionosphere_model.beta[0] = parseDval(line.substr(5, 12));
-                    nav_data.ionosphere_model.beta[1] = parseDval(line.substr(17, 12));
-                    nav_data.ionosphere_model.beta[2] = parseDval(line.substr(29, 12));
-                    nav_data.ionosphere_model.beta[3] = parseDval(line.substr(41, 12));
+                }
+                else if (label.find("ION BETA") != std::string::npos) {
+                    auto parseDval = [](const std::string& s) -> double {
+                        std::string v = s;
+                        v.erase(0, v.find_first_not_of(' '));
+                        v.erase(v.find_last_not_of(' ') + 1);
+                        if (v.empty()) return 0.0;
+                        auto dp = v.find('D'); if (dp != std::string::npos) v[dp] = 'E';
+                        dp = v.find('d'); if (dp != std::string::npos) v[dp] = 'E';
+                        try { return std::stod(v); } catch (...) { return 0.0; }
+                    };
+                    nav_data.ionosphere_model.beta[0] = parseDval(line.substr(2, 12));
+                    nav_data.ionosphere_model.beta[1] = parseDval(line.substr(14, 12));
+                    nav_data.ionosphere_model.beta[2] = parseDval(line.substr(26, 12));
+                    nav_data.ionosphere_model.beta[3] = parseDval(line.substr(38, 12));
+                }
+                // Parse IONOSPHERIC CORR (RINEX 3: GPSA / GPSB)
+                else if (label.find("IONOSPHERIC CORR") != std::string::npos) {
+                    auto parseDval = [](const std::string& s) -> double {
+                        std::string v = s;
+                        v.erase(0, v.find_first_not_of(' '));
+                        v.erase(v.find_last_not_of(' ') + 1);
+                        if (v.empty()) return 0.0;
+                        auto dp = v.find('D'); if (dp != std::string::npos) v[dp] = 'E';
+                        dp = v.find('d'); if (dp != std::string::npos) v[dp] = 'E';
+                        try { return std::stod(v); } catch (...) { return 0.0; }
+                    };
+                    std::string corr_type = line.substr(0, 4);
+                    corr_type.erase(corr_type.find_last_not_of(' ') + 1);
+                    if (corr_type == "GPSA") {
+                        nav_data.ionosphere_model.alpha[0] = parseDval(line.substr(5, 12));
+                        nav_data.ionosphere_model.alpha[1] = parseDval(line.substr(17, 12));
+                        nav_data.ionosphere_model.alpha[2] = parseDval(line.substr(29, 12));
+                        nav_data.ionosphere_model.alpha[3] = parseDval(line.substr(41, 12));
+                        nav_data.ionosphere_model.valid = true;
+                    } else if (corr_type == "GPSB") {
+                        nav_data.ionosphere_model.beta[0] = parseDval(line.substr(5, 12));
+                        nav_data.ionosphere_model.beta[1] = parseDval(line.substr(17, 12));
+                        nav_data.ionosphere_model.beta[2] = parseDval(line.substr(29, 12));
+                        nav_data.ionosphere_model.beta[3] = parseDval(line.substr(41, 12));
+                    }
                 }
             }
         }
+        header_read_ = true;
     }
 
     if (!header_found) {
         // Header already processed, rewind might not work, so just continue
+    }
+
+    if (isRinex4()) {
+        return readRinex4NavigationData(nav_data);
+    }
+
+    if (header_.version >= 5.0) {
+        std::cerr << "Unsupported RINEX version for navigation data: "
+                  << header_.version << std::endl;
+        return false;
     }
 
     std::vector<std::string> eph_lines;
@@ -602,7 +636,7 @@ bool RINEXReader::readNavigationData(NavigationData& nav_data) {
     int skip_lines_remaining = 0;
 
     // Detect RINEX version for navigation file format differences
-    bool is_rinex3 = (header_.version >= 3.0);
+    bool is_rinex3 = (header_.version >= 3.0 && header_.version < 4.0);
 
     try {
         while (readLine(line)) {
@@ -710,6 +744,98 @@ bool RINEXReader::readNavigationData(NavigationData& nav_data) {
         throw;
     }
 
+    return !nav_data.isEmpty();
+}
+
+bool RINEXReader::readRinex4NavigationData(NavigationData& nav_data) {
+    // RINEX 4 makes the navigation record boundary explicit.  Keep the
+    // complete body between two '>' headers so unsupported STO/EOP/ION (or
+    // unsupported EPH message types) can be skipped without feeding their
+    // fields to the legacy ephemeris parser.
+    std::string line;
+    rinex4::NavigationRecordHeader active_header;
+    std::vector<std::string> body;
+    bool have_active_record = false;
+    bool active_record_supported = false;
+
+    const auto finish_record = [&]() {
+        if (!have_active_record || !active_record_supported) {
+            body.clear();
+            return;
+        }
+
+        Ephemeris eph;
+        if (!parseNavigationMessage(body, eph)) {
+            std::cerr << "Skipping RINEX 4 EPH " << active_header.source << ' '
+                      << active_header.message_type
+                      << ": incompatible or malformed navigation body"
+                      << std::endl;
+            body.clear();
+            return;
+        }
+
+        const SatelliteId expected_satellite(
+            systemFromRinexChar(active_header.system), active_header.prn);
+        if (eph.satellite != expected_satellite) {
+            std::cerr << "Skipping RINEX 4 EPH " << active_header.source
+                      << ": body satellite does not match record header"
+                      << std::endl;
+            body.clear();
+            return;
+        }
+
+        nav_data.addEphemeris(eph);
+        body.clear();
+    };
+
+    while (readLine(line)) {
+        const size_t first_non_space = line.find_first_not_of(" \t");
+        const bool is_record_header =
+            first_non_space != std::string::npos && line[first_non_space] == '>';
+        if (is_record_header) {
+            finish_record();
+            have_active_record = false;
+            active_record_supported = false;
+            active_header = rinex4::NavigationRecordHeader();
+
+            if (!rinex4::parseNavigationRecordHeader(line, active_header)) {
+                std::cerr << "Skipping malformed RINEX 4 navigation record header: "
+                          << line << std::endl;
+                have_active_record = true;
+                continue;
+            }
+
+            have_active_record = true;
+            if (active_header.record_type != "EPH") {
+                std::cerr << "Skipping unsupported RINEX 4 navigation record type: "
+                          << active_header.record_type << std::endl;
+                continue;
+            }
+
+            active_record_supported = rinex4::supportsEphemerisMessage(
+                active_header.system, active_header.message_type);
+            if (!active_record_supported) {
+                std::cerr << "Skipping unsupported RINEX 4 EPH "
+                          << active_header.source << ' '
+                          << active_header.message_type << std::endl;
+            }
+            continue;
+        }
+
+        if (!have_active_record) {
+            if (line.find_first_not_of(" \t\r\n") != std::string::npos) {
+                std::cerr << "Skipping RINEX 4 navigation data before a record header"
+                          << std::endl;
+            }
+            continue;
+        }
+
+        if (active_record_supported && !line.empty()) {
+            body.push_back(line);
+        }
+    }
+
+    finish_record();
     return !nav_data.isEmpty();
 }
 

--- a/src/io/rinex4.cpp
+++ b/src/io/rinex4.cpp
@@ -1,1 +1,72 @@
 #include <libgnss++/io/rinex4.hpp>
+
+#include <cctype>
+#include <sstream>
+
+namespace libgnss::io::rinex4 {
+
+namespace {
+
+bool isKnownConstellation(char system) {
+    return system == 'G' || system == 'R' || system == 'E' ||
+           system == 'C' || system == 'J' || system == 'S' ||
+           system == 'I';
+}
+
+}  // namespace
+
+bool parseNavigationRecordHeader(const std::string& line,
+                                 NavigationRecordHeader& record) {
+    std::istringstream fields(line);
+    std::string marker;
+    if (!(fields >> marker >> record.record_type >> record.source >> record.message_type) ||
+        marker != ">") {
+        return false;
+    }
+    fields >> record.subtype;
+
+    if (record.record_type.size() != 3 || record.source.empty() ||
+        record.message_type.empty()) {
+        return false;
+    }
+
+    // EPH records identify a transmitting satellite (for example G01),
+    // whereas STO/ION/EOP records may identify only a constellation (for
+    // example R).  Validate the satellite form only when it is required.
+    if (record.record_type == "EPH") {
+        if (record.source.size() != 3 ||
+            !isKnownConstellation(record.source[0]) ||
+            !std::isdigit(static_cast<unsigned char>(record.source[1])) ||
+            !std::isdigit(static_cast<unsigned char>(record.source[2]))) {
+            return false;
+        }
+        record.system = record.source[0];
+        record.prn = (record.source[1] - '0') * 10 + (record.source[2] - '0');
+        if (record.prn <= 0) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool supportsEphemerisMessage(char system, const std::string& message_type) {
+    // These are the RINEX 4 records whose body layout is compatible with the
+    // existing RINEX 2/3 parser.  New signal-specific records (CNAV/CNVx,
+    // NavIC L1NV, and GLONASS CDMA L1OC/L3OC) must not be passed to it: doing
+    // so would turn their fields into a plausible but incorrect ephemeris.
+    switch (system) {
+        case 'G':
+        case 'J':
+            return message_type == "LNAV";
+        case 'R':
+            return message_type == "FDMA";
+        case 'E':
+            return message_type == "FNAV" || message_type == "INAV";
+        case 'C':
+            return message_type == "D1" || message_type == "D2";
+        default:
+            return false;
+    }
+}
+
+}  // namespace libgnss::io::rinex4

--- a/tests/test_rinex_writer.cpp
+++ b/tests/test_rinex_writer.cpp
@@ -30,6 +30,21 @@ std::string rinexObsField(const std::string& value,
     return field;
 }
 
+std::string rinex4GpsLnavBody() {
+    // RINEX 4.02 Table A12-compatible GPS LNAV body.  The data-record
+    // header is deliberately kept separate so tests exercise the new
+    // dispatch boundary rather than a RINEX 3-style first-line heuristic.
+    return R"(G04 2019 03 14 04 00 00 1.330170780420e-04 7.275957614183e-12 0.000000000000e+00
+     9.800000000000e+01-1.718750000000e+00 4.639836124941e-09 2.148941747752e+00
+    -1.881271600723e-07 3.355251392350e-04 8.245930075645e-06 5.153800453186e+03
+     3.600000000000e+05-1.676380634308e-08 5.171400020311e-01 1.490116119385e-08
+     9.601921900531e-01 2.187187500000e+02-1.736906885738e+00-8.044977962767e-09
+    -2.932264997750e-10 1.000000000000e+00 2.044000000000e+03 0.000000000000e+00
+     4.000000000000e+00 6.300000000000e+01-8.847564458847e-09 8.660000000000e+02
+     3.553500000000e+05 4.000000000000e+00
+)";
+}
+
 Ephemeris makeGpsEphemeris() {
     Ephemeris eph;
     eph.satellite = SatelliteId(GNSSSystem::GPS, 3);
@@ -186,6 +201,108 @@ TEST(RINEXReaderTest, ParsesTimeOfFirstObsHeader) {
 
     EXPECT_EQ(header.first_obs.week, 2328);
     EXPECT_NEAR(header.first_obs.tow, 357255.5, 1e-9);
+
+    reader.close();
+    std::filesystem::remove(temp_path);
+}
+
+TEST(RINEXReaderTest, DetectsRinex4AndDoesNotUseRinex3EpochColumns) {
+    const auto temp_path =
+        std::filesystem::temp_directory_path() / "libgnss_rinex4_observation_dispatch.obs";
+    std::filesystem::remove(temp_path);
+
+    {
+        std::ofstream file(temp_path);
+        ASSERT_TRUE(file.is_open());
+        file << rinexHeaderLine(
+            "     4.02           OBSERVATION DATA    M",
+            "RINEX VERSION / TYPE");
+        file << rinexHeaderLine(
+            "G    4 C1C L1C C2W L2W",
+            "SYS / # / OBS TYPES");
+        file << rinexHeaderLine("", "END OF HEADER");
+        // The extra second digits intentionally shift the RINEX 3 fixed
+        // columns.  Phase 1 must reject this explicitly until token-based
+        // RINEX 4 observation parsing is implemented.
+        file << "> 2024 08 03 09 51 20.1234567890123  0  1\n";
+        file << "G04" << rinexObsField("22011162.552")
+             << rinexObsField("115669443.467")
+             << rinexObsField("22022262.423")
+             << rinexObsField("120222443.467") << "\n";
+    }
+
+    io::RINEXReader reader;
+    ASSERT_TRUE(reader.open(temp_path.string()));
+    io::RINEXReader::RINEXHeader header;
+    ASSERT_TRUE(reader.readHeader(header));
+    EXPECT_DOUBLE_EQ(header.version, 4.02);
+    EXPECT_TRUE(reader.isRinex4());
+
+    ObservationData epoch;
+    testing::internal::CaptureStderr();
+    EXPECT_FALSE(reader.readObservationEpoch(epoch));
+    const std::string diagnostic = testing::internal::GetCapturedStderr();
+    EXPECT_NE(diagnostic.find("RINEX 4 observation epochs are not supported yet"),
+              std::string::npos);
+
+    reader.close();
+    std::filesystem::remove(temp_path);
+}
+
+TEST(RINEXReaderTest, DispatchesRinex4LnavAndSkipsUnsupportedRecordBoundary) {
+    const auto temp_path =
+        std::filesystem::temp_directory_path() / "libgnss_rinex4_navigation_dispatch.nav";
+    std::filesystem::remove(temp_path);
+
+    {
+        std::ofstream file(temp_path);
+        ASSERT_TRUE(file.is_open());
+        file << rinexHeaderLine(
+            "     4.02           NAVIGATION DATA     M",
+            "RINEX VERSION / TYPE");
+        file << rinexHeaderLine("", "END OF HEADER");
+        file << "> STO R FDMA\n";
+        file << "this system record is intentionally unsupported\n";
+        file << "> EPH I05 LNAV\n";
+        file << "this syntactically valid but unsupported EPH is skipped\n";
+        file << "> EPH G04 LNAV\n";
+        file << rinex4GpsLnavBody();
+        std::string bds_d1_body = rinex4GpsLnavBody();
+        bds_d1_body.replace(0, 3, "C01");
+        file << "> EPH C01 D1\n";
+        file << bds_d1_body;
+        file << "> EPH G04 CNAV\n";
+        file << "this EPH message type is deliberately unsupported\n";
+    }
+
+    io::RINEXReader reader;
+    ASSERT_TRUE(reader.open(temp_path.string()));
+    io::RINEXReader::RINEXHeader header;
+    ASSERT_TRUE(reader.readHeader(header));
+    EXPECT_TRUE(reader.isRinex4());
+
+    NavigationData nav_data;
+    testing::internal::CaptureStderr();
+    ASSERT_TRUE(reader.readNavigationData(nav_data));
+    const std::string diagnostic = testing::internal::GetCapturedStderr();
+    EXPECT_NE(diagnostic.find("Skipping unsupported RINEX 4 navigation record type: STO"),
+              std::string::npos);
+    EXPECT_NE(diagnostic.find("Skipping unsupported RINEX 4 EPH I05 LNAV"),
+              std::string::npos);
+    EXPECT_NE(diagnostic.find("Skipping unsupported RINEX 4 EPH G04 CNAV"),
+              std::string::npos);
+
+    const auto it = nav_data.ephemeris_data.find(SatelliteId(GNSSSystem::GPS, 4));
+    ASSERT_NE(it, nav_data.ephemeris_data.end());
+    ASSERT_EQ(it->second.size(), 1U);
+    EXPECT_EQ(it->second.front().satellite, SatelliteId(GNSSSystem::GPS, 4));
+    EXPECT_EQ(it->second.front().week, 2044);
+    EXPECT_NEAR(it->second.front().toes, 360000.0, 1e-6);
+
+    const auto bds_it = nav_data.ephemeris_data.find(
+        SatelliteId(GNSSSystem::BeiDou, 1));
+    ASSERT_NE(bds_it, nav_data.ephemeris_data.end());
+    ASSERT_EQ(bds_it->second.size(), 1U);
 
     reader.close();
     std::filesystem::remove(temp_path);


### PR DESCRIPTION
## Summary

- detect RINEX 4 explicitly instead of routing it through RINEX 3 parsing
- reject RINEX 4 observation epochs with a clear diagnostic until the token-based parser lands
- parse RINEX 4 navigation data-record headers and reuse compatible legacy ephemeris bodies
- skip unsupported navigation record types and message types at explicit record boundaries
- document the completed Phase 1 slice and add regression coverage

## Why

RINEX 4 observation epochs and navigation records are not safely interchangeable with the existing RINEX 3 fixed-column paths. Explicit dispatch prevents plausible but incorrect parsing while establishing the boundary for follow-up observation and navigation support.

## Impact

Existing RINEX 2/3 behavior remains unchanged. RINEX 4 navigation supports GPS/QZSS LNAV, GLONASS FDMA, Galileo FNAV/INAV, and BeiDou D1/D2 bodies that match the existing parser. Other RINEX 4 records are rejected or skipped deterministically with diagnostics.

## Validation

- focused RINEX tests: 13/13 passed
- core test suite: 800 passed, 66 skipped, 0 failed
- full CTest suite: 65/65 passed
- MkDocs strict build passed
- git diff --check passed