### PR TITLE
feat(python): extend solve_ppp_file and add solve_clas_kinematic_file

### DIFF
--- a/python/libgnsspp/__init__.py
+++ b/python/libgnsspp/__init__.py
@@ -77,25 +77,130 @@ def solve_ppp_file(
     enable_ar: bool = False,
     sp3_path: str = "",
     clk_path: str = "",
+    ssr_path: str = "",
+    config_path: str = "",
+    ar_method: str = "",
+    ar_ratio_threshold: float = 0.0,
+    use_dynamics_model: bool = False,
+    clas_osr: bool = False,
+    estimate_ionosphere: bool = False,
+    estimate_troposphere: bool = True,
+    extra_args: list[str] | None = None,
 ) -> Solution:
-    arguments = [
-        "ppp",
-        "--obs",
-        obs_path,
-        "--nav",
-        nav_path,
-        "--quiet",
-        "--kinematic" if kinematic_mode else "--static",
-    ]
+    """Run gnss_ppp on RINEX observation files and return the Solution.
+
+    Parameters
+    ----------
+    obs_path:
+        Path to the rover RINEX observation file.
+    nav_path:
+        Path to the broadcast navigation file.
+    ssr_path:
+        Path to the expanded SSR corrections CSV (CLAS/MADOCA).
+    config_path:
+        Optional TOML config file (``--config``). CLI arguments override it.
+    kinematic_mode:
+        Enable kinematic processing (``--kinematic``).
+    use_dynamics_model:
+        Enable the dynamics / IMU-free kinematic model (``--use-dynamics-model``).
+    enable_ar:
+        Enable ambiguity resolution (``--enable-ar``).
+    ar_method:
+        AR method string, e.g. ``"wlnl"`` or ``"lambda"`` (``--ar-method``).
+    ar_ratio_threshold:
+        AR ratio threshold; 0.0 leaves the default (``--ar-ratio-threshold``).
+    clas_osr:
+        Enable the CLAS OSR PPP-RTK filter path (``--clas-osr``).
+    estimate_ionosphere:
+        Estimate per-satellite ionosphere states (``--estimate-ionosphere``).
+    estimate_troposphere:
+        Estimate zenith troposphere (default True).
+    sp3_path:
+        Precise orbit SP3 file.
+    clk_path:
+        Precise clock CLK file.
+    extra_args:
+        Additional raw CLI arguments appended verbatim.
+    """
+    arguments = ["ppp", "--obs", obs_path, "--nav", nav_path, "--quiet"]
+    if config_path:
+        arguments.extend(["--config", config_path])
+    if kinematic_mode:
+        arguments.append("--kinematic")
+    if use_dynamics_model:
+        arguments.append("--use-dynamics-model")
     if enable_ar:
         arguments.append("--enable-ar")
+    if ar_method:
+        arguments.extend(["--ar-method", ar_method])
+    if ar_ratio_threshold > 0.0:
+        arguments.extend(["--ar-ratio-threshold", str(ar_ratio_threshold)])
+    if clas_osr:
+        arguments.extend(["--clas-osr", "--no-ionosphere-free"])
+    if estimate_ionosphere:
+        arguments.append("--estimate-ionosphere")
+    if not estimate_troposphere:
+        arguments.append("--no-estimate-troposphere")
+    if ssr_path:
+        arguments.extend(["--ssr", ssr_path])
     if sp3_path:
         arguments.extend(["--sp3", sp3_path])
     if clk_path:
         arguments.extend(["--clk", clk_path])
     if max_epochs > 0:
         arguments.extend(["--max-epochs", str(max_epochs)])
+    if extra_args:
+        arguments.extend(extra_args)
     return _run_gnss_and_load_solution(arguments)
+
+
+def solve_clas_kinematic_file(
+    obs_path: str,
+    nav_path: str,
+    ssr_path: str,
+    max_epochs: int = 0,
+    config_path: str = "",
+    extra_args: list[str] | None = None,
+) -> Solution:
+    """Convenience wrapper for CLAS PPP-RTK kinematic positioning.
+
+    Equivalent to::
+
+        gnss_ppp --obs <obs> --nav <nav> --ssr <ssr> \\
+                 --kinematic --use-dynamics-model --clas-osr \\
+                 --no-ionosphere-free --estimate-ionosphere \\
+                 --estimate-troposphere --enable-ar --ar-method wlnl \\
+                 --ar-ratio-threshold 3.0
+
+    Parameters
+    ----------
+    obs_path:
+        Path to the rover RINEX observation file.
+    nav_path:
+        Path to the broadcast navigation file.
+    ssr_path:
+        Path to the expanded CLAS SSR corrections CSV.
+    config_path:
+        Optional TOML config file to override defaults.
+    extra_args:
+        Additional raw CLI arguments.
+    """
+    return solve_ppp_file(
+        obs_path=obs_path,
+        nav_path=nav_path,
+        ssr_path=ssr_path,
+        config_path=config_path,
+        kinematic_mode=True,
+        use_dynamics_model=True,
+        enable_ar=True,
+        ar_method="wlnl",
+        ar_ratio_threshold=3.0,
+        clas_osr=True,
+        estimate_ionosphere=True,
+        estimate_troposphere=True,
+        max_epochs=max_epochs,
+        extra_args=extra_args,
+    )
 
 
 def solve_rtk_file(
@@ -136,6 +241,7 @@ __all__ = [
     "preprocess_spp_file",
     "read_rinex_header",
     "read_rinex_observation_epochs",
+    "solve_clas_kinematic_file",
     "solve_ppp_file",
     "solve_rtk_file",
     "solve_spp_file",

--- a/tests/test_python_bindings.py
+++ b/tests/test_python_bindings.py
@@ -194,6 +194,32 @@ class PythonBindingsSmokeTest(unittest.TestCase):
             )
         )
 
+    def test_solve_ppp_file_accepts_new_kwargs(self) -> None:
+        """solve_ppp_file should accept the extended keyword arguments without error."""
+        solution = libgnsspp.solve_ppp_file(
+            str(ROOT_DIR / "data" / "rover_static.obs"),
+            str(ROOT_DIR / "data" / "navigation_static.nav"),
+            max_epochs=3,
+            kinematic_mode=False,
+            enable_ar=False,
+            estimate_troposphere=True,
+            estimate_ionosphere=False,
+        )
+        self.assertGreaterEqual(solution.size(), 1)
+
+    def test_solve_clas_kinematic_file_is_importable(self) -> None:
+        """solve_clas_kinematic_file must be importable and callable with correct signature."""
+        import inspect
+        sig = inspect.signature(libgnsspp.solve_clas_kinematic_file)
+        required = {
+            name
+            for name, param in sig.parameters.items()
+            if param.default is inspect.Parameter.empty
+        }
+        self.assertIn("obs_path", required)
+        self.assertIn("nav_path", required)
+        self.assertIn("ssr_path", required)
+
     def test_solve_rtk_file_returns_short_baseline_solution_records(self) -> None:
         solution = libgnsspp.solve_rtk_file(
             str(ROOT_DIR / "data" / "short_baseline" / "TSK200JPN_R_20240010000_01D_30S_MO.rnx"),


### PR DESCRIPTION
## Summary

Makes the Python API first-class for CLAS PPP-RTK kinematic use cases.

### Extended `solve_ppp_file`

New keyword arguments:

| argument | type | description |
|---|---|---|
| `ssr_path` | `str` | Expanded SSR corrections CSV |
| `config_path` | `str` | TOML config file (`--config`) |
| `ar_method` | `str` | AR method, e.g. `"wlnl"` |
| `ar_ratio_threshold` | `float` | AR ratio threshold |
| `use_dynamics_model` | `bool` | `--use-dynamics-model` |
| `clas_osr` | `bool` | `--clas-osr --no-ionosphere-free` |
| `estimate_ionosphere` | `bool` | `--estimate-ionosphere` |
| `estimate_troposphere` | `bool` | default `True` |
| `extra_args` | `list[str]` | verbatim extra CLI args |

### New `solve_clas_kinematic_file`

One-call convenience for CLAS PPP-RTK kinematic positioning:

```python
import libgnsspp

solution = libgnsspp.solve_clas_kinematic_file(
    obs_path="rover.obs",
    nav_path="base.nav",
    ssr_path="ssr_expanded.csv",
)
fixed = [r for r in solution.records() if r.is_fixed()]
print(f"fix rate: {100*len(fixed)/solution.size():.1f}%")
```

Equivalent CLI:
```bash
gnss ppp --obs rover.obs --nav base.nav --ssr ssr_expanded.csv \
         --kinematic --use-dynamics-model --clas-osr \
         --no-ionosphere-free --estimate-ionosphere \
         --estimate-troposphere --enable-ar --ar-method wlnl \
         --ar-ratio-threshold 3.0
```

## Test plan

- [x] `test_solve_ppp_file_accepts_new_kwargs` — extended kwargs accepted
- [x] `test_solve_clas_kinematic_file_is_importable` — signature check passes
- [x] All core ctests pass

Made with [Cursor](https://cursor.com)