### PR TITLE
fix: upload only validated release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,6 +92,7 @@ jobs:
           '
 
     - name: Check package contents and generate checksums
+      id: package_assets
       shell: bash
       run: |
         set -euo pipefail
@@ -102,6 +103,11 @@ jobs:
         test "${#deb[@]}" -eq 1
         [[ "$(basename "${tgz[0]}")" == *"${version}"* ]]
         [[ "$(basename "${deb[0]}")" == *"${version}"* ]]
+        test -f "${tgz[0]}"
+        test ! -L "${tgz[0]}"
+        test -f "${deb[0]}"
+        test ! -L "${deb[0]}"
+        checksums="dist/SHA256SUMS"
 
         # Consume the complete listing before grep exits so pipefail cannot
         # turn a successful content match into a SIGPIPE failure.
@@ -115,6 +121,17 @@ jobs:
           sha256sum "$(basename "${tgz[0]}")" "$(basename "${deb[0]}")" > SHA256SUMS
           sha256sum -c SHA256SUMS
         )
+        test -f "${checksums}"
+        test ! -L "${checksums}"
+
+        # Export only the three validated regular files. CPack may leave
+        # staging directories under dist/, which must never become release
+        # upload arguments.
+        {
+          printf 'tgz=%s\n' "${tgz[0]}"
+          printf 'deb=%s\n' "${deb[0]}"
+          printf 'checksums=%s\n' "${checksums}"
+        } >> "${GITHUB_OUTPUT}"
 
     - name: Preserve release assets as a workflow artifact
       uses: actions/upload-artifact@v7
@@ -128,6 +145,9 @@ jobs:
       env:
         GH_TOKEN: ${{ github.token }}
         RELEASE_TAG: ${{ github.ref_name }}
+        TGZ_ASSET: ${{ steps.package_assets.outputs.tgz }}
+        DEB_ASSET: ${{ steps.package_assets.outputs.deb }}
+        CHECKSUMS_ASSET: ${{ steps.package_assets.outputs.checksums }}
       run: |
         set -euo pipefail
         notes_file="docs/releases/${RELEASE_TAG}.md"
@@ -150,6 +170,9 @@ jobs:
 
         # Upload separately even after creation so retries repair a partial
         # release and replace stale assets deterministically.
-        gh release upload "${RELEASE_TAG}" dist/* \
+        gh release upload "${RELEASE_TAG}" \
+          "${TGZ_ASSET}" \
+          "${DEB_ASSET}" \
+          "${CHECKSUMS_ASSET}" \
           --repo "${GITHUB_REPOSITORY}" \
           --clobber

--- a/docs/release_runbook.md
+++ b/docs/release_runbook.md
@@ -36,6 +36,8 @@ workflow never creates a Git tag.
 
 - Confirm the workflow artifact contains exactly one TGZ, one DEB, and
   `SHA256SUMS`; verify the checksums locally with `sha256sum -c SHA256SUMS`.
+- The GitHub Release upload is limited to those three validated regular files;
+  CPack staging directories under `dist/` are not release assets.
 - The DEB declares Eigen development headers and the Python runtime,
   NumPy, and Matplotlib dependencies, and the workflow installs it in a
   fresh Ubuntu 24.04 amd64 container before running the offline demo.

--- a/tests/test_release_contracts.py
+++ b/tests/test_release_contracts.py
@@ -106,6 +106,26 @@ class ReleaseWorkflowContractTest(unittest.TestCase):
         self.assertIn("--clobber", self.release_workflow)
         self.assertNotIn("git tag", self.release_workflow)
 
+    def test_release_upload_is_limited_to_three_validated_regular_files(self) -> None:
+        self.assertIn("id: package_assets", self.release_workflow)
+        self.assertIn('test -f "${tgz[0]}"', self.release_workflow)
+        self.assertIn('test ! -L "${tgz[0]}"', self.release_workflow)
+        self.assertIn('test -f "${deb[0]}"', self.release_workflow)
+        self.assertIn('test ! -L "${deb[0]}"', self.release_workflow)
+        self.assertIn("test -f \"${checksums}\"", self.release_workflow)
+        self.assertIn("test ! -L \"${checksums}\"", self.release_workflow)
+        self.assertIn("printf 'tgz=%s\\n' \"${tgz[0]}\"", self.release_workflow)
+        self.assertIn("printf 'deb=%s\\n' \"${deb[0]}\"", self.release_workflow)
+        self.assertIn("printf 'checksums=%s\\n' \"${checksums}\"", self.release_workflow)
+        self.assertIn("TGZ_ASSET: ${{ steps.package_assets.outputs.tgz }}", self.release_workflow)
+        self.assertIn("DEB_ASSET: ${{ steps.package_assets.outputs.deb }}", self.release_workflow)
+        self.assertIn("CHECKSUMS_ASSET: ${{ steps.package_assets.outputs.checksums }}", self.release_workflow)
+        self.assertIn('"${TGZ_ASSET}"', self.release_workflow)
+        self.assertIn('"${DEB_ASSET}"', self.release_workflow)
+        self.assertIn('"${CHECKSUMS_ASSET}"', self.release_workflow)
+        self.assertNotIn("gh release upload \"${RELEASE_TAG}\" dist/*", self.release_workflow)
+        self.assertNotIn("gh release upload \"${RELEASE_TAG}\" dist/", self.release_workflow)
+
     def test_release_uses_only_the_contents_write_permission(self) -> None:
         self.assertIn("permissions:\n  contents: write", self.release_workflow)
         self.assertNotIn("packages:", self.release_workflow)


### PR DESCRIPTION
## Summary

- export the validated TGZ, DEB, and checksum paths from the package verification step
- upload only those three regular, non-symlink files to GitHub Releases
- prohibit the broad `dist/*` upload contract and document the CPack staging-directory boundary

## Root cause

The v0.2.0 Release job successfully built, packaged, smoke-installed, and checksummed the distribution, then passed `dist/*` to `gh release upload`. CPack leaves `dist/_CPack_Packages` as a directory, so `gh` uploaded `SHA256SUMS` and then failed when it reached that directory.

The existing v0.2.0 tag was not moved. Its verified workflow artifact was used to restore the published TGZ and DEB, and the public downloads now pass `sha256sum -c`.

## Impact

Tagged release retries keep `--clobber` repair behavior while never passing CPack staging directories to the release API.

## Validation

- `python3 tests/test_release_contracts.py` (11 tests)
- `bash scripts/ci/run_hygiene.sh` (includes actionlint)
- `python3 -m mkdocs build --strict`
- `git diff --check`
- confirmed the real CPack output contains `dist/_CPack_Packages`
