### PR TITLE
docs: add runnable use-case guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ handling without an external RTKLIB runtime.
 - Products: `SP3`, `CLK`, `IONEX`, `DCB`
 - Extras: benchmarks, web dashboard, Python bindings, Docker, ROS 2 playback
 
+[Choose a use case](docs/use_cases.md): [RTKLIB migration](docs/use_cases/rtklib_migration.md),
+[ROS2 receiver/bag replay](docs/use_cases/ros2.md), or [QZSS L6 / CLAS / MADOCA](docs/use_cases/qzss_l6.md).
+
 ![Feature overview](docs/libgnsspp_feature_overview.png)
 
 ## Try it

--- a/docs/index.md
+++ b/docs/index.md
@@ -8,6 +8,7 @@ checked benchmark artifacts.
 
 ## Start here
 
+- [Use cases](use_cases.md)
 - [Robotics quick start](robotics_quickstart.md)
 - [Research quick start](research_quickstart.md)
 - [Self-contained offline demo](self_contained_demo.md)

--- a/docs/use_cases.md
+++ b/docs/use_cases.md
@@ -1,0 +1,16 @@
+# Use cases
+
+Choose the row that matches the input already on your desk. Each route is
+intentionally small: make one first artifact, inspect it, then decide whether
+the longer validation path is worth the time.
+
+| Who | Input | First output | Rough time | Guide |
+|---|---|---|---:|---|
+| RTKLIB user moving an `rnx2rtkp` batch job | Rover/base/navigation RINEX and an RTKLIB-style configuration | One libgnss++ `.pos` file, with optional KML | 5–15 min after the native build | [RTKLIB migration](use_cases/rtklib_migration.md) |
+| ROS2 or robotics developer checking a receiver bag | ROS2 package, a UBX/SBF receiver, or an existing bag | Doctor JSON plus a replay `.pos`/KML pair when a bag is available | 5–10 min | [ROS2](use_cases/ros2.md) |
+| QZSS L6 / CLAS / MADOCA investigator | Raw L6 bytes, Compact SSR, or L6E/L6D files and matching RINEX | L6 frame/subframe CSV, correction CSV, or PPP summary JSON | 2–15 min | [QZSS L6 and CLAS/MADOCA](use_cases/qzss_l6.md) |
+
+The routes share the repository's [interfaces](interfaces.md),
+[validation](validation.md), and [benchmark](benchmarks.md) contracts. A first
+artifact is a wiring check, not a claim about field accuracy or deployment
+fitness.

--- a/docs/use_cases/qzss_l6.md
+++ b/docs/use_cases/qzss_l6.md
@@ -1,0 +1,165 @@
+# QZSS L6, CLAS, and MADOCA
+
+Use this route when the input is a QZSS L6 capture or a correction file. The
+small offline smoke below exercises the existing raw-frame decoder without a
+receiver, credentials, or network access. The later commands show the
+repository's CLAS/PPP and native MADOCA paths with your own local files.
+
+## First output: decode a small L6 capture
+
+The repository already contains the deterministic frame builder used by the
+CLI tests. Create five valid 250-byte frames from it:
+
+```bash
+mkdir -p output/use_cases/qzss_l6
+python3 - <<'PY'
+from pathlib import Path
+from tests.cli_cases._support import build_qzss_l6_frame
+
+capture = b"".join(
+    build_qzss_l6_frame(
+        prn=199,
+        facility_id=0,
+        subframe_start=(index == 0),
+        alert=False,
+        data_part=b"CLAS-L6-SMOKE",
+    )
+    for index in range(5)
+)
+Path("output/use_cases/qzss_l6/smoke_l6.bin").write_bytes(capture)
+PY
+```
+
+Run the exact repository decoder and retain its text summary and CSV files:
+
+```bash
+python3 apps/gnss.py qzss-l6-info \
+  --input output/use_cases/qzss_l6/smoke_l6.bin \
+  --limit 100 \
+  --extract-data-parts output/use_cases/qzss_l6/data_parts.csv \
+  --extract-subframes output/use_cases/qzss_l6/subframes.csv \
+  | tee output/use_cases/qzss_l6/summary.txt
+```
+
+The first line is a `summary:` record with `frames`, `valid`, `subframes`,
+`prns`, and related counts. `data_parts.csv` begins with
+`frame_index,prn,vendor_id,facility_id,reserved_bits,subframe_start,alert`;
+`subframes.csv` begins with
+`subframe_index,prn,vendor_id,facility_id,frame_count,alert_frames`. A
+non-zero process exit, a missing `summary:` line, or an empty CSV is a failed
+smoke. This fixture is a decoder wiring check, not a CLAS correction stream.
+
+For a real capture, add the existing extraction switches as needed:
+`--extract-compact-messages`, `--extract-compact-corrections`,
+`--extract-service-info`, and `--show-preview`. The full option surface is in
+the [interfaces guide](../interfaces.md).
+
+## CLAS PPP path
+
+With a rover observation file, matching navigation file, and a raw L6 capture
+that contains the corrections required by the selected epochs, run the
+repository's no-credential local path:
+
+```bash
+python3 apps/gnss.py clas-ppp \
+  --profile clas \
+  --obs <rover.obs> \
+  --nav <navigation.nav> \
+  --qzss-l6 <qzss-l6-capture.bin> \
+  --qzss-gps-week 2200 \
+  --out output/use_cases/qzss_l6/clas_solution.pos \
+  --summary-json output/use_cases/qzss_l6/clas_summary.json
+```
+
+The summary JSON exposes the route's measurable artifacts, including
+`correction_profile`, `ssr_transport`, `correction_encoding`, `qzss_l6`,
+`epochs`, `ppp_float_epochs`, `ppp_fixed_epochs`, `fallback_epochs`,
+`ppp_solution_rate_pct`, `atmos_messages`, `atmos_rows`,
+`ppp_atmospheric_trop_corrections`, and
+`ppp_atmospheric_ionosphere_corrections`. Exit criteria are a zero process
+return, a non-empty `.pos` beginning with `% LibGNSS++ Position Solution`, and
+a summary whose `qzss_l6` and epoch counts describe the input rather than an
+empty fallback run. The [CLAS validated-datasets notes](../clas_validated_datasets.md)
+show the same command family and its validation expectations.
+
+## Native MADOCA L6E/L6D path
+
+`apps/gnss.py ppp` dispatches to the native `gnss_ppp` executable. Build it
+before asking the dispatcher for help. Use the existing [Robotics quick
+start](../robotics_quickstart.md) for the full native build, or run this
+small prerequisite from the repository root:
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --target gnss_ppp --parallel 2
+test -x build/apps/gnss_ppp
+```
+
+For native MADOCA Compact SSR materialization, inspect the current CLI and
+then provide an L6E file plus its matching navigation data:
+
+```bash
+python3 apps/gnss.py ppp --help
+python3 apps/gnss.py ppp \
+  --obs <rover.obs> \
+  --nav <navigation.nav> \
+  --madoca-l6 <madoca-l6e-file> \
+  --madoca-materialization-dump \
+    output/use_cases/qzss_l6/madoca_l6e_materialization.csv \
+  --summary-json output/use_cases/qzss_l6/madoca_materialization_summary.json \
+  --madoca-materialization-dump-only
+```
+
+The materialization CSV is the first output for this diagnostic path. Its
+header starts with `schema_version,sat,system,prn,week,tow,orbit_frame` and
+continues with orbit/clock validity, reference epochs, IODs, RAC orbit
+components, `clock_m`, `code_biases_m`, and `phase_biases_m` fields. A
+non-empty file with at least one row and a zero return is the materialization
+exit condition. For PPP application, retain the L6E input, add the L6D file,
+and select the required per-frequency ambiguity mode:
+
+```bash
+python3 apps/gnss.py ppp \
+  --obs <rover.obs> \
+  --nav <navigation.nav> \
+  --madoca-l6 <madoca-l6e-file> \
+  --madoca-l6d <madoca-l6d-file> \
+  --ar-method per-freq \
+  --out output/use_cases/qzss_l6/madoca_solution.pos \
+  --summary-json output/use_cases/qzss_l6/madoca_summary.json
+```
+
+`--madoca-l6d` is an opt-in per-frequency application path and requires an
+L6E input. Use `--madoca-l6d-shadow <file>` when only the diagnostic shadow
+comparison is wanted. A successful application has a non-empty libgnss++
+`.pos` and summary JSON; check the summary's `processed_epochs`,
+`valid_solutions`, `ppp_float_solutions`, `ppp_fixed_solutions`,
+`fallback_solutions`, and MADOCA input/materialization fields before
+comparing it.
+
+## Supported boundary and next step
+
+The current boundaries are intentionally specific:
+
+- `qzss-l6-info` decodes the raw CSSR type 4073 stream. Its Python decoder
+  has explicit branches for the direct CLAS vendor path at subtypes
+  1/2/3/4/5/6/7/8/9/10/11/12.
+- The native `libgnss++` QZSS L6 decoder exposes handlers for subtypes
+  1/2/3/4/5/6/7/8/9/11; subtypes 10 and 12 stop at the native switch's
+  unknown-subtype boundary. This is a different interface boundary from the
+  inspection CLI.
+- Native MADOCA L6E handles Compact SSR subtypes 1/2/3/4/5/7, while the
+  L6D decoder covers the implemented MT1/MT2 ionosphere-region corrections.
+- `clas-ppp` adapts raw L6 into the repository's compact-correction PPP path;
+  native `ppp` consumes the MADOCA L6E/L6D options described above.
+
+These are implemented slices, not a claim of full L6D, L6E, CLAS, MADOCA,
+vendor, facility, or message coverage, nor a claim of PPP accuracy for every
+capture. Use the [validation guide](../validation.md), [benchmark notes](../benchmarks.md),
+and [interfaces](../interfaces.md) to define a measured next step. The
+[CLAS decoder gap note](../references/claslib-gap.md) records known boundary
+details.
+
+Next step: retain the raw capture, input file hashes, GPS-week/time window,
+materialization or summary keys, and a reference solution before tuning or
+claiming correction performance.

--- a/docs/use_cases/ros2.md
+++ b/docs/use_cases/ros2.md
@@ -1,0 +1,139 @@
+# ROS2 receiver and bag replay
+
+Use this route when the input is a ROS2 receiver stream or an existing bag.
+It deliberately starts with diagnostics, then checks whether the bag contains
+the topics needed by the repository's existing replay node. The first output
+is a JSON health report; a replay `.pos`/KML pair is the first position
+artifact when a suitable bag is available.
+
+Run dispatcher and `output/use_cases/...` commands from the repository root.
+The ROS2 build changes the current shell's environment;
+each new shell used for recording or replay must source the same
+`ros2/install/setup.bash` file.
+
+## 1. Check the receiver path
+
+The doctor command is runnable before a ROS2 workspace is built. Replace the
+device URI with the receiver in scope:
+
+```bash
+mkdir -p output/use_cases
+python3 apps/gnss.py ros2-doctor \
+  --device /dev/ttyUSB0 \
+  --json > output/use_cases/ros2_doctor.json
+```
+
+The JSON has `root`, `ok`, `checks`, and `commands` keys. A zero exit and an
+`ok` value of `true` mean the serial-device checks passed; retain the report
+even when they do not. `ros2-doctor --help` lists `--strict` for a CI-style
+failure on warnings. A missing device is a diagnostic result, not a reason to
+invent a playback result.
+
+If `ros2` or `colcon` is not installed, stop this route after saving the
+doctor output and follow the [interfaces guide](../interfaces.md) for the
+non-ROS2 CLI surfaces. Do not run the build, launch, or bag commands below
+until the ROS2 dependencies are present.
+
+## 2. Inspect an existing bag
+
+For a bag directory, run the repository's bag doctor before playback:
+
+```bash
+python3 apps/gnss.py ros2-bag-doctor \
+  --bag <bag-directory> \
+  --summary-json output/use_cases/ros2_bag_doctor_summary.json
+```
+
+The report contains `status`, `replayable_raw_binary`, `topic_status`,
+`topics`, `checks`, and `commands`. `status: ready` requires message-level
+`/gnss/raw_binary` and `/gnss/fix` data; metadata-only bags are reported as
+`partial-metadata`. If there is no bag, skip this step and use the live launch
+path below. A skipped step is not evidence that replay is ready.
+
+## 3. Build and use the existing driver/replay path
+
+The commands below are the sequence documented by
+`ros2/gnss_raw_driver/README.md`:
+
+```bash
+# Run this block from the repository root.
+REPO_ROOT="$(pwd)"
+cd ros2
+colcon build --symlink-install --packages-select gnss_raw_driver
+source install/setup.bash
+ros2 launch gnss_raw_driver gnss_raw_driver.launch.py \
+  device:=/dev/ttyUSB0 baud_rate:=115200 protocol:=auto frame_id:=gnss \
+  publish_raw_binary:=true
+```
+
+The launch keeps this shell in `$REPO_ROOT/ros2` until you stop it with
+Ctrl-C. After stopping it, return to the repository root before running any
+dispatcher or output command:
+
+```bash
+cd "$REPO_ROOT"
+```
+
+In another shell, start from this repository, source the ROS2 workspace again,
+and record a small bag while the launch is running:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+source ros2/install/setup.bash
+ros2 bag record /gnss/raw_binary /gnss/raw /gnss/fix
+```
+
+Then inspect and replay that bag with the existing processor node:
+
+```bash
+cd "$(git rev-parse --show-toplevel)"
+source ros2/install/setup.bash
+python3 apps/gnss.py ros2-bag-doctor \
+  --bag <bag-directory> \
+  --summary-json output/use_cases/ros2_bag_doctor_summary.json
+ros2 bag play <bag-directory>
+ros2 run gnss_raw_driver gnss_bag_processor_node --ros-args \
+  -p protocol:=auto \
+  -p output_pos:=output/use_cases/ros2_bag_replay.pos \
+  -p output_kml:=output/use_cases/ros2_bag_replay.kml
+```
+
+The driver dependencies are a ROS2 installation, `colcon`, the
+`gnss_raw_driver` package, and a receiver/serial permission for live capture.
+Replay additionally needs a bag containing the topics named above. The
+processor's `protocol:=auto` may be changed only to a protocol supported by
+the existing node; inspect the package README before doing so.
+
+## First artifacts and exit criteria
+
+The diagnostic exit is the JSON file and its `ok`/`status` fields. The replay
+exit is a zero-returning processor with non-empty
+`output/use_cases/ros2_bag_replay.pos` and, when requested,
+`output/use_cases/ros2_bag_replay.kml`:
+
+```bash
+test -s output/use_cases/ros2_doctor.json
+test -s output/use_cases/ros2_bag_doctor_summary.json
+test -s output/use_cases/ros2_bag_replay.pos
+test -s output/use_cases/ros2_bag_replay.kml
+grep -q '^% LibGNSS++ Position Solution' \
+  output/use_cases/ros2_bag_replay.pos
+```
+
+Use the [validation guide](../validation.md) to decide what to verify in the
+solution, and the [benchmark notes](../benchmarks.md) for offline comparisons.
+The [interfaces guide](../interfaces.md) describes the node and artifact
+contracts. These commands check wiring and reproducibility; they do not
+establish production real-time safety, scheduler margin, or localization
+safety.
+
+## Boundary and next step
+
+This route covers the repository's raw-binary topics and bag processor. It is
+not a claim that every ROS2 distribution, receiver protocol, QoS profile, TF
+tree, or estimator integration is supported. A missing ROS2 installation or
+bag has a clear skip path, not a passing replay result.
+
+Next step: archive the doctor JSON, bag summary, exact launch/playback
+arguments, and the validation evidence for the downstream node or estimator
+before treating the artifact as a candidate input.

--- a/docs/use_cases/rtklib_migration.md
+++ b/docs/use_cases/rtklib_migration.md
@@ -1,0 +1,136 @@
+# RTKLIB migration: `rnx2rtkp` to `gnss solve`
+
+Use this route when an existing workflow is organized around
+`rnx2rtkp`: rover/base/navigation RINEX in, a text position file out, and a
+repeatable configuration in between. The first useful result is a non-empty
+libgnss++ `.pos` file from the same observation window.
+
+## First run
+
+`apps/gnss.py solve` dispatches to the native `gnss_solve` executable. Build
+that executable before asking the dispatcher for help. The existing
+[Robotics quick start](../robotics_quickstart.md) shows the broader native
+build and data flow; this is the smallest copy/paste prerequisite for this
+route when run from the repository root:
+
+```bash
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --target gnss_solve --parallel 2
+test -x build/apps/gnss_solve
+```
+
+Check the command surface and create an output directory:
+
+```bash
+python3 apps/gnss.py solve --help
+mkdir -p output/use_cases
+```
+
+With a PPC-Dataset run (or another directory containing the three named
+files), run a bounded 200-epoch sample:
+
+```bash
+RUN_DIR=data/PPC-Dataset/tokyo/run1
+test -r "$RUN_DIR/rover.obs" -a -r "$RUN_DIR/base.obs" -a -r "$RUN_DIR/base.nav"
+
+python3 apps/gnss.py solve \
+  --config configs/examples/solve.example.toml \
+  --rover "$RUN_DIR/rover.obs" \
+  --base "$RUN_DIR/base.obs" \
+  --nav "$RUN_DIR/base.nav" \
+  --mode kinematic \
+  --preset low-cost \
+  --ratio 2.4 \
+  --max-epochs 200 \
+  --out output/use_cases/rtklib_migration.pos \
+  --kml output/use_cases/rtklib_migration.kml
+```
+
+The `--config` file is an in-tree TOML example with a `[gnss_solve]` table;
+explicit command-line values take precedence. Use `python3 apps/gnss.py
+solve --help-advanced` to inspect additional controls before copying an
+RTKLIB tuning value into a new profile.
+
+## Mapping the `rnx2rtkp` mindset
+
+| `rnx2rtkp` concept | libgnss++ boundary |
+|---|---|
+| Positional rover/base/nav RINEX inputs | `--rover <file>`, `--base <file>`, and `--nav <file>`; `--data-dir <dir>` is the shortcut for `rover.obs`, `base.obs`, and `navigation.nav` |
+| `-k <rtklib.conf>` option file | `--config <path>` with flat TOML defaults under `[gnss_solve]`; command-line flags override the file |
+| `-m`/position mode and receiver tuning | `--mode auto\|kinematic\|static\|moving-base`, plus a named `--preset survey\|low-cost\|moving-base\|odaiba` |
+| `-o <output.pos>` | `--out <file>`; `--kml <file>` is an optional second artifact |
+| RTKLIB status/Q/ns fields | libgnss++ status, satellite count, PDOP, ratio, baseline, and residual telemetry in its own `.pos` schema |
+
+There is no promise that every RTKLIB configuration key has a one-to-one
+`gnss solve` option. Start with the inputs, mode, preset, ratio, and epoch
+window; record any remaining tuning as an explicit experiment.
+
+## `.pos` compatibility boundary
+
+Both tools commonly use the `.pos` suffix, but the file schemas differ. A
+libgnss++ output starts with `% LibGNSS++ Position Solution` and writes
+`GPS_Week GPS_TOW X Y Z Lat Lon Height Status NumSat PDOP Ratio Baseline`
+followed by RTK update telemetry. It is directly consumable by repository
+tools such as `gnss stats`, `gnss compare`, the web UI, and the Python artifact
+helpers. Do not treat the suffix alone as a drop-in RTKLIB interchange
+contract.
+
+To bring an RTKLIB text solution into the libgnss++ artifact surface, use the
+existing adapter:
+
+```bash
+python3 scripts/convert_rtklib_pos.py \
+  output/rtklib_solution.pos \
+  output/use_cases/rtklib_solution_libgnss.pos
+```
+
+The adapter reads RTKLIB date/time, latitude, longitude, height, quality, and
+satellite columns and writes the libgnss++ GPS-week/TOW/ECEF/LLH/status form.
+Inspect the converted header before using it in a comparison.
+
+## Fair comparison checklist
+
+Compare solver behavior only after fixing the experimental inputs:
+
+- use the same rover, base, navigation, antenna coordinates, and signal
+  selection;
+- use the same start/end epoch or the same `--skip-epochs` and `--max-epochs`
+  window;
+- use the same base coordinates (RINEX header or an explicit `--base-ecef`);
+- compare matched `(GPS week, TOW)` rows and keep missing rows visible;
+- keep presets, ratio thresholds, interpolation, and output-status filters
+  recorded beside each artifact;
+- score against an independent reference only after both files are written.
+
+The repository's [validation guide](../validation.md) defines sign-off
+terminology and [benchmarks](../benchmarks.md) documents the RTKLIB `demo5`
+comparison inputs. [Interfaces](../interfaces.md) lists the CLI, file, Python,
+and web consumers of the output.
+
+## First output and exit criteria
+
+The bounded run is wired correctly when it returns zero, creates both files,
+and the position file is non-empty with the libgnss++ header:
+
+```bash
+test -s output/use_cases/rtklib_migration.pos
+test -s output/use_cases/rtklib_migration.kml
+grep -q '^% LibGNSS++ Position Solution' output/use_cases/rtklib_migration.pos
+python3 apps/gnss.py stats output/use_cases/rtklib_migration.pos
+```
+
+For a migration decision, also archive the exact command, input hashes, time
+window, and a matched-row comparison. A produced file by itself is not an
+accuracy or compatibility sign-off.
+
+## Boundary and next step
+
+This guide covers batch RTK post-processing. It does not establish one-to-one
+RTKLIB option parity, a universal accuracy ranking, or suitability for every
+receiver and baseline. For a measured migration, run the relevant [validation
+gates](../validation.md), then use the [benchmark reproduction
+notes](../benchmarks.md) with the same data and time window.
+
+Next step: convert or normalize the reference solution if needed, compare
+matched epochs, and promote a named TOML configuration only after the result
+is reproducible.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,6 +22,11 @@ markdown_extensions:
       permalink: true
 nav:
   - Home: index.md
+  - Use cases:
+      - Overview: use_cases.md
+      - RTKLIB migration: use_cases/rtklib_migration.md
+      - ROS2 receiver and bag replay: use_cases/ros2.md
+      - QZSS L6, CLAS, and MADOCA: use_cases/qzss_l6.md
   - Robotics Quick Start: robotics_quickstart.md
   - Research Quick Start: research_quickstart.md
   - Self-contained Offline Demo: self_contained_demo.md

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -432,6 +432,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_docs_site.py
     )
     add_test(
+        NAME python_use_case_guide_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_use_case_guides.py
+    )
+    add_test(
         NAME python_experiment_runner_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_experiment_runner.py
     )
@@ -515,6 +519,7 @@ if(GTest_FOUND)
         python_gnss_solve_cli_tests
         python_observable_native_cli_contract_tests
         python_search_imu_time_offset_tests
+        python_use_case_guide_tests
         python_release_contract_tests
         python_community_health_tests
     )

--- a/tests/test_use_case_guides.py
+++ b/tests/test_use_case_guides.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""Contract checks for the short, copy/paste-oriented use-case routes."""
+
+import re
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+GUIDES = {
+    "rtklib": ROOT_DIR / "docs" / "use_cases" / "rtklib_migration.md",
+    "ros2": ROOT_DIR / "docs" / "use_cases" / "ros2.md",
+    "qzss": ROOT_DIR / "docs" / "use_cases" / "qzss_l6.md",
+}
+
+
+class UseCaseGuideTest(unittest.TestCase):
+    def test_three_routes_and_required_sections(self) -> None:
+        overview = ROOT_DIR / "docs" / "use_cases.md"
+        self.assertTrue(overview.is_file())
+        overview_text = overview.read_text(encoding="utf-8")
+        for guide_key, guide_path in GUIDES.items():
+            self.assertTrue(guide_path.is_file(), guide_key)
+            self.assertIn(f"use_cases/{guide_path.name}", overview_text)
+
+            guide = guide_path.read_text(encoding="utf-8")
+            self.assertRegex(guide, r"```bash")
+            self.assertRegex(guide.lower(), r"first (output|artifacts?)")
+            self.assertRegex(guide.lower(), r"exit criteria")
+            self.assertRegex(guide.lower(), r"boundary|does not")
+            self.assertIn("Next step", guide)
+
+    def test_commands_are_the_existing_route_surfaces(self) -> None:
+        rtklib = GUIDES["rtklib"].read_text(encoding="utf-8")
+        for token in (
+            "python3 apps/gnss.py solve",
+            "--config configs/examples/solve.example.toml",
+            "--rover",
+            "--base",
+            "--nav",
+            "--out",
+            "scripts/convert_rtklib_pos.py",
+            "build/apps/gnss_solve",
+            "../robotics_quickstart.md",
+        ):
+            self.assertIn(token, rtklib)
+
+        ros2 = GUIDES["ros2"].read_text(encoding="utf-8")
+        for token in (
+            "ros2-doctor",
+            "ros2-bag-doctor",
+            "colcon build --symlink-install --packages-select gnss_raw_driver",
+            "ros2 bag play",
+            "ros2 run gnss_raw_driver gnss_bag_processor_node",
+        ):
+            self.assertIn(token, ros2)
+
+        qzss = GUIDES["qzss"].read_text(encoding="utf-8")
+        for token in (
+            "qzss-l6-info",
+            "--extract-data-parts",
+            "--extract-subframes",
+            "clas-ppp",
+            "--qzss-l6",
+            "--qzss-gps-week",
+            "--madoca-l6",
+            "--madoca-l6d",
+            "--ar-method per-freq",
+            "build/apps/gnss_ppp",
+            "../robotics_quickstart.md",
+        ):
+            self.assertIn(token, qzss)
+
+    def test_referenced_small_fixtures_exist(self) -> None:
+        for relative_path in (
+            "configs/examples/solve.example.toml",
+            "scripts/convert_rtklib_pos.py",
+            "ros2/gnss_raw_driver/README.md",
+            "tests/cli_cases/_support.py",
+        ):
+            self.assertTrue((ROOT_DIR / relative_path).is_file(), relative_path)
+
+    def test_native_build_and_ros2_shell_contracts_are_documented(self) -> None:
+        rtklib = GUIDES["rtklib"].read_text(encoding="utf-8")
+        qzss = GUIDES["qzss"].read_text(encoding="utf-8")
+        ros2 = GUIDES["ros2"].read_text(encoding="utf-8")
+        self.assertIn("cmake --build build --target gnss_solve", rtklib)
+        self.assertIn("test -x build/apps/gnss_solve", rtklib)
+        self.assertIn("cmake --build build --target gnss_ppp", qzss)
+        self.assertIn("test -x build/apps/gnss_ppp", qzss)
+        self.assertIn("source install/setup.bash", ros2)
+        self.assertIn("source ros2/install/setup.bash", ros2)
+        self.assertIn("git rev-parse --show-toplevel", ros2)
+
+    def test_entrypoint_and_mkdocs_links(self) -> None:
+        readme = (ROOT_DIR / "README.md").read_text(encoding="utf-8")
+        index = (ROOT_DIR / "docs" / "index.md").read_text(encoding="utf-8")
+        nav = (ROOT_DIR / "mkdocs.yml").read_text(encoding="utf-8")
+
+        self.assertIn("docs/use_cases.md", readme)
+        self.assertIn("docs/use_cases/rtklib_migration.md", readme)
+        self.assertIn("docs/use_cases/ros2.md", readme)
+        self.assertIn("docs/use_cases/qzss_l6.md", readme)
+        self.assertIn("[Use cases](use_cases.md)", index)
+        self.assertIn("  - Use cases:", nav)
+        for relative_path in (
+            "use_cases.md",
+            "use_cases/rtklib_migration.md",
+            "use_cases/ros2.md",
+            "use_cases/qzss_l6.md",
+        ):
+            self.assertIn(relative_path, nav)
+
+    def test_guides_link_to_interfaces_validation_and_benchmarks(self) -> None:
+        for guide_path in GUIDES.values():
+            guide = guide_path.read_text(encoding="utf-8")
+            for relative_path in ("../interfaces.md", "../validation.md", "../benchmarks.md"):
+                self.assertIn(relative_path, guide, guide_path.name)
+
+    def test_positive_overclaim_tokens_are_absent(self) -> None:
+        forbidden = (
+            r"\bfully compatible\b",
+            r"\bcomplete compatibility\b",
+            r"\buniversally superior\b",
+            r"\bfull coverage\b",
+            r"\bguarantees? production (?:real[- ]time|field)",
+        )
+        for guide_path in GUIDES.values():
+            guide = guide_path.read_text(encoding="utf-8").lower()
+            for token in forbidden:
+                self.assertIsNone(re.search(token, guide), f"{token}: {guide_path.name}")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Value
Help high-intent visitors choose an RTKLIB migration, ROS2, or QZSS L6/CLAS/MADOCA route within 60 seconds and reach a first verifiable artifact.

## What changed
- add a three-persona use-case decision page
- add copy/paste RTKLIB migration, ROS2 receiver/bag, and QZSS L6 guides
- document expected artifacts, exit criteria, prerequisites, and non-guarantees
- link the routes near the top of README and from Pages navigation
- add a stdlib use-case contract test to the core suite

## Validation
- `python3 tests/test_cli_ux.py`
- `python3 tests/test_use_case_guides.py`
- `python3 tests/test_qzss_l6_bias.py`
- QZSS five-frame generation and `qzss-l6-info` CSV/summary smoke
- native `gnss_solve` and `gnss_ppp` build/help checks
- `bash scripts/ci/run_hygiene.sh`
- `python3 -m mkdocs build --strict`
- `git diff --check`

ROS2 node smoke is environment-gated because ROS2 dependencies are unavailable; the guide and CI retain an explicit diagnostic/skip boundary.
