### PR TITLE
docs: add 200-star growth launch kit

### DIFF
--- a/docs/growth_launch_runbook.md
+++ b/docs/growth_launch_runbook.md
@@ -1,0 +1,238 @@
+# v0.2.0 growth launch runbook
+
+This is a maintainer runbook for a small, human-reviewed outreach sequence.
+The value is a reproducible measurement trail from the current public baseline
+toward 200 GitHub stars; it is not an instruction to automate posting,
+coordinate votes, or publish private traffic data.
+
+## Baseline and evidence
+
+The read-only baseline supplied on **2026-08-12 JST** is:
+
+| Public metric | Baseline | Target/delta |
+|---|---:|---:|
+| GitHub stars | 183 | 200 / gap 17 |
+| Forks | 21 | context only |
+| Watchers | 7 | context only |
+
+Source: the maintainer's read-only GitHub repository/release metadata snapshot
+for [`rsasaki0109/gnssplusplus-library`](https://github.com/rsasaki0109/gnssplusplus-library)
+and the [v0.2.0 release](https://github.com/rsasaki0109/gnssplusplus-library/releases/tag/v0.2.0),
+captured on that date. The release assets were each at one download in the
+supplied evidence. The GitHub traffic API was also checked with owner access,
+but its views/clones values are intentionally not written here: keep those
+owner-only values in ignored local snapshots only.
+
+The measurement interpretation follows GitHub's [traffic REST API
+reference](https://docs.github.com/en/rest/metrics/traffic) and [repository
+traffic guidance](https://docs.github.com/en/repositories/viewing-activity-and-data-for-your-repository/viewing-traffic-to-a-repository).
+Traffic details require repository push/admin visibility and cover a rolling
+14-day window. The script records an exact UTC `captured_at` in each local
+snapshot; the baseline above is the supplied date-level evidence, not a claim
+that an unseen private timestamp is reproducible.
+
+## Preflight gate
+
+Complete this list before drafting a post. Record the check date and URLs in
+the local launch notes, not in a public post:
+
+- Confirm the `v0.2.0` release, assets, [self-contained offline demo](https://github.com/rsasaki0109/gnssplusplus-library/blob/develop/docs/self_contained_demo.md), and the three [use-case routes](https://github.com/rsasaki0109/gnssplusplus-library/blob/develop/docs/use_cases.md) are live.
+- Confirm the [RTKLIB migration guide](https://github.com/rsasaki0109/gnssplusplus-library/blob/develop/docs/use_cases/rtklib_migration.md), [ROS2 guide](https://github.com/rsasaki0109/gnssplusplus-library/blob/develop/docs/use_cases/ros2.md), and [QZSS L6/CLAS/MADOCA guide](https://github.com/rsasaki0109/gnssplusplus-library/blob/develop/docs/use_cases/qzss_l6.md) still contain runnable commands and boundary notes.
+- Verify every benchmark or accuracy statement against the [validation guide](https://github.com/rsasaki0109/gnssplusplus-library/blob/develop/docs/validation.md); prefer the demo and measured artifact contracts over a broad performance claim.
+- Disclose maintainer affiliation in every channel that requires or benefits from it. Do not present the maintainer as an independent user.
+- Read the current rules for the selected channel immediately before posting. The [Show HN guidance](https://news.ycombinator.com/showhn.html) and [ROS Discourse release-announcement guideline](https://discourse.ros.org/t/community-software-release-announcements-guideline/1305) are references, not permanent permission.
+- Use one post per relevant channel, with a distinct time window and a channel-specific purpose. Do not send a cross-post blast.
+- Do not ask for stars, upvotes, likes, coordinated votes, or reciprocal engagement. Do not use automated posting, browser automation, or a bot to answer replies.
+
+The supplied referrer evidence included GitHub, Google, LinkedIn, X/t.co, and
+an RTKLIB technical blog. Referrers are context for choosing a channel, not
+proof that a channel caused a star or a conversion.
+
+## Seven-day staged sequence
+
+Leave enough time between steps to attribute a change in the local snapshots.
+The default spacing is at least 36 hours; do not start the next channel while
+the previous one still has unanswered technical questions.
+
+| Day | Channel and purpose | Gate and measurement |
+|---:|---|---|
+| 0 | Baseline, preflight, and maintainer review | Capture a snapshot immediately before the first post; verify all links and claims. |
+| 1 | [Show HN](https://news.ycombinator.com/showhn.html): invite demo/technical feedback | Post only if the current Show HN rules fit; capture at 24 hours and answer substantive questions. |
+| 3 | [ROS Discourse](https://discourse.ros.org/t/community-software-release-announcements-guideline/1305): make the ROS2 getting-started path discoverable | Follow the current release guideline and support-route expectations; capture before and after the post. |
+| 5 | Existing LinkedIn/X audience: concise release and demo pointer | Use the maintainer's existing audience, disclose affiliation, and avoid repeated cross-post text. |
+| 7 | Optional niche technical forum, only after a fresh rule check | Post only when self-promotion and affiliation disclosure are clearly allowed; otherwise skip and record the reason. |
+
+Reddit and `r/cpp` are **not** assumed to allow promotion. They are an
+optional rule-gated idea only: read the current community rules, verify that a
+maintainer release with self-promotion is permitted, and skip when the rule or
+moderator expectation is unclear. No lack of a Reddit post is a launch failure.
+
+## Ready-to-paste drafts
+
+Replace no links with tracking redirects and do not add a star/vote request.
+These drafts are starting points for a maintainer to edit after the channel
+rule check.
+
+### Show HN
+
+**Show HN title**
+
+`Show HN: libgnss++ v0.2.0 – C++20 GNSS toolkit with an offline demo`
+
+**Body**
+
+```text
+I maintain libgnss++, a C++20 GNSS toolkit for SPP/RTK/PPP, RTCM, UBX/SBF,
+ROS2 playback, and QZSS L6 correction inspection. v0.2.0 includes a tracked
+offline PPP demo so the first artifact can be checked without a receiver or
+network service.
+
+Start here:
+- Repository: https://github.com/rsasaki0109/gnssplusplus-library
+- Release: https://github.com/rsasaki0109/gnssplusplus-library/releases/tag/v0.2.0
+- Offline demo: https://github.com/rsasaki0109/gnssplusplus-library/blob/develop/docs/self_contained_demo.md
+- Use-case routes: https://github.com/rsasaki0109/gnssplusplus-library/blob/develop/docs/use_cases.md
+
+I am looking for technical feedback on the copy/paste path, artifact schema,
+and boundary documentation. The project has explicit validation and benchmark
+notes; the demo is a wiring check, not a field-accuracy or deployment claim.
+I maintain the repository and will answer issues and reproducibility questions.
+This is a request for technical feedback, not for stars or votes.
+```
+
+### ROS Discourse
+
+**ROS Discourse title**
+
+`[Release] libgnss++ v0.2.0: offline demo and ROS2 receiver/bag replay path`
+
+**Body**
+
+```text
+I maintain libgnss++ and am sharing v0.2.0 for ROS2 and GNSS developers.
+The first step is an offline demo; the ROS2 route then runs ros2-doctor,
+ros2-bag-doctor, and the existing receiver/bag processor path.
+
+Release: https://github.com/rsasaki0109/gnssplusplus-library/releases/tag/v0.2.0
+Demo: https://github.com/rsasaki0109/gnssplusplus-library/blob/develop/docs/self_contained_demo.md
+ROS2 guide: https://github.com/rsasaki0109/gnssplusplus-library/blob/develop/docs/use_cases/ros2.md
+Support: https://github.com/rsasaki0109/gnssplusplus-library/blob/develop/SUPPORT.md
+
+The guide documents dependency checks, skip behavior when ROS2 or a bag is
+missing, expected JSON/.pos artifacts, and the boundary around production
+real-time safety. Please use the issue tracker/support route for bugs or
+reproduction details. I am the maintainer; this is a release announcement,
+not a request for votes or stars.
+```
+
+### LinkedIn/X
+
+```text
+libgnss++ v0.2.0 is out: a C++20 GNSS toolkit with a tracked offline PPP demo,
+RTKLIB migration, ROS2 bag replay, and QZSS L6/CLAS/MADOCA getting-started
+routes. I maintain the project and welcome technical feedback.
+
+Release: https://github.com/rsasaki0109/gnssplusplus-library/releases/tag/v0.2.0
+Demo: https://github.com/rsasaki0109/gnssplusplus-library/blob/develop/docs/self_contained_demo.md
+Routes: https://github.com/rsasaki0109/gnssplusplus-library/blob/develop/docs/use_cases.md
+```
+
+### Optional technical forum
+
+Use this only after the current forum rule gate passes. Keep the affiliation
+disclosure in the post rather than hiding it in a profile:
+
+```text
+Maintainer disclosure: I maintain libgnss++ and am sharing its v0.2.0 release
+under this forum's current software-promotion rules. The useful first artifact
+is the offline demo; the technical routes cover RTKLIB migration, ROS2 bag
+replay, and QZSS L6/CLAS/MADOCA inspection.
+
+Release: https://github.com/rsasaki0109/gnssplusplus-library/releases/tag/v0.2.0
+Technical routes: https://github.com/rsasaki0109/gnssplusplus-library/blob/develop/docs/use_cases.md
+RTKLIB route: https://github.com/rsasaki0109/gnssplusplus-library/blob/develop/docs/use_cases/rtklib_migration.md
+ROS2 route: https://github.com/rsasaki0109/gnssplusplus-library/blob/develop/docs/use_cases/ros2.md
+QZSS route: https://github.com/rsasaki0109/gnssplusplus-library/blob/develop/docs/use_cases/qzss_l6.md
+
+I am asking for reproducibility or interface feedback, not votes, likes, or
+stars. I will follow the forum's support and disclosure rules.
+```
+
+## Snapshot and comparison commands
+
+The collector uses only `GH_TOKEN` or `GITHUB_TOKEN`, never prints the token,
+and requires owner-level visibility for traffic endpoints. Supply the secret
+through the calling environment or secret manager; do not put it in a command
+line, a tracked file, or a launch note. A 401/403 is a gate failure to resolve,
+not a reason to try another person's token. If owner traffic is unavailable,
+retain only the public page/release evidence and mark the traffic measurement
+skipped.
+
+All outputs below stay under the ignored `output/growth/` directory. Never
+commit the JSON or Markdown files: they can contain owner-only traffic values.
+
+Capture a baseline immediately before the first post:
+
+```bash
+mkdir -p output/growth
+python3 scripts/metrics/capture_growth_snapshot.py \
+  --repo rsasaki0109/gnssplusplus-library \
+  --output output/growth/baseline.json \
+  --markdown output/growth/baseline.md
+```
+
+Capture each later checkpoint with a distinct filename and compare it to the
+baseline. The output and comparison input must be different files:
+
+```bash
+python3 scripts/metrics/capture_growth_snapshot.py \
+  --repo rsasaki0109/gnssplusplus-library \
+  --output output/growth/day-3.json \
+  --markdown output/growth/day-3.md \
+  --compare-to output/growth/baseline.json
+```
+
+For deterministic local tests, pass an explicit `--captured-at
+2026-08-12T00:00:00Z`. For a live launch, omit it so the script records the
+UTC capture time. Snapshot at baseline, 24 hours, 72 hours, and day 7; add a
+before/after snapshot when a channel is delayed or skipped.
+
+The comparison reports the star delta and gap to 200, plus approximate
+rolling-window views/clones and release-asset download deltas. A clone is not
+a user, a view is not a person, an asset download is not an installation, and
+a star is not a channel conversion. Keep those distinctions in any report.
+
+## Response and measurement checklist
+
+For every channel:
+
+- Answer technical questions from the repository's support route and link to
+  the exact guide or validation note that resolves them.
+- Correct a misleading claim publicly and record the correction in the local
+  launch notes.
+- Disclose maintainer affiliation when a reply could otherwise look like an
+  independent endorsement.
+- Do not ask friends or collaborators to vote, like, star, or repeat the post.
+- At 24h, 72h, and day 7, save the snapshot path, channel timestamp, post URL,
+  substantive replies, and any rule-gate skip reason.
+
+Use these decision thresholds as operating rules, not as causal conclusions:
+
+- **24h:** preserve the baseline and one checkpoint. If there are no
+  substantive questions, do not compensate with another channel immediately.
+- **72h:** if the star delta is at least 5 or there are at least two useful
+  technical replies/referrals, continue the staged sequence and prioritize
+  answering them. If the delta is below 2 and there is no qualified referral,
+  hold the next channel and inspect message/route fit.
+- **Day 7:** at least 17 additional stars reaches the stated 200 target; stop
+  amplification and archive the evidence. A delta of 5–16 permits one
+  documentation-focused follow-up only when there is substantive engagement.
+  A delta of 0–4 means stop the sequence, improve the demo/use-case route, and
+  do not start a larger cross-post campaign.
+
+These thresholds do not attribute stars to a specific post. GitHub's traffic
+window rolls for 14 days, so adjacent snapshots overlap; compare cadence and
+window notes, not a fabricated per-channel conversion rate. The maintainer's
+decision record should contain the public baseline, local snapshot filenames,
+channel timestamps, rule checks, and next action while excluding raw tokens and
+owner-only files from Git.

--- a/docs/release_runbook.md
+++ b/docs/release_runbook.md
@@ -4,6 +4,10 @@ This runbook covers the tag-driven v0.2.0 release. Release automation is
 intentionally started only by an annotated `vMAJOR.MINOR.PATCH` tag pushed to
 the repository.
 
+For human-reviewed post-release outreach and reproducible, owner-only growth
+measurement, use the [growth launch runbook](growth_launch_runbook.md). It does
+not automate posting or change repository publication state.
+
 ## Before tagging
 
 1. Merge the validated release change into `develop` and confirm the merge

--- a/scripts/metrics/capture_growth_snapshot.py
+++ b/scripts/metrics/capture_growth_snapshot.py
@@ -1,0 +1,599 @@
+#!/usr/bin/env python3
+"""Capture a reproducible, authenticated GitHub growth snapshot.
+
+The repository and traffic endpoints are deliberately queried through the
+GitHub REST API instead of the ``gh`` CLI so that this tool has no shelling
+out, no implicit credential lookup, and no token-bearing diagnostic output.
+Traffic data requires push/admin visibility and is intended to remain in the
+ignored ``output/growth/`` directory.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import re
+import sys
+import tempfile
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+from typing import Any, Mapping, Sequence
+
+
+API_ROOT = "https://api.github.com"
+DEFAULT_REPO = "rsasaki0109/gnssplusplus-library"
+SCHEMA_VERSION = "growth_snapshot.v1"
+TARGET_STARS = 200
+API_TIMEOUT_SECONDS = 20.0
+API_HEADERS = {
+    "Accept": "application/vnd.github+json",
+    "User-Agent": "gnssplusplus-growth-snapshot/1.0",
+    "X-GitHub-Api-Version": "2022-11-28",
+}
+
+
+class SnapshotError(RuntimeError):
+    """A safe, user-facing snapshot failure."""
+
+
+def validate_repo(repo: str) -> str:
+    """Validate and return an ``owner/name`` repository identifier."""
+
+    if not re.fullmatch(r"[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+", repo):
+        raise SnapshotError(
+            f"invalid repository {repo!r}; expected an owner/name identifier"
+        )
+    return repo
+
+
+def _git_config_candidates(root: Path) -> list[Path]:
+    git_path = root / ".git"
+    candidates: list[Path] = []
+    if git_path.is_dir():
+        candidates.append(git_path / "config")
+    elif git_path.is_file():
+        try:
+            gitdir_line = next(
+                line for line in git_path.read_text(encoding="utf-8").splitlines()
+                if line.startswith("gitdir: ")
+            )
+        except (StopIteration, OSError, UnicodeDecodeError):
+            return candidates
+        gitdir = Path(gitdir_line[len("gitdir: ") :])
+        if not gitdir.is_absolute():
+            gitdir = (root / gitdir).resolve()
+        candidates.append(gitdir / "config")
+        common_dir_file = gitdir / "commondir"
+        try:
+            common_dir = Path(common_dir_file.read_text(encoding="utf-8").strip())
+            if not common_dir.is_absolute():
+                common_dir = (gitdir / common_dir).resolve()
+            candidates.append(common_dir / "config")
+        except (OSError, UnicodeDecodeError):
+            pass
+    return candidates
+
+
+def _repo_from_remote_url(url: str) -> str | None:
+    value = url.strip()
+    match = re.search(
+        r"github\.com[:/]([^/\s]+)/([^/\s]+?)(?:\.git)?/?$", value
+    )
+    if not match:
+        return None
+    return f"{match.group(1)}/{match.group(2)}"
+
+
+def infer_default_repo() -> str:
+    """Infer this checkout's GitHub repository without invoking Git."""
+
+    for env_name in ("GITHUB_REPOSITORY",):
+        value = os.environ.get(env_name)
+        if value:
+            try:
+                return validate_repo(value)
+            except SnapshotError:
+                pass
+
+    root = Path(__file__).resolve().parents[2]
+    for config_path in _git_config_candidates(root):
+        try:
+            lines = config_path.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeDecodeError):
+            continue
+        in_origin = False
+        for line in lines:
+            stripped = line.strip()
+            if stripped.startswith("["):
+                in_origin = stripped.lower() == '[remote "origin"]'
+                continue
+            if in_origin and stripped.startswith("url = "):
+                repo = _repo_from_remote_url(stripped[6:])
+                if repo:
+                    return validate_repo(repo)
+    return DEFAULT_REPO
+
+
+def resolve_token(environment: Mapping[str, str] | None = None) -> str:
+    """Read only the explicitly supported GitHub token environment names."""
+
+    env = os.environ if environment is None else environment
+    for name in ("GH_TOKEN", "GITHUB_TOKEN"):
+        value = env.get(name)
+        if value:
+            return value
+    raise SnapshotError(
+        "GitHub API authentication is required; set GH_TOKEN or GITHUB_TOKEN "
+        "in the calling environment (the token is never printed or stored)."
+    )
+
+
+class GitHubClient:
+    """Small JSON-only GitHub REST client with safe error messages."""
+
+    def __init__(
+        self,
+        token: str,
+        *,
+        api_root: str = API_ROOT,
+        timeout: float = API_TIMEOUT_SECONDS,
+    ) -> None:
+        if not token:
+            raise SnapshotError("GitHub API token is empty")
+        self._token = token
+        self._api_root = api_root.rstrip("/")
+        self._timeout = timeout
+
+    def get(self, endpoint: str) -> Any:
+        path = endpoint if endpoint.startswith("/") else f"/{endpoint}"
+        url = f"{self._api_root}{path}"
+        headers = dict(API_HEADERS)
+        headers["Authorization"] = f"Bearer {self._token}"
+        request = urllib.request.Request(url, headers=headers, method="GET")
+        try:
+            with urllib.request.urlopen(request, timeout=self._timeout) as response:
+                raw = response.read()
+        except urllib.error.HTTPError as exc:
+            if exc.code == 401:
+                raise SnapshotError(
+                    "GitHub API returned 401: the supplied token is invalid or "
+                    "expired; refresh GH_TOKEN/GITHUB_TOKEN"
+                ) from exc
+            if exc.code == 403:
+                raise SnapshotError(
+                    "GitHub API returned 403: traffic endpoints require push or "
+                    "admin visibility, or the API rate limit was reached"
+                ) from exc
+            if exc.code == 404:
+                raise SnapshotError(
+                    "GitHub API returned 404: check the repository name and token "
+                    "access (traffic may be unavailable without repository access)"
+                ) from exc
+            raise SnapshotError(f"GitHub API returned HTTP {exc.code}") from exc
+        except urllib.error.URLError as exc:
+            raise SnapshotError(f"GitHub API request failed: {exc.reason}") from exc
+        try:
+            return json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise SnapshotError("GitHub API returned invalid JSON") from exc
+
+
+def _integer(value: Any) -> int | None:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_daily_rows(
+    payload: Mapping[str, Any], source_key: str = "views"
+) -> list[dict[str, Any]]:
+    rows = payload.get(source_key)
+    if not isinstance(rows, list):
+        return []
+    normalized: list[dict[str, Any]] = []
+    for row in rows:
+        if not isinstance(row, Mapping):
+            continue
+        item: dict[str, Any] = {}
+        for key in ("timestamp", "count", "uniques"):
+            if key in row:
+                item[key] = row[key]
+        if item:
+            normalized.append(item)
+    return normalized
+
+
+def _normalize_traffic(payload: Any, source_key: str = "views") -> dict[str, Any]:
+    source = payload if isinstance(payload, Mapping) else {}
+    return {
+        "count": _integer(source.get("count")),
+        "uniques": _integer(source.get("uniques")),
+        "daily": _normalize_daily_rows(source, source_key),
+    }
+
+
+def _normalize_referrers(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, list):
+        return []
+    rows: list[dict[str, Any]] = []
+    for row in payload:
+        if not isinstance(row, Mapping):
+            continue
+        item: dict[str, Any] = {}
+        for key in ("referrer", "count", "uniques"):
+            if key in row:
+                item[key] = row[key]
+        if item:
+            rows.append(item)
+    return rows
+
+
+def _normalize_paths(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, list):
+        return []
+    rows: list[dict[str, Any]] = []
+    for row in payload:
+        if not isinstance(row, Mapping):
+            continue
+        item: dict[str, Any] = {}
+        for key in ("path", "title", "count", "uniques"):
+            if key in row:
+                item[key] = row[key]
+        if item:
+            rows.append(item)
+    return rows
+
+
+def _normalize_assets(payload: Any) -> tuple[list[dict[str, Any]], int]:
+    if not isinstance(payload, list):
+        return [], 0
+    assets: list[dict[str, Any]] = []
+    total = 0
+    for asset in payload:
+        if not isinstance(asset, Mapping):
+            continue
+        downloads = _integer(asset.get("download_count"))
+        if downloads is None:
+            downloads = 0
+        total += downloads
+        assets.append(
+            {
+                "name": asset.get("name"),
+                "download_count": downloads,
+                "size": _integer(asset.get("size")),
+                "browser_download_url": asset.get("browser_download_url"),
+            }
+        )
+    return assets, total
+
+
+def _normalize_releases(payload: Any) -> list[dict[str, Any]]:
+    if not isinstance(payload, list):
+        raise SnapshotError("GitHub releases endpoint returned a non-list payload")
+    releases: list[dict[str, Any]] = []
+    for release in payload:
+        if not isinstance(release, Mapping):
+            continue
+        assets, asset_downloads = _normalize_assets(release.get("assets"))
+        releases.append(
+            {
+                "tag_name": release.get("tag_name"),
+                "name": release.get("name"),
+                "published_at": release.get("published_at"),
+                "html_url": release.get("html_url"),
+                "draft": bool(release.get("draft", False)),
+                "prerelease": bool(release.get("prerelease", False)),
+                "assets": assets,
+                "asset_downloads": asset_downloads,
+            }
+        )
+    return releases
+
+
+def normalize_captured_at(value: str | None = None) -> str:
+    if value is None:
+        parsed = dt.datetime.now(dt.timezone.utc)
+    else:
+        text = value.strip()
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        try:
+            parsed = dt.datetime.fromisoformat(text)
+        except ValueError as exc:
+            raise SnapshotError(
+                "--captured-at must be an ISO-8601 timestamp"
+            ) from exc
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=dt.timezone.utc)
+    parsed = parsed.astimezone(dt.timezone.utc).replace(microsecond=0)
+    return parsed.isoformat().replace("+00:00", "Z")
+
+
+def capture_snapshot(
+    repo: str,
+    client: Any,
+    *,
+    captured_at: str | None = None,
+) -> dict[str, Any]:
+    """Collect all endpoint payloads through a client-like ``get`` object."""
+
+    repo = validate_repo(repo)
+    prefix = f"/repos/{repo}"
+    metadata = client.get(prefix)
+    if not isinstance(metadata, Mapping):
+        raise SnapshotError("GitHub repository endpoint returned a non-object payload")
+
+    views = client.get(f"{prefix}/traffic/views")
+    clones = client.get(f"{prefix}/traffic/clones")
+    referrers = client.get(f"{prefix}/traffic/popular/referrers")
+    popular_paths = client.get(f"{prefix}/traffic/popular/paths")
+    releases = client.get(f"{prefix}/releases?per_page=100")
+    subscribers = _integer(metadata.get("subscribers_count"))
+    watchers = subscribers if subscribers is not None else _integer(metadata.get("watchers_count"))
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "captured_at": normalize_captured_at(captured_at),
+        "repo": repo,
+        "public": {
+            "stars": _integer(metadata.get("stargazers_count")),
+            "forks": _integer(metadata.get("forks_count")),
+            # GitHub's legacy watchers_count can mirror stargazers_count.
+            # The public UI's Watchers value is subscribers_count.
+            "watchers": watchers,
+            "subscribers": subscribers if subscribers is not None else watchers,
+            "html_url": metadata.get("html_url") or f"https://github.com/{repo}",
+        },
+        "traffic": {
+            "window_days": 14,
+            "views": _normalize_traffic(views),
+            "clones": _normalize_traffic(clones, "clones"),
+            "referrers": _normalize_referrers(referrers),
+            "popular_paths": _normalize_paths(popular_paths),
+        },
+        "releases": _normalize_releases(releases),
+    }
+
+
+def _traffic_delta(
+    current: Mapping[str, Any], baseline: Mapping[str, Any]
+) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key in ("count", "uniques"):
+        current_value = _integer(current.get(key))
+        baseline_value = _integer(baseline.get(key))
+        result[key] = {
+            "current": current_value,
+            "baseline": baseline_value,
+            "delta": (
+                current_value - baseline_value
+                if current_value is not None and baseline_value is not None
+                else None
+            ),
+        }
+    return result
+
+
+def _asset_download_total(snapshot: Mapping[str, Any]) -> int:
+    total = 0
+    releases = snapshot.get("releases", [])
+    if not isinstance(releases, list):
+        return total
+    for release in releases:
+        if isinstance(release, Mapping):
+            total += _integer(release.get("asset_downloads")) or 0
+    return total
+
+
+def compare_snapshots(
+    current: Mapping[str, Any], baseline: Mapping[str, Any], *, target_stars: int = TARGET_STARS
+) -> dict[str, Any]:
+    current_public = current.get("public", {})
+    baseline_public = baseline.get("public", {})
+    current_stars = _integer(current_public.get("stars")) if isinstance(current_public, Mapping) else None
+    baseline_stars = _integer(baseline_public.get("stars")) if isinstance(baseline_public, Mapping) else None
+    stars_delta = (
+        current_stars - baseline_stars
+        if current_stars is not None and baseline_stars is not None
+        else None
+    )
+    gap = max(0, target_stars - current_stars) if current_stars is not None else None
+
+    current_traffic = current.get("traffic", {})
+    baseline_traffic = baseline.get("traffic", {})
+    traffic_deltas: dict[str, Any] = {}
+    for key in ("views", "clones"):
+        current_section = current_traffic.get(key, {}) if isinstance(current_traffic, Mapping) else {}
+        baseline_section = baseline_traffic.get(key, {}) if isinstance(baseline_traffic, Mapping) else {}
+        traffic_deltas[key] = _traffic_delta(
+            current_section if isinstance(current_section, Mapping) else {},
+            baseline_section if isinstance(baseline_section, Mapping) else {},
+        )
+
+    current_assets = _asset_download_total(current)
+    baseline_assets = _asset_download_total(baseline)
+    return {
+        "target_stars": target_stars,
+        "baseline_captured_at": baseline.get("captured_at"),
+        "current_captured_at": current.get("captured_at"),
+        "stars_delta": stars_delta,
+        "star_delta": stars_delta,
+        "gap_to_200": gap,
+        "star_gap_to_200": gap,
+        "traffic": traffic_deltas,
+        "release_assets": {
+            "current_downloads": current_assets,
+            "baseline_downloads": baseline_assets,
+            "delta": current_assets - baseline_assets,
+        },
+        "approximate": True,
+        "note": (
+            "Views and clones are rolling 14-day GitHub traffic windows; "
+            "deltas can overlap and are not unique users or conversions."
+        ),
+    }
+
+
+def render_markdown(snapshot: Mapping[str, Any]) -> str:
+    public = snapshot.get("public", {})
+    traffic = snapshot.get("traffic", {})
+    lines = [
+        "# GitHub growth snapshot",
+        "",
+        f"- Repository: `{snapshot.get('repo', 'unknown')}`",
+        f"- Captured at (UTC): `{snapshot.get('captured_at', 'unknown')}`",
+        f"- Stars: `{public.get('stars')}` (target: `{TARGET_STARS}`)",
+        f"- Forks: `{public.get('forks')}`",
+        f"- Watchers: `{public.get('watchers')}`",
+        "",
+        "## Rolling traffic",
+        "",
+        "GitHub traffic endpoints cover a rolling 14-day window. Counts are not "
+        "unique people, and this file is intended for the ignored growth output "
+        "directory.",
+        "",
+        "| Metric | Count | Uniques |",
+        "|---|---:|---:|",
+    ]
+    for label, key in (("Views", "views"), ("Clones", "clones")):
+        section = traffic.get(key, {}) if isinstance(traffic, Mapping) else {}
+        lines.append(f"| {label} | {section.get('count')} | {section.get('uniques')} |")
+
+    lines.extend(["", "## Releases and assets", "", "| Release | Asset downloads |", "|---|---:|"])
+    releases = snapshot.get("releases", [])
+    if isinstance(releases, list) and releases:
+        for release in releases:
+            if isinstance(release, Mapping):
+                lines.append(
+                    f"| `{release.get('tag_name')}` | {release.get('asset_downloads', 0)} |"
+                )
+    else:
+        lines.append("| _(none returned)_ | 0 |")
+
+    comparison = snapshot.get("comparison")
+    if isinstance(comparison, Mapping):
+        lines.extend(
+            [
+                "",
+                "## Comparison",
+                "",
+                f"- Stars delta: `{comparison.get('stars_delta')}`",
+                f"- Gap to 200 stars: `{comparison.get('gap_to_200')}`",
+                f"- Release asset download delta: `{comparison.get('release_assets', {}).get('delta')}`",
+                f"- Approximate rolling-window comparison: `{comparison.get('approximate')}`",
+                f"- Note: {comparison.get('note')}",
+            ]
+        )
+    return "\n".join(lines) + "\n"
+
+
+def _ensure_safe_output(path: Path) -> None:
+    if path.exists() and path.is_symlink():
+        raise SnapshotError(f"refusing symlink output path: {path}")
+    if path.exists() and path.is_dir():
+        raise SnapshotError(f"output path is a directory: {path}")
+
+
+def validate_output_paths(
+    output: Path, markdown: Path | None, compare_to: Path | None
+) -> None:
+    _ensure_safe_output(output)
+    if markdown is not None:
+        _ensure_safe_output(markdown)
+    resolved_output = output.resolve()
+    if markdown is not None and resolved_output == markdown.resolve():
+        raise SnapshotError("--output and --markdown must be different files")
+    if compare_to is not None:
+        if resolved_output == compare_to.resolve():
+            raise SnapshotError("--output must not overwrite --compare-to")
+        if markdown is not None and markdown.resolve() == compare_to.resolve():
+            raise SnapshotError("--markdown must not overwrite --compare-to")
+
+
+def _atomic_write(path: Path, text: str) -> None:
+    _ensure_safe_output(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    temporary_path: Path | None = None
+    try:
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent)
+        )
+        temporary_path = Path(temporary_name)
+        with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+            handle.write(text)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(temporary_path, path)
+        temporary_path = None
+    finally:
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink()
+            except FileNotFoundError:
+                pass
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise SnapshotError(f"cannot read comparison snapshot: {path}") from exc
+    if not isinstance(payload, dict):
+        raise SnapshotError(f"comparison snapshot is not a JSON object: {path}")
+    return payload
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Capture authenticated GitHub public and rolling-traffic metrics."
+    )
+    parser.add_argument(
+        "--repo",
+        default=None,
+        help="GitHub owner/name (default: infer this checkout's origin)",
+    )
+    parser.add_argument("--output", required=True, help="JSON snapshot output path")
+    parser.add_argument("--markdown", help="Optional Markdown summary output path")
+    parser.add_argument("--compare-to", help="Prior JSON snapshot for a comparison")
+    parser.add_argument(
+        "--captured-at",
+        help="Deterministic ISO-8601 capture timestamp; normalized to UTC",
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    output_path = Path(args.output)
+    markdown_path = Path(args.markdown) if args.markdown else None
+    compare_path = Path(args.compare_to) if args.compare_to else None
+    try:
+        validate_output_paths(output_path, markdown_path, compare_path)
+        repo = validate_repo(args.repo) if args.repo else infer_default_repo()
+        token = resolve_token()
+        client = GitHubClient(token)
+        snapshot = capture_snapshot(repo, client, captured_at=args.captured_at)
+        if compare_path is not None:
+            snapshot["comparison"] = compare_snapshots(snapshot, _load_json(compare_path))
+        _atomic_write(
+            output_path,
+            json.dumps(snapshot, ensure_ascii=False, indent=2, sort_keys=True) + "\n",
+        )
+        if markdown_path is not None:
+            _atomic_write(markdown_path, render_markdown(snapshot))
+        print(f"growth snapshot written: {output_path}")
+        if markdown_path is not None:
+            print(f"growth markdown written: {markdown_path}")
+        return 0
+    except SnapshotError as exc:
+        print(f"growth snapshot error: {exc}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -412,6 +412,10 @@ if(GTest_FOUND)
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_release_contracts.py
     )
     add_test(
+        NAME python_growth_snapshot_tests
+        COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_growth_snapshot.py
+    )
+    add_test(
         NAME python_community_health_tests
         COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_SOURCE_DIR}/test_community_health.py
     )
@@ -521,6 +525,7 @@ if(GTest_FOUND)
         python_search_imu_time_offset_tests
         python_use_case_guide_tests
         python_release_contract_tests
+        python_growth_snapshot_tests
         python_community_health_tests
     )
     set(GNSSPP_EXTENDED_TESTS

--- a/tests/test_growth_snapshot.py
+++ b/tests/test_growth_snapshot.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+"""Network-independent tests for the GitHub growth snapshot collector."""
+
+from __future__ import annotations
+
+import contextlib
+import copy
+import importlib.util
+import io
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+from urllib.error import HTTPError
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+SCRIPT_PATH = ROOT_DIR / "scripts" / "metrics" / "capture_growth_snapshot.py"
+SPEC = importlib.util.spec_from_file_location("capture_growth_snapshot", SCRIPT_PATH)
+assert SPEC is not None and SPEC.loader is not None
+growth = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(growth)
+
+
+class FakeClient:
+    def __init__(self, payloads: dict[str, object]) -> None:
+        self.payloads = payloads
+        self.calls: list[str] = []
+
+    def get(self, endpoint: str) -> object:
+        self.calls.append(endpoint)
+        return copy.deepcopy(self.payloads[endpoint])
+
+
+def fixture_client(stars: int = 183, asset_downloads: int = 1) -> FakeClient:
+    repo = "/repos/rsasaki0109/gnssplusplus-library"
+    return FakeClient(
+        {
+            repo: {
+                "stargazers_count": stars,
+                "forks_count": 21,
+                "watchers_count": 183,
+                "subscribers_count": 7,
+                "html_url": "https://github.com/rsasaki0109/gnssplusplus-library",
+            },
+            f"{repo}/traffic/views": {
+                "count": 42,
+                "uniques": 12,
+                "views": [{"timestamp": "2026-08-12T00:00:00Z", "count": 4, "uniques": 2}],
+            },
+            f"{repo}/traffic/clones": {
+                "count": 24,
+                "uniques": 8,
+                "clones": [{"timestamp": "2026-08-12T00:00:00Z", "count": 6, "uniques": 3}],
+            },
+            f"{repo}/traffic/popular/referrers": [
+                {"referrer": "github.com", "count": 10, "uniques": 5},
+                {"referrer": "Google", "count": 4, "uniques": 3},
+            ],
+            f"{repo}/traffic/popular/paths": [
+                {"path": "/rsasaki0109/gnssplusplus-library", "title": "repo", "count": 11, "uniques": 6}
+            ],
+            f"{repo}/releases?per_page=100": [
+                {
+                    "tag_name": "v0.2.0",
+                    "name": "libgnss++ v0.2.0",
+                    "published_at": "2026-08-01T00:00:00Z",
+                    "html_url": "https://github.com/rsasaki0109/gnssplusplus-library/releases/tag/v0.2.0",
+                    "assets": [
+                        {
+                            "name": "libgnsspp.tar.gz",
+                            "download_count": asset_downloads,
+                            "size": 123,
+                            "browser_download_url": "https://example.invalid/asset",
+                        }
+                    ],
+                }
+            ],
+        }
+    )
+
+
+class GrowthSnapshotTest(unittest.TestCase):
+    def test_endpoint_aggregation_and_deterministic_timestamp(self) -> None:
+        client = fixture_client()
+        snapshot = growth.capture_snapshot(
+            "rsasaki0109/gnssplusplus-library",
+            client,
+            captured_at="2026-08-12T09:00:00+09:00",
+        )
+        self.assertEqual(snapshot["schema_version"], "growth_snapshot.v1")
+        self.assertEqual(snapshot["captured_at"], "2026-08-12T00:00:00Z")
+        self.assertEqual(snapshot["public"]["stars"], 183)
+        self.assertEqual(snapshot["public"]["forks"], 21)
+        self.assertEqual(snapshot["public"]["watchers"], 7)
+        self.assertEqual(snapshot["public"]["subscribers"], 7)
+        self.assertEqual(snapshot["traffic"]["views"]["count"], 42)
+        self.assertEqual(snapshot["traffic"]["clones"]["uniques"], 8)
+        self.assertEqual(snapshot["traffic"]["clones"]["daily"][0]["count"], 6)
+        self.assertEqual(snapshot["traffic"]["referrers"][0]["referrer"], "github.com")
+        self.assertEqual(snapshot["releases"][0]["asset_downloads"], 1)
+        self.assertEqual(len(client.calls), 6)
+
+    def test_markdown_and_comparison_math(self) -> None:
+        current = growth.capture_snapshot(
+            "rsasaki0109/gnssplusplus-library",
+            fixture_client(stars=183, asset_downloads=3),
+            captured_at="2026-08-12T00:00:00Z",
+        )
+        baseline = growth.capture_snapshot(
+            "rsasaki0109/gnssplusplus-library",
+            fixture_client(stars=180, asset_downloads=1),
+            captured_at="2026-08-10T00:00:00Z",
+        )
+        baseline["traffic"]["views"]["count"] = 17
+        baseline["traffic"]["views"]["uniques"] = 5
+        current["comparison"] = growth.compare_snapshots(current, baseline)
+        self.assertEqual(current["comparison"]["stars_delta"], 3)
+        self.assertEqual(current["comparison"]["gap_to_200"], 17)
+        self.assertEqual(current["comparison"]["traffic"]["views"]["count"]["delta"], 25)
+        self.assertEqual(current["comparison"]["release_assets"]["delta"], 2)
+        markdown = growth.render_markdown(current)
+        self.assertIn("Stars: `183`", markdown)
+        self.assertIn("Gap to 200 stars: `17`", markdown)
+        self.assertIn("rolling 14-day", markdown)
+        self.assertIn("v0.2.0", markdown)
+
+    def test_missing_token_error_is_clear_and_redacted(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "snapshot.json"
+            stderr = io.StringIO()
+            with mock.patch.dict(os.environ, {}, clear=True), contextlib.redirect_stderr(stderr):
+                result = growth.main(
+                    ["--repo", "owner/name", "--output", str(output)]
+                )
+            self.assertEqual(result, 2)
+            self.assertIn("GH_TOKEN", stderr.getvalue())
+            self.assertNotIn("ghs_", stderr.getvalue())
+            self.assertFalse(output.exists())
+
+    def test_http_auth_error_does_not_expose_token(self) -> None:
+        secret = "ghs_example_secret"
+        error = HTTPError("https://api.github.com/repos/owner/name", 401, "unauthorized", {}, None)
+        with mock.patch.object(growth.urllib.request, "urlopen", side_effect=error):
+            with self.assertRaises(growth.SnapshotError) as raised:
+                growth.GitHubClient(secret).get("/repos/owner/name")
+        self.assertIn("401", str(raised.exception))
+        self.assertNotIn(secret, str(raised.exception))
+
+    def test_invalid_repo_and_output_collision_are_rejected(self) -> None:
+        with self.assertRaises(growth.SnapshotError):
+            growth.validate_repo("not-an-owner-name")
+        with tempfile.TemporaryDirectory() as directory:
+            output = Path(directory) / "snapshot.json"
+            output.write_text("{}", encoding="utf-8")
+            with self.assertRaises(growth.SnapshotError):
+                growth.validate_output_paths(output, None, output)
+
+    def test_symlink_output_is_rejected_when_supported(self) -> None:
+        with tempfile.TemporaryDirectory() as directory:
+            root = Path(directory)
+            target = root / "target.json"
+            target.write_text("{}", encoding="utf-8")
+            link = root / "link.json"
+            try:
+                link.symlink_to(target)
+            except (OSError, NotImplementedError):
+                self.skipTest("symlinks unavailable")
+            with self.assertRaises(growth.SnapshotError):
+                growth.validate_output_paths(link, None, None)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a maintainer-only, seven-day outreach runbook for the v0.2.0 launch
- add a stdlib GitHub metrics snapshot/compare tool with safe local outputs
- add network-independent tests and register them in the core CTest suite

## Baseline

- 183 GitHub Stars on 2026-08-12
- target: 200 Stars (gap: 17)
- owner-only traffic values are intentionally excluded from this PR

## Validation

- `python3 tests/test_growth_snapshot.py`
- `python3 tests/test_release_contracts.py`
- `python3 tests/test_community_health.py`
- `python3 tests/test_cli_ux.py`
- `bash scripts/ci/run_hygiene.sh`
- strict MkDocs build
- real authenticated GitHub API snapshot written only under `/tmp`
