### PR TITLE
docs: add community onboarding

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,7 @@
 name: Bug report
 description: Report a reproducible regression or unexpected solver/tool behavior.
 title: "[bug] "
-labels: ["bug", "needs-triage"]
+labels: ["bug"]
 body:
   - type: textarea
     id: observed

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,11 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
-  - name: Validation and sign-off docs
-    url: https://github.com/rsasaki0109/gnssplusplus-library/blob/develop/docs/validation.md
-    about: Use this to choose the smallest relevant sign-off before opening a slice.
+  - name: Support and questions
+    url: https://github.com/rsasaki0109/gnssplusplus-library/issues/new?template=question.yml
+    about: Search the docs first, then use the structured question form for help.
+  - name: Documentation and quick starts
+    url: https://rsasaki0109.github.io/gnssplusplus-library/
+    about: Read the published quick starts, interfaces, and validation notes.
+  - name: Private security report
+    url: https://github.com/rsasaki0109/gnssplusplus-library/security/advisories/new
+    about: Report a suspected vulnerability privately; do not publish details in an issue.

--- a/.github/ISSUE_TEMPLATE/development_slice.yml
+++ b/.github/ISSUE_TEMPLATE/development_slice.yml
@@ -1,7 +1,7 @@
 name: Development slice
 description: Plan one scoped implementation, analysis, or sign-off slice.
 title: "[slice] "
-labels: ["needs-triage"]
+labels: ["help wanted"]
 body:
   - type: dropdown
     id: slice_type

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,50 @@
+name: Feature request
+description: Propose one focused improvement with a concrete user outcome.
+title: "[feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Keep one user-visible value per request. Do not include credentials,
+        private datasets, or vulnerability details here; use SECURITY.md for
+        private security reporting.
+  - type: textarea
+    id: user_problem
+    attributes:
+      label: User problem
+      description: Who is blocked, and what are they trying to do today?
+      placeholder: "As a ..., I need ... because ..."
+    validations:
+      required: true
+  - type: textarea
+    id: smallest_value
+    attributes:
+      label: Smallest useful outcome
+      description: What is the minimum behavior or artifact that would help?
+      placeholder: "A command, option, report field, parser path, or doc change that ..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposed_shape
+    attributes:
+      label: Proposed shape
+      description: Give an example command, API, config, or documentation flow if useful.
+    validations:
+      required: false
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      description: List concrete checks or artifacts that would show the request is complete.
+      placeholder: "Focused test passes; command emits ...; docs example works ..."
+    validations:
+      required: true
+  - type: textarea
+    id: data_needs
+    attributes:
+      label: Data and credential needs
+      description: State required datasets, network access, credentials, and safe skip behavior. Write None when no special inputs are needed.
+      placeholder: "None, or GNSSPP_DATA_ROOT=...; CI can skip clearly when absent."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,48 @@
+name: Question
+description: Ask for usage or documentation help with enough context to reproduce the question.
+title: "[question] "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Search the quick starts and existing issues first. Never post
+        credentials, private datasets, or suspected vulnerability details.
+  - type: textarea
+    id: goal
+    attributes:
+      label: Goal
+      description: What are you trying to accomplish with libgnss++?
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Which version or commit, operating system, command, and input format are involved?
+      placeholder: "v0.2.0; Ubuntu 24.04; gnss ppp; RINEX 3 ..."
+    validations:
+      required: true
+  - type: textarea
+    id: tried
+    attributes:
+      label: What you tried
+      description: Include the smallest command, relevant output, and documentation or issue pages you searched.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected result or remaining question
+      description: What did you expect, and what remains unclear?
+    validations:
+      required: true
+  - type: textarea
+    id: data_needs
+    attributes:
+      label: Data and credential needs
+      description: State whether a public fixture is enough or whether local data is required. Do not attach private data.
+      placeholder: "Public synthetic fixture is enough, or describe the redacted input shape."
+    validations:
+      required: true

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,29 @@
+# Code of Conduct
+
+libgnss++ aims to be a respectful, practical place to learn, ask questions,
+and improve GNSS software. Participate in good faith, assume context may be
+missing, and give feedback about code and ideas rather than people.
+
+## Scope
+
+This policy applies in the repository, its issue and pull-request tracker,
+published documentation, and project spaces when they are used for libgnss++
+work. It covers maintainers, contributors, reviewers, and visitors.
+
+Unacceptable conduct includes harassment, discrimination, threats, personal
+attacks, sexualized attention, doxxing, deliberate disruption, and publishing
+someone else's private information. Technical disagreement is welcome when it
+stays focused, specific, and professional.
+
+## Reporting and enforcement
+
+For conduct concerns, contact the maintainer privately at
+`rsasaki0109@gmail.com` (the address published on the maintainer's GitHub
+profile). For abuse of GitHub accounts or content, use
+[GitHub's abuse reporting form](https://github.com/contact/report-abuse).
+
+Maintainers may investigate privately, remove or edit violating content,
+close issues or pull requests, and restrict or end participation when needed.
+Actions should be proportionate to the conduct and may be taken without
+publicly disclosing reporter details. Questions about an enforcement decision
+may be sent to the same maintainer address.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,12 @@
 # Contributing
 
+## 15-minute first contribution
+
+New to the project? Start with the [community onboarding guide](docs/community.md)
+to choose a docs-only, Python tool/test, or C++ lane and run its smallest
+validation command. It also links the structured question, bug, and feature
+forms plus private security reporting.
+
 ## Branch And PR Workflow
 
 - Do not push new feature work directly to `develop`.

--- a/README.md
+++ b/README.md
@@ -381,6 +381,7 @@ docker run --rm -it -p 8085:8085 -v "$PWD:/workspace" \
 - [Interfaces](docs/interfaces.md)
 - [Architecture](docs/architecture.md)
 - [Reference analyses](docs/references/index.md)
+- [Community onboarding](docs/community.md)
 - [Contributing](CONTRIBUTING.md)
 
 ## Install

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security policy
+
+## Supported versions
+
+The `v0.2.x` line is supported on a best-effort basis. Older versions may be
+useful for reproducing history but do not receive a security response promise.
+
+## Reporting a vulnerability
+
+Please do not put vulnerability details in a public issue, pull request, or
+support form. Use GitHub's
+[private vulnerability reporting](https://github.com/rsasaki0109/gnssplusplus-library/security/advisories/new)
+to send the report to the maintainers. The repository owner will enable this
+feature after this policy merges; if the private-report link is unavailable,
+send a private report to `rsasaki0109@gmail.com` instead.
+
+Useful reports include the affected version or commit, a minimal
+reproduction, impact, and any input or parser boundary involved. Remove
+credentials, private datasets, and other sensitive material before sending.
+
+## Scope
+
+Reports are in scope for vulnerabilities in GNSS input and parser handling
+(including RINEX, RTCM, UBX, SBF, NMEA, and BINEX), network streams or product
+fetching, the CLI and Python bindings, installed tooling, and release or
+container packaging. Ordinary field-accuracy differences, expected errors on
+malformed inputs, and local environment problems are not security reports by
+themselves.
+
+## Response expectations
+
+Security handling is best-effort and has no SLA. Maintainers will acknowledge
+reports when practical, investigate reproducible impact, and coordinate a
+fix or mitigation when warranted. Do not assume a report is accepted until a
+maintainer confirms it privately.

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,18 @@
+# Support
+
+Use the smallest route that matches the question. Please do not include
+credentials, private datasets, or sensitive receiver logs in public issues.
+
+1. Start with the [quick start](https://rsasaki0109.github.io/gnssplusplus-library/quickstart/),
+   search the [documentation index](https://rsasaki0109.github.io/gnssplusplus-library/),
+   and check existing issues.
+2. For a usage question or unclear documentation, open the
+   [question form](https://github.com/rsasaki0109/gnssplusplus-library/issues/new?template=question.yml).
+3. For a reproducible regression or unexpected tool result, use the
+   [bug report form](https://github.com/rsasaki0109/gnssplusplus-library/issues/new?template=bug_report.yml)
+   with the smallest command and relevant output.
+4. For a proposed capability, use the
+   [feature request form](https://github.com/rsasaki0109/gnssplusplus-library/issues/new?template=feature_request.yml)
+   and describe the user problem and smallest useful outcome.
+5. For a suspected vulnerability, do not open an issue; follow
+   [SECURITY.md](SECURITY.md)'s private reporting route.

--- a/docs/community.md
+++ b/docs/community.md
@@ -1,0 +1,72 @@
+# Community onboarding
+
+Welcome. The fastest path for a first contribution is one small, reviewable
+change with one clear user value. This **15-minute first contribution** path
+helps you choose a lane, find an appropriately sized issue, and run a focused
+check before opening a pull request.
+
+## Route the conversation
+
+- Search the [quick start](quickstart.md), [interfaces](interfaces.md), and
+  [validation](validation.md) pages first.
+- Ask for usage or documentation help with the
+  [question form](https://github.com/rsasaki0109/gnssplusplus-library/issues/new?template=question.yml).
+- Report a reproducible regression with the
+  [bug report form](https://github.com/rsasaki0109/gnssplusplus-library/issues/new?template=bug_report.yml).
+- Propose one focused capability with the
+  [feature form](https://github.com/rsasaki0109/gnssplusplus-library/issues/new?template=feature_request.yml).
+- Report suspected vulnerabilities privately using
+  [SECURITY.md](https://github.com/rsasaki0109/gnssplusplus-library/blob/develop/SECURITY.md);
+  do not put them in a public issue.
+
+Good starting searches are [good first issue](https://github.com/rsasaki0109/gnssplusplus-library/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22)
+and [help wanted](https://github.com/rsasaki0109/gnssplusplus-library/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22).
+
+## Three contribution lanes
+
+Pick one lane and keep the first change narrow. In every lane, finish with
+`git diff --check` and describe the exact check in the pull request.
+
+### Docs-only
+
+Edit the smallest page or example, then build the site strictly:
+
+```bash
+python3 -m mkdocs build --strict --site-dir /tmp/libgnsspp-site
+```
+
+Install the pinned docs requirements from `requirements-docs.txt` first if
+MkDocs is not available locally.
+
+### Python tool or test
+
+Keep the change focused on one CLI surface, helper, or pure-Python regression
+and run the small CLI UX suite:
+
+```bash
+python3 tests/test_cli_ux.py
+```
+
+For a new pure-Python contract, add a stdlib-only test under `tests/` and run
+that file directly as well.
+
+### C++
+
+For a library, parser, or native CLI change, configure a Release test build
+and run the consolidated test target:
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=ON -DGNSSPP_BUILD_PYTHON_BINDINGS=OFF
+cmake --build build --target gnss_run_tests --parallel 2
+ctest --test-dir build -R '^run_tests$' --output-on-failure
+```
+
+Use a focused existing test or fixture when the full target is not needed,
+and state any dataset or credential requirement explicitly.
+
+## Before opening the pull request
+
+Keep the branch based on current `develop`, explain the user-visible value,
+name non-goals, and include the smallest passing command. The longer
+[contributor guide](contributing.md) covers PR boundaries and the broader CI
+lanes.

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ checked benchmark artifacts.
 - [Self-contained offline demo](self_contained_demo.md)
 - [v0.2.0 release highlights](releases/v0.2.0.md)
 - [Maintainer release runbook](release_runbook.md)
+- [Community onboarding](community.md)
 - [Dataset gallery](dataset_gallery.md)
 - [Architecture notes](architecture.md)
 - [Quick start](quickstart.md)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,7 @@ nav:
   - Self-contained Offline Demo: self_contained_demo.md
   - v0.2.0 Release Highlights: releases/v0.2.0.md
   - Maintainer Release Runbook: release_runbook.md
+  - Community Onboarding: community.md
   - Dataset Gallery: dataset_gallery.md
   - Architecture: architecture.md
   - Quick Start: quickstart.md

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -412,6 +412,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_release_contracts.py
     )
     add_test(
+        NAME python_community_health_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_community_health.py
+    )
+    add_test(
         NAME python_bindings_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_python_bindings.py
     )
@@ -512,6 +516,7 @@ if(GTest_FOUND)
         python_observable_native_cli_contract_tests
         python_search_imu_time_offset_tests
         python_release_contract_tests
+        python_community_health_tests
     )
     set(GNSSPP_EXTENDED_TESTS
         python_packaging_tests

--- a/tests/test_community_health.py
+++ b/tests/test_community_health.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""Pure-stdlib regression checks for the public community onboarding surface."""
+
+from __future__ import annotations
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+ISSUE_TEMPLATE_DIR = ROOT_DIR / ".github" / "ISSUE_TEMPLATE"
+ALLOWED_LABELS = {
+    "bug",
+    "documentation",
+    "enhancement",
+    "good first issue",
+    "help wanted",
+    "question",
+}
+
+
+def read(relative_path: str) -> str:
+    return (ROOT_DIR / relative_path).read_text(encoding="utf-8")
+
+
+def form_labels(relative_path: str) -> set[str]:
+    text = read(relative_path)
+    match = re.search(r"^labels:\s*\[(.*?)\]\s*$", text, re.MULTILINE)
+    if match is None:
+        return set()
+    return {
+        item.strip().strip("\"'")
+        for item in match.group(1).split(",")
+        if item.strip()
+    }
+
+
+class CommunityHealthTest(unittest.TestCase):
+    def test_required_community_files_exist(self) -> None:
+        for relative_path in (
+            "CODE_OF_CONDUCT.md",
+            "SECURITY.md",
+            "SUPPORT.md",
+            ".github/ISSUE_TEMPLATE/feature_request.yml",
+            ".github/ISSUE_TEMPLATE/question.yml",
+            "docs/community.md",
+        ):
+            with self.subTest(path=relative_path):
+                self.assertTrue((ROOT_DIR / relative_path).is_file())
+
+    def test_issue_forms_use_only_existing_labels_and_no_stale_triage_label(self) -> None:
+        forms = sorted(ISSUE_TEMPLATE_DIR.glob("*.yml"))
+        self.assertTrue(forms)
+        for path in forms:
+            text = path.read_text(encoding="utf-8")
+            with self.subTest(path=path.name):
+                self.assertNotIn("needs-triage", text)
+                self.assertTrue(form_labels(str(path.relative_to(ROOT_DIR))) <= ALLOWED_LABELS)
+        self.assertEqual(form_labels(".github/ISSUE_TEMPLATE/bug_report.yml"), {"bug"})
+        self.assertEqual(form_labels(".github/ISSUE_TEMPLATE/development_slice.yml"), {"help wanted"})
+        self.assertEqual(form_labels(".github/ISSUE_TEMPLATE/feature_request.yml"), {"enhancement"})
+        self.assertEqual(form_labels(".github/ISSUE_TEMPLATE/question.yml"), {"question"})
+
+    def test_issue_config_disables_blank_issues_and_routes_support_docs_security(self) -> None:
+        config = read(".github/ISSUE_TEMPLATE/config.yml")
+        self.assertIn("blank_issues_enabled: false", config)
+        self.assertIn("name: Support and questions", config)
+        self.assertIn("name: Documentation and quick starts", config)
+        self.assertIn("name: Private security report", config)
+        self.assertIn("issues/new?template=question.yml", config)
+        self.assertIn("rsasaki0109.github.io/gnssplusplus-library/", config)
+        self.assertIn("security/advisories/new", config)
+        self.assertNotIn("discussions", config.lower())
+
+    def test_forms_have_structured_user_value_and_data_fields(self) -> None:
+        feature = read(".github/ISSUE_TEMPLATE/feature_request.yml")
+        question = read(".github/ISSUE_TEMPLATE/question.yml")
+        for field in ("user_problem", "smallest_value", "acceptance", "data_needs"):
+            with self.subTest(form="feature", field=field):
+                self.assertIn(f"id: {field}", feature)
+        for field in ("goal", "context", "tried", "expected", "data_needs"):
+            with self.subTest(form="question", field=field):
+                self.assertIn(f"id: {field}", question)
+
+    def test_policy_routing_and_enforcement_contracts(self) -> None:
+        conduct = read("CODE_OF_CONDUCT.md")
+        security = read("SECURITY.md")
+        support = read("SUPPORT.md")
+        self.assertIn("rsasaki0109@gmail.com", conduct)
+        self.assertIn("github.com/contact/report-abuse", conduct)
+        self.assertIn("Scope", conduct)
+        self.assertIn("enforcement", conduct.lower())
+        self.assertIn("v0.2.x", security)
+        self.assertIn("security/advisories/new", security)
+        self.assertIn("best-effort", security)
+        self.assertIn("no SLA", security)
+        for token in ("RINEX", "RTCM", "UBX", "Python bindings"):
+            with self.subTest(token=token):
+                self.assertIn(token, security)
+        for token in ("question.yml", "bug_report.yml", "feature_request.yml", "SECURITY.md"):
+            with self.subTest(token=token):
+                self.assertIn(token, support)
+
+    def test_first_contribution_links_and_three_lanes_are_visible(self) -> None:
+        community = read("docs/community.md")
+        contributing = read("CONTRIBUTING.md")
+        docs_index = read("docs/index.md")
+        mkdocs = read("mkdocs.yml")
+        readme = read("README.md")
+        self.assertIn("15-minute first contribution", community)
+        for token in (
+            "Docs-only",
+            "Python tool or test",
+            "C++",
+            "good first issue",
+            "help wanted",
+            "python3 -m mkdocs build --strict",
+            "python3 tests/test_cli_ux.py",
+            "cmake -S . -B build",
+        ):
+            with self.subTest(token=token):
+                self.assertIn(token, community)
+        self.assertIn("docs/community.md", contributing)
+        self.assertIn("15-minute first contribution", contributing)
+        self.assertIn("Community onboarding", docs_index)
+        self.assertIn("Community Onboarding: community.md", mkdocs)
+        self.assertIn("docs/community.md", readme)
+        self.assertNotIn("discussions", community.lower())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Value
Give first-time users and contributors a clear route to ask, propose, contribute, and report security issues privately.

## What changed
- add Code of Conduct, security, and support policies
- add structured question and feature Issue Forms
- remove the nonexistent `needs-triage` label and disable blank issues
- publish a 15-minute first-contribution guide for docs, Python, and C++ lanes
- add a stdlib community-health contract test to the core test suite

## Validation
- `python3 tests/test_community_health.py`
- `python3 tests/test_cli_ux.py`
- `bash scripts/ci/run_hygiene.sh`
- `python3 -m mkdocs build --strict --site-dir /tmp/gnsspp-community-review-site`
- YAML parse of all `.github/ISSUE_TEMPLATE/*.yml`
- `git diff --check`

After merge, private vulnerability reporting will be enabled in repository settings.
