### PR TITLE
Add RINEX 4 observation parsing

### DIFF
--- a/docs/rinex4_plan.md
+++ b/docs/rinex4_plan.md
@@ -1,9 +1,9 @@
 # RINEX 4.02 Plan
 
-This plan scopes the RINEX 4 work before implementation.  The intent for
-iter1 is to record the parser state, isolate the RINEX 4 surface area, and add
-only a compile-time skeleton.  Functional parsing changes should start in
-iter2.
+This plan scoped the RINEX 4 work before implementation.  The original iter1
+intent was to record parser state, isolate the RINEX 4 surface area, and add a
+compile-time skeleton; the completed Phase 1 and Phase 2 slices now add the
+documented reader behavior incrementally.
 
 ## Reference Sources
 
@@ -171,6 +171,17 @@ Phase 2, observation support:
 - Add CRINEX policy tests that verify `.crx`/`.crx.gz` is rejected with a clear
   message or preprocessed through an external converter.
 
+**DONE in the Phase 2 observation slice.**  RINEX 4 epoch metadata is parsed
+token-wise, including the Table A3 receiver-clock and optional five-digit
+picosecond extension fields.  GPS and QZSS rows reuse the RINEX 3 selection
+policy, continuation headers are covered, and event/cycle-slip records are
+consumed before scanning for the next normal epoch.  Event records do not
+produce `ObservationData` epochs, while a valid flag 0/1 epoch with zero
+satellites is returned as an intentionally empty epoch; malformed or
+truncated normal records fail instead of returning partial data.  Native
+CRINEX decompression remains out of scope and matching suffixes are rejected
+explicitly.
+
 Phase 3, `EPH` navigation support (PARTIAL after Phase 1 safe dispatch):
 
 - Parse RINEX 4 `EPH` data record headers. **DONE in the Phase 1 slice.**
@@ -203,40 +214,47 @@ Phase 6, writer support:
 
 ## End-State Acceptance Gates
 
-These gates cover the complete roadmap, not just the current safe-dispatch
-slice. The RINEX 4 observation-row gate is intentionally deferred to Phase 2.
+These are end-state gates for the complete roadmap, not just the current
+safe-dispatch and observation slices.  The reader gates completed by Phases 1
+and 2 are marked by the corresponding status sections below.
 
 - Existing RINEX 2/3 tests continue to pass.
 - RINEX 4 observation fixture parses header, epoch time, satellite count, and
-  at least GPS/QZSS observation rows.
+  at least GPS/QZSS observation rows. **MET by Phase 2.**
 - RINEX 4 navigation fixture with `> EPH G.. LNAV` parses at parity with the
   equivalent RINEX 3 record.
 - Unsupported RINEX 4 records fail or skip deterministically with diagnostics.
 - CRINEX input policy is explicit and tested.
 
-## Safe-Dispatch Slice Non-Goals
+## Safe-Dispatch and Observation Slice Non-Goals
 
-- No full RINEX 4 observation parser behavior changes beyond the Phase 1
-  detection/rejection boundary.
+- No complete RINEX 4 observation model: event metadata is intentionally not
+  retained in `ObservationData`, and cycle-slip records are consumed rather
+  than exposed.
 - No native CRINEX decompressor.
 - No NavIC or GLONASS CDMA message implementation.
 - No writer behavior changes.
 
 ## Phase 1 Implementation Status: DONE
 
-The safe-dispatch slice is implemented in the reader while the Phase 2
-observation parser remains intentionally out of scope:
+The safe-dispatch slice is implemented in the reader:
 
 - `RINEXReader::isRinex4()` identifies versions 4.00 through 4.99 explicitly;
   RINEX 2 and 3 continue through their existing paths.
-- RINEX 4 observation epochs are detected and rejected with a diagnostic
-  rather than being passed to the fixed-column RINEX 3 parser.
+- RINEX 4 observation epochs are dispatched to the dedicated Phase 2 parser;
+  RINEX 2 and 3 continue through their existing paths.
 - RINEX 4 navigation data-record headers are parsed in `rinex4.hpp/cpp`.
   Compatible GPS/QZSS LNAV, GLONASS FDMA, Galileo FNAV/INAV, and BeiDou D1/D2
   EPH bodies reuse the existing ephemeris parser.
 - STO/EOP/ION records and unsupported EPH message types are skipped at the
   next `>` record boundary with diagnostics, preventing silent body misparse.
 
-Token-based RINEX 4 observation epochs, receiver-clock offsets, expanded
-second precision, and new navigation message models remain Phase 2 and later
-work as specified above.
+## Phase 2 Implementation Status: DONE
+
+The observation slice now handles token-based RINEX 4 epoch fields, fixed
+Table A3 receiver-clock offsets, optional extra second digits, GPS/QZSS
+observation rows, continuation headers, deterministic event/cycle-slip
+skipping (with zero-satellite normal epochs preserved), strict truncation
+checks, and explicit CRINEX suffix rejection.
+Event metadata retention, richer cycle-slip data models, and all new
+navigation message models remain deferred as listed above.

--- a/include/libgnss++/io/rinex.hpp
+++ b/include/libgnss++/io/rinex.hpp
@@ -13,7 +13,7 @@ namespace io {
 /**
  * @brief RINEX file reader/writer
  * 
- * Supports RINEX 2.x and 3.x formats for observation and navigation files
+ * Supports RINEX 2.x/3.x and the scoped RINEX 4 observation/navigation reader
  */
 class RINEXReader {
 public:
@@ -50,7 +50,7 @@ public:
         Vector3d approximate_position;
         Vector3d antenna_delta;
         std::vector<std::string> observation_types;
-        // RINEX 3: per-system observation types (key = system char, e.g. "G", "R", "E")
+        // RINEX 3/4: per-system observation types (key = system char, e.g. "G", "R", "E")
         std::map<char, std::vector<std::string>> system_obs_types;
         std::map<SatelliteId, int> glonass_frequency_channels;
         double interval = 0.0;
@@ -170,8 +170,9 @@ private:
     bool qzss_prefer_l1l_ = false;
     bool qzss_prefer_l5_secondary_ = false;
     bool preserve_additional_frequency_bands_ = false;
+    bool last_rinex4_epoch_was_event_ = false;
 
-    // State for parsing RINEX 3 "SYS / # / OBS TYPES" records that span
+    // State for parsing RINEX 3/4 "SYS / # / OBS TYPES" records that span
     // continuation lines (systems with more than 13 observation types, e.g.
     // GPS=22 or QZSS=24). Tracks the system whose type list is still being
     // filled so that continuation lines (blank system column) append correctly.
@@ -192,6 +193,27 @@ private:
      * @brief Parse observation epoch (RINEX 3.x)
      */
     bool parseObservationEpochV3(const std::string& line, ObservationData& obs_data);
+
+    /**
+     * @brief Parse a RINEX 4 observation/event epoch.
+     */
+    bool parseObservationEpochV4(const std::string& line, ObservationData& obs_data);
+
+    /**
+     * @brief Parse one satellite record using the shared RINEX 3/4 selection
+     * policy.  Strict mode is used for RINEX 4 so truncated rows cannot be
+     * reported as a partial successful epoch.
+     */
+    bool parseObservationSatelliteRecord(const std::string& sat_line,
+                                         ObservationData& obs_data,
+                                         bool strict);
+
+    /**
+     * @brief Read and parse the declared satellite records.
+     */
+    bool parseObservationRows(int num_sats,
+                              ObservationData& obs_data,
+                              bool strict);
     
     /**
      * @brief Parse navigation message

--- a/include/libgnss++/io/rinex4.hpp
+++ b/include/libgnss++/io/rinex4.hpp
@@ -38,4 +38,38 @@ bool parseNavigationRecordHeader(const std::string& line,
  */
 bool supportsEphemerisMessage(char system, const std::string& message_type);
 
+/**
+ * @brief Parsed metadata from a RINEX 4 observation epoch record.
+ */
+struct ObservationEpochHeader {
+    int year = 0;
+    int month = 0;
+    int day = 0;
+    int hour = 0;
+    int minute = 0;
+    double second = 0.0;
+    int flag = 0;
+    int record_count = 0;
+    double receiver_clock_offset = 0.0;
+    bool has_receiver_clock_offset = false;
+    int extra_second_digits = 0;
+    bool has_date = false;
+};
+
+/**
+ * @brief Parse a RINEX 4 observation epoch/event record.
+ *
+ * The required calendar, seconds, flag, and count fields are read as tokens
+ * so the optional picosecond extension cannot shift the flag or count.  The
+ * optional clock estimate and extension are then checked at their fixed
+ * Table A3 locations.
+ */
+bool parseObservationEpochHeader(const std::string& line,
+                                 ObservationEpochHeader& epoch);
+
+/**
+ * @brief Return true only for CompactRINEX filename suffixes.
+ */
+bool isCompactRinexPath(const std::string& filename);
+
 }  // namespace libgnss::io::rinex4

--- a/src/io/rinex.cpp
+++ b/src/io/rinex.cpp
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <cctype>
 #include <set>
+#include <utility>
 
 namespace libgnss {
 namespace io {
@@ -405,9 +406,15 @@ RINEXReader::RINEXReader()
     : qzss_prefer_l1l_(PPPEnvOverrides::fromEnvironment().qzss_prefer_l1l) {}
 
 bool RINEXReader::open(const std::string& filename) {
+    if (rinex4::isCompactRinexPath(filename)) {
+        std::cerr << "CompactRINEX input is not supported natively (.crx/.crx.gz): "
+                  << filename << std::endl;
+        return false;
+    }
     file_.open(filename);
     current_line_ = 0;
     header_read_ = false;
+    last_rinex4_epoch_was_event_ = false;
     return file_.is_open();
 }
 
@@ -490,17 +497,17 @@ bool RINEXReader::readObservationEpoch(ObservationData& obs_data) {
                 }
             }
         } else if (isRinex4()) {
-            // RINEX 4 epoch records allow more precise seconds and an
-            // optional receiver-clock field.  The fixed-column RINEX 3
-            // parser below is intentionally not used here: accepting a
-            // shifted flag/count field would silently misread every
-            // satellite row.  Token-based RINEX 4 observation parsing is a
-            // separate follow-up slice.
             if (!line.empty() && line[0] == '>') {
-                std::cerr << "RINEX 4 observation epochs are not supported yet; "
-                             "use a RINEX 3-compatible input or preprocess the file"
-                          << std::endl;
-                return false;
+                if (!parseObservationEpochV4(line, obs_data)) {
+                    return false;
+                }
+                // Event and cycle-slip records are consumed by the RINEX 4
+                // parser but are not ordinary ObservationData epochs.  Keep
+                // scanning so readAllObservations() reaches the next epoch.
+                if (last_rinex4_epoch_was_event_) {
+                    continue;
+                }
+                return true;
             }
         } else if (header_.version >= 3.0 && header_.version < 4.0) {
             // RINEX 3.x format starts with '>'
@@ -904,7 +911,7 @@ bool RINEXReader::parseHeaderLine(const std::string& line, RINEXHeader& header) 
         }
     }
     else if (label.find("SYS / # / OBS TYPES") != std::string::npos) {
-        // RINEX 3: Per-system observation types
+        // RINEX 3/4: Per-system observation types
         // Format: "G   22 C1C L1C C2X L2X ..." (system char at pos 0, count at
         // pos 3-6, types at pos 7+, up to 13 types per line). When a system has
         // more than 13 types, the remainder continue on following lines whose
@@ -1236,153 +1243,8 @@ bool RINEXReader::parseObservationEpochV3(const std::string& epoch_line, Observa
         num_sats_str.erase(0, num_sats_str.find_first_not_of(' '));
         int num_sats = num_sats_str.empty() ? 0 : std::stoi(num_sats_str);
 
-        // Read each satellite line
-        for (int s = 0; s < num_sats; ++s) {
-            std::string sat_line;
-            if (!readLine(sat_line)) break;
-            if (sat_line.length() < 3) continue;
-
-            // Parse system char and PRN
-            char sys_char = sat_line[0];
-            std::string prn_str = sat_line.substr(1, 2);
-            prn_str.erase(0, prn_str.find_first_not_of(' '));
-            if (prn_str.empty()) continue;
-            int prn = std::stoi(prn_str);
-
-            const GNSSSystem system = systemFromRinexChar(sys_char);
-            if (system == GNSSSystem::UNKNOWN) continue;
-
-            auto sys_it = header_.system_obs_types.find(sys_char);
-            const std::vector<std::string>& obs_types =
-                (sys_it != header_.system_obs_types.end()) ? sys_it->second : header_.observation_types;
-            int num_obs_types = static_cast<int>(obs_types.size());
-            if (num_obs_types == 0) num_obs_types = 4;
-
-            SatelliteId sat(system, prn);
-
-            // Parse observation values
-            // Each observation occupies 16 characters starting at position 3
-            // Format: 14.3f + LLI(1) + SS(1) = 16 chars per observation
-            std::vector<double> obs_values(num_obs_types, 0.0);
-            std::vector<int> lli_flags(num_obs_types, 0);
-            std::vector<int> signal_strength(num_obs_types, 0);
-
-            for (int i = 0; i < num_obs_types; ++i) {
-                size_t col_start = 3 + i * 16;
-                if (col_start + 14 > sat_line.length()) continue;
-
-                std::string obs_str = sat_line.substr(col_start, 14);
-                obs_str.erase(0, obs_str.find_first_not_of(' '));
-                obs_str.erase(obs_str.find_last_not_of(' ') + 1);
-
-                if (!obs_str.empty()) {
-                    try {
-                        obs_values[i] = std::stod(obs_str);
-                    } catch (...) {
-                        obs_values[i] = 0.0;
-                    }
-                }
-
-                // Parse LLI flag (position col_start + 14)
-                if (col_start + 14 < sat_line.length() && sat_line[col_start + 14] != ' ') {
-                    lli_flags[i] = sat_line[col_start + 14] - '0';
-                }
-
-                // Parse signal strength (position col_start + 15)
-                if (col_start + 15 < sat_line.length() && sat_line[col_start + 15] != ' ') {
-                    signal_strength[i] = sat_line[col_start + 15] - '0';
-                }
-            }
-
-            ObservationSelection primary_selection;
-            ObservationSelection secondary_selection;
-            std::map<std::string, Observation> tracking_observations;
-            std::map<int, ObservationSelection> band_selections;
-
-            // RTKLIB fixes its normal-frequency slots from the RINEX header,
-            // not from whichever values happen to be present this epoch.
-            // Preserve that identity so a missing L2W remains a zero L[1]
-            // instead of falling through to an extended L2L observation.
-            if (sat.system == GNSSSystem::GPS) {
-                obs_data.setRinexFrequencySlot(GNSSSystem::GPS, 0, "1C");
-                static constexpr char kGpsL2Priority[] = "PYWCMNDLXS";
-                for (const char* priority = kGpsL2Priority;
-                     *priority != '\0'; ++priority) {
-                    const std::string candidate =
-                        std::string("2") + *priority;
-                    const bool declared = std::any_of(
-                        obs_types.begin(), obs_types.end(),
-                        [&candidate](const std::string& type) {
-                            return type.size() >= 3 &&
-                                   type.substr(1) == candidate;
-                        });
-                    if (declared) {
-                        obs_data.setRinexFrequencySlot(
-                            GNSSSystem::GPS, 1, candidate);
-                        break;
-                    }
-                }
-            }
-
-            for (size_t i = 0; i < obs_types.size() && i < obs_values.size(); ++i) {
-                const std::string& obs_type = obs_types[i];
-                if (obs_values[i] != 0.0 && obs_type.size() >= 3) {
-                    const std::string tracking_code = obs_type.substr(1);
-                    auto [it, inserted] = tracking_observations.try_emplace(
-                        tracking_code);
-                    Observation& exact = it->second;
-                    if (inserted) {
-                        exact.satellite = sat;
-                        exact.signal = signalForObservationType(
-                            sat.system, obs_type,
-                            isPrimaryBand(sat.system, rinexBand(obs_type)));
-                        exact.valid = true;
-                    }
-                    assignObservationField(exact,
-                                           obs_type,
-                                           obs_values[i],
-                                           lli_flags[i],
-                                           signal_strength[i]);
-                }
-                maybeAssignSelectedObservation(primary_selection,
-                                               sat,
-                                               obs_type,
-                                               obs_values[i],
-                                               lli_flags[i],
-                                               signal_strength[i],
-                                               qzss_prefer_l1l_,
-                                               qzss_prefer_l5_secondary_,
-                                               true);
-                maybeAssignSelectedObservation(secondary_selection,
-                                               sat,
-                                               obs_type,
-                                               obs_values[i],
-                                               lli_flags[i],
-                                               signal_strength[i],
-                                               qzss_prefer_l1l_,
-                                               qzss_prefer_l5_secondary_,
-                                               false);
-                if (preserve_additional_frequency_bands_) {
-                    const int band = rinexBand(obs_type);
-                    const bool primary_band = isPrimaryBand(sat.system, band);
-                    if (primary_band || isSecondaryBand(sat.system, band)) {
-                        maybeAssignSelectedObservation(
-                            band_selections[band], sat, obs_type, obs_values[i],
-                            lli_flags[i], signal_strength[i], qzss_prefer_l1l_,
-                            qzss_prefer_l5_secondary_, primary_band);
-                    }
-                }
-            }
-
-            appendSelectedObservations(
-                primary_selection, secondary_selection, band_selections,
-                preserve_additional_frequency_bands_,
-                header_.glonass_frequency_channels, obs_data);
-            for (auto& [tracking_code, exact] : tracking_observations) {
-                annotateGlonassFrequencyChannel(
-                    exact, header_.glonass_frequency_channels);
-                obs_data.addRinexTrackingObservation(tracking_code, exact);
-            }
+        if (!parseObservationRows(num_sats, obs_data, false)) {
+            return false;
         }
 
     } catch (const std::exception& e) {
@@ -1390,6 +1252,249 @@ bool RINEXReader::parseObservationEpochV3(const std::string& epoch_line, Observa
         return false;
     }
 
+    return true;
+}
+
+bool RINEXReader::parseObservationSatelliteRecord(
+    const std::string& sat_line,
+    ObservationData& obs_data,
+    bool strict) {
+    if (sat_line.size() < 3) {
+        return !strict;
+    }
+
+    const char sys_char = sat_line[0];
+    const bool exact_prn = std::isdigit(static_cast<unsigned char>(sat_line[1])) != 0 &&
+                           std::isdigit(static_cast<unsigned char>(sat_line[2])) != 0;
+    if (strict && !exact_prn) {
+        return false;
+    }
+    std::string prn_str = sat_line.substr(1, 2);
+    if (!strict) {
+        prn_str.erase(0, prn_str.find_first_not_of(' '));
+    }
+    if (prn_str.empty() || (strict && !exact_prn)) {
+        return !strict;
+    }
+
+    int prn = 0;
+    try {
+        prn = std::stoi(prn_str);
+    } catch (...) {
+        return !strict;
+    }
+    if (strict && prn <= 0) {
+        return false;
+    }
+    const GNSSSystem system = systemFromRinexChar(sys_char);
+    if (system == GNSSSystem::UNKNOWN) {
+        return !strict;
+    }
+
+    auto sys_it = header_.system_obs_types.find(sys_char);
+    const std::vector<std::string>& obs_types =
+        (sys_it != header_.system_obs_types.end()) ? sys_it->second : header_.observation_types;
+    int num_obs_types = static_cast<int>(obs_types.size());
+    if (num_obs_types == 0) {
+        num_obs_types = 4;
+    }
+
+    SatelliteId sat(system, prn);
+    std::vector<double> obs_values(num_obs_types, 0.0);
+    std::vector<int> lli_flags(num_obs_types, 0);
+    std::vector<int> signal_strength(num_obs_types, 0);
+
+    for (int i = 0; i < num_obs_types; ++i) {
+        const size_t col_start = 3 + static_cast<size_t>(i) * 16;
+        const std::string& row = sat_line;
+        if (col_start + 14 > row.length()) {
+            if (strict) {
+                return false;
+            }
+            continue;
+        }
+        if (strict && col_start + 16 > row.length()) {
+            return false;
+        }
+
+        std::string obs_str = row.substr(col_start, 14);
+        obs_str.erase(0, obs_str.find_first_not_of(' '));
+        if (!obs_str.empty()) {
+            obs_str.erase(obs_str.find_last_not_of(' ') + 1);
+            try {
+                size_t consumed = 0;
+                const double value = std::stod(obs_str, &consumed);
+                if (strict && (consumed != obs_str.size() || !std::isfinite(value))) {
+                    return false;
+                }
+                obs_values[i] = value;
+            } catch (...) {
+                if (strict) {
+                    return false;
+                }
+                obs_values[i] = 0.0;
+            }
+        }
+
+        const size_t lli_pos = col_start + 14;
+        const size_t strength_pos = col_start + 15;
+        if (lli_pos < row.length() && row[lli_pos] != ' ') {
+            if (strict && !std::isdigit(static_cast<unsigned char>(row[lli_pos]))) {
+                return false;
+            }
+            lli_flags[i] = row[lli_pos] - '0';
+        }
+        if (strength_pos < row.length() && row[strength_pos] != ' ') {
+            if (strict && !std::isdigit(static_cast<unsigned char>(row[strength_pos]))) {
+                return false;
+            }
+            signal_strength[i] = row[strength_pos] - '0';
+        }
+    }
+
+    ObservationSelection primary_selection;
+    ObservationSelection secondary_selection;
+    std::map<std::string, Observation> tracking_observations;
+    std::map<int, ObservationSelection> band_selections;
+
+    // RTKLIB fixes its normal-frequency slots from the RINEX header, not
+    // from whichever values happen to be present in this epoch.
+    if (sat.system == GNSSSystem::GPS) {
+        obs_data.setRinexFrequencySlot(GNSSSystem::GPS, 0, "1C");
+        static constexpr char kGpsL2Priority[] = "PYWCMNDLXS";
+        for (const char* priority = kGpsL2Priority;
+             *priority != '\0'; ++priority) {
+            const std::string candidate = std::string("2") + *priority;
+            const bool declared = std::any_of(
+                obs_types.begin(), obs_types.end(),
+                [&candidate](const std::string& type) {
+                    return type.size() >= 3 && type.substr(1) == candidate;
+                });
+            if (declared) {
+                obs_data.setRinexFrequencySlot(GNSSSystem::GPS, 1, candidate);
+                break;
+            }
+        }
+    }
+
+    for (size_t i = 0; i < obs_types.size() && i < obs_values.size(); ++i) {
+        const std::string& obs_type = obs_types[i];
+        if (obs_values[i] != 0.0 && obs_type.size() >= 3) {
+            const std::string tracking_code = obs_type.substr(1);
+            auto [it, inserted] = tracking_observations.try_emplace(tracking_code);
+            Observation& exact = it->second;
+            if (inserted) {
+                exact.satellite = sat;
+                exact.signal = signalForObservationType(
+                    sat.system, obs_type,
+                    isPrimaryBand(sat.system, rinexBand(obs_type)));
+                exact.valid = true;
+            }
+            assignObservationField(exact, obs_type, obs_values[i],
+                                   lli_flags[i], signal_strength[i]);
+        }
+        maybeAssignSelectedObservation(primary_selection, sat, obs_type,
+                                       obs_values[i], lli_flags[i],
+                                       signal_strength[i], qzss_prefer_l1l_,
+                                       qzss_prefer_l5_secondary_, true);
+        maybeAssignSelectedObservation(secondary_selection, sat, obs_type,
+                                       obs_values[i], lli_flags[i],
+                                       signal_strength[i], qzss_prefer_l1l_,
+                                       qzss_prefer_l5_secondary_, false);
+        if (preserve_additional_frequency_bands_) {
+            const int band = rinexBand(obs_type);
+            const bool primary_band = isPrimaryBand(sat.system, band);
+            if (primary_band || isSecondaryBand(sat.system, band)) {
+                maybeAssignSelectedObservation(
+                    band_selections[band], sat, obs_type, obs_values[i],
+                    lli_flags[i], signal_strength[i], qzss_prefer_l1l_,
+                    qzss_prefer_l5_secondary_, primary_band);
+            }
+        }
+    }
+
+    appendSelectedObservations(primary_selection, secondary_selection,
+                               band_selections,
+                               preserve_additional_frequency_bands_,
+                               header_.glonass_frequency_channels, obs_data);
+    for (auto& [tracking_code, exact] : tracking_observations) {
+        annotateGlonassFrequencyChannel(exact, header_.glonass_frequency_channels);
+        obs_data.addRinexTrackingObservation(tracking_code, exact);
+    }
+    return true;
+}
+
+bool RINEXReader::parseObservationRows(int num_sats,
+                                       ObservationData& obs_data,
+                                       bool strict) {
+    for (int s = 0; s < num_sats; ++s) {
+        std::string sat_line;
+        if (!readLine(sat_line)) {
+            return !strict;
+        }
+        if (sat_line.size() < 3) {
+            if (strict) {
+                return false;
+            }
+            continue;
+        }
+
+        if (!parseObservationSatelliteRecord(sat_line, obs_data, strict)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool RINEXReader::parseObservationEpochV4(const std::string& epoch_line,
+                                          ObservationData& obs_data) {
+    last_rinex4_epoch_was_event_ = false;
+    obs_data.clear();
+    ObservationData parsed;
+    rinex4::ObservationEpochHeader epoch;
+    if (!rinex4::parseObservationEpochHeader(epoch_line, epoch)) {
+        std::cerr << "RINEX 4 observation epoch header is malformed" << std::endl;
+        return false;
+    }
+
+    if (epoch.has_date) {
+        std::ostringstream time_text;
+        time_text << epoch.year << ' ' << epoch.month << ' ' << epoch.day << ' '
+                  << epoch.hour << ' ' << epoch.minute << ' '
+                  << std::setprecision(17) << epoch.second;
+        parsed.time = parseTime(time_text.str(), header_.version);
+    } else if (epoch.flag <= 1) {
+        std::cerr << "RINEX 4 normal epoch is missing date/time fields" << std::endl;
+        return false;
+    }
+
+    if (epoch.flag >= 2) {
+        last_rinex4_epoch_was_event_ = true;
+        for (int record = 0; record < epoch.record_count; ++record) {
+            std::string special_record;
+            if (!readLine(special_record)) {
+                std::cerr << "RINEX 4 event record is truncated" << std::endl;
+                return false;
+            }
+            if (epoch.flag == 4) {
+                // Header event records can change observation types for later
+                // epochs.  Ignore ordinary comments, but let valid labels
+                // update the same header state used during initial parsing.
+                parseHeaderLine(special_record, header_);
+            }
+        }
+        return true;
+    }
+
+    if (!parseObservationRows(epoch.record_count, parsed, true)) {
+        std::cerr << "RINEX 4 observation epoch has truncated or malformed satellite records"
+                  << std::endl;
+        return false;
+    }
+    parsed.receiver_clock_bias = epoch.has_receiver_clock_offset
+                                     ? epoch.receiver_clock_offset
+                                     : 0.0;
+    obs_data = std::move(parsed);
     return true;
 }
 

--- a/src/io/rinex4.cpp
+++ b/src/io/rinex4.cpp
@@ -1,6 +1,8 @@
 #include <libgnss++/io/rinex4.hpp>
 
 #include <cctype>
+#include <algorithm>
+#include <cmath>
 #include <sstream>
 
 namespace libgnss::io::rinex4 {
@@ -67,6 +69,227 @@ bool supportsEphemerisMessage(char system, const std::string& message_type) {
         default:
             return false;
     }
+}
+
+namespace {
+
+std::string trim(const std::string& value) {
+    const size_t first = value.find_first_not_of(' ');
+    if (first == std::string::npos) {
+        return {};
+    }
+    const size_t last = value.find_last_not_of(' ');
+    return value.substr(first, last - first + 1);
+}
+
+bool isUnsignedDigits(const std::string& value) {
+    return !value.empty() &&
+           std::all_of(value.begin(), value.end(), [](unsigned char c) {
+               return std::isdigit(c) != 0;
+           });
+}
+
+bool isUnsignedDigitsOfWidth(const std::string& value, size_t width) {
+    return value.size() == width && isUnsignedDigits(value);
+}
+
+bool isCountToken(const std::string& value) {
+    return value.size() >= 1 && value.size() <= 3 && isUnsignedDigits(value);
+}
+
+bool parseFixedDecimal(const std::string& text, int fractional_digits, double& value) {
+    const std::string token = trim(text);
+    if (token.empty()) {
+        return false;
+    }
+    const size_t dot = token.find('.');
+    if (dot == std::string::npos || token.find('.', dot + 1) != std::string::npos) {
+        return false;
+    }
+    const size_t integer_begin = (token[0] == '+' || token[0] == '-') ? 1 : 0;
+    if (integer_begin == token.size() || dot <= integer_begin ||
+        dot - integer_begin == 0 || token.size() - dot - 1 !=
+            static_cast<size_t>(fractional_digits)) {
+        return false;
+    }
+    if (!isUnsignedDigits(token.substr(integer_begin, dot - integer_begin)) ||
+        !isUnsignedDigits(token.substr(dot + 1))) {
+        return false;
+    }
+    try {
+        value = std::stod(token);
+    } catch (...) {
+        return false;
+    }
+    return std::isfinite(value);
+}
+
+bool isLeapYear(int year) {
+    return (year % 4 == 0 && year % 100 != 0) || year % 400 == 0;
+}
+
+bool validCalendar(const ObservationEpochHeader& epoch) {
+    if (epoch.year < 1980 || epoch.year > 9999 || epoch.month < 1 || epoch.month > 12 ||
+        epoch.day < 1 || epoch.hour < 0 || epoch.hour > 23 || epoch.minute < 0 ||
+        epoch.minute > 59 || epoch.second < 0.0 || epoch.second > 60.0) {
+        return false;
+    }
+    static constexpr int kDaysInMonth[] = {
+        31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    int days = kDaysInMonth[epoch.month - 1];
+    if (epoch.month == 2 && isLeapYear(epoch.year)) {
+        days = 29;
+    }
+    return epoch.day <= days;
+}
+
+bool parseSecondsToken(const std::string& token, double& seconds) {
+    const size_t dot = token.find('.');
+    if (dot == std::string::npos || token.find_first_of("eEdD") != std::string::npos) {
+        return false;
+    }
+    const size_t fractional_digits = token.size() - dot - 1;
+    if (fractional_digits != 7) {
+        return false;
+    }
+    if (!parseFixedDecimal(token, static_cast<int>(fractional_digits), seconds)) {
+        return false;
+    }
+    return seconds >= 0.0 && seconds <= 60.0;
+}
+
+}  // namespace
+
+bool parseObservationEpochHeader(const std::string& line,
+                                 ObservationEpochHeader& epoch) {
+    epoch = ObservationEpochHeader();
+    if (line.empty() || line[0] != '>') {
+        return false;
+    }
+
+    std::istringstream tokens(line.substr(1));
+    std::string year_token;
+    if (!(tokens >> year_token)) {
+        return false;
+    }
+
+    // Event records may omit their date/time fields.  Their flag and count
+    // remain in the normal fixed columns, and the data records are consumed
+    // by RINEXReader before it searches for the next ordinary epoch.
+    if (year_token.size() != 4 || !isUnsignedDigits(year_token)) {
+        int flag = 0;
+        int count = 0;
+        std::string count_token;
+        if (!isUnsignedDigitsOfWidth(year_token, 1) ||
+            !(tokens >> count_token) || !isCountToken(count_token)) {
+            return false;
+        }
+        try {
+            flag = std::stoi(year_token);
+            count = std::stoi(count_token);
+        } catch (...) {
+            return false;
+        }
+        if (flag < 2 || flag > 6 || count < 0 || count > 999) {
+            return false;
+        }
+        epoch.flag = flag;
+        epoch.record_count = count;
+        return true;
+    }
+
+    std::string month_token;
+    std::string day_token;
+    std::string hour_token;
+    std::string minute_token;
+    std::string second_token;
+    std::string flag_token;
+    std::string count_token;
+    if (!(tokens >> month_token >> day_token >> hour_token >> minute_token >>
+          second_token >> flag_token >> count_token)) {
+        return false;
+    }
+    if (!isUnsignedDigitsOfWidth(month_token, 2) ||
+        !isUnsignedDigitsOfWidth(day_token, 2) ||
+        !isUnsignedDigitsOfWidth(hour_token, 2) ||
+        !isUnsignedDigitsOfWidth(minute_token, 2) ||
+        !isUnsignedDigitsOfWidth(flag_token, 1) || !isCountToken(count_token)) {
+        return false;
+    }
+    try {
+        epoch.year = std::stoi(year_token);
+        epoch.month = std::stoi(month_token);
+        epoch.day = std::stoi(day_token);
+        epoch.hour = std::stoi(hour_token);
+        epoch.minute = std::stoi(minute_token);
+        epoch.flag = std::stoi(flag_token);
+        epoch.record_count = std::stoi(count_token);
+    } catch (...) {
+        return false;
+    }
+    if (!parseSecondsToken(second_token, epoch.second) || epoch.flag < 0 || epoch.flag > 6 ||
+        epoch.record_count < 0 || epoch.record_count > 999) {
+        return false;
+    }
+    epoch.has_date = true;
+
+    // Table A3: six reserved columns follow the count, then F15.12, one
+    // reserved column, and an optional I5 extension.  A short line simply
+    // omits optional fields; a present but malformed field is rejected.
+    if (line.size() > 35) {
+        const size_t reserved_length = std::min<size_t>(6, line.size() - 35);
+        if (line.compare(35, reserved_length,
+                         std::string(reserved_length, ' ')) != 0) {
+            return false;
+        }
+    }
+    if (line.size() > 41) {
+        const std::string clock_field = line.substr(41, 15);
+        if (!trim(clock_field).empty()) {
+            if (!parseFixedDecimal(clock_field, 12, epoch.receiver_clock_offset)) {
+                return false;
+            }
+            epoch.has_receiver_clock_offset = true;
+        }
+    }
+    if (line.size() > 57) {
+        const std::string extra_field = line.substr(57, 5);
+        const std::string extra = trim(extra_field);
+        if (!extra.empty()) {
+            if (extra.size() != 5 || !isUnsignedDigits(extra)) {
+                return false;
+            }
+            try {
+                epoch.extra_second_digits = std::stoi(extra);
+            } catch (...) {
+                return false;
+            }
+            double combined_second = 0.0;
+            if (!parseFixedDecimal(second_token + extra, 12, combined_second)) {
+                return false;
+            }
+            epoch.second = combined_second;
+        }
+    }
+    if (line.size() > 62 && !trim(line.substr(62)).empty()) {
+        return false;
+    }
+    if (epoch.second > 60.0) {
+        return false;
+    }
+    return validCalendar(epoch);
+}
+
+bool isCompactRinexPath(const std::string& filename) {
+    std::string lower = filename;
+    std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    const auto ends_with = [&lower](const std::string& suffix) {
+        return lower.size() >= suffix.size() &&
+               lower.compare(lower.size() - suffix.size(), suffix.size(), suffix) == 0;
+    };
+    return ends_with(".crx") || ends_with(".crx.gz");
 }
 
 }  // namespace libgnss::io::rinex4

--- a/tests/test_rinex_writer.cpp
+++ b/tests/test_rinex_writer.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <libgnss++/io/rinex.hpp>
+#include <libgnss++/io/rinex4.hpp>
 
 #include <filesystem>
 #include <fstream>
@@ -206,7 +207,7 @@ TEST(RINEXReaderTest, ParsesTimeOfFirstObsHeader) {
     std::filesystem::remove(temp_path);
 }
 
-TEST(RINEXReaderTest, DetectsRinex4AndDoesNotUseRinex3EpochColumns) {
+TEST(RINEXReaderTest, ParsesRinex4EpochPrecisionClockAndGpsQzssRows) {
     const auto temp_path =
         std::filesystem::temp_directory_path() / "libgnss_rinex4_observation_dispatch.obs";
     std::filesystem::remove(temp_path);
@@ -221,14 +222,18 @@ TEST(RINEXReaderTest, DetectsRinex4AndDoesNotUseRinex3EpochColumns) {
             "G    4 C1C L1C C2W L2W",
             "SYS / # / OBS TYPES");
         file << rinexHeaderLine("", "END OF HEADER");
-        // The extra second digits intentionally shift the RINEX 3 fixed
-        // columns.  Phase 1 must reject this explicitly until token-based
-        // RINEX 4 observation parsing is implemented.
-        file << "> 2024 08 03 09 51 20.1234567890123  0  1\n";
+        std::string epoch = "> 2024 08 03 09 51 20.1234567  0  2";
+        epoch.append(41 - epoch.size(), ' ');
+        epoch += "-0.123456789012 12345\n";
+        file << epoch;
         file << "G04" << rinexObsField("22011162.552")
              << rinexObsField("115669443.467")
              << rinexObsField("22022262.423")
              << rinexObsField("120222443.467") << "\n";
+        file << "J01" << rinexObsField("22011163.552")
+             << rinexObsField("115669444.467")
+             << rinexObsField("22022263.423")
+             << rinexObsField("120222444.467") << "\n";
     }
 
     io::RINEXReader reader;
@@ -239,14 +244,207 @@ TEST(RINEXReaderTest, DetectsRinex4AndDoesNotUseRinex3EpochColumns) {
     EXPECT_TRUE(reader.isRinex4());
 
     ObservationData epoch;
-    testing::internal::CaptureStderr();
-    EXPECT_FALSE(reader.readObservationEpoch(epoch));
-    const std::string diagnostic = testing::internal::GetCapturedStderr();
-    EXPECT_NE(diagnostic.find("RINEX 4 observation epochs are not supported yet"),
-              std::string::npos);
+    ASSERT_TRUE(reader.readObservationEpoch(epoch));
+    EXPECT_NEAR(epoch.receiver_clock_bias, -0.123456789012, 1e-15);
+    EXPECT_EQ(epoch.time.week, 2325);
+    EXPECT_NEAR(epoch.time.tow, 553880.1234567123, 1e-9);
+    ASSERT_EQ(epoch.observations.size(), 4U);
+    EXPECT_EQ(epoch.observations[0].satellite, SatelliteId(GNSSSystem::GPS, 4));
+    EXPECT_EQ(epoch.observations[2].satellite, SatelliteId(GNSSSystem::QZSS, 1));
+    const auto* gps_l1 = epoch.getObservation(
+        SatelliteId(GNSSSystem::GPS, 4), SignalType::GPS_L1CA);
+    ASSERT_NE(gps_l1, nullptr);
+    EXPECT_TRUE(gps_l1->has_pseudorange);
 
     reader.close();
     std::filesystem::remove(temp_path);
+}
+
+TEST(RINEXReaderTest, AccumulatesRinex4ObservationTypeContinuation) {
+    const auto temp_path =
+        std::filesystem::temp_directory_path() / "libgnss_rinex4_obs_types_continuation.obs";
+    std::filesystem::remove(temp_path);
+    {
+        std::ofstream file(temp_path);
+        ASSERT_TRUE(file.is_open());
+        file << rinexHeaderLine(
+            "     4.02           OBSERVATION DATA    M", "RINEX VERSION / TYPE");
+        file << rinexHeaderLine(
+            "G   14 C1C L1C C2W L2W C5Q L5Q D5Q S5Q C1L L1L D1L S1L C2L",
+            "SYS / # / OBS TYPES");
+        file << rinexHeaderLine("       S2L", "SYS / # / OBS TYPES");
+        file << rinexHeaderLine("", "END OF HEADER");
+        file << "> 2024 08 03 09 51 20.0000000  0  2\n";
+        const std::vector<std::string> values = {
+            "22011162.552", "115669443.467", "22022262.423", "120222443.467",
+            "22033362.552", "115669543.467", "22044462.423", "120222543.467",
+            "22055562.552", "115669643.467", "22066662.423", "120222643.467",
+            "22077762.552", "115669743.467"};
+        std::string gps_row = "G04";
+        std::string qzss_row = "J01";
+        for (const auto& value : values) {
+            gps_row += rinexObsField(value);
+            qzss_row += rinexObsField(value);
+        }
+        file << gps_row << "\n" << qzss_row << "\n";
+    }
+
+    io::RINEXReader reader;
+    ASSERT_TRUE(reader.open(temp_path.string()));
+    io::RINEXReader::RINEXHeader header;
+    ASSERT_TRUE(reader.readHeader(header));
+    ASSERT_EQ(header.system_obs_types['G'].size(), 14U);
+    EXPECT_EQ(header.system_obs_types['G'].back(), "S2L");
+    EXPECT_EQ(header.observation_types.size(), 14U);
+    ObservationData epoch;
+    ASSERT_TRUE(reader.readObservationEpoch(epoch));
+    ASSERT_EQ(epoch.observations.size(), 4U);
+    EXPECT_EQ(epoch.observations[0].satellite, SatelliteId(GNSSSystem::GPS, 4));
+    EXPECT_EQ(epoch.observations[2].satellite, SatelliteId(GNSSSystem::QZSS, 1));
+    reader.close();
+    std::filesystem::remove(temp_path);
+}
+
+TEST(RINEXReaderTest, SkipsRinex4EventAndCycleSlipRecordsBeforeNextEpoch) {
+    const auto temp_path =
+        std::filesystem::temp_directory_path() / "libgnss_rinex4_events.obs";
+    std::filesystem::remove(temp_path);
+    {
+        std::ofstream file(temp_path);
+        ASSERT_TRUE(file.is_open());
+        file << rinexHeaderLine(
+            "     4.02           OBSERVATION DATA    M", "RINEX VERSION / TYPE");
+        file << rinexHeaderLine("G    4 C1C L1C C2W L2W", "SYS / # / OBS TYPES");
+        file << rinexHeaderLine("", "END OF HEADER");
+        file << "> 2024 08 03 09 51 20.0000000  0  0\n";
+        file << ">                              2 1\n";
+        file << rinexHeaderLine("event comment", "COMMENT");
+        file << ">                              6 1\n";
+        file << "G04" << rinexObsField("99999999.000")
+             << rinexObsField("1.000") << rinexObsField("2.000")
+             << rinexObsField("3.000") << "\n";
+        file << "> 2024 08 03 09 51 21.0000000  0  1\n";
+        file << "G04" << rinexObsField("22011162.552")
+             << rinexObsField("115669443.467")
+             << rinexObsField("22022262.423")
+             << rinexObsField("120222443.467") << "\n";
+    }
+
+    io::RINEXReader reader;
+    ASSERT_TRUE(reader.open(temp_path.string()));
+    io::RINEXReader::RINEXHeader header;
+    ASSERT_TRUE(reader.readHeader(header));
+    ObservationData empty_epoch;
+    ASSERT_TRUE(reader.readObservationEpoch(empty_epoch));
+    EXPECT_TRUE(empty_epoch.isEmpty());
+    ObservationData epoch;
+    ASSERT_TRUE(reader.readObservationEpoch(epoch));
+    EXPECT_EQ(epoch.time.week, 2325);
+    EXPECT_NEAR(epoch.time.tow, 553881.0, 1e-9);
+    ASSERT_EQ(epoch.observations.size(), 2U);
+    EXPECT_EQ(epoch.observations.front().satellite, SatelliteId(GNSSSystem::GPS, 4));
+    reader.close();
+    std::filesystem::remove(temp_path);
+}
+
+TEST(RINEXReaderTest, FeedsRinex4HeaderEventRecordsIntoHeaderParser) {
+    const auto temp_path =
+        std::filesystem::temp_directory_path() / "libgnss_rinex4_header_event.obs";
+    std::filesystem::remove(temp_path);
+    {
+        std::ofstream file(temp_path);
+        ASSERT_TRUE(file.is_open());
+        file << rinexHeaderLine(
+            "     4.02           OBSERVATION DATA    M", "RINEX VERSION / TYPE");
+        file << rinexHeaderLine("G    4 C1C L1C C2W L2W", "SYS / # / OBS TYPES");
+        file << rinexHeaderLine("", "END OF HEADER");
+        file << ">                              4 1\n";
+        file << rinexHeaderLine("G    4 C1C L1C C5Q L5Q", "SYS / # / OBS TYPES");
+        file << "> 2024 08 03 09 51 22.0000000  0  1\n";
+        file << "G04" << rinexObsField("22011162.552")
+             << rinexObsField("115669443.467")
+             << rinexObsField("22022262.423")
+             << rinexObsField("120222443.467") << "\n";
+    }
+
+    io::RINEXReader reader;
+    ASSERT_TRUE(reader.open(temp_path.string()));
+    io::RINEXReader::RINEXHeader header;
+    ASSERT_TRUE(reader.readHeader(header));
+    ObservationData epoch;
+    ASSERT_TRUE(reader.readObservationEpoch(epoch));
+    ASSERT_EQ(epoch.observations.size(), 2U);
+    reader.close();
+    std::filesystem::remove(temp_path);
+}
+
+TEST(RINEXReaderTest, RejectsTruncatedRinex4ObservationEpoch) {
+    const auto temp_path =
+        std::filesystem::temp_directory_path() / "libgnss_rinex4_truncated.obs";
+    std::filesystem::remove(temp_path);
+    {
+        std::ofstream file(temp_path);
+        ASSERT_TRUE(file.is_open());
+        file << rinexHeaderLine(
+            "     4.02           OBSERVATION DATA    M", "RINEX VERSION / TYPE");
+        file << rinexHeaderLine("G    4 C1C L1C C2W L2W", "SYS / # / OBS TYPES");
+        file << rinexHeaderLine("", "END OF HEADER");
+        file << "> 2024 08 03 09 51 23.0000000  0  2\n";
+        file << "G04" << rinexObsField("22011162.552")
+             << rinexObsField("115669443.467")
+             << rinexObsField("22022262.423")
+             << rinexObsField("120222443.467") << "\n";
+    }
+
+    io::RINEXReader reader;
+    ASSERT_TRUE(reader.open(temp_path.string()));
+    io::RINEXReader::RINEXHeader header;
+    ASSERT_TRUE(reader.readHeader(header));
+    ObservationData epoch;
+    EXPECT_FALSE(reader.readObservationEpoch(epoch));
+    EXPECT_TRUE(epoch.isEmpty());
+    reader.close();
+    std::filesystem::remove(temp_path);
+}
+
+TEST(RINEXReaderTest, RejectsMalformedRinex4EpochTokenWidthsAndCounts) {
+    io::rinex4::ObservationEpochHeader epoch;
+    EXPECT_FALSE(io::rinex4::parseObservationEpochHeader(
+        "> 0001 08 03 09 51 23.0000000  0  1", epoch));
+    EXPECT_FALSE(io::rinex4::parseObservationEpochHeader(
+        "> 2024 8 03 09 51 23.0000000  0  1", epoch));
+    EXPECT_FALSE(io::rinex4::parseObservationEpochHeader(
+        "> 2024 08 03 09 51 23.0000000  0  1000", epoch));
+    EXPECT_FALSE(io::rinex4::parseObservationEpochHeader(
+        ">                              2 1000", epoch));
+}
+
+TEST(RINEXReaderTest, RejectsCompactRinexSuffixesButNotSimilarNames) {
+    const auto base = std::filesystem::temp_directory_path();
+    const auto crx = base / "libgnss_rinex4_policy.CRX";
+    const auto crx_gz = base / "libgnss_rinex4_policy.CRX.GZ";
+    const auto similar = base / "libgnss_rinex4_policy.crx.tmp";
+    std::filesystem::remove(crx);
+    std::filesystem::remove(crx_gz);
+    std::filesystem::remove(similar);
+    {
+        std::ofstream(crx) << "not decoded\n";
+        std::ofstream(crx_gz) << "not decoded\n";
+        std::ofstream(similar) << "not compact\n";
+    }
+
+    io::RINEXReader reader;
+    testing::internal::CaptureStderr();
+    EXPECT_FALSE(reader.open(crx.string()));
+    EXPECT_FALSE(reader.open(crx_gz.string()));
+    const std::string diagnostic = testing::internal::GetCapturedStderr();
+    EXPECT_NE(diagnostic.find("CompactRINEX input is not supported natively"),
+              std::string::npos);
+    EXPECT_TRUE(reader.open(similar.string()));
+    reader.close();
+    std::filesystem::remove(crx);
+    std::filesystem::remove(crx_gz);
+    std::filesystem::remove(similar);
 }
 
 TEST(RINEXReaderTest, DispatchesRinex4LnavAndSkipsUnsupportedRecordBoundary) {


### PR DESCRIPTION
## Summary

- parse RINEX 4 observation epoch metadata without routing it through RINEX 3 fixed columns
- preserve the optional receiver clock offset and five-digit picosecond extension from Table A3
- reuse shared RINEX 3/4 satellite observation selection for GPS and QZSS records
- consume event, header-event, and cycle-slip records without emitting false observation epochs
- reject malformed, truncated, and CompactRINEX inputs deterministically
- document the completed Phase 2 scope and add regression coverage

## Why

RINEX 4 observation epoch metadata includes fields that cannot be safely interpreted by the existing RINEX 3 epoch-column parser. Dedicated parsing prevents shifted flag/count fields and partial epochs while retaining the established observation-selection policy.

## Impact

RINEX 4.02 observation files can now provide normal flag 0/1 epochs, GPS/QZSS satellite rows, receiver clock estimates, picosecond time extensions, and observation-type continuation headers. Event metadata and cycle-slip values are consumed but not retained in the current `ObservationData` model. Native CRINEX decompression remains out of scope.

This is a stacked PR based on #463. Review and merge #463 first; after that this PR can be retargeted to `develop`.

## Validation

- focused RINEX reader tests: 14/14 passed
- full CTest suite: 65/65 passed
- MkDocs strict build passed
- `git diff --check` passed
