### PR TITLE
docs: improve first-run onboarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,62 @@ handling without an external RTKLIB runtime.
 
 ![Feature overview](docs/libgnsspp_feature_overview.png)
 
+## Try it
+
+The fastest first run uses the published runtime image; no local build is
+needed:
+
+```bash
+mkdir -p output
+docker run --rm \
+  -v "$PWD/output:/workspace/output" \
+  ghcr.io/rsasaki0109/gnssplusplus-library:develop \
+  demo --output-dir /workspace/output/self-contained-demo
+```
+
+The command runs the tracked, project-authored synthetic PPP fixture entirely
+offline after the image is available. It should report 8 processed and 8 valid
+PPP solutions and write `demo_solution.pos`, `demo_solution.kml`, and
+`demo_summary.json` under `output/self-contained-demo/`. This validates
+CLI/build/artifact plumbing, not field accuracy, real-world satellite
+geometry, or RTK fix performance. See the [full demo guide](docs/self_contained_demo.md)
+for provenance and native-build instructions.
+
+Prefer a native source checkout? Build the PPP executable and run the same
+tracked demo:
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --target gnss_ppp --parallel 2
+python3 apps/gnss.py demo
+```
+
+## Use the C++20 library
+
+The install exports a standard CMake package and the `libgnsspp::gnss_lib`
+target for downstream C++20 applications:
+
+```cmake
+cmake_minimum_required(VERSION 3.14)
+project(my_gnss_app LANGUAGES CXX)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+find_package(libgnsspp CONFIG REQUIRED)
+add_executable(my_gnss_app main.cpp)
+target_link_libraries(my_gnss_app PRIVATE libgnsspp::gnss_lib)
+```
+
+Build the complete exported library set before installing it:
+`cmake --build build --parallel 2`, followed by
+`cmake --install build --prefix <prefix>`. Configure the consumer with
+`-DCMAKE_PREFIX_PATH=<prefix>`. Start with the
+[simple SPP example](examples/simple_spp.cpp), the
+[RTK positioning example](examples/rtk_positioning.cpp), the
+[public API header](include/libgnss++/gnss.hpp), and the
+[interface notes](docs/interfaces.md).
+
 ## Results And Validation Status
 
 | Area | Public comparison | Evidence / status |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,14 +10,34 @@ python3 apps/gnss.py doctor
 
 ## Docker
 
+For the no-build self-contained demo, use the published image and mount only
+the output directory:
+
+```bash
+docker pull ghcr.io/rsasaki0109/gnssplusplus-library:develop
+mkdir -p output
+docker run --rm \
+  -v "$PWD/output:/workspace/output" \
+  ghcr.io/rsasaki0109/gnssplusplus-library:develop \
+  demo --output-dir /workspace/output/self-contained-demo
+```
+
+The demo uses the tracked synthetic PPP fixture and should produce 8 processed
+and 8 valid solutions plus `.pos`, KML, and JSON artifacts. It is an offline
+plumbing check, not a field-accuracy or RTK-fix benchmark. For other commands,
+build a local image explicitly:
+
 ```bash
 docker build -t libgnsspp:latest .
-docker pull ghcr.io/rsasaki0109/gnssplusplus-library:develop
 docker run --rm -it -v "$PWD:/workspace" libgnsspp:latest --help
 docker compose up gnss-web
 ```
 
-The container installs the `gnss` dispatcher and Python helpers under `/opt/libgnsspp`. Sample datasets are not embedded, so mount your source tree or your own dataset directory into `/workspace`.
+The container installs the `gnss` dispatcher and Python helpers under
+`/opt/libgnsspp`, along with the tracked demo fixture under
+`/opt/libgnsspp/share/libgnsspp/demo`. Larger sample datasets are not embedded;
+mount your source tree or your own dataset directory into `/workspace` for
+dataset-dependent commands.
 
 ## First solutions
 

--- a/docs/self_contained_demo.md
+++ b/docs/self_contained_demo.md
@@ -1,15 +1,34 @@
 # Self-contained offline demo
 
-The demo is the shortest way to verify a fresh checkout can run a positioning
-pipeline without a dataset download, network service, or credentials. After
-the normal native build, run one command from the repository root:
+The demo is the shortest way to verify the published runtime can run a
+positioning pipeline without a dataset download, network service, or
+credentials.
+
+## Public image (no build)
+
+Pull the public image once, then run the tracked demo with only an output mount:
 
 ```bash
-python3 apps/gnss.py demo
+docker pull ghcr.io/rsasaki0109/gnssplusplus-library:develop
+mkdir -p output
+docker run --rm \
+  -v "$PWD/output:/workspace/output" \
+  ghcr.io/rsasaki0109/gnssplusplus-library:develop \
+  demo --output-dir /workspace/output/self-contained-demo
 ```
 
-The command runs the built `gnss_ppp` executable against the three tracked
-files in `demo/fixtures/` and writes:
+The image contains the same tracked, project-authored synthetic PPP fixture as
+the source checkout. A successful run has eight processed and eight valid PPP
+solutions and writes the `.pos`, KML, and JSON artifacts listed below. The run
+itself is offline after the image is present; the synthetic fixture validates
+CLI/build/artifact plumbing, not field accuracy, real-world satellite geometry,
+or RTK fix performance.
+
+## Artifacts
+
+Both the public image and native command run the built `gnss_ppp` executable
+against the three tracked files in `demo/fixtures/` (or the installed prefix)
+and write:
 
 ```text
 output/self-contained-demo/demo_solution.pos
@@ -38,7 +57,7 @@ NTRIP, HTTP, or any other network/credential source. A missing binary is
 reported with the build command rather than silently falling back to a fake
 solution.
 
-## Docker
+## Local Docker image
 
 Build the existing runtime image, then run the same command with the output
 directory mounted for easy inspection:

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import hashlib
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -15,6 +16,11 @@ from pathlib import Path
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 BUILD_DIR = Path(os.environ.get("GNSSPP_BINARY_DIR", ROOT_DIR / "build"))
+PUBLIC_IMAGE = "ghcr.io/rsasaki0109/gnssplusplus-library:develop"
+PUBLIC_DEMO_COMMAND = re.compile(
+    re.escape(PUBLIC_IMAGE)
+    + r"\s+demo\s+--output-dir\s+/workspace/output/self-contained-demo"
+)
 
 # Platform-dependent artifact names (MSVC: gnss_spp.exe / gnss_lib.lib,
 # GNU: gnss_spp / libgnss_lib.a).
@@ -68,6 +74,33 @@ class PackagingSmokeTest(unittest.TestCase):
         self.assertIn("ghcr.io/rsasaki0109/gnssplusplus-library", docker_workflow_text)
         self.assertIn("docker/build-push-action", docker_workflow_text)
 
+    def test_public_demo_docs_keep_image_tag_and_fixture_caveat(self) -> None:
+        documents = {
+            "README.md": (ROOT_DIR / "README.md").read_text(encoding="utf-8"),
+            "docs/quickstart.md": (
+                ROOT_DIR / "docs" / "quickstart.md"
+            ).read_text(encoding="utf-8"),
+            "docs/self_contained_demo.md": (
+                ROOT_DIR / "docs" / "self_contained_demo.md"
+            ).read_text(encoding="utf-8"),
+        }
+        for name, text in documents.items():
+            normalized = re.sub(r"\\\s*\n\s*", " ", text)
+            with self.subTest(document=name):
+                self.assertRegex(normalized, PUBLIC_DEMO_COMMAND)
+                self.assertIn(PUBLIC_IMAGE, normalized)
+
+        readme_text = documents["README.md"]
+        quickstart_text = documents["docs/quickstart.md"]
+        demo_text = documents["docs/self_contained_demo.md"]
+        self.assertIn("tracked, project-authored synthetic PPP fixture", readme_text)
+        self.assertIn("not field accuracy", readme_text)
+        self.assertRegex(readme_text, r"find_package\(libgnsspp CONFIG REQUIRED\)")
+        self.assertIn("libgnsspp::gnss_lib", readme_text)
+        self.assertIn("Larger sample datasets are not embedded", quickstart_text)
+        self.assertIn("synthetic PPP fixture", quickstart_text)
+        self.assertIn("not field accuracy", demo_text)
+
     def test_cmake_install_exports_expected_layout(self) -> None:
         self.assertTrue(BUILD_DIR.exists(), "build directory must exist before packaging test")
 
@@ -75,6 +108,65 @@ class PackagingSmokeTest(unittest.TestCase):
             prefix = Path(temp_dir) / "prefix"
             subprocess.run(
                 ["cmake", "--install", str(BUILD_DIR), "--prefix", str(prefix)],
+                check=True,
+                cwd=ROOT_DIR,
+            )
+
+            consumer_dir = Path(temp_dir) / "consumer"
+            consumer_dir.mkdir()
+            (consumer_dir / "CMakeLists.txt").write_text(
+                "\n".join(
+                    [
+                        "cmake_minimum_required(VERSION 3.14)",
+                        "project(libgnsspp_consumer_smoke LANGUAGES CXX)",
+                        "set(CMAKE_CXX_STANDARD 20)",
+                        "set(CMAKE_CXX_STANDARD_REQUIRED ON)",
+                        "find_package(libgnsspp CONFIG REQUIRED)",
+                        "add_executable(consumer main.cpp)",
+                        "target_link_libraries(consumer PRIVATE libgnsspp::gnss_lib)",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            (consumer_dir / "main.cpp").write_text(
+                "\n".join(
+                    [
+                        "#include <libgnss++/core/types.hpp>",
+                        "",
+                        "int main() {",
+                        "    libgnss::SatelliteId satellite(libgnss::GNSSSystem::GPS, 1);",
+                        "    return satellite.toString().empty() ? 1 : 0;",
+                        "}",
+                    ]
+                )
+                + "\n",
+                encoding="utf-8",
+            )
+            consumer_build = consumer_dir / "build"
+            subprocess.run(
+                [
+                    "cmake",
+                    "-S",
+                    str(consumer_dir),
+                    "-B",
+                    str(consumer_build),
+                    "-DCMAKE_BUILD_TYPE=Release",
+                    f"-DCMAKE_PREFIX_PATH={prefix}",
+                ],
+                check=True,
+                cwd=ROOT_DIR,
+            )
+            subprocess.run(
+                [
+                    "cmake",
+                    "--build",
+                    str(consumer_build),
+                    "--config",
+                    "Release",
+                    "--parallel",
+                    "2",
+                ],
                 check=True,
                 cwd=ROOT_DIR,
             )


### PR DESCRIPTION
## Summary
- put the public GHCR self-contained PPP demo near the top of the README
- make Docker, fixture provenance, and C++20 package-consumer guidance consistent across onboarding docs
- execute the documented installed CMake consumer path in packaging coverage

## Why
The validation evidence is strong, but a first-time visitor currently reaches it before seeing a fast, trustworthy way to try the project. This makes the first successful run visible in about 30 seconds and removes the pulled-image/local-tag mismatch.

## Validation
- public GHCR image demo: 8/8 valid PPP solutions; .pos, KML, and JSON artifacts
- python3 -m unittest tests.test_packaging (3 tests, including installed downstream C++20 consumer)
- focused packaging + CLI UX tests (23 tests)
- python3 -m mkdocs build --strict
- bash scripts/ci/run_hygiene.sh
- git diff --check