### PR TITLE
docs: fix Pages canonical URLs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: libgnss++
 site_description: Modern C++ GNSS/RTK/PPP/CLAS toolkit
-site_url: https://rsasaki0109.github.io/gnssplusplus-library/docs/
+site_url: https://rsasaki0109.github.io/gnssplusplus-library/
 repo_url: https://github.com/rsasaki0109/gnssplusplus-library
 repo_name: rsasaki0109/gnssplusplus-library
 docs_dir: docs

--- a/tests/test_docs_site.py
+++ b/tests/test_docs_site.py
@@ -9,6 +9,7 @@ from pathlib import Path
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 ARCHITECTURE_PNG = ROOT_DIR / "docs" / "libgnsspp_architecture.png"
+SITE_URL = "https://rsasaki0109.github.io/gnssplusplus-library/"
 
 
 class DocsSiteTest(unittest.TestCase):
@@ -40,6 +41,17 @@ class DocsSiteTest(unittest.TestCase):
                 cwd=ROOT_DIR,
                 check=True,
             )
+            index_html = (site_dir / "index.html").read_text(encoding="utf-8")
+            sitemap_xml = (site_dir / "sitemap.xml").read_text(encoding="utf-8")
+            self.assertIn(f'<link rel="canonical" href="{SITE_URL}">', index_html)
+            sitemap_urls = [
+                line.strip()[len("<loc>") : -len("</loc>")]
+                for line in sitemap_xml.splitlines()
+                if line.strip().startswith("<loc>") and line.strip().endswith("</loc>")
+            ]
+            self.assertTrue(sitemap_urls)
+            self.assertIn(SITE_URL, sitemap_urls)
+            self.assertTrue(all(url.startswith(SITE_URL) for url in sitemap_urls))
             self.assertTrue((site_dir / "index.html").exists())
             self.assertTrue((site_dir / "architecture" / "index.html").exists() or (site_dir / "architecture.html").exists())
             self.assertTrue((site_dir / "libgnsspp_architecture.png").exists())


### PR DESCRIPTION
## What changed

- Point MkDocs `site_url` at the actual deployed Pages root.
- Assert the generated homepage canonical URL uses that root.
- Assert the generated sitemap contains the deployed root and keeps every URL under it.

## Why

The site is deployed at `https://rsasaki0109.github.io/gnssplusplus-library/`, but generated canonical and sitemap URLs used the nonexistent `/docs/` prefix. Search engines therefore received URLs that return 404.

## User impact

Published documentation now advertises crawlable canonical and sitemap URLs that match the live Pages deployment.

## Validation

- `python3 tests/test_docs_site.py`
- `python3 -m mkdocs build --strict`
- `git diff --check`
