### PR TITLE
Fix macOS clang build: value-initialize const PositionSolution in test_types

### DIFF
--- a/tests/test_types.cpp
+++ b/tests/test_types.cpp
@@ -94,7 +94,9 @@ TEST_F(TypesTest, PropagatedSolutionIsValidWithoutCurrentSatellitesButNeverFixed
 }
 
 TEST_F(TypesTest, PositionSolutionCovariancesDefaultToInvalid) {
-    const PositionSolution solution;
+    // Value-initialize: const default initialization is ill-formed without a
+    // user-provided default constructor (strict clang/macOS builds).
+    const PositionSolution solution{};
 
     // An omitted covariance must be rejected by consumers rather than being
     // interpreted as whatever coefficients Eigen happened to leave behind.

--- a/tests/test_urban_continuity_bundle.py
+++ b/tests/test_urban_continuity_bundle.py
@@ -154,7 +154,8 @@ class UrbanContinuityBundleTest(unittest.TestCase):
                 hashlib.sha256(fused_path.read_bytes()).hexdigest(),
             )
             self.assertIn(payload["binary"]["version_available"], (True, False))
-            self.assertEqual(payload["manifest_path"], str(manifest_path))
+            # display_path resolves symlinks (macOS: /var -> /private/var).
+            self.assertEqual(payload["manifest_path"], str(manifest_path.resolve()))
             self.assertEqual(payload["dataset_provenance"]["dataset"], "PPC-Dataset")
             self.assertIn("upstream", payload["dataset_provenance"])
             self.assertIn("license", payload["dataset_provenance"])


### PR DESCRIPTION
## Summary