### PR TITLE
feat: NTRIP auto-reconnect and stream stats dashboard

### DIFF
--- a/apps/commands/visualization/gnss_web.html
+++ b/apps/commands/visualization/gnss_web.html
@@ -513,6 +513,28 @@
 
     <section class="card" style="margin-top: 18px;">
       <div class="section-title">
+        <h2>📡 NTRIP / RTCM stream</h2>
+        <span class="tiny">Reads JSON from <code>gnss stream --stats-json</code></span>
+      </div>
+      <div style="display:flex;gap:8px;align-items:center;margin-bottom:10px;flex-wrap:wrap;">
+        <label for="stream-stats-path" style="font-size:13px;white-space:nowrap;">stats JSON path:</label>
+        <input id="stream-stats-path" type="text" placeholder="output/ntrip_stats.json"
+               style="flex:1;min-width:220px;padding:4px 8px;border:1px solid #ccc;border-radius:4px;font-size:13px;">
+        <button id="stream-stats-refresh-btn" type="button" style="padding:4px 10px;font-size:13px;cursor:pointer;">Refresh</button>
+      </div>
+      <div id="stream-stats-summary" style="font-size:13px;color:#444;margin-bottom:8px;">
+        Start <code>gnss stream --input ntrip://... --reconnect --stats-json output/ntrip_stats.json</code>.
+      </div>
+      <table id="stream-stats-table" style="width:100%;font-size:12px;">
+        <thead>
+          <tr><th align="left">RTCM type</th><th align="left">Name</th><th align="right">Count</th></tr>
+        </thead>
+        <tbody></tbody>
+      </table>
+    </section>
+
+    <section class="card" style="margin-top: 18px;">
+      <div class="section-title">
         <h2>⚡ Live PPP view</h2>
         <span class="tiny">Updates every second while <code>gnss_ppp --live-output</code> is running</span>
       </div>
@@ -1623,6 +1645,53 @@
       setInterval(refreshStatus, 2000);
     }
 
+    // ── NTRIP / RTCM stream stats ───────────────────────────────────────────
+    const streamStatsPathInput = document.getElementById("stream-stats-path");
+    const streamStatsSummary = document.getElementById("stream-stats-summary");
+    const streamStatsTableBody = document.querySelector("#stream-stats-table tbody");
+    const streamStatsRefreshBtn = document.getElementById("stream-stats-refresh-btn");
+
+    function renderStreamStats(data) {
+      if (!streamStatsSummary || !streamStatsTableBody) return;
+      if (!data || !data.available) {
+        streamStatsSummary.textContent = data?.error || "stats file not available";
+        streamStatsTableBody.innerHTML = "";
+        return;
+      }
+      const connected = data.connected ? "connected" : "disconnected";
+      const lastName = data.last_message_name || "—";
+      streamStatsSummary.textContent =
+        `${connected}  messages=${data.messages_total || 0}` +
+        `  reconnect=${data.reconnect_count || 0}` +
+        `  last=${lastName}` +
+        (data.source ? `  source=${data.source}` : "");
+      const counts = data.message_counts || {};
+      const rows = Object.entries(counts)
+        .sort((a, b) => Number(b[1]) - Number(a[1]))
+        .map(([typeId, count]) => {
+          const name = `type ${typeId}`;
+          return `<tr><td>${typeId}</td><td>${name}</td><td align="right">${count}</td></tr>`;
+        });
+      streamStatsTableBody.innerHTML = rows.join("") ||
+        `<tr><td colspan="3">No RTCM messages yet</td></tr>`;
+    }
+
+    async function refreshStreamStats() {
+      if (!streamStatsPathInput) return;
+      const statsPath = streamStatsPathInput.value.trim();
+      if (!statsPath) return;
+      try {
+        const data = await fetchJson(`/api/stream-stats?path=${encodeURIComponent(statsPath)}`);
+        renderStreamStats(data);
+      } catch (error) {
+        renderStreamStats({ available: false, error: String(error) });
+      }
+    }
+
+    if (streamStatsRefreshBtn) {
+      streamStatsRefreshBtn.addEventListener("click", refreshStreamStats);
+    }
+
     // ── Live PPP view ────────────────────────────────────────────────────────
     const liveCanvas = document.getElementById("live-ppp-canvas");
     const livePauseBtn = document.getElementById("live-pause-btn");
@@ -1844,6 +1913,8 @@
     window.addEventListener("load", () => {
       drawLivePoints();
       setInterval(pollLive, 1000);
+      refreshStreamStats();
+      setInterval(refreshStreamStats, 2000);
     });
   </script>
 </body>

--- a/apps/commands/visualization/gnss_web.py
+++ b/apps/commands/visualization/gnss_web.py
@@ -1011,6 +1011,28 @@ def make_handler(args: argparse.Namespace):
                         pass
                     self._write_json({"available": True, "points": points, "last_tow": last_tow})
                     return
+                if parsed.path == "/api/stream-stats":
+                    stats_arg = query.get("path", [""])[0]
+                    if not stats_arg:
+                        self._write_json({"error": "missing stream stats path"}, HTTPStatus.BAD_REQUEST)
+                        return
+                    try:
+                        stats_path = resolve_under_root(root_dir, stats_arg)
+                    except ValueError:
+                        self._write_json({"error": "stream stats path escapes artifact root"}, HTTPStatus.BAD_REQUEST)
+                        return
+                    if not stats_path.exists():
+                        self._write_json({"available": False, "error": "stats file not found"})
+                        return
+                    try:
+                        payload = json.loads(stats_path.read_text(encoding="utf-8"))
+                    except (OSError, json.JSONDecodeError) as exc:
+                        self._write_json({"available": False, "error": str(exc)})
+                        return
+                    payload["available"] = True
+                    payload["path"] = relative_display(stats_path, root_dir)
+                    self._write_json(payload)
+                    return
                 if parsed.path == "/api/moving-base-matches":
                     csv_arg = query.get("path", [""])[0]
                     if not csv_arg:

--- a/apps/native/gnss_stream.cpp
+++ b/apps/native/gnss_stream.cpp
@@ -2,12 +2,14 @@
 
 #include <algorithm>
 #include <cerrno>
+#include <chrono>
 #include <cstdint>
 #include <cstring>
 #include <filesystem>
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <sstream>
 #include <string>
 
 #ifndef _WIN32
@@ -74,6 +76,9 @@ void printUsage(const char* argv0) {
         << "Options:\n"
         << "  --output <file|serial://...|tcp://host:port> Relay decoded RTCM frames to a binary file, serial sink, or TCP sink\n"
         << "  --limit <count>           Stop after this many messages (0 = until EOF)\n"
+        << "  --reconnect               Auto-reconnect NTRIP streams after disconnect\n"
+        << "  --reconnect-delay-ms <ms> Delay before NTRIP reconnect (default: 2000)\n"
+        << "  --stats-json <path>       Write stream stats JSON for gnss web dashboard\n"
         << "  --decode-observations     Print decoded observation epoch summaries\n"
         << "  --decode-navigation       Print decoded navigation message summaries\n"
         << "  --quiet                   Suppress per-message type lines\n"
@@ -332,15 +337,91 @@ struct RelaySink {
     }
 };
 
+std::string jsonEscape(const std::string& value) {
+    std::string escaped;
+    escaped.reserve(value.size());
+    for (char ch : value) {
+        switch (ch) {
+            case '\\':
+                escaped += "\\\\";
+                break;
+            case '"':
+                escaped += "\\\"";
+                break;
+            case '\n':
+                escaped += "\\n";
+                break;
+            case '\r':
+                escaped += "\\r";
+                break;
+            default:
+                escaped += ch;
+                break;
+        }
+    }
+    return escaped;
+}
+
+void writeStreamStatsJson(const std::string& path,
+                          const libgnss::io::RTCMReader& reader,
+                          size_t message_count,
+                          const libgnss::io::RTCMMessage* last_message) {
+    const auto stats = reader.getStats();
+    std::ostringstream out;
+    out << std::fixed << std::setprecision(3);
+    out << "{\n";
+    out << "  \"source\": \"" << jsonEscape(reader.source()) << "\",\n";
+    out << "  \"connected\": " << (reader.isConnected() ? "true" : "false") << ",\n";
+    out << "  \"reconnect_count\": " << reader.reconnectCount() << ",\n";
+    out << "  \"messages_total\": " << message_count << ",\n";
+    out << "  \"valid_messages\": " << stats.valid_messages << ",\n";
+    out << "  \"crc_errors\": " << stats.crc_errors << ",\n";
+    out << "  \"decode_errors\": " << stats.decode_errors << ",\n";
+    if (last_message != nullptr) {
+        out << "  \"last_message_type\": "
+            << static_cast<uint16_t>(last_message->type) << ",\n";
+        out << "  \"last_message_name\": \""
+            << jsonEscape(libgnss::io::rtcm_utils::getMessageTypeName(last_message->type))
+            << "\",\n";
+    } else {
+        out << "  \"last_message_type\": null,\n";
+        out << "  \"last_message_name\": null,\n";
+    }
+    out << "  \"message_counts\": {\n";
+    bool first = true;
+    for (const auto& entry : stats.message_counts) {
+        if (!first) {
+            out << ",\n";
+        }
+        first = false;
+        out << "    \"" << static_cast<uint16_t>(entry.first) << "\": " << entry.second;
+    }
+    out << "\n  },\n";
+    const auto now = std::chrono::system_clock::now();
+    const auto epoch_seconds =
+        std::chrono::duration_cast<std::chrono::seconds>(now.time_since_epoch()).count();
+    out << "  \"updated_at_epoch_s\": " << epoch_seconds << "\n";
+    out << "}\n";
+
+    std::filesystem::create_directories(std::filesystem::path(path).parent_path());
+    std::ofstream file(path, std::ios::trunc);
+    if (file) {
+        file << out.str();
+    }
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
     std::string input_path;
     std::string output_path;
+    std::string stats_json_path;
     size_t limit = 0;
     bool decode_observations = false;
     bool decode_navigation = false;
     bool quiet = false;
+    bool reconnect = false;
+    int reconnect_delay_ms = 2000;
 
     for (int i = 1; i < argc; ++i) {
         const std::string arg = argv[i];
@@ -350,6 +431,12 @@ int main(int argc, char** argv) {
             output_path = argv[++i];
         } else if (arg == "--limit" && i + 1 < argc) {
             limit = static_cast<size_t>(std::stoull(argv[++i]));
+        } else if (arg == "--reconnect") {
+            reconnect = true;
+        } else if (arg == "--reconnect-delay-ms" && i + 1 < argc) {
+            reconnect_delay_ms = std::stoi(argv[++i]);
+        } else if (arg == "--stats-json" && i + 1 < argc) {
+            stats_json_path = argv[++i];
         } else if (arg == "--decode-observations") {
             decode_observations = true;
         } else if (arg == "--decode-navigation") {
@@ -377,6 +464,9 @@ int main(int argc, char** argv) {
         std::cerr << "Error: failed to open RTCM source: " << input_path << "\n";
         return 1;
     }
+    if (reconnect) {
+        reader.setAutoReconnect(true, reconnect_delay_ms);
+    }
 
     RelaySink output_sink;
     if (!output_path.empty()) {
@@ -389,8 +479,37 @@ int main(int argc, char** argv) {
     libgnss::io::RTCMProcessor processor;
     size_t message_count = 0;
     libgnss::io::RTCMMessage message;
-    while ((limit == 0 || message_count < limit) && reader.readMessage(message)) {
+    libgnss::io::RTCMMessage last_message;
+    bool has_last_message = false;
+    while (limit == 0 || message_count < limit) {
+        if (!reader.readMessage(message)) {
+            if (reconnect && reader.isNtripSource() && (limit == 0 || message_count < limit)) {
+                if (!quiet) {
+                    std::cerr << "[gnss_stream] waiting for NTRIP data"
+                              << " reconnect_count=" << reader.reconnectCount();
+                    const std::string error = reader.lastError();
+                    if (!error.empty()) {
+                        std::cerr << " last_error=" << error;
+                    }
+                    std::cerr << "\n";
+                }
+                if (!stats_json_path.empty()) {
+                    writeStreamStatsJson(stats_json_path, reader, message_count, nullptr);
+                }
+                continue;
+            }
+            break;
+        }
         ++message_count;
+        last_message = message;
+        has_last_message = true;
+        if (!stats_json_path.empty()) {
+            writeStreamStatsJson(
+                stats_json_path,
+                reader,
+                message_count,
+                has_last_message ? &last_message : nullptr);
+        }
         if (output_sink.isOpen() && !output_sink.write(message)) {
             std::cerr << "Error: failed to relay RTCM frame to output sink\n";
             output_sink.close();
@@ -424,12 +543,20 @@ int main(int argc, char** argv) {
     }
 
     output_sink.close();
+    if (!stats_json_path.empty()) {
+        writeStreamStatsJson(
+            stats_json_path,
+            reader,
+            message_count,
+            has_last_message ? &last_message : nullptr);
+    }
     reader.close();
 
     const auto stats = reader.getStats();
     std::cout << "summary: messages=" << message_count
               << " valid=" << stats.valid_messages
               << " crc_errors=" << stats.crc_errors
-              << " decode_errors=" << stats.decode_errors << "\n";
+              << " decode_errors=" << stats.decode_errors
+              << " reconnect_count=" << reader.reconnectCount() << "\n";
     return 0;
 }

--- a/include/libgnss++/io/ntrip.hpp
+++ b/include/libgnss++/io/ntrip.hpp
@@ -32,12 +32,18 @@ public:
                  const std::string& password = "");
     void disconnect();
 
+    void setAutoReconnect(bool enabled, int delay_ms = 2000);
+    bool autoReconnectEnabled() const { return auto_reconnect_; }
+    int reconnectDelayMs() const { return reconnect_delay_ms_; }
+    int reconnectCount() const { return reconnect_count_; }
+
     bool isConnected() const { return socket_fd_ >= 0; }
     bool readMessage(RTCMMessage& message, int timeout_ms = 1000);
     bool readMessages(std::vector<RTCMMessage>& messages, int timeout_ms = 1000);
 
     RTCMProcessor::RTCMStats getStats() const { return processor_.getStats(); }
     std::string getLastError() const { return last_error_; }
+    const NTRIPStreamInfo& connectionInfo() const { return connection_info_; }
 
     static bool parseURL(const std::string& url, NTRIPStreamInfo& info);
 
@@ -47,6 +53,11 @@ private:
     std::vector<uint8_t> buffer_;
     std::deque<RTCMMessage> pending_messages_;
     std::string last_error_;
+    NTRIPStreamInfo connection_info_;
+    bool has_connection_info_ = false;
+    bool auto_reconnect_ = false;
+    int reconnect_delay_ms_ = 2000;
+    int reconnect_count_ = 0;
 
     static std::string base64Encode(const std::string& input);
 
@@ -54,6 +65,7 @@ private:
     bool readResponseHeader();
     bool receiveIntoBuffer(int timeout_ms);
     size_t consumeBufferedMessages(std::vector<RTCMMessage>& messages);
+    bool tryReconnect();
 };
 
 }  // namespace io

--- a/include/libgnss++/io/rtcm.hpp
+++ b/include/libgnss++/io/rtcm.hpp
@@ -292,9 +292,17 @@ public:
      */
     RTCMProcessor::RTCMStats getStats() const;
 
+    bool isNtripSource() const { return ntrip_client_ != nullptr; }
+    void setAutoReconnect(bool enabled, int delay_ms = 2000);
+    int reconnectCount() const;
+    bool isConnected() const;
+    std::string lastError() const;
+    const std::string& source() const { return source_; }
+
 private:
     RTCMProcessor processor_;
     bool is_open_ = false;
+    std::string source_;
     std::vector<uint8_t> buffer_;
     size_t buffer_pos_ = 0;
     NTRIPClient* ntrip_client_ = nullptr;

--- a/src/io/ntrip.cpp
+++ b/src/io/ntrip.cpp
@@ -2,8 +2,10 @@
 
 #include <algorithm>
 #include <cerrno>
+#include <chrono>
 #include <cstring>
 #include <iterator>
+#include <thread>
 
 #ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
@@ -63,6 +65,27 @@ std::string trimSlashes(std::string value) {
 
 NTRIPClient::~NTRIPClient() {
     disconnect();
+}
+
+void NTRIPClient::setAutoReconnect(bool enabled, int delay_ms) {
+    auto_reconnect_ = enabled;
+    reconnect_delay_ms_ = std::max(0, delay_ms);
+}
+
+bool NTRIPClient::tryReconnect() {
+    if (!has_connection_info_) {
+        last_error_ = "no stored NTRIP connection info";
+        return false;
+    }
+    ++reconnect_count_;
+    if (reconnect_delay_ms_ > 0) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(reconnect_delay_ms_));
+    }
+    return connect(connection_info_.host,
+                   connection_info_.port,
+                   connection_info_.mountpoint,
+                   connection_info_.username,
+                   connection_info_.password);
 }
 
 bool NTRIPClient::parseURL(const std::string& url, NTRIPStreamInfo& info) {
@@ -183,6 +206,8 @@ bool NTRIPClient::connect(const std::string& host,
         return false;
     }
 
+    connection_info_ = info;
+    has_connection_info_ = true;
     last_error_.clear();
     return true;
 }
@@ -236,12 +261,24 @@ bool NTRIPClient::readMessages(std::vector<RTCMMessage>& messages, int timeout_m
         return true;
     }
 
-    if (!isConnected() || !receiveIntoBuffer(timeout_ms)) {
-        return false;
+    for (int attempt = 0; attempt < 2; ++attempt) {
+        if (!isConnected()) {
+            if (!auto_reconnect_ || !tryReconnect()) {
+                return false;
+            }
+        }
+
+        if (receiveIntoBuffer(timeout_ms)) {
+            consumeBufferedMessages(messages);
+            return !messages.empty();
+        }
+
+        if (isConnected()) {
+            return false;
+        }
     }
 
-    consumeBufferedMessages(messages);
-    return !messages.empty();
+    return false;
 }
 
 std::string NTRIPClient::base64Encode(const std::string& input) {

--- a/src/io/rtcm.cpp
+++ b/src/io/rtcm.cpp
@@ -3386,6 +3386,7 @@ RTCMReader::~RTCMReader() {
 
 bool RTCMReader::open(const std::string& source) {
     close();
+    source_ = source;
     if (source.rfind("ntrip://", 0) == 0 || source.rfind("http://", 0) == 0 ||
         source.rfind("https://", 0) == 0) {
         return readFromNetwork(source);
@@ -3580,6 +3581,24 @@ RTCMProcessor::RTCMStats RTCMReader::getStats() const {
         return ntrip_client_->getStats();
     }
     return processor_.getStats();
+}
+
+void RTCMReader::setAutoReconnect(bool enabled, int delay_ms) {
+    if (ntrip_client_) {
+        ntrip_client_->setAutoReconnect(enabled, delay_ms);
+    }
+}
+
+int RTCMReader::reconnectCount() const {
+    return ntrip_client_ ? ntrip_client_->reconnectCount() : 0;
+}
+
+bool RTCMReader::isConnected() const {
+    return ntrip_client_ ? ntrip_client_->isConnected() : is_open_;
+}
+
+std::string RTCMReader::lastError() const {
+    return ntrip_client_ ? ntrip_client_->getLastError() : std::string();
 }
 
 // rtcm_utils implementation

--- a/tests/test_ntrip.cpp
+++ b/tests/test_ntrip.cpp
@@ -219,6 +219,16 @@ TEST(NTRIPClientTest, RejectsIncompleteCasterUrl) {
     EXPECT_FALSE(io::NTRIPClient::parseURL("ntrip://:badport/MOUNT", info));
 }
 
+TEST(NTRIPClientTest, AutoReconnectDefaultsAreDisabled) {
+    io::NTRIPClient client;
+    EXPECT_FALSE(client.autoReconnectEnabled());
+    EXPECT_EQ(client.reconnectDelayMs(), 2000);
+    EXPECT_EQ(client.reconnectCount(), 0);
+    client.setAutoReconnect(true, 500);
+    EXPECT_TRUE(client.autoReconnectEnabled());
+    EXPECT_EQ(client.reconnectDelayMs(), 500);
+}
+
 #ifndef _WIN32
 TEST(NTRIPClientTest, ConnectsAndReadsRtcmMessage) {
     static constexpr char kOkHeader[] = "ICY 200 OK\r\nNtrip-Version: Ntrip/2.0\r\n\r\n";

--- a/tests/test_web_http_ux.py
+++ b/tests/test_web_http_ux.py
@@ -415,6 +415,29 @@ class WebHttpUxTest(unittest.TestCase):
                 self.assertEqual(status, 200)
                 self.assertEqual(live_incremental["points"], [])
                 self.assertEqual(live_incremental["last_tow"], 101.0)
+
+                stream_stats = output / "stream_stats.json"
+                stream_stats.write_text(
+                    json.dumps(
+                        {
+                            "source": "ntrip://caster/MOUNT1",
+                            "connected": True,
+                            "reconnect_count": 2,
+                            "messages_total": 5,
+                            "last_message_type": 1005,
+                            "last_message_name": "Stationary RTK reference station ARP",
+                            "message_counts": {"1005": 5},
+                        }
+                    ),
+                    encoding="utf-8",
+                )
+                status, _, stats_payload = fetch_json(
+                    f"{base_url}/api/stream-stats?path=output/stream_stats.json"
+                )
+                self.assertEqual(status, 200)
+                self.assertTrue(stats_payload["available"])
+                self.assertEqual(stats_payload["reconnect_count"], 2)
+                self.assertEqual(stats_payload["message_counts"]["1005"], 5)
             finally:
                 server.shutdown()
                 server.server_close()


### PR DESCRIPTION
## Summary

Operational improvements for NTRIP/RTCM streaming and the web dashboard.

### NTRIP auto-reconnect
- `NTRIPClient::setAutoReconnect(delay_ms)` retries after disconnect
- `RTCMReader` exposes reconnect count, connection state, and last error
- `gnss stream --reconnect --reconnect-delay-ms 2000` keeps NTRIP sources alive

### Stream stats JSON
```bash
gnss stream --input ntrip://user:pass@caster:2101/MOUNT \
            --reconnect --stats-json output/ntrip_stats.json
```
Writes message counts, last RTCM type/name, reconnect count, and connection state.

### Web dashboard
- New `/api/stream-stats?path=...` endpoint
- New **NTRIP / RTCM stream** panel with live type table (2s refresh)

## Test plan

- [x] NTRIP unit tests pass (7/7)
- [x] Web HTTP UX tests pass (8/8), including `/api/stream-stats`
- [x] `gnss_stream` builds cleanly

Made with [Cursor](https://cursor.com)