### PR TITLE
CLAS: enable post-reset quarantine by default (floor=5.0, max_nfix=7)

### DIFF
--- a/include/libgnss++/algorithms/ppp_env_overrides.hpp
+++ b/include/libgnss++/algorithms/ppp_env_overrides.hpp
@@ -302,15 +302,16 @@ struct PPPEnvOverrides {
     // hold series is quarantined from FIX publication until the next
     // full-state reset; these administrative FLOAT outputs do not advance
     // FLOATCNT. Default 0.0 disables the feature (bit-identical); any value
-    // > 0 activates it.
-    double clas_post_reset_ratio_floor = 0.0;
+    // > 0 activates it. Default 5.0 (validated across 6 PPC runs).
+    double clas_post_reset_ratio_floor = 5.0;
     // GNSS_PPP_CLAS_POST_RESET_QUARANTINE_MAX_NFIX: when > 0 and
     // GNSS_PPP_CLAS_POST_RESET_RATIO_FLOOR is active, restricts the
     // quarantine trigger to seeds whose fixed-ambiguity count (nfix) is at
     // most this value. Seeds with nfix above the limit pass through the
-    // quarantine gate unconditionally. Default 0 (unrestricted — every
-    // qualifying seed is quarantined regardless of nfix).
-    int clas_post_reset_quarantine_max_nfix = 0;
+    // quarantine gate unconditionally. Default 7 (separates the nagoya_run2
+    // cold-start burst at nfix=7 from good mature-hold clusters at nfix>=13,
+    // validated across 6 PPC runs with zero new >3m errors).
+    int clas_post_reset_quarantine_max_nfix = 7;
     // GNSS_PPP_CLAS_HOLD_CONT_MIN_TRACK: measurement-only override for the
     // CLAS kinematic maxdiff-only hold-continuation carve-out's minimum
     // track-record age gate (kClasHoldContinuationMinTrackRecordFixes at its

--- a/src/algorithms/ppp_env_overrides.cpp
+++ b/src/algorithms/ppp_env_overrides.cpp
@@ -289,9 +289,9 @@ PPPEnvOverrides PPPEnvOverrides::fromEnvironment() {
     overrides.clas_phase_row_dump =
         envExactOne("GNSS_PPP_CLAS_PHASE_ROW_DUMP");
     overrides.clas_post_reset_ratio_floor =
-        envDoubleOr("GNSS_PPP_CLAS_POST_RESET_RATIO_FLOOR", 0.0);
+        envDoubleOr("GNSS_PPP_CLAS_POST_RESET_RATIO_FLOOR", 5.0);
     overrides.clas_post_reset_quarantine_max_nfix =
-        envIntOr("GNSS_PPP_CLAS_POST_RESET_QUARANTINE_MAX_NFIX", 0);
+        envIntOr("GNSS_PPP_CLAS_POST_RESET_QUARANTINE_MAX_NFIX", 7);
     overrides.clas_hold_cont_min_track =
         envIntOr("GNSS_PPP_CLAS_HOLD_CONT_MIN_TRACK", -1);
     const std::string clas_nl_datum_fix =


### PR DESCRIPTION
## Summary

Flips the two post-reset quarantine knobs from OFF to their validated defaults, eliminating the nagoya_run2 destructive burst with zero side-effects across all 6 PPC runs.

| knob | before | after |
|---|---|---|
| `GNSS_PPP_CLAS_POST_RESET_RATIO_FLOOR` | 0.0 (off) | **5.0** |
| `GNSS_PPP_CLAS_POST_RESET_QUARANTINE_MAX_NFIX` | 0 (unrestricted) | **7** |

Both remain env-overridable; `RATIO_FLOOR=0` restores legacy behavior.

## 6-run verification (PR #477)

| run | Δfix | base >3m | new >3m | rms change |
|---|---|---|---|---|
| tokyo_run1  | **+0** | 0 | 0 | — |
| tokyo_run2  | **+0** | 0 | 0 | — |
| tokyo_run3  | **+0** | 0 | 0 | — |
| nagoya_run1 | **+0** | 0 | 0 | — |
| nagoya_run2 | **-19** | **19** | **0** ✅ | 0.625→0.554 m ✅ |
| nagoya_run3 | **+0** | 0 | 0 | — |
| **TOTAL** | -19 | **19** | **0** | 0.377→0.359 m |

Made with [Cursor](https://cursor.com)