### PR TITLE
feat: live per-epoch output and web dashboard live PPP view

### DIFF
--- a/apps/commands/visualization/gnss_web.html
+++ b/apps/commands/visualization/gnss_web.html
@@ -504,6 +504,28 @@
         <tbody></tbody>
       </table>
     </section>
+
+    <section class="card" style="margin-top: 18px;">
+      <div class="section-title">
+        <h2>⚡ Live PPP view</h2>
+        <span class="tiny">Updates every second while <code>gnss_ppp --live-output</code> is running</span>
+      </div>
+      <div style="display:flex;gap:8px;align-items:center;margin-bottom:10px;">
+        <label for="live-pos-path" style="font-size:13px;white-space:nowrap;">.pos file path (relative to root):</label>
+        <input id="live-pos-path" type="text" placeholder="output/solution.pos"
+               style="flex:1;padding:4px 8px;border:1px solid #ccc;border-radius:4px;font-size:13px;">
+        <button onclick="livePoints=[];liveLastTow=0;drawLivePoints();"
+                style="padding:4px 10px;font-size:13px;cursor:pointer;">Reset</button>
+      </div>
+      <canvas id="live-ppp-canvas" width="900" height="340"
+              style="width:100%;border:1px solid #eee;border-radius:6px;background:#fafafa;"></canvas>
+      <div id="live-status" style="font-size:12px;color:#888;margin-top:6px;">
+        Enter a .pos path above and start <code>gnss_ppp --live-output</code>.
+        Legend: <span style="color:#2ecc71">■</span> Fixed &nbsp;
+                <span style="color:#f39c12">■</span> Float &nbsp;
+                <span style="color:#e74c3c">■</span> SPP
+      </div>
+    </section>
   </main>
   <script>
     const STATUS_COLORS = {"FIXED":"#2ecc71","FLOAT":"#f39c12","DGPS":"#3498db","SPP":"#e74c3c"};
@@ -1592,8 +1614,73 @@
       setInterval(refreshStatus, 2000);
     }
 
+    // ── Live PPP view ────────────────────────────────────────────────────────
+    const liveCanvas = document.getElementById("live-ppp-canvas");
+    let liveLastTow = 0;
+    let livePoints = [];
+
+    function drawLivePoints() {
+      if (!liveCanvas) return;
+      const ctx = liveCanvas.getContext("2d");
+      const W = liveCanvas.width, H = liveCanvas.height;
+      ctx.clearRect(0, 0, W, H);
+      if (livePoints.length === 0) {
+        ctx.fillStyle = "#888"; ctx.font = "13px sans-serif";
+        ctx.fillText("Waiting for gnss_ppp --live-output data…", 12, H / 2);
+        return;
+      }
+      // Simple lat/lon to canvas mapping
+      const lats = livePoints.map(p => p.lat), lons = livePoints.map(p => p.lon);
+      const minLat = Math.min(...lats), maxLat = Math.max(...lats);
+      const minLon = Math.min(...lons), maxLon = Math.max(...lons);
+      const pad = 20;
+      const scaleX = (W - 2 * pad) / (maxLon - minLon || 1e-6);
+      const scaleY = (H - 2 * pad) / (maxLat - minLat || 1e-6);
+      for (const p of livePoints) {
+        const x = pad + (p.lon - minLon) * scaleX;
+        const y = H - pad - (p.lat - minLat) * scaleY;
+        ctx.beginPath();
+        ctx.arc(x, y, 3, 0, 2 * Math.PI);
+        ctx.fillStyle = p.color;
+        ctx.fill();
+      }
+      // Latest point
+      const last = livePoints[livePoints.length - 1];
+      const lx = pad + (last.lon - minLon) * scaleX;
+      const ly = H - pad - (last.lat - minLat) * scaleY;
+      ctx.beginPath(); ctx.arc(lx, ly, 6, 0, 2 * Math.PI);
+      ctx.strokeStyle = "#fff"; ctx.lineWidth = 2; ctx.stroke();
+      // Stats
+      const fixed = livePoints.filter(p => p.status.includes("FIXED")).length;
+      ctx.fillStyle = "#333"; ctx.font = "12px sans-serif";
+      ctx.fillText(`${livePoints.length} epochs  fix: ${(100*fixed/livePoints.length).toFixed(1)}%  TOW: ${last.tow}`, 8, 16);
+    }
+
+    async function pollLive() {
+      const posInput = document.getElementById("live-pos-path");
+      if (!posInput) return;
+      const posPath = posInput.value.trim();
+      if (!posPath) return;
+      try {
+        const data = await fetchJson(`/api/live-pos?path=${encodeURIComponent(posPath)}&after=${liveLastTow}`);
+        if (data.points && data.points.length > 0) {
+          livePoints = livePoints.concat(data.points);
+          liveLastTow = data.last_tow;
+          drawLivePoints();
+          document.getElementById("live-status").textContent =
+            `${livePoints.length} epochs, last TOW ${liveLastTow.toFixed(1)}`;
+        }
+      } catch (e) { /* ignore transient errors */ }
+    }
+
     init().catch((error) => {
       document.body.innerHTML = `<main><pre class="status-pre">${String(error)}</pre></main>`;
+    });
+
+    // Start live polling after page load
+    window.addEventListener("load", () => {
+      drawLivePoints();
+      setInterval(pollLive, 1000);
     });
   </script>
 </body>

--- a/apps/commands/visualization/gnss_web.py
+++ b/apps/commands/visualization/gnss_web.py
@@ -964,6 +964,53 @@ def make_handler(args: argparse.Namespace):
                         }
                     )
                     return
+                if parsed.path == "/api/live-pos":
+                    # Stream incremental updates from a live gnss_ppp --live-output file.
+                    # Query params: path=<relative .pos path>, after=<GPS TOW float, default 0>
+                    pos_arg = query.get("path", [""])[0]
+                    after_tow = float(query.get("after", ["0"])[0])
+                    if not pos_arg:
+                        self._write_json({"error": "missing pos path"}, HTTPStatus.BAD_REQUEST)
+                        return
+                    try:
+                        pos_path = resolve_under_root(root_dir, pos_arg)
+                    except ValueError:
+                        self._write_json({"error": "pos path escapes artifact root"}, HTTPStatus.BAD_REQUEST)
+                        return
+                    if not pos_path.exists():
+                        self._write_json({"available": False, "points": [], "last_tow": after_tow})
+                        return
+                    STATUS_INT = {1: "SPP", 2: "DGPS", 3: "FLOAT", 4: "FIXED", 5: "PPP_FLOAT", 6: "PPP_FIXED", 7: "PROPAGATED"}
+                    STATUS_COLOR = {"PPP_FIXED": "#2ecc71", "FIXED": "#2ecc71", "PPP_FLOAT": "#f39c12", "FLOAT": "#f39c12"}
+                    points: list[dict] = []
+                    last_tow = after_tow
+                    try:
+                        with pos_path.open() as fh:
+                            for line in fh:
+                                if line.startswith("%"):
+                                    continue
+                                parts = line.split()
+                                if len(parts) < 10:
+                                    continue
+                                tow = float(parts[1])
+                                if tow <= after_tow:
+                                    continue
+                                status_int = int(parts[8])
+                                status = STATUS_INT.get(status_int, "UNKNOWN")
+                                points.append({
+                                    "tow": round(tow, 3),
+                                    "lat": float(parts[5]),
+                                    "lon": float(parts[6]),
+                                    "height": float(parts[7]),
+                                    "status": status,
+                                    "color": STATUS_COLOR.get(status, "#e74c3c"),
+                                    "satellites": int(parts[9]),
+                                })
+                                last_tow = tow
+                    except OSError:
+                        pass
+                    self._write_json({"available": True, "points": points, "last_tow": last_tow})
+                    return
                 if parsed.path == "/api/moving-base-matches":
                     csv_arg = query.get("path", [""])[0]
                     if not csv_arg:

--- a/apps/native/gnss_ppp.cpp
+++ b/apps/native/gnss_ppp.cpp
@@ -47,6 +47,7 @@ struct Options {
     std::string summary_json_path;
     std::string kml_path;
     std::string geojson_path;
+    bool live_output = false;
     int max_epochs = 0;
     int convergence_min_epochs = 20;
     std::string convergence_policy = "legacy-3d";
@@ -136,6 +137,7 @@ void printUsage(const char* program_name) {
         << "  --out <solution.pos>     Output position file (required)\n"
         << "  --summary-json <summary.json>\n"
         << "                          Optional machine-readable run summary\n"
+        << "  --live-output            Write one .pos line per epoch (enables gnss web live view)\n"
         << "  --kml <solution.kml>     Optional KML output (fix=green, float=yellow)\n"
         << "  --geojson <solution.geojson>\n"
         << "                          Optional GeoJSON output with status/sat/pdop properties\n"
@@ -320,6 +322,8 @@ Options parseArguments(int argc, char* argv[]) {
             options.kml_path = argv[++i];
         } else if (arg == "--geojson" && i + 1 < argc) {
             options.geojson_path = argv[++i];
+        } else if (arg == "--live-output") {
+            options.live_output = true;
         } else if (arg == "--max-epochs" && i + 1 < argc) {
             options.max_epochs = std::stoi(argv[++i]);
         } else if (arg == "--convergence-min-epochs" && i + 1 < argc) {
@@ -1291,6 +1295,17 @@ int main(int argc, char* argv[]) {
         libgnss::Solution solutions;
         libgnss::ObservationData observation_data;
         int processed_epochs = 0;
+
+        std::ofstream live_stream;
+        if (options.live_output && !options.out_path.empty()) {
+            live_stream.open(options.out_path, std::ios::out | std::ios::trunc);
+            if (!live_stream.is_open()) {
+                std::cerr << "Error: failed to open live output file: "
+                          << options.out_path << "\n";
+                return 1;
+            }
+            libgnss::Solution::writeHeader(live_stream);
+        }
         int valid_solutions = 0;
         int ppp_float_solutions = 0;
         int ppp_fixed_solutions = 0;
@@ -1367,6 +1382,9 @@ int main(int argc, char* argv[]) {
             processed_epochs++;
             if (solution.isValid()) {
                 solutions.addSolution(solution);
+                if (live_stream.is_open()) {
+                    libgnss::Solution::appendSolutionLine(live_stream, solution);
+                }
                 valid_solutions++;
                 if (solution.status == libgnss::SolutionStatus::PPP_FLOAT) {
                     ppp_float_solutions++;
@@ -1383,7 +1401,9 @@ int main(int argc, char* argv[]) {
             return 1;
         }
 
-        if (!solutions.writeToFile(options.out_path)) {
+        if (live_stream.is_open()) {
+            live_stream.close();
+        } else if (!solutions.writeToFile(options.out_path)) {
             std::cerr << "Error: failed to write solution file: " << options.out_path << "\n";
             return 1;
         }

--- a/include/libgnss++/core/solution.hpp
+++ b/include/libgnss++/core/solution.hpp
@@ -233,6 +233,20 @@ public:
     bool writeKML(const std::string& filename) const;
 
     /**
+     * @brief Append a single solution epoch to an already-open output stream.
+     *
+     * Used by the live / streaming output path to flush one line per epoch
+     * rather than writing the whole file at the end.  The stream must already
+     * contain the pos-format header written by writeHeader().
+     */
+    static void appendSolutionLine(std::ostream& out, const PositionSolution& sol);
+
+    /**
+     * @brief Write the pos-format file header to a stream.
+     */
+    static void writeHeader(std::ostream& out);
+
+    /**
      * @brief Write solutions in GeoJSON format for visualization.
      *
      * Emits a FeatureCollection with one LineString per status group

--- a/src/core/solution.cpp
+++ b/src/core/solution.cpp
@@ -378,32 +378,41 @@ Solution::SolutionStatistics Solution::calculateStatistics(const Vector3d& refer
     return stats;
 }
 
+void Solution::writeHeader(std::ostream& out) {
+    out << "% LibGNSS++ Position Solution\n"
+        << "% Format: pos\n"
+        << "% Columns: GPS_Week GPS_TOW X(m) Y(m) Z(m) Lat(deg) Lon(deg) Height(m)"
+           " Status Satellites PDOP Ratio FixedAmbiguities Iterations\n";
+}
+
+void Solution::appendSolutionLine(std::ostream& out, const PositionSolution& sol) {
+    out << std::fixed << std::setprecision(6)
+        << sol.time.week << " " << sol.time.tow << " "
+        << sol.position_ecef(0) << " "
+        << sol.position_ecef(1) << " "
+        << sol.position_ecef(2) << " "
+        << sol.position_geodetic.latitude  * 180.0 / M_PI << " "
+        << sol.position_geodetic.longitude * 180.0 / M_PI << " "
+        << sol.position_geodetic.height << " "
+        << static_cast<int>(sol.status) << " "
+        << sol.num_satellites << " "
+        << sol.pdop << " "
+        << sol.ratio << " "
+        << sol.num_fixed_ambiguities << " "
+        << sol.iterations << "\n";
+    out.flush();
+}
+
 bool Solution::writeToFile(const std::string& filename, const std::string& format) const {
     std::ofstream file(filename);
     if (!file.is_open()) {
         return false;
     }
-    
-    // Write header
-    file << "% LibGNSS++ Position Solution\n";
-    file << "% Format: " << format << "\n";
-    file << "% Columns: GPS_Week GPS_TOW X(m) Y(m) Z(m) Lat(deg) Lon(deg) Height(m) Status Satellites PDOP Ratio FixedAmbiguities Iterations\n";
-    
+    (void)format;
+    writeHeader(file);
     for (const auto& sol : solutions) {
-        file << std::fixed << std::setprecision(6);
-        file << sol.time.week << " " << sol.time.tow << " ";
-        file << sol.position_ecef(0) << " " << sol.position_ecef(1) << " " << sol.position_ecef(2) << " ";
-        file << sol.position_geodetic.latitude * 180.0/M_PI << " ";
-        file << sol.position_geodetic.longitude * 180.0/M_PI << " ";
-        file << sol.position_geodetic.height << " ";
-        file << static_cast<int>(sol.status) << " ";
-        file << sol.num_satellites << " ";
-        file << sol.pdop << " ";
-        file << sol.ratio << " ";
-        file << sol.num_fixed_ambiguities << " ";
-        file << sol.iterations << "\n";
+        appendSolutionLine(file, sol);
     }
-    
     return true;
 }
 


### PR DESCRIPTION
## Summary

Adds real-time trajectory visualization: `gnss_ppp --live-output` flushes one `.pos` line per epoch, and `gnss web` polls it every second to render a live lat/lon scatter on the dashboard.

### `gnss_ppp --live-output`

Opens the output `.pos` file at startup, writes the header once, then appends and flushes one line per valid epoch — no more wait-until-end batch write.

```bash
gnss ppp --obs rover.obs --nav base.nav --ssr ssr.csv \
         --out output/solution.pos --live-output \
         --kinematic --use-dynamics-model --clas-osr \
         --enable-ar --ar-method wlnl --ar-ratio-threshold 3.0 \
         --estimate-ionosphere --estimate-troposphere
```

### `gnss web` — `/api/live-pos` endpoint

New HTTP endpoint `GET /api/live-pos?path=<rel>&after=<tow>` returns incremental JSON:

```json
{"available": true, "points": [{"tow":..., "lat":..., "lon":..., "status":"PPP_FIXED", "color":"#2ecc71", "satellites":9}], "last_tow": 556410.4}
```

### Web dashboard — ⚡ Live PPP view panel

New section in `gnss_web.html`:
- Canvas with lat/lon scatter, colour-coded by status (green=fixed, yellow=float, red=SPP)
- Path input for the `.pos` file relative to `--root`
- Auto-polls every 1 s; shows epoch count and fix rate
- Reset button clears accumulated points

**Workflow:**
1. `gnss ppp ... --out output/solution.pos --live-output` (terminal 1)
2. `gnss web --root .` (terminal 2)
3. Open `http://localhost:8085` → "Live PPP view" → enter `output/solution.pos`

## Test plan

- [x] Build succeeds, no new warnings
- [x] All web tests pass (10 passed, 1 skipped)
- [x] `--live-output` and batch mode produce identical `.pos` content

Made with [Cursor](https://cursor.com)