### PR TITLE
feat: guide users from solutions to inspection

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ python3 apps/gnss.py demo
 After the native demo, run `python3 apps/gnss.py next`. It validates the local
 demo result and gives one copy-paste next command for SPP, RTK, PPP, ROS2,
 QZSS, or C++ integration. The check is local; it does not transmit or store
-usage data. Installed builds expose the same command as `gnss next`.
+usage data. After a standard SPP, RTK, or PPP output is created, the same
+command validates that it contains solution epochs and advances to a KML
+inspection step. Installed builds expose the command as `gnss next`.
 
 ## Use the C++20 library
 

--- a/apps/commands/diagnostics/gnss_next.py
+++ b/apps/commands/diagnostics/gnss_next.py
@@ -7,6 +7,7 @@ import argparse
 import json
 import os
 from pathlib import Path
+import sys
 
 
 GOALS = {
@@ -18,6 +19,9 @@ GOALS = {
         ),
         "guide": "docs/quickstart.md",
         "inputs": "rover observation RINEX and navigation RINEX",
+        "result": "output/spp_solution.pos",
+        "entrypoint": "spp",
+        "required": ("data/rover_static.obs", "data/navigation_static.nav"),
     },
     "rtk": {
         "label": "rover/base positioning (RTK)",
@@ -30,6 +34,13 @@ GOALS = {
         ),
         "guide": "docs/use_cases/rtklib_migration.md",
         "inputs": "rover, base, and navigation RINEX",
+        "result": "output/rtk_solution.pos",
+        "entrypoint": "solve",
+        "required": (
+            "data/short_baseline/TSK200JPN_R_20240010000_01D_30S_MO.rnx",
+            "data/short_baseline/TSKB00JPN_R_20240010000_01D_30S_MO.rnx",
+            "data/short_baseline/BRDC00IGS_R_20240010000_01D_MN.rnx",
+        ),
     },
     "ppp": {
         "label": "precise point positioning (PPP)",
@@ -39,6 +50,9 @@ GOALS = {
         ),
         "guide": "docs/quickstart.md",
         "inputs": "rover observation RINEX plus navigation or precise products",
+        "result": "output/ppp_solution.pos",
+        "entrypoint": "ppp",
+        "required": ("data/rover_static.obs", "data/navigation_static.nav"),
     },
     "robotics": {
         "label": "ROS2 and robotics integration",
@@ -107,6 +121,48 @@ def valid_demo_summary(path: Path) -> bool:
     )
 
 
+def count_position_epochs(path: Path) -> int:
+    """Count data rows in a libgnss++/RTKLIB-style position output."""
+    if not path.is_file():
+        return 0
+    try:
+        return sum(
+            1
+            for line in path.read_text(encoding="utf-8", errors="replace").splitlines()
+            if line.strip()
+            and not line.lstrip().startswith(("%", "#"))
+        )
+    except OSError:
+        return 0
+
+
+def completed_result(
+    workspace: Path,
+    goal: str | None,
+) -> tuple[str, Path, int] | None:
+    """Return the selected or newest valid standard positioning result."""
+    goal_ids = (goal,) if goal is not None else tuple(GOALS)
+    candidates: list[tuple[int, str, Path, int]] = []
+    for goal_id in goal_ids:
+        route = GOALS[goal_id]
+        result_relative = route.get("result")
+        if not isinstance(result_relative, str):
+            continue
+        result_path = workspace / result_relative
+        epochs = count_position_epochs(result_path)
+        if epochs < 1:
+            continue
+        try:
+            modified_ns = result_path.stat().st_mtime_ns
+        except OSError:
+            continue
+        candidates.append((modified_ns, goal_id, result_path, epochs))
+    if not candidates:
+        return None
+    _, goal_id, result_path, epochs = max(candidates)
+    return goal_id, result_path, epochs
+
+
 def cli_prefix(workspace: Path) -> str:
     if (workspace / "apps" / "gnss.py").is_file():
         if os.name == "nt":
@@ -115,11 +171,20 @@ def cli_prefix(workspace: Path) -> str:
     return "gnss"
 
 
+def open_command(path: str) -> str:
+    if os.name == "nt":
+        return f"Start-Process {path}"
+    if sys.platform == "darwin":
+        return f"open {path}"
+    return f"xdg-open {path}"
+
+
 def build_payload(workspace: Path, goal: str | None) -> dict[str, object]:
     workspace = workspace.expanduser().resolve()
     demo_summary = workspace / "output" / "self-contained-demo" / "demo_summary.json"
     demo_complete = valid_demo_summary(demo_summary)
     cli = cli_prefix(workspace)
+    result = completed_result(workspace, goal) if demo_complete else None
 
     if not demo_complete:
         recommendation = {
@@ -129,6 +194,34 @@ def build_payload(workspace: Path, goal: str | None) -> dict[str, object]:
             "guide": "docs/self_contained_demo.md",
         }
         stage = "first-run"
+    elif result is not None:
+        detected_goal, result_path, epochs = result
+        relative_result = result_path.relative_to(workspace).as_posix()
+        kml_relative = Path(relative_result).with_suffix(".kml").as_posix()
+        kml_path = workspace / kml_relative
+        kml_ready = kml_path.is_file() and kml_path.stat().st_size > 0
+        if kml_ready:
+            recommendation = {
+                "id": f"open-{detected_goal}-result",
+                "label": f"open the completed {detected_goal.upper()} KML track",
+                "command": open_command(kml_relative),
+                "guide": GOALS[detected_goal]["guide"],
+                "result": relative_result,
+                "kml": kml_relative,
+                "epochs": epochs,
+            }
+        else:
+            recommendation = {
+                "id": f"inspect-{detected_goal}-result",
+                "label": f"inspect the completed {detected_goal.upper()} result as KML",
+                "command": (
+                    f"{cli} pos2kml {relative_result} {kml_relative} --status all"
+                ),
+                "guide": GOALS[detected_goal]["guide"],
+                "result": relative_result,
+                "epochs": epochs,
+            }
+        stage = "inspect-result"
     elif goal is None:
         recommendation = {
             "id": "choose-goal",
@@ -139,17 +232,36 @@ def build_payload(workspace: Path, goal: str | None) -> dict[str, object]:
         stage = "choose-goal"
     else:
         route = GOALS[goal]
-        recommendation = {
-            "id": goal,
-            "label": route["label"],
-            "command": route["command"].format(cli=cli),
-            "guide": route["guide"],
-            "inputs": route["inputs"],
-        }
+        required = route.get("required", ())
+        assert isinstance(required, tuple)
+        missing_inputs = [
+            relative_path
+            for relative_path in required
+            if not (workspace / relative_path).is_file()
+        ]
+        if missing_inputs:
+            recommendation = {
+                "id": f"prepare-{goal}-inputs",
+                "label": f"prepare the inputs for {route['label']}",
+                "command": f"{cli} help {route['entrypoint']}",
+                "guide": route["guide"],
+                "inputs": route["inputs"],
+                "inputs_ready": False,
+                "missing_inputs": missing_inputs,
+            }
+        else:
+            recommendation = {
+                "id": goal,
+                "label": route["label"],
+                "command": route["command"].format(cli=cli),
+                "guide": route["guide"],
+                "inputs": route["inputs"],
+                "inputs_ready": True,
+            }
         stage = "apply-to-data"
 
     return {
-        "schema_version": "gnss-next.v1",
+        "schema_version": "gnss-next.v2",
         "stage": stage,
         "workspace": str(workspace),
         "demo": {
@@ -157,6 +269,7 @@ def build_payload(workspace: Path, goal: str | None) -> dict[str, object]:
             "summary": str(demo_summary),
         },
         "selected_goal": goal,
+        "detected_goal": result[0] if result is not None else None,
         "recommendation": recommendation,
         "available_goals": [
             {"id": goal_id, "label": route["label"]}
@@ -178,6 +291,12 @@ def format_text(payload: dict[str, object]) -> str:
     ]
     if "inputs" in recommendation:
         lines.append(f"Inputs: {recommendation['inputs']}")
+    if "result" in recommendation:
+        lines.append(f"Result: {recommendation['result']} ({recommendation['epochs']} epochs)")
+    if recommendation.get("missing_inputs"):
+        lines.append("Missing:")
+        for relative_path in recommendation["missing_inputs"]:
+            lines.append(f"  {relative_path}")
     lines.append(f"Guide:  {recommendation['guide']}")
 
     if payload["stage"] == "choose-goal":

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -18,7 +18,14 @@ python3 apps/gnss.py next --goal rtk
 ```
 
 `gnss next` only inspects local artifacts. Use `--format json` to integrate the
-same progress decision into another interface.
+same progress decision into another interface. It reports four local stages:
+`first-run`, `choose-goal`, `apply-to-data`, and `inspect-result`. Standard
+`output/spp_solution.pos`, `output/rtk_solution.pos`, and
+`output/ppp_solution.pos` files advance to inspection only when they contain at
+least one solution epoch; empty or header-only outputs remain at
+`apply-to-data`. If a documented standard input is not present, the command
+lists the missing paths and opens focused command help instead of recommending
+a processing command that is guaranteed to fail.
 
 ## Docker
 

--- a/tests/test_gnss_next.py
+++ b/tests/test_gnss_next.py
@@ -38,7 +38,7 @@ class GnssNextTest(unittest.TestCase):
 
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         payload = json.loads(result.stdout)
-        self.assertEqual(payload["schema_version"], "gnss-next.v1")
+        self.assertEqual(payload["schema_version"], "gnss-next.v2")
         self.assertEqual(payload["stage"], "first-run")
         self.assertFalse(payload["demo"]["complete"])
         self.assertEqual(payload["recommendation"]["id"], "run-offline-demo")
@@ -86,6 +86,14 @@ class GnssNextTest(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
+            for relative_path in (
+                "data/short_baseline/TSK200JPN_R_20240010000_01D_30S_MO.rnx",
+                "data/short_baseline/TSKB00JPN_R_20240010000_01D_30S_MO.rnx",
+                "data/short_baseline/BRDC00IGS_R_20240010000_01D_MN.rnx",
+            ):
+                input_path = workspace / relative_path
+                input_path.parent.mkdir(parents=True, exist_ok=True)
+                input_path.touch()
             result = self.run_next(workspace, "--goal", "rtk", "--format", "json")
 
         self.assertEqual(result.returncode, 0, msg=result.stderr)
@@ -93,7 +101,33 @@ class GnssNextTest(unittest.TestCase):
         self.assertEqual(payload["stage"], "apply-to-data")
         self.assertEqual(payload["selected_goal"], "rtk")
         self.assertEqual(payload["recommendation"]["id"], "rtk")
+        self.assertTrue(payload["recommendation"]["inputs_ready"])
         self.assertIn(" solve ", payload["recommendation"]["command"])
+
+    def test_missing_standard_inputs_recommends_preparation(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss-next-prepare-") as temp_dir:
+            workspace = Path(temp_dir)
+            summary = workspace / "output" / "self-contained-demo" / "demo_summary.json"
+            summary.parent.mkdir(parents=True)
+            summary.write_text(
+                json.dumps(
+                    {
+                        "processed_epochs": 8,
+                        "valid_solutions": 8,
+                        "demo": {"schema_version": "self-contained-demo.v1"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = self.run_next(workspace, "--goal", "rtk", "--format", "json")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["stage"], "apply-to-data")
+        self.assertEqual(payload["recommendation"]["id"], "prepare-rtk-inputs")
+        self.assertFalse(payload["recommendation"]["inputs_ready"])
+        self.assertEqual(len(payload["recommendation"]["missing_inputs"]), 3)
+        self.assertIn("help solve", payload["recommendation"]["command"])
 
     def test_invalid_demo_summary_does_not_count_as_complete(self) -> None:
         with tempfile.TemporaryDirectory(prefix="gnss-next-invalid-") as temp_dir:
@@ -108,8 +142,115 @@ class GnssNextTest(unittest.TestCase):
         self.assertEqual(payload["stage"], "first-run")
         self.assertFalse(payload["demo"]["complete"])
 
+    def test_completed_rtk_result_advances_to_inspection(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss-next-inspect-") as temp_dir:
+            workspace = Path(temp_dir)
+            summary = workspace / "output" / "self-contained-demo" / "demo_summary.json"
+            summary.parent.mkdir(parents=True)
+            summary.write_text(
+                json.dumps(
+                    {
+                        "processed_epochs": 8,
+                        "valid_solutions": 8,
+                        "demo": {"schema_version": "self-contained-demo.v1"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result_path = workspace / "output" / "rtk_solution.pos"
+            result_path.write_text(
+                "% header\n2024/01/01 00:00:00.000 35.0 139.0 10.0 1 12\n",
+                encoding="utf-8",
+            )
+            result = self.run_next(workspace, "--goal", "rtk", "--format", "json")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["stage"], "inspect-result")
+        self.assertEqual(payload["detected_goal"], "rtk")
+        self.assertEqual(payload["recommendation"]["epochs"], 1)
+        self.assertIn(
+            "pos2kml output/rtk_solution.pos output/rtk_solution.kml --status all",
+            payload["recommendation"]["command"],
+        )
+
+    def test_comment_only_result_does_not_count_as_complete(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss-next-empty-result-") as temp_dir:
+            workspace = Path(temp_dir)
+            summary = workspace / "output" / "self-contained-demo" / "demo_summary.json"
+            summary.parent.mkdir(parents=True)
+            summary.write_text(
+                json.dumps(
+                    {
+                        "processed_epochs": 8,
+                        "valid_solutions": 8,
+                        "demo": {"schema_version": "self-contained-demo.v1"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (workspace / "output" / "ppp_solution.pos").write_text(
+                "% no valid solutions\n",
+                encoding="utf-8",
+            )
+            result = self.run_next(workspace, "--goal", "ppp", "--format", "json")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["stage"], "apply-to-data")
+        self.assertIsNone(payload["detected_goal"])
+
+    def test_existing_kml_is_opened_instead_of_regenerated(self) -> None:
+        with tempfile.TemporaryDirectory(prefix="gnss-next-open-kml-") as temp_dir:
+            workspace = Path(temp_dir)
+            summary = workspace / "output" / "self-contained-demo" / "demo_summary.json"
+            summary.parent.mkdir(parents=True)
+            summary.write_text(
+                json.dumps(
+                    {
+                        "processed_epochs": 8,
+                        "valid_solutions": 8,
+                        "demo": {"schema_version": "self-contained-demo.v1"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            (workspace / "output" / "spp_solution.pos").write_text(
+                "2024/01/01 00:00:00.000 35.0 139.0 10.0 5 8\n",
+                encoding="utf-8",
+            )
+            (workspace / "output" / "spp_solution.kml").write_text(
+                "<kml></kml>\n",
+                encoding="utf-8",
+            )
+            result = self.run_next(workspace, "--goal", "spp", "--format", "json")
+
+        self.assertEqual(result.returncode, 0, msg=result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(payload["stage"], "inspect-result")
+        self.assertEqual(payload["recommendation"]["id"], "open-spp-result")
+        self.assertEqual(payload["recommendation"]["kml"], "output/spp_solution.kml")
+        self.assertNotIn("pos2kml", payload["recommendation"]["command"])
+
     def test_source_checkout_uses_platform_python_launcher(self) -> None:
-        result = self.run_next(ROOT_DIR, "--goal", "rtk", "--format", "json")
+        with tempfile.TemporaryDirectory(prefix="gnss-next-source-") as temp_dir:
+            workspace = Path(temp_dir)
+            dispatcher = workspace / "apps" / "gnss.py"
+            dispatcher.parent.mkdir(parents=True)
+            dispatcher.touch()
+            summary = workspace / "output" / "self-contained-demo" / "demo_summary.json"
+            summary.parent.mkdir(parents=True)
+            summary.write_text(
+                json.dumps(
+                    {
+                        "processed_epochs": 8,
+                        "valid_solutions": 8,
+                        "demo": {"schema_version": "self-contained-demo.v1"},
+                    }
+                ),
+                encoding="utf-8",
+            )
+            result = self.run_next(workspace, "--goal", "rtk", "--format", "json")
 
         self.assertEqual(result.returncode, 0, msg=result.stderr)
         payload = json.loads(result.stdout)


### PR DESCRIPTION
Extends gnss next from first-run activation into post-solution inspection. Valid SPP, RTK, and PPP position outputs are detected locally, counted, and advanced to the inspect-result stage. Missing KML files get a pos2kml command; existing KML files get a platform-native open command. Header-only outputs do not count as complete. Missing documented inputs are listed and routed to focused help instead of a command guaranteed to fail. JSON schema advances to gnss-next.v2. Tests: 42 related Python tests passed; Python compilation and diff checks passed; a real 20-epoch PPC RTK replay was auto-detected with its generated KML.