### PR TITLE
feat: guide users to their next GNSS workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,11 @@ cmake --build build --target gnss_ppp --parallel 2
 python3 apps/gnss.py demo
 ```
 
+After the native demo, run `python3 apps/gnss.py next`. It validates the local
+demo result and gives one copy-paste next command for SPP, RTK, PPP, ROS2,
+QZSS, or C++ integration. The check is local; it does not transmit or store
+usage data. Installed builds expose the same command as `gnss next`.
+
 ## Use the C++20 library
 
 The install exports a standard CMake package and the `libgnsspp::gnss_lib`

--- a/apps/commands/diagnostics/gnss_demo.py
+++ b/apps/commands/diagnostics/gnss_demo.py
@@ -202,6 +202,13 @@ def main() -> int:
     print(f"  position: {paths['pos']}")
     print(f"  kml:      {paths['kml']}")
     print(f"  summary:  {paths['summary']}")
+    source_next = (
+        "py apps/gnss.py next" if os.name == "nt" else "python3 apps/gnss.py next"
+    )
+    print(
+        f"Next: run `gnss next` (`{source_next}` from a source checkout) "
+        "to choose a route for your own data."
+    )
     return 0
 
 

--- a/apps/commands/diagnostics/gnss_next.py
+++ b/apps/commands/diagnostics/gnss_next.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+"""Recommend one concrete next step from the user's local progress."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+
+
+GOALS = {
+    "spp": {
+        "label": "single-receiver positioning (SPP)",
+        "command": (
+            "{cli} spp --obs data/rover_static.obs "
+            "--nav data/navigation_static.nav --out output/spp_solution.pos"
+        ),
+        "guide": "docs/quickstart.md",
+        "inputs": "rover observation RINEX and navigation RINEX",
+    },
+    "rtk": {
+        "label": "rover/base positioning (RTK)",
+        "command": (
+            "{cli} solve "
+            "--rover data/short_baseline/TSK200JPN_R_20240010000_01D_30S_MO.rnx "
+            "--base data/short_baseline/TSKB00JPN_R_20240010000_01D_30S_MO.rnx "
+            "--nav data/short_baseline/BRDC00IGS_R_20240010000_01D_MN.rnx "
+            "--mode static --out output/rtk_solution.pos"
+        ),
+        "guide": "docs/use_cases/rtklib_migration.md",
+        "inputs": "rover, base, and navigation RINEX",
+    },
+    "ppp": {
+        "label": "precise point positioning (PPP)",
+        "command": (
+            "{cli} ppp --static --obs data/rover_static.obs "
+            "--nav data/navigation_static.nav --out output/ppp_solution.pos"
+        ),
+        "guide": "docs/quickstart.md",
+        "inputs": "rover observation RINEX plus navigation or precise products",
+    },
+    "robotics": {
+        "label": "ROS2 and robotics integration",
+        "command": "{cli} ros2-doctor --json-out output/ros2_doctor.json",
+        "guide": "docs/use_cases/ros2.md",
+        "inputs": "a ROS2 environment, receiver, or recorded bag",
+    },
+    "qzss": {
+        "label": "QZSS L6 / CLAS / MADOCA",
+        "command": "{cli} qzss-l6-info --help",
+        "guide": "docs/use_cases/qzss_l6.md",
+        "inputs": "raw QZSS L6, Compact SSR, or matching RINEX",
+    },
+    "cpp": {
+        "label": "C++20 library integration",
+        "command": "cmake --build build --parallel 2",
+        "guide": "docs/interfaces.md",
+        "inputs": "a configured source build and a C++20 application",
+    },
+}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog=os.environ.get("GNSS_CLI_NAME"),
+        description=(
+            "Inspect local first-run progress and recommend exactly one next command. "
+            "No usage data is transmitted or stored."
+        ),
+    )
+    parser.add_argument(
+        "--goal",
+        choices=tuple(GOALS),
+        help="Choose a route after the offline demo succeeds.",
+    )
+    parser.add_argument(
+        "--workspace",
+        type=Path,
+        default=Path.cwd(),
+        help="Workspace containing output/ (default: current directory).",
+    )
+    parser.add_argument(
+        "--format",
+        choices=("text", "json"),
+        default="text",
+        help="Output format (default: text).",
+    )
+    return parser.parse_args()
+
+
+def valid_demo_summary(path: Path) -> bool:
+    if not path.is_file():
+        return False
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return False
+    if not isinstance(payload, dict):
+        return False
+    demo = payload.get("demo")
+    return (
+        isinstance(demo, dict)
+        and demo.get("schema_version") == "self-contained-demo.v1"
+        and payload.get("processed_epochs") == 8
+        and payload.get("valid_solutions") == 8
+    )
+
+
+def cli_prefix(workspace: Path) -> str:
+    if (workspace / "apps" / "gnss.py").is_file():
+        if os.name == "nt":
+            return "py apps/gnss.py"
+        return "python3 apps/gnss.py"
+    return "gnss"
+
+
+def build_payload(workspace: Path, goal: str | None) -> dict[str, object]:
+    workspace = workspace.expanduser().resolve()
+    demo_summary = workspace / "output" / "self-contained-demo" / "demo_summary.json"
+    demo_complete = valid_demo_summary(demo_summary)
+    cli = cli_prefix(workspace)
+
+    if not demo_complete:
+        recommendation = {
+            "id": "run-offline-demo",
+            "label": "verify the installation with the offline PPP demo",
+            "command": f"{cli} demo --output-dir output/self-contained-demo",
+            "guide": "docs/self_contained_demo.md",
+        }
+        stage = "first-run"
+    elif goal is None:
+        recommendation = {
+            "id": "choose-goal",
+            "label": "choose the route closest to your own data",
+            "command": f"{cli} next --goal spp",
+            "guide": "docs/use_cases.md",
+        }
+        stage = "choose-goal"
+    else:
+        route = GOALS[goal]
+        recommendation = {
+            "id": goal,
+            "label": route["label"],
+            "command": route["command"].format(cli=cli),
+            "guide": route["guide"],
+            "inputs": route["inputs"],
+        }
+        stage = "apply-to-data"
+
+    return {
+        "schema_version": "gnss-next.v1",
+        "stage": stage,
+        "workspace": str(workspace),
+        "demo": {
+            "complete": demo_complete,
+            "summary": str(demo_summary),
+        },
+        "selected_goal": goal,
+        "recommendation": recommendation,
+        "available_goals": [
+            {"id": goal_id, "label": route["label"]}
+            for goal_id, route in GOALS.items()
+        ],
+        "privacy": "Local artifact inspection only; no usage data is transmitted or stored.",
+    }
+
+
+def format_text(payload: dict[str, object]) -> str:
+    recommendation = payload["recommendation"]
+    assert isinstance(recommendation, dict)
+    lines = [
+        f"Progress: {payload['stage']}",
+        f"Next: {recommendation['label']}",
+        "",
+        f"  {recommendation['command']}",
+        "",
+    ]
+    if "inputs" in recommendation:
+        lines.append(f"Inputs: {recommendation['inputs']}")
+    lines.append(f"Guide:  {recommendation['guide']}")
+
+    if payload["stage"] == "choose-goal":
+        lines.extend(["", "Other goals:"])
+        for route in payload["available_goals"]:
+            assert isinstance(route, dict)
+            lines.append(f"  --goal {route['id']:<9} {route['label']}")
+    lines.extend(["", str(payload["privacy"])])
+    return "\n".join(lines)
+
+
+def main() -> int:
+    args = parse_args()
+    payload = build_payload(args.workspace, args.goal)
+    if args.format == "json":
+        print(json.dumps(payload, indent=2, sort_keys=True))
+    else:
+        print(format_text(payload))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/apps/gnss.py
+++ b/apps/gnss.py
@@ -82,6 +82,11 @@ COMMANDS = {
         "target": python_target("gnss_demo.py"),
         "summary": "Run the tracked offline PPP demo and emit a .pos, KML, and JSON summary.",
     },
+    "next": {
+        "kind": "python",
+        "target": python_target("gnss_next.py"),
+        "summary": "Inspect local progress and recommend one concrete next command.",
+    },
     "robotics-smoke": {
         "kind": "python",
         "target": python_target("gnss_robotics_smoke.py"),

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -8,6 +8,18 @@ cmake --build build -j
 python3 apps/gnss.py doctor
 ```
 
+At any point, ask for one concrete next step. Before a successful demo this
+recommends the offline first run; afterwards it offers a route based on the
+kind of data or integration you want to use:
+
+```bash
+python3 apps/gnss.py next
+python3 apps/gnss.py next --goal rtk
+```
+
+`gnss next` only inspects local artifacts. Use `--format json` to integrate the
+same progress decision into another interface.
+
 ## Docker
 
 For the no-build self-contained demo, use the published image and mount only

--- a/tests/test_cli_ux.py
+++ b/tests/test_cli_ux.py
@@ -100,6 +100,7 @@ class CliUxTest(unittest.TestCase):
         for command in (
             "doctor",
             "demo",
+            "next",
             "solve",
             "ppp",
             "clas-ppp",
@@ -128,6 +129,7 @@ class CliUxTest(unittest.TestCase):
         expectations = {
             "doctor": ("usage: gnss doctor", "--strict"),
             "demo": ("usage: gnss demo", "--output-dir"),
+            "next": ("usage: gnss next", "--goal", "--workspace"),
             "qzss-l6-info": (
                 "usage: gnss qzss-l6-info",
                 "--compact-bias-row-materialization",
@@ -154,6 +156,7 @@ class CliUxTest(unittest.TestCase):
             "commands": ("Usage: gnss commands", "--json", "--query"),
             "doctor": ("usage: gnss doctor", "--strict"),
             "demo": ("usage: gnss demo", "--output-dir"),
+            "next": ("usage: gnss next", "--goal", "--workspace"),
             "qzss-l6-info": (
                 "usage: gnss qzss-l6-info",
                 "--compact-bias-row-materialization",

--- a/tests/test_gnss_next.py
+++ b/tests/test_gnss_next.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Regression tests for the local-progress next-step guide."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+
+ROOT_DIR = Path(__file__).resolve().parents[1]
+GNSS_CLI = ROOT_DIR / "apps" / "gnss.py"
+
+
+class GnssNextTest(unittest.TestCase):
+    def run_next(self, workspace: Path, *args: str) -> subprocess.CompletedProcess[str]:
+        return subprocess.run(
+            [
+                sys.executable,
+                str(GNSS_CLI),
+                "next",
+                "--workspace",
+                str(workspace),
+                *args,
+            ],
+            cwd=ROOT_DIR,
+            check=False,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_first_run_recommends_offline_demo(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss-next-first-") as temp_dir:
+            result = self.run_next(Path(temp_dir), "--format", "json")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["schema_version"], "gnss-next.v1")
+        self.assertEqual(payload["stage"], "first-run")
+        self.assertFalse(payload["demo"]["complete"])
+        self.assertEqual(payload["recommendation"]["id"], "run-offline-demo")
+        self.assertIn(
+            "demo --output-dir output/self-contained-demo",
+            payload["recommendation"]["command"],
+        )
+
+    def test_valid_demo_recommends_goal_selection(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss-next-complete-") as temp_dir:
+            workspace = Path(temp_dir)
+            summary = workspace / "output" / "self-contained-demo" / "demo_summary.json"
+            summary.parent.mkdir(parents=True)
+            summary.write_text(
+                json.dumps(
+                    {
+                        "processed_epochs": 8,
+                        "valid_solutions": 8,
+                        "demo": {"schema_version": "self-contained-demo.v1"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = self.run_next(workspace, "--format", "json")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["stage"], "choose-goal")
+        self.assertTrue(payload["demo"]["complete"])
+        self.assertEqual(payload["recommendation"]["id"], "choose-goal")
+        self.assertEqual(len(payload["available_goals"]), 6)
+
+    def test_selected_goal_returns_one_actionable_command(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss-next-goal-") as temp_dir:
+            workspace = Path(temp_dir)
+            summary = workspace / "output" / "self-contained-demo" / "demo_summary.json"
+            summary.parent.mkdir(parents=True)
+            summary.write_text(
+                json.dumps(
+                    {
+                        "processed_epochs": 8,
+                        "valid_solutions": 8,
+                        "demo": {"schema_version": "self-contained-demo.v1"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = self.run_next(workspace, "--goal", "rtk", "--format", "json")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["stage"], "apply-to-data")
+        self.assertEqual(payload["selected_goal"], "rtk")
+        self.assertEqual(payload["recommendation"]["id"], "rtk")
+        self.assertIn(" solve ", payload["recommendation"]["command"])
+
+    def test_invalid_demo_summary_does_not_count_as_complete(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss-next-invalid-") as temp_dir:
+            workspace = Path(temp_dir)
+            summary = workspace / "output" / "self-contained-demo" / "demo_summary.json"
+            summary.parent.mkdir(parents=True)
+            summary.write_text("{}\n", encoding="utf-8")
+            result = self.run_next(workspace, "--format", "json")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["stage"], "first-run")
+        self.assertFalse(payload["demo"]["complete"])
+
+    def test_source_checkout_uses_platform_python_launcher(self) -> None:
+        result = self.run_next(ROOT_DIR, "--goal", "rtk", "--format", "json")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        payload = json.loads(result.stdout)
+        expected_prefix = "py apps/gnss.py" if sys.platform == "win32" else "python3 apps/gnss.py"
+        self.assertTrue(
+            payload["recommendation"]["command"].startswith(expected_prefix),
+            payload["recommendation"]["command"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds a local-progress gnss next command that guides first-time users through the offline demo and then recommends one concrete workflow for SPP, RTK, PPP, ROS2, QZSS, or C++ integration. Includes JSON output, cross-platform source commands, README and quick-start guidance, and regression coverage. No usage data is stored or transmitted. Tests: 38 related Python tests passed; Release gnss_ppp build passed; offline demo produced 8 processed and 8 valid solutions; live next-step transition and RTK recommendation passed.