### PR TITLE
release: prepare v0.2.0 distribution

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -37,6 +37,8 @@ jobs:
         tags: |
           type=ref,event=branch
           type=ref,event=tag
+          type=semver,pattern={{version}}
+          type=semver,pattern={{major}}.{{minor}}
           type=sha,format=short
           type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,155 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  release:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 45
+    steps:
+    - name: Check out the release tag
+      uses: actions/checkout@v7
+      with:
+        # Check out the immutable event commit. The identity gate below
+        # proves that the triggering ref is its annotated release tag.
+        ref: ${{ github.sha }}
+        fetch-depth: 0
+
+    - name: Verify annotated tag and event commit identity
+      shell: bash
+      run: |
+        set -euo pipefail
+        tag_ref="refs/tags/${GITHUB_REF_NAME}"
+        test "${GITHUB_REF}" = "${tag_ref}"
+        git show-ref --verify --quiet "${tag_ref}"
+        test "$(git cat-file -t "${tag_ref}")" = "tag"
+        test "$(git rev-parse HEAD)" = "${GITHUB_SHA}"
+        test "$(git rev-parse "${tag_ref}^{}")" = "${GITHUB_SHA}"
+
+    - name: Install release dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install --yes --no-install-recommends \
+          build-essential \
+          cmake \
+          dpkg-dev \
+          libeigen3-dev \
+          pybind11-dev \
+          python3 \
+          python3-dev \
+          python3-matplotlib \
+          python3-numpy
+
+    - name: Validate tag and project version
+      run: python3 scripts/release/validate_version.py --tag "${GITHUB_REF_NAME}" --cmake-file CMakeLists.txt
+
+    - name: Configure release build
+      run: |
+        cmake -S . -B build \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DBUILD_TESTING=OFF \
+          -DGNSSPP_BUILD_PYTHON_BINDINGS=ON
+
+    - name: Build release
+      run: cmake --build build --parallel 2
+
+    - name: Build TGZ and DEB packages
+      run: |
+        set -euo pipefail
+        rm -rf dist
+        mkdir -p dist
+        cpack --config build/CPackConfig.cmake -G TGZ -B dist
+        cpack --config build/CPackConfig.cmake -G DEB -B dist
+
+    - name: Smoke-install DEB in Ubuntu 24.04 and run the demo
+      shell: bash
+      run: |
+        set -euo pipefail
+        docker run --rm --platform linux/amd64 \
+          -v "${PWD}/dist:/dist:ro" \
+          ubuntu:24.04 \
+          bash -euxo pipefail -c '
+            export DEBIAN_FRONTEND=noninteractive
+            apt-get update
+            deb="$(find /dist -maxdepth 1 -type f -name "*.deb" -print -quit)"
+            test -n "${deb}"
+            apt-get install --yes --no-install-recommends "${deb}"
+            demo_dir="$(mktemp -d)"
+            gnss demo --output-dir "${demo_dir}"
+            test -s "${demo_dir}/demo_solution.pos"
+            test -s "${demo_dir}/demo_solution.kml"
+            test -s "${demo_dir}/demo_summary.json"
+          '
+
+    - name: Check package contents and generate checksums
+      shell: bash
+      run: |
+        set -euo pipefail
+        version="${GITHUB_REF_NAME#v}"
+        mapfile -t tgz < <(find dist -maxdepth 1 -type f -name '*.tar.gz' -print | sort)
+        mapfile -t deb < <(find dist -maxdepth 1 -type f -name '*.deb' -print | sort)
+        test "${#tgz[@]}" -eq 1
+        test "${#deb[@]}" -eq 1
+        [[ "$(basename "${tgz[0]}")" == *"${version}"* ]]
+        [[ "$(basename "${deb[0]}")" == *"${version}"* ]]
+
+        # Consume the complete listing before grep exits so pipefail cannot
+        # turn a successful content match into a SIGPIPE failure.
+        tar -tzf "${tgz[0]}" | grep -F -- 'share/libgnsspp/demo/synthetic_ppp.obs' >/dev/null
+        tar -tzf "${tgz[0]}" | grep -E -- '/bin/gnss$' >/dev/null
+        dpkg-deb --contents "${deb[0]}" | grep -F -- 'share/libgnsspp/demo/synthetic_ppp.obs' >/dev/null
+        dpkg-deb --contents "${deb[0]}" | grep -E -- '/bin/gnss$' >/dev/null
+
+        (
+          cd dist
+          sha256sum "$(basename "${tgz[0]}")" "$(basename "${deb[0]}")" > SHA256SUMS
+          sha256sum -c SHA256SUMS
+        )
+
+    - name: Preserve release assets as a workflow artifact
+      uses: actions/upload-artifact@v7
+      with:
+        name: libgnsspp-${{ github.ref_name }}-dist
+        path: dist/
+        if-no-files-found: error
+        retention-days: 30
+
+    - name: Create or update the GitHub Release
+      env:
+        GH_TOKEN: ${{ github.token }}
+        RELEASE_TAG: ${{ github.ref_name }}
+      run: |
+        set -euo pipefail
+        notes_file="docs/releases/${RELEASE_TAG}.md"
+        if ! gh release view "${RELEASE_TAG}" --repo "${GITHUB_REPOSITORY}" >/dev/null 2>&1; then
+          release_args=(
+            --generate-notes
+            --repo "${GITHUB_REPOSITORY}"
+            --title "libgnss++ ${RELEASE_TAG}"
+          )
+          if [[ -f "${notes_file}" ]]; then
+            # gh combines this maintainer-authored preface with its generated
+            # release notes when both --notes-file and --generate-notes are
+            # supplied.
+            release_args+=(--notes-file "${notes_file}")
+          fi
+          # --verify-tag is intentional: gh must never create a tag as a side
+          # effect of this release workflow.
+          gh release create "${RELEASE_TAG}" --verify-tag "${release_args[@]}"
+        fi
+
+        # Upload separately even after creation so retries repair a partial
+        # release and replace stale assets deterministically.
+        gh release upload "${RELEASE_TAG}" dist/* \
+          --repo "${GITHUB_REPOSITORY}" \
+          --clobber

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.14)
-project(gnss_lib VERSION 0.1.0 LANGUAGES C CXX)
+project(gnss_lib VERSION 0.2.0 LANGUAGES C CXX)
 
 set(GNSSPP_CXX_STANDARD 20 CACHE STRING
     "C++ standard (use 17 with legacy Eigen 3.3 toolchains that reject C++20 rewritten comparisons)")
@@ -415,6 +415,14 @@ set(CPACK_RESOURCE_FILE_LICENSE ${CMAKE_CURRENT_SOURCE_DIR}/LICENSE)
 set(CPACK_GENERATOR "TGZ;DEB")
 set(CPACK_DEBIAN_PACKAGE_MAINTAINER "libgnss++ maintainers")
 set(CPACK_DEBIAN_FILE_NAME DEB-DEFAULT)
+# The installed command surface includes Python-based diagnostics and demo
+# tooling, while the exported static CMake targets expose Eigen headers to
+# downstream consumers. Keep those runtime/development requirements explicit
+# in the Debian package metadata; shlibdeps adds the platform C/C++ runtime
+# dependencies discovered from the installed ELF executables.
+set(CPACK_DEBIAN_PACKAGE_DEPENDS
+    "libeigen3-dev, python3, python3-numpy, python3-matplotlib")
+set(CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON)
 include(CPack)
 
 # Visibility library (fisheye camera, satellite LOS/NLOS)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ needed:
 mkdir -p output
 docker run --rm \
   -v "$PWD/output:/workspace/output" \
-  ghcr.io/rsasaki0109/gnssplusplus-library:develop \
+  ghcr.io/rsasaki0109/gnssplusplus-library:v0.2.0 \
   demo --output-dir /workspace/output/self-contained-demo
 ```
 
@@ -71,6 +71,9 @@ Build the complete exported library set before installing it:
 [RTK positioning example](examples/rtk_positioning.cpp), the
 [public API header](include/libgnss++/gnss.hpp), and the
 [interface notes](docs/interfaces.md).
+
+See the [v0.2.0 release highlights](docs/releases/v0.2.0.md) and
+[maintainer release runbook](docs/release_runbook.md) for distribution details.
 
 ## Results And Validation Status
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,6 +1,6 @@
 services:
   gnss-web:
-    image: ${LIBGNSSPP_IMAGE:-ghcr.io/rsasaki0109/gnssplusplus-library:develop}
+    image: ${LIBGNSSPP_IMAGE:-ghcr.io/rsasaki0109/gnssplusplus-library:v0.2.0}
     build:
       context: .
       target: runtime

--- a/docs/index.md
+++ b/docs/index.md
@@ -11,6 +11,8 @@ checked benchmark artifacts.
 - [Robotics quick start](robotics_quickstart.md)
 - [Research quick start](research_quickstart.md)
 - [Self-contained offline demo](self_contained_demo.md)
+- [v0.2.0 release highlights](releases/v0.2.0.md)
+- [Maintainer release runbook](release_runbook.md)
 - [Dataset gallery](dataset_gallery.md)
 - [Architecture notes](architecture.md)
 - [Quick start](quickstart.md)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -14,11 +14,11 @@ For the no-build self-contained demo, use the published image and mount only
 the output directory:
 
 ```bash
-docker pull ghcr.io/rsasaki0109/gnssplusplus-library:develop
+docker pull ghcr.io/rsasaki0109/gnssplusplus-library:v0.2.0
 mkdir -p output
 docker run --rm \
   -v "$PWD/output:/workspace/output" \
-  ghcr.io/rsasaki0109/gnssplusplus-library:develop \
+  ghcr.io/rsasaki0109/gnssplusplus-library:v0.2.0 \
   demo --output-dir /workspace/output/self-contained-demo
 ```
 

--- a/docs/release_runbook.md
+++ b/docs/release_runbook.md
@@ -1,0 +1,51 @@
+# Maintainer release runbook
+
+This runbook covers the tag-driven v0.2.0 release. Release automation is
+intentionally started only by an annotated `vMAJOR.MINOR.PATCH` tag pushed to
+the repository.
+
+## Before tagging
+
+1. Merge the validated release change into `develop` and confirm the merge
+   commit is the intended release source.
+2. Run the targeted release tests, packaging smoke test, and strict MkDocs
+   build from a clean checkout.
+3. Confirm `CMakeLists.txt` contains the version represented by the tag:
+
+   ```bash
+   python3 scripts/release/validate_version.py \
+     --tag v0.2.0 --cmake-file CMakeLists.txt
+   ```
+
+## Start the release
+
+From the validated `develop` merge commit, create and push the annotated tag:
+
+```bash
+git tag -a v0.2.0 -m "libgnss++ v0.2.0"
+git push origin v0.2.0
+```
+
+The release workflow checks out the event commit, then refuses to proceed
+unless the local `v0.2.0` ref is an annotated tag that peels exactly to that
+commit and matches CMake. It builds repeatable tag-driven packages for Ubuntu
+24.04 amd64 and verifies the tag with `gh release create --verify-tag`; the
+workflow never creates a Git tag.
+
+## Verify publication
+
+- Confirm the workflow artifact contains exactly one TGZ, one DEB, and
+  `SHA256SUMS`; verify the checksums locally with `sha256sum -c SHA256SUMS`.
+- The DEB declares Eigen development headers and the Python runtime,
+  NumPy, and Matplotlib dependencies, and the workflow installs it in a
+  fresh Ubuntu 24.04 amd64 container before running the offline demo.
+- Treat the binaries and packages as Ubuntu 24.04 amd64 release artifacts;
+  the TGZ is not a universal portability promise.
+- Confirm the GitHub Release for `v0.2.0` contains those assets and generated
+  notes plus `docs/releases/v0.2.0.md` when that file is present.
+- Confirm GHCR has `v0.2.0`, `0.2.0`, and `0.2` aliases, together with the
+  normal branch/ref, short-SHA, and `latest` tags.
+
+If a rerun finds an existing release, it uploads the freshly checked assets
+with `--clobber`. A version mistake requires a new corrective tag; do not
+move or delete a published release tag as part of a routine rerun.

--- a/docs/releases/v0.2.0.md
+++ b/docs/releases/v0.2.0.md
@@ -1,0 +1,15 @@
+# libgnss++ v0.2.0
+
+## Highlights
+
+- Native C++20 GNSS tooling and the exported `libgnsspp::gnss_lib` CMake
+  package now report version `0.2.0`.
+- A release-tag workflow builds repeatable, tag-driven TGZ and Debian packages
+  for Ubuntu 24.04 amd64, checks their contents, and publishes `SHA256SUMS`
+  with the release assets. These binaries target that environment; the TGZ is
+  not claimed to be universally portable.
+- The public Docker quick start uses the stable `v0.2.0` image tag and its
+  tracked, offline synthetic PPP demo fixture.
+
+The demo validates CLI, build, and packaging plumbing. Its synthetic inputs
+are not a field-accuracy or real-world satellite-geometry benchmark.

--- a/docs/self_contained_demo.md
+++ b/docs/self_contained_demo.md
@@ -9,11 +9,11 @@ credentials.
 Pull the public image once, then run the tracked demo with only an output mount:
 
 ```bash
-docker pull ghcr.io/rsasaki0109/gnssplusplus-library:develop
+docker pull ghcr.io/rsasaki0109/gnssplusplus-library:v0.2.0
 mkdir -p output
 docker run --rm \
   -v "$PWD/output:/workspace/output" \
-  ghcr.io/rsasaki0109/gnssplusplus-library:develop \
+  ghcr.io/rsasaki0109/gnssplusplus-library:v0.2.0 \
   demo --output-dir /workspace/output/self-contained-demo
 ```
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -25,6 +25,8 @@ nav:
   - Robotics Quick Start: robotics_quickstart.md
   - Research Quick Start: research_quickstart.md
   - Self-contained Offline Demo: self_contained_demo.md
+  - v0.2.0 Release Highlights: releases/v0.2.0.md
+  - Maintainer Release Runbook: release_runbook.md
   - Dataset Gallery: dataset_gallery.md
   - Architecture: architecture.md
   - Quick Start: quickstart.md

--- a/scripts/release/validate_version.py
+++ b/scripts/release/validate_version.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Validate an exact release tag against the canonical CMake project version."""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+
+_VERSION = r"(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)\.(?:0|[1-9][0-9]*)"
+_TAG_PATTERN = re.compile(rf"^v(?P<version>{_VERSION})$")
+_CMAKE_PROJECT_PATTERN = re.compile(
+    rf"(?im)^\s*project\s*\(\s*gnss_lib\s+VERSION\s+(?P<version>{_VERSION})(?=\s|\))"
+)
+
+
+def version_from_tag(tag: str) -> str:
+    """Return the version in an exact ``vMAJOR.MINOR.PATCH`` tag."""
+
+    match = _TAG_PATTERN.fullmatch(tag)
+    if match is None:
+        raise ValueError("tag must match exact vMAJOR.MINOR.PATCH SemVer")
+    return match.group("version")
+
+
+def version_from_cmake(cmake_file: Path) -> str:
+    """Read the single canonical ``project(gnss_lib VERSION ...)`` declaration."""
+
+    text = cmake_file.read_text(encoding="utf-8")
+    matches = list(_CMAKE_PROJECT_PATTERN.finditer(text))
+    if len(matches) != 1:
+        raise ValueError(
+            f"expected one project(gnss_lib VERSION ...) declaration in {cmake_file}"
+        )
+    return matches[0].group("version")
+
+
+def validate_versions(tag: str, cmake_file: Path) -> str:
+    """Validate and return the shared version string."""
+
+    tag_version = version_from_tag(tag)
+    cmake_version = version_from_cmake(cmake_file)
+    if tag_version != cmake_version:
+        raise ValueError(
+            f"tag {tag!r} resolves to {tag_version}, but {cmake_file} declares {cmake_version}"
+        )
+    return tag_version
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--tag", required=True, help="release tag, exactly vMAJOR.MINOR.PATCH")
+    parser.add_argument(
+        "--cmake-file",
+        type=Path,
+        default=Path("CMakeLists.txt"),
+        help="canonical CMake project file (default: CMakeLists.txt)",
+    )
+    args = parser.parse_args(argv)
+
+    try:
+        version = validate_versions(args.tag, args.cmake_file)
+    except (OSError, ValueError) as error:
+        print(f"release version validation failed: {error}", file=sys.stderr)
+        return 1
+
+    print(f"release version validated: {args.tag} == CMake {version}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -408,6 +408,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_packaging.py
     )
     add_test(
+        NAME python_release_contract_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_release_contracts.py
+    )
+    add_test(
         NAME python_bindings_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_python_bindings.py
     )
@@ -507,6 +511,7 @@ if(GTest_FOUND)
         python_gnss_solve_cli_tests
         python_observable_native_cli_contract_tests
         python_search_imu_time_offset_tests
+        python_release_contract_tests
     )
     set(GNSSPP_EXTENDED_TESTS
         python_packaging_tests

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -16,7 +16,7 @@ from pathlib import Path
 
 ROOT_DIR = Path(__file__).resolve().parents[1]
 BUILD_DIR = Path(os.environ.get("GNSSPP_BINARY_DIR", ROOT_DIR / "build"))
-PUBLIC_IMAGE = "ghcr.io/rsasaki0109/gnssplusplus-library:develop"
+PUBLIC_IMAGE = "ghcr.io/rsasaki0109/gnssplusplus-library:v0.2.0"
 PUBLIC_DEMO_COMMAND = re.compile(
     re.escape(PUBLIC_IMAGE)
     + r"\s+demo\s+--output-dir\s+/workspace/output/self-contained-demo"
@@ -67,7 +67,7 @@ class PackagingSmokeTest(unittest.TestCase):
 
         compose_text = compose_file.read_text(encoding="utf-8")
         self.assertIn("gnss-web", compose_text)
-        self.assertIn("ghcr.io/rsasaki0109/gnssplusplus-library:develop", compose_text)
+        self.assertIn(PUBLIC_IMAGE, compose_text)
         self.assertIn("8085:8085", compose_text)
 
         docker_workflow_text = docker_workflow.read_text(encoding="utf-8")

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Unit and static-contract tests for the v0.2.0 release surface."""
+
+from __future__ import annotations
+
+import importlib.util
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+VALIDATOR_PATH = ROOT_DIR / "scripts" / "release" / "validate_version.py"
+RELEASE_WORKFLOW_PATH = ROOT_DIR / ".github" / "workflows" / "release.yml"
+DOCKER_WORKFLOW_PATH = ROOT_DIR / ".github" / "workflows" / "docker.yml"
+PUBLIC_IMAGE = "ghcr.io/rsasaki0109/gnssplusplus-library:v0.2.0"
+
+
+def load_validator_module():
+    spec = importlib.util.spec_from_file_location("release_validate_version", VALIDATOR_PATH)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"failed to load validator module from {VALIDATOR_PATH}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+validator = load_validator_module()
+
+
+class ReleaseVersionValidatorTest(unittest.TestCase):
+    def test_valid_v020_matches_cmake(self) -> None:
+        self.assertEqual(
+            validator.validate_versions("v0.2.0", ROOT_DIR / "CMakeLists.txt"),
+            "0.2.0",
+        )
+
+    def test_invalid_and_prerelease_tags_are_rejected(self) -> None:
+        for tag in ("0.2.0", "v0.2", "v0.2.0-rc1", "v01.2.3"):
+            with self.subTest(tag=tag):
+                with self.assertRaisesRegex(ValueError, "exact vMAJOR.MINOR.PATCH"):
+                    validator.version_from_tag(tag)
+
+    def test_mismatched_tag_is_rejected(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss_release_version_") as temp_dir:
+            cmake_file = Path(temp_dir) / "CMakeLists.txt"
+            cmake_file.write_text(
+                "cmake_minimum_required(VERSION 3.14)\n"
+                "project(gnss_lib VERSION 0.2.1 LANGUAGES C CXX)\n",
+                encoding="utf-8",
+            )
+            with self.assertRaisesRegex(ValueError, "declares 0.2.1"):
+                validator.validate_versions("v0.2.0", cmake_file)
+
+
+class ReleaseWorkflowContractTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.release_workflow = RELEASE_WORKFLOW_PATH.read_text(encoding="utf-8")
+        cls.docker_workflow = DOCKER_WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    def test_release_is_tag_only_and_checks_out_the_triggering_tag(self) -> None:
+        self.assertIn('on:\n  push:\n    tags:\n      - "v*.*.*"', self.release_workflow)
+        self.assertNotIn("workflow_dispatch", self.release_workflow)
+        self.assertNotIn("branches:", self.release_workflow)
+        self.assertIn("runs-on: ubuntu-24.04", self.release_workflow)
+        self.assertIn("ref: ${{ github.sha }}", self.release_workflow)
+        self.assertIn("fetch-depth: 0", self.release_workflow)
+        self.assertIn('tag_ref="refs/tags/${GITHUB_REF_NAME}"', self.release_workflow)
+        self.assertIn('test "${GITHUB_REF}" = "${tag_ref}"', self.release_workflow)
+        self.assertIn('git show-ref --verify --quiet "${tag_ref}"', self.release_workflow)
+        self.assertIn('git cat-file -t "${tag_ref}"', self.release_workflow)
+        self.assertIn('git rev-parse HEAD)" = "${GITHUB_SHA}"', self.release_workflow)
+        self.assertIn('git rev-parse "${tag_ref}^{}")" = "${GITHUB_SHA}"', self.release_workflow)
+        self.assertIn(
+            "python3 scripts/release/validate_version.py --tag \"${GITHUB_REF_NAME}\"",
+            self.release_workflow,
+        )
+
+    def test_release_builds_both_packages_and_checks_contents(self) -> None:
+        self.assertIn("-DCMAKE_BUILD_TYPE=Release", self.release_workflow)
+        self.assertIn("cpack --config build/CPackConfig.cmake -G TGZ -B dist", self.release_workflow)
+        self.assertIn("cpack --config build/CPackConfig.cmake -G DEB -B dist", self.release_workflow)
+        self.assertIn("tar -tzf", self.release_workflow)
+        self.assertIn("dpkg-deb --contents", self.release_workflow)
+        self.assertIn("Smoke-install DEB in Ubuntu 24.04 and run the demo", self.release_workflow)
+        self.assertIn("docker run --rm --platform linux/amd64", self.release_workflow)
+        self.assertIn("ubuntu:24.04", self.release_workflow)
+        self.assertIn("apt-get install --yes --no-install-recommends", self.release_workflow)
+        self.assertIn('test -s "${demo_dir}/demo_solution.pos"', self.release_workflow)
+        self.assertIn('test -s "${demo_dir}/demo_solution.kml"', self.release_workflow)
+        self.assertIn('test -s "${demo_dir}/demo_summary.json"', self.release_workflow)
+        self.assertIn("SHA256SUMS", self.release_workflow)
+        self.assertIn("sha256sum -c SHA256SUMS", self.release_workflow)
+        self.assertIn("actions/upload-artifact@v7", self.release_workflow)
+        self.assertIn("if-no-files-found: error", self.release_workflow)
+
+    def test_release_creation_is_tag_verified_and_asset_upload_is_retry_safe(self) -> None:
+        self.assertIn("gh release create", self.release_workflow)
+        self.assertIn("--verify-tag", self.release_workflow)
+        self.assertIn('gh release create "${RELEASE_TAG}" --verify-tag', self.release_workflow)
+        self.assertIn("--generate-notes", self.release_workflow)
+        self.assertIn('notes_file="docs/releases/${RELEASE_TAG}.md"', self.release_workflow)
+        self.assertIn("--notes-file", self.release_workflow)
+        self.assertIn("gh release upload", self.release_workflow)
+        self.assertIn("--clobber", self.release_workflow)
+        self.assertNotIn("git tag", self.release_workflow)
+
+    def test_release_uses_only_the_contents_write_permission(self) -> None:
+        self.assertIn("permissions:\n  contents: write", self.release_workflow)
+        self.assertNotIn("packages:", self.release_workflow)
+        self.assertNotIn("actions:", self.release_workflow)
+
+    def test_debian_dependencies_cover_installed_surfaces(self) -> None:
+        cmake_text = (ROOT_DIR / "CMakeLists.txt").read_text(encoding="utf-8")
+        self.assertIn("CPACK_DEBIAN_PACKAGE_DEPENDS", cmake_text)
+        for dependency in ("libeigen3-dev", "python3", "python3-numpy", "python3-matplotlib"):
+            with self.subTest(dependency=dependency):
+                self.assertIn(dependency, cmake_text)
+        self.assertIn("CPACK_DEBIAN_PACKAGE_SHLIBDEPS ON", cmake_text)
+
+    def test_docker_metadata_keeps_existing_tags_and_adds_minor_semver_aliases(self) -> None:
+        tag_lines = {
+            line.strip()
+            for line in self.docker_workflow.splitlines()
+            if line.strip().startswith("type=")
+        }
+        self.assertIn("type=ref,event=branch", tag_lines)
+        self.assertIn("type=ref,event=tag", tag_lines)
+        self.assertIn("type=semver,pattern={{version}}", tag_lines)
+        self.assertIn("type=semver,pattern={{major}}.{{minor}}", tag_lines)
+        self.assertIn("type=sha,format=short", tag_lines)
+        self.assertIn("type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}", tag_lines)
+        self.assertNotIn("type=semver,pattern={{major}}", tag_lines)
+
+        compose_text = (ROOT_DIR / "compose.yaml").read_text(encoding="utf-8")
+        self.assertIn(PUBLIC_IMAGE, compose_text)
+
+    def test_public_onboarding_docs_use_stable_image(self) -> None:
+        for relative_path in ("README.md", "docs/quickstart.md", "docs/self_contained_demo.md"):
+            text = (ROOT_DIR / relative_path).read_text(encoding="utf-8")
+            with self.subTest(path=relative_path):
+                self.assertIn(PUBLIC_IMAGE, text)
+                legacy_image = "ghcr.io/rsasaki0109/gnssplusplus-library:" + "develop"
+                self.assertNotIn(legacy_image, text)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- publish `.deb`, `.tar.gz`, and `SHA256SUMS` from an annotated `v*.*.*` tag
- reject lightweight, moved, or CMake-version-mismatched tags before publishing
- publish GHCR aliases `v0.2.0`, `0.2.0`, and `0.2`, and point stable onboarding at `v0.2.0`
- document the v0.2.0 scope and the maintainer release/verification runbook

## Why

A star-growth onboarding path needs one stable, auditable install target. This PR turns the already-tested demo and C++ package into a repeatable tagged release without making a branch push capable of publishing a GitHub Release.

## Validation

- `python3 tests/test_release_contracts.py` (10 tests)
- `python3 scripts/release/validate_version.py --tag v0.2.0`
- `bash scripts/ci/run_hygiene.sh`
- `python3 -m mkdocs build --strict`
- focused packaging/docs/CLI tests (23 tests)
- full `tests.test_packaging` against a fresh Release build (3 tests)
- CPack TGZ + DEB, checksum verification
- clean `ubuntu:24.04` DEB install and `gnss demo` smoke: 8/8 valid solutions and all three output artifacts

The tag-only Release workflow will be exercised after this PR passes CI and is merged.