### PR TITLE
Add RINEX 4 GLONASS CDMA ephemerides

### DIFF
--- a/docs/rinex4_plan.md
+++ b/docs/rinex4_plan.md
@@ -182,15 +182,16 @@ truncated normal records fail instead of returning partial data.  Native
 CRINEX decompression remains out of scope and matching suffixes are rejected
 explicitly.
 
-Phase 3, `EPH` navigation support (PARTIAL after Phase 1 safe dispatch):
+Phase 3, `EPH` navigation metadata and compatible-body support (DONE):
 
-- Parse RINEX 4 `EPH` data record headers. **DONE in the Phase 1 slice.**
+- Parse RINEX 4 `EPH` data record headers and preserve typed message
+  provenance on `Ephemeris`. **DONE in the Phase 3 slice.**
 - Reuse current GPS/Galileo/BeiDou/QZSS/GLONASS FDMA bodies where compatible.
-  **PARTIAL in the Phase 1 slice; message metadata and new-message models
-  remain future work.**
-- Add explicit skip/error handling for unsupported `L1NV`, `L1OC`, and `L3OC`
-  before implementing them.
-- Preserve message type metadata for Galileo `FNAV` vs `INAV`.
+  **DONE for the compatible message types; global ephemeris selection is
+  unchanged.**
+- Reject nonblank EPH subtypes and trailing header tokens, skip unsupported
+  EPH bodies at the next `>` boundary, and validate Galileo FNAV/INAV clock
+  source bits. **DONE in the Phase 3 slice.**
 
 Phase 4, system data records:
 
@@ -202,6 +203,8 @@ Phase 4, system data records:
 
 Phase 5, new navigation messages:
 
+- Implement GPS/QZSS CNAV/CNV2, BeiDou CNV1/CNV2/CNV3, and SBAS navigation
+  body models.
 - Implement NavIC L1 `L1NV` parsing.
 - Implement GLONASS `L1OC` and `L3OC` parsing.
 - Add conformance fixtures from public RINEX 4.02 files before enabling these

--- a/docs/rinex4_plan.md
+++ b/docs/rinex4_plan.md
@@ -1,9 +1,9 @@
 # RINEX 4.02 Plan
 
-This plan scopes the RINEX 4 work before implementation.  The intent for
-iter1 is to record the parser state, isolate the RINEX 4 surface area, and add
-only a compile-time skeleton.  Functional parsing changes should start in
-iter2.
+This plan scoped the RINEX 4 work before implementation.  The original iter1
+intent was to record parser state, isolate the RINEX 4 surface area, and add a
+compile-time skeleton; the completed Phase 1 and Phase 2 slices now add the
+documented reader behavior incrementally.
 
 ## Reference Sources
 
@@ -171,6 +171,17 @@ Phase 2, observation support:
 - Add CRINEX policy tests that verify `.crx`/`.crx.gz` is rejected with a clear
   message or preprocessed through an external converter.
 
+**DONE in the Phase 2 observation slice.**  RINEX 4 epoch metadata is parsed
+token-wise, including the Table A3 receiver-clock and optional five-digit
+picosecond extension fields.  GPS and QZSS rows reuse the RINEX 3 selection
+policy, continuation headers are covered, and event/cycle-slip records are
+consumed before scanning for the next normal epoch.  Event records do not
+produce `ObservationData` epochs, while a valid flag 0/1 epoch with zero
+satellites is returned as an intentionally empty epoch; malformed or
+truncated normal records fail instead of returning partial data.  Native
+CRINEX decompression remains out of scope and matching suffixes are rejected
+explicitly.
+
 Phase 3, `EPH` navigation support (PARTIAL after Phase 1 safe dispatch):
 
 - Parse RINEX 4 `EPH` data record headers. **DONE in the Phase 1 slice.**
@@ -203,40 +214,47 @@ Phase 6, writer support:
 
 ## End-State Acceptance Gates
 
-These gates cover the complete roadmap, not just the current safe-dispatch
-slice. The RINEX 4 observation-row gate is intentionally deferred to Phase 2.
+These are end-state gates for the complete roadmap, not just the current
+safe-dispatch and observation slices.  The reader gates completed by Phases 1
+and 2 are marked by the corresponding status sections below.
 
 - Existing RINEX 2/3 tests continue to pass.
 - RINEX 4 observation fixture parses header, epoch time, satellite count, and
-  at least GPS/QZSS observation rows.
+  at least GPS/QZSS observation rows. **MET by Phase 2.**
 - RINEX 4 navigation fixture with `> EPH G.. LNAV` parses at parity with the
   equivalent RINEX 3 record.
 - Unsupported RINEX 4 records fail or skip deterministically with diagnostics.
 - CRINEX input policy is explicit and tested.
 
-## Safe-Dispatch Slice Non-Goals
+## Safe-Dispatch and Observation Slice Non-Goals
 
-- No full RINEX 4 observation parser behavior changes beyond the Phase 1
-  detection/rejection boundary.
+- No complete RINEX 4 observation model: event metadata is intentionally not
+  retained in `ObservationData`, and cycle-slip records are consumed rather
+  than exposed.
 - No native CRINEX decompressor.
 - No NavIC or GLONASS CDMA message implementation.
 - No writer behavior changes.
 
 ## Phase 1 Implementation Status: DONE
 
-The safe-dispatch slice is implemented in the reader while the Phase 2
-observation parser remains intentionally out of scope:
+The safe-dispatch slice is implemented in the reader:
 
 - `RINEXReader::isRinex4()` identifies versions 4.00 through 4.99 explicitly;
   RINEX 2 and 3 continue through their existing paths.
-- RINEX 4 observation epochs are detected and rejected with a diagnostic
-  rather than being passed to the fixed-column RINEX 3 parser.
+- RINEX 4 observation epochs are dispatched to the dedicated Phase 2 parser;
+  RINEX 2 and 3 continue through their existing paths.
 - RINEX 4 navigation data-record headers are parsed in `rinex4.hpp/cpp`.
   Compatible GPS/QZSS LNAV, GLONASS FDMA, Galileo FNAV/INAV, and BeiDou D1/D2
   EPH bodies reuse the existing ephemeris parser.
 - STO/EOP/ION records and unsupported EPH message types are skipped at the
   next `>` record boundary with diagnostics, preventing silent body misparse.
 
-Token-based RINEX 4 observation epochs, receiver-clock offsets, expanded
-second precision, and new navigation message models remain Phase 2 and later
-work as specified above.
+## Phase 2 Implementation Status: DONE
+
+The observation slice now handles token-based RINEX 4 epoch fields, fixed
+Table A3 receiver-clock offsets, optional extra second digits, GPS/QZSS
+observation rows, continuation headers, deterministic event/cycle-slip
+skipping (with zero-satellite normal epochs preserved), strict truncation
+checks, and explicit CRINEX suffix rejection.
+Event metadata retention, richer cycle-slip data models, and all new
+navigation message models remain deferred as listed above.

--- a/docs/rinex4_plan.md
+++ b/docs/rinex4_plan.md
@@ -211,9 +211,22 @@ Phase 5, new navigation messages:
 - Implement GPS/QZSS CNAV/CNV2, BeiDou CNV1/CNV2/CNV3, and SBAS navigation
   body models.
 - Implement NavIC L1 `L1NV` parsing.
-- Implement GLONASS `L1OC` and `L3OC` parsing.
 - Add conformance fixtures from public RINEX 4.02 files before enabling these
   records in production flows.
+
+Phase 5a, GLONASS CDMA navigation (DONE):
+
+- Parse `> EPH R.. L1OC/L3OC` A16/A17 bodies with a strict, transactional
+  nine-line parser, including required integer/range checks and the required
+  19-character blank spare field (A19 format).
+- Preserve the typed message provenance and optional CDMA payload on
+  `Ephemeris`; map the broadcast state vector from km to metres and convert
+  UTC `toc`/`t_tm` to GPST with nearest-week handling.
+- Keep the existing GLONASS FDMA path and ephemeris selection policy unchanged;
+  malformed CDMA records recover at the next explicit `>` boundary.
+
+The remaining Phase 5 work is GPS/QZSS CNAV/CNV2, BeiDou CNV1/CNV2/CNV3, SBAS,
+and NavIC `L1NV` body models.  Those records remain deliberately unsupported.
 
 Phase 6, writer support:
 
@@ -241,7 +254,8 @@ and 2 are marked by the corresponding status sections below.
   retained in `ObservationData`, and cycle-slip records are consumed rather
   than exposed.
 - No native CRINEX decompressor.
-- No NavIC or GLONASS CDMA EPH message implementation.
+- No GPS/QZSS CNAV/CNV2, BeiDou CNV1/CNV2/CNV3, SBAS, or NavIC L1NV EPH body
+  implementation; GLONASS CDMA L1OC/L3OC is covered by Phase 5a.
 - No writer behavior changes.
 - No conversion of system-record epochs into a common GPS time scale or
   application of the parsed system data to navigation selection.
@@ -256,7 +270,8 @@ The safe-dispatch slice is implemented in the reader:
   RINEX 2 and 3 continue through their existing paths.
 - RINEX 4 navigation data-record headers are parsed in `rinex4.hpp/cpp`.
   Compatible GPS/QZSS LNAV, GLONASS FDMA, Galileo FNAV/INAV, and BeiDou D1/D2
-  EPH bodies reuse the existing ephemeris parser.
+  EPH bodies reuse the existing ephemeris parser; GLONASS CDMA L1OC/L3OC uses
+  the dedicated Phase 5a parser.
 - STO/EOP/ION records and unsupported EPH message types are skipped at the
   next `>` record boundary with diagnostics, preventing silent body misparse.
 
@@ -267,8 +282,8 @@ Table A3 receiver-clock offsets, optional extra second digits, GPS/QZSS
 observation rows, continuation headers, deterministic event/cycle-slip
 skipping (with zero-satellite normal epochs preserved), strict truncation
 checks, and explicit CRINEX suffix rejection.
-Event metadata retention, richer cycle-slip data models, and all new EPH
-navigation message models remain deferred as listed above.
+Event metadata retention, richer cycle-slip data models, and the remaining new
+EPH navigation message models remain deferred as listed above.
 
 ## Phase 4 Implementation Status: DONE
 

--- a/docs/rinex4_plan.md
+++ b/docs/rinex4_plan.md
@@ -193,13 +193,18 @@ Phase 3, `EPH` navigation metadata and compatible-body support (DONE):
   EPH bodies at the next `>` boundary, and validate Galileo FNAV/INAV clock
   source bits. **DONE in the Phase 3 slice.**
 
-Phase 4, system data records:
+Phase 4, system data records (DONE):
 
-- Add internal containers for `STO`, `EOP`, and `ION`.
-- Start with ION because QZSS/NavIC ION subtypes matter for MADOCA/RINEX 4
-  convergence.
-- Decide whether these containers live in `NavigationData` or a RINEX-specific
-  sidecar.
+- Add internal containers for `STO`, `EOP`, and `ION`. **DONE in the Phase 4
+  slice** as a RINEX-specific `RINEXReader` sidecar, leaving the existing
+  `NavigationData` selection and legacy ionosphere model unchanged.
+- Parse the Table A33/A34 `STO`/`EOP` records and the A35--A40 Klobuchar,
+  NeQuick-G, BDGIM, NavIC KLOB/NEQN, and GLONASS CDMA ION models with strict
+  fixed-field validation. **DONE in the Phase 4 slice.**
+- Reject unsupported message/type/subtype combinations and malformed bodies
+  transactionally while preserving the next `>` boundary. The `LEG` STO
+  spelling is retained only for the explicit RINEX 4.02 Table A41 example;
+  Table 21 remains the normative message-type matrix.
 
 Phase 5, new navigation messages:
 
@@ -226,17 +231,20 @@ and 2 are marked by the corresponding status sections below.
   at least GPS/QZSS observation rows. **MET by Phase 2.**
 - RINEX 4 navigation fixture with `> EPH G.. LNAV` parses at parity with the
   equivalent RINEX 3 record.
-- Unsupported RINEX 4 records fail or skip deterministically with diagnostics.
+- Supported RINEX 4 `STO`/`EOP`/`ION` records are retained in the reader
+  sidecar; unsupported records fail or skip deterministically with diagnostics.
 - CRINEX input policy is explicit and tested.
 
-## Safe-Dispatch and Observation Slice Non-Goals
+## Safe-Dispatch, Observation, and System-Record Slice Non-Goals
 
 - No complete RINEX 4 observation model: event metadata is intentionally not
   retained in `ObservationData`, and cycle-slip records are consumed rather
   than exposed.
 - No native CRINEX decompressor.
-- No NavIC or GLONASS CDMA message implementation.
+- No NavIC or GLONASS CDMA EPH message implementation.
 - No writer behavior changes.
+- No conversion of system-record epochs into a common GPS time scale or
+  application of the parsed system data to navigation selection.
 
 ## Phase 1 Implementation Status: DONE
 
@@ -259,5 +267,15 @@ Table A3 receiver-clock offsets, optional extra second digits, GPS/QZSS
 observation rows, continuation headers, deterministic event/cycle-slip
 skipping (with zero-satellite normal epochs preserved), strict truncation
 checks, and explicit CRINEX suffix rejection.
-Event metadata retention, richer cycle-slip data models, and all new
+Event metadata retention, richer cycle-slip data models, and all new EPH
 navigation message models remain deferred as listed above.
+
+## Phase 4 Implementation Status: DONE
+
+RINEX 4 `STO`, `EOP`, and `ION` records are parsed into the
+`RINEXReader::rinex4SystemData()` sidecar.  The implementation covers the
+Table A33/A34 fixed records and the A35--A40 ION payload models, validates
+system/message/subtype combinations and numeric/date fields, and appends only
+complete records.  Unsupported or malformed records are diagnosed and
+discarded at the next explicit `>` boundary without changing RINEX 2/3 or
+legacy `NavigationData` behavior.

--- a/include/libgnss++/core/navigation.hpp
+++ b/include/libgnss++/core/navigation.hpp
@@ -9,6 +9,31 @@
 namespace libgnss {
 
 /**
+ * @brief Broadcast navigation message provenance used by RINEX 4 records.
+ *
+ * Existing RINEX 2/3, RTCM, and UBX construction paths leave this at
+ * Unknown. The value is metadata only; it does not alter ephemeris
+ * selection policy.
+ */
+enum class NavigationMessageType {
+    Unknown,
+    LNAV,
+    FDMA,
+    FNAV,
+    INAV,
+    D1,
+    D2,
+    SBAS,
+    CNAV,
+    CNV1,
+    CNV2,
+    CNV3,
+    L1NV,
+    L1OC,
+    L3OC,
+};
+
+/**
  * @brief Satellite ephemeris data
  */
 struct Ephemeris {
@@ -65,6 +90,7 @@ struct Ephemeris {
     uint16_t iodc;          ///< Issue of data clock
     uint16_t iode;          ///< Issue of data ephemeris
     int data_source_code = 0;  ///< RINEX nav "data sources" word (Galileo: bit0 I/NAV E1-B, bit1 F/NAV E5a, bit2 I/NAV E5b, bit8 clock E5a/F-NAV, bit9 clock E5b/I-NAV)
+    NavigationMessageType navigation_message_type = NavigationMessageType::Unknown;
 
     bool valid = false;     ///< Ephemeris validity flag
     

--- a/include/libgnss++/core/navigation.hpp
+++ b/include/libgnss++/core/navigation.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <optional>
 #include <vector>
 #include <map>
 #include <memory>
@@ -31,6 +32,39 @@ enum class NavigationMessageType {
     L1NV,
     L1OC,
     L3OC,
+};
+
+/**
+ * @brief RINEX 4 GLONASS CDMA-specific broadcast fields.
+ *
+ * The common state-vector and clock values remain in Ephemeris.  These
+ * optional fields preserve the A16/A17 values that have no legacy FDMA
+ * counterpart without changing ephemeris selection policy.
+ */
+struct GlonassCdmaNavigationData {
+    double beta = 0.0;  ///< Broadcast clock acceleration term.
+    int data_validity = 0;  ///< 0 valid, 1 invalid, from A16/A17.
+    int satellite_type = 0;  ///< Satellite type (M), decimal integer field.
+    int source_flags = 0;  ///< RT/RE source flags, decimal 4-bit value (0..15).
+    double aode = 0.0;  ///< Age of data ephemeris (EE), days.
+    double aodc = 0.0;  ///< Age of data clock (ET), days.
+    int attitude_flag = 0;  ///< P2 attitude flag.
+    int sign_flag = 0;  ///< Yaw sign flag (sn).
+    int urai_orbit = 0;  ///< FE orbit accuracy index.
+    int urai_clock = 0;  ///< FT clock accuracy index.
+    double tin = 0.0;  ///< Reference time of attitude data, UTC(SU) seconds of day.
+    double tau1 = 0.0;  ///< Attitude time constant Tau1 (seconds).
+    double tau2 = 0.0;  ///< Attitude time constant Tau2 (seconds).
+    double yaw_angle = 0.0;  ///< Initial yaw angle psi_in (radians).
+    double angular_rate = 0.0;  ///< Initial angular rate omega_in (rad/s).
+    double angular_acceleration = 0.0;  ///< Initial angular acceleration (rad/s2).
+    double max_angular_rate = 0.0;  ///< Maximum angular rate (rad/s).
+    double pc_x = 0.0;  ///< X phase-center offset in manufacturer coordinates (m).
+    double pc_y = 0.0;  ///< Y phase-center offset in manufacturer coordinates (m).
+    double pc_z = 0.0;  ///< Z phase-center offset in manufacturer coordinates (m).
+    double transmission_time_utc_week = 0.0;  ///< Raw t_tm before UTC→GPST conversion.
+    std::optional<double> tgd_l2ocp;  ///< L1OC A16 TGD_L2OCp; blank is preserved.
+    std::optional<double> isc_l3ocp;  ///< L3OC A17 ISC_L3OCp; blank is preserved.
 };
 
 /**
@@ -91,6 +125,7 @@ struct Ephemeris {
     uint16_t iode;          ///< Issue of data ephemeris
     int data_source_code = 0;  ///< RINEX nav "data sources" word (Galileo: bit0 I/NAV E1-B, bit1 F/NAV E5a, bit2 I/NAV E5b, bit8 clock E5a/F-NAV, bit9 clock E5b/I-NAV)
     NavigationMessageType navigation_message_type = NavigationMessageType::Unknown;
+    std::optional<GlonassCdmaNavigationData> glonass_cdma_data;
 
     bool valid = false;     ///< Ephemeris validity flag
     

--- a/include/libgnss++/io/rinex.hpp
+++ b/include/libgnss++/io/rinex.hpp
@@ -13,7 +13,7 @@ namespace io {
 /**
  * @brief RINEX file reader/writer
  * 
- * Supports RINEX 2.x and 3.x formats for observation and navigation files
+ * Supports RINEX 2.x/3.x and the scoped RINEX 4 observation/navigation reader
  */
 class RINEXReader {
 public:
@@ -50,7 +50,7 @@ public:
         Vector3d approximate_position;
         Vector3d antenna_delta;
         std::vector<std::string> observation_types;
-        // RINEX 3: per-system observation types (key = system char, e.g. "G", "R", "E")
+        // RINEX 3/4: per-system observation types (key = system char, e.g. "G", "R", "E")
         std::map<char, std::vector<std::string>> system_obs_types;
         std::map<SatelliteId, int> glonass_frequency_channels;
         double interval = 0.0;
@@ -170,8 +170,9 @@ private:
     bool qzss_prefer_l1l_ = false;
     bool qzss_prefer_l5_secondary_ = false;
     bool preserve_additional_frequency_bands_ = false;
+    bool last_rinex4_epoch_was_event_ = false;
 
-    // State for parsing RINEX 3 "SYS / # / OBS TYPES" records that span
+    // State for parsing RINEX 3/4 "SYS / # / OBS TYPES" records that span
     // continuation lines (systems with more than 13 observation types, e.g.
     // GPS=22 or QZSS=24). Tracks the system whose type list is still being
     // filled so that continuation lines (blank system column) append correctly.
@@ -192,6 +193,27 @@ private:
      * @brief Parse observation epoch (RINEX 3.x)
      */
     bool parseObservationEpochV3(const std::string& line, ObservationData& obs_data);
+
+    /**
+     * @brief Parse a RINEX 4 observation/event epoch.
+     */
+    bool parseObservationEpochV4(const std::string& line, ObservationData& obs_data);
+
+    /**
+     * @brief Parse one satellite record using the shared RINEX 3/4 selection
+     * policy.  Strict mode is used for RINEX 4 so truncated rows cannot be
+     * reported as a partial successful epoch.
+     */
+    bool parseObservationSatelliteRecord(const std::string& sat_line,
+                                         ObservationData& obs_data,
+                                         bool strict);
+
+    /**
+     * @brief Read and parse the declared satellite records.
+     */
+    bool parseObservationRows(int num_sats,
+                              ObservationData& obs_data,
+                              bool strict);
     
     /**
      * @brief Parse navigation message

--- a/include/libgnss++/io/rinex.hpp
+++ b/include/libgnss++/io/rinex.hpp
@@ -6,6 +6,7 @@
 #include <memory>
 #include "../core/observation.hpp"
 #include "../core/navigation.hpp"
+#include "rinex4.hpp"
 
 namespace libgnss {
 namespace io {
@@ -162,6 +163,16 @@ public:
      */
     int getCurrentLine() const { return current_line_; }
 
+    /**
+     * @brief Get the RINEX 4 STO/EOP/ION records parsed from this file.
+     *
+     * The sidecar retains the originating system-time fields and is kept
+     * separate from NavigationData's broadcast ephemeris containers.
+     */
+    const rinex4::SystemData& rinex4SystemData() const {
+        return rinex4_system_data_;
+    }
+
 private:
     std::ifstream file_;
     RINEXHeader header_;
@@ -171,6 +182,7 @@ private:
     bool qzss_prefer_l5_secondary_ = false;
     bool preserve_additional_frequency_bands_ = false;
     bool last_rinex4_epoch_was_event_ = false;
+    rinex4::SystemData rinex4_system_data_;
 
     // State for parsing RINEX 3/4 "SYS / # / OBS TYPES" records that span
     // continuation lines (systems with more than 13 observation types, e.g.

--- a/include/libgnss++/io/rinex4.hpp
+++ b/include/libgnss++/io/rinex4.hpp
@@ -38,4 +38,38 @@ bool parseNavigationRecordHeader(const std::string& line,
  */
 bool supportsEphemerisMessage(char system, const std::string& message_type);
 
+/**
+ * @brief Parsed metadata from a RINEX 4 observation epoch record.
+ */
+struct ObservationEpochHeader {
+    int year = 0;
+    int month = 0;
+    int day = 0;
+    int hour = 0;
+    int minute = 0;
+    double second = 0.0;
+    int flag = 0;
+    int record_count = 0;
+    double receiver_clock_offset = 0.0;
+    bool has_receiver_clock_offset = false;
+    int extra_second_digits = 0;
+    bool has_date = false;
+};
+
+/**
+ * @brief Parse a RINEX 4 observation epoch/event record.
+ *
+ * The required calendar, seconds, flag, and count fields are read as tokens
+ * so the optional picosecond extension cannot shift the flag or count.  The
+ * optional clock estimate and extension are then checked at their fixed
+ * Table A3 locations.
+ */
+bool parseObservationEpochHeader(const std::string& line,
+                                 ObservationEpochHeader& epoch);
+
+/**
+ * @brief Return true only for CompactRINEX filename suffixes.
+ */
+bool isCompactRinexPath(const std::string& filename);
+
 }  // namespace libgnss::io::rinex4

--- a/include/libgnss++/io/rinex4.hpp
+++ b/include/libgnss++/io/rinex4.hpp
@@ -2,6 +2,7 @@
 
 #include <libgnss++/core/navigation.hpp>
 #include <array>
+#include <optional>
 #include <string>
 #include <variant>
 #include <vector>
@@ -73,6 +74,53 @@ struct CalendarTime {
     int minute = 0;
     int second = 0;
 };
+
+/**
+ * @brief Strictly parsed RINEX 4 A16/A17 GLONASS CDMA body.
+ *
+ * Epoch and transmission time remain in the originating UTC scale here;
+ * RINEXReader converts them with the existing leap-second policy before
+ * storing the resulting Ephemeris.
+ */
+struct GlonassCdmaEphemerisRecord {
+    NavigationRecordHeader header;
+    CalendarTime toc;
+    double minus_tau_n = 0.0;  ///< First clock field is -TauN in A16/A17.
+    double gamma_n = 0.0;
+    double beta = 0.0;
+    std::array<double, 3> position_km{};  ///< A16/A17 X,Y,Z positions (km).
+    std::array<double, 3> velocity_km_per_s{};  ///< X,Y,Z velocities (km/s).
+    std::array<double, 3> acceleration_km_per_s2{};  ///< X,Y,Z accelerations (km/s2).
+    int signal_health = 0;  ///< 0 healthy, 1 unhealthy.
+    int data_validity = 0;  ///< 0 valid, 1 invalid.
+    std::optional<double> tgd_l2ocp;  ///< L1OC delay; blank is absent.
+    std::optional<double> isc_l3ocp;  ///< L3OC inter-signal correction; blank is absent.
+    int satellite_type = 0;  ///< Satellite type M.
+    int source_flags = 0;  ///< Four-bit RE/RT source flag value.
+    double aode = 0.0;  ///< Age of ephemeris data EE (days).
+    double aodc = 0.0;  ///< Age of clock data ET (days).
+    int attitude_flag = 0;  ///< 0 nominal yaw steering, 1 rate-limited manoeuvre.
+    double tin = 0.0;  ///< Attitude reference time (UTC(SU) seconds of day).
+    double tau1 = 0.0;  ///< Attitude time constant Tau1 (seconds).
+    double tau2 = 0.0;  ///< Attitude time constant Tau2 (seconds).
+    double yaw_angle = 0.0;  ///< Initial yaw angle (radians).
+    int sign_flag = 0;  ///< Yaw sign flag.
+    double angular_rate = 0.0;  ///< Initial angular rate (rad/s).
+    double angular_acceleration = 0.0;  ///< Initial angular acceleration (rad/s2).
+    double max_angular_rate = 0.0;  ///< Maximum angular rate (rad/s).
+    std::array<double, 3> phase_center_m{};  ///< A16/A17 X,Y,Z offsets (m).
+    int urai_orbit = 0;  ///< Orbit URAI index FE.
+    int urai_clock = 0;  ///< Clock URAI index FT.
+    double transmission_time_utc_week = 0.0;  ///< UTC week seconds t_tm.
+};
+
+/**
+ * @brief Parse one complete RINEX 4 A16/A17 GLONASS CDMA body transactionally.
+ */
+bool parseGlonassCdmaEphemerisRecord(
+    const NavigationRecordHeader& header,
+    const std::vector<std::string>& body,
+    GlonassCdmaEphemerisRecord& record);
 
 struct SystemTimeOffsetRecord {
     NavigationRecordHeader header;

--- a/include/libgnss++/io/rinex4.hpp
+++ b/include/libgnss++/io/rinex4.hpp
@@ -1,7 +1,10 @@
 #pragma once
 
 #include <libgnss++/core/navigation.hpp>
+#include <array>
 #include <string>
+#include <variant>
+#include <vector>
 
 namespace libgnss::io::rinex4 {
 
@@ -54,6 +57,147 @@ const char* navigationMessageTypeName(NavigationMessageType type);
  * @brief Check whether a typed EPH message can reuse the existing body parser.
  */
 bool supportsEphemerisMessage(char system, NavigationMessageType type);
+
+/**
+ * @brief Calendar fields used by RINEX 4 system-data records.
+ *
+ * These fields deliberately remain in the originating system time scale;
+ * converting them to GPS time would give STO/EOP/ION records an ambiguous
+ * meaning before their constellation and message context are applied.
+ */
+struct CalendarTime {
+    int year = 0;
+    int month = 0;
+    int day = 0;
+    int hour = 0;
+    int minute = 0;
+    int second = 0;
+};
+
+struct SystemTimeOffsetRecord {
+    NavigationRecordHeader header;
+    CalendarTime reference_epoch;
+    std::string correction_type;
+    std::string sbas_id;
+    std::string utc_id;
+    double transmission_time = 0.0;
+    double a0 = 0.0;
+    double a1 = 0.0;
+    double a2 = 0.0;
+};
+
+struct EarthOrientationRecord {
+    NavigationRecordHeader header;
+    CalendarTime reference_epoch;
+    double x_p = 0.0;
+    double x_p_rate = 0.0;
+    double x_p_acceleration = 0.0;
+    double y_p = 0.0;
+    double y_p_rate = 0.0;
+    double y_p_acceleration = 0.0;
+    double transmission_time = 0.0;
+    double delta_ut1 = 0.0;
+    double delta_ut1_rate = 0.0;
+    double delta_ut1_acceleration = 0.0;
+};
+
+struct KlobucharIonosphere {
+    CalendarTime transmit_time;
+    std::array<double, 4> alpha{};
+    std::array<double, 4> beta{};
+};
+
+struct NequickGIonosphere {
+    CalendarTime transmit_time;
+    std::array<double, 3> ai{};
+    int disturbance_flags = 0;
+};
+
+struct BdgimIonosphere {
+    CalendarTime transmit_time;
+    std::array<double, 9> alpha{};  ///< A37 Alpha_1 through Alpha_9.
+};
+
+struct NavicKlobucharIonosphere {
+    CalendarTime transmit_time;
+    double issue_of_data = 0.0;
+    std::array<double, 4> alpha{};
+    std::array<double, 4> beta{};
+    std::array<double, 4> region_bounds{};  ///< [longitude_min, longitude_max, latitude_min, latitude_max].
+};
+
+struct NavicNequickNIonosphere {
+    CalendarTime transmit_time;
+    double issue_of_data = 0.0;
+    std::array<std::array<double, 3>, 3> coefficients{};  ///< Region order, each [a0, a1, a2].
+    std::array<std::array<double, 4>, 3> region_bounds{};  ///< Region order, each [longitude_min, longitude_max, MODIP_min, MODIP_max].
+    std::array<int, 3> disturbance_flags{};  ///< Disturbance flag in region order.
+};
+
+struct GlonassCdmaIonosphere {
+    CalendarTime transmit_time;
+    double c_a = 0.0;
+    double c_f10_7 = 0.0;
+    double c_ap = 0.0;
+};
+
+using IonospherePayload = std::variant<KlobucharIonosphere,
+                                       NequickGIonosphere,
+                                       BdgimIonosphere,
+                                       NavicKlobucharIonosphere,
+                                       NavicNequickNIonosphere,
+                                       GlonassCdmaIonosphere>;
+
+struct IonosphereRecord {
+    NavigationRecordHeader header;
+    IonospherePayload payload;
+};
+
+/**
+ * @brief RINEX-specific sidecar for parsed STO/EOP/ION records.
+ *
+ * The sidecar is kept separate from NavigationData's broadcast ephemeris and
+ * legacy Klobuchar selection fields.  A record is appended only after its
+ * complete body validates, so malformed records cannot leave partial state.
+ */
+struct SystemData {
+    std::vector<SystemTimeOffsetRecord> system_time_offsets;
+    std::vector<EarthOrientationRecord> earth_orientation_parameters;
+    std::vector<IonosphereRecord> ionosphere_records;
+
+    void clear() {
+        system_time_offsets.clear();
+        earth_orientation_parameters.clear();
+        ionosphere_records.clear();
+    }
+
+    bool empty() const {
+        return system_time_offsets.empty() &&
+               earth_orientation_parameters.empty() &&
+               ionosphere_records.empty();
+    }
+};
+
+/**
+ * @brief Parse a complete RINEX 4 STO record body transactionally.
+ */
+bool parseSystemTimeOffsetRecord(const NavigationRecordHeader& header,
+                                 const std::vector<std::string>& body,
+                                 SystemTimeOffsetRecord& record);
+
+/**
+ * @brief Parse a complete RINEX 4 EOP record body transactionally.
+ */
+bool parseEarthOrientationRecord(const NavigationRecordHeader& header,
+                                 const std::vector<std::string>& body,
+                                 EarthOrientationRecord& record);
+
+/**
+ * @brief Parse a complete RINEX 4 ION record body transactionally.
+ */
+bool parseIonosphereRecord(const NavigationRecordHeader& header,
+                           const std::vector<std::string>& body,
+                           IonosphereRecord& record);
 
 /**
  * @brief Parsed metadata from a RINEX 4 observation epoch record.

--- a/include/libgnss++/io/rinex4.hpp
+++ b/include/libgnss++/io/rinex4.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <libgnss++/core/navigation.hpp>
 #include <string>
 
 namespace libgnss::io::rinex4 {
@@ -21,6 +22,7 @@ struct NavigationRecordHeader {
     std::string subtype;
     char system = '\0';
     int prn = 0;
+    NavigationMessageType navigation_message_type = NavigationMessageType::Unknown;
 };
 
 /**
@@ -37,6 +39,21 @@ bool parseNavigationRecordHeader(const std::string& line,
  * @brief Check whether an EPH message can reuse the existing body parser.
  */
 bool supportsEphemerisMessage(char system, const std::string& message_type);
+
+/**
+ * @brief Convert a RINEX 4 navigation message token to typed provenance.
+ */
+NavigationMessageType navigationMessageTypeFromRinexToken(const std::string& token);
+
+/**
+ * @brief Return the canonical RINEX token for typed navigation provenance.
+ */
+const char* navigationMessageTypeName(NavigationMessageType type);
+
+/**
+ * @brief Check whether a typed EPH message can reuse the existing body parser.
+ */
+bool supportsEphemerisMessage(char system, NavigationMessageType type);
 
 /**
  * @brief Parsed metadata from a RINEX 4 observation epoch record.

--- a/src/io/rinex.cpp
+++ b/src/io/rinex.cpp
@@ -406,6 +406,7 @@ RINEXReader::RINEXReader()
     : qzss_prefer_l1l_(PPPEnvOverrides::fromEnvironment().qzss_prefer_l1l) {}
 
 bool RINEXReader::open(const std::string& filename) {
+    rinex4_system_data_.clear();
     if (rinex4::isCompactRinexPath(filename)) {
         std::cerr << "CompactRINEX input is not supported natively (.crx/.crx.gz): "
                   << filename << std::endl;
@@ -755,6 +756,8 @@ bool RINEXReader::readNavigationData(NavigationData& nav_data) {
 }
 
 bool RINEXReader::readRinex4NavigationData(NavigationData& nav_data) {
+    rinex4_system_data_.clear();
+
     // RINEX 4 makes the navigation record boundary explicit.  Keep the
     // complete body between two '>' headers so unsupported STO/EOP/ION (or
     // unsupported EPH message types) can be skipped without feeding their
@@ -767,6 +770,48 @@ bool RINEXReader::readRinex4NavigationData(NavigationData& nav_data) {
 
     const auto finish_record = [&]() {
         if (!have_active_record || !active_record_supported) {
+            body.clear();
+            return;
+        }
+
+        if (active_header.record_type == "STO") {
+            rinex4::SystemTimeOffsetRecord record;
+            if (!rinex4::parseSystemTimeOffsetRecord(active_header, body, record)) {
+                std::cerr << "Skipping malformed RINEX 4 STO body for "
+                          << active_header.source << ' '
+                          << active_header.message_type << std::endl;
+            } else {
+                rinex4_system_data_.system_time_offsets.push_back(std::move(record));
+            }
+            body.clear();
+            return;
+        }
+        if (active_header.record_type == "EOP") {
+            rinex4::EarthOrientationRecord record;
+            if (!rinex4::parseEarthOrientationRecord(active_header, body, record)) {
+                std::cerr << "Skipping malformed RINEX 4 EOP body for "
+                          << active_header.source << ' '
+                          << active_header.message_type << std::endl;
+            } else {
+                rinex4_system_data_.earth_orientation_parameters.push_back(
+                    std::move(record));
+            }
+            body.clear();
+            return;
+        }
+        if (active_header.record_type == "ION") {
+            rinex4::IonosphereRecord record;
+            if (!rinex4::parseIonosphereRecord(active_header, body, record)) {
+                std::cerr << "Skipping malformed or unsupported RINEX 4 ION body for "
+                          << active_header.source << ' '
+                          << active_header.message_type;
+                if (!active_header.subtype.empty()) {
+                    std::cerr << ' ' << active_header.subtype;
+                }
+                std::cerr << std::endl;
+            } else {
+                rinex4_system_data_.ionosphere_records.push_back(std::move(record));
+            }
             body.clear();
             return;
         }
@@ -841,8 +886,14 @@ bool RINEXReader::readRinex4NavigationData(NavigationData& nav_data) {
 
             have_active_record = true;
             if (active_header.record_type != "EPH") {
-                std::cerr << "Skipping unsupported RINEX 4 navigation record type: "
-                          << active_header.record_type << std::endl;
+                if (active_header.record_type == "STO" ||
+                    active_header.record_type == "EOP" ||
+                    active_header.record_type == "ION") {
+                    active_record_supported = true;
+                } else {
+                    std::cerr << "Skipping unsupported RINEX 4 navigation record type: "
+                              << active_header.record_type << std::endl;
+                }
                 continue;
             }
 
@@ -870,7 +921,7 @@ bool RINEXReader::readRinex4NavigationData(NavigationData& nav_data) {
     }
 
     finish_record();
-    return !nav_data.isEmpty();
+    return !nav_data.isEmpty() || !rinex4_system_data_.empty();
 }
 
 bool RINEXReader::parseHeaderLine(const std::string& line, RINEXHeader& header) {

--- a/src/io/rinex.cpp
+++ b/src/io/rinex.cpp
@@ -10,6 +10,7 @@
 #include <cmath>
 #include <cctype>
 #include <set>
+#include <utility>
 
 namespace libgnss {
 namespace io {
@@ -405,9 +406,15 @@ RINEXReader::RINEXReader()
     : qzss_prefer_l1l_(PPPEnvOverrides::fromEnvironment().qzss_prefer_l1l) {}
 
 bool RINEXReader::open(const std::string& filename) {
+    if (rinex4::isCompactRinexPath(filename)) {
+        std::cerr << "CompactRINEX input is not supported natively (.crx/.crx.gz): "
+                  << filename << std::endl;
+        return false;
+    }
     file_.open(filename);
     current_line_ = 0;
     header_read_ = false;
+    last_rinex4_epoch_was_event_ = false;
     return file_.is_open();
 }
 
@@ -490,17 +497,17 @@ bool RINEXReader::readObservationEpoch(ObservationData& obs_data) {
                 }
             }
         } else if (isRinex4()) {
-            // RINEX 4 epoch records allow more precise seconds and an
-            // optional receiver-clock field.  The fixed-column RINEX 3
-            // parser below is intentionally not used here: accepting a
-            // shifted flag/count field would silently misread every
-            // satellite row.  Token-based RINEX 4 observation parsing is a
-            // separate follow-up slice.
             if (!line.empty() && line[0] == '>') {
-                std::cerr << "RINEX 4 observation epochs are not supported yet; "
-                             "use a RINEX 3-compatible input or preprocess the file"
-                          << std::endl;
-                return false;
+                if (!parseObservationEpochV4(line, obs_data)) {
+                    return false;
+                }
+                // Event and cycle-slip records are consumed by the RINEX 4
+                // parser but are not ordinary ObservationData epochs.  Keep
+                // scanning so readAllObservations() reaches the next epoch.
+                if (last_rinex4_epoch_was_event_) {
+                    continue;
+                }
+                return true;
             }
         } else if (header_.version >= 3.0 && header_.version < 4.0) {
             // RINEX 3.x format starts with '>'
@@ -904,7 +911,7 @@ bool RINEXReader::parseHeaderLine(const std::string& line, RINEXHeader& header) 
         }
     }
     else if (label.find("SYS / # / OBS TYPES") != std::string::npos) {
-        // RINEX 3: Per-system observation types
+        // RINEX 3/4: Per-system observation types
         // Format: "G   22 C1C L1C C2X L2X ..." (system char at pos 0, count at
         // pos 3-6, types at pos 7+, up to 13 types per line). When a system has
         // more than 13 types, the remainder continue on following lines whose
@@ -1236,153 +1243,8 @@ bool RINEXReader::parseObservationEpochV3(const std::string& epoch_line, Observa
         num_sats_str.erase(0, num_sats_str.find_first_not_of(' '));
         int num_sats = num_sats_str.empty() ? 0 : std::stoi(num_sats_str);
 
-        // Read each satellite line
-        for (int s = 0; s < num_sats; ++s) {
-            std::string sat_line;
-            if (!readLine(sat_line)) break;
-            if (sat_line.length() < 3) continue;
-
-            // Parse system char and PRN
-            char sys_char = sat_line[0];
-            std::string prn_str = sat_line.substr(1, 2);
-            prn_str.erase(0, prn_str.find_first_not_of(' '));
-            if (prn_str.empty()) continue;
-            int prn = std::stoi(prn_str);
-
-            const GNSSSystem system = systemFromRinexChar(sys_char);
-            if (system == GNSSSystem::UNKNOWN) continue;
-
-            auto sys_it = header_.system_obs_types.find(sys_char);
-            const std::vector<std::string>& obs_types =
-                (sys_it != header_.system_obs_types.end()) ? sys_it->second : header_.observation_types;
-            int num_obs_types = static_cast<int>(obs_types.size());
-            if (num_obs_types == 0) num_obs_types = 4;
-
-            SatelliteId sat(system, prn);
-
-            // Parse observation values
-            // Each observation occupies 16 characters starting at position 3
-            // Format: 14.3f + LLI(1) + SS(1) = 16 chars per observation
-            std::vector<double> obs_values(num_obs_types, 0.0);
-            std::vector<int> lli_flags(num_obs_types, 0);
-            std::vector<int> signal_strength(num_obs_types, 0);
-
-            for (int i = 0; i < num_obs_types; ++i) {
-                size_t col_start = 3 + i * 16;
-                if (col_start + 14 > sat_line.length()) continue;
-
-                std::string obs_str = sat_line.substr(col_start, 14);
-                obs_str.erase(0, obs_str.find_first_not_of(' '));
-                obs_str.erase(obs_str.find_last_not_of(' ') + 1);
-
-                if (!obs_str.empty()) {
-                    try {
-                        obs_values[i] = std::stod(obs_str);
-                    } catch (...) {
-                        obs_values[i] = 0.0;
-                    }
-                }
-
-                // Parse LLI flag (position col_start + 14)
-                if (col_start + 14 < sat_line.length() && sat_line[col_start + 14] != ' ') {
-                    lli_flags[i] = sat_line[col_start + 14] - '0';
-                }
-
-                // Parse signal strength (position col_start + 15)
-                if (col_start + 15 < sat_line.length() && sat_line[col_start + 15] != ' ') {
-                    signal_strength[i] = sat_line[col_start + 15] - '0';
-                }
-            }
-
-            ObservationSelection primary_selection;
-            ObservationSelection secondary_selection;
-            std::map<std::string, Observation> tracking_observations;
-            std::map<int, ObservationSelection> band_selections;
-
-            // RTKLIB fixes its normal-frequency slots from the RINEX header,
-            // not from whichever values happen to be present this epoch.
-            // Preserve that identity so a missing L2W remains a zero L[1]
-            // instead of falling through to an extended L2L observation.
-            if (sat.system == GNSSSystem::GPS) {
-                obs_data.setRinexFrequencySlot(GNSSSystem::GPS, 0, "1C");
-                static constexpr char kGpsL2Priority[] = "PYWCMNDLXS";
-                for (const char* priority = kGpsL2Priority;
-                     *priority != '\0'; ++priority) {
-                    const std::string candidate =
-                        std::string("2") + *priority;
-                    const bool declared = std::any_of(
-                        obs_types.begin(), obs_types.end(),
-                        [&candidate](const std::string& type) {
-                            return type.size() >= 3 &&
-                                   type.substr(1) == candidate;
-                        });
-                    if (declared) {
-                        obs_data.setRinexFrequencySlot(
-                            GNSSSystem::GPS, 1, candidate);
-                        break;
-                    }
-                }
-            }
-
-            for (size_t i = 0; i < obs_types.size() && i < obs_values.size(); ++i) {
-                const std::string& obs_type = obs_types[i];
-                if (obs_values[i] != 0.0 && obs_type.size() >= 3) {
-                    const std::string tracking_code = obs_type.substr(1);
-                    auto [it, inserted] = tracking_observations.try_emplace(
-                        tracking_code);
-                    Observation& exact = it->second;
-                    if (inserted) {
-                        exact.satellite = sat;
-                        exact.signal = signalForObservationType(
-                            sat.system, obs_type,
-                            isPrimaryBand(sat.system, rinexBand(obs_type)));
-                        exact.valid = true;
-                    }
-                    assignObservationField(exact,
-                                           obs_type,
-                                           obs_values[i],
-                                           lli_flags[i],
-                                           signal_strength[i]);
-                }
-                maybeAssignSelectedObservation(primary_selection,
-                                               sat,
-                                               obs_type,
-                                               obs_values[i],
-                                               lli_flags[i],
-                                               signal_strength[i],
-                                               qzss_prefer_l1l_,
-                                               qzss_prefer_l5_secondary_,
-                                               true);
-                maybeAssignSelectedObservation(secondary_selection,
-                                               sat,
-                                               obs_type,
-                                               obs_values[i],
-                                               lli_flags[i],
-                                               signal_strength[i],
-                                               qzss_prefer_l1l_,
-                                               qzss_prefer_l5_secondary_,
-                                               false);
-                if (preserve_additional_frequency_bands_) {
-                    const int band = rinexBand(obs_type);
-                    const bool primary_band = isPrimaryBand(sat.system, band);
-                    if (primary_band || isSecondaryBand(sat.system, band)) {
-                        maybeAssignSelectedObservation(
-                            band_selections[band], sat, obs_type, obs_values[i],
-                            lli_flags[i], signal_strength[i], qzss_prefer_l1l_,
-                            qzss_prefer_l5_secondary_, primary_band);
-                    }
-                }
-            }
-
-            appendSelectedObservations(
-                primary_selection, secondary_selection, band_selections,
-                preserve_additional_frequency_bands_,
-                header_.glonass_frequency_channels, obs_data);
-            for (auto& [tracking_code, exact] : tracking_observations) {
-                annotateGlonassFrequencyChannel(
-                    exact, header_.glonass_frequency_channels);
-                obs_data.addRinexTrackingObservation(tracking_code, exact);
-            }
+        if (!parseObservationRows(num_sats, obs_data, false)) {
+            return false;
         }
 
     } catch (const std::exception& e) {
@@ -1390,6 +1252,249 @@ bool RINEXReader::parseObservationEpochV3(const std::string& epoch_line, Observa
         return false;
     }
 
+    return true;
+}
+
+bool RINEXReader::parseObservationSatelliteRecord(
+    const std::string& sat_line,
+    ObservationData& obs_data,
+    bool strict) {
+    if (sat_line.size() < 3) {
+        return !strict;
+    }
+
+    const char sys_char = sat_line[0];
+    const bool exact_prn = std::isdigit(static_cast<unsigned char>(sat_line[1])) != 0 &&
+                           std::isdigit(static_cast<unsigned char>(sat_line[2])) != 0;
+    if (strict && !exact_prn) {
+        return false;
+    }
+    std::string prn_str = sat_line.substr(1, 2);
+    if (!strict) {
+        prn_str.erase(0, prn_str.find_first_not_of(' '));
+    }
+    if (prn_str.empty() || (strict && !exact_prn)) {
+        return !strict;
+    }
+
+    int prn = 0;
+    try {
+        prn = std::stoi(prn_str);
+    } catch (...) {
+        return !strict;
+    }
+    if (strict && prn <= 0) {
+        return false;
+    }
+    const GNSSSystem system = systemFromRinexChar(sys_char);
+    if (system == GNSSSystem::UNKNOWN) {
+        return !strict;
+    }
+
+    auto sys_it = header_.system_obs_types.find(sys_char);
+    const std::vector<std::string>& obs_types =
+        (sys_it != header_.system_obs_types.end()) ? sys_it->second : header_.observation_types;
+    int num_obs_types = static_cast<int>(obs_types.size());
+    if (num_obs_types == 0) {
+        num_obs_types = 4;
+    }
+
+    SatelliteId sat(system, prn);
+    std::vector<double> obs_values(num_obs_types, 0.0);
+    std::vector<int> lli_flags(num_obs_types, 0);
+    std::vector<int> signal_strength(num_obs_types, 0);
+
+    for (int i = 0; i < num_obs_types; ++i) {
+        const size_t col_start = 3 + static_cast<size_t>(i) * 16;
+        const std::string& row = sat_line;
+        if (col_start + 14 > row.length()) {
+            if (strict) {
+                return false;
+            }
+            continue;
+        }
+        if (strict && col_start + 16 > row.length()) {
+            return false;
+        }
+
+        std::string obs_str = row.substr(col_start, 14);
+        obs_str.erase(0, obs_str.find_first_not_of(' '));
+        if (!obs_str.empty()) {
+            obs_str.erase(obs_str.find_last_not_of(' ') + 1);
+            try {
+                size_t consumed = 0;
+                const double value = std::stod(obs_str, &consumed);
+                if (strict && (consumed != obs_str.size() || !std::isfinite(value))) {
+                    return false;
+                }
+                obs_values[i] = value;
+            } catch (...) {
+                if (strict) {
+                    return false;
+                }
+                obs_values[i] = 0.0;
+            }
+        }
+
+        const size_t lli_pos = col_start + 14;
+        const size_t strength_pos = col_start + 15;
+        if (lli_pos < row.length() && row[lli_pos] != ' ') {
+            if (strict && !std::isdigit(static_cast<unsigned char>(row[lli_pos]))) {
+                return false;
+            }
+            lli_flags[i] = row[lli_pos] - '0';
+        }
+        if (strength_pos < row.length() && row[strength_pos] != ' ') {
+            if (strict && !std::isdigit(static_cast<unsigned char>(row[strength_pos]))) {
+                return false;
+            }
+            signal_strength[i] = row[strength_pos] - '0';
+        }
+    }
+
+    ObservationSelection primary_selection;
+    ObservationSelection secondary_selection;
+    std::map<std::string, Observation> tracking_observations;
+    std::map<int, ObservationSelection> band_selections;
+
+    // RTKLIB fixes its normal-frequency slots from the RINEX header, not
+    // from whichever values happen to be present in this epoch.
+    if (sat.system == GNSSSystem::GPS) {
+        obs_data.setRinexFrequencySlot(GNSSSystem::GPS, 0, "1C");
+        static constexpr char kGpsL2Priority[] = "PYWCMNDLXS";
+        for (const char* priority = kGpsL2Priority;
+             *priority != '\0'; ++priority) {
+            const std::string candidate = std::string("2") + *priority;
+            const bool declared = std::any_of(
+                obs_types.begin(), obs_types.end(),
+                [&candidate](const std::string& type) {
+                    return type.size() >= 3 && type.substr(1) == candidate;
+                });
+            if (declared) {
+                obs_data.setRinexFrequencySlot(GNSSSystem::GPS, 1, candidate);
+                break;
+            }
+        }
+    }
+
+    for (size_t i = 0; i < obs_types.size() && i < obs_values.size(); ++i) {
+        const std::string& obs_type = obs_types[i];
+        if (obs_values[i] != 0.0 && obs_type.size() >= 3) {
+            const std::string tracking_code = obs_type.substr(1);
+            auto [it, inserted] = tracking_observations.try_emplace(tracking_code);
+            Observation& exact = it->second;
+            if (inserted) {
+                exact.satellite = sat;
+                exact.signal = signalForObservationType(
+                    sat.system, obs_type,
+                    isPrimaryBand(sat.system, rinexBand(obs_type)));
+                exact.valid = true;
+            }
+            assignObservationField(exact, obs_type, obs_values[i],
+                                   lli_flags[i], signal_strength[i]);
+        }
+        maybeAssignSelectedObservation(primary_selection, sat, obs_type,
+                                       obs_values[i], lli_flags[i],
+                                       signal_strength[i], qzss_prefer_l1l_,
+                                       qzss_prefer_l5_secondary_, true);
+        maybeAssignSelectedObservation(secondary_selection, sat, obs_type,
+                                       obs_values[i], lli_flags[i],
+                                       signal_strength[i], qzss_prefer_l1l_,
+                                       qzss_prefer_l5_secondary_, false);
+        if (preserve_additional_frequency_bands_) {
+            const int band = rinexBand(obs_type);
+            const bool primary_band = isPrimaryBand(sat.system, band);
+            if (primary_band || isSecondaryBand(sat.system, band)) {
+                maybeAssignSelectedObservation(
+                    band_selections[band], sat, obs_type, obs_values[i],
+                    lli_flags[i], signal_strength[i], qzss_prefer_l1l_,
+                    qzss_prefer_l5_secondary_, primary_band);
+            }
+        }
+    }
+
+    appendSelectedObservations(primary_selection, secondary_selection,
+                               band_selections,
+                               preserve_additional_frequency_bands_,
+                               header_.glonass_frequency_channels, obs_data);
+    for (auto& [tracking_code, exact] : tracking_observations) {
+        annotateGlonassFrequencyChannel(exact, header_.glonass_frequency_channels);
+        obs_data.addRinexTrackingObservation(tracking_code, exact);
+    }
+    return true;
+}
+
+bool RINEXReader::parseObservationRows(int num_sats,
+                                       ObservationData& obs_data,
+                                       bool strict) {
+    for (int s = 0; s < num_sats; ++s) {
+        std::string sat_line;
+        if (!readLine(sat_line)) {
+            return !strict;
+        }
+        if (sat_line.size() < 3) {
+            if (strict) {
+                return false;
+            }
+            continue;
+        }
+
+        if (!parseObservationSatelliteRecord(sat_line, obs_data, strict)) {
+            return false;
+        }
+    }
+    return true;
+}
+
+bool RINEXReader::parseObservationEpochV4(const std::string& epoch_line,
+                                          ObservationData& obs_data) {
+    last_rinex4_epoch_was_event_ = false;
+    obs_data.clear();
+    ObservationData parsed;
+    rinex4::ObservationEpochHeader epoch;
+    if (!rinex4::parseObservationEpochHeader(epoch_line, epoch)) {
+        std::cerr << "RINEX 4 observation epoch header is malformed" << std::endl;
+        return false;
+    }
+
+    if (epoch.has_date) {
+        std::ostringstream time_text;
+        time_text << epoch.year << ' ' << epoch.month << ' ' << epoch.day << ' '
+                  << epoch.hour << ' ' << epoch.minute << ' '
+                  << std::setprecision(17) << epoch.second;
+        parsed.time = parseTime(time_text.str(), header_.version);
+    } else if (epoch.flag <= 1) {
+        std::cerr << "RINEX 4 normal epoch is missing date/time fields" << std::endl;
+        return false;
+    }
+
+    if (epoch.flag >= 2) {
+        last_rinex4_epoch_was_event_ = true;
+        for (int record = 0; record < epoch.record_count; ++record) {
+            std::string special_record;
+            if (!readLine(special_record)) {
+                std::cerr << "RINEX 4 event record is truncated" << std::endl;
+                return false;
+            }
+            if (epoch.flag == 4) {
+                // Header event records can change observation types for later
+                // epochs.  Ignore ordinary comments, but let valid labels
+                // update the same header state used during initial parsing.
+                parseHeaderLine(special_record, header_);
+            }
+        }
+        return true;
+    }
+
+    if (!parseObservationRows(epoch.record_count, parsed, true)) {
+        std::cerr << "RINEX 4 observation epoch has truncated or malformed satellite records"
+                  << std::endl;
+        return false;
+    }
+    parsed.receiver_clock_bias = epoch.has_receiver_clock_offset
+                                     ? epoch.receiver_clock_offset
+                                     : 0.0;
+    obs_data = std::move(parsed);
     return true;
 }
 

--- a/src/io/rinex.cpp
+++ b/src/io/rinex.cpp
@@ -791,6 +791,33 @@ bool RINEXReader::readRinex4NavigationData(NavigationData& nav_data) {
             return;
         }
 
+        if (active_header.system == 'E') {
+            const bool inav_e1b_source = (eph.data_source_code & (1 << 0)) != 0;
+            const bool fnav_e5a_source = (eph.data_source_code & (1 << 1)) != 0;
+            const bool inav_e5b_source = (eph.data_source_code & (1 << 2)) != 0;
+            const bool fnav_clock_source = (eph.data_source_code & (1 << 8)) != 0;
+            const bool inav_clock_source = (eph.data_source_code & (1 << 9)) != 0;
+            const bool header_is_fnav =
+                active_header.navigation_message_type == NavigationMessageType::FNAV;
+            const bool header_is_inav =
+                active_header.navigation_message_type == NavigationMessageType::INAV;
+            const bool source_matches_header =
+                (header_is_fnav && fnav_e5a_source && fnav_clock_source &&
+                 !inav_e1b_source && !inav_e5b_source && !inav_clock_source) ||
+                (header_is_inav && (inav_e1b_source || inav_e5b_source) &&
+                 inav_clock_source && !fnav_e5a_source && !fnav_clock_source);
+            if (!source_matches_header) {
+                std::cerr << "Skipping RINEX 4 Galileo EPH " << active_header.source
+                          << ' ' << active_header.message_type
+                          << ": body data-source clock bit contradicts header"
+                          << std::endl;
+                body.clear();
+                return;
+            }
+        }
+
+        eph.navigation_message_type = active_header.navigation_message_type;
+
         nav_data.addEphemeris(eph);
         body.clear();
     };
@@ -820,7 +847,7 @@ bool RINEXReader::readRinex4NavigationData(NavigationData& nav_data) {
             }
 
             active_record_supported = rinex4::supportsEphemerisMessage(
-                active_header.system, active_header.message_type);
+                active_header.system, active_header.navigation_message_type);
             if (!active_record_supported) {
                 std::cerr << "Skipping unsupported RINEX 4 EPH "
                           << active_header.source << ' '

--- a/src/io/rinex.cpp
+++ b/src/io/rinex.cpp
@@ -816,6 +816,96 @@ bool RINEXReader::readRinex4NavigationData(NavigationData& nav_data) {
             return;
         }
 
+        if (active_header.system == 'R' &&
+            (active_header.message_type == "L1OC" ||
+             active_header.message_type == "L3OC")) {
+            rinex4::GlonassCdmaEphemerisRecord record;
+            if (!rinex4::parseGlonassCdmaEphemerisRecord(
+                    active_header, body, record)) {
+                std::cerr << "Skipping malformed RINEX 4 GLONASS "
+                          << active_header.message_type << " body for "
+                          << active_header.source << std::endl;
+                body.clear();
+                return;
+            }
+
+            Ephemeris eph;
+            std::ostringstream epoch_text;
+            epoch_text << record.toc.year << ' ' << record.toc.month << ' '
+                       << record.toc.day << ' ' << record.toc.hour << ' '
+                       << record.toc.minute << ' ' << record.toc.second;
+            const GNSSTime toc_utc = parseTime(epoch_text.str(), header_.version);
+            const GNSSTime toc_gpst = utcToGpst(
+                toc_utc, record.toc.year, record.toc.month, record.toc.day);
+
+            GNSSTime tof_utc = normalizeWeekTow(
+                toc_utc.week, record.transmission_time_utc_week);
+            const double week_delta = tof_utc.tow - toc_utc.tow;
+            if (week_delta < -302400.0) {
+                ++tof_utc.week;
+            } else if (week_delta > 302400.0) {
+                --tof_utc.week;
+            }
+            const GNSSTime tof_gpst = utcToGpst(
+                tof_utc, record.toc.year, record.toc.month, record.toc.day);
+
+            eph.satellite = SatelliteId(GNSSSystem::GLONASS, active_header.prn);
+            eph.toc = toc_gpst;
+            eph.toe = toc_gpst;
+            eph.tof = tof_gpst;
+            eph.toes = toc_gpst.tow;
+            eph.week = static_cast<uint16_t>(toc_gpst.week);
+            // A16/A17 transmit -TauN; Ephemeris stores the actual TauN and
+            // computeGlonassState() applies the broadcast leading minus sign.
+            eph.glonass_taun = -record.minus_tau_n;
+            eph.glonass_gamn = record.gamma_n;
+            eph.glonass_position = Vector3d(
+                record.position_km[0] * 1e3,
+                record.position_km[1] * 1e3,
+                record.position_km[2] * 1e3);
+            eph.glonass_velocity = Vector3d(
+                record.velocity_km_per_s[0] * 1e3,
+                record.velocity_km_per_s[1] * 1e3,
+                record.velocity_km_per_s[2] * 1e3);
+            eph.glonass_acceleration = Vector3d(
+                record.acceleration_km_per_s2[0] * 1e3,
+                record.acceleration_km_per_s2[1] * 1e3,
+                record.acceleration_km_per_s2[2] * 1e3);
+            eph.health = static_cast<uint8_t>(record.signal_health);
+            eph.valid = record.signal_health == 0 && record.data_validity == 0;
+            eph.navigation_message_type = active_header.navigation_message_type;
+
+            GlonassCdmaNavigationData cdma;
+            cdma.beta = record.beta;
+            cdma.data_validity = record.data_validity;
+            cdma.satellite_type = record.satellite_type;
+            cdma.source_flags = record.source_flags;
+            cdma.aode = record.aode;
+            cdma.aodc = record.aodc;
+            cdma.attitude_flag = record.attitude_flag;
+            cdma.sign_flag = record.sign_flag;
+            cdma.urai_orbit = record.urai_orbit;
+            cdma.urai_clock = record.urai_clock;
+            cdma.tin = record.tin;
+            cdma.tau1 = record.tau1;
+            cdma.tau2 = record.tau2;
+            cdma.yaw_angle = record.yaw_angle;
+            cdma.angular_rate = record.angular_rate;
+            cdma.angular_acceleration = record.angular_acceleration;
+            cdma.max_angular_rate = record.max_angular_rate;
+            cdma.pc_x = record.phase_center_m[0];
+            cdma.pc_y = record.phase_center_m[1];
+            cdma.pc_z = record.phase_center_m[2];
+            cdma.transmission_time_utc_week = record.transmission_time_utc_week;
+            cdma.tgd_l2ocp = record.tgd_l2ocp;
+            cdma.isc_l3ocp = record.isc_l3ocp;
+            eph.glonass_cdma_data = std::move(cdma);
+
+            nav_data.addEphemeris(eph);
+            body.clear();
+            return;
+        }
+
         Ephemeris eph;
         if (!parseNavigationMessage(body, eph)) {
             std::cerr << "Skipping RINEX 4 EPH " << active_header.source << ' '

--- a/src/io/rinex4.cpp
+++ b/src/io/rinex4.cpp
@@ -3,7 +3,10 @@
 #include <cctype>
 #include <algorithm>
 #include <cmath>
+#include <iterator>
+#include <limits>
 #include <sstream>
+#include <utility>
 
 namespace libgnss::io::rinex4 {
 
@@ -19,6 +22,7 @@ bool isKnownConstellation(char system) {
 
 bool parseNavigationRecordHeader(const std::string& line,
                                  NavigationRecordHeader& record) {
+    record = NavigationRecordHeader();
     std::istringstream fields(line);
     std::string marker;
     if (!(fields >> marker >> record.record_type >> record.source >> record.message_type) ||
@@ -49,19 +53,26 @@ bool parseNavigationRecordHeader(const std::string& line,
 
     // EPH records identify a transmitting satellite (for example G01),
     // whereas STO/ION/EOP records may identify only a constellation (for
-    // example R).  Validate the satellite form only when it is required.
-    if (record.record_type == "EPH") {
-        if (record.source.size() != 3 ||
-            !isKnownConstellation(record.source[0]) ||
-            !std::isdigit(static_cast<unsigned char>(record.source[1])) ||
+    // example R).  Keep the distinction in the parsed header so system-data
+    // validators can apply their record-specific source rules.
+    if (record.source.size() != 1 && record.source.size() != 3) {
+        return false;
+    }
+    if (!isKnownConstellation(record.source[0])) {
+        return false;
+    }
+    record.system = record.source[0];
+    if (record.source.size() == 3) {
+        if (!std::isdigit(static_cast<unsigned char>(record.source[1])) ||
             !std::isdigit(static_cast<unsigned char>(record.source[2]))) {
             return false;
         }
-        record.system = record.source[0];
         record.prn = (record.source[1] - '0') * 10 + (record.source[2] - '0');
         if (record.prn <= 0) {
             return false;
         }
+    } else if (record.record_type == "EPH") {
+        return false;
     }
     record.navigation_message_type =
         navigationMessageTypeFromRinexToken(record.message_type);
@@ -221,7 +232,533 @@ bool parseSecondsToken(const std::string& token, double& seconds) {
     return seconds >= 0.0 && seconds <= 60.0;
 }
 
+bool parseDateField(const std::string& field, size_t width, int& value) {
+    if (field.size() != width || !isUnsignedDigits(field)) {
+        return false;
+    }
+    try {
+        size_t consumed = 0;
+        value = std::stoi(field, &consumed);
+        return consumed == field.size();
+    } catch (...) {
+        return false;
+    }
+}
+
+bool validCalendar(const CalendarTime& time) {
+    if (time.year < 1 || time.year > 9999 || time.month < 1 || time.month > 12 ||
+        time.hour < 0 || time.hour > 23 || time.minute < 0 || time.minute > 59 ||
+        time.second < 0 || time.second > 60) {
+        return false;
+    }
+    static constexpr int kDaysInMonth[] = {
+        31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    int days = kDaysInMonth[time.month - 1];
+    if (time.month == 2 && isLeapYear(time.year)) {
+        days = 29;
+    }
+    return time.day >= 1 && time.day <= days;
+}
+
+bool parseCalendarPrefix(const std::string& line,
+                         CalendarTime& time,
+                         size_t& field_start) {
+    if (line.size() < 24 ||
+        line[0] != ' ' || line[1] != ' ' || line[2] != ' ' || line[3] != ' ' ||
+        line[8] != ' ' || line[11] != ' ' || line[14] != ' ' ||
+        line[17] != ' ' || line[20] != ' ' || line[23] != ' ') {
+        return false;
+    }
+    CalendarTime parsed;
+    if (!parseDateField(line.substr(4, 4), 4, parsed.year) ||
+        !parseDateField(line.substr(9, 2), 2, parsed.month) ||
+        !parseDateField(line.substr(12, 2), 2, parsed.day) ||
+        !parseDateField(line.substr(15, 2), 2, parsed.hour) ||
+        !parseDateField(line.substr(18, 2), 2, parsed.minute) ||
+        !parseDateField(line.substr(21, 2), 2, parsed.second) ||
+        !validCalendar(parsed)) {
+        return false;
+    }
+    time = parsed;
+    field_start = 24;
+    return true;
+}
+
+bool parseFloatingField(const std::string& field, double& value) {
+    std::string token = trim(field);
+    if (token.empty()) {
+        return false;
+    }
+    for (char& c : token) {
+        if (c == 'D' || c == 'd') {
+            c = 'E';
+        }
+    }
+    try {
+        size_t consumed = 0;
+        value = std::stod(token, &consumed);
+        return consumed == token.size() && std::isfinite(value);
+    } catch (...) {
+        return false;
+    }
+}
+
+bool parseFixedNumbers(const std::string& line,
+                       size_t field_start,
+                       size_t count,
+                       std::vector<double>& values) {
+    const size_t end = field_start + count * 19;
+    if (line.size() < end) {
+        return false;
+    }
+    std::vector<double> parsed;
+    parsed.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        double value = 0.0;
+        if (!parseFloatingField(line.substr(field_start + i * 19, 19), value)) {
+            return false;
+        }
+        parsed.push_back(value);
+    }
+    if (!trim(line.substr(end)).empty()) {
+        return false;
+    }
+    values = std::move(parsed);
+    return true;
+}
+
+bool parseContinuationNumbers(const std::string& line,
+                              size_t field_start,
+                              size_t count,
+                              std::vector<double>& values) {
+    if (line.size() < 4 || line.compare(0, 4, "    ") != 0) {
+        return false;
+    }
+    return parseFixedNumbers(line, field_start, count, values);
+}
+
+bool parseA18Fields(const std::string& line,
+                    size_t field_start,
+                    size_t count,
+                    std::vector<std::string>& values) {
+    const size_t expected_end = field_start + count * 19 - 1;
+    if (line.size() > expected_end && !trim(line.substr(expected_end)).empty()) {
+        return false;
+    }
+    std::string padded = line;
+    padded.resize(expected_end, ' ');
+    std::vector<std::string> parsed;
+    parsed.reserve(count);
+    for (size_t i = 0; i < count; ++i) {
+        const size_t start = field_start + i * 19;
+        if (start == 0 || padded[start - 1] != ' ') {
+            return false;
+        }
+        parsed.push_back(trim(padded.substr(start, 18)));
+    }
+    values = std::move(parsed);
+    return true;
+}
+
+bool parseDateAndNumbers(const std::string& line,
+                         CalendarTime& time,
+                         size_t count,
+                         std::vector<double>& values) {
+    size_t field_start = 0;
+    return parseCalendarPrefix(line, time, field_start) &&
+           parseFixedNumbers(line, field_start, count, values);
+}
+
+bool isSystemTimeMessage(char system, const std::string& message_type) {
+    if (message_type == "LNAV") {
+        return system == 'G' || system == 'J' || system == 'I';
+    }
+    if (message_type == "FDMA" || message_type == "LXOC") {
+        return system == 'R';
+    }
+    if (message_type == "IFNV" || message_type == "LEG") {
+        return system == 'E';
+    }
+    if (message_type == "D1D2") {
+        return system == 'C';
+    }
+    if (message_type == "SBAS") {
+        return system == 'S';
+    }
+    if (message_type == "CNVX") {
+        return system == 'G' || system == 'J' || system == 'C';
+    }
+    if (message_type == "L1NV") {
+        return system == 'I';
+    }
+    return false;
+}
+
+bool isEarthOrientationMessage(char system, const std::string& message_type) {
+    if (message_type == "CNVX") {
+        return system == 'G' || system == 'C' || system == 'J';
+    }
+    if (message_type == "LNAV" || message_type == "L1NV") {
+        return system == 'I';
+    }
+    if (message_type == "LXOC") {
+        return system == 'R';
+    }
+    return false;
+}
+
+bool isTimeOffsetCode(const std::string& code) {
+    static constexpr const char* kCodes[] = {
+        "GPUT", "GLUT", "GLGP", "GAUT", "GAGP", "GAGL",
+        "BDUT", "BDGP", "BDGL", "BDGA", "QZUT", "QZGP",
+        "QZGL", "QZGA", "QZBD", "IRUT", "IRGP", "IRGL",
+        "IRGA", "IRBD", "IRQZ", "SBUT", "SBGP", "SBGL",
+        "SBGA", "SBBD", "SBQZ", "SBIR"};
+    return std::any_of(std::begin(kCodes), std::end(kCodes),
+                       [&](const char* value) { return code == value; });
+}
+
+const char* timeSystemPrefix(char system) {
+    switch (system) {
+        case 'G': return "GP";
+        case 'R': return "GL";
+        case 'E': return "GA";
+        case 'C': return "BD";
+        case 'J': return "QZ";
+        case 'I': return "IR";
+        case 'S': return "SB";
+        default: return "";
+    }
+}
+
+bool isUtcId(const std::string& value) {
+    static constexpr const char* kIds[] = {
+        "UTC(USNO)", "UTC(SU)", "UTCGAL", "UTC(NTSC)", "UTC(NICT)",
+        "UTC(NPLI)", "UTCIRN", "UTC(OP)", "UTC(NIST)"};
+    return std::any_of(std::begin(kIds), std::end(kIds),
+                       [&](const char* id) { return value == id; });
+}
+
+bool isSbasId(const std::string& value) {
+    static constexpr const char* kIds[] = {
+        "WAAS", "EGNOS", "MSAS", "GAGAN", "SDCM", "BDSBAS",
+        "KASS", "A-SBAS", "SPAN"};
+    return std::any_of(std::begin(kIds), std::end(kIds),
+                       [&](const char* id) { return value == id; });
+}
+
+bool isUtcIdForSystem(char system, const std::string& value) {
+    if (!isUtcId(value)) {
+        return false;
+    }
+    switch (system) {
+        case 'G': return value == "UTC(USNO)";
+        case 'R': return value == "UTC(SU)";
+        case 'E': return value == "UTCGAL";
+        case 'C': return value == "UTC(NTSC)";
+        case 'J': return value == "UTC(NICT)";
+        case 'I': return value == "UTCIRN" || value == "UTC(NPLI)";
+        // Table 27 defines the SBAS UTC realization identifiers explicitly;
+        // the identifiers used by the other constellations are not valid for
+        // an SBUT record.
+        case 'S': return value == "UTC(USNO)" || value == "UTC(NICT)" ||
+                         value == "UTC(NIST)" || value == "UTC(OP)" ||
+                         value == "UTC(NTSC)";
+        default: return false;
+    }
+}
+
+bool validStoContext(const NavigationRecordHeader& header,
+                     const std::string& correction_type,
+                     const std::string& sbas_id,
+                     const std::string& utc_id) {
+    if (header.record_type != "STO" || !header.subtype.empty() ||
+        !isSystemTimeMessage(header.system, header.message_type) ||
+        !isTimeOffsetCode(correction_type) ||
+        correction_type.substr(0, 2) != timeSystemPrefix(header.system)) {
+        return false;
+    }
+    const bool is_sbas_utc = correction_type == "SBUT";
+    const bool is_utc = correction_type.size() == 4 &&
+                        correction_type.substr(2) == "UT";
+    if (is_sbas_utc) {
+        return header.system == 'S' && isSbasId(sbas_id) &&
+               isUtcIdForSystem(header.system, utc_id);
+    }
+    return sbas_id.empty() &&
+           (is_utc ? isUtcIdForSystem(header.system, utc_id) : utc_id.empty());
+}
+
+bool validIonosphereHeader(const NavigationRecordHeader& header) {
+    if (header.record_type != "ION") {
+        return false;
+    }
+    if (header.system == 'E') {
+        return header.message_type == "IFNV" && header.subtype.empty();
+    }
+    if (header.system == 'R') {
+        return header.message_type == "LXOC" && header.subtype.empty();
+    }
+    if (header.system == 'I') {
+        if (header.message_type == "L1NV") {
+            return header.subtype == "KLOB" || header.subtype == "NEQN";
+        }
+        return header.message_type == "LNAV" && header.subtype.empty();
+    }
+    if (header.system == 'C' &&
+        (header.message_type == "D1D2" || header.message_type == "CNVX")) {
+        return header.subtype.empty();
+    }
+    if (header.system == 'G' || header.system == 'J') {
+        if (header.message_type == "LNAV") {
+            return header.subtype.empty();
+        }
+        if (header.message_type == "CNVX") {
+            return header.system == 'J'
+                ? (header.subtype == "WIDE" || header.subtype == "JAPN")
+                : header.subtype.empty();
+        }
+    }
+    return false;
+}
+
 }  // namespace
+
+bool parseSystemTimeOffsetRecord(const NavigationRecordHeader& header,
+                                 const std::vector<std::string>& body,
+                                 SystemTimeOffsetRecord& record) {
+    if (body.size() != 2 || !isSystemTimeMessage(header.system, header.message_type) ||
+        header.record_type != "STO" || !header.subtype.empty()) {
+        return false;
+    }
+
+    SystemTimeOffsetRecord parsed;
+    parsed.header = header;
+    size_t field_start = 0;
+    std::vector<std::string> text_fields;
+    if (!parseCalendarPrefix(body[0], parsed.reference_epoch, field_start) ||
+        !parseA18Fields(body[0], field_start, 3, text_fields) ||
+        text_fields.size() != 3 ||
+        !validStoContext(header, text_fields[0], text_fields[1], text_fields[2])) {
+        return false;
+    }
+    std::vector<double> numbers;
+    if (!parseContinuationNumbers(body[1], 4, 4, numbers)) {
+        return false;
+    }
+    parsed.correction_type = text_fields[0];
+    parsed.sbas_id = text_fields[1];
+    parsed.utc_id = text_fields[2];
+    parsed.transmission_time = numbers[0];
+    parsed.a0 = numbers[1];
+    parsed.a1 = numbers[2];
+    parsed.a2 = numbers[3];
+    record = std::move(parsed);
+    return true;
+}
+
+bool parseEarthOrientationRecord(const NavigationRecordHeader& header,
+                                 const std::vector<std::string>& body,
+                                 EarthOrientationRecord& record) {
+    if (body.size() != 3 || header.record_type != "EOP" ||
+        !header.subtype.empty() || !isEarthOrientationMessage(
+            header.system, header.message_type)) {
+        return false;
+    }
+
+    EarthOrientationRecord parsed;
+    parsed.header = header;
+    std::vector<double> numbers;
+    if (!parseDateAndNumbers(body[0], parsed.reference_epoch, 3, numbers)) {
+        return false;
+    }
+    parsed.x_p = numbers[0];
+    parsed.x_p_rate = numbers[1];
+    parsed.x_p_acceleration = numbers[2];
+
+    if (body[1].size() < 23 || body[1][0] != ' ' || body[1][1] != ' ' ||
+        body[1][2] != ' ' || body[1][3] != ' ') {
+        return false;
+    }
+    if (!trim(body[1].substr(4, 19)).empty()) {
+        return false;
+    }
+    std::vector<double> y_values;
+    std::vector<double> ut1_values;
+    if (!parseContinuationNumbers(body[1], 23, 3, y_values) ||
+        !parseContinuationNumbers(body[2], 4, 4, ut1_values)) {
+        return false;
+    }
+    parsed.y_p = y_values[0];
+    parsed.y_p_rate = y_values[1];
+    parsed.y_p_acceleration = y_values[2];
+    parsed.transmission_time = ut1_values[0];
+    parsed.delta_ut1 = ut1_values[1];
+    parsed.delta_ut1_rate = ut1_values[2];
+    parsed.delta_ut1_acceleration = ut1_values[3];
+    record = std::move(parsed);
+    return true;
+}
+
+bool parseIonosphereRecord(const NavigationRecordHeader& header,
+                           const std::vector<std::string>& body,
+                           IonosphereRecord& record) {
+    if (!validIonosphereHeader(header)) {
+        return false;
+    }
+
+    IonosphereRecord parsed;
+    parsed.header = header;
+    std::vector<double> numbers;
+
+    if ((header.system == 'G' || header.system == 'J' ||
+         header.system == 'I') &&
+        (header.message_type == "LNAV" ||
+         (header.message_type == "CNVX" &&
+          (header.system == 'G' || header.system == 'J')))) {
+        KlobucharIonosphere model;
+        if (body.size() != 3 ||
+            !parseDateAndNumbers(body[0], model.transmit_time, 3, numbers)) {
+            return false;
+        }
+        model.alpha[0] = numbers[0];
+        model.alpha[1] = numbers[1];
+        model.alpha[2] = numbers[2];
+        std::vector<double> beta;
+        if (!parseContinuationNumbers(body[1], 4, 4, beta) ||
+            !parseContinuationNumbers(body[2], 4, 1, numbers)) {
+            return false;
+        }
+        model.alpha[3] = beta[0];
+        model.beta[0] = beta[1];
+        model.beta[1] = beta[2];
+        model.beta[2] = beta[3];
+        model.beta[3] = numbers[0];
+        parsed.payload = model;
+    } else if (header.system == 'C' && header.message_type == "D1D2") {
+        KlobucharIonosphere model;
+        if (body.size() != 3 ||
+            !parseDateAndNumbers(body[0], model.transmit_time, 3, numbers)) {
+            return false;
+        }
+        model.alpha[0] = numbers[0];
+        model.alpha[1] = numbers[1];
+        model.alpha[2] = numbers[2];
+        std::vector<double> beta;
+        if (!parseContinuationNumbers(body[1], 4, 4, beta) ||
+            !parseContinuationNumbers(body[2], 4, 1, numbers)) {
+            return false;
+        }
+        model.alpha[3] = beta[0];
+        model.beta[0] = beta[1];
+        model.beta[1] = beta[2];
+        model.beta[2] = beta[3];
+        model.beta[3] = numbers[0];
+        parsed.payload = model;
+    } else if (header.system == 'E') {
+        NequickGIonosphere model;
+        if (body.size() != 2 ||
+            !parseDateAndNumbers(body[0], model.transmit_time, 3, numbers)) {
+            return false;
+        }
+        model.ai[0] = numbers[0];
+        model.ai[1] = numbers[1];
+        model.ai[2] = numbers[2];
+        std::vector<double> flags;
+        if (!parseContinuationNumbers(body[1], 4, 1, flags)) {
+            return false;
+        }
+        if (!std::isfinite(flags[0]) || flags[0] < 0.0 || flags[0] > 31.0 ||
+            std::floor(flags[0]) != flags[0]) {
+            return false;
+        }
+        model.disturbance_flags = static_cast<int>(flags[0]);
+        parsed.payload = model;
+    } else if (header.system == 'C' && header.message_type == "CNVX") {
+        BdgimIonosphere model;
+        if (body.size() != 3 ||
+            !parseDateAndNumbers(body[0], model.transmit_time, 3, numbers)) {
+            return false;
+        }
+        model.alpha[0] = numbers[0];
+        model.alpha[1] = numbers[1];
+        model.alpha[2] = numbers[2];
+        std::vector<double> line1;
+        std::vector<double> line2;
+        if (!parseContinuationNumbers(body[1], 4, 4, line1) ||
+            !parseContinuationNumbers(body[2], 4, 2, line2)) {
+            return false;
+        }
+        for (size_t i = 0; i < line1.size(); ++i) {
+            model.alpha[3 + i] = line1[i];
+        }
+        model.alpha[7] = line2[0];
+        model.alpha[8] = line2[1];
+        parsed.payload = model;
+    } else if (header.system == 'I' && header.message_type == "L1NV" &&
+               header.subtype == "KLOB") {
+        NavicKlobucharIonosphere model;
+        if (body.size() != 4 ||
+            !parseDateAndNumbers(body[0], model.transmit_time, 1, numbers)) {
+            return false;
+        }
+        model.issue_of_data = numbers[0];
+        std::vector<double> alpha;
+        std::vector<double> beta;
+        std::vector<double> region_bounds;
+        if (!parseContinuationNumbers(body[1], 4, 4, alpha) ||
+            !parseContinuationNumbers(body[2], 4, 4, beta) ||
+            !parseContinuationNumbers(body[3], 4, 4, region_bounds)) {
+            return false;
+        }
+        std::copy(alpha.begin(), alpha.end(), model.alpha.begin());
+        std::copy(beta.begin(), beta.end(), model.beta.begin());
+        std::copy(region_bounds.begin(), region_bounds.end(), model.region_bounds.begin());
+        parsed.payload = model;
+    } else if (header.system == 'I' && header.message_type == "L1NV" &&
+               header.subtype == "NEQN") {
+        NavicNequickNIonosphere model;
+        if (body.size() != 7 ||
+            !parseDateAndNumbers(body[0], model.transmit_time, 1, numbers)) {
+            return false;
+        }
+        model.issue_of_data = numbers[0];
+        for (size_t region = 0; region < 3; ++region) {
+            std::vector<double> coefficients;
+            std::vector<double> bounds;
+            if (!parseContinuationNumbers(body[1 + region * 2], 4, 4, coefficients) ||
+                !parseContinuationNumbers(body[2 + region * 2], 4, 4, bounds)) {
+                return false;
+            }
+            model.coefficients[region][0] = coefficients[0];
+            model.coefficients[region][1] = coefficients[1];
+            model.coefficients[region][2] = coefficients[2];
+            if (!std::isfinite(coefficients[3]) || coefficients[3] < 0.0 ||
+                coefficients[3] > static_cast<double>(std::numeric_limits<int>::max()) ||
+                std::floor(coefficients[3]) != coefficients[3]) {
+                return false;
+            }
+            model.disturbance_flags[region] = static_cast<int>(coefficients[3]);
+            std::copy(bounds.begin(), bounds.end(), model.region_bounds[region].begin());
+        }
+        parsed.payload = model;
+    } else if (header.system == 'R' && header.message_type == "LXOC") {
+        GlonassCdmaIonosphere model;
+        if (body.size() != 1 ||
+            !parseDateAndNumbers(body[0], model.transmit_time, 3, numbers)) {
+            return false;
+        }
+        model.c_a = numbers[0];
+        model.c_f10_7 = numbers[1];
+        model.c_ap = numbers[2];
+        parsed.payload = model;
+    } else {
+        return false;
+    }
+
+    record = std::move(parsed);
+    return true;
+}
 
 bool parseObservationEpochHeader(const std::string& line,
                                  ObservationEpochHeader& epoch) {

--- a/src/io/rinex4.cpp
+++ b/src/io/rinex4.cpp
@@ -124,16 +124,17 @@ const char* navigationMessageTypeName(NavigationMessageType type) {
 }
 
 bool supportsEphemerisMessage(char system, NavigationMessageType type) {
-    // These are the RINEX 4 records whose body layout is compatible with the
-    // existing RINEX 2/3 parser.  New signal-specific records (CNAV/CNVx,
-    // NavIC L1NV, and GLONASS CDMA L1OC/L3OC) must not be passed to it: doing
-    // so would turn their fields into a plausible but incorrect ephemeris.
+    // Existing RINEX 2/3 parser compatibility is explicit. GLONASS CDMA
+    // records have their own strict body parser below and are therefore also
+    // enabled here without entering the legacy FDMA path.
     switch (system) {
         case 'G':
         case 'J':
             return type == NavigationMessageType::LNAV;
         case 'R':
-            return type == NavigationMessageType::FDMA;
+            return type == NavigationMessageType::FDMA ||
+                   type == NavigationMessageType::L1OC ||
+                   type == NavigationMessageType::L3OC;
         case 'E':
             return type == NavigationMessageType::FNAV ||
                    type == NavigationMessageType::INAV;
@@ -337,6 +338,94 @@ bool parseContinuationNumbers(const std::string& line,
     return parseFixedNumbers(line, field_start, count, values);
 }
 
+bool validCdmaContinuationLine(const std::string& line) {
+    return line.size() == 80 && line.compare(0, 4, "    ") == 0;
+}
+
+bool parseCdmaField(const std::string& line,
+                    size_t index,
+                    double& value) {
+    if (index >= 4 || line.size() > 80 || line.size() < 4 + (index + 1) * 19 ||
+        line.compare(0, 4, "    ") != 0) {
+        return false;
+    }
+    return parseFloatingField(line.substr(4 + index * 19, 19), value);
+}
+
+bool parseOptionalCdmaField(const std::string& line,
+                            size_t index,
+                            std::optional<double>& value) {
+    if (index >= 4 || line.size() > 80 || line.size() < 4 + 3 * 19 ||
+        line.compare(0, 4, "    ") != 0) {
+        return false;
+    }
+    const size_t field_start = 4 + index * 19;
+    if (line.size() <= field_start) {
+        value.reset();
+        return true;
+    }
+    if (line.size() < field_start + 19) {
+        value.reset();
+        return trim(line.substr(field_start)).empty();
+    }
+    const std::string field = line.substr(field_start, 19);
+    if (trim(field).empty()) {
+        value.reset();
+        return true;
+    }
+    double parsed = 0.0;
+    if (!parseFloatingField(field, parsed)) {
+        return false;
+    }
+    value = parsed;
+    return true;
+}
+
+bool parseCdmaInteger(double value, int minimum, int maximum, int& result) {
+    if (!std::isfinite(value) || std::floor(value) != value ||
+        value < static_cast<double>(minimum) ||
+        value > static_cast<double>(maximum)) {
+        return false;
+    }
+    result = static_cast<int>(value);
+    return true;
+}
+
+bool parseCdmaNonnegativeInteger(double value, int& result) {
+    return parseCdmaInteger(value, 0, std::numeric_limits<int>::max(), result);
+}
+
+bool parseCdmaNonnegativeFinite(double value, double& result) {
+    if (!std::isfinite(value) || value < 0.0) {
+        return false;
+    }
+    result = value;
+    return true;
+}
+
+bool parseCdmaEpochPrefix(const std::string& line,
+                          const std::string& source,
+                          CalendarTime& time) {
+    if (line.size() != 80 || source.size() != 3 ||
+        line.compare(0, 3, source) != 0 || line[3] != ' ' ||
+        line[8] != ' ' || line[11] != ' ' || line[14] != ' ' ||
+        line[17] != ' ' || line[20] != ' ') {
+        return false;
+    }
+    CalendarTime parsed;
+    if (!parseDateField(line.substr(4, 4), 4, parsed.year) ||
+        !parseDateField(line.substr(9, 2), 2, parsed.month) ||
+        !parseDateField(line.substr(12, 2), 2, parsed.day) ||
+        !parseDateField(line.substr(15, 2), 2, parsed.hour) ||
+        !parseDateField(line.substr(18, 2), 2, parsed.minute) ||
+        !parseDateField(line.substr(21, 2), 2, parsed.second) ||
+        !validCalendar(parsed)) {
+        return false;
+    }
+    time = parsed;
+    return true;
+}
+
 bool parseA18Fields(const std::string& line,
                     size_t field_start,
                     size_t count,
@@ -523,6 +612,124 @@ bool validIonosphereHeader(const NavigationRecordHeader& header) {
 }
 
 }  // namespace
+
+bool parseGlonassCdmaEphemerisRecord(
+    const NavigationRecordHeader& header,
+    const std::vector<std::string>& body,
+    GlonassCdmaEphemerisRecord& record) {
+    if (header.record_type != "EPH" || header.system != 'R' ||
+        (header.message_type != "L1OC" && header.message_type != "L3OC") ||
+        !header.subtype.empty() || header.source.size() != 3 ||
+        body.size() != 9) {
+        return false;
+    }
+
+    GlonassCdmaEphemerisRecord parsed;
+    parsed.header = header;
+    if (!parseCdmaEpochPrefix(body[0], header.source, parsed.toc)) {
+        return false;
+    }
+    std::vector<double> clock;
+    if (!parseFixedNumbers(body[0], 23, 3, clock)) {
+        return false;
+    }
+    parsed.minus_tau_n = clock[0];
+    parsed.gamma_n = clock[1];
+    parsed.beta = clock[2];
+
+    std::vector<double> values;
+    if (!validCdmaContinuationLine(body[1]) ||
+        !parseFixedNumbers(body[1], 4, 4, values) ||
+        !parseCdmaInteger(values[3], 0, 1, parsed.signal_health)) {
+        return false;
+    }
+    parsed.position_km[0] = values[0];
+    parsed.velocity_km_per_s[0] = values[1];
+    parsed.acceleration_km_per_s2[0] = values[2];
+
+    if (!validCdmaContinuationLine(body[2]) ||
+        !parseFixedNumbers(body[2], 4, 4, values) ||
+        !parseCdmaInteger(values[3], 0, 1, parsed.data_validity)) {
+        return false;
+    }
+    parsed.position_km[1] = values[0];
+    parsed.velocity_km_per_s[1] = values[1];
+    parsed.acceleration_km_per_s2[1] = values[2];
+
+    double z_position = 0.0;
+    double z_velocity = 0.0;
+    double z_acceleration = 0.0;
+    if (!parseCdmaField(body[3], 0, z_position) ||
+        !parseCdmaField(body[3], 1, z_velocity) ||
+        !parseCdmaField(body[3], 2, z_acceleration)) {
+        return false;
+    }
+    parsed.position_km[2] = z_position;
+    parsed.velocity_km_per_s[2] = z_velocity;
+    parsed.acceleration_km_per_s2[2] = z_acceleration;
+    if (parsed.header.message_type == "L1OC") {
+        if (!parseOptionalCdmaField(body[3], 3, parsed.tgd_l2ocp)) {
+            return false;
+        }
+    } else if (!parseOptionalCdmaField(body[3], 3, parsed.isc_l3ocp)) {
+        return false;
+    }
+
+    if (!validCdmaContinuationLine(body[4]) ||
+        !parseFixedNumbers(body[4], 4, 4, values) ||
+        !parseCdmaNonnegativeInteger(values[0], parsed.satellite_type) ||
+        !parseCdmaInteger(values[1], 0, 15, parsed.source_flags) ||
+        !parseCdmaNonnegativeFinite(values[2], parsed.aode) ||
+        !parseCdmaNonnegativeFinite(values[3], parsed.aodc)) {
+        return false;
+    }
+
+    if (!validCdmaContinuationLine(body[5]) ||
+        !parseFixedNumbers(body[5], 4, 4, values) ||
+        !parseCdmaInteger(values[0], 0, 1, parsed.attitude_flag) ||
+        values[1] < 0.0 || values[1] >= 86400.0) {
+        return false;
+    }
+    parsed.tin = values[1];
+    parsed.tau1 = values[2];
+    parsed.tau2 = values[3];
+
+    if (!validCdmaContinuationLine(body[6]) ||
+        !parseFixedNumbers(body[6], 4, 4, values) ||
+        !parseCdmaInteger(values[1], 0, 1, parsed.sign_flag)) {
+        return false;
+    }
+    parsed.yaw_angle = values[0];
+    parsed.angular_rate = values[2];
+    parsed.angular_acceleration = values[3];
+
+    if (!validCdmaContinuationLine(body[7]) ||
+        !parseFixedNumbers(body[7], 4, 4, values)) {
+        return false;
+    }
+    parsed.max_angular_rate = values[0];
+    parsed.phase_center_m[0] = values[1];
+    parsed.phase_center_m[1] = values[2];
+    parsed.phase_center_m[2] = values[3];
+
+    double urai_orbit = 0.0;
+    double urai_clock = 0.0;
+    double transmission_time = 0.0;
+    if (!validCdmaContinuationLine(body[8]) ||
+        !parseCdmaField(body[8], 0, urai_orbit) ||
+        !parseCdmaField(body[8], 1, urai_clock) ||
+        !trim(body[8].substr(4 + 2 * 19, 19)).empty() ||
+        !parseCdmaField(body[8], 3, transmission_time) ||
+        !parseCdmaNonnegativeInteger(urai_orbit, parsed.urai_orbit) ||
+        !parseCdmaNonnegativeInteger(urai_clock, parsed.urai_clock) ||
+        transmission_time < 0.0 || transmission_time >= 604800.0) {
+        return false;
+    }
+    parsed.transmission_time_utc_week = transmission_time;
+
+    record = std::move(parsed);
+    return true;
+}
 
 bool parseSystemTimeOffsetRecord(const NavigationRecordHeader& header,
                                  const std::vector<std::string>& body,

--- a/src/io/rinex4.cpp
+++ b/src/io/rinex4.cpp
@@ -25,10 +25,25 @@ bool parseNavigationRecordHeader(const std::string& line,
         marker != ">") {
         return false;
     }
-    fields >> record.subtype;
+    record.subtype.clear();
+    std::string trailing_token;
+    if (fields >> record.subtype) {
+        // RINEX 4.02 Table 22 does not define EPH subtypes yet. A nonblank
+        // token is therefore not valid EPH metadata, and any further token
+        // is malformed for every record type.
+        if (record.record_type == "EPH" || (fields >> trailing_token)) {
+            return false;
+        }
+    }
 
     if (record.record_type.size() != 3 || record.source.empty() ||
         record.message_type.empty()) {
+        return false;
+    }
+    if (std::any_of(record.message_type.begin(), record.message_type.end(),
+                    [](unsigned char c) {
+                        return std::isalpha(c) && !std::isupper(c);
+                    })) {
         return false;
     }
 
@@ -48,10 +63,56 @@ bool parseNavigationRecordHeader(const std::string& line,
             return false;
         }
     }
+    record.navigation_message_type =
+        navigationMessageTypeFromRinexToken(record.message_type);
     return true;
 }
 
 bool supportsEphemerisMessage(char system, const std::string& message_type) {
+    return supportsEphemerisMessage(
+        system, navigationMessageTypeFromRinexToken(message_type));
+}
+
+NavigationMessageType navigationMessageTypeFromRinexToken(const std::string& token) {
+    if (token == "LNAV") return NavigationMessageType::LNAV;
+    if (token == "FDMA") return NavigationMessageType::FDMA;
+    if (token == "FNAV") return NavigationMessageType::FNAV;
+    if (token == "INAV") return NavigationMessageType::INAV;
+    if (token == "D1") return NavigationMessageType::D1;
+    if (token == "D2") return NavigationMessageType::D2;
+    if (token == "SBAS") return NavigationMessageType::SBAS;
+    if (token == "CNAV") return NavigationMessageType::CNAV;
+    if (token == "CNV1") return NavigationMessageType::CNV1;
+    if (token == "CNV2") return NavigationMessageType::CNV2;
+    if (token == "CNV3") return NavigationMessageType::CNV3;
+    if (token == "L1NV") return NavigationMessageType::L1NV;
+    if (token == "L1OC") return NavigationMessageType::L1OC;
+    if (token == "L3OC") return NavigationMessageType::L3OC;
+    return NavigationMessageType::Unknown;
+}
+
+const char* navigationMessageTypeName(NavigationMessageType type) {
+    switch (type) {
+        case NavigationMessageType::LNAV: return "LNAV";
+        case NavigationMessageType::FDMA: return "FDMA";
+        case NavigationMessageType::FNAV: return "FNAV";
+        case NavigationMessageType::INAV: return "INAV";
+        case NavigationMessageType::D1: return "D1";
+        case NavigationMessageType::D2: return "D2";
+        case NavigationMessageType::SBAS: return "SBAS";
+        case NavigationMessageType::CNAV: return "CNAV";
+        case NavigationMessageType::CNV1: return "CNV1";
+        case NavigationMessageType::CNV2: return "CNV2";
+        case NavigationMessageType::CNV3: return "CNV3";
+        case NavigationMessageType::L1NV: return "L1NV";
+        case NavigationMessageType::L1OC: return "L1OC";
+        case NavigationMessageType::L3OC: return "L3OC";
+        case NavigationMessageType::Unknown: return "UNKNOWN";
+    }
+    return "UNKNOWN";
+}
+
+bool supportsEphemerisMessage(char system, NavigationMessageType type) {
     // These are the RINEX 4 records whose body layout is compatible with the
     // existing RINEX 2/3 parser.  New signal-specific records (CNAV/CNVx,
     // NavIC L1NV, and GLONASS CDMA L1OC/L3OC) must not be passed to it: doing
@@ -59,13 +120,15 @@ bool supportsEphemerisMessage(char system, const std::string& message_type) {
     switch (system) {
         case 'G':
         case 'J':
-            return message_type == "LNAV";
+            return type == NavigationMessageType::LNAV;
         case 'R':
-            return message_type == "FDMA";
+            return type == NavigationMessageType::FDMA;
         case 'E':
-            return message_type == "FNAV" || message_type == "INAV";
+            return type == NavigationMessageType::FNAV ||
+                   type == NavigationMessageType::INAV;
         case 'C':
-            return message_type == "D1" || message_type == "D2";
+            return type == NavigationMessageType::D1 ||
+                   type == NavigationMessageType::D2;
         default:
             return false;
     }

--- a/src/io/rinex4.cpp
+++ b/src/io/rinex4.cpp
@@ -1,6 +1,8 @@
 #include <libgnss++/io/rinex4.hpp>
 
 #include <cctype>
+#include <algorithm>
+#include <cmath>
 #include <sstream>
 
 namespace libgnss::io::rinex4 {
@@ -67,6 +69,227 @@ bool supportsEphemerisMessage(char system, const std::string& message_type) {
         default:
             return false;
     }
+}
+
+namespace {
+
+std::string trim(const std::string& value) {
+    const size_t first = value.find_first_not_of(' ');
+    if (first == std::string::npos) {
+        return {};
+    }
+    const size_t last = value.find_last_not_of(' ');
+    return value.substr(first, last - first + 1);
+}
+
+bool isUnsignedDigits(const std::string& value) {
+    return !value.empty() &&
+           std::all_of(value.begin(), value.end(), [](unsigned char c) {
+               return std::isdigit(c) != 0;
+           });
+}
+
+bool isUnsignedDigitsOfWidth(const std::string& value, size_t width) {
+    return value.size() == width && isUnsignedDigits(value);
+}
+
+bool isCountToken(const std::string& value) {
+    return value.size() >= 1 && value.size() <= 3 && isUnsignedDigits(value);
+}
+
+bool parseFixedDecimal(const std::string& text, int fractional_digits, double& value) {
+    const std::string token = trim(text);
+    if (token.empty()) {
+        return false;
+    }
+    const size_t dot = token.find('.');
+    if (dot == std::string::npos || token.find('.', dot + 1) != std::string::npos) {
+        return false;
+    }
+    const size_t integer_begin = (token[0] == '+' || token[0] == '-') ? 1 : 0;
+    if (integer_begin == token.size() || dot <= integer_begin ||
+        dot - integer_begin == 0 || token.size() - dot - 1 !=
+            static_cast<size_t>(fractional_digits)) {
+        return false;
+    }
+    if (!isUnsignedDigits(token.substr(integer_begin, dot - integer_begin)) ||
+        !isUnsignedDigits(token.substr(dot + 1))) {
+        return false;
+    }
+    try {
+        value = std::stod(token);
+    } catch (...) {
+        return false;
+    }
+    return std::isfinite(value);
+}
+
+bool isLeapYear(int year) {
+    return (year % 4 == 0 && year % 100 != 0) || year % 400 == 0;
+}
+
+bool validCalendar(const ObservationEpochHeader& epoch) {
+    if (epoch.year < 1980 || epoch.year > 9999 || epoch.month < 1 || epoch.month > 12 ||
+        epoch.day < 1 || epoch.hour < 0 || epoch.hour > 23 || epoch.minute < 0 ||
+        epoch.minute > 59 || epoch.second < 0.0 || epoch.second > 60.0) {
+        return false;
+    }
+    static constexpr int kDaysInMonth[] = {
+        31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+    int days = kDaysInMonth[epoch.month - 1];
+    if (epoch.month == 2 && isLeapYear(epoch.year)) {
+        days = 29;
+    }
+    return epoch.day <= days;
+}
+
+bool parseSecondsToken(const std::string& token, double& seconds) {
+    const size_t dot = token.find('.');
+    if (dot == std::string::npos || token.find_first_of("eEdD") != std::string::npos) {
+        return false;
+    }
+    const size_t fractional_digits = token.size() - dot - 1;
+    if (fractional_digits != 7) {
+        return false;
+    }
+    if (!parseFixedDecimal(token, static_cast<int>(fractional_digits), seconds)) {
+        return false;
+    }
+    return seconds >= 0.0 && seconds <= 60.0;
+}
+
+}  // namespace
+
+bool parseObservationEpochHeader(const std::string& line,
+                                 ObservationEpochHeader& epoch) {
+    epoch = ObservationEpochHeader();
+    if (line.empty() || line[0] != '>') {
+        return false;
+    }
+
+    std::istringstream tokens(line.substr(1));
+    std::string year_token;
+    if (!(tokens >> year_token)) {
+        return false;
+    }
+
+    // Event records may omit their date/time fields.  Their flag and count
+    // remain in the normal fixed columns, and the data records are consumed
+    // by RINEXReader before it searches for the next ordinary epoch.
+    if (year_token.size() != 4 || !isUnsignedDigits(year_token)) {
+        int flag = 0;
+        int count = 0;
+        std::string count_token;
+        if (!isUnsignedDigitsOfWidth(year_token, 1) ||
+            !(tokens >> count_token) || !isCountToken(count_token)) {
+            return false;
+        }
+        try {
+            flag = std::stoi(year_token);
+            count = std::stoi(count_token);
+        } catch (...) {
+            return false;
+        }
+        if (flag < 2 || flag > 6 || count < 0 || count > 999) {
+            return false;
+        }
+        epoch.flag = flag;
+        epoch.record_count = count;
+        return true;
+    }
+
+    std::string month_token;
+    std::string day_token;
+    std::string hour_token;
+    std::string minute_token;
+    std::string second_token;
+    std::string flag_token;
+    std::string count_token;
+    if (!(tokens >> month_token >> day_token >> hour_token >> minute_token >>
+          second_token >> flag_token >> count_token)) {
+        return false;
+    }
+    if (!isUnsignedDigitsOfWidth(month_token, 2) ||
+        !isUnsignedDigitsOfWidth(day_token, 2) ||
+        !isUnsignedDigitsOfWidth(hour_token, 2) ||
+        !isUnsignedDigitsOfWidth(minute_token, 2) ||
+        !isUnsignedDigitsOfWidth(flag_token, 1) || !isCountToken(count_token)) {
+        return false;
+    }
+    try {
+        epoch.year = std::stoi(year_token);
+        epoch.month = std::stoi(month_token);
+        epoch.day = std::stoi(day_token);
+        epoch.hour = std::stoi(hour_token);
+        epoch.minute = std::stoi(minute_token);
+        epoch.flag = std::stoi(flag_token);
+        epoch.record_count = std::stoi(count_token);
+    } catch (...) {
+        return false;
+    }
+    if (!parseSecondsToken(second_token, epoch.second) || epoch.flag < 0 || epoch.flag > 6 ||
+        epoch.record_count < 0 || epoch.record_count > 999) {
+        return false;
+    }
+    epoch.has_date = true;
+
+    // Table A3: six reserved columns follow the count, then F15.12, one
+    // reserved column, and an optional I5 extension.  A short line simply
+    // omits optional fields; a present but malformed field is rejected.
+    if (line.size() > 35) {
+        const size_t reserved_length = std::min<size_t>(6, line.size() - 35);
+        if (line.compare(35, reserved_length,
+                         std::string(reserved_length, ' ')) != 0) {
+            return false;
+        }
+    }
+    if (line.size() > 41) {
+        const std::string clock_field = line.substr(41, 15);
+        if (!trim(clock_field).empty()) {
+            if (!parseFixedDecimal(clock_field, 12, epoch.receiver_clock_offset)) {
+                return false;
+            }
+            epoch.has_receiver_clock_offset = true;
+        }
+    }
+    if (line.size() > 57) {
+        const std::string extra_field = line.substr(57, 5);
+        const std::string extra = trim(extra_field);
+        if (!extra.empty()) {
+            if (extra.size() != 5 || !isUnsignedDigits(extra)) {
+                return false;
+            }
+            try {
+                epoch.extra_second_digits = std::stoi(extra);
+            } catch (...) {
+                return false;
+            }
+            double combined_second = 0.0;
+            if (!parseFixedDecimal(second_token + extra, 12, combined_second)) {
+                return false;
+            }
+            epoch.second = combined_second;
+        }
+    }
+    if (line.size() > 62 && !trim(line.substr(62)).empty()) {
+        return false;
+    }
+    if (epoch.second > 60.0) {
+        return false;
+    }
+    return validCalendar(epoch);
+}
+
+bool isCompactRinexPath(const std::string& filename) {
+    std::string lower = filename;
+    std::transform(lower.begin(), lower.end(), lower.begin(), [](unsigned char c) {
+        return static_cast<char>(std::tolower(c));
+    });
+    const auto ends_with = [&lower](const std::string& suffix) {
+        return lower.size() >= suffix.size() &&
+               lower.compare(lower.size() - suffix.size(), suffix.size(), suffix) == 0;
+    };
+    return ends_with(".crx") || ends_with(".crx.gz");
 }
 
 }  // namespace libgnss::io::rinex4

--- a/tests/test_rinex_writer.cpp
+++ b/tests/test_rinex_writer.cpp
@@ -64,6 +64,50 @@ std::string rinex4GalileoBody(int data_source_code) {
     return body;
 }
 
+std::vector<std::string> rinex4GlonassCdmaBody(bool blank_delay = false) {
+    std::vector<std::string> body = {
+        "R26 2024 02 03 00 15 00-1.605716170161e-05 1.652011860642e-12-2.081668171172e-17",
+        "     1.812154053020e+04-2.071979139000e+00 5.729816621169e-10 1.000000000000e+00",
+        "    -2.325615360260e+03 1.285475494340e+00-1.047737896442e-09 1.000000000000e+00",
+        "     1.781341854668e+04 2.280306640081e+00-9.458744898438e-10 0.000000000000e+00",
+        "     2.000000000000e+00 1.000000000000e+01 7.500000000000e-01 7.500000000000e-01",
+        "     0.000000000000e+00 0.000000000000e+00 0.000000000000e+00 0.000000000000e+00",
+        "     0.000000000000e+00 0.000000000000e+00 0.000000000000e+00 0.000000000000e+00",
+        "     0.000000000000e+00 0.000000000000e+00 0.000000000000e+00 0.000000000000e+00",
+        "     1.500000000000e+01 5.000000000000e+00                    5.184000000000e+05",
+    };
+    if (blank_delay) {
+        body[3].resize(61);
+    }
+    return body;
+}
+
+void writeRinex4GlonassCdmaBody(std::ofstream& file,
+                                bool blank_delay = false) {
+    for (const auto& line : rinex4GlonassCdmaBody(blank_delay)) {
+        file << line << '\n';
+    }
+}
+
+std::vector<std::string> rinex4GlonassFdmaBody() {
+    std::istringstream stream(rinex4GpsLnavBody());
+    std::vector<std::string> body;
+    std::string line;
+    for (int i = 0; i < 4 && std::getline(stream, line); ++i) {
+        if (i == 0) {
+            line.replace(0, 3, "R26");
+        }
+        body.push_back(line);
+    }
+    return body;
+}
+
+void writeRinex4GlonassFdmaBody(std::ofstream& file) {
+    for (const auto& line : rinex4GlonassFdmaBody()) {
+        file << line << '\n';
+    }
+}
+
 std::string rinex4SystemNumber(double value) {
     std::ostringstream stream;
     stream << std::scientific << std::setprecision(12) << std::setw(19)
@@ -594,9 +638,9 @@ TEST(RINEXReaderTest, DispatchesRinex4LnavAndSkipsUnsupportedRecordBoundary) {
               std::string::npos);
     EXPECT_NE(diagnostic.find("Skipping unsupported RINEX 4 EPH I05 L1NV"),
               std::string::npos);
-    EXPECT_NE(diagnostic.find("Skipping unsupported RINEX 4 EPH R01 L1OC"),
+    EXPECT_NE(diagnostic.find("Skipping malformed RINEX 4 GLONASS L1OC body"),
               std::string::npos);
-    EXPECT_NE(diagnostic.find("Skipping unsupported RINEX 4 EPH R01 L3OC"),
+    EXPECT_NE(diagnostic.find("Skipping malformed RINEX 4 GLONASS L3OC body"),
               std::string::npos);
     EXPECT_NE(diagnostic.find("Skipping unsupported RINEX 4 EPH G04 CNAV"),
               std::string::npos);
@@ -619,6 +663,162 @@ TEST(RINEXReaderTest, DispatchesRinex4LnavAndSkipsUnsupportedRecordBoundary) {
 
     reader.close();
     std::filesystem::remove(temp_path);
+}
+
+TEST(RINEXReaderTest, ParsesRinex4GlonassCdmaAndRecoversAtBoundaries) {
+    const auto temp_path =
+        std::filesystem::temp_directory_path() / "libgnss_rinex4_glonass_cdma.nav";
+    std::filesystem::remove(temp_path);
+    {
+        std::ofstream file(temp_path);
+        ASSERT_TRUE(file.is_open());
+        file << rinexHeaderLine(
+            "     4.02           NAVIGATION DATA     M",
+            "RINEX VERSION / TYPE");
+        file << rinexHeaderLine("", "END OF HEADER");
+
+        file << "> EPH R26 L1OC\n";
+        writeRinex4GlonassCdmaBody(file);
+
+        file << "> EPH R26 FDMA\n";
+        writeRinex4GlonassFdmaBody(file);
+
+        file << "> EPH R26 L1OC\n";
+        const auto truncated = rinex4GlonassCdmaBody();
+        for (size_t i = 0; i + 1 < truncated.size(); ++i) {
+            file << truncated[i] << '\n';
+        }
+
+        file << "> EPH R26 L3OC\n";
+        writeRinex4GlonassCdmaBody(file, true);
+
+        file << "> EPH R26 L3OC\n";
+        auto bad_spare = rinex4GlonassCdmaBody();
+        bad_spare[8].replace(42, 19, std::string(19, 'X'));
+        for (const auto& line : bad_spare) {
+            file << line << '\n';
+        }
+
+        file << "> EPH G04 LNAV\n";
+        file << rinex4GpsLnavBody();
+    }
+
+    io::RINEXReader reader;
+    ASSERT_TRUE(reader.open(temp_path.string()));
+    io::RINEXReader::RINEXHeader header;
+    ASSERT_TRUE(reader.readHeader(header));
+    NavigationData nav_data;
+    testing::internal::CaptureStderr();
+    ASSERT_TRUE(reader.readNavigationData(nav_data));
+    const std::string diagnostic = testing::internal::GetCapturedStderr();
+    EXPECT_NE(diagnostic.find("Skipping malformed RINEX 4 GLONASS L1OC body"),
+              std::string::npos);
+    EXPECT_NE(diagnostic.find("Skipping malformed RINEX 4 GLONASS L3OC body"),
+              std::string::npos);
+
+    const auto glonass_it = nav_data.ephemeris_data.find(
+        SatelliteId(GNSSSystem::GLONASS, 26));
+    ASSERT_NE(glonass_it, nav_data.ephemeris_data.end());
+    ASSERT_EQ(glonass_it->second.size(), 3U);
+    const Ephemeris* l1oc = nullptr;
+    const Ephemeris* l3oc = nullptr;
+    const Ephemeris* fdma = nullptr;
+    for (const auto& eph : glonass_it->second) {
+        if (eph.navigation_message_type == NavigationMessageType::L1OC) {
+            l1oc = &eph;
+        } else if (eph.navigation_message_type == NavigationMessageType::L3OC) {
+            l3oc = &eph;
+        } else if (eph.navigation_message_type == NavigationMessageType::FDMA) {
+            fdma = &eph;
+        }
+    }
+    ASSERT_NE(l1oc, nullptr);
+    ASSERT_NE(l3oc, nullptr);
+    ASSERT_NE(fdma, nullptr);
+    EXPECT_FALSE(fdma->glonass_cdma_data.has_value());
+    ASSERT_TRUE(l1oc->glonass_cdma_data.has_value());
+    ASSERT_TRUE(l3oc->glonass_cdma_data.has_value());
+    EXPECT_NEAR(l1oc->glonass_taun, 1.605716170161e-05, 1e-18);
+    EXPECT_NEAR(l1oc->glonass_position.x(), 1.812154053020e+07, 1e-6);
+    EXPECT_NEAR(l1oc->glonass_velocity.y(), 1.285475494340e+03, 1e-9);
+    EXPECT_EQ(l1oc->health, 1);
+    EXPECT_FALSE(l1oc->valid);
+    EXPECT_EQ(l1oc->glonass_cdma_data->source_flags, 10);
+    EXPECT_DOUBLE_EQ(l1oc->glonass_cdma_data->aode, 0.75);
+    EXPECT_DOUBLE_EQ(l1oc->glonass_cdma_data->aodc, 0.75);
+    ASSERT_TRUE(l1oc->glonass_cdma_data->tgd_l2ocp.has_value());
+    EXPECT_DOUBLE_EQ(*l1oc->glonass_cdma_data->tgd_l2ocp, 0.0);
+    EXPECT_FALSE(l3oc->glonass_cdma_data->isc_l3ocp.has_value());
+    EXPECT_DOUBLE_EQ(l3oc->glonass_cdma_data->transmission_time_utc_week,
+                     518400.0);
+    EXPECT_EQ(l1oc->toc.week, l1oc->tof.week);
+    EXPECT_NEAR(l1oc->tof.tow - l1oc->toc.tow, -900.0, 1e-6);
+
+    const auto gps_it = nav_data.ephemeris_data.find(
+        SatelliteId(GNSSSystem::GPS, 4));
+    ASSERT_NE(gps_it, nav_data.ephemeris_data.end());
+    ASSERT_EQ(gps_it->second.size(), 1U);
+    reader.close();
+    std::filesystem::remove(temp_path);
+}
+
+TEST(RINEXReaderTest, GlonassCdmaParserIsTransactionalAndStrict) {
+    io::rinex4::NavigationRecordHeader header;
+    ASSERT_TRUE(io::rinex4::parseNavigationRecordHeader(
+        "> EPH R26 L1OC", header));
+
+    const auto valid = rinex4GlonassCdmaBody();
+    io::rinex4::GlonassCdmaEphemerisRecord parsed;
+    ASSERT_TRUE(io::rinex4::parseGlonassCdmaEphemerisRecord(
+        header, valid, parsed));
+    EXPECT_EQ(parsed.source_flags, 10);
+    EXPECT_DOUBLE_EQ(parsed.aode, 0.75);
+    EXPECT_DOUBLE_EQ(parsed.aodc, 0.75);
+
+    parsed.minus_tau_n = 42.0;
+    auto truncated = valid;
+    truncated.pop_back();
+    EXPECT_FALSE(io::rinex4::parseGlonassCdmaEphemerisRecord(
+        header, truncated, parsed));
+    EXPECT_DOUBLE_EQ(parsed.minus_tau_n, 42.0);
+
+    auto bad_spare = valid;
+    bad_spare[8].replace(42, 19, std::string(19, 'X'));
+    EXPECT_FALSE(io::rinex4::parseGlonassCdmaEphemerisRecord(
+        header, bad_spare, parsed));
+    EXPECT_DOUBLE_EQ(parsed.minus_tau_n, 42.0);
+
+    auto bad_integer = valid;
+    bad_integer[1].replace(61, 19, rinex4SystemNumber(2.0));
+    EXPECT_FALSE(io::rinex4::parseGlonassCdmaEphemerisRecord(
+        header, bad_integer, parsed));
+    EXPECT_DOUBLE_EQ(parsed.minus_tau_n, 42.0);
+
+    auto bad_prefix = valid;
+    bad_prefix[1][0] = 'X';
+    EXPECT_FALSE(io::rinex4::parseGlonassCdmaEphemerisRecord(
+        header, bad_prefix, parsed));
+    EXPECT_DOUBLE_EQ(parsed.minus_tau_n, 42.0);
+
+    auto bad_numeric = valid;
+    bad_numeric[1].replace(4, 19, std::string(16, ' ') + "NaN");
+    EXPECT_FALSE(io::rinex4::parseGlonassCdmaEphemerisRecord(
+        header, bad_numeric, parsed));
+    EXPECT_DOUBLE_EQ(parsed.minus_tau_n, 42.0);
+
+    auto extra_body = valid;
+    extra_body.push_back(valid.back());
+    EXPECT_FALSE(io::rinex4::parseGlonassCdmaEphemerisRecord(
+        header, extra_body, parsed));
+    EXPECT_DOUBLE_EQ(parsed.minus_tau_n, 42.0);
+
+    auto shortened_optional = rinex4GlonassCdmaBody(true);
+    io::rinex4::NavigationRecordHeader l3_header;
+    ASSERT_TRUE(io::rinex4::parseNavigationRecordHeader(
+        "> EPH R26 L3OC", l3_header));
+    ASSERT_TRUE(io::rinex4::parseGlonassCdmaEphemerisRecord(
+        l3_header, shortened_optional, parsed));
+    EXPECT_FALSE(parsed.isc_l3ocp.has_value());
 }
 
 TEST(RINEXReaderTest, PreservesRinex4GalileoMessageProvenanceAndRejectsContradiction) {

--- a/tests/test_rinex_writer.cpp
+++ b/tests/test_rinex_writer.cpp
@@ -1,5 +1,6 @@
 #include <gtest/gtest.h>
 #include <libgnss++/io/rinex.hpp>
+#include <libgnss++/io/rinex4.hpp>
 
 #include <filesystem>
 #include <fstream>
@@ -206,7 +207,7 @@ TEST(RINEXReaderTest, ParsesTimeOfFirstObsHeader) {
     std::filesystem::remove(temp_path);
 }
 
-TEST(RINEXReaderTest, DetectsRinex4AndDoesNotUseRinex3EpochColumns) {
+TEST(RINEXReaderTest, ParsesRinex4EpochPrecisionClockAndGpsQzssRows) {
     const auto temp_path =
         std::filesystem::temp_directory_path() / "libgnss_rinex4_observation_dispatch.obs";
     std::filesystem::remove(temp_path);
@@ -221,14 +222,18 @@ TEST(RINEXReaderTest, DetectsRinex4AndDoesNotUseRinex3EpochColumns) {
             "G    4 C1C L1C C2W L2W",
             "SYS / # / OBS TYPES");
         file << rinexHeaderLine("", "END OF HEADER");
-        // The extra second digits intentionally shift the RINEX 3 fixed
-        // columns.  Phase 1 must reject this explicitly until token-based
-        // RINEX 4 observation parsing is implemented.
-        file << "> 2024 08 03 09 51 20.1234567890123  0  1\n";
+        std::string epoch = "> 2024 08 03 09 51 20.1234567  0  2";
+        epoch.append(41 - epoch.size(), ' ');
+        epoch += "-0.123456789012 12345\n";
+        file << epoch;
         file << "G04" << rinexObsField("22011162.552")
              << rinexObsField("115669443.467")
              << rinexObsField("22022262.423")
              << rinexObsField("120222443.467") << "\n";
+        file << "J01" << rinexObsField("22011163.552")
+             << rinexObsField("115669444.467")
+             << rinexObsField("22022263.423")
+             << rinexObsField("120222444.467") << "\n";
     }
 
     io::RINEXReader reader;
@@ -239,14 +244,207 @@ TEST(RINEXReaderTest, DetectsRinex4AndDoesNotUseRinex3EpochColumns) {
     EXPECT_TRUE(reader.isRinex4());
 
     ObservationData epoch;
-    testing::internal::CaptureStderr();
-    EXPECT_FALSE(reader.readObservationEpoch(epoch));
-    const std::string diagnostic = testing::internal::GetCapturedStderr();
-    EXPECT_NE(diagnostic.find("RINEX 4 observation epochs are not supported yet"),
-              std::string::npos);
+    ASSERT_TRUE(reader.readObservationEpoch(epoch));
+    EXPECT_NEAR(epoch.receiver_clock_bias, -0.123456789012, 1e-15);
+    EXPECT_EQ(epoch.time.week, 2325);
+    EXPECT_NEAR(epoch.time.tow, 553880.1234567123, 1e-9);
+    ASSERT_EQ(epoch.observations.size(), 4U);
+    EXPECT_EQ(epoch.observations[0].satellite, SatelliteId(GNSSSystem::GPS, 4));
+    EXPECT_EQ(epoch.observations[2].satellite, SatelliteId(GNSSSystem::QZSS, 1));
+    const auto* gps_l1 = epoch.getObservation(
+        SatelliteId(GNSSSystem::GPS, 4), SignalType::GPS_L1CA);
+    ASSERT_NE(gps_l1, nullptr);
+    EXPECT_TRUE(gps_l1->has_pseudorange);
 
     reader.close();
     std::filesystem::remove(temp_path);
+}
+
+TEST(RINEXReaderTest, AccumulatesRinex4ObservationTypeContinuation) {
+    const auto temp_path =
+        std::filesystem::temp_directory_path() / "libgnss_rinex4_obs_types_continuation.obs";
+    std::filesystem::remove(temp_path);
+    {
+        std::ofstream file(temp_path);
+        ASSERT_TRUE(file.is_open());
+        file << rinexHeaderLine(
+            "     4.02           OBSERVATION DATA    M", "RINEX VERSION / TYPE");
+        file << rinexHeaderLine(
+            "G   14 C1C L1C C2W L2W C5Q L5Q D5Q S5Q C1L L1L D1L S1L C2L",
+            "SYS / # / OBS TYPES");
+        file << rinexHeaderLine("       S2L", "SYS / # / OBS TYPES");
+        file << rinexHeaderLine("", "END OF HEADER");
+        file << "> 2024 08 03 09 51 20.0000000  0  2\n";
+        const std::vector<std::string> values = {
+            "22011162.552", "115669443.467", "22022262.423", "120222443.467",
+            "22033362.552", "115669543.467", "22044462.423", "120222543.467",
+            "22055562.552", "115669643.467", "22066662.423", "120222643.467",
+            "22077762.552", "115669743.467"};
+        std::string gps_row = "G04";
+        std::string qzss_row = "J01";
+        for (const auto& value : values) {
+            gps_row += rinexObsField(value);
+            qzss_row += rinexObsField(value);
+        }
+        file << gps_row << "\n" << qzss_row << "\n";
+    }
+
+    io::RINEXReader reader;
+    ASSERT_TRUE(reader.open(temp_path.string()));
+    io::RINEXReader::RINEXHeader header;
+    ASSERT_TRUE(reader.readHeader(header));
+    ASSERT_EQ(header.system_obs_types['G'].size(), 14U);
+    EXPECT_EQ(header.system_obs_types['G'].back(), "S2L");
+    EXPECT_EQ(header.observation_types.size(), 14U);
+    ObservationData epoch;
+    ASSERT_TRUE(reader.readObservationEpoch(epoch));
+    ASSERT_EQ(epoch.observations.size(), 4U);
+    EXPECT_EQ(epoch.observations[0].satellite, SatelliteId(GNSSSystem::GPS, 4));
+    EXPECT_EQ(epoch.observations[2].satellite, SatelliteId(GNSSSystem::QZSS, 1));
+    reader.close();
+    std::filesystem::remove(temp_path);
+}
+
+TEST(RINEXReaderTest, SkipsRinex4EventAndCycleSlipRecordsBeforeNextEpoch) {
+    const auto temp_path =
+        std::filesystem::temp_directory_path() / "libgnss_rinex4_events.obs";
+    std::filesystem::remove(temp_path);
+    {
+        std::ofstream file(temp_path);
+        ASSERT_TRUE(file.is_open());
+        file << rinexHeaderLine(
+            "     4.02           OBSERVATION DATA    M", "RINEX VERSION / TYPE");
+        file << rinexHeaderLine("G    4 C1C L1C C2W L2W", "SYS / # / OBS TYPES");
+        file << rinexHeaderLine("", "END OF HEADER");
+        file << "> 2024 08 03 09 51 20.0000000  0  0\n";
+        file << ">                              2 1\n";
+        file << rinexHeaderLine("event comment", "COMMENT");
+        file << ">                              6 1\n";
+        file << "G04" << rinexObsField("99999999.000")
+             << rinexObsField("1.000") << rinexObsField("2.000")
+             << rinexObsField("3.000") << "\n";
+        file << "> 2024 08 03 09 51 21.0000000  0  1\n";
+        file << "G04" << rinexObsField("22011162.552")
+             << rinexObsField("115669443.467")
+             << rinexObsField("22022262.423")
+             << rinexObsField("120222443.467") << "\n";
+    }
+
+    io::RINEXReader reader;
+    ASSERT_TRUE(reader.open(temp_path.string()));
+    io::RINEXReader::RINEXHeader header;
+    ASSERT_TRUE(reader.readHeader(header));
+    ObservationData empty_epoch;
+    ASSERT_TRUE(reader.readObservationEpoch(empty_epoch));
+    EXPECT_TRUE(empty_epoch.isEmpty());
+    ObservationData epoch;
+    ASSERT_TRUE(reader.readObservationEpoch(epoch));
+    EXPECT_EQ(epoch.time.week, 2325);
+    EXPECT_NEAR(epoch.time.tow, 553881.0, 1e-9);
+    ASSERT_EQ(epoch.observations.size(), 2U);
+    EXPECT_EQ(epoch.observations.front().satellite, SatelliteId(GNSSSystem::GPS, 4));
+    reader.close();
+    std::filesystem::remove(temp_path);
+}
+
+TEST(RINEXReaderTest, FeedsRinex4HeaderEventRecordsIntoHeaderParser) {
+    const auto temp_path =
+        std::filesystem::temp_directory_path() / "libgnss_rinex4_header_event.obs";
+    std::filesystem::remove(temp_path);
+    {
+        std::ofstream file(temp_path);
+        ASSERT_TRUE(file.is_open());
+        file << rinexHeaderLine(
+            "     4.02           OBSERVATION DATA    M", "RINEX VERSION / TYPE");
+        file << rinexHeaderLine("G    4 C1C L1C C2W L2W", "SYS / # / OBS TYPES");
+        file << rinexHeaderLine("", "END OF HEADER");
+        file << ">                              4 1\n";
+        file << rinexHeaderLine("G    4 C1C L1C C5Q L5Q", "SYS / # / OBS TYPES");
+        file << "> 2024 08 03 09 51 22.0000000  0  1\n";
+        file << "G04" << rinexObsField("22011162.552")
+             << rinexObsField("115669443.467")
+             << rinexObsField("22022262.423")
+             << rinexObsField("120222443.467") << "\n";
+    }
+
+    io::RINEXReader reader;
+    ASSERT_TRUE(reader.open(temp_path.string()));
+    io::RINEXReader::RINEXHeader header;
+    ASSERT_TRUE(reader.readHeader(header));
+    ObservationData epoch;
+    ASSERT_TRUE(reader.readObservationEpoch(epoch));
+    ASSERT_EQ(epoch.observations.size(), 2U);
+    reader.close();
+    std::filesystem::remove(temp_path);
+}
+
+TEST(RINEXReaderTest, RejectsTruncatedRinex4ObservationEpoch) {
+    const auto temp_path =
+        std::filesystem::temp_directory_path() / "libgnss_rinex4_truncated.obs";
+    std::filesystem::remove(temp_path);
+    {
+        std::ofstream file(temp_path);
+        ASSERT_TRUE(file.is_open());
+        file << rinexHeaderLine(
+            "     4.02           OBSERVATION DATA    M", "RINEX VERSION / TYPE");
+        file << rinexHeaderLine("G    4 C1C L1C C2W L2W", "SYS / # / OBS TYPES");
+        file << rinexHeaderLine("", "END OF HEADER");
+        file << "> 2024 08 03 09 51 23.0000000  0  2\n";
+        file << "G04" << rinexObsField("22011162.552")
+             << rinexObsField("115669443.467")
+             << rinexObsField("22022262.423")
+             << rinexObsField("120222443.467") << "\n";
+    }
+
+    io::RINEXReader reader;
+    ASSERT_TRUE(reader.open(temp_path.string()));
+    io::RINEXReader::RINEXHeader header;
+    ASSERT_TRUE(reader.readHeader(header));
+    ObservationData epoch;
+    EXPECT_FALSE(reader.readObservationEpoch(epoch));
+    EXPECT_TRUE(epoch.isEmpty());
+    reader.close();
+    std::filesystem::remove(temp_path);
+}
+
+TEST(RINEXReaderTest, RejectsMalformedRinex4EpochTokenWidthsAndCounts) {
+    io::rinex4::ObservationEpochHeader epoch;
+    EXPECT_FALSE(io::rinex4::parseObservationEpochHeader(
+        "> 0001 08 03 09 51 23.0000000  0  1", epoch));
+    EXPECT_FALSE(io::rinex4::parseObservationEpochHeader(
+        "> 2024 8 03 09 51 23.0000000  0  1", epoch));
+    EXPECT_FALSE(io::rinex4::parseObservationEpochHeader(
+        "> 2024 08 03 09 51 23.0000000  0  1000", epoch));
+    EXPECT_FALSE(io::rinex4::parseObservationEpochHeader(
+        ">                              2 1000", epoch));
+}
+
+TEST(RINEXReaderTest, RejectsCompactRinexSuffixesButNotSimilarNames) {
+    const auto base = std::filesystem::temp_directory_path();
+    const auto crx = base / "libgnss_rinex4_policy.CRX";
+    const auto crx_gz = base / "libgnss_rinex4_policy.CRX.GZ";
+    const auto similar = base / "libgnss_rinex4_policy.crx.tmp";
+    std::filesystem::remove(crx);
+    std::filesystem::remove(crx_gz);
+    std::filesystem::remove(similar);
+    {
+        std::ofstream(crx) << "not decoded\n";
+        std::ofstream(crx_gz) << "not decoded\n";
+        std::ofstream(similar) << "not compact\n";
+    }
+
+    io::RINEXReader reader;
+    testing::internal::CaptureStderr();
+    EXPECT_FALSE(reader.open(crx.string()));
+    EXPECT_FALSE(reader.open(crx_gz.string()));
+    const std::string diagnostic = testing::internal::GetCapturedStderr();
+    EXPECT_NE(diagnostic.find("CompactRINEX input is not supported natively"),
+              std::string::npos);
+    EXPECT_TRUE(reader.open(similar.string()));
+    reader.close();
+    std::filesystem::remove(crx);
+    std::filesystem::remove(crx_gz);
+    std::filesystem::remove(similar);
 }
 
 TEST(RINEXReaderTest, DispatchesRinex4LnavAndSkipsUnsupportedRecordBoundary) {

--- a/tests/test_rinex_writer.cpp
+++ b/tests/test_rinex_writer.cpp
@@ -6,6 +6,7 @@
 #include <fstream>
 #include <iomanip>
 #include <sstream>
+#include <vector>
 
 using namespace libgnss;
 
@@ -61,6 +62,65 @@ std::string rinex4GalileoBody(int data_source_code) {
     const std::string source_field = source_stream.str();
     body.replace(line_start + 23, source_field.size(), source_field);
     return body;
+}
+
+std::string rinex4SystemNumber(double value) {
+    std::ostringstream stream;
+    stream << std::scientific << std::setprecision(12) << std::setw(19)
+           << value;
+    return stream.str();
+}
+
+std::string rinex4SystemDate(int year, int month, int day,
+                             int hour, int minute, int second) {
+    std::ostringstream stream;
+    stream << "    " << std::setfill('0') << std::setw(4) << year << ' '
+           << std::setw(2) << month << ' ' << std::setw(2) << day << ' '
+           << std::setw(2) << hour << ' ' << std::setw(2) << minute << ' '
+           << std::setw(2) << second;
+    return stream.str();
+}
+
+std::string rinex4SystemDateNumbers(const std::vector<double>& values) {
+    std::string line = rinex4SystemDate(2024, 2, 3, 4, 5, 6);
+    line += ' ';
+    for (const double value : values) {
+        line += rinex4SystemNumber(value);
+    }
+    return line;
+}
+
+std::string rinex4SystemNumbers(const std::vector<double>& values) {
+    std::string line = "    ";
+    for (const double value : values) {
+        line += rinex4SystemNumber(value);
+    }
+    return line;
+}
+
+std::string rinex4StoEpochLine(const std::string& correction_type,
+                               const std::string& sbas_id = {},
+                               const std::string& utc_id = {}) {
+    std::string line = rinex4SystemDate(2024, 2, 3, 4, 5, 6);
+    line += ' ';
+    line += correction_type;
+    line.resize(24 + 18, ' ');
+    line += ' ';
+    line += sbas_id;
+    line.resize(24 + 2 * 19 - 1, ' ');
+    line += ' ';
+    line += utc_id;
+    line.resize(24 + 3 * 19 - 1, ' ');
+    return line;
+}
+
+std::string rinex4EopBodyLine1(bool malformed_spare) {
+    std::string line = "    ";
+    line += malformed_spare ? std::string(19, 'X') : std::string(19, ' ');
+    line += rinex4SystemNumber(0.4);
+    line += rinex4SystemNumber(0.5);
+    line += rinex4SystemNumber(0.6);
+    return line;
 }
 
 Ephemeris makeGpsEphemeris() {
@@ -527,8 +587,9 @@ TEST(RINEXReaderTest, DispatchesRinex4LnavAndSkipsUnsupportedRecordBoundary) {
     testing::internal::CaptureStderr();
     ASSERT_TRUE(reader.readNavigationData(nav_data));
     const std::string diagnostic = testing::internal::GetCapturedStderr();
-    EXPECT_NE(diagnostic.find("Skipping unsupported RINEX 4 navigation record type: STO"),
+    EXPECT_NE(diagnostic.find("Skipping malformed RINEX 4 STO body"),
               std::string::npos);
+    EXPECT_TRUE(reader.rinex4SystemData().system_time_offsets.empty());
     EXPECT_NE(diagnostic.find("Skipping unsupported RINEX 4 EPH I05 LNAV"),
               std::string::npos);
     EXPECT_NE(diagnostic.find("Skipping unsupported RINEX 4 EPH I05 L1NV"),
@@ -604,6 +665,326 @@ TEST(RINEXReaderTest, PreservesRinex4GalileoMessageProvenanceAndRejectsContradic
     }
     EXPECT_TRUE(found_fnav);
     EXPECT_TRUE(found_inav);
+    reader.close();
+    std::filesystem::remove(temp_path);
+}
+
+TEST(RINEXReaderTest, ParsesRinex4SystemRecordsAndSkipsInvalidBoundaries) {
+    const auto temp_path =
+        std::filesystem::temp_directory_path() / "libgnss_rinex4_system_records.nav";
+    std::filesystem::remove(temp_path);
+    {
+        std::ofstream file(temp_path);
+        ASSERT_TRUE(file.is_open());
+        file << rinexHeaderLine(
+            "     4.02           NAVIGATION DATA     M",
+            "RINEX VERSION / TYPE");
+        file << rinexHeaderLine("", "END OF HEADER");
+
+        file << "> STO G24 CNVX\n";
+        file << rinex4StoEpochLine("GPUT", "", "UTC(USNO)") << '\n';
+        file << rinex4SystemNumbers({253224.0, 9.0e-10, -1.0e-14, 0.0}) << '\n';
+
+        file << "> STO G24 CNVX BAD\n";
+        file << rinex4StoEpochLine("GPUT", "", "UTC(USNO)") << '\n';
+        file << rinex4SystemNumbers({1.0, 2.0, 3.0, 4.0}) << '\n';
+
+        file << "> EOP G24 CNVX\n";
+        file << rinex4SystemDateNumbers({0.2, -0.0002, 0.0}) << '\n';
+        file << rinex4EopBodyLine1(false) << '\n';
+        file << rinex4SystemNumbers({253248.0, -0.17, -0.00007, 0.0}) << '\n';
+
+        file << "> EOP G24 CNVX\n";
+        file << rinex4SystemDateNumbers({0.2, -0.0002, 0.0}) << '\n';
+        file << rinex4EopBodyLine1(true) << '\n';
+        file << rinex4SystemNumbers({253248.0, -0.17, -0.00007, 0.0}) << '\n';
+
+        file << "> ION J01 CNVX WIDE\n";
+        file << rinex4SystemDateNumbers({1.0, 2.0, 3.0}) << '\n';
+        file << rinex4SystemNumbers({4.0, 5.0, 6.0, 7.0}) << '\n';
+        file << rinex4SystemNumbers({8.0}) << '\n';
+
+        file << "> ION J01 CNVX BAD\n";
+        file << rinex4SystemDateNumbers({1.0, 2.0, 3.0}) << '\n';
+        file << rinex4SystemNumbers({4.0, 5.0, 6.0, 7.0}) << '\n';
+        file << rinex4SystemNumbers({8.0}) << '\n';
+
+        file << "> ION E13 IFNV\n";
+        file << rinex4SystemDateNumbers({54.5, 0.35, 0.013}) << '\n';
+        file << rinex4SystemNumbers({0.0}) << '\n';
+
+        file << "> ION C03 CNVX\n";
+        file << rinex4SystemDateNumbers({1.0, 2.0, 3.0}) << '\n';
+        file << rinex4SystemNumbers({4.0, 5.0, 6.0, 7.0}) << '\n';
+        file << rinex4SystemNumbers({8.0, 9.0}) << '\n';
+
+        file << "> ION C03 D1D2\n";
+        file << rinex4SystemDateNumbers({10.0, 11.0, 12.0}) << '\n';
+        file << rinex4SystemNumbers({13.0, 14.0, 15.0, 16.0}) << '\n';
+        file << rinex4SystemNumbers({17.0}) << '\n';
+
+        file << "> ION I10 L1NV KLOB\n";
+        file << rinex4SystemDateNumbers({1.0}) << '\n';
+        file << rinex4SystemNumbers({2.0, 3.0, 4.0, 5.0}) << '\n';
+        file << rinex4SystemNumbers({6.0, 7.0, 8.0, 9.0}) << '\n';
+        file << rinex4SystemNumbers({10.0, 11.0, 12.0, 13.0}) << '\n';
+
+        file << "> ION I10 L1NV NEQN\n";
+        file << rinex4SystemDateNumbers({2.0}) << '\n';
+        for (int line = 0; line < 6; ++line) {
+            file << rinex4SystemNumbers({1.0 + line, 2.0 + line,
+                                          3.0 + line, 0.0}) << '\n';
+        }
+
+        file << "> ION R26 LXOC\n";
+        file << rinex4SystemDateNumbers({1.0, 2.0, 3.0}) << '\n';
+
+        file << "> ION G14 CNVX\n";
+        file << rinex4SystemDateNumbers({21.0, 22.0, 23.0}) << '\n';
+        file << rinex4SystemNumbers({24.0, 25.0, 26.0, 27.0}) << '\n';
+        file << rinex4SystemNumbers({28.0}) << '\n';
+
+        file << "> EPH G04 LNAV\n";
+        file << rinex4GpsLnavBody();
+    }
+
+    io::RINEXReader reader;
+    ASSERT_TRUE(reader.open(temp_path.string()));
+    io::RINEXReader::RINEXHeader header;
+    ASSERT_TRUE(reader.readHeader(header));
+    NavigationData nav_data;
+    testing::internal::CaptureStderr();
+    ASSERT_TRUE(reader.readNavigationData(nav_data));
+    const std::string diagnostic = testing::internal::GetCapturedStderr();
+    EXPECT_NE(diagnostic.find("Skipping malformed RINEX 4 EOP body"),
+              std::string::npos);
+    EXPECT_NE(diagnostic.find("Skipping malformed or unsupported RINEX 4 ION body"),
+              std::string::npos);
+
+    const auto& system_data = reader.rinex4SystemData();
+    ASSERT_EQ(system_data.system_time_offsets.size(), 1U);
+    EXPECT_EQ(system_data.system_time_offsets.front().correction_type, "GPUT");
+    EXPECT_EQ(system_data.system_time_offsets.front().utc_id, "UTC(USNO)");
+    EXPECT_NEAR(system_data.system_time_offsets.front().transmission_time,
+                253224.0, 1e-9);
+
+    ASSERT_EQ(system_data.earth_orientation_parameters.size(), 1U);
+    EXPECT_NEAR(system_data.earth_orientation_parameters.front().x_p, 0.2, 1e-12);
+    EXPECT_NEAR(system_data.earth_orientation_parameters.front().delta_ut1,
+                -0.17, 1e-12);
+
+    ASSERT_EQ(system_data.ionosphere_records.size(), 8U);
+    EXPECT_TRUE(std::holds_alternative<io::rinex4::KlobucharIonosphere>(
+        system_data.ionosphere_records[0].payload));
+    EXPECT_TRUE(std::holds_alternative<io::rinex4::NequickGIonosphere>(
+        system_data.ionosphere_records[1].payload));
+    EXPECT_TRUE(std::holds_alternative<io::rinex4::BdgimIonosphere>(
+        system_data.ionosphere_records[2].payload));
+    EXPECT_TRUE(std::holds_alternative<io::rinex4::NavicKlobucharIonosphere>(
+        system_data.ionosphere_records[4].payload));
+    EXPECT_TRUE(std::holds_alternative<io::rinex4::NavicNequickNIonosphere>(
+        system_data.ionosphere_records[5].payload));
+    EXPECT_TRUE(std::holds_alternative<io::rinex4::GlonassCdmaIonosphere>(
+        system_data.ionosphere_records[6].payload));
+    EXPECT_TRUE(std::holds_alternative<io::rinex4::KlobucharIonosphere>(
+        system_data.ionosphere_records[3].payload));
+    const auto& qzss_klob = std::get<io::rinex4::KlobucharIonosphere>(
+        system_data.ionosphere_records[0].payload);
+    EXPECT_DOUBLE_EQ(qzss_klob.alpha[0], 1.0);
+    EXPECT_DOUBLE_EQ(qzss_klob.beta[3], 8.0);
+    EXPECT_EQ(std::get<io::rinex4::NequickGIonosphere>(
+                  system_data.ionosphere_records[1].payload).ai[0],
+              54.5);
+    EXPECT_DOUBLE_EQ(std::get<io::rinex4::BdgimIonosphere>(
+                         system_data.ionosphere_records[2].payload).alpha[8],
+                     9.0);
+    EXPECT_DOUBLE_EQ(std::get<io::rinex4::KlobucharIonosphere>(
+                         system_data.ionosphere_records[3].payload).alpha[0],
+                     10.0);
+    EXPECT_DOUBLE_EQ(std::get<io::rinex4::NavicKlobucharIonosphere>(
+                         system_data.ionosphere_records[4].payload).issue_of_data,
+                     1.0);
+    EXPECT_EQ(std::get<io::rinex4::NavicNequickNIonosphere>(
+                  system_data.ionosphere_records[5].payload).disturbance_flags[0],
+              0);
+    EXPECT_DOUBLE_EQ(std::get<io::rinex4::GlonassCdmaIonosphere>(
+                         system_data.ionosphere_records[6].payload).c_f10_7,
+                     2.0);
+    EXPECT_TRUE(std::holds_alternative<io::rinex4::KlobucharIonosphere>(
+        system_data.ionosphere_records[7].payload));
+    EXPECT_DOUBLE_EQ(std::get<io::rinex4::KlobucharIonosphere>(
+                         system_data.ionosphere_records[7].payload).alpha[0],
+                     21.0);
+
+    const auto eph_it = nav_data.ephemeris_data.find(
+        SatelliteId(GNSSSystem::GPS, 4));
+    ASSERT_NE(eph_it, nav_data.ephemeris_data.end());
+    ASSERT_EQ(eph_it->second.size(), 1U);
+    reader.close();
+    std::filesystem::remove(temp_path);
+}
+
+TEST(RINEXReaderTest, SystemRecordParsersAreTransactionalAndStrict) {
+    io::rinex4::NavigationRecordHeader sto_header;
+    ASSERT_TRUE(io::rinex4::parseNavigationRecordHeader(
+        "> STO G24 CNVX", sto_header));
+    io::rinex4::SystemTimeOffsetRecord sto;
+    sto.a0 = 42.0;
+    const std::vector<std::string> malformed_sto = {
+        rinex4StoEpochLine("GPUT", "", "UTC(USNO)"),
+        rinex4SystemNumbers({1.0, 2.0, 3.0})};
+    EXPECT_FALSE(io::rinex4::parseSystemTimeOffsetRecord(
+        sto_header, malformed_sto, sto));
+    EXPECT_DOUBLE_EQ(sto.a0, 42.0);
+
+    std::string malformed_prefix_sto = rinex4SystemNumbers({1.0, 2.0, 3.0, 4.0});
+    malformed_prefix_sto[0] = 'X';
+    EXPECT_FALSE(io::rinex4::parseSystemTimeOffsetRecord(
+        sto_header,
+        {rinex4StoEpochLine("GPUT", "", "UTC(USNO)"), malformed_prefix_sto},
+        sto));
+
+    const std::vector<std::string> gps_code_for_glonass = {
+        rinex4StoEpochLine("GPUT", "", "UTC(USNO)"),
+        rinex4SystemNumbers({1.0, 2.0, 3.0, 4.0})};
+    io::rinex4::NavigationRecordHeader glonass_sto_header;
+    ASSERT_TRUE(io::rinex4::parseNavigationRecordHeader(
+        "> STO R FDMA", glonass_sto_header));
+    EXPECT_FALSE(io::rinex4::parseSystemTimeOffsetRecord(
+        glonass_sto_header, gps_code_for_glonass, sto));
+    const std::vector<std::string> valid_glonass_sto = {
+        rinex4StoEpochLine("GLUT", "", "UTC(SU)"),
+        rinex4SystemNumbers({1.0, 2.0, 3.0, 4.0})};
+    EXPECT_TRUE(io::rinex4::parseSystemTimeOffsetRecord(
+        glonass_sto_header, valid_glonass_sto, sto));
+
+    io::rinex4::NavigationRecordHeader sbas_sto_header;
+    ASSERT_TRUE(io::rinex4::parseNavigationRecordHeader(
+        "> STO S SBAS", sbas_sto_header));
+    const std::vector<std::string> sbas_sto_with_glonass_utc = {
+        rinex4StoEpochLine("SBUT", "GAGAN", "UTC(SU)"),
+        rinex4SystemNumbers({1.0, 2.0, 3.0, 4.0})};
+    EXPECT_FALSE(io::rinex4::parseSystemTimeOffsetRecord(
+        sbas_sto_header, sbas_sto_with_glonass_utc, sto));
+    const std::vector<std::string> valid_sbas_sto = {
+        rinex4StoEpochLine("SBUT", "GAGAN", "UTC(NICT)"),
+        rinex4SystemNumbers({1.0, 2.0, 3.0, 4.0})};
+    EXPECT_TRUE(io::rinex4::parseSystemTimeOffsetRecord(
+        sbas_sto_header, valid_sbas_sto, sto));
+
+    io::rinex4::NavigationRecordHeader legacy_sto_header;
+    ASSERT_TRUE(io::rinex4::parseNavigationRecordHeader(
+        "> STO E LEG", legacy_sto_header));
+    std::string short_legacy_sto = rinex4StoEpochLine("GAGP");
+    short_legacy_sto.erase(short_legacy_sto.find_last_not_of(' ') + 1);
+    EXPECT_TRUE(io::rinex4::parseSystemTimeOffsetRecord(
+        legacy_sto_header,
+        {short_legacy_sto, rinex4SystemNumbers({1.0, 2.0, 3.0, 4.0})},
+        sto));
+
+    io::rinex4::EarthOrientationRecord eop;
+    io::rinex4::NavigationRecordHeader eop_gps_lnav_header;
+    ASSERT_TRUE(io::rinex4::parseNavigationRecordHeader(
+        "> EOP G24 LNAV", eop_gps_lnav_header));
+    EXPECT_FALSE(io::rinex4::parseEarthOrientationRecord(
+        eop_gps_lnav_header,
+        {rinex4SystemDateNumbers({1.0, 2.0, 3.0}),
+         rinex4EopBodyLine1(false), rinex4SystemNumbers({4.0, 5.0, 6.0, 7.0})},
+        eop));
+
+    io::rinex4::NavigationRecordHeader eop_navic_lnav_header;
+    ASSERT_TRUE(io::rinex4::parseNavigationRecordHeader(
+        "> EOP I10 LNAV", eop_navic_lnav_header));
+    EXPECT_TRUE(io::rinex4::parseEarthOrientationRecord(
+        eop_navic_lnav_header,
+        {rinex4SystemDateNumbers({1.0, 2.0, 3.0}),
+         rinex4EopBodyLine1(false), rinex4SystemNumbers({4.0, 5.0, 6.0, 7.0})},
+        eop));
+
+    io::rinex4::NavigationRecordHeader eop_header;
+    ASSERT_TRUE(io::rinex4::parseNavigationRecordHeader(
+        "> EOP G24 CNVX", eop_header));
+    eop.x_p = 17.0;
+    const std::vector<std::string> malformed_eop = {
+        rinex4SystemDateNumbers({1.0, 2.0, 3.0}),
+        rinex4EopBodyLine1(true),
+        rinex4SystemNumbers({4.0, 5.0, 6.0, 7.0})};
+    EXPECT_FALSE(io::rinex4::parseEarthOrientationRecord(
+        eop_header, malformed_eop, eop));
+    EXPECT_DOUBLE_EQ(eop.x_p, 17.0);
+
+    io::rinex4::NavigationRecordHeader ion_header;
+    ASSERT_TRUE(io::rinex4::parseNavigationRecordHeader(
+        "> ION J01 CNVX WIDE", ion_header));
+    const std::vector<std::string> malformed_ion = {
+        rinex4SystemDateNumbers({1.0, 2.0, 3.0}),
+        rinex4SystemNumbers({4.0, 5.0, 6.0, 7.0}),
+        "    malformed"};
+    io::rinex4::IonosphereRecord ion;
+    EXPECT_FALSE(io::rinex4::parseIonosphereRecord(
+        ion_header, malformed_ion, ion));
+
+    io::rinex4::NavigationRecordHeader invalid_flags_header;
+    ASSERT_TRUE(io::rinex4::parseNavigationRecordHeader(
+        "> ION E13 IFNV", invalid_flags_header));
+    EXPECT_FALSE(io::rinex4::parseIonosphereRecord(
+        invalid_flags_header,
+        {rinex4SystemDateNumbers({1.0, 2.0, 3.0}),
+         rinex4SystemNumbers({32.0})},
+        ion));
+    EXPECT_FALSE(io::rinex4::parseIonosphereRecord(
+        invalid_flags_header,
+        {rinex4SystemDateNumbers({1.0, 2.0, 3.0}),
+         rinex4SystemNumbers({1.5})},
+        ion));
+
+    io::rinex4::NavigationRecordHeader invalid_idf_header;
+    ASSERT_TRUE(io::rinex4::parseNavigationRecordHeader(
+        "> ION I10 L1NV NEQN", invalid_idf_header));
+    std::vector<std::string> invalid_idf_body = {
+        rinex4SystemDateNumbers({1.0})};
+    for (int line = 0; line < 6; ++line) {
+        invalid_idf_body.push_back(rinex4SystemNumbers(
+            {1.0 + line, 2.0 + line, 3.0 + line,
+             line == 0 ? 1.5 : 0.0}));
+    }
+    EXPECT_FALSE(io::rinex4::parseIonosphereRecord(
+        invalid_idf_header, invalid_idf_body, ion));
+
+    std::vector<std::string> high_idf_body = {
+        rinex4SystemDateNumbers({1.0})};
+    for (int line = 0; line < 6; ++line) {
+        high_idf_body.push_back(rinex4SystemNumbers(
+            {1.0 + line, 2.0 + line, 3.0 + line,
+             line == 0 ? 32.0 : 0.0}));
+    }
+    EXPECT_TRUE(io::rinex4::parseIonosphereRecord(
+        invalid_idf_header, high_idf_body, ion));
+}
+
+TEST(RINEXReaderTest, SystemRecordOnlyNavigationFileReturnsSuccess) {
+    const auto temp_path =
+        std::filesystem::temp_directory_path() / "libgnss_rinex4_system_only.nav";
+    std::filesystem::remove(temp_path);
+    {
+        std::ofstream file(temp_path);
+        ASSERT_TRUE(file.is_open());
+        file << rinexHeaderLine(
+            "     4.02           NAVIGATION DATA     M",
+            "RINEX VERSION / TYPE");
+        file << rinexHeaderLine("", "END OF HEADER");
+        file << "> STO G24 CNVX\n";
+        file << rinex4StoEpochLine("GPUT", "", "UTC(USNO)") << '\n';
+        file << rinex4SystemNumbers({1.0, 2.0, 3.0, 4.0}) << '\n';
+    }
+    io::RINEXReader reader;
+    ASSERT_TRUE(reader.open(temp_path.string()));
+    io::RINEXReader::RINEXHeader header;
+    ASSERT_TRUE(reader.readHeader(header));
+    NavigationData nav_data;
+    ASSERT_TRUE(reader.readNavigationData(nav_data));
+    EXPECT_TRUE(nav_data.ephemeris_data.empty());
+    ASSERT_EQ(reader.rinex4SystemData().system_time_offsets.size(), 1U);
     reader.close();
     std::filesystem::remove(temp_path);
 }

--- a/tests/test_rinex_writer.cpp
+++ b/tests/test_rinex_writer.cpp
@@ -4,6 +4,8 @@
 
 #include <filesystem>
 #include <fstream>
+#include <iomanip>
+#include <sstream>
 
 using namespace libgnss;
 
@@ -44,6 +46,21 @@ std::string rinex4GpsLnavBody() {
      4.000000000000e+00 6.300000000000e+01-8.847564458847e-09 8.660000000000e+02
      3.553500000000e+05 4.000000000000e+00
 )";
+}
+
+std::string rinex4GalileoBody(int data_source_code) {
+    std::string body = rinex4GpsLnavBody();
+    body.replace(0, 3, "E04");
+    size_t line_start = 0;
+    for (int line = 0; line < 5; ++line) {
+        line_start = body.find('\n', line_start) + 1;
+    }
+    std::ostringstream source_stream;
+    source_stream << ' ' << std::scientific << std::setprecision(12)
+                  << static_cast<double>(data_source_code);
+    const std::string source_field = source_stream.str();
+    body.replace(line_start + 23, source_field.size(), source_field);
+    return body;
 }
 
 Ephemeris makeGpsEphemeris() {
@@ -447,6 +464,27 @@ TEST(RINEXReaderTest, RejectsCompactRinexSuffixesButNotSimilarNames) {
     std::filesystem::remove(similar);
 }
 
+TEST(RINEXReaderTest, ParsesRinex4NavigationMessageTypesAndRejectsExtraMetadata) {
+    io::rinex4::NavigationRecordHeader header;
+    ASSERT_TRUE(io::rinex4::parseNavigationRecordHeader(
+        "> EPH E04 FNAV", header));
+    EXPECT_EQ(header.navigation_message_type, NavigationMessageType::FNAV);
+    EXPECT_STREQ(io::rinex4::navigationMessageTypeName(
+                     header.navigation_message_type), "FNAV");
+    EXPECT_EQ(io::rinex4::navigationMessageTypeFromRinexToken("inav"),
+              NavigationMessageType::Unknown);
+    EXPECT_FALSE(io::rinex4::parseNavigationRecordHeader(
+        "> EPH E04 inav", header));
+    EXPECT_FALSE(io::rinex4::parseNavigationRecordHeader(
+        "> EPH E04 FNAV SUBTYPE", header));
+    EXPECT_FALSE(io::rinex4::parseNavigationRecordHeader(
+        "> EPH E04 FNAV EXTRA", header));
+    EXPECT_TRUE(io::rinex4::parseNavigationRecordHeader(
+        "> STO R FDMA TEST", header));
+    EXPECT_FALSE(io::rinex4::parseNavigationRecordHeader(
+        "> STO R FDMA TEST EXTRA", header));
+}
+
 TEST(RINEXReaderTest, DispatchesRinex4LnavAndSkipsUnsupportedRecordBoundary) {
     const auto temp_path =
         std::filesystem::temp_directory_path() / "libgnss_rinex4_navigation_dispatch.nav";
@@ -463,6 +501,12 @@ TEST(RINEXReaderTest, DispatchesRinex4LnavAndSkipsUnsupportedRecordBoundary) {
         file << "this system record is intentionally unsupported\n";
         file << "> EPH I05 LNAV\n";
         file << "this syntactically valid but unsupported EPH is skipped\n";
+        file << "> EPH I05 L1NV\n";
+        file << "this NavIC L1NV body is intentionally unsupported\n";
+        file << "> EPH R01 L1OC\n";
+        file << "this GLONASS L1OC body is intentionally unsupported\n";
+        file << "> EPH R01 L3OC\n";
+        file << "this GLONASS L3OC body is intentionally unsupported\n";
         file << "> EPH G04 LNAV\n";
         file << rinex4GpsLnavBody();
         std::string bds_d1_body = rinex4GpsLnavBody();
@@ -487,6 +531,12 @@ TEST(RINEXReaderTest, DispatchesRinex4LnavAndSkipsUnsupportedRecordBoundary) {
               std::string::npos);
     EXPECT_NE(diagnostic.find("Skipping unsupported RINEX 4 EPH I05 LNAV"),
               std::string::npos);
+    EXPECT_NE(diagnostic.find("Skipping unsupported RINEX 4 EPH I05 L1NV"),
+              std::string::npos);
+    EXPECT_NE(diagnostic.find("Skipping unsupported RINEX 4 EPH R01 L1OC"),
+              std::string::npos);
+    EXPECT_NE(diagnostic.find("Skipping unsupported RINEX 4 EPH R01 L3OC"),
+              std::string::npos);
     EXPECT_NE(diagnostic.find("Skipping unsupported RINEX 4 EPH G04 CNAV"),
               std::string::npos);
 
@@ -494,6 +544,8 @@ TEST(RINEXReaderTest, DispatchesRinex4LnavAndSkipsUnsupportedRecordBoundary) {
     ASSERT_NE(it, nav_data.ephemeris_data.end());
     ASSERT_EQ(it->second.size(), 1U);
     EXPECT_EQ(it->second.front().satellite, SatelliteId(GNSSSystem::GPS, 4));
+    EXPECT_EQ(it->second.front().navigation_message_type,
+              NavigationMessageType::LNAV);
     EXPECT_EQ(it->second.front().week, 2044);
     EXPECT_NEAR(it->second.front().toes, 360000.0, 1e-6);
 
@@ -501,7 +553,57 @@ TEST(RINEXReaderTest, DispatchesRinex4LnavAndSkipsUnsupportedRecordBoundary) {
         SatelliteId(GNSSSystem::BeiDou, 1));
     ASSERT_NE(bds_it, nav_data.ephemeris_data.end());
     ASSERT_EQ(bds_it->second.size(), 1U);
+    EXPECT_EQ(bds_it->second.front().navigation_message_type,
+              NavigationMessageType::D1);
 
+    reader.close();
+    std::filesystem::remove(temp_path);
+}
+
+TEST(RINEXReaderTest, PreservesRinex4GalileoMessageProvenanceAndRejectsContradiction) {
+    const auto temp_path =
+        std::filesystem::temp_directory_path() / "libgnss_rinex4_galileo_metadata.nav";
+    std::filesystem::remove(temp_path);
+    {
+        std::ofstream file(temp_path);
+        ASSERT_TRUE(file.is_open());
+        file << rinexHeaderLine(
+            "     4.02           NAVIGATION DATA     M",
+            "RINEX VERSION / TYPE");
+        file << rinexHeaderLine("", "END OF HEADER");
+        file << "> EPH E04 FNAV\n";
+        file << rinex4GalileoBody((1 << 8) + (1 << 1));
+        file << "> EPH E04 FNAV\n";
+        file << rinex4GalileoBody((1 << 9) | 1);
+        file << "> EPH E04 INAV\n";
+        file << rinex4GalileoBody((1 << 9) | 1);
+    }
+
+    io::RINEXReader reader;
+    ASSERT_TRUE(reader.open(temp_path.string()));
+    io::RINEXReader::RINEXHeader header;
+    ASSERT_TRUE(reader.readHeader(header));
+    NavigationData nav_data;
+    testing::internal::CaptureStderr();
+    ASSERT_TRUE(reader.readNavigationData(nav_data));
+    const std::string diagnostic = testing::internal::GetCapturedStderr();
+    EXPECT_NE(diagnostic.find("body data-source clock bit contradicts header"),
+              std::string::npos);
+
+    const auto it = nav_data.ephemeris_data.find(
+        SatelliteId(GNSSSystem::Galileo, 4));
+    ASSERT_NE(it, nav_data.ephemeris_data.end());
+    ASSERT_EQ(it->second.size(), 2U);
+    bool found_fnav = false;
+    bool found_inav = false;
+    for (const auto& eph : it->second) {
+        found_fnav = found_fnav ||
+                     eph.navigation_message_type == NavigationMessageType::FNAV;
+        found_inav = found_inav ||
+                     eph.navigation_message_type == NavigationMessageType::INAV;
+    }
+    EXPECT_TRUE(found_fnav);
+    EXPECT_TRUE(found_inav);
     reader.close();
     std::filesystem::remove(temp_path);
 }
@@ -547,6 +649,7 @@ TEST(RINEXWriterTest, WritesGpsNavigationMessageReadableByReader) {
     EXPECT_NEAR(actual.omega_dot, expected.omega_dot, 1e-18);
     EXPECT_NEAR(actual.tgd, expected.tgd, 1e-18);
     EXPECT_EQ(actual.iodc, expected.iodc);
+    EXPECT_EQ(actual.navigation_message_type, NavigationMessageType::Unknown);
 
     reader.close();
     std::filesystem::remove(temp_path);


### PR DESCRIPTION
## Summary

- parse RINEX 4.02 GLONASS L1OC and L3OC ephemeris bodies with a strict transactional nine-line parser
- retain typed CDMA-specific metadata while mapping common clock and ECEF state fields into `Ephemeris`
- convert UTC epochs and transmission time to GPST with nearest-week handling
- preserve the existing GLONASS FDMA path and ephemeris selection policy
- add official Table A18 fixtures plus malformed-record and boundary-recovery coverage

## Why

RINEX 4 GLONASS CDMA records were previously skipped because their A16/A17 layouts are incompatible with the legacy four-line FDMA parser.

## Impact

Navigation readers can now retain and use L1OC/L3OC state vectors without silently interpreting CDMA fields as FDMA data. Unsupported Phase 5 message families remain deliberately skipped.

## Validation

- latest full build succeeded
- CTest: 65/65 passed
- RINEXReaderTest: 21/21 passed
- focused GLONASS tests: 3/3 passed
- MkDocs strict build passed
- `git diff --check` passed

## Stack

This Draft PR is stacked on Phase 4: #466.
